### PR TITLE
Reuse X7 entry ROC threshold masks

### DIFF
--- a/NostalgiaForInfinityX7.py
+++ b/NostalgiaForInfinityX7.py
@@ -12725,6 +12725,12 @@ class NostalgiaForInfinityX7(IStrategy):
     # |________/\______/|__/  \__/\______/       |________|__/  \__/  |__/  |________|__/  |__/
     #
 
+    roc_9_1d_gt_neg_20 = roc_9_1d > -20.0
+    roc_9_4h_lt_20 = roc_9_4h < 20.0
+    roc_9_1d_lt_100 = roc_9_1d < 100.0
+    roc_9_1d_gt_neg_30 = roc_9_1d > -30.0
+    roc_9_4h_gt_neg_20 = roc_9_4h > -20.0
+
     for enabled_long_entry_signal in long_entry_signal_params:
       long_entry_condition_index = int(enabled_long_entry_signal.rsplit("_", 2)[1])
       if long_entry_signal_params[enabled_long_entry_signal]:
@@ -12761,7 +12767,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 5m down move, 15m high
             & ((rsi_3 > 3.0) | (aroonu_14_15m < 80.0))
             # 5m down move, 1h high, 4h overbought
-            & ((rsi_3 > 3.0) | (stochrsi_k_1h < 80.0) | (roc_9_4h < 20.0))
+            & ((rsi_3 > 3.0) | (stochrsi_k_1h < 80.0) | (roc_9_4h_lt_20))
             # 5m & 4h down move, 4h high
             & ((rsi_3 > 5.0) | (rsi_3_4h > 35.0) | aroonu_14_4h_lt_70)
             # 15m down move, 1h downtrend, 1h high
@@ -12805,7 +12811,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 4h high, 15m downtrend
             & (rsi_3_15m_gt_3 | aroonu_14_4h_lt_70 | (roc_9_15m > -20.0))
             # 15m down move, 4h high, 1d overbought
-            & (rsi_3_15m_gt_3 | (aroonu_14_4h < 85.0) | (roc_9_1d < 100.0))
+            & (rsi_3_15m_gt_3 | (aroonu_14_4h < 85.0) | (roc_9_1d_lt_100))
             # 15m down move, 1h high, 4h overbought
             & (rsi_3_15m_gt_3 | (stochrsi_k_1h < 90.0) | (roc_9_4h < 10.0))
             # 15m down move, 4h high & overbought
@@ -12823,7 +12829,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 4h down move, 1d still high
             & ((rsi_3_15m > 5.0) | (rsi_3_4h > 5.0) | (stochrsi_k_1d < 40.0))
             # 15m & 4h down move, 1d downtrend
-            & ((rsi_3_15m > 5.0) | (rsi_3_4h > 5.0) | (roc_9_1d > -20.0))
+            & ((rsi_3_15m > 5.0) | (rsi_3_4h > 5.0) | (roc_9_1d_gt_neg_20))
             # 15m & 4h down move, 1h still high
             & ((rsi_3_15m > 5.0) | (rsi_3_4h > 10.0) | (stochrsi_k_1h < 50.0))
             # 15m & 4h down move, 1d high
@@ -12933,7 +12939,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 1d overbought
             & ((rsi_3_1h > 5.0) | rsi_3_4h_gt_20 | (roc_9_1d < 40.0))
             # 1h & 1d down move, 1d downtrend
-            & ((rsi_3_1h > 5.0) | (rsi_3_1d > 5.0) | (roc_9_1d > -30.0))
+            & ((rsi_3_1h > 5.0) | (rsi_3_1d > 5.0) | (roc_9_1d_gt_neg_30))
             # 1h down move, 1h still high, 4h high
             & ((rsi_3_1h > 5.0) | (aroonu_14_1h < 50.0) | (aroonu_14_4h < 90.0))
             # 1h down move, 1d high, 4h downtrend
@@ -12987,11 +12993,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h still high, 1d overbought
             & ((rsi_3_1h > 25.0) | (stochrsi_k_1h < 50.0) | (roc_9_1d < 40.0))
             # 1h down move, 4h & 1d overbought
-            & ((rsi_3_1h > 25.0) | (roc_9_4h < 80.0) | (roc_9_1d < 100.0))
+            & ((rsi_3_1h > 25.0) | (roc_9_4h < 80.0) | (roc_9_1d_lt_100))
             # 1h & 4h down move, 4h downtrend
-            & ((rsi_3_1h > 30.0) | (rsi_3_4h > 30.0) | (roc_9_4h > -20.0))
+            & ((rsi_3_1h > 30.0) | (rsi_3_4h > 30.0) | (roc_9_4h_gt_neg_20))
             # 1h down move, 4h high, 1d downtrend
-            & ((rsi_3_1h > 35.0) | (aroonu_14_4h < 90.0) | (roc_9_1d > -20.0))
+            & ((rsi_3_1h > 35.0) | (aroonu_14_4h < 90.0) | (roc_9_1d_gt_neg_20))
             # 1h down move, 1d high & overbought
             & ((rsi_3_1h > 35.0) | (aroonu_14_1d < 90.0) | (roc_9_1d < 80.0))
             # 1h down move, 4h & 1d overbought
@@ -13005,7 +13011,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h high, 1d overbought
             & ((rsi_3_1h > 40.0) | (aroonu_14_1h < 80.0) | (roc_9_1d < 100.0))
             # 1h down move, 1h high, 4h overbought
-            & ((rsi_3_1h > 40.0) | (stochrsi_k_1h < 80.0) | (roc_9_4h < 20.0))
+            & ((rsi_3_1h > 40.0) | (stochrsi_k_1h < 80.0) | (roc_9_4h_lt_20))
             # 1h down move, 1h & 4h high
             & ((rsi_3_1h > 45.0) | (aroonu_14_1h < 80.0) | (aroonu_14_4h < 100.0))
             # 1h down move, 1h high & overbought
@@ -13045,7 +13051,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 1h high, 1d overbought
             & ((rsi_3_4h > 60.0) | (stochrsi_k_1h < 90.0) | (roc_9_1d < 60.0))
             # 1d down move, 1h high, 1d downtrend
-            & ((rsi_3_1d > 5.0) | (stochrsi_k_1h < 90.0) | (roc_9_1d > -20.0))
+            & ((rsi_3_1d > 5.0) | (stochrsi_k_1h < 90.0) | (roc_9_1d_gt_neg_20))
             # 1d down move, 1h still high, 4h high
             & ((rsi_3_1d > 20.0) | (aroonu_14_1h < 50.0) | (aroonu_14_4h < 90.0))
             # 1d down move, 1h & 4h high
@@ -13057,7 +13063,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1d down move, 1d high & overbought
             & ((rsi_3_1d > 60.0) | (aroonu_14_1d < 80.0) | roc_9_1d_lt_50)
             # 1h down move, 4h high, 1d overbought
-            & ((rsi_3_change_pct_1h > -75.0) | (aroonu_14_4h < 90.0) | (roc_9_1d < 100.0))
+            & ((rsi_3_change_pct_1h > -75.0) | (aroonu_14_4h < 90.0) | (roc_9_1d_lt_100))
             # 15m & 1h & 4h downtrend
             & ((cmf_20_15m > -0.3) | (cmf_20_1h > -0.3) | (cmf_20_4h > -0.3))
             # 15m high, 1d overbought
@@ -13079,7 +13085,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1d high, 4h downtrend, 1d overbought
             & ((aroonu_14_1d < 85.0) | (roc_9_4h > -25.0) | roc_9_1d_lt_50)
             # 1d high, 1h & 4h downtrend
-            & ((aroonu_14_1d < 90.0) | (roc_9_1h > -10.0) | (roc_9_4h > -20.0))
+            & ((aroonu_14_1d < 90.0) | (roc_9_1h > -10.0) | (roc_9_4h_gt_neg_20))
             # 1d high, 4h & 1d overbought
             & ((aroonu_14_1d < 90.0) | (roc_9_4h < 40.0) | (roc_9_1d < 80.0))
             # 1h high, 4h overbought
@@ -13099,7 +13105,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h downtrend, 4h high & overbought
             & ((roc_9_1h > -25.0) | (aroonu_14_4h < 80.0) | (roc_9_4h < 80.0))
             # 1h & 4h overbought, 1d downtrend
-            & ((roc_9_1h < 20.0) | (roc_9_4h < 20.0) | (roc_9_1d > -40.0))
+            & ((roc_9_1h < 20.0) | (roc_9_4h_lt_20) | (roc_9_1d > -40.0))
             # 1d P&D, 1d downtrend
             & ((change_pct_1d > -5.0) | (change_pct_1d.shift(288) < 30.0) | (cmf_20_1d > -0.0))
             # 1d green with top wick, 1h down move
@@ -13168,7 +13174,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 5m down move, 4h high & overbought
             & ((rsi_3 > 3.0) | (aroonu_14_4h < 100.0) | (roc_9_4h < 20.0))
             # 5m down move, 4h & 1d overbought
-            & ((rsi_3 > 3.0) | (roc_9_4h < 20.0) | (roc_9_1d < 40.0))
+            & ((rsi_3 > 3.0) | (roc_9_4h_lt_20) | (roc_9_1d < 40.0))
             # 5m down move, 1d downtrend
             & ((rsi_3 > 3.0) | (roc_9_1d > -40.0))
             # 5m & 15m down move, 15m still high
@@ -13372,13 +13378,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 15m sill high, 4h high
             & ((rsi_3_15m > 10.0) | (stochrsi_k_15m < 40.0) | (aroonu_14_4h < 60.0))
             # 15m down move, 4h high, 1d downtrend
-            & ((rsi_3_15m > 10.0) | (stochrsi_k_4h < 80.0) | (roc_9_1d > -30.0))
+            & ((rsi_3_15m > 10.0) | (stochrsi_k_4h < 80.0) | (roc_9_1d_gt_neg_30))
             # 15m & 1h down move, 4h downtrend
             & ((rsi_3_15m > 15.0) | (rsi_3_1h > 15.0) | (roc_9_4h > -20.0))
             # 15m & 1h down move, 1h downtrend
             & ((rsi_3_15m > 15.0) | rsi_3_1h_gt_20 | (cmf_20_1h > -0.30))
             # 15m & 1h down move, 1d overbought
-            & ((rsi_3_15m > 15.0) | (rsi_3_1h > 25.0) | (roc_9_1d < 100.0))
+            & ((rsi_3_15m > 15.0) | (rsi_3_1h > 25.0) | (roc_9_1d_lt_100))
             # 15m & 1h down move, 4h high
             & ((rsi_3_15m > 15.0) | (rsi_3_1h > 30.0) | (aroonu_14_4h < 80.0))
             # 15m & 1h down move, 1h high
@@ -13410,13 +13416,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 1h & 1d high
             & ((rsi_3_15m > 15.0) | (aroonu_14_1h < 70.0) | (aroonu_14_1d < 90.0))
             # 15m down move, 4h high, 4h downtrend
-            & ((rsi_3_15m > 15.0) | (aroonu_14_4h < 60.0) | (roc_9_4h > -20.0))
+            & ((rsi_3_15m > 15.0) | (aroonu_14_4h < 60.0) | (roc_9_4h_gt_neg_20))
             # 15m down move, 4h & 1d high
             & ((rsi_3_15m > 15.0) | (aroonu_14_4h < 75.0) | (aroonu_14_1d < 100.0))
             # 15m down move, 4h high & overbought
             & ((rsi_3_15m > 15.0) | (aroonu_14_4h < 80.0) | (roc_9_4h < 10.0))
             # 15m down move, 15m still high, 1d overbought
-            & ((rsi_3_15m > 15.0) | (stochrsi_k_15m < 50.0) | (roc_9_1d < 100.0))
+            & ((rsi_3_15m > 15.0) | (stochrsi_k_15m < 50.0) | (roc_9_1d_lt_100))
             # 15m down move, 1h high & overbought
             & ((rsi_3_15m > 15.0) | (stochrsi_k_1h < 90.0) | (roc_9_1h < 10.0))
             # 15m down move, 4h high, 1d overbought
@@ -13442,11 +13448,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 1h & 1d high
             & ((rsi_3_15m > 20.0) | (aroonu_14_1h < 80.0) | (aroonu_14_1d < 80.0))
             # 15m down move, 1h high, 1d downtrend
-            & ((rsi_3_15m > 20.0) | (aroonu_14_1h < 90.0) | (roc_9_1d > -30.0))
+            & ((rsi_3_15m > 20.0) | (aroonu_14_1h < 90.0) | (roc_9_1d_gt_neg_30))
             # 15m down move, 1h high, 1d overbought
-            & ((rsi_3_15m > 20.0) | (stochrsi_k_1h < 70.0) | (roc_9_1d < 100.0))
+            & ((rsi_3_15m > 20.0) | (stochrsi_k_1h < 70.0) | (roc_9_1d_lt_100))
             # 15m down move, 1h high, 1d downtrend
-            & ((rsi_3_15m > 20.0) | (stochrsi_k_1h < 80.0) | (roc_9_1d > -20.0))
+            & ((rsi_3_15m > 20.0) | (stochrsi_k_1h < 80.0) | (roc_9_1d_gt_neg_20))
             # 15m down move, 1h high & overbought
             & ((rsi_3_15m > 20.0) | (stochrsi_k_1h < 90.0) | (roc_9_1h < 10.0))
             # 15m & 1h down move, 1d overbought
@@ -13466,7 +13472,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 4h high & overbought
             & ((rsi_3_15m > 30.0) | aroonu_14_4h_lt_70 | (roc_9_4h < 50.0))
             # 15m down move, 1h high, 1d downtrend
-            & ((rsi_3_15m > 30.0) | (stochrsi_k_1h < 80.0) | (roc_9_1d > -20.0))
+            & ((rsi_3_15m > 30.0) | (stochrsi_k_1h < 80.0) | (roc_9_1d_gt_neg_20))
             # 15m down move, 4h high & overbought
             & ((rsi_3_15m > 30.0) | (stochrsi_k_4h < 80.0) | (roc_9_4h < 30.0))
             # 15m down move, 1h high, 4h overbought
@@ -13506,7 +13512,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 1d still high
             & ((rsi_3_1h > 5.0) | (rsi_3_4h > 5.0) | (stochrsi_k_1d < 50.0))
             # 1h & 4h down move, 1d downtrend
-            & ((rsi_3_1h > 5.0) | (rsi_3_4h > 5.0) | (roc_9_1d > -30.0))
+            & ((rsi_3_1h > 5.0) | (rsi_3_4h > 5.0) | (roc_9_1d_gt_neg_30))
             # 1h % 4h down move, 4h downtrend
             & ((rsi_3_1h > 5.0) | (rsi_3_4h > 10.0) | (cmf_20_4h > -0.30))
             # 1h & 4h down move, 4h still high
@@ -13592,11 +13598,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1d high & overbought
             & (rsi_3_1h_gt_20 | (aroonu_14_1d < 100.0) | (roc_9_1d < 20.0))
             # 1h down move, 1d high, 4h downtrend
-            & (rsi_3_1h_gt_20 | (stochrsi_k_1d < 80.0) | (roc_9_4h > -20.0))
+            & (rsi_3_1h_gt_20 | (stochrsi_k_1d < 80.0) | (roc_9_4h_gt_neg_20))
             # 1h & 4h down move, 4h high
             & ((rsi_3_1h > 25.0) | (rsi_3_4h > 30.0) | (aroonu_14_4h < 60.0))
             # 1h & 4h down move, 1d downtrend
-            & ((rsi_3_1h > 25.0) | (rsi_3_4h > 30.0) | (roc_9_1d > -30.0))
+            & ((rsi_3_1h > 25.0) | (rsi_3_4h > 30.0) | (roc_9_1d_gt_neg_30))
             # 1h down move, 1h & 4h high
             & ((rsi_3_1h > 25.0) | (aroonu_14_1h < 60.0) | (aroonu_14_4h < 90.0))
             # 1h down move, 1h high
@@ -13606,9 +13612,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1d high & overbought
             & ((rsi_3_1h > 25.0) | (aroonu_14_1d < 80.0) | (roc_9_1d < 40.0))
             # 1h down move, 4h & 1d overbought
-            & ((rsi_3_1h > 25.0) | (roc_9_4h < 30.0) | (roc_9_1d < 100.0))
+            & ((rsi_3_1h > 25.0) | (roc_9_4h < 30.0) | (roc_9_1d_lt_100))
             # 1h & 4h down move, 4h downtrend
-            & ((rsi_3_1h > 30.0) | (rsi_3_4h > 30.0) | (roc_9_4h > -20.0))
+            & ((rsi_3_1h > 30.0) | (rsi_3_4h > 30.0) | (roc_9_4h_gt_neg_20))
             # 1h down move, 1h & 4h high
             & ((rsi_3_1h > 30.0) | (aroonu_14_1h < 60.0) | (aroonu_14_4h < 100.0))
             # 1h down move, 1h high, 4h overbought
@@ -13624,13 +13630,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 1h still high
             & ((rsi_3_1h > 35.0) | (rsi_3_4h > 35.0) | (stochrsi_k_1h < 40.0))
             # 1h down move, 1h still high, 4h downtrend
-            & ((rsi_3_1h > 35.0) | (aroonu_14_1h < 50.0) | (roc_9_4h > -20.0))
+            & ((rsi_3_1h > 35.0) | (aroonu_14_1h < 50.0) | (roc_9_4h_gt_neg_20))
             # 1h down move, 1h high, 1d downtrend
             & ((rsi_3_1h > 35.0) | (aroonu_14_1h < 70.0) | (roc_9_1d > -25.0))
             # 1h down move, 4h high & overbought
             & ((rsi_3_1h > 35.0) | (aroonu_14_4h < 85.0) | (roc_9_4h < 100.0))
             # 1h down move, 4h high, 1d overbought
-            & ((rsi_3_1h > 35.0) | (aroonu_14_4h < 85.0) | (roc_9_1d < 100.0))
+            & ((rsi_3_1h > 35.0) | (aroonu_14_4h < 85.0) | (roc_9_1d_lt_100))
             # 1h down move, 1d high, 4h overbought
             & ((rsi_3_1h > 35.0) | (aroonu_14_1d < 100.0) | (roc_9_4h < 40.0))
             # 1h down move, 1h still high, 1d overbought
@@ -13642,7 +13648,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h high, 1d overbought
             & ((rsi_3_1h > 40.0) | (aroonu_14_1h < 80.0) | (roc_9_1d < 10.0))
             # 1h down move, 4h still high, 1d overbought
-            & ((rsi_3_1h > 40.0) | (aroonu_14_4h < 40.0) | (roc_9_1d < 100.0))
+            & ((rsi_3_1h > 40.0) | (aroonu_14_4h < 40.0) | (roc_9_1d_lt_100))
             # 1h & 4h down move, 4h high
             & ((rsi_3_1h > 45.0) | (rsi_3_4h > 60.0) | (aroonu_14_4h < 100.0))
             # 1h & 4h down move, 1d overbought
@@ -13668,7 +13674,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h & 1d down move, 1d still high
             & ((rsi_3_4h > 3.0) | (rsi_3_1d > 20.0) | (stochrsi_k_1d < 40.0))
             # 4h & 1d down move, 1d downtrend
-            & ((rsi_3_4h > 5.0) | (rsi_3_1d > 15.0) | (roc_9_1d > -20.0))
+            & ((rsi_3_4h > 5.0) | (rsi_3_1d > 15.0) | (roc_9_1d_gt_neg_20))
             # 4h down move, 15m still high
             & ((rsi_3_4h > 5.0) | (stochrsi_k_15m < 50.0))
             # 4h & 1d down move, 1h still not low enough
@@ -13704,7 +13710,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h & 1d down move, 1d overbought
             & ((rsi_3_4h > 25.0) | (rsi_3_1d > 40.0) | (roc_9_1d < 30.0))
             # 4h down move, 4h still high, 1d overbought
-            & ((rsi_3_4h > 25.0) | (aroonu_14_4h < 40.0) | (roc_9_1d < 100.0))
+            & ((rsi_3_4h > 25.0) | (aroonu_14_4h < 40.0) | (roc_9_1d_lt_100))
             # 4h down move, 4h still high. 4h downtrend
             & ((rsi_3_4h > 25.0) | (aroonu_14_4h < 50.0) | (cmf_20_4h > -0.40))
             # 4h down move, 4h still high, 1d downtrend
@@ -13726,11 +13732,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 4h high, 1d downtrend
             & ((rsi_3_4h > 40.0) | (stochrsi_k_4h < 70.0) | (roc_9_1d > -60.0))
             # 4h down move, 1d high & overbought
-            & ((rsi_3_4h > 40.0) | (stochrsi_k_1d < 90.0) | (roc_9_1d < 100.0))
+            & ((rsi_3_4h > 40.0) | (stochrsi_k_1d < 90.0) | (roc_9_1d_lt_100))
             # 4h & 1d down move, 1d high
             & ((rsi_3_4h > 45.0) | (rsi_3_1d > 45.0) | (aroonu_14_1d < 100.0))
             # 4h down move, 4h high, 1d downtrend
-            & ((rsi_3_4h > 45.0) | aroonu_14_4h_lt_70 | (roc_9_1d > -30.0))
+            & ((rsi_3_4h > 45.0) | aroonu_14_4h_lt_70 | (roc_9_1d_gt_neg_30))
             # 4h down move, 4h high & overbought
             & ((rsi_3_4h > 50.0) | aroonu_14_4h_lt_70 | (roc_9_4h < 10.0))
             # 4h down move, 1d high & overbought
@@ -13738,21 +13744,21 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 1d high, 4h overbought
             & ((rsi_3_4h > 55.0) | (stochrsi_k_1d < 90.0) | (roc_9_4h < 10.0))
             # 4h down move, 4h high & overbought
-            & ((rsi_3_4h > 60.0) | aroonu_14_4h_lt_70 | (roc_9_4h < 20.0))
+            & ((rsi_3_4h > 60.0) | aroonu_14_4h_lt_70 | (roc_9_4h_lt_20))
             # 4h down move, 1d high & overbought
             & ((rsi_3_4h > 60.0) | (aroonu_14_1d < 100.0) | (roc_9_1d < 200.0))
             # 4h down move, 4h & 1d overbought
-            & ((rsi_3_4h > 60.0) | (roc_9_4h < 20.0) | (roc_9_1d < 20.0))
+            & ((rsi_3_4h > 60.0) | (roc_9_4h_lt_20) | (roc_9_1d < 20.0))
             # 4h down move, 4h overbought
             & ((rsi_3_4h > 60.0) | (roc_9_4h < 60.0))
             # 1d down move, 1d high, 1d downtrend
-            & ((rsi_3_1d > 5.0) | (aroonu_14_1d < 80.0) | (roc_9_1d > -20.0))
+            & ((rsi_3_1d > 5.0) | (aroonu_14_1d < 80.0) | (roc_9_1d_gt_neg_20))
             # 1d down move, 1h & 4h high
             & ((rsi_3_1d > 10.0) | (aroonu_14_1h < 50.0) | (aroonu_14_4h < 90.0))
             # 1d down move, 1h high
             & ((rsi_3_1d > 10.0) | (aroonu_14_1h < 70.0))
             # 1d down move, 1h high, 1d downtrend
-            & ((rsi_3_1d > 10.0) | (stochrsi_k_1h < 80.0) | (roc_9_1d > -20.0))
+            & ((rsi_3_1d > 10.0) | (stochrsi_k_1h < 80.0) | (roc_9_1d_gt_neg_20))
             # 1d down move, 1h overbought, 1d downtrend
             & ((rsi_3_1d > 15.0) | (roc_9_1h < 20.0) | roc_9_1d_gt_neg_50)
             # 1d down move, 1h high, 1d downtrend
@@ -13760,7 +13766,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1d down move, 1h high, 1d overbought
             & ((rsi_3_1d > 25.0) | (aroonu_14_1h < 70.0) | (roc_9_1d < 25.0))
             # 1d down move, 1d still high, 1d downtrend
-            & ((rsi_3_1d > 25.0) | (stochrsi_k_1d < 50.0) | (roc_9_1d > -20.0))
+            & ((rsi_3_1d > 25.0) | (stochrsi_k_1d < 50.0) | (roc_9_1d_gt_neg_20))
             # 1d down move, 1h high & overbought
             & ((rsi_3_1d > 40.0) | (aroonu_14_1d < 70.0) | (roc_9_1d < 80.0))
             # 1d down move, 4h high & overbought
@@ -13798,7 +13804,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h high, 1h & 4h overbought
             & ((aroonu_14_4h < 100.0) | (roc_9_1h < 10.0) | (roc_9_4h < 20.0))
             # 1d high, 1d downtrend
-            & ((aroonu_14_1d < 80.0) | (roc_9_1d > -30.0))
+            & ((aroonu_14_1d < 80.0) | (roc_9_1d_gt_neg_30))
             # 1d high, 1h & 4h downtrend
             & ((aroonu_14_1d < 85.0) | (roc_9_1h > -30.0) | (roc_9_4h > -50.0))
             # 1d high, 4h & 1d overbought
@@ -13812,11 +13818,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h high, 1d overbought
             & ((stochrsi_k_1h < 70.0) | (roc_9_1d < 40.0))
             # 1h high, 4h downtrend
-            & ((stochrsi_k_1h < 80.0) | (roc_9_4h > -20.0))
+            & ((stochrsi_k_1h < 80.0) | (roc_9_4h_gt_neg_20))
             # 1h high, 4h overbought
             & ((stochrsi_k_1h < 80.0) | (roc_9_4h < 80.0))
             # 4h high, 1h & 4h overbought
-            & ((stochrsi_k_4h < 80.0) | (roc_9_1h < 10.0) | (roc_9_4h < 20.0))
+            & ((stochrsi_k_4h < 80.0) | (roc_9_1h < 10.0) | (roc_9_4h_lt_20))
             # 1d high, 1h & 1d overbought
             & ((stochrsi_k_1d < 80.0) | (roc_9_1h < 10.0) | (roc_9_1d < 80.0))
             # 1d high, 4h & 1d overbought
@@ -13851,11 +13857,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 5m down move, 15m high, 1d overbought
             & ((rsi_3 > 5.0) | (aroonu_14_15m < 70.0) | (roc_9_1d < 40.0))
             # 5m down move, 15m still high, 1d downtrend
-            & ((rsi_3 > 5.0) | (stochrsi_k_15m < 50.0) | (roc_9_1d > -20.0))
+            & ((rsi_3 > 5.0) | (stochrsi_k_15m < 50.0) | (roc_9_1d_gt_neg_20))
             # 5m down move, 1h still high, 4h downtrend
             & ((rsi_3 > 5.0) | (stochrsi_k_1h < 50.0) | (roc_9_4h > -10.0))
             # 5m down move, 1h high. 1d downtrend
-            & ((rsi_3 > 5.0) | (stochrsi_k_1h < 80.0) | (roc_9_1d > -30.0))
+            & ((rsi_3 > 5.0) | (stochrsi_k_1h < 80.0) | (roc_9_1d_gt_neg_30))
             # 5m down move, 15m & 1h high
             & ((rsi_3 > 10.0) | (aroonu_14_15m < 70.0) | (aroonu_14_1h < 100.0))
             # 5m down move, 15m & 1d high
@@ -13877,11 +13883,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 15m still high, 1h high
             & ((rsi_3_15m > 10.0) | (aroonu_14_15m < 50.0) | (stochrsi_k_1h < 80.0))
             # 15m down move, 15m still high, 1d overbought
-            & ((rsi_3_15m > 10.0) | (aroonu_14_15m < 50.0) | (roc_9_1d < 100.0))
+            & ((rsi_3_15m > 10.0) | (aroonu_14_15m < 50.0) | (roc_9_1d_lt_100))
             # 15m down move, 15m high, 1d overbought
             & ((rsi_3_15m > 10.0) | (aroonu_14_15m < 60.0) | roc_9_1d_lt_50)
             # 15m down move, 4h high, 1d downtrend
-            & ((rsi_3_15m > 10.0) | (stochrsi_k_4h < 80.0) | (roc_9_1d > -20.0))
+            & ((rsi_3_15m > 10.0) | (stochrsi_k_4h < 80.0) | (roc_9_1d_gt_neg_20))
             # 15m & 1h down move, 4h still high
             & ((rsi_3_15m > 15.0) | (rsi_3_1h > 35.0) | (aroonu_14_4h < 50.0))
             # 15m & 1h down move, 1h high
@@ -13905,11 +13911,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 15m still high, 1h still high
             & ((rsi_3_15m > 15.0) | (aroonu_14_15m < 40.0) | (aroonu_14_1h < 50.0))
             # 15m down move, 15m high, 4h downtrend
-            & ((rsi_3_15m > 15.0) | (aroonu_14_15m < 60.0) | (roc_9_4h > -20.0))
+            & ((rsi_3_15m > 15.0) | (aroonu_14_15m < 60.0) | (roc_9_4h_gt_neg_20))
             # 15m down move, 15m high, 1d downtrend
             & ((rsi_3_15m > 15.0) | (aroonu_14_15m < 60.0) | (roc_9_1d > -70.0))
             # 15m down move, 15m high, 1d overbought
-            & ((rsi_3_15m > 15.0) | (aroonu_14_15m < 60.0) | (roc_9_1d < 100.0))
+            & ((rsi_3_15m > 15.0) | (aroonu_14_15m < 60.0) | (roc_9_1d_lt_100))
             # 15m down move, 15m & 1h high
             & ((rsi_3_15m > 15.0) | (aroonu_14_15m < 70.0) | (aroonu_14_1h < 70.0))
             # 15m down move, 15m & 4h high
@@ -13925,7 +13931,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 1h high, 1d overbought
             & ((rsi_3_15m > 15.0) | (stochrsi_k_1h < 80.0) | (roc_9_1d < 20.0))
             # 15m down move, 4h & 1d overbought
-            & ((rsi_3_15m > 15.0) | (roc_9_4h < 25.0) | (roc_9_1d < 100.0))
+            & ((rsi_3_15m > 15.0) | (roc_9_4h < 25.0) | (roc_9_1d_lt_100))
             # 15m & 1h down move, 1h still high
             & ((rsi_3_15m > 20.0) | (rsi_3_1h > 25.0) | (aroonu_14_1h < 40.0))
             # 15m & 1h down move, 1h high
@@ -13965,11 +13971,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 15m high, 4h overbought
             & ((rsi_3_15m > 20.0) | (aroonu_14_15m < 60.0) | (roc_9_4h < 10.0))
             # 15m down move, 15m high, 4h overbought
-            & ((rsi_3_15m > 20.0) | (aroonu_14_15m < 70.0) | (roc_9_4h < 20.0))
+            & ((rsi_3_15m > 20.0) | (aroonu_14_15m < 70.0) | (roc_9_4h_lt_20))
             # 15m down move, 15m high, 4h downtrend
             & ((rsi_3_15m > 20.0) | (aroonu_14_15m < 70.0) | (roc_9_4h > -10.0))
             # 15m down move, 15m high, 1d downtrend
-            & ((rsi_3_15m > 20.0) | (aroonu_14_15m < 70.0) | (roc_9_1d > -20.0))
+            & ((rsi_3_15m > 20.0) | (aroonu_14_15m < 70.0) | (roc_9_1d_gt_neg_20))
             # 15m down move, 15m high, 1d overbought
             & ((rsi_3_15m > 20.0) | (aroonu_14_15m < 70.0) | roc_9_1d_lt_50)
             # 15m down move, 1h high, 4h overbought
@@ -13977,17 +13983,17 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 4h high & overbought
             & ((rsi_3_15m > 20.0) | aroonu_14_4h_lt_70 | (roc_9_4h < 50.0))
             # 15m down move, 1h high, 4h downtrend
-            & ((rsi_3_15m > 20.0) | (stochrsi_k_1h < 60.0) | (roc_9_4h > -20.0))
+            & ((rsi_3_15m > 20.0) | (stochrsi_k_1h < 60.0) | (roc_9_4h_gt_neg_20))
             # 15m down move, 1h high, 1d overbought
             & ((rsi_3_15m > 20.0) | (stochrsi_k_1h < 80.0) | (roc_9_1d < 30.0))
             # 15m down move, 1h high
             & ((rsi_3_15m > 20.0) | (stochrsi_k_1h < 90.0))
             # 15m down move, 4h still high, 1d downtrend
-            & ((rsi_3_15m > 20.0) | (stochrsi_k_4h < 40.0) | (roc_9_1d > -20.0))
+            & ((rsi_3_15m > 20.0) | (stochrsi_k_4h < 40.0) | (roc_9_1d_gt_neg_20))
             # 15m down move, 4h high, 1d downtrend
-            & ((rsi_3_15m > 20.0) | (stochrsi_k_4h < 80.0) | (roc_9_1d > -30.0))
+            & ((rsi_3_15m > 20.0) | (stochrsi_k_4h < 80.0) | (roc_9_1d_gt_neg_30))
             # 15m down move, 4h & 1d overbought
-            & ((rsi_3_15m > 20.0) | (roc_9_4h < 25.0) | (roc_9_1d < 100.0))
+            & ((rsi_3_15m > 20.0) | (roc_9_4h < 25.0) | (roc_9_1d_lt_100))
             # 15m & 1h down move, 15m high
             & ((rsi_3_15m > 25.0) | (rsi_3_1h > 30.0) | (aroonu_14_15m < 70.0))
             # 15m & 4h down move, 15m high
@@ -14003,7 +14009,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1d down move, 1d high
             & ((rsi_3_15m > 25.0) | (rsi_3_1d > 45.0) | (aroonu_14_1d < 90.0))
             # 15m down move, 15m high, 4h downtrend
-            & ((rsi_3_15m > 25.0) | (aroonu_14_15m < 70.0) | (roc_9_4h > -20.0))
+            & ((rsi_3_15m > 25.0) | (aroonu_14_15m < 70.0) | (roc_9_4h_gt_neg_20))
             # 15m down move, 15m high, 4h overbought
             & ((rsi_3_15m > 25.0) | (aroonu_14_15m < 70.0) | (roc_9_4h < 10.0))
             # 15m down move, 15m high, 1d overbought
@@ -14057,7 +14063,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 1h high, 1d downtrend
             & ((rsi_3_15m > 35.0) | (stochrsi_k_1h < 90.0) | roc_9_1d_gt_neg_50)
             # 15m down move, 4h high & overbought
-            & ((rsi_3_15m > 35.0) | (stochrsi_k_4h < 90.0) | (roc_9_4h < 20.0))
+            & ((rsi_3_15m > 35.0) | (stochrsi_k_4h < 90.0) | (roc_9_4h_lt_20))
             # 15m down move, 15m high, 1h downtrend
             & ((rsi_3_15m > 40.0) | (aroonu_14_15m < 70.0) | (roc_9_1h > -20.0))
             # 15m down move, 15m & 4h high
@@ -14099,7 +14105,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1d high & overbought
             & ((rsi_3_1h > 25.0) | (aroonu_14_1d < 80.0) | (roc_9_1d < 20.0))
             # 1h down move, 4h high, 1d downtrend
-            & ((rsi_3_1h > 25.0) | (stochrsi_k_4h < 60.0) | (roc_9_1d > -20.0))
+            & ((rsi_3_1h > 25.0) | (stochrsi_k_4h < 60.0) | (roc_9_1d_gt_neg_20))
             # 1h down move, 4h downtrend, 1d overbought
             & ((rsi_3_1h > 25.0) | (roc_9_4h > -40.0) | roc_9_1d_lt_50)
             # 1h down move, 15m & 1h still high
@@ -14107,11 +14113,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h still high 1d overbought
             & ((rsi_3_1h > 30.0) | (aroonu_14_1h < 50.0) | (roc_9_1d < 200.0))
             # 1h down move, 1h high, 4h downtrend
-            & ((rsi_3_1h > 30.0) | (aroonu_14_1h < 60.0) | (roc_9_4h > -20.0))
+            & ((rsi_3_1h > 30.0) | (aroonu_14_1h < 60.0) | (roc_9_4h_gt_neg_20))
             # 1h down move, 1h high, 1d overbought
             & ((rsi_3_1h > 30.0) | (aroonu_14_1h < 70.0) | (roc_9_1d < 30.0))
             # 1h down move, 4h high & overbought
-            & ((rsi_3_1h > 30.0) | (stochrsi_k_4h < 60.0) | (roc_9_4h < 20.0))
+            & ((rsi_3_1h > 30.0) | (stochrsi_k_4h < 60.0) | (roc_9_4h_lt_20))
             # 1h down move, 4h & 1h overbought
             & ((rsi_3_1h > 30.0) | (roc_9_4h < 30.0) | (roc_9_1d < 40.0))
             # 1h & 1d down move, 1h high
@@ -14129,7 +14135,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h & 1d high
             & ((rsi_3_1h > 35.0) | (aroonu_14_1h < 80.0) | (aroonu_14_1d < 90.0))
             # 1h down move, 1h downtrend, 4h overbought
-            & ((rsi_3_1h > 35.0) | (cmf_20_1h > -0.30) | (roc_9_4h < 20.0))
+            & ((rsi_3_1h > 35.0) | (cmf_20_1h > -0.30) | (roc_9_4h_lt_20))
             # 1h down move, 1h high, 1d downtrend
             & ((rsi_3_1h > 35.0) | (aroonu_14_1h < 70.0) | (roc_9_1d > -80.0))
             # 1h down move, 1h high, 1d overbought
@@ -14149,7 +14155,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h still high, 4h high
             & ((rsi_3_1h > 40.0) | (aroonu_14_1h < 50.0) | (stochrsi_k_4h < 80.0))
             # 1h down move, 1h still high, 1d overbought
-            & ((rsi_3_1h > 40.0) | (aroonu_14_1h < 50.0) | (roc_9_1d < 100.0))
+            & ((rsi_3_1h > 40.0) | (aroonu_14_1h < 50.0) | (roc_9_1d_lt_100))
             # 1h down move, 1h high, 4h overbought
             & ((rsi_3_1h > 40.0) | (aroonu_14_1h < 70.0) | (roc_9_4h < 20.0))
             # 1h down move, 1h high, 1d downtrend
@@ -14163,7 +14169,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 15m high, 4h overbought
             & ((rsi_3_1h > 45.0) | (aroonu_14_15m < 70.0) | (roc_9_4h < 30.0))
             # 1h down move, 1h high, 4h overbought
-            & ((rsi_3_1h > 45.0) | (aroonu_14_1h < 100.0) | (roc_9_4h < 20.0))
+            & ((rsi_3_1h > 45.0) | (aroonu_14_1h < 100.0) | (roc_9_4h_lt_20))
             # 1h down move, 4h high & overbought
             & ((rsi_3_1h > 45.0) | (aroonu_14_4h < 80.0) | (roc_9_4h < 20.0))
             # 1h down move, 4h high & overbought
@@ -14189,27 +14195,27 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h high, 1d high
             & ((rsi_3_1h > 55.0) | (stochrsi_k_1h < 70.0) | (aroonu_14_1d < 100.0))
             # 1h down move, 1h high, 1d downtrend
-            & ((rsi_3_1h > 55.0) | (stochrsi_k_1h < 80.0) | (roc_9_1d > -30.0))
+            & ((rsi_3_1h > 55.0) | (stochrsi_k_1h < 80.0) | (roc_9_1d_gt_neg_30))
             # 1h down move, 4h high & overbought
             & ((rsi_3_1h > 55.0) | (stochrsi_k_4h < 80.0) | (roc_9_4h < 100.0))
             # 1h down move, 1h high, 1d overbought
-            & ((rsi_3_1h > 60.0) | (stochrsi_k_1h < 80.0) | (roc_9_1d < 100.0))
+            & ((rsi_3_1h > 60.0) | (stochrsi_k_1h < 80.0) | (roc_9_1d_lt_100))
             # 1h down move, 15m & 1h high
             & ((rsi_3_1h > 65.0) | (aroonu_14_15m < 70.0) | (aroonu_14_1h < 100.0))
             # 1h down move, 1h high & overbought
             & ((rsi_3_1h > 65.0) | (stochrsi_k_1h < 80.0) | (roc_9_1h < 10.0))
             # 4h down move, 1h still high, 1d downtrend
-            & ((rsi_3_4h > 3.0) | (stochrsi_k_1h < 40.0) | (roc_9_1d > -30.0))
+            & ((rsi_3_4h > 3.0) | (stochrsi_k_1h < 40.0) | (roc_9_1d_gt_neg_30))
             # 4h down move, 1h still high, 4h downtrend
             & ((rsi_3_4h > 3.0) | (stochrsi_k_1h < 50.0) | (roc_9_4h > -30.0))
             # 4h down move, 4h & 1d downtrend
-            & ((rsi_3_4h > 3.0) | (roc_9_4h > -20.0) | (roc_9_1d > -20.0))
+            & ((rsi_3_4h > 3.0) | (roc_9_4h_gt_neg_20) | (roc_9_1d_gt_neg_20))
             # 4h down move, 15m high, 1h still high
             & ((rsi_3_4h > 5.0) | (aroonu_14_15m < 70.0) | (stochrsi_k_1h < 50.0))
             # 4h down move, 15m high
             & ((rsi_3_4h > 5.0) | (stochrsi_k_15m < 70.0))
             # 4h down move, 4h still high, 1d downtrend
-            & ((rsi_3_4h > 5.0) | (stochrsi_k_4h < 40.0) | (roc_9_1d > -20.0))
+            & ((rsi_3_4h > 5.0) | (stochrsi_k_4h < 40.0) | (roc_9_1d_gt_neg_20))
             # 4h & 1d down move, 1d still high
             & ((rsi_3_4h > 10.0) | (rsi_3_1d > 20.0) | (stochrsi_k_1d < 50.0))
             # 4h & 1d down move, 1d downtrend
@@ -14271,7 +14277,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 15m & 4h still high
             & ((rsi_3_4h > 25.0) | (aroonu_14_15m < 50.0) | (aroonu_14_4h < 50.0))
             # 4h down move, 15m high, 1d overbought
-            & ((rsi_3_4h > 25.0) | (aroonu_14_15m < 70.0) | (roc_9_1d < 100.0))
+            & ((rsi_3_4h > 25.0) | (aroonu_14_15m < 70.0) | (roc_9_1d_lt_100))
             # 4h down move, 1h high, 1d overbought
             & ((rsi_3_4h > 25.0) | (aroonu_14_1h < 90.0) | roc_9_1d_lt_50)
             # 4h down move, 4h & 1d high
@@ -14279,23 +14285,23 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 4h high, 1d downtrend
             & ((rsi_3_4h > 25.0) | (aroonu_14_4h < 60.0) | (roc_9_1d > -70.0))
             # 4h down move, 4h high, 1d downtrend
-            & ((rsi_3_4h > 25.0) | aroonu_14_4h_lt_70 | (roc_9_1d > -20.0))
+            & ((rsi_3_4h > 25.0) | aroonu_14_4h_lt_70 | (roc_9_1d_gt_neg_20))
             # 4h down move, 4h high, 1d overbought
             & ((rsi_3_4h > 25.0) | aroonu_14_4h_lt_70 | (roc_9_1d < 40.0))
             # 4h down move, 1h still high, 1d overbought
-            & ((rsi_3_4h > 25.0) | (stochrsi_k_1h < 50.0) | (roc_9_1d < 100.0))
+            & ((rsi_3_4h > 25.0) | (stochrsi_k_1h < 50.0) | (roc_9_1d_lt_100))
             # 4h down move, 4h high, 1d downtrend
             & ((rsi_3_4h > 25.0) | (stochrsi_k_4h < 80.0) | roc_9_1d_gt_neg_50)
             # 4h down move, 1h high, 1h downtrend
             & ((rsi_3_4h > 30.0) | (aroonu_14_1h < 70.0) | (roc_9_1h > -10.0))
             # 4h & 1d down move, 1d overbought
-            & ((rsi_3_4h > 30.0) | (rsi_3_1d > 50.0) | (roc_9_1d < 100.0))
+            & ((rsi_3_4h > 30.0) | (rsi_3_1d > 50.0) | (roc_9_1d_lt_100))
             # 4h down move, 1d downtrend, 1d overbought
             & ((rsi_3_4h > 30.0) | (cmf_20_1d > -0.30) | (roc_9_1d < 40.0))
             # 4h down move, 15m high, 4h high
             & ((rsi_3_4h > 30.0) | (aroonu_14_15m < 60.0) | (aroonu_14_4h < 90.0))
             # 4h down move, 1h high, 1d downtrend
-            & ((rsi_3_4h > 30.0) | (aroonu_14_1h < 90.0) | (roc_9_1d > -20.0))
+            & ((rsi_3_4h > 30.0) | (aroonu_14_1h < 90.0) | (roc_9_1d_gt_neg_20))
             # 4h down move, 1h high, 1d downtrend
             & ((rsi_3_4h > 30.0) | (stochrsi_k_1h < 80.0) | (roc_9_1d > -40.0))
             # 4h down move, 1h high, 1d overbought
@@ -14311,7 +14317,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 4h & 1d high
             & ((rsi_3_4h > 35.0) | (aroonu_14_4h < 80.0) | (aroonu_14_1d < 100.0))
             # 4h down move, 1d high, 1d downtrend
-            & ((rsi_3_4h > 35.0) | (stochrsi_k_1d < 60.0) | (roc_9_1d > -30.0))
+            & ((rsi_3_4h > 35.0) | (stochrsi_k_1d < 60.0) | (roc_9_1d_gt_neg_30))
             # 4h down move, 1d high & overbought
             & ((rsi_3_4h > 35.0) | (stochrsi_k_1d < 90.0) | (roc_9_1d < 40.0))
             # 4h down move, 15m still high, 1d overbought
@@ -14335,7 +14341,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 15m high, 4h high
             & ((rsi_3_4h > 45.0) | (aroonu_14_15m < 70.0) | (stochrsi_k_4h < 70.0))
             # 4h down move, 4h high, 1d overbought
-            & ((rsi_3_4h > 45.0) | (aroonu_14_4h < 60.0) | (roc_9_1d < 100.0))
+            & ((rsi_3_4h > 45.0) | (aroonu_14_4h < 60.0) | (roc_9_1d_lt_100))
             # 4h down move, 4h high & overbought
             & ((rsi_3_4h > 45.0) | (aroonu_14_4h < 80.0) | (roc_9_4h < 30.0))
             # 4h down move, 1d high & overbought
@@ -14359,13 +14365,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 1d high, 4h overbought
             & ((rsi_3_4h > 50.0) | (aroonu_14_1d < 90.0) | (roc_9_4h < 10.0))
             # 4h down move, 4h high, 1d downtrend
-            & ((rsi_3_4h > 50.0) | (stochrsi_k_4h < 60.0) | (roc_9_1d > -20.0))
+            & ((rsi_3_4h > 50.0) | (stochrsi_k_4h < 60.0) | (roc_9_1d_gt_neg_20))
             # 4h down move, 4h downtrend, 1d overbought
-            & ((rsi_3_4h > 50.0) | (roc_9_4h > -20.0) | (roc_9_1d < 20.0))
+            & ((rsi_3_4h > 50.0) | (roc_9_4h_gt_neg_20) | (roc_9_1d < 20.0))
             # 4h down move, 1h high, 4h overbought
-            & ((rsi_3_4h > 55.0) | (aroonu_14_1h < 100.0) | (roc_9_4h < 20.0))
+            & ((rsi_3_4h > 55.0) | (aroonu_14_1h < 100.0) | (roc_9_4h_lt_20))
             # 4h down move, 4h high & overbought
-            & ((rsi_3_4h > 55.0) | aroonu_14_4h_lt_70 | (roc_9_4h < 20.0))
+            & ((rsi_3_4h > 55.0) | aroonu_14_4h_lt_70 | (roc_9_4h_lt_20))
             # 4h down move, 1d high & overbought
             & ((rsi_3_4h > 55.0) | (aroonu_14_1d < 90.0) | (roc_9_1d < 60.0))
             # 4h down move, 4h high & overbought
@@ -14375,7 +14381,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 4h high & overbought
             & ((rsi_3_4h > 60.0) | aroonu_14_4h_lt_70 | (roc_9_4h < 30.0))
             # 4h down move, 4h still high, 1d downtrend
-            & ((rsi_3_4h > 60.0) | (stochrsi_k_4h < 50.0) | (roc_9_1d > -30.0))
+            & ((rsi_3_4h > 60.0) | (stochrsi_k_4h < 50.0) | (roc_9_1d_gt_neg_30))
             # 4h down move, 4h & 1d overbought
             & ((rsi_3_4h > 60.0) | (roc_9_4h < 30.0) | roc_9_1d_lt_50)
             # 4h down move, 15m high, 4h high
@@ -14387,11 +14393,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1d down move, 15m still high, 4h high
             & ((rsi_3_1d > 10.0) | (aroonu_14_15m < 70.0) | (stochrsi_k_4h < 80.0))
             # 1d down move, 4h & 1d downtrend
-            & ((rsi_3_1d > 10.0) | (roc_9_4h > -20.0) | (roc_9_1d > -60.0))
+            & ((rsi_3_1d > 10.0) | (roc_9_4h_gt_neg_20) | (roc_9_1d > -60.0))
             # 1d down move, 4h & 1d downtrend
             & ((rsi_3_1d > 10.0) | (roc_9_4h > -30.0) | roc_9_1d_gt_neg_50)
             # 1d down move, 1h high, 1d downtrend
-            & ((rsi_3_1d > 15.0) | (aroonu_14_1h < 85.0) | (roc_9_1d > -30.0))
+            & ((rsi_3_1d > 15.0) | (aroonu_14_1h < 85.0) | (roc_9_1d_gt_neg_30))
             # 1d down move, 4h & 1d downtrend
             & ((rsi_3_1d > 15.0) | (roc_9_4h > -10.0) | (roc_9_1d > -40.0))
             # 1d down move, 15m high, 1h high
@@ -14399,7 +14405,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1d down move, 15m high, 1h high
             & ((rsi_3_1d > 20.0) | (aroonu_14_15m < 70.0) | (aroonu_14_1h < 100.0))
             # 1d down move, 4h high, 4h downtrend
-            & ((rsi_3_1d > 20.0) | (stochrsi_k_4h < 70.0) | (roc_9_4h > -20.0))
+            & ((rsi_3_1d > 20.0) | (stochrsi_k_4h < 70.0) | (roc_9_4h_gt_neg_20))
             # 1d down move, 15m high, 4h high
             & ((rsi_3_1d > 25.0) | (aroonu_14_15m < 70.0) | (stochrsi_k_4h < 80.0))
             # 1d down move, 15m high, 4h downtrend
@@ -14407,7 +14413,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1d down move, 1h & 1d high
             & ((rsi_3_1d > 25.0) | (aroonu_14_1h < 80.0) | (aroonu_14_1d < 80.0))
             # 1d down move, 1d still high, 1d downtrend
-            & ((rsi_3_1d > 25.0) | (stochrsi_k_1d < 50.0) | (roc_9_1d > -20.0))
+            & ((rsi_3_1d > 25.0) | (stochrsi_k_1d < 50.0) | (roc_9_1d_gt_neg_20))
             # 1d down move, 1d high & overbought
             & ((rsi_3_1d > 30.0) | (aroonu_14_1d < 60.0) | (roc_9_1d < 10.0))
             # 1d down move, 1h high, 1d downtrend
@@ -14427,11 +14433,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m still high, 1h downtrend, 4h overbought
             & ((aroonu_14_15m < 50.0) | (roc_9_1h > -10.0) | (roc_9_4h < 40.0))
             # 15m high, 4h high & overbought
-            & ((aroonu_14_15m < 60.0) | aroonu_14_4h_lt_70 | (roc_9_4h < 20.0))
+            & ((aroonu_14_15m < 60.0) | aroonu_14_4h_lt_70 | (roc_9_4h_lt_20))
             # 15m & 4h high, 1d overbought
             & ((aroonu_14_15m < 60.0) | aroonu_14_4h_lt_70 | (roc_9_1d < 10.0))
             # 15m high, 15m & 4h overbought
-            & ((aroonu_14_15m < 60.0) | (roc_9_15m < 10.0) | (roc_9_4h < 20.0))
+            & ((aroonu_14_15m < 60.0) | (roc_9_15m < 10.0) | (roc_9_4h_lt_20))
             # 15m high, 4h downtrend
             & ((aroonu_14_15m < 60.0) | (roc_9_4h > -30.0))
             # 15m & 1h & 4h high
@@ -14441,9 +14447,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 4h high, 4h overbought
             & ((aroonu_14_15m < 70.0) | aroonu_14_4h_lt_70 | (roc_9_4h < 10.0))
             # 15m & 4h high, 1d downtrend
-            & ((aroonu_14_15m < 70.0) | aroonu_14_4h_lt_70 | (roc_9_1d > -20.0))
+            & ((aroonu_14_15m < 70.0) | aroonu_14_4h_lt_70 | (roc_9_1d_gt_neg_20))
             # 15m & 1d high, 1d overbought
-            & ((aroonu_14_15m < 70.0) | (aroonu_14_1d < 90.0) | (roc_9_1d < 100.0))
+            & ((aroonu_14_15m < 70.0) | (aroonu_14_1d < 90.0) | (roc_9_1d_lt_100))
             # 15m high, 4h downtrend, 1d overbought
             & ((aroonu_14_15m < 70.0) | (roc_9_4h > -30.0) | (roc_9_1d < 200.0))
             # 4h down move, 1h still high, 1d downtrend
@@ -14453,7 +14459,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h high, 1d high & overbought
             & ((aroonu_14_1h < 90.0) | (aroonu_14_1d < 100.0) | (roc_9_1d < 30.0))
             # 1h high, 4h downtrend
-            & ((aroonu_14_1h < 90.0) | (roc_9_4h > -20.0))
+            & ((aroonu_14_1h < 90.0) | (roc_9_4h_gt_neg_20))
             # 1h high, 4h & 1d overbought
             & ((aroonu_14_1h < 90.0) | (roc_9_4h < 10.0) | (roc_9_1d < 20.0))
             # 4h & 1d high, 4h overbought
@@ -14461,7 +14467,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h & 1d high, 1d downtrend
             & ((aroonu_14_4h < 80.0) | (aroonu_14_1d < 100.0) | (roc_9_1d > -20.0))
             # 1d high, 4h & 1d downtrend
-            & ((aroonu_14_1d < 80.0) | (roc_9_4h > -20.0) | (roc_9_1d > -20.0))
+            & ((aroonu_14_1d < 80.0) | (roc_9_4h_gt_neg_20) | (roc_9_1d_gt_neg_20))
             # 1d high, 1h & 4h downtrend
             & ((aroonu_14_1d < 85.0) | (roc_9_1h > -30.0) | (roc_9_4h > -50.0))
             # 1d high, 4h downtrend
@@ -14475,15 +14481,15 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1d high
             & ((stochrsi_k_15m < 90.0) | (stochrsi_k_1d < 90.0))
             # 1h high, 4h & 1d downtrend
-            & ((stochrsi_k_1h < 60.0) | (roc_9_4h > -30.0) | (roc_9_1d > -30.0))
+            & ((stochrsi_k_1h < 60.0) | (roc_9_4h > -30.0) | (roc_9_1d_gt_neg_30))
             # 1h high, 4h downtrend
             & ((stochrsi_k_1h < 70.0) | (roc_9_4h > -30.0))
             # 1h high, 1d downtrend
-            & ((stochrsi_k_1h < 70.0) | (roc_9_1d > -20.0))
+            & ((stochrsi_k_1h < 70.0) | (roc_9_1d_gt_neg_20))
             # 4h high, 4h overbought, 1d downtrend
-            & ((stochrsi_k_4h < 90.0) | (roc_9_4h < 20.0) | (roc_9_1d > -20.0))
+            & ((stochrsi_k_4h < 90.0) | (roc_9_4h_lt_20) | (roc_9_1d_gt_neg_20))
             # 1d still high, 4h & 1d downtrend
-            & ((stochrsi_k_1d < 50.0) | (roc_9_4h > -30.0) | (roc_9_1d > -30.0))
+            & ((stochrsi_k_1d < 50.0) | (roc_9_4h > -30.0) | (roc_9_1d_gt_neg_30))
             # 1d P&D, 4h downtrend
             & ((change_pct_1d > -50.0) | (change_pct_1d.shift(288) < 50.0) | (rsi_3_4h > 15.0))
             # 1d P&D, 15m high
@@ -14493,7 +14499,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1d red, previous 1d top wick, 15m high
             & ((change_pct_1d > -10.0) | (top_wick_pct_1d.shift(288) < 40.0) | (aroonu_14_15m < 70.0))
             # 1d green with top wick, 4h overbought
-            & ((change_pct_1d < 15.0) | (top_wick_pct_1d < 15.0) | (roc_9_4h < 20.0))
+            & ((change_pct_1d < 15.0) | (top_wick_pct_1d < 15.0) | (roc_9_4h_lt_20))
             # 1d green, 15m down move, 1h high
             & ((change_pct_1d < 50.0) | (rsi_3_15m > 25.0) | (aroonu_14_1h < 70.0))
             # 1d green, 4h down move, 4h still high
@@ -14544,7 +14550,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 5m & 1d down move, 15m still high
             & ((rsi_3 > 3.0) | (rsi_3_1d > 20.0) | (stochrsi_k_15m < 40.0))
             # 5m down move, 1h high, 4h overbought
-            & ((rsi_3 > 3.0) | (stochrsi_k_1h < 80.0) | (roc_9_4h < 20.0))
+            & ((rsi_3 > 3.0) | (stochrsi_k_1h < 80.0) | (roc_9_4h_lt_20))
             # 5m & 4h down move, 15m still high
             & ((rsi_3 > 5.0) | (rsi_3_4h > 25.0) | (stochrsi_k_15m < 50.0))
             # 5m down move, 4h high, 1h overbought
@@ -14580,7 +14586,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 1h high
             & ((rsi_3_15m > 10.0) | (rsi_3_1h > 25.0) | (aroonu_14_1h < 80.0))
             # 15m down move, 4h high, 1d overbought
-            & ((rsi_3_15m > 10.0) | aroonu_14_4h_lt_70 | (roc_9_1d < 100.0))
+            & ((rsi_3_15m > 10.0) | aroonu_14_4h_lt_70 | (roc_9_1d_lt_100))
             # 15m down move, 4h & 1d high
             & ((rsi_3_15m > 10.0) | (aroonu_14_4h < 90.0) | (aroonu_14_1d < 100.0))
             # 15m down move, 1h high, 1d downtrend
@@ -14592,7 +14598,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 4h down move, 1d high
             & ((rsi_3_15m > 15.0) | (rsi_3_4h > 15.0) | (stochrsi_k_1d < 80.0))
             # 15m down move, 4h high & overbought
-            & ((rsi_3_15m > 15.0) | aroonu_14_4h_lt_70 | (roc_9_4h < 20.0))
+            & ((rsi_3_15m > 15.0) | aroonu_14_4h_lt_70 | (roc_9_4h_lt_20))
             # 15m down move, 4h high & overbought
             & ((rsi_3_15m > 15.0) | (stochrsi_k_4h < 90.0) | (roc_9_4h < 10.0))
             # 15m down move, 4h & 1d downtrend
@@ -14600,7 +14606,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 1h high
             & ((rsi_3_15m > 20.0) | rsi_3_1h_gt_20 | (aroonu_14_1h < 70.0))
             # 15m down move, 4h high, 1d overbought
-            & ((rsi_3_15m > 20.0) | (aroonu_14_4h < 90.0) | (roc_9_1d < 100.0))
+            & ((rsi_3_15m > 20.0) | (aroonu_14_4h < 90.0) | (roc_9_1d_lt_100))
             # 15m down move, 4h high, 1h overbought
             & ((rsi_3_15m > 20.0) | (aroonu_14_4h < 100.0) | (roc_9_1h < 30.0))
             # 15m down move, 1h high & overbought
@@ -14624,7 +14630,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 15m still high
             & ((rsi_3_1h > 3.0) | (stochrsi_k_15m < 50.0))
             # 1h down move, 1h still high, 4h overbought
-            & ((rsi_3_1h > 3.0) | (stochrsi_k_1h < 50.0) | (roc_9_4h < 20.0))
+            & ((rsi_3_1h > 3.0) | (stochrsi_k_1h < 50.0) | (roc_9_4h_lt_20))
             # 1h & 4h & 1d down move
             & ((rsi_3_1h > 5.0) | (rsi_3_4h > 5.0) | (rsi_3_1d > 10.0))
             # 1h & 4h down move, 1h downtrend
@@ -14638,7 +14644,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1d high & overbought
             & ((rsi_3_1h > 5.0) | (stochrsi_k_1d < 90.0) | (roc_9_1d < 20.0))
             # 1h down move, 1d overbought
-            & ((rsi_3_1h > 5.0) | (roc_9_1d < 100.0))
+            & ((rsi_3_1h > 5.0) | (roc_9_1d_lt_100))
             # 1h & 4h & 1d down move
             & ((rsi_3_1h > 10.0) | (rsi_3_4h > 10.0) | (rsi_3_1d > 15.0))
             # 1h & 4h down move, 4h still high
@@ -14702,17 +14708,17 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 4h & 1d downtrend
             & ((rsi_3_1h > 30.0) | (roc_9_4h > -25.0) | (roc_9_1d > -60.0))
             # 1h down move, 4h & 1d overbought
-            & ((rsi_3_1h > 30.0) | (roc_9_4h < 20.0) | (roc_9_1d < 100.0))
+            & ((rsi_3_1h > 30.0) | (roc_9_4h_lt_20) | (roc_9_1d_lt_100))
             # 1h down move, 1h high, 1d overbought
             & ((rsi_3_1h > 35.0) | (aroonu_14_1h < 70.0) | (roc_9_1d < 20.0))
             # 1h down move, 4h high, 1d overbought
-            & ((rsi_3_1h > 35.0) | (aroonu_14_4h < 85.0) | (roc_9_1d < 100.0))
+            & ((rsi_3_1h > 35.0) | (aroonu_14_4h < 85.0) | (roc_9_1d_lt_100))
             # 1h down move, 1h still high, 1d overbought
             & ((rsi_3_1h > 35.0) | (stochrsi_k_1h < 50.0) | (roc_9_1d < 200.0))
             # 1h down move, 1h high, 4h downtrend
-            & ((rsi_3_1h > 35.0) | (stochrsi_k_1h < 70.0) | (roc_9_4h > -20.0))
+            & ((rsi_3_1h > 35.0) | (stochrsi_k_1h < 70.0) | (roc_9_4h_gt_neg_20))
             # 1h down move, 1h high, 4h overbought
-            & ((rsi_3_1h > 40.0) | (stochrsi_k_1h < 80.0) | (roc_9_4h < 20.0))
+            & ((rsi_3_1h > 40.0) | (stochrsi_k_1h < 80.0) | (roc_9_4h_lt_20))
             # 1h down move, 1h & 4h high
             & ((rsi_3_1h > 45.0) | (aroonu_14_1h < 70.0) | (aroonu_14_4h < 100.0))
             # 1h down move, 4h high, 1d downtrend
@@ -14730,7 +14736,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h & 1d down move, 1d high
             & ((rsi_3_4h > 5.0) | (rsi_3_1d > 45.0) | (aroonu_14_1d < 70.0))
             # 4h down move, 4h & 1d downtrend
-            & ((rsi_3_4h > 5.0) | (roc_9_4h > -15.0) | (roc_9_1d > -20.0))
+            & ((rsi_3_4h > 5.0) | (roc_9_4h > -15.0) | (roc_9_1d_gt_neg_20))
             # 4h & 1d down move, 1h still high
             & ((rsi_3_4h > 10.0) | (rsi_3_1d > 10.0) | (aroonu_14_1h < 40.0))
             # 4h & 1d down move, 1h high
@@ -14750,19 +14756,19 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 1d high & overbought
             & (rsi_3_4h_gt_20 | (aroonu_14_1d < 80.0) | (roc_9_1d < 80.0))
             # 4h down move, 4h & 1d downtrend
-            & (rsi_3_4h_gt_20 | (roc_9_4h > -20.0) | (roc_9_1d > -30.0))
+            & (rsi_3_4h_gt_20 | (roc_9_4h_gt_neg_20) | (roc_9_1d_gt_neg_30))
             # 4h down move, 4h still high, 1d downtrend
             & ((rsi_3_4h > 30.0) | (aroonu_14_4h < 50.0) | (roc_9_1d > -40.0))
             # 4h down move, 1d high & overbought
             & ((rsi_3_4h > 40.0) | (stochrsi_k_1d < 90.0) | (roc_9_1d < 200.0))
             # 4h down move, 4h high, 1d downtrend
-            & ((rsi_3_4h > 45.0) | aroonu_14_4h_lt_70 | (roc_9_1d > -30.0))
+            & ((rsi_3_4h > 45.0) | aroonu_14_4h_lt_70 | (roc_9_1d_gt_neg_30))
             # 4h down move, 4h high & overbought
             & ((rsi_3_4h > 60.0) | aroonu_14_4h_lt_70 | (roc_9_4h < 10.0))
             # 4h down move, 4h & 1d overbought
-            & ((rsi_3_4h > 60.0) | (roc_9_4h < 20.0) | (roc_9_1d < 20.0))
+            & ((rsi_3_4h > 60.0) | (roc_9_4h_lt_20) | (roc_9_1d < 20.0))
             # 1h still high, 4h & 1d downtrend
-            & ((aroonu_14_1h < 40.0) | (roc_9_4h > -20.0) | (roc_9_1d > -40.0))
+            & ((aroonu_14_1h < 40.0) | (roc_9_4h_gt_neg_20) | (roc_9_1d > -40.0))
             # 1h & 4h high, 1h overbought
             & ((aroonu_14_1h < 70.0) | (aroonu_14_4h < 100.0) | (roc_9_1h < 80.0))
             # 1h high, 1d overbought
@@ -14788,7 +14794,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1d high, 1h & 1d overbought
             & ((aroonu_14_1d < 80.0) | (roc_9_1h < 30.0) | (roc_9_1d < 200.0))
             # 1d high, 4h & 1d overbought
-            & ((aroonu_14_1d < 90.0) | (roc_9_4h < 20.0) | roc_9_1d_lt_50)
+            & ((aroonu_14_1d < 90.0) | (roc_9_4h_lt_20) | roc_9_1d_lt_50)
             # 1h high, 4h overbought
             & ((stochrsi_k_1h < 80.0) | (roc_9_4h < 80.0))
             # 4h & 1d overbought
@@ -14951,7 +14957,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1d high & overbought
             & ((rsi_3_1h > 25.0) | (aroonu_14_1d < 90.0) | (roc_9_1d < 30.0))
             # 1h down move, 4h high, 1d downtrend
-            & ((rsi_3_1h > 25.0) | (stochrsi_k_4h < 80.0) | (roc_9_1d > -30.0))
+            & ((rsi_3_1h > 25.0) | (stochrsi_k_4h < 80.0) | (roc_9_1d_gt_neg_30))
             # 1h & 4h down move, 4h high
             & ((rsi_3_1h > 30.0) | (rsi_3_4h > 50.0) | (aroonu_14_4h < 85.0))
             # 1h down move, 1h & 4h high
@@ -14983,7 +14989,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 15m high, 1h high
             & ((rsi_3_1h > 40.0) | (aroonu_14_15m < 60.0) | (aroonu_14_1h < 70.0))
             # 1h down move, 1h still high, 1d overbought
-            & ((rsi_3_1h > 40.0) | (aroonu_14_1h < 40.0) | (roc_9_1d < 100.0))
+            & ((rsi_3_1h > 40.0) | (aroonu_14_1h < 40.0) | (roc_9_1d_lt_100))
             # 1h down move, 1h high, 4h overbought
             & ((rsi_3_1h > 40.0) | (aroonu_14_1h < 70.0) | (roc_9_4h < 30.0))
             # 1h down move, 1h & 4h high
@@ -14991,7 +14997,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1d high & overbought
             & ((rsi_3_1h > 40.0) | (aroonu_14_1d < 80.0) | roc_9_1d_lt_50)
             # 1h down move, 1h & 4h overbought
-            & ((rsi_3_1h > 40.0) | (roc_9_1h < 20.0) | (roc_9_4h < 20.0))
+            & ((rsi_3_1h > 40.0) | (roc_9_1h < 20.0) | (roc_9_4h_lt_20))
             # 1h down move, 1h overbought
             & ((rsi_3_1h > 40.0) | (roc_9_1h < 30.0))
             # 1h & 4h down move, 1d overbought
@@ -15003,7 +15009,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h high, 1d overbought
             & ((rsi_3_1h > 45.0) | (stochrsi_k_1h < 70.0) | roc_9_1d_lt_50)
             # 1h down move, 1h high, 1d downtrend
-            & ((rsi_3_1h > 50.0) | (aroonu_14_1h < 90.0) | (roc_9_1d > -30.0))
+            & ((rsi_3_1h > 50.0) | (aroonu_14_1h < 90.0) | (roc_9_1d_gt_neg_30))
             # 1h down move, 4h high, 1h overbought
             & ((rsi_3_1h > 50.0) | (aroonu_14_4h < 90.0) | (roc_9_1h < 40.0))
             # 1h down move, 4h & 1d high
@@ -15011,7 +15017,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 4h high, 1d downtrend
             & ((rsi_3_1h > 50.0) | (stochrsi_k_4h < 60.0) | (roc_9_1d > -60.0))
             # 1h down move, 4h & 1d overbought
-            & ((rsi_3_1h > 50.0) | (roc_9_4h < 20.0) | (roc_9_1d < 80.0))
+            & ((rsi_3_1h > 50.0) | (roc_9_4h_lt_20) | (roc_9_1d < 80.0))
             # 1h down move, 15m high, 1h high
             & ((rsi_3_1h > 55.0) | (aroonu_14_15m < 60.0) | (stochrsi_k_1h < 80.0))
             # 1h down move, 1h high & overbought
@@ -15021,7 +15027,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 4h high, 1d overbought
             & ((rsi_3_1h > 60.0) | (aroonu_14_4h < 80.0) | (roc_9_1d < 40.0))
             # 4h & 1d down move, 4h downtrend
-            & ((rsi_3_4h > 3.0) | (rsi_3_1d > 10.0) | (roc_9_4h > -20.0))
+            & ((rsi_3_4h > 3.0) | (rsi_3_1d > 10.0) | (roc_9_4h_gt_neg_20))
             # 4h & 1d down move, 1h still not low enough
             & ((rsi_3_4h > 5.0) | (rsi_3_1d > 10.0) | (stochrsi_k_1h < 30.0))
             # 4h down move, 1d high, 4h downtrend
@@ -15055,7 +15061,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h & 1ddown move, 1d high
             & (rsi_3_4h_gt_20 | (rsi_3_1d > 20.0) | (aroonu_14_1d < 80.0))
             # 4h down move, 1d high, 1d downtrend
-            & (rsi_3_4h_gt_20 | (aroonu_14_1d < 80.0) | (roc_9_1d > -30.0))
+            & (rsi_3_4h_gt_20 | (aroonu_14_1d < 80.0) | (roc_9_1d_gt_neg_30))
             # 4h down move, 1d high & overbought
             & (rsi_3_4h_gt_20 | (aroonu_14_1d < 80.0) | (roc_9_1d < 70.0))
             # 4h down move, 4h still high. 4h downtrend
@@ -15117,19 +15123,19 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1d high, 4h & 1d overbought
             & ((aroonu_14_1d < 100.0) | (roc_9_4h < 20.0) | (roc_9_1d < 80.0))
             # 15m high, 4h & 1d downtrend
-            & ((stochrsi_k_15m < 70.0) | (roc_9_4h > -30.0) | (roc_9_1d > -30.0))
+            & ((stochrsi_k_15m < 70.0) | (roc_9_4h > -30.0) | (roc_9_1d_gt_neg_30))
             # 1h high, 4h & 1d overbought
-            & ((stochrsi_k_1h < 90.0) | (roc_9_4h < 20.0) | (roc_9_1d < 100.0))
+            & ((stochrsi_k_1h < 90.0) | (roc_9_4h_lt_20) | (roc_9_1d_lt_100))
             # 4h high, 1h overbought, 1d downtrend
             & ((stochrsi_k_4h < 80.0) | (roc_9_1h < 40.0) | (roc_9_1d > -70.0))
             # 4h high, 4h & 1d overbought
-            & ((stochrsi_k_4h < 80.0) | (roc_9_4h < 80.0) | (roc_9_1d < 100.0))
+            & ((stochrsi_k_4h < 80.0) | (roc_9_4h < 80.0) | (roc_9_1d_lt_100))
             # 4h high, 1h & 4h overbought
             & ((stochrsi_k_4h < 90.0) | (roc_9_1h < 10.0) | (roc_9_4h < 80.0))
             # 4h high, 1h & 4h overbought
             & ((stochrsi_k_4h < 90.0) | (roc_9_1h < 20.0) | (roc_9_4h < 50.0))
             # 1d high, 4h & 1d overbought
-            & ((stochrsi_k_1d < 90.0) | (roc_9_4h < 40.0) | (roc_9_1d < 100.0))
+            & ((stochrsi_k_1d < 90.0) | (roc_9_4h < 40.0) | (roc_9_1d_lt_100))
             # 1d P&D, dh downtrend
             & ((change_pct_1d > -50.0) | (change_pct_1d.shift(288) < 50.0) | (rsi_3_4h > 15.0))
             # big drop in the last 20 days, 1d high, 1d downtrend
@@ -15162,9 +15168,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 5m & 15m down move, 15m still high
             & ((rsi_3 > 3.0) | (rsi_3_15m > 15.0) | (aroonu_14_15m < 40.0))
             # 5m & 15m down move, 1d downtrend
-            & ((rsi_3 > 3.0) | (rsi_3_15m > 15.0) | (roc_9_1d > -20.0))
+            & ((rsi_3 > 3.0) | (rsi_3_15m > 15.0) | (roc_9_1d_gt_neg_20))
             # 5m & 15m down move, 1d downtrend
-            & ((rsi_3 > 3.0) | (rsi_3_15m > 25.0) | (roc_9_1d > -30.0))
+            & ((rsi_3 > 3.0) | (rsi_3_15m > 25.0) | (roc_9_1d_gt_neg_30))
             # 5m & 1h down move, 1h still not low enough
             & ((rsi_3 > 3.0) | rsi_3_1h_gt_20 | (aroonu_14_1h < 30.0))
             # 5m & 1h down move, 1h still high
@@ -15180,13 +15186,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 5m & 1d down move, 15m still high
             & ((rsi_3 > 3.0) | (rsi_3_1d > 20.0) | (stochrsi_k_15m < 40.0))
             # 5m down move, 4h & 1d overbought
-            & ((rsi_3 > 3.0) | (roc_9_4h < 20.0) | (roc_9_1d < 40.0))
+            & ((rsi_3 > 3.0) | (roc_9_4h_lt_20) | (roc_9_1d < 40.0))
             # 5m & 1h down move, 4h high
             & ((rsi_3 > 5.0) | (rsi_3_1h > 40.0) | (aroonu_14_4h < 60.0))
             # 5m & 1h down move, 1h high
             & ((rsi_3 > 5.0) | (rsi_3_1h > 60.0) | (aroonu_14_1h < 80.0))
             # 5m & 4h down move, 1d downtrend
-            & ((rsi_3 > 5.0) | (rsi_3_4h > 5.0) | (roc_9_1d > -20.0))
+            & ((rsi_3 > 5.0) | (rsi_3_4h > 5.0) | (roc_9_1d_gt_neg_20))
             # 5m & 4h down move, 4h still high
             & ((rsi_3 > 5.0) | (rsi_3_4h > 15.0) | (aroonu_14_4h < 40.0))
             # 5m & 4h down move, 15m still high
@@ -15336,11 +15342,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 15m still high, 1h still high
             & ((rsi_3_15m > 10.0) | (aroonu_14_15m < 40.0) | (stochrsi_k_1h < 50.0))
             # 15m down move, 4h high & overbought
-            & ((rsi_3_15m > 10.0) | (aroonu_14_4h < 90.0) | (roc_9_4h < 20.0))
+            & ((rsi_3_15m > 10.0) | (aroonu_14_4h < 90.0) | (roc_9_4h_lt_20))
             # 15m down move, 1h still not low enough, 1d overbought
-            & ((rsi_3_15m > 10.0) | (stochrsi_k_1h < 30.0) | (roc_9_1d < 100.0))
+            & ((rsi_3_15m > 10.0) | (stochrsi_k_1h < 30.0) | (roc_9_1d_lt_100))
             # 15m down move, 1h still high, 4h downtrend
-            & ((rsi_3_15m > 10.0) | (stochrsi_k_1h < 50.0) | (roc_9_4h > -20.0))
+            & ((rsi_3_15m > 10.0) | (stochrsi_k_1h < 50.0) | (roc_9_4h_gt_neg_20))
             # 15m down move, 4h high & overbought
             & ((rsi_3_15m > 10.0) | (stochrsi_k_4h < 70.0) | (roc_9_4h < 10.0))
             # 15m down move, 4h high, 1d overbought
@@ -15358,7 +15364,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 1h still high
             & ((rsi_3_15m > 15.0) | (rsi_3_1h > 25.0) | (stochrsi_k_1h < 40.0))
             # 15m & 1h down move, 1d overbought
-            & ((rsi_3_15m > 15.0) | (rsi_3_1h > 25.0) | (roc_9_1d < 100.0))
+            & ((rsi_3_15m > 15.0) | (rsi_3_1h > 25.0) | (roc_9_1d_lt_100))
             # 15m & 1h down move, 1d high
             & ((rsi_3_15m > 15.0) | (rsi_3_1h > 30.0) | (stochrsi_k_1d < 80.0))
             # 15m & 1h down move, 4h high
@@ -15404,7 +15410,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 1h & 4h high
             & ((rsi_3_15m > 15.0) | (aroonu_14_1h < 85.0) | (stochrsi_k_4h < 90.0))
             # 15m down move, 4h high, 4h downtrend
-            & ((rsi_3_15m > 15.0) | (aroonu_14_4h < 60.0) | (roc_9_4h > -20.0))
+            & ((rsi_3_15m > 15.0) | (aroonu_14_4h < 60.0) | (roc_9_4h_gt_neg_20))
             # 15m down move, 4h & 1d high
             & ((rsi_3_15m > 15.0) | aroonu_14_4h_lt_70 | (aroonu_14_1d < 100.0))
             # 15m down move, 4h high & overbought
@@ -15416,13 +15422,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 1h still high, 4h overbought
             & ((rsi_3_15m > 15.0) | (stochrsi_k_1h < 50.0) | (roc_9_4h < 10.0))
             # 15m down move, 1h high, 4h downtrend
-            & ((rsi_3_15m > 15.0) | (stochrsi_k_1h < 80.0) | (roc_9_4h > -20.0))
+            & ((rsi_3_15m > 15.0) | (stochrsi_k_1h < 80.0) | (roc_9_4h_gt_neg_20))
             # 15m down move, 4h high & overbought
-            & ((rsi_3_15m > 15.0) | (stochrsi_k_4h < 90.0) | (roc_9_4h < 20.0))
+            & ((rsi_3_15m > 15.0) | (stochrsi_k_4h < 90.0) | (roc_9_4h_lt_20))
             # 15m & 1h down move, 1h still high
             & ((rsi_3_15m > 20.0) | rsi_3_1h_gt_20 | (stochrsi_k_1h < 20.0))
             # 15m & 1h down move, 1d downtrend
-            & ((rsi_3_15m > 20.0) | (rsi_3_1h > 30.0) | (roc_9_1d > -30.0))
+            & ((rsi_3_15m > 20.0) | (rsi_3_1h > 30.0) | (roc_9_1d_gt_neg_30))
             # 15m & 1h down move, 1h overbought
             & ((rsi_3_15m > 20.0) | (rsi_3_1h > 50.0) | (roc_9_1h < 10.0))
             # 15m & 1h down move, 4h high
@@ -15460,7 +15466,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 4h high, 1h overbought
             & ((rsi_3_15m > 20.0) | (aroonu_14_4h < 100.0) | (roc_9_1h < 30.0))
             # 15m down move, 1d high, 4h downtrend
-            & ((rsi_3_15m > 20.0) | (aroonu_14_1d < 90.0) | (roc_9_4h > -20.0))
+            & ((rsi_3_15m > 20.0) | (aroonu_14_1d < 90.0) | (roc_9_4h_gt_neg_20))
             # 15m down move, 1d high, 4h overbought
             & ((rsi_3_15m > 20.0) | (aroonu_14_1d < 100.0) | (roc_9_4h < 20.0))
             # 15m down move, 1d high, 1d overbought
@@ -15506,7 +15512,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 4h high, 1d overbought
             & ((rsi_3_15m > 25.0) | (aroonu_14_4h < 80.0) | (roc_9_1d < 100.0))
             # 15m down move, 1h high, 1d downtrend
-            & ((rsi_3_15m > 25.0) | (stochrsi_k_1h < 70.0) | (roc_9_1d > -20.0))
+            & ((rsi_3_15m > 25.0) | (stochrsi_k_1h < 70.0) | (roc_9_1d_gt_neg_20))
             # 15m down move, 1h high & overbought
             & ((rsi_3_15m > 25.0) | (stochrsi_k_1h < 90.0) | (roc_9_1h < 20.0))
             # 15m down move, 4h high & overbought
@@ -15548,7 +15554,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 4h down move, 1h high
             & ((rsi_3_15m > 40.0) | (rsi_3_4h > 45.0) | (stochrsi_k_1h < 90.0))
             # 15m down move, 15m still high, 1d high
-            & ((rsi_3_15m > 40.0) | (stochrsi_k_15m < 40.0) | (roc_9_1d < 100.0))
+            & ((rsi_3_15m > 40.0) | (stochrsi_k_15m < 40.0) | (roc_9_1d_lt_100))
             # 15m down move, 4h high & overbought
             & ((rsi_3_15m > 40.0) | (aroonu_14_4h < 100.0) | (roc_9_4h < 40.0))
             # 15m down move, 1h high, 4h overbought
@@ -15596,7 +15602,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h high, 1d overbought
             & (rsi_3_1h_gt_20 | (aroonu_14_1h < 70.0) | (roc_9_1d < 20.0))
             # 1h down move, 1d high, 4h downtrend
-            & (rsi_3_1h_gt_20 | (stochrsi_k_1d < 80.0) | (roc_9_4h > -20.0))
+            & (rsi_3_1h_gt_20 | (stochrsi_k_1d < 80.0) | (roc_9_4h_gt_neg_20))
             # 1h down move, 4h downtrend, 1d overbought
             & (rsi_3_1h_gt_20 | (roc_9_4h > -10.0) | (roc_9_1d < 20.0))
             # 1h & 4h down move, 1h still high
@@ -15610,9 +15616,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h still high, 4h overbought
             & ((rsi_3_1h > 25.0) | (aroonu_14_1h < 50.0) | (roc_9_4h < 60.0))
             # 1h down move, 4h high, 1d overbought
-            & ((rsi_3_1h > 25.0) | (aroonu_14_4h < 40.0) | (roc_9_1d < 100.0))
+            & ((rsi_3_1h > 25.0) | (aroonu_14_4h < 40.0) | (roc_9_1d_lt_100))
             # 1h down move, 1d still high, 1d downtrend
-            & ((rsi_3_1h > 25.0) | (stochrsi_k_1d < 50.0) | (roc_9_1d > -20.0))
+            & ((rsi_3_1h > 25.0) | (stochrsi_k_1d < 50.0) | (roc_9_1d_gt_neg_20))
             # 1h & 4h down move, 1d high
             & ((rsi_3_1h > 30.0) | (rsi_3_4h > 35.0) | (rsi_14_1d < 80.0))
             # 1h & 4h down move, 4h high
@@ -15626,7 +15632,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 4h high & overbought
             & ((rsi_3_1h > 30.0) | (aroonu_14_4h < 85.0) | (roc_9_4h < 80.0))
             # 1h down move, 1d still high, 1d downtrend
-            & ((rsi_3_1h > 30.0) | (aroonu_14_1d < 40.0) | (roc_9_1d > -20.0))
+            & ((rsi_3_1h > 30.0) | (aroonu_14_1d < 40.0) | (roc_9_1d_gt_neg_20))
             # 1h down move, 1d high, 4h downtrend
             & ((rsi_3_1h > 30.0) | (aroonu_14_1d < 100.0) | (roc_9_4h > -30.0))
             # 1h down move, 1d high & overbought
@@ -15638,7 +15644,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h & 4h high
             & ((rsi_3_1h > 35.0) | (aroonu_14_1h < 60.0) | aroonu_14_4h_lt_70)
             # 1h down move, 4h high, 1d downtrend
-            & ((rsi_3_1h > 35.0) | aroonu_14_4h_lt_70 | (roc_9_1d > -30.0))
+            & ((rsi_3_1h > 35.0) | aroonu_14_4h_lt_70 | (roc_9_1d_gt_neg_30))
             # 1h down move, 1d high, 4h overbought
             & ((rsi_3_1h > 35.0) | (aroonu_14_1d < 90.0) | (roc_9_4h < 40.0))
             # 1h down move, 4h & 1d overbought
@@ -15660,7 +15666,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1d high & overbought
             & ((rsi_3_1h > 40.0) | (aroonu_14_1d < 80.0) | roc_9_1d_lt_50)
             # 1h down move, 1d high, 4h overbought
-            & ((rsi_3_1h > 40.0) | (stochrsi_k_1d < 90.0) | (roc_9_4h < 20.0))
+            & ((rsi_3_1h > 40.0) | (stochrsi_k_1d < 90.0) | (roc_9_4h_lt_20))
             # 1h down move, 1h overbought
             & ((rsi_3_1h > 40.0) | (roc_9_1h < 30.0))
             # 1h & 4h down move, 1d overbought
@@ -15668,17 +15674,17 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h still not low enough, 1d downtrend
             & ((rsi_3_1h > 45.0) | (aroonu_14_1h < 30.0) | (roc_9_1d > -25.0))
             # 1h down move, 1h still high, 1d overbought
-            & ((rsi_3_1h > 45.0) | (stochrsi_k_1h < 40.0) | (roc_9_1d < 100.0))
+            & ((rsi_3_1h > 45.0) | (stochrsi_k_1h < 40.0) | (roc_9_1d_lt_100))
             # 1h down move, 4h high, 1h overbought
             & ((rsi_3_1h > 50.0) | (aroonu_14_4h < 85.0) | (roc_9_1h < 20.0))
             # 1h down move, 1d high, 4h overbought
-            & ((rsi_3_1h > 50.0) | (aroonu_14_1d < 90.0) | (roc_9_4h < 20.0))
+            & ((rsi_3_1h > 50.0) | (aroonu_14_1d < 90.0) | (roc_9_4h_lt_20))
             # 1h down move, 1h high & overbought
             & ((rsi_3_1h > 50.0) | (stochrsi_k_1h < 80.0) | (roc_9_1h < 10.0))
             # 1h down move, 1h & 4h overbought
             & ((rsi_3_1h > 50.0) | (roc_9_1h < 10.0) | (roc_9_4h < 100.0))
             # 1h down move, 4h & 1d overbought
-            & ((rsi_3_1h > 50.0) | (roc_9_4h < 20.0) | (roc_9_1d < 20.0))
+            & ((rsi_3_1h > 50.0) | (roc_9_4h_lt_20) | (roc_9_1d < 20.0))
             # 1h & 4h down move, 1h high
             & ((rsi_3_1h > 55.0) | (rsi_3_4h > 55.0) | (stochrsi_k_1h < 70.0))
             # 1h down move, 1h high, 4h overbought
@@ -15694,7 +15700,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h high, 1d downtrend
             & ((rsi_3_1h > 60.0) | (stochrsi_k_1h < 70.0) | (roc_9_1d > -10.0))
             # 1h down move, 1h high, 1d overbought
-            & ((rsi_3_1h > 60.0) | (stochrsi_k_1h < 80.0) | (roc_9_1d < 100.0))
+            & ((rsi_3_1h > 60.0) | (stochrsi_k_1h < 80.0) | (roc_9_1d_lt_100))
             # 1h down move, 1h high, 4h overbought
             & ((rsi_3_1h > 65.0) | (aroonu_14_1h < 70.0) | (roc_9_4h < 25.0))
             # 1h down move, 1h high, 1d overbought
@@ -15742,11 +15748,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 15m high
             & (rsi_3_4h_gt_20 | (stochrsi_k_15m < 80.0))
             # 4h down move, 1h high, 4h downtrend
-            & (rsi_3_4h_gt_20 | (stochrsi_k_1h < 70.0) | (roc_9_4h > -20.0))
+            & (rsi_3_4h_gt_20 | (stochrsi_k_1h < 70.0) | (roc_9_4h_gt_neg_20))
             # 4h down move, 4h still high, 4h downtrend
             & ((rsi_3_4h > 25.0) | (aroonu_14_4h < 50.0) | (cmf_20_4h > -0.40))
             # 4h down move, 4h high, 1d downtrend
-            & ((rsi_3_4h > 25.0) | (stochrsi_k_4h < 70.0) | (roc_9_1d > -30.0))
+            & ((rsi_3_4h > 25.0) | (stochrsi_k_4h < 70.0) | (roc_9_1d_gt_neg_30))
             # 4h & 1d down move, 1d high
             & ((rsi_3_4h > 30.0) | (rsi_3_1d > 50.0) | (aroonu_14_1d < 90.0))
             # 4h down move, 1h high, 1h downtrend
@@ -15756,11 +15762,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 1h still high, 1d overbought
             & ((rsi_3_4h > 30.0) | (stochrsi_k_1h < 40.0) | (roc_9_1d < 30.0))
             # 4h & 1d down move, 1d overbought
-            & ((rsi_3_4h > 35.0) | (rsi_3_1d > 50.0) | (roc_9_1d < 100.0))
+            & ((rsi_3_4h > 35.0) | (rsi_3_1d > 50.0) | (roc_9_1d_lt_100))
             # 4h down move, 4h & 1d high
             & ((rsi_3_4h > 35.0) | (aroonu_14_4h < 80.0) | (aroonu_14_1d < 100.0))
             # 4h down move, 4h high, 1d downtrend
-            & ((rsi_3_4h > 45.0) | aroonu_14_4h_lt_70 | (roc_9_1d > -30.0))
+            & ((rsi_3_4h > 45.0) | aroonu_14_4h_lt_70 | (roc_9_1d_gt_neg_30))
             # 4h & 1d down move, 1d high
             & ((rsi_3_4h > 40.0) | (rsi_3_1d > 60.0) | (aroonu_14_1d < 100.0))
             # 4h down move, 4h high, 1d downtrend
@@ -15768,17 +15774,17 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 1d high & overbought
             & ((rsi_3_4h > 45.0) | (aroonu_14_1d < 70.0) | (roc_9_1d < 20.0))
             # 4h down move, 4h high & overbought
-            & ((rsi_3_4h > 45.0) | (stochrsi_k_4h < 60.0) | (roc_9_4h < 20.0))
+            & ((rsi_3_4h > 45.0) | (stochrsi_k_4h < 60.0) | (roc_9_4h_lt_20))
             # 4h down move, 4h high, 1d overbought
             & ((rsi_3_4h > 45.0) | (stochrsi_k_4h < 80.0) | (roc_9_1d < 10.0))
             # 4h down move, 4h high & overbought
             & ((rsi_3_4h > 50.0) | (aroonu_14_4h < 80.0) | (roc_9_4h < 10.0))
             # 4h down move, 1h high, 1d downtrend
-            & ((rsi_3_4h > 50.0) | (stochrsi_k_1h < 80.0) | (roc_9_1d > -30.0))
+            & ((rsi_3_4h > 50.0) | (stochrsi_k_1h < 80.0) | (roc_9_1d_gt_neg_30))
             # 4h down move, 4h high & overbought
-            & ((rsi_3_4h > 55.0) | aroonu_14_4h_lt_70 | (roc_9_4h < 20.0))
+            & ((rsi_3_4h > 55.0) | aroonu_14_4h_lt_70 | (roc_9_4h_lt_20))
             # 4h down move, 4h high, 1d overbought
-            & ((rsi_3_4h > 55.0) | aroonu_14_4h_lt_70 | (roc_9_1d < 100.0))
+            & ((rsi_3_4h > 55.0) | aroonu_14_4h_lt_70 | (roc_9_1d_lt_100))
             # 4h down move, 1d high & overbought
             & ((rsi_3_4h > 55.0) | (aroonu_14_1d < 90.0) | (roc_9_1d < 60.0))
             # 4h down move, 4h & 1d high
@@ -15794,7 +15800,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 4h high & overbought
             & ((rsi_3_4h > 65.0) | (aroonu_14_4h < 80.0) | (roc_9_4h < 20.0))
             # 1d down move, 1d still not low enough, 1d downtrend
-            & ((rsi_3_1d > 5.0) | (aroonu_14_1d < 20.0) | (roc_9_1d > -20.0))
+            & ((rsi_3_1d > 5.0) | (aroonu_14_1d < 20.0) | (roc_9_1d_gt_neg_20))
             # 1d down move, 15m still high
             & ((rsi_3_1d > 5.0) | (stochrsi_k_15m < 40.0))
             # 1d down move, 1h high
@@ -15802,7 +15808,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1d down move, 4h downtrend, 4h high
             & ((rsi_3_1d > 20.0) | (cmf_20_4h > -0.25) | aroonu_14_4h_lt_70)
             # 1d down move, 1d still high, 1d downtrend
-            & ((rsi_3_1d > 25.0) | (stochrsi_k_1d < 50.0) | (roc_9_1d > -20.0))
+            & ((rsi_3_1d > 25.0) | (stochrsi_k_1d < 50.0) | (roc_9_1d_gt_neg_20))
             # 1d down move, 4h & 1d high
             & ((rsi_3_1d > 40.0) | aroonu_14_4h_lt_70 | (aroonu_14_1d < 100.0))
             # 1d down move, 1d high & overbought
@@ -15844,13 +15850,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h & 1d high, 4h overbought
             & ((aroonu_14_4h < 90.0) | (aroonu_14_1d < 100.0) | (roc_9_4h < 30.0))
             # 4h high, 4h overbought, 1d downtrend
-            & ((aroonu_14_4h < 90.0) | (roc_9_4h < 20.0) | (roc_9_1d > -40.0))
+            & ((aroonu_14_4h < 90.0) | (roc_9_4h_lt_20) | (roc_9_1d > -40.0))
             # 1d high, 4h & 1d overbought
             & ((aroonu_14_1d < 70.0) | (roc_9_4h < 30.0) | (roc_9_1d < 200.0))
             # 1d high, 1h & 1d overbought
             & ((aroonu_14_1d < 80.0) | (roc_9_1h < 20.0) | roc_9_1d_lt_50)
             # 1d high, 1d downtrend
-            & ((aroonu_14_1d < 80.0) | (roc_9_1d > -30.0))
+            & ((aroonu_14_1d < 80.0) | (roc_9_1d_gt_neg_30))
             # 1d high, 1h & 4h downtrend
             & ((aroonu_14_1d < 85.0) | (roc_9_1h > -30.0) | (roc_9_4h > -50.0))
             # 1d high, 1h & 1d overbought
@@ -15866,13 +15872,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h high, 1h overbought, 4h downtrend
             & ((stochrsi_k_1h < 80.0) | (roc_9_1h < 10.0) | (roc_9_4h > -10.0))
             # 1h high, 4h & 1d downtrend
-            & ((stochrsi_k_1h < 80.0) | (roc_9_4h > -20.0) | (roc_9_1d > -80.0))
+            & ((stochrsi_k_1h < 80.0) | (roc_9_4h_gt_neg_20) | (roc_9_1d > -80.0))
             # 1h down move, 1h & 1d overbought
             & ((stochrsi_k_1h < 90.0) | (roc_9_1h < 10.0) | roc_9_1d_lt_50)
             # 1h high & overbought
             & ((stochrsi_k_1h < 90.0) | (roc_9_1h < 40.0))
             # 4h high, 1h & 4h overbought
-            & ((stochrsi_k_4h < 70.0) | (roc_9_1h < 10.0) | (roc_9_4h < 20.0))
+            & ((stochrsi_k_4h < 70.0) | (roc_9_1h < 10.0) | (roc_9_4h_lt_20))
             # 4h high, 1h & 1d overbought
             & ((stochrsi_k_4h < 70.0) | (roc_9_1h < 20.0) | (roc_9_1d < 200.0))
             # 4h high, 4h & 1d overbought
@@ -15884,7 +15890,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h high, 4h & 1d overbought
             & ((stochrsi_k_4h < 90.0) | (roc_9_4h < 10.0) | (roc_9_1d < 10.0))
             # 1d hihg, 1h & 1d overbought
-            & ((stochrsi_k_1d < 90.0) | (roc_9_1h < 30.0) | (roc_9_1d < 100.0))
+            & ((stochrsi_k_1d < 90.0) | (roc_9_1h < 30.0) | (roc_9_1d_lt_100))
             # 1d P&D, dh downtrend
             & ((change_pct_1d > -50.0) | (change_pct_1d.shift(288) < 50.0) | (rsi_3_4h > 15.0))
             # big drop in the last 20 days, 1d high, 1d downtrend
@@ -15979,7 +15985,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 1h & 4h overbought
             & ((rsi_3_15m > 30.0) | (roc_9_1h < 60.0) | (roc_9_4h < 80.0))
             # 15m down move, 4h & 1d overbought
-            & ((rsi_3_15m > 40.0) | (roc_9_4h < 100.0) | (roc_9_1d < 100.0))
+            & ((rsi_3_15m > 40.0) | (roc_9_4h < 100.0) | (roc_9_1d_lt_100))
             # 1h down move, 4h overbought, 1d downtrend
             & ((rsi_3_1h > 15.0) | (roc_9_4h < 50.0) | (roc_9_1d > -30.0))
             # 1h & 4h down move, 4h high
@@ -15997,7 +16003,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h still high, 1d overbought
             & (rsi_3_1h_gt_20 | (stochrsi_k_1h < 40.0) | (roc_9_4h < 10.0))
             # 1h down move, 4h & 1d overbought
-            & (rsi_3_1h_gt_20 | (roc_9_4h < 40.0) | (roc_9_1d < 100.0))
+            & (rsi_3_1h_gt_20 | (roc_9_4h < 40.0) | (roc_9_1d_lt_100))
             # 1h down move, 1d high, 4h overbought
             & ((rsi_3_1h > 25.0) | (aroonu_14_1d < 100.0) | (roc_9_4h < 60.0))
             # 1h down move, 4h high & overbought
@@ -16019,7 +16025,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h high & overbought
             & ((rsi_3_1h > 50.0) | (aroonu_14_1h < 90.0) | (roc_9_1h < 10.0))
             # 1h down move, 1h high, 1d downtrend
-            & ((rsi_3_1h > 50.0) | (stochrsi_k_1h < 70.0) | (roc_9_1d > -20.0))
+            & ((rsi_3_1h > 50.0) | (stochrsi_k_1h < 70.0) | (roc_9_1d_gt_neg_20))
             # 1h down move, 1h & 1d overbought
             & ((rsi_3_1h > 50.0) | (roc_9_1h < 25.0) | (roc_9_1d < 200.0))
             # 1h down move, 1h high, 4h overbought
@@ -16095,13 +16101,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h & 1d high, 4h overbought
             & ((aroonu_14_4h < 85.0) | (aroonu_14_1d < 90.0) | (roc_9_4h < 60.0))
             # 4h high, 1h & 4h overbought
-            & ((aroonu_14_4h < 85.0) | (roc_9_1h < 10.0) | (roc_9_4h < 20.0))
+            & ((aroonu_14_4h < 85.0) | (roc_9_1h < 10.0) | (roc_9_4h_lt_20))
             # 4h high, 1d high & overbought
             & ((aroonu_14_4h < 90.0) | (aroonu_14_1d < 100.0) | (roc_9_1d < 30.0))
             # 4h high, 1h & 4h overbought
             & ((aroonu_14_4h < 90.0) | (roc_9_1h < 40.0) | (roc_9_4h < 40.0))
             # 4h high, 4h & 1d overbought
-            & ((aroonu_14_4h < 90.0) | (roc_9_4h < 30.0) | (roc_9_1d < 100.0))
+            & ((aroonu_14_4h < 90.0) | (roc_9_4h < 30.0) | (roc_9_1d_lt_100))
             # 4h high, 1h & 4h overbought
             & ((aroonu_14_4h < 100.0) | (roc_9_1h < 40.0) | (roc_9_4h < 80.0))
             # 1d high, 1h & 4h overbought
@@ -16113,15 +16119,15 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h high, 4h overbought. 1d downtrend
             & ((stochrsi_k_1h < 80.0) | (roc_9_4h < 40.0) | (cmf_20_1d > -0.25))
             # 4h high, 1h & 4h overbought
-            & ((stochrsi_k_4h < 90.0) | (roc_9_1h < 10.0) | (roc_9_4h < 20.0))
+            & ((stochrsi_k_4h < 90.0) | (roc_9_1h < 10.0) | (roc_9_4h_lt_20))
             # 4h high & 4h & 1d overbought
-            & ((stochrsi_k_4h < 90.0) | (roc_9_4h < 20.0) | (roc_9_1d < 20.0))
+            & ((stochrsi_k_4h < 90.0) | (roc_9_4h_lt_20) | (roc_9_1d < 20.0))
             # 1d high, 1h & 4h overbought
-            & ((stochrsi_k_1d < 80.0) | (roc_9_1h < 10.0) | (roc_9_4h < 20.0))
+            & ((stochrsi_k_1d < 80.0) | (roc_9_1h < 10.0) | (roc_9_4h_lt_20))
             # 1d hihg, 1h & 1d overbought
-            & ((stochrsi_k_1d < 90.0) | (roc_9_1h < 30.0) | (roc_9_1d < 100.0))
+            & ((stochrsi_k_1d < 90.0) | (roc_9_1h < 30.0) | (roc_9_1d_lt_100))
             # 1d high, 4h & 1d overbought
-            & ((stochrsi_k_1d < 90.0) | (roc_9_4h < 40.0) | (roc_9_1d < 100.0))
+            & ((stochrsi_k_1d < 90.0) | (roc_9_4h < 40.0) | (roc_9_1d_lt_100))
           )
 
           # Logic
@@ -16179,7 +16185,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 15m still high, 1d high
             & (rsi_3_15m_gt_3 | (aroonu_14_15m < 40.0) | (aroonu_14_1d < 80.0))
             # 15m down move, 15m still high, 1d downtrend
-            & (rsi_3_15m_gt_3 | (aroonu_14_15m < 50.0) | (roc_9_1d > -20.0))
+            & (rsi_3_15m_gt_3 | (aroonu_14_15m < 50.0) | (roc_9_1d_gt_neg_20))
             # 15m down move, 1h still high, 1d high
             & (rsi_3_15m_gt_3 | (aroonu_14_1h < 50.0) | (aroonu_14_1d < 70.0))
             # 15m down move, 1h & 4h high
@@ -16193,7 +16199,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 4h high & overbought
             & (rsi_3_15m_gt_3 | (stochrsi_k_4h < 80.0) | (roc_9_4h < 10.0))
             # 15m down move, 4h & 1d downtrend
-            & (rsi_3_15m_gt_3 | (roc_9_4h > -20.0) | (roc_9_1d > -20.0))
+            & (rsi_3_15m_gt_3 | (roc_9_4h_gt_neg_20) | (roc_9_1d_gt_neg_20))
             # 15m & 1h down move, 1d downtrend
             & ((rsi_3_15m > 5.0) | (rsi_3_1h > 5.0) | (roc_9_1d > -10.0))
             # 15m & 1h down move, 1d high
@@ -16221,7 +16227,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 1h & 4h overbought
             & ((rsi_3_15m > 5.0) | (roc_9_1h < 25.0) | (roc_9_4h < 25.0))
             # 15m down move, 4h & 1d overbought
-            & ((rsi_3_15m > 5.0) | (roc_9_4h < 30.0) | (roc_9_1d < 100.0))
+            & ((rsi_3_15m > 5.0) | (roc_9_4h < 30.0) | (roc_9_1d_lt_100))
             # 15m & 1h down move, 1h high
             & ((rsi_3_15m > 10.0) | (rsi_3_1h > 10.0) | (aroonu_14_1h < 70.0))
             # 15m & 1h down move, 1d high
@@ -16273,11 +16279,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 1h high, 15m downtrend
             & ((rsi_3_15m > 10.0) | (stochrsi_k_1h < 80.0) | (roc_9_15m > -10.0))
             # 15m down move, 1h high, 1d downtrend
-            & ((rsi_3_15m > 10.0) | (stochrsi_k_1h < 90.0) | (roc_9_1d > -30.0))
+            & ((rsi_3_15m > 10.0) | (stochrsi_k_1h < 90.0) | (roc_9_1d_gt_neg_30))
             # 15m down move, 1h high, 1d overbought
             & ((rsi_3_15m > 10.0) | (stochrsi_k_1h < 90.0) | (roc_9_1d < 30.0))
             # 15m down move, 4h high & overbought
-            & ((rsi_3_15m > 10.0) | (stochrsi_k_4h < 90.0) | (roc_9_4h < 20.0))
+            & ((rsi_3_15m > 10.0) | (stochrsi_k_4h < 90.0) | (roc_9_4h_lt_20))
             # 15m & 1h down move, 1d overbought
             & ((rsi_3_15m > 15.0) | (rsi_3_1h > 15.0) | (roc_9_1d < 30.0))
             # 15m & 1h down move, 1d high
@@ -16297,7 +16303,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 1h & 4h high
             & ((rsi_3_15m > 15.0) | (aroonu_14_1h < 80.0) | (aroonu_14_4h < 100.0))
             # 15m down move, 4h high, 4h downtrend
-            & ((rsi_3_15m > 15.0) | (aroonu_14_4h < 60.0) | (roc_9_4h > -20.0))
+            & ((rsi_3_15m > 15.0) | (aroonu_14_4h < 60.0) | (roc_9_4h_gt_neg_20))
             # 15m down move, 4h & 1d high
             & ((rsi_3_15m > 15.0) | (aroonu_14_4h < 80.0) | (aroonu_14_1d < 100.0))
             # 15m down move, 1h high, 4h downtrend
@@ -16329,7 +16335,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 1h high & overbought
             & ((rsi_3_15m > 20.0) | (aroonu_14_1h < 100.0) | (roc_9_1h < 50.0))
             # 15m down move, 4h high & overbought
-            & ((rsi_3_15m > 20.0) | aroonu_14_4h_lt_70 | (roc_9_4h < 20.0))
+            & ((rsi_3_15m > 20.0) | aroonu_14_4h_lt_70 | (roc_9_4h_lt_20))
             # 15m down move, 4h high, 1d overbought
             & ((rsi_3_15m > 20.0) | (aroonu_14_4h < 80.0) | (roc_9_1d < 60.0))
             # 15m & 4h down move, 4h high
@@ -16339,7 +16345,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 15m high, 1h high
             & ((rsi_3_15m > 30.0) | (aroonu_14_15m < 60.0) | (aroonu_14_1h < 90.0))
             # 15m down move, 15m high, 4h downtrend
-            & ((rsi_3_15m > 25.0) | (aroonu_14_15m < 60.0) | (roc_9_4h > -20.0))
+            & ((rsi_3_15m > 25.0) | (aroonu_14_15m < 60.0) | (roc_9_4h_gt_neg_20))
             # 15m down move, 1h high, 4h overbought
             & ((rsi_3_15m > 25.0) | (aroonu_14_1h < 90.0) | (roc_9_4h < 30.0))
             # 15m down move, 1h high, 4h overbought
@@ -16513,7 +16519,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 4h & 1d downtrend
             & (rsi_3_1h_gt_20 | (roc_9_4h > -30.0) | (roc_9_1d > -40.0))
             # 1h & 4h down move, 1d overbought
-            & ((rsi_3_1h > 25.0) | (rsi_3_4h > 40.0) | (roc_9_1d < 100.0))
+            & ((rsi_3_1h > 25.0) | (rsi_3_4h > 40.0) | (roc_9_1d_lt_100))
             # 1h down move, 15m still high, 1h high
             & ((rsi_3_1h > 25.0) | (aroonu_14_15m < 50.0) | (aroonu_14_1h < 90.0))
             # 1h down move, 1h high, 1d overbought
@@ -16541,7 +16547,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 1h high
             & ((rsi_3_1h > 30.0) | (rsi_3_4h > 30.0) | (aroonu_14_1h < 90.0))
             # 1h & 4h down move, 4h downtrend
-            & ((rsi_3_1h > 30.0) | (rsi_3_4h > 30.0) | (roc_9_4h > -20.0))
+            & ((rsi_3_1h > 30.0) | (rsi_3_4h > 30.0) | (roc_9_4h_gt_neg_20))
             # 1h down move, 1h downtrend, 1h high
             & ((rsi_3_1h > 30.0) | (cmf_20_1h > -0.25) | (stochrsi_k_1h < 70.0))
             # 1h down move, 4h downtrend, 4h high
@@ -16553,7 +16559,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 4h high, 1h overbought
             & ((rsi_3_1h > 30.0) | (aroonu_14_4h < 80.0) | (roc_9_1h < 50.0))
             # 1h down move, 4h high, 1d downtrend
-            & ((rsi_3_1h > 30.0) | (aroonu_14_4h < 90.0) | (roc_9_1d > -30.0))
+            & ((rsi_3_1h > 30.0) | (aroonu_14_4h < 90.0) | (roc_9_1d_gt_neg_30))
             # 1h down move, 4h high, 1d overbought
             & ((rsi_3_1h > 30.0) | (aroonu_14_4h < 100.0) | (roc_9_1d < 20.0))
             # 1h down move, 4h & 1d overbought
@@ -16577,7 +16583,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h downtrend, 4h overbought
             & ((rsi_3_1h > 35.0) | (roc_9_1h > -30.0) | (roc_9_4h < 100.0))
             # 1h down move, 4h & 1d overbought
-            & ((rsi_3_1h > 35.0) | (roc_9_4h < 20.0) | (roc_9_1d < 70.0))
+            & ((rsi_3_1h > 35.0) | (roc_9_4h_lt_20) | (roc_9_1d < 70.0))
             # 1h down move, 1h & 4h high
             & ((rsi_3_1h > 40.0) | (aroonu_14_1h < 70.0) | (aroonu_14_4h < 100.0))
             # 1h down move, 1h high & overbought
@@ -16589,7 +16595,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h  high & overbought
             & ((rsi_3_1h > 40.0) | (stochrsi_k_1h < 80.0) | (roc_9_1h < 10.0))
             # 1h down move, 4h & 1d overbought
-            & ((rsi_3_1h > 40.0) | (roc_9_4h < 20.0) | (roc_9_1d < 100.0))
+            & ((rsi_3_1h > 40.0) | (roc_9_4h_lt_20) | (roc_9_1d_lt_100))
             # 1h down move, 4h & 1d overbought
             & ((rsi_3_1h > 40.0) | (roc_9_4h < 30.0) | (roc_9_1d < 40.0))
             # 1h down move, 1h high, 1d overbought
@@ -16599,7 +16605,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h high, 1d downtrend
             & ((rsi_3_1h > 50.0) | (aroonu_14_1h < 60.0) | (roc_9_1d > -70.0))
             # 1h down move, 1h high, 1d overbought
-            & ((rsi_3_1h > 50.0) | (stochrsi_k_1h < 70.0) | (roc_9_1d < 100.0))
+            & ((rsi_3_1h > 50.0) | (stochrsi_k_1h < 70.0) | (roc_9_1d_lt_100))
             # 1h down move, 4h high, 1d downtrend
             & ((rsi_3_1h > 50.0) | (stochrsi_k_4h < 60.0) | (roc_9_1d > -60.0))
             # 1h down move, 1h high
@@ -16617,7 +16623,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h & 1d down move, 1d still high
             & ((rsi_3_4h > 5.0) | (rsi_3_1d > 20.0) | (aroonu_14_1d < 50.0))
             # 4h down move, 15m still high, 1d downtrend
-            & ((rsi_3_4h > 5.0) | (aroonu_14_15m < 50.0) | (roc_9_1d > -30.0))
+            & ((rsi_3_4h > 5.0) | (aroonu_14_15m < 50.0) | (roc_9_1d_gt_neg_30))
             # 4h & 1d down move, 1d downtrend
             & ((rsi_3_4h > 10.0) | (rsi_3_1d > 25.0) | roc_9_1d_gt_neg_50)
             # 4h down move, 1d high & overbought
@@ -16637,9 +16643,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 1d high & overbought
             & (rsi_3_4h_gt_20 | (aroonu_14_1d < 80.0) | (roc_9_1d < 200.0))
             # 4h down move, 4h & 1d downtrend
-            & (rsi_3_4h_gt_20 | (roc_9_4h > -20.0) | (roc_9_1d > -30.0))
+            & (rsi_3_4h_gt_20 | (roc_9_4h_gt_neg_20) | (roc_9_1d_gt_neg_30))
             # 4h down move, 15m high, 1d overbought
-            & ((rsi_3_4h > 25.0) | (aroonu_14_15m < 70.0) | (roc_9_1d < 100.0))
+            & ((rsi_3_4h > 25.0) | (aroonu_14_15m < 70.0) | (roc_9_1d_lt_100))
             # 4h down move, 4h high
             & ((rsi_3_4h > 25.0) | (aroonu_14_4h < 80.0))
             # 4h down move, 1d high, 1h downtrend
@@ -16651,7 +16657,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 4h still not low enough, 1d overbought
             & ((rsi_3_4h > 30.0) | (stochrsi_k_4h < 20.0) | (roc_9_1d < 60.0))
             # 4h down move, 1d high, 1d downtrend
-            & ((rsi_3_4h > 35.0) | (stochrsi_k_1d < 60.0) | (roc_9_1d > -30.0))
+            & ((rsi_3_4h > 35.0) | (stochrsi_k_1d < 60.0) | (roc_9_1d_gt_neg_30))
             # 4h down move, 1h high, 1d overbought
             & ((rsi_3_4h > 45.0) | (aroonu_14_1h < 85.0) | roc_9_1d_lt_50)
             # 4h down move, 1d high, 1d downtrend
@@ -16659,11 +16665,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 1d high & overbought
             & ((rsi_3_4h > 45.0) | (stochrsi_k_1d < 90.0) | (roc_9_1d < 25.0))
             # 4h down move, 4h still high, 1d downtrend
-            & ((rsi_3_4h > 50.0) | (rsi_14_4h < 40.0) | (roc_9_1d > -30.0))
+            & ((rsi_3_4h > 50.0) | (rsi_14_4h < 40.0) | (roc_9_1d_gt_neg_30))
             # 4h down move, 4h high & overbought
             & ((rsi_3_4h > 50.0) | (aroonu_14_4h < 80.0) | (roc_9_4h < 10.0))
             # 4h down move, 4h still high, 1d downtrend
-            & ((rsi_3_4h > 50.0) | (stochrsi_k_4h < 50.0) | (roc_9_1d > -30.0))
+            & ((rsi_3_4h > 50.0) | (stochrsi_k_4h < 50.0) | (roc_9_1d_gt_neg_30))
             # 4h down move, 4h & 1d overbought
             & ((rsi_3_4h > 50.0) | (roc_9_4h < 10.0) | (roc_9_1d < 40.0))
             # 1d down move, 4h still high, 1d downtrend
@@ -16677,7 +16683,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1d down move, 1h & 4h high
             & ((rsi_3_1d > 15.0) | (aroonu_14_1h < 90.0) | (aroonu_14_4h < 100.0))
             # 1d down move, 1h high, 1d downtrend
-            & ((rsi_3_1d > 20.0) | (aroonu_14_1h < 100.0) | (roc_9_1d > -30.0))
+            & ((rsi_3_1d > 20.0) | (aroonu_14_1h < 100.0) | (roc_9_1d_gt_neg_30))
             # 1d down move, 1h still high, 4h downtrend
             & ((rsi_3_1d > 25.0) | (stochrsi_k_1h < 50.0) | (roc_9_4h > -30.0))
             # 1d down move, 1h high & overbought
@@ -16707,7 +16713,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h high, 4h & 1d overbought
             & ((aroonu_14_1h < 80.0) | (roc_9_4h < 10.0) | (roc_9_1d < 40.0))
             # 1h high, 4h & 1d downtrend
-            & ((aroonu_14_1h < 85.0) | (roc_9_4h > -20.0) | roc_9_1d_gt_neg_50)
+            & ((aroonu_14_1h < 85.0) | (roc_9_4h_gt_neg_20) | roc_9_1d_gt_neg_50)
             # 1h & 4h high, 1h overbought
             & ((aroonu_14_1h < 100.0) | (aroonu_14_4h < 100.0) | (roc_9_1h < 10.0))
             # 4h high, 4h & 1d overbought
@@ -16739,7 +16745,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h high, 1h & 4h overbought
             & ((stochrsi_k_4h < 90.0) | (roc_9_1h < 20.0) | (roc_9_4h < 50.0))
             # 1d high, 4h & 1d overbought
-            & ((stochrsi_k_1d < 90.0) | (roc_9_4h < 100.0) | (roc_9_1d < 100.0))
+            & ((stochrsi_k_1d < 90.0) | (roc_9_4h < 100.0) | (roc_9_1d_lt_100))
             # 1d P&D, 4h overbought
             & ((change_pct_1d > -10.0) | (change_pct_1d.shift(288) < 30.0) | (roc_9_4h < 10.0))
             # big drop in the last 20 days, 1d high, 1d downtrend
@@ -16871,7 +16877,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 15m still not low enough
             & ((rsi_3_1h > 5.0) | (rsi_3_4h > 5.0) | (stochrsi_k_15m < 20.0))
             # 1h & 4h down move, 1d downtrend
-            & ((rsi_3_1h > 5.0) | (rsi_3_4h > 5.0) | (roc_9_1d > -30.0))
+            & ((rsi_3_1h > 5.0) | (rsi_3_4h > 5.0) | (roc_9_1d_gt_neg_30))
             # 1h & 4h down move, 1d still high
             & ((rsi_3_1h > 5.0) | (rsi_3_4h > 15.0) | (aroonu_14_1d < 40.0))
             # 1h & 4h down move, 1h high
@@ -17001,7 +17007,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1d high & overbought
             & (rsi_3_1h_gt_20 | (aroonu_14_1d < 100.0) | (roc_9_1d < 30.0))
             # 1h down move, 1d high, 4h downtrend
-            & (rsi_3_1h_gt_20 | (stochrsi_k_1d < 80.0) | (roc_9_4h > -20.0))
+            & (rsi_3_1h_gt_20 | (stochrsi_k_1d < 80.0) | (roc_9_4h_gt_neg_20))
             # 1h & 4h down move, 15m high
             & ((rsi_3_1h > 25.0) | (rsi_3_4h > 25.0) | (stochrsi_k_15m < 70.0))
             # 1h & 4h down move, 4h high
@@ -17025,7 +17031,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h high & overbought
             & ((rsi_3_1h > 25.0) | (aroonu_14_1d < 100.0) | (roc_9_1d < 20.0))
             # 1h down move, 4h high & overbought
-            & ((rsi_3_1h > 25.0) | (stochrsi_k_4h < 80.0) | (roc_9_4h < 20.0))
+            & ((rsi_3_1h > 25.0) | (stochrsi_k_4h < 80.0) | (roc_9_4h_lt_20))
             # 1h & 4h down move, 1d downtrend
             & ((rsi_3_1h > 30.0) | (rsi_3_4h > 30.0) | roc_9_1d_gt_neg_50)
             # 1h & 4h down move, 15m high
@@ -17063,13 +17069,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h & 1d high
             & ((rsi_3_1h > 35.0) | (aroonu_14_1h < 70.0) | (aroonu_14_1d < 100.0))
             # 1h down move, 4h high, 1d downtrend
-            & ((rsi_3_1h > 35.0) | (aroonu_14_4h < 90.0) | (roc_9_1d > -20.0))
+            & ((rsi_3_1h > 35.0) | (aroonu_14_4h < 90.0) | (roc_9_1d_gt_neg_20))
             # 1h down move, 4h high & overbought
             & ((rsi_3_1h > 35.0) | (stochrsi_k_4h < 90.0) | (roc_9_4h < 10.0))
             # 1h down move, 4h & 1d downtrend
             & ((rsi_3_1h > 35.0) | (roc_9_4h > -10.0) | (roc_9_1d > -60.0))
             # 1h down move, 4h high & overbought
-            & ((rsi_3_1h > 40.0) | (aroonu_14_4h < 90.0) | (roc_9_4h < 20.0))
+            & ((rsi_3_1h > 40.0) | (aroonu_14_4h < 90.0) | (roc_9_4h_lt_20))
             # 1h down move, 4h high, 1d downtrend
             & ((rsi_3_1h > 40.0) | (stochrsi_k_4h < 60.0) | roc_9_1d_gt_neg_50)
             # 1h down move, 4h high & overbought
@@ -17081,7 +17087,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1d high & overbought
             & ((rsi_3_1h > 50.0) | (stochrsi_k_1d < 90.0) | (roc_9_1d < 20.0))
             # 1h down move, 4h & 1d overbought
-            & ((rsi_3_1h > 60.0) | (roc_9_4h < 30.0) | (roc_9_1d < 100.0))
+            & ((rsi_3_1h > 60.0) | (roc_9_4h < 30.0) | (roc_9_1d_lt_100))
             # 4h & 1d down move
             & ((rsi_3_4h > 3.0) | (rsi_3_1d > 15.0))
             # 4h & 1d down move, 1d high
@@ -17091,7 +17097,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h & 1d down move, 4h downtrend
             & ((rsi_3_4h > 5.0) | (rsi_3_1d > 15.0) | (roc_9_4h > -10.0))
             # 4h & 1d down move, 1d downtrend
-            & ((rsi_3_4h > 5.0) | (rsi_3_1d > 15.0) | (roc_9_1d > -20.0))
+            & ((rsi_3_4h > 5.0) | (rsi_3_1d > 15.0) | (roc_9_1d_gt_neg_20))
             # 4h & 1d down move, 1d still high
             & ((rsi_3_4h > 5.0) | (rsi_3_1d > 20.0) | (aroonu_14_1d < 40.0))
             # 4h & 1d down move, 1d still high
@@ -17101,9 +17107,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h & 1d down move, 1d high
             & ((rsi_3_4h > 5.0) | (rsi_3_1d > 30.0) | (aroonu_14_1d < 70.0))
             # 4h down move, 1h & 4h downtrend
-            & ((rsi_3_4h > 5.0) | (roc_9_1h > -15.0) | (roc_9_4h > -20.0))
+            & ((rsi_3_4h > 5.0) | (roc_9_1h > -15.0) | (roc_9_4h_gt_neg_20))
             # 4h down move, 4h & 1d downtrend
-            & ((rsi_3_4h > 5.0) | (roc_9_4h > -20.0) | (roc_9_1d > -20.0))
+            & ((rsi_3_4h > 5.0) | (roc_9_4h_gt_neg_20) | (roc_9_1d_gt_neg_20))
             # 4h & 1d down move, 15m still not low enough
             & ((rsi_3_4h > 10.0) | (rsi_3_1d > 10.0) | (aroonu_14_15m < 30.0))
             # 4h & 1d down move, 1d downtrend
@@ -17165,17 +17171,17 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 15m high
             & (rsi_3_4h_gt_20 | (stochrsi_k_15m < 70.0))
             # 4h down move, 4h still not low enough, 1d downtrend
-            & (rsi_3_4h_gt_20 | (stochrsi_k_4h < 30.0) | (roc_9_1d > -20.0))
+            & (rsi_3_4h_gt_20 | (stochrsi_k_4h < 30.0) | (roc_9_1d_gt_neg_20))
             # 4h down move, 4h & 1d downtrend
-            & (rsi_3_4h_gt_20 | (roc_9_4h > -20.0) | (roc_9_1d > -20.0))
+            & (rsi_3_4h_gt_20 | (roc_9_4h_gt_neg_20) | (roc_9_1d_gt_neg_20))
             # 4h down move, 1d high, 4h downtrend
-            & (rsi_3_4h_gt_20 | (stochrsi_k_1d < 80.0) | (roc_9_4h > -20.0))
+            & (rsi_3_4h_gt_20 | (stochrsi_k_1d < 80.0) | (roc_9_4h_gt_neg_20))
             # 4h & 1d down move, 1h high
             & ((rsi_3_4h > 25.0) | (rsi_3_1d > 25.0) | (aroonu_14_1h < 90.0))
             # 4h & 1d down move, 1d high
             & ((rsi_3_4h > 25.0) | (rsi_3_1d > 25.0) | (aroonu_14_1d < 90.0))
             # 4h down move, 4h still high, 1d downtrend
-            & ((rsi_3_4h > 25.0) | (aroonu_14_4h < 40.0) | (roc_9_1d > -20.0))
+            & ((rsi_3_4h > 25.0) | (aroonu_14_4h < 40.0) | (roc_9_1d_gt_neg_20))
             # 4h down move, 4h high, 1h downtrend
             & ((rsi_3_4h > 25.0) | (aroonu_14_4h < 60.0) | (roc_9_1h > -10.0))
             # 4h down move, 1d high & overbought
@@ -17183,11 +17189,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 1d high, 4h downtrend
             & ((rsi_3_4h > 25.0) | (aroonu_14_1d < 100.0) | (roc_9_4h > -20.0))
             # 4h down move, 4h still high, 1d downtrend
-            & ((rsi_3_4h > 25.0) | (stochrsi_k_4h < 40.0) | (roc_9_1d > -30.0))
+            & ((rsi_3_4h > 25.0) | (stochrsi_k_4h < 40.0) | (roc_9_1d_gt_neg_30))
             # 4h down move, 4h high, 1d downtrend
-            & ((rsi_3_4h > 25.0) | (stochrsi_k_4h < 70.0) | (roc_9_1d > -20.0))
+            & ((rsi_3_4h > 25.0) | (stochrsi_k_4h < 70.0) | (roc_9_1d_gt_neg_20))
             # 4h down move, 1d overbought
-            & ((rsi_3_4h > 25.0) | (roc_9_1d < 100.0))
+            & ((rsi_3_4h > 25.0) | (roc_9_1d_lt_100))
             # 4h down move, 1h high, 4h downtrend
             & ((rsi_3_4h > 30.0) | (aroonu_14_1h < 60.0) | (roc_9_4h > -10.0))
             # 4h down move, 4h still high, 1d high
@@ -17227,7 +17233,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 4h high & overbought
             & ((rsi_3_4h > 60.0) | (stochrsi_k_4h < 80.0) | (roc_9_4h < 10.0))
             # 1d down move, 1d high, 1d downtrend
-            & ((rsi_3_1d > 15.0) | (aroonu_14_1d < 70.0) | (roc_9_1d > -20.0))
+            & ((rsi_3_1d > 15.0) | (aroonu_14_1d < 70.0) | (roc_9_1d_gt_neg_20))
             # 1d down move, 1d still high
             & ((rsi_3_1d > 15.0) | (stochrsi_k_1d < 40.0))
             # 1d down move, 4h & 1d downtrend
@@ -17237,9 +17243,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1d down move, 4h high, 4h downtrend
             & ((rsi_3_1d > 20.0) | (aroonu_14_4h < 50.0) | (roc_9_4h > -40.0))
             # 1d down move, 1d high, 1d downtrend
-            & ((rsi_3_1d > 25.0) | (aroonu_14_1d < 80.0) | (roc_9_1d > -30.0))
+            & ((rsi_3_1d > 25.0) | (aroonu_14_1d < 80.0) | (roc_9_1d_gt_neg_30))
             # 1d down move, 1d still high, 1d downtrend
-            & ((rsi_3_1d > 25.0) | (stochrsi_k_1d < 50.0) | (roc_9_1d > -20.0))
+            & ((rsi_3_1d > 25.0) | (stochrsi_k_1d < 50.0) | (roc_9_1d_gt_neg_20))
             # 1d down move, 4h & 1d high
             & ((rsi_3_1d > 30.0) | (aroonu_14_4h < 90.0) | (aroonu_14_1d < 90.0))
             # 1h & 4h downtrend, 4h high
@@ -17249,13 +17255,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1d high, 4h overbought
             & ((aroonu_14_15m < 70.0) | (aroonu_14_1d < 100.0) | (roc_9_4h < 20.0))
             # 15m & 4h high, 1d downtrend
-            & ((aroonu_14_15m < 85.0) | (aroonu_14_4h < 85.0) | (roc_9_1d > -20.0))
+            & ((aroonu_14_15m < 85.0) | (aroonu_14_4h < 85.0) | (roc_9_1d_gt_neg_20))
             # 1h still high, 1h & 4h downtrend
             & ((aroonu_14_1h < 50.0) | (roc_9_1h > -20.0) | (roc_9_4h > -30.0))
             # 1h & 4h high, 4h overbought
             & ((aroonu_14_1h < 80.0) | (aroonu_14_4h < 100.0) | (roc_9_4h < 10.0))
             # 4h high, 4h & 1d downtrend
-            & ((aroonu_14_4h < 60.0) | (roc_9_4h > -30.0) | (roc_9_1d > -30.0))
+            & ((aroonu_14_4h < 60.0) | (roc_9_4h > -30.0) | (roc_9_1d_gt_neg_30))
             # 4h & 1d high, 4h overbought
             & (aroonu_14_4h_lt_70 | (aroonu_14_1d < 100.0) | (roc_9_4h < 30.0))
             # 4h & 1d high, 1d overbought
@@ -17265,7 +17271,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1d high, 4h & 1d overbought
             & ((aroonu_14_1d < 70.0) | (roc_9_4h < 30.0) | (roc_9_1d < 200.0))
             # 1d high, 4h downtrend, 1d overbought
-            & ((aroonu_14_1d < 85.0) | (roc_9_4h > -20.0) | (roc_9_1d < 200.0))
+            & ((aroonu_14_1d < 85.0) | (roc_9_4h_gt_neg_20) | (roc_9_1d < 200.0))
             # 1d high, 1h & 4h downtrend
             & ((aroonu_14_1d < 100.0) | (roc_9_1h > -30.0) | (roc_9_4h > -30.0))
             # 1d high, 1h & 1d overbought
@@ -17273,13 +17279,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1d high, 4h & 1d overbought
             & ((aroonu_14_1d < 100.0) | (roc_9_4h < 30.0) | (roc_9_1d < 60.0))
             # 15m still high, 1h & 4h downtrend
-            & ((stochrsi_k_15m < 50.0) | (roc_9_1h > -20.0) | (roc_9_4h > -20.0))
+            & ((stochrsi_k_15m < 50.0) | (roc_9_1h > -20.0) | (roc_9_4h_gt_neg_20))
             # 4h high, 1h & 4h overbought
             & ((stochrsi_k_4h < 90.0) | (roc_9_1h < 20.0) | (roc_9_4h < 30.0))
             # 4h high, 4h & 1d overbought
-            & ((stochrsi_k_4h < 90.0) | (roc_9_4h < 20.0) | (roc_9_1d < 80.0))
+            & ((stochrsi_k_4h < 90.0) | (roc_9_4h_lt_20) | (roc_9_1d < 80.0))
             # 1d still high, 4h & 1d downtrend
-            & ((stochrsi_k_1d < 50.0) | (roc_9_4h > -30.0) | (roc_9_1d > -30.0))
+            & ((stochrsi_k_1d < 50.0) | (roc_9_4h > -30.0) | (roc_9_1d_gt_neg_30))
             # big drop in the last 20 days, 1d high, 1d downtrend
             & ((close > (high_max_20_1d * 0.20)) | (stochrsi_k_1d < 70.0) | (roc_9_1d > -15.0))
           )
@@ -17316,11 +17322,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 5m down move, 4h high & overbought
             & ((rsi_3 > 3.0) | (aroonu_14_4h < 100.0) | (roc_9_4h < 20.0))
             # 5m down move, 1h high, 4h overbought
-            & ((rsi_3 > 3.0) | (stochrsi_k_1h < 80.0) | (roc_9_4h < 20.0))
+            & ((rsi_3 > 3.0) | (stochrsi_k_1h < 80.0) | (roc_9_4h_lt_20))
             # 5m down move, 1d high & overbought
             & ((rsi_3 > 3.0) | (stochrsi_k_1d < 90.0) | (roc_9_1d < 20.0))
             # 5m & 1h down move, 1d overbought
-            & ((rsi_3 > 5.0) | (rsi_3_1h > 25.0) | (roc_9_1d < 100.0))
+            & ((rsi_3 > 5.0) | (rsi_3_1h > 25.0) | (roc_9_1d_lt_100))
             # 5m & 1d down move, 1h high
             & ((rsi_3 > 5.0) | (rsi_3_1d > 20.0) | (aroonu_14_1h < 90.0))
             # 5m & 1h down move, 1h high
@@ -17376,7 +17382,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 1d high & overbought
             & (rsi_3_15m_gt_3 | (aroonu_14_1d < 100.0) | (roc_9_1d < 40.0))
             # 15m down move, 1h high, 1d downtrend
-            & (rsi_3_15m_gt_3 | (stochrsi_k_1h < 80.0) | (roc_9_1d > -20.0))
+            & (rsi_3_15m_gt_3 | (stochrsi_k_1h < 80.0) | (roc_9_1d_gt_neg_20))
             # 15m down move, 4h high & overbought
             & (rsi_3_15m_gt_3 | (stochrsi_k_4h < 80.0) | (roc_9_4h < 40.0))
             # 15m down move, 4h high, 1d overbought
@@ -17420,7 +17426,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 4h high & overbought
             & ((rsi_3_15m > 5.0) | (aroonu_14_4h < 80.0) | (roc_9_4h < 50.0))
             # 15m down move, 1d still high, 1d downtrend
-            & ((rsi_3_15m > 5.0) | (stochrsi_k_1d < 50.0) | (roc_9_1d > -20.0))
+            & ((rsi_3_15m > 5.0) | (stochrsi_k_1d < 50.0) | (roc_9_1d_gt_neg_20))
             # 15m down move, 1d downtrend
             & ((rsi_3_15m > 5.0) | (roc_9_1d > -60.0))
             # 15m down move, 1h & 1d high
@@ -17448,7 +17454,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 4h high
             & ((rsi_3_15m > 10.0) | (rsi_3_1h > 25.0) | (stochrsi_k_4h < 80.0))
             # 15m & 1h down move, 4h overbought
-            & ((rsi_3_15m > 10.0) | (rsi_3_1h > 25.0) | (roc_9_4h < 20.0))
+            & ((rsi_3_15m > 10.0) | (rsi_3_1h > 25.0) | (roc_9_4h_lt_20))
             # 15m & 1h down move, 1h high
             & ((rsi_3_15m > 10.0) | (rsi_3_1h > 30.0) | (stochrsi_k_1h < 60.0))
             # 15m & 1h down move, 1d high
@@ -17472,7 +17478,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1d down move, 4h high
             & ((rsi_3_15m > 10.0) | (rsi_3_1d > 20.0) | (stochrsi_k_4h < 70.0))
             # 15m down move, 15m still high, 1d downtrend
-            & ((rsi_3_15m > 10.0) | (aroonu_14_15m < 40.0) | (roc_9_1d > -30.0))
+            & ((rsi_3_15m > 10.0) | (aroonu_14_15m < 40.0) | (roc_9_1d_gt_neg_30))
             # 15m down move, 15m still high, 1d overbought
             & ((rsi_3_15m > 10.0) | (aroonu_14_15m < 50.0) | (roc_9_1d < 30.0))
             # 15m down move, 15m high, 1h high
@@ -17522,13 +17528,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 4h high, 1d overbought
             & ((rsi_3_15m > 15.0) | (stochrsi_k_4h < 90.0) | (roc_9_1d < 30.0))
             # 15m down move, 1d high & overbought
-            & ((rsi_3_15m > 15.0) | (stochrsi_k_1d < 90.0) | (roc_9_1d < 100.0))
+            & ((rsi_3_15m > 15.0) | (stochrsi_k_1d < 90.0) | (roc_9_1d_lt_100))
             # 15m down move, 4h & 1d downtrend
             & ((rsi_3_15m > 15.0) | (roc_9_4h > -10.0) | (roc_9_1d > -40.0))
             # 15m & 1h down move, 4h high
             & ((rsi_3_15m > 20.0) | rsi_3_1h_gt_20 | (stochrsi_k_4h < 80.0))
             # 15m & 1h down move, 1d overbought
-            & ((rsi_3_15m > 20.0) | (rsi_3_1h > 25.0) | (roc_9_1d < 100.0))
+            & ((rsi_3_15m > 20.0) | (rsi_3_1h > 25.0) | (roc_9_1d_lt_100))
             # 15m & 1d down move, 4h high
             & ((rsi_3_15m > 20.0) | (rsi_3_1d > 20.0) | (aroonu_14_4h < 90.0))
             # 15m down move, 15m & 1h high
@@ -17558,7 +17564,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 1d overbought
             & ((rsi_3_1h > 3.0) | (rsi_3_4h > 25.0) | (roc_9_1d < 20.0))
             # 1h down move, 4h still high, 1d downtrend
-            & ((rsi_3_1h > 3.0) | (stochrsi_k_4h < 50.0) | (roc_9_1d > -20.0))
+            & ((rsi_3_1h > 3.0) | (stochrsi_k_4h < 50.0) | (roc_9_1d_gt_neg_20))
             # 1h & 4h down move, 1h still high
             & ((rsi_3_1h > 5.0) | (rsi_3_4h > 10.0) | (aroonu_14_1h < 50.0))
             # 1h & 4h down move, 1d high
@@ -17568,11 +17574,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 4h still high
             & ((rsi_3_1h > 5.0) | (rsi_3_4h > 35.0) | (rsi_14_4h < 40.0))
             # 1h down move, 4h high, 1d downtrend
-            & ((rsi_3_1h > 5.0) | aroonu_14_4h_lt_70 | (roc_9_1d > -30.0))
+            & ((rsi_3_1h > 5.0) | aroonu_14_4h_lt_70 | (roc_9_1d_gt_neg_30))
             # 1h down move, 1d high, 1h downtrend
             & ((rsi_3_1h > 5.0) | (aroonu_14_1d < 90.0) | (roc_9_1h > -40.0))
             # 1h down move, 4h & 1d downtrend
-            & ((rsi_3_1h > 5.0) | (roc_9_4h > -20.0) | (roc_9_1d > -20.0))
+            & ((rsi_3_1h > 5.0) | (roc_9_4h_gt_neg_20) | (roc_9_1d_gt_neg_20))
             # 1h & 4h & 1d down move
             & ((rsi_3_1h > 10.0) | (rsi_3_4h > 10.0) | (rsi_3_1d > 15.0))
             # 1h & 4h down move, 1d downtrend
@@ -17646,7 +17652,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1d high, 4h downtrend
             & ((rsi_3_1h > 25.0) | (aroonu_14_1d < 80.0) | (roc_9_4h > -70.0))
             # 1h down move, 4h high, 1d downtrend
-            & ((rsi_3_1h > 25.0) | (stochrsi_k_4h < 80.0) | (roc_9_1d > -30.0))
+            & ((rsi_3_1h > 25.0) | (stochrsi_k_4h < 80.0) | (roc_9_1d_gt_neg_30))
             # 1h down move, 4h & 1d downtrend
             & ((rsi_3_1h > 25.0) | (roc_9_4h > -30.0) | (roc_9_1d > -60.0))
             # 1h & 4h down move, 1h high
@@ -17672,7 +17678,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1d high & overbought
             & ((rsi_3_1h > 35.0) | (aroonu_14_1d < 100.0) | (roc_9_1d < 200.0))
             # 1h down move, 1h high, 4h downtrend
-            & ((rsi_3_1h > 35.0) | (stochrsi_k_1h < 70.0) | (roc_9_4h > -20.0))
+            & ((rsi_3_1h > 35.0) | (stochrsi_k_1h < 70.0) | (roc_9_4h_gt_neg_20))
             # 1h & 1d down move, 1h high
             & ((rsi_3_1h > 40.0) | (rsi_3_1d > 40.0) | (aroonu_14_1h < 90.0))
             # 1h down move, 1h high, 1d downtrend
@@ -17680,11 +17686,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 4h high, 1d overbought
             & ((rsi_3_1h > 40.0) | (aroonu_14_4h < 80.0) | (roc_9_1d < 40.0))
             # 1h down move, 4h high & overbought
-            & ((rsi_3_1h > 40.0) | (aroonu_14_4h < 90.0) | (roc_9_4h < 20.0))
+            & ((rsi_3_1h > 40.0) | (aroonu_14_4h < 90.0) | (roc_9_4h_lt_20))
             # 1h down move, 1h high, 4h overbought
-            & ((rsi_3_1h > 40.0) | (stochrsi_k_1h < 80.0) | (roc_9_4h < 20.0))
+            & ((rsi_3_1h > 40.0) | (stochrsi_k_1h < 80.0) | (roc_9_4h_lt_20))
             # 1h down move, 4h high & overbought
-            & ((rsi_3_1h > 40.0) | (stochrsi_k_4h < 80.0) | (roc_9_4h < 20.0))
+            & ((rsi_3_1h > 40.0) | (stochrsi_k_4h < 80.0) | (roc_9_4h_lt_20))
             # 1h down move, 1d high, 4h overbought
             & ((rsi_3_1h > 45.0) | (aroonu_14_1d < 100.0) | (roc_9_4h < 40.0))
             # 1h down move, 1h high, 1d downtrend
@@ -17730,11 +17736,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 4h still high, 1d downtrend
             & ((rsi_3_4h > 30.0) | (aroonu_14_4h < 50.0) | (roc_9_1d > -40.0))
             # 4h down move, 1d high, 1d downtrend
-            & ((rsi_3_4h > 35.0) | (stochrsi_k_1d < 60.0) | (roc_9_1d > -30.0))
+            & ((rsi_3_4h > 35.0) | (stochrsi_k_1d < 60.0) | (roc_9_1d_gt_neg_30))
             # 4h down move, 1d high, 1d downtrend
             & ((rsi_3_4h > 45.0) | (aroonu_14_1d < 80.0) | (roc_9_1d > -15.0))
             # 4h down move, 4h still high, 1d downtrend
-            & ((rsi_3_4h > 50.0) | (rsi_14_4h < 40.0) | (roc_9_1d > -30.0))
+            & ((rsi_3_4h > 50.0) | (rsi_14_4h < 40.0) | (roc_9_1d_gt_neg_30))
             # 1d down move, 4h high, 1d downtrend
             & ((rsi_3_1d > 15.0) | (stochrsi_k_4h < 70.0) | (roc_9_1d > -70.0))
             # 1d down move, 1h high & overbought
@@ -17748,7 +17754,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1d high, 1d overbought
             & ((aroonu_14_15m < 70.0) | (aroonu_14_1d < 90.0) | (roc_9_1d < 30.0))
             # 1h still high, 4h & 1d downtrend
-            & ((aroonu_14_1h < 40.0) | (roc_9_4h > -20.0) | (roc_9_1d > -40.0))
+            & ((aroonu_14_1h < 40.0) | (roc_9_4h_gt_neg_20) | (roc_9_1d > -40.0))
             # 1h & 4h high, 1d downtrend
             & ((aroonu_14_1h < 70.0) | (aroonu_14_4h < 100.0) | (roc_9_1d > -20.0))
             # 1h & 4h high, 1d overbought
@@ -17772,7 +17778,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h & 1d high, 4h overbought
             & ((aroonu_14_4h < 90.0) | (aroonu_14_1d < 100.0) | (roc_9_4h < 100.0))
             # 4h high, 1h & 4h overbought
-            & ((aroonu_14_4h < 90.0) | (roc_9_1h < 10.0) | (roc_9_4h < 20.0))
+            & ((aroonu_14_4h < 90.0) | (roc_9_1h < 10.0) | (roc_9_4h_lt_20))
             # 4h & 1d high, 4h overbought
             & ((aroonu_14_4h < 100.0) | (aroonu_14_1d < 100.0) | (roc_9_4h < 30.0))
             # 4h & 1d high, 1d overbought
@@ -17790,9 +17796,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h high, 1h & 4h overbought
             & ((stochrsi_k_4h < 80.0) | (roc_9_1h < 40.0) | (roc_9_4h < 100.0))
             # 1d high, 4h & 1d overbought
-            & ((stochrsi_k_1d < 90.0) | (roc_9_4h < 20.0) | (roc_9_1d < 100.0))
+            & ((stochrsi_k_1d < 90.0) | (roc_9_4h_lt_20) | (roc_9_1d_lt_100))
             # 1h & 4h overbought, 1d downtrend
-            & ((roc_9_1h < 40.0) | (roc_9_4h < 50.0) | (roc_9_1d > -30.0))
+            & ((roc_9_1h < 40.0) | (roc_9_4h < 50.0) | (roc_9_1d_gt_neg_30))
             # big drop in the last 20 days, 1d high, 1d downtrend
             & ((close > (high_max_20_1d * 0.20)) | (stochrsi_k_1d < 70.0) | (roc_9_1d > -15.0))
           )
@@ -17825,7 +17831,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h & 4h down move
             & (rsi_3_15m_gt_3 | (rsi_3_1h > 5.0) | (rsi_3_4h > 10.0))
             # 15m & 1h down move, 1d downtrend
-            & (rsi_3_15m_gt_3 | (rsi_3_1h > 5.0) | (roc_9_1d > -30.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h > 5.0) | (roc_9_1d_gt_neg_30))
             # 15m & 1h down move, 1d high
             & (rsi_3_15m_gt_3 | (rsi_3_1h > 10.0) | (aroonu_14_1d < 100.0))
             # 15m & 1h down move, 1h high
@@ -17865,7 +17871,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 4h & 1d downtrend
             & ((rsi_3_15m > 15.0) | (roc_9_4h > -10.0) | (roc_9_1d > -40.0))
             # 15m down move, 1h high & overbought
-            & ((rsi_3_15m > 25.0) | (aroonu_14_1d < 90.0) | (roc_9_1d < 100.0))
+            & ((rsi_3_15m > 25.0) | (aroonu_14_1d < 90.0) | (roc_9_1d_lt_100))
             # 1h & 4h down move, 1h still not low enough
             & ((rsi_3_1h > 3.0) | (rsi_3_4h > 3.0) | (aroonu_14_1h < 20.0))
             # 1h & 4h down move
@@ -17887,7 +17893,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h downtrend, 4h high
             & ((rsi_3_1h > 3.0) | (stochrsi_k_4h < 70.0))
             # 1h down move, 1h & 4h downtrend
-            & ((rsi_3_1h > 3.0) | (roc_9_1h > -20.0) | (roc_9_4h > -20.0))
+            & ((rsi_3_1h > 3.0) | (roc_9_1h > -20.0) | (roc_9_4h_gt_neg_20))
             # 1h & 4h down move, 4h still high
             & ((rsi_3_1h > 5.0) | (rsi_3_4h > 10.0) | (aroonu_14_4h < 50.0))
             # 1h & 4h down move, 1d high
@@ -17895,7 +17901,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 4h still high
             & ((rsi_3_1h > 5.0) | (rsi_3_4h > 30.0) | (rsi_14_4h < 40.0))
             # 1h & 1d down move, 1d downtrend
-            & ((rsi_3_1h > 5.0) | (rsi_3_1d > 5.0) | (roc_9_1d > -20.0))
+            & ((rsi_3_1h > 5.0) | (rsi_3_1d > 5.0) | (roc_9_1d_gt_neg_20))
             # 1h down move, 1h high
             & ((rsi_3_1h > 5.0) | (aroonu_14_1h < 60.0))
             # 1h down move, 4h high
@@ -17903,9 +17909,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1d high & overbought
             & ((rsi_3_1h > 5.0) | (aroonu_14_1d < 90.0) | (roc_9_1d < 30.0))
             # 1h down move, 4h & 1d downtrend
-            & ((rsi_3_1h > 5.0) | (roc_9_4h > -20.0) | (roc_9_1d > -25.0))
+            & ((rsi_3_1h > 5.0) | (roc_9_4h_gt_neg_20) | (roc_9_1d > -25.0))
             # 1h down move, 1d overbought
-            & ((rsi_3_1h > 5.0) | (roc_9_1d < 100.0))
+            & ((rsi_3_1h > 5.0) | (roc_9_1d_lt_100))
             # 1h & 4h down move, 1d downtrend
             & ((rsi_3_1h > 10.0) | (rsi_3_4h > 10.0) | (roc_9_1d > -20.0))
             # 1h & 4h down move, 4h still high
@@ -17995,11 +18001,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 4h high, 1d downtrend
             & ((rsi_3_1h > 25.0) | (aroonu_14_4h < 80.0) | (roc_9_1d > -20.0))
             # 1h down move, 1d high & overbought
-            & ((rsi_3_1h > 25.0) | (aroonu_14_1d < 90.0) | (roc_9_1d < 100.0))
+            & ((rsi_3_1h > 25.0) | (aroonu_14_1d < 90.0) | (roc_9_1d_lt_100))
             # 1h down move, 1h still high, 1d overbought
             & ((rsi_3_1h > 25.0) | (stochrsi_k_1h < 50.0) | (roc_9_1d < 40.0))
             # 1h down move, 1h downtrend, 4h overbought
-            & ((rsi_3_1h > 25.0) | (roc_9_1h > -20.0) | (roc_9_4h < 20.0))
+            & ((rsi_3_1h > 25.0) | (roc_9_1h > -20.0) | (roc_9_4h_lt_20))
             # 1h down move, 1d overbought
             & ((rsi_3_1h > 25.0) | (roc_9_1d < 200.0))
             # 1h down move, 4h high
@@ -18015,7 +18021,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 1h still high
             & ((rsi_3_4h > 5.0) | (stochrsi_k_1h < 40.0))
             # 4h down move, 1h & 4h downtrend
-            & ((rsi_3_4h > 5.0) | (roc_9_1h > -15.0) | (roc_9_4h > -20.0))
+            & ((rsi_3_4h > 5.0) | (roc_9_1h > -15.0) | (roc_9_4h_gt_neg_20))
             # 4h down move, 4h downtrend
             & ((rsi_3_4h > 5.0) | (roc_9_4h > -40.0))
             # 4h & 1d down move, 1d high
@@ -18041,9 +18047,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 1d high & overbought
             & ((rsi_3_4h > 30.0) | (aroonu_14_1d < 100.0) | (roc_9_1d < 30.0))
             # 4h down move, 1h high & overbought
-            & ((rsi_3_4h > 35.0) | (aroonu_14_1d < 90.0) | (roc_9_1d < 100.0))
+            & ((rsi_3_4h > 35.0) | (aroonu_14_1d < 90.0) | (roc_9_1d_lt_100))
             # 4h down move, 4h still high, 1d downtrend
-            & ((rsi_3_4h > 50.0) | (rsi_14_4h < 40.0) | (roc_9_1d > -30.0))
+            & ((rsi_3_4h > 50.0) | (rsi_14_4h < 40.0) | (roc_9_1d_gt_neg_30))
             # 4h down move, 4h high, 1d overbought
             & ((rsi_3_4h > 50.0) | aroonu_14_4h_lt_70 | (roc_9_1d < 40.0))
             # 4h down move, 4h high
@@ -18053,7 +18059,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h downtrend, 4h high
             & ((cmf_20_4h > -0.50) | aroonu_14_4h_lt_70)
             # 1h & 1d high, 4h downtrend
-            & ((aroonu_14_1h < 40.0) | (aroonu_14_1d < 70.0) | (roc_9_4h > -20.0))
+            & ((aroonu_14_1h < 40.0) | (aroonu_14_1d < 70.0) | (roc_9_4h_gt_neg_20))
             # 1h still high, 1h & 4h downtrend
             & ((aroonu_14_1h < 40.0) | (roc_9_1h > -20.0) | (roc_9_4h > -30.0))
             # 1h & 4h high, 1d overbought
@@ -18077,7 +18083,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h high, 1d downtrend
             & ((aroonu_14_4h < 80.0) | (roc_9_1d > -30.0))
             # 1d still high, 1d downtrend
-            & ((aroonu_14_1d < 50.0) | (roc_9_1d > -30.0))
+            & ((aroonu_14_1d < 50.0) | (roc_9_1d_gt_neg_30))
             # 1d high, 15m downtrend
             & ((aroonu_14_1d < 70.0) | (roc_9_15m > -50.0))
             # 1d high, 1h downtrend
@@ -18091,7 +18097,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1d high, 4h & 1d overbought
             & ((aroonu_14_1d < 100.0) | (roc_9_4h < 20.0) | (roc_9_1d < 80.0))
             # 1h still high, 4h & 1d downtrend
-            & ((stochrsi_k_1h < 50.0) | (roc_9_4h > -20.0) | roc_9_1d_gt_neg_50)
+            & ((stochrsi_k_1h < 50.0) | (roc_9_4h_gt_neg_20) | roc_9_1d_gt_neg_50)
             # 1h high, 15m downtrend
             & ((stochrsi_k_1h < 70.0) | (roc_9_15m > -30.0))
             # 4h high, 1d downtrend
@@ -18099,7 +18105,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1d high, 1h downtrend
             & ((stochrsi_k_1d < 90.0) | (roc_9_1h > -20.0))
             # 1d high, 1d downtrend
-            & ((stochrsi_k_1d < 60.0) | (roc_9_1d > -30.0))
+            & ((stochrsi_k_1d < 60.0) | (roc_9_1d_gt_neg_30))
             # 15m downtrend, 1d overbought
             & ((roc_9_15m > -60.0) | (roc_9_1d < 200.0))
             # 1h downtrend, 1d overbought
@@ -18288,7 +18294,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 4h down move, 1d high
           long_entry_logic.append((rsi_3_4h > 25.0) | (stochrsi_k_1d < 90.0))
           # 4h down move, 4h & 1d downtrend
-          long_entry_logic.append((rsi_3_4h > 25.0) | (roc_9_4h > -20.0) | (roc_9_1d > -20.0))
+          long_entry_logic.append((rsi_3_4h > 25.0) | (roc_9_4h_gt_neg_20) | (roc_9_1d_gt_neg_20))
           # 4h down move, 4h & 1d high
           long_entry_logic.append((rsi_3_4h > 30.0) | (aroonu_14_4h < 80.0) | (aroonu_14_1d < 100.0))
           # 4h down move, 1h high
@@ -18314,17 +18320,17 @@ class NostalgiaForInfinityX7(IStrategy):
           # 4h high, 1d overbought
           long_entry_logic.append(aroonu_14_4h_lt_70 | (roc_9_1d < 80.0))
           # 4h high, 1h & 1d downtrend
-          long_entry_logic.append(aroonu_14_4h_lt_70 | (roc_9_1h > -20.0) | (roc_9_1d > -20.0))
+          long_entry_logic.append(aroonu_14_4h_lt_70 | (roc_9_1h > -20.0) | (roc_9_1d_gt_neg_20))
           # 4h high, 1h & 4h overbought
           long_entry_logic.append((aroonu_14_4h < 80.0) | (roc_9_1h < 10.0) | (roc_9_4h < 10.0))
           # 4h high & overbought
           long_entry_logic.append((aroonu_14_4h < 90.0) | (roc_9_4h < 80.0))
           # 1d high, 4h & 1d downtrend
-          long_entry_logic.append((aroonu_14_1d < 80.0) | (roc_9_4h > -20.0) | (roc_9_1d > -20.0))
+          long_entry_logic.append((aroonu_14_1d < 80.0) | (roc_9_4h_gt_neg_20) | (roc_9_1d_gt_neg_20))
           # 1h high, 4h overbought
           long_entry_logic.append((stochrsi_k_1h < 80.0) | (roc_9_4h < 80.0))
           # 4h high, 1h & 1d downtrend
-          long_entry_logic.append((stochrsi_k_4h < 70.0) | (roc_9_1h > -20.0) | (roc_9_1d > -20.0))
+          long_entry_logic.append((stochrsi_k_4h < 70.0) | (roc_9_1h > -20.0) | (roc_9_1d_gt_neg_20))
           # 4h high, 1h & 4h overbought
           long_entry_logic.append((stochrsi_k_4h < 80.0) | (roc_9_1h < 10.0) | (roc_9_4h < 10.0))
           # 4h high, 4h & 1d overbought
@@ -18509,7 +18515,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1h & 4h down move, 4h still high
           long_entry_logic.append(rsi_3_1h_gt_20 | rsi_3_4h_gt_20 | (aroonu_14_4h < 50.0))
           # 1h & 4h down move, 1d downtrend
-          long_entry_logic.append(rsi_3_1h_gt_20 | rsi_3_4h_gt_20 | (roc_9_1d > -30.0))
+          long_entry_logic.append(rsi_3_1h_gt_20 | rsi_3_4h_gt_20 | (roc_9_1d_gt_neg_30))
           # 1h & 4h down move, 1d high
           long_entry_logic.append(rsi_3_1h_gt_20 | (rsi_3_4h > 35.0) | (aroonu_14_1d < 80.0))
           # 1h & 4h down move, 4h high
@@ -18561,7 +18567,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 4h & 1d down move, 1d high
           long_entry_logic.append((rsi_3_4h > 5.0) | (rsi_3_1d > 30.0) | (aroonu_14_1d < 70.0))
           # 4h down move, 1h & 4h downtrend
-          long_entry_logic.append((rsi_3_4h > 5.0) | (roc_9_1h > -15.0) | (roc_9_4h > -20.0))
+          long_entry_logic.append((rsi_3_4h > 5.0) | (roc_9_1h > -15.0) | (roc_9_4h_gt_neg_20))
           # 4h & 1d down move
           long_entry_logic.append((rsi_3_4h > 10.0) | (rsi_3_1d > 20.0))
           # 4h & 1d down move, 1d high
@@ -18575,9 +18581,9 @@ class NostalgiaForInfinityX7(IStrategy):
           # 4h & 1d down move, 1d overbought
           long_entry_logic.append(rsi_3_4h_gt_20 | (rsi_3_1d > 45.0) | (roc_9_1d < 40.0))
           # 4h down move, 4h still not low enough, 1d downtrend
-          long_entry_logic.append(rsi_3_4h_gt_20 | (stochrsi_k_4h < 30.0) | (roc_9_1d > -20.0))
+          long_entry_logic.append(rsi_3_4h_gt_20 | (stochrsi_k_4h < 30.0) | (roc_9_1d_gt_neg_20))
           # 4h down move, 4h & 1d downtrend
-          long_entry_logic.append(rsi_3_4h_gt_20 | (roc_9_4h > -20.0) | (roc_9_1d > -20.0))
+          long_entry_logic.append(rsi_3_4h_gt_20 | (roc_9_4h_gt_neg_20) | (roc_9_1d_gt_neg_20))
           # 4h down move, 4h high
           long_entry_logic.append((rsi_3_4h > 30.0) | (aroonu_14_4h < 90.0))
           # 4h down move, 4h & 1d high
@@ -18587,11 +18593,11 @@ class NostalgiaForInfinityX7(IStrategy):
           # 4h down move, 4h overbought
           long_entry_logic.append((rsi_3_4h > 60.0) | (roc_9_4h < 40.0))
           # 1d down move, 4h & 1d downtrend
-          long_entry_logic.append((rsi_3_1d > 10.0) | (roc_9_4h > -20.0) | (roc_9_1d > -20.0))
+          long_entry_logic.append((rsi_3_1d > 10.0) | (roc_9_4h_gt_neg_20) | (roc_9_1d_gt_neg_20))
           # 15m down move, 1d high, 1d downtrend
           long_entry_logic.append((rsi_3_1d > 15.0) | (aroonu_14_1d < 70.0) | (roc_9_1d > -40.0))
           # 1d down move, 1d high, 1d downtrend
-          long_entry_logic.append((rsi_3_1d > 25.0) | (aroonu_14_1d < 80.0) | (roc_9_1d > -30.0))
+          long_entry_logic.append((rsi_3_1d > 25.0) | (aroonu_14_1d < 80.0) | (roc_9_1d_gt_neg_30))
           # 4h & 1d high, 4h overbought
           long_entry_logic.append((aroonu_14_4h < 80.0) | (aroonu_14_1d < 100.0) | (roc_9_4h < 20.0))
           # 4h high, 1h overbought
@@ -18603,7 +18609,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 4h high, 4h overbought
           long_entry_logic.append((stochrsi_k_4h < 70.0) | (roc_9_4h < 40.0))
           # 4h high, 4h overbought, 1d downtrend
-          long_entry_logic.append((stochrsi_k_4h < 90.0) | (roc_9_4h < 20.0) | (roc_9_1d > -20.0))
+          long_entry_logic.append((stochrsi_k_4h < 90.0) | (roc_9_4h_lt_20) | (roc_9_1d_gt_neg_20))
           # 1d green, 4h down move, 4h still high
           long_entry_logic.append((change_pct_1d < 40.0) | (rsi_3_4h > 35.0) | (aroonu_14_4h < 40.0))
           # 4h top wick, 1h down move, 1h still high
@@ -18700,7 +18706,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 4h high
             & (rsi_3_15m_gt_3 | (aroonu_14_4h < 80.0))
             # 15m down move, 4h & 1d downtrend
-            & (rsi_3_15m_gt_3 | (roc_9_4h > -20.0) | (roc_9_1d > -20.0))
+            & (rsi_3_15m_gt_3 | (roc_9_4h_gt_neg_20) | (roc_9_1d_gt_neg_20))
             # 15m & 1h down move, 1h still high
             & ((rsi_3_15m > 5.0) | rsi_3_1h_gt_20 | (stochrsi_k_1h < 40.0))
             # 15m & 1h down move, 1h high
@@ -18736,7 +18742,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 4h down move, 4h overbought
             & ((rsi_3_15m > 10.0) | (rsi_3_4h > 55.0) | (roc_9_4h < 50.0))
             # 15m down move, 15m still not low enough, 1d downtrend
-            & ((rsi_3_15m > 10.0) | (aroonu_14_15m < 30.0) | (roc_9_1d > -30.0))
+            & ((rsi_3_15m > 10.0) | (aroonu_14_15m < 30.0) | (roc_9_1d_gt_neg_30))
             # 15m down move, 15m still high, 1d overbought
             & ((rsi_3_15m > 10.0) | (aroonu_14_15m < 50.0) | (roc_9_1d < 30.0))
             # 15m down move, 4h & 1d high
@@ -18760,7 +18766,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 15m still high, 1h high
             & ((rsi_3_15m > 15.0) | (aroonu_14_15m < 50.0) | (aroonu_14_1h < 80.0))
             # 15m down move, 4h high, 4h downtrend
-            & ((rsi_3_15m > 15.0) | (aroonu_14_4h < 60.0) | (roc_9_4h > -20.0))
+            & ((rsi_3_15m > 15.0) | (aroonu_14_4h < 60.0) | (roc_9_4h_gt_neg_20))
             # 15m down move, 1d high, 4h overbought
             & ((rsi_3_15m > 15.0) | (stochrsi_k_1d < 90.0) | (roc_9_4h < 40.0))
             # 15m down move, 1h & 4h overbought
@@ -18768,7 +18774,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 4h & 1d downtrend
             & ((rsi_3_15m > 15.0) | (roc_9_4h > -10.0) | (roc_9_1d > -40.0))
             # 15m down move, 4h & 1d overbought
-            & ((rsi_3_15m > 15.0) | (roc_9_4h < 20.0) | (roc_9_1d < 60.0))
+            & ((rsi_3_15m > 15.0) | (roc_9_4h_lt_20) | (roc_9_1d < 60.0))
             # 15m & 1h down move, 15m high
             & ((rsi_3_15m > 20.0) | rsi_3_1h_gt_20 | (aroonu_14_15m < 60.0))
             # 15m & 1h down move, 1h high
@@ -18778,7 +18784,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 1h high
             & ((rsi_3_15m > 20.0) | (aroonu_14_1h < 90.0))
             # 15m down move, 4h high & overbought
-            & ((rsi_3_15m > 20.0) | aroonu_14_4h_lt_70 | (roc_9_4h < 20.0))
+            & ((rsi_3_15m > 20.0) | aroonu_14_4h_lt_70 | (roc_9_4h_lt_20))
             # 15m down move, 1h high
             & ((rsi_3_15m > 20.0) | (stochrsi_k_1h < 80.0))
             # 15m down move, 4h high
@@ -18852,7 +18858,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h high, 4h overbought
             & (rsi_3_1h_gt_20 | (aroonu_14_1h < 70.0) | (roc_9_4h < 10.0))
             # 1h & 4h down move, 1d overbought
-            & ((rsi_3_1h > 25.0) | (rsi_3_4h > 40.0) | (roc_9_1d < 100.0))
+            & ((rsi_3_1h > 25.0) | (rsi_3_4h > 40.0) | (roc_9_1d_lt_100))
             # 1h down move, 1h & 1d high
             & ((rsi_3_1h > 25.0) | (aroonu_14_1h < 70.0) | (aroonu_14_1d < 90.0))
             # 1h down move, 1h still high, 1d overbought
@@ -18866,15 +18872,15 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h still high, 1d overbought
             & ((rsi_3_1h > 35.0) | (stochrsi_k_1h < 50.0) | (roc_9_1d < 200.0))
             # 1h down move, 1h high, 4h downtrend
-            & ((rsi_3_1h > 35.0) | (stochrsi_k_1h < 70.0) | (roc_9_4h > -20.0))
+            & ((rsi_3_1h > 35.0) | (stochrsi_k_1h < 70.0) | (roc_9_4h_gt_neg_20))
             # 1h down move, 4h & 1d overbought
-            & ((rsi_3_1h > 35.0) | (roc_9_4h < 20.0) | (roc_9_1d < 80.0))
+            & ((rsi_3_1h > 35.0) | (roc_9_4h_lt_20) | (roc_9_1d < 80.0))
             # 1h down move, 1h & 4h high
             & ((rsi_3_1h > 40.0) | (aroonu_14_1h < 70.0) | (aroonu_14_4h < 90.0))
             # 1h down move, 1h high, 1d overbought
             & ((rsi_3_1h > 40.0) | (aroonu_14_1h < 85.0) | (roc_9_1d < 80.0))
             # 1h down move, 1h high, 4h downtrend
-            & ((rsi_3_1h > 40.0) | (stochrsi_k_1h < 80.0) | (roc_9_4h > -20.0))
+            & ((rsi_3_1h > 40.0) | (stochrsi_k_1h < 80.0) | (roc_9_4h_gt_neg_20))
             # 1h down move, 1h high, 1h overbought
             & ((rsi_3_1h > 50.0) | (aroonu_14_1h < 70.0) | (roc_9_1h < 25.0))
             # 1h down move, 4h high, 1d downtrend
@@ -18916,7 +18922,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 1h still not low enough, 1d downtrend
             & ((rsi_3_4h > 15.0) | (stochrsi_k_1h < 20.0) | (roc_9_1d > -20.0))
             # 4h down move, 4h still high, 1d downtrend
-            & (rsi_3_4h_gt_20 | (stochrsi_k_4h < 40.0) | (roc_9_1d > -20.0))
+            & (rsi_3_4h_gt_20 | (stochrsi_k_4h < 40.0) | (roc_9_1d_gt_neg_20))
             # 4h down move, 4h still high, 1d downtrend
             & ((rsi_3_4h > 25.0) | (aroonu_14_4h < 50.0) | (roc_9_1d > -40.0))
             # 4h down move, 4h still high, 1d downtrend
@@ -18928,13 +18934,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 1h high, 1d overbought
             & ((rsi_3_4h > 45.0) | (aroonu_14_1h < 85.0) | roc_9_1d_lt_50)
             # 4h down move, 4h still high, 1d downtrend
-            & ((rsi_3_4h > 50.0) | (rsi_14_4h < 40.0) | (roc_9_1d > -30.0))
+            & ((rsi_3_4h > 50.0) | (rsi_14_4h < 40.0) | (roc_9_1d_gt_neg_30))
             # 4h down move, 4h high & overbought
             & ((rsi_3_4h > 50.0) | (aroonu_14_4h < 80.0) | (roc_9_4h < 10.0))
             # 4h down move, 4h still high, 1d downtrend
-            & ((rsi_3_4h > 50.0) | (stochrsi_k_4h < 50.0) | (roc_9_1d > -30.0))
+            & ((rsi_3_4h > 50.0) | (stochrsi_k_4h < 50.0) | (roc_9_1d_gt_neg_30))
             # 1d down move, 1h still high, 1d downtrend
-            & ((rsi_3_1d > 5.0) | (stochrsi_k_1h < 50.0) | (roc_9_1d > -30.0))
+            & ((rsi_3_1d > 5.0) | (stochrsi_k_1h < 50.0) | (roc_9_1d_gt_neg_30))
             # 1d down move, 1h high, 1d downtrend
             & ((rsi_3_1d > 10.0) | (aroonu_14_1h < 80.0) | (roc_9_1d > -10.0))
             # 1d down move, 1d high, 1d downtrend
@@ -18942,7 +18948,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1d down move, 1h high & overbought
             & ((rsi_3_1d > 35.0) | (stochrsi_k_1h < 90.0) | (roc_9_1h < 10.0))
             # 1d downtrend, 1d high & overbought
-            & ((cmf_20_1d > -0.30) | (aroonu_14_1d < 85.0) | (roc_9_1d < 100.0))
+            & ((cmf_20_1d > -0.30) | (aroonu_14_1d < 85.0) | (roc_9_1d_lt_100))
             # 15m high, 1h high & overbought
             & ((aroonu_14_15m < 60.0) | (aroonu_14_1h < 85.0) | (roc_9_1h < 10.0))
             # 1h high, 4h high, 1h overbought
@@ -18964,7 +18970,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1d high, 1h & 4h downtrend
             & ((aroonu_14_1d < 85.0) | (roc_9_1h > -30.0) | (roc_9_4h > -50.0))
             # 1d high, 1h & 1d overbought
-            & ((aroonu_14_1d < 85.0) | (roc_9_1h < 20.0) | (roc_9_1d < 100.0))
+            & ((aroonu_14_1d < 85.0) | (roc_9_1h < 20.0) | (roc_9_1d_lt_100))
             # 1d high, 4h & 1d overbought
             & ((aroonu_14_1d < 90.0) | (roc_9_4h < 30.0) | (roc_9_1d < 60.0))
             # 1h high, 1d overbought
@@ -19103,7 +19109,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 15m still not low enough
             & ((rsi_3_1h > 3.0) | (stochrsi_k_15m < 20.0))
             # 1h down move, 4h still high, 1d downtrend
-            & ((rsi_3_1h > 3.0) | (stochrsi_k_4h < 50.0) | (roc_9_1d > -20.0))
+            & ((rsi_3_1h > 3.0) | (stochrsi_k_4h < 50.0) | (roc_9_1d_gt_neg_20))
             # 1h & 4h down move, 15m still not low enough
             & ((rsi_3_1h > 5.0) | (rsi_3_4h > 5.0) | (stochrsi_k_15m < 30.0))
             # 1h & 4h down move, 4h still not low enough
@@ -19173,7 +19179,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h high
             & (rsi_3_1h_gt_20 | (aroonu_14_1h < 70.0))
             # 1h down move, 4h still high, 1d downtrend
-            & (rsi_3_1h_gt_20 | (aroonu_14_4h < 40.0) | (roc_9_1d > -20.0))
+            & (rsi_3_1h_gt_20 | (aroonu_14_4h < 40.0) | (roc_9_1d_gt_neg_20))
             # 1h down move, 4h high
             & (rsi_3_1h_gt_20 | (aroonu_14_4h < 85.0))
             # 1h down move, 1h still not low enough, 4h stil high
@@ -19181,7 +19187,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 4h still high, 1d downtrend
             & (rsi_3_1h_gt_20 | (stochrsi_k_4h < 40.0) | (roc_9_1d > -40.0))
             # 1h down move, 1d high, 4h downtrend
-            & (rsi_3_1h_gt_20 | (stochrsi_k_1d < 80.0) | (roc_9_4h > -20.0))
+            & (rsi_3_1h_gt_20 | (stochrsi_k_1d < 80.0) | (roc_9_4h_gt_neg_20))
             # 1h down move, 4h high
             & (rsi_3_1h_gt_20 | (stochrsi_k_4h < 80.0))
             # 1h & 4h down move, 1h still not low enough
@@ -19201,7 +19207,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 4h still high
             & ((rsi_3_1h > 30.0) | (rsi_3_4h > 30.0) | (stochrsi_k_4h < 50.0))
             # 1h & 4h down move, 1d overbought
-            & ((rsi_3_1h > 30.0) | (rsi_3_4h > 30.0) | (roc_9_1d < 100.0))
+            & ((rsi_3_1h > 30.0) | (rsi_3_4h > 30.0) | (roc_9_1d_lt_100))
             # 1h & dh down move, 4h high
             & ((rsi_3_1h > 30.0) | (rsi_3_4h > 50.0) | (aroonu_14_4h < 85.0))
             # 1h down move, 4h & 1d downtrend
@@ -19217,7 +19223,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 4h still high, 1d downtrend
             & ((rsi_3_1h > 30.0) | (stochrsi_k_4h < 40.0) | (roc_9_1d > -80.0))
             # 1h down move, 4h high & overbought
-            & ((rsi_3_1h > 30.0) | (stochrsi_k_4h < 90.0) | (roc_9_4h < 20.0))
+            & ((rsi_3_1h > 30.0) | (stochrsi_k_4h < 90.0) | (roc_9_4h_lt_20))
             # 1h down move, 4h & 1d overbought
             & ((rsi_3_1h > 30.0) | (roc_9_4h < 10.0) | (roc_9_1d < 30.0))
             # 1h & 4h down move, 1h still high
@@ -19235,7 +19241,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h overbought
             & ((rsi_3_1h > 50.0) | (roc_9_1h < 40.0))
             # 1h down move, 4h & 1d overbought
-            & ((rsi_3_1h > 60.0) | (roc_9_4h < 30.0) | (roc_9_1d < 100.0))
+            & ((rsi_3_1h > 60.0) | (roc_9_4h < 30.0) | (roc_9_1d_lt_100))
             # 4h & 1d down move, 1d still high
             & ((rsi_3_4h > 5.0) | (rsi_3_1d > 20.0) | (aroonu_14_1d < 40.0))
             # 4h & 1d down move, 4h still not low enough
@@ -19273,13 +19279,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 15m high, 4h high
             & ((rsi_3_4h > 25.0) | (aroonu_14_15m < 70.0) | (aroonu_14_4h < 80.0))
             # 4h down move, 4h still high, 1d downtrend
-            & ((rsi_3_4h > 25.0) | (aroonu_14_4h < 40.0) | (roc_9_1d > -20.0))
+            & ((rsi_3_4h > 25.0) | (aroonu_14_4h < 40.0) | (roc_9_1d_gt_neg_20))
             # 4h down move, 4h still high, 4h downtrend
             & ((rsi_3_4h > 25.0) | (aroonu_14_4h < 50.0) | (cmf_20_4h > -0.40))
             # 4h down move, 4h high, 1d high
             & ((rsi_3_4h > 30.0) | aroonu_14_4h_lt_70 | (stochrsi_k_1d < 80.0))
             # 4h down move, 1d still high, 1d downtrend
-            & ((rsi_3_4h > 30.0) | (aroonu_14_1d < 40.0) | (roc_9_1d > -20.0))
+            & ((rsi_3_4h > 30.0) | (aroonu_14_1d < 40.0) | (roc_9_1d_gt_neg_20))
             # 4h down move, 1d high & overbought
             & ((rsi_3_4h > 30.0) | (aroonu_14_1d < 100.0) | (roc_9_1d < 20.0))
             # 4h down move, 4h still not low enough, 1d overbought
@@ -19293,23 +19299,23 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 4h high
             & ((rsi_3_4h > 40.0) | (aroonu_14_4h < 100.0))
             # 4h down move, 4h still high, 1d downtrend
-            & ((rsi_3_4h > 50.0) | (rsi_14_4h < 40.0) | (roc_9_1d > -30.0))
+            & ((rsi_3_4h > 50.0) | (rsi_14_4h < 40.0) | (roc_9_1d_gt_neg_30))
             # 4h down move, 4h still high, 1d downtrend
-            & ((rsi_3_4h > 50.0) | (stochrsi_k_4h < 50.0) | (roc_9_1d > -30.0))
+            & ((rsi_3_4h > 50.0) | (stochrsi_k_4h < 50.0) | (roc_9_1d_gt_neg_30))
             # 4h down move, 4h overbought
             & ((rsi_3_4h > 55.0) | (roc_9_4h < 30.0))
             # 4h down move, 4h overbought
             & ((rsi_3_4h > 60.0) | (roc_9_4h < 40.0))
             # 1d down move, 4h & 1d downtrend
-            & ((rsi_3_1d > 10.0) | (roc_9_4h > -20.0) | (roc_9_1d > -30.0))
+            & ((rsi_3_1d > 10.0) | (roc_9_4h_gt_neg_20) | (roc_9_1d_gt_neg_30))
             # 1d down move, 1d high, 1d downtrend
-            & ((rsi_3_1d > 15.0) | (aroonu_14_1d < 70.0) | (roc_9_1d > -20.0))
+            & ((rsi_3_1d > 15.0) | (aroonu_14_1d < 70.0) | (roc_9_1d_gt_neg_20))
             # 1d down move, 4h & 1d downtrend
             & ((rsi_3_1d > 15.0) | (roc_9_4h > -10.0) | (roc_9_1d > -40.0))
             # 4h & 1d downtrend, 1d high
             & ((cmf_20_4h > -0.50) | (cmf_20_1d > -0.50) | (aroonu_14_1d < 85.0))
             # 4h still not low enough, 4h & 1d downtrend
-            & ((aroonu_14_4h < 30.0) | (roc_9_4h > -20.0) | (roc_9_1d > -25.0))
+            & ((aroonu_14_4h < 30.0) | (roc_9_4h_gt_neg_20) | (roc_9_1d > -25.0))
             # 4h & 1d high, 4h overbought
             & (aroonu_14_4h_lt_70 | (aroonu_14_1d < 100.0) | (roc_9_4h < 30.0))
             # 4h & 1d high, 1d overbought
@@ -19317,13 +19323,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h high, 1h & 4h overbought
             & ((aroonu_14_4h < 80.0) | (roc_9_1h < 40.0) | (roc_9_4h < 40.0))
             # 1d high, 4h downtrend, 1d overbought
-            & ((aroonu_14_1d < 85.0) | (roc_9_4h > -20.0) | (roc_9_1d < 200.0))
+            & ((aroonu_14_1d < 85.0) | (roc_9_4h_gt_neg_20) | (roc_9_1d < 200.0))
             # 1d high, 4h & 1d overbought
             & ((aroonu_14_1d < 90.0) | (roc_9_4h < 30.0) | (roc_9_1d < 60.0))
             # 4h high, 1h & 4h overbought
             & ((stochrsi_k_4h < 70.0) | (roc_9_1h < 40.0) | (roc_9_4h < 40.0))
             # 4h high, 4h & 1d overbought
-            & ((stochrsi_k_4h < 80.0) | (roc_9_4h < 20.0) | (roc_9_1d < 20.0))
+            & ((stochrsi_k_4h < 80.0) | (roc_9_4h_lt_20) | (roc_9_1d < 20.0))
             # 1d green, 4h down move, 4h still high
             & ((change_pct_1d < 40.0) | (rsi_3_4h > 35.0) | (aroonu_14_4h < 40.0))
           )
@@ -19353,7 +19359,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 5m & 1d down move, 1d downtrend
             & ((rsi_3 > 3.0) | (rsi_3_1d > 15.0) | (cmf_20_1d > -0.25))
             # 5m down move, 1h high, 4h overbought
-            & ((rsi_3 > 3.0) | (stochrsi_k_1h < 80.0) | (roc_9_4h < 20.0))
+            & ((rsi_3 > 3.0) | (stochrsi_k_1h < 80.0) | (roc_9_4h_lt_20))
             # 5m down move, 1d high & overbought
             & ((rsi_3 > 3.0) | (stochrsi_k_1d < 90.0) | (roc_9_1d < 20.0))
             # 15m & 1h down move, 1h still not low enough
@@ -19413,13 +19419,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 15m still high, 4h high
             & ((rsi_3_15m > 15.0) | (aroonu_14_15m < 50.0) | (stochrsi_k_4h < 80.0))
             # 15m down move, 4h high, 4h downtrend
-            & ((rsi_3_15m > 15.0) | (aroonu_14_4h < 60.0) | (roc_9_4h > -20.0))
+            & ((rsi_3_15m > 15.0) | (aroonu_14_4h < 60.0) | (roc_9_4h_gt_neg_20))
             # 15m down move, 4h & 1d high
             & ((rsi_3_15m > 15.0) | (aroonu_14_4h < 75.0) | (aroonu_14_1d < 100.0))
             # 15m down move, 15m still not low enough, 1h still high
             & ((rsi_3_15m > 15.0) | (stochrsi_k_15m < 30.0) | (stochrsi_k_1h < 50.0))
             # 15m down move, 4h & 1d overbought
-            & ((rsi_3_15m > 15.0) | (roc_9_4h < 20.0) | (roc_9_1d < 60.0))
+            & ((rsi_3_15m > 15.0) | (roc_9_4h_lt_20) | (roc_9_1d < 60.0))
             # 15m & 1h down move, 1h high
             & ((rsi_3_15m > 20.0) | rsi_3_1h_gt_20 | (stochrsi_k_1h < 70.0))
             # 15m & 4h down move, 4h high
@@ -19461,13 +19467,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 4h down move, 4h high
             & ((rsi_3_15m > 35.0) | (rsi_3_4h > 35.0) | (stochrsi_k_4h < 80.0))
             # 15m down move, 15m still high, 4h overbought
-            & ((rsi_3_15m > 35.0) | (aroonu_14_15m < 40.0) | (roc_9_4h < 20.0))
+            & ((rsi_3_15m > 35.0) | (aroonu_14_15m < 40.0) | (roc_9_4h_lt_20))
             # 15m down move, 15m still high, 1d overbought
             & ((rsi_3_15m > 35.0) | (aroonu_14_15m < 40.0) | (roc_9_1d < 30.0))
             # 15m down move, 4h high & overbought
-            & ((rsi_3_15m > 35.0) | (aroonu_14_4h < 60.0) | (roc_9_4h < 20.0))
+            & ((rsi_3_15m > 35.0) | (aroonu_14_4h < 60.0) | (roc_9_4h_lt_20))
             # 15m down move, 4h high & overbought
-            & ((rsi_3_15m > 35.0) | (stochrsi_k_4h < 70.0) | (roc_9_4h < 20.0))
+            & ((rsi_3_15m > 35.0) | (stochrsi_k_4h < 70.0) | (roc_9_4h_lt_20))
             # 15m still high, 4h high
             & ((rsi_3_15m < 40.0) | (aroonu_14_4h < 85.0))
             # 1h & 4h down move, 4h still not low enough
@@ -19495,7 +19501,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h still not low enough
             & ((rsi_3_1h > 3.0) | (stochrsi_k_1h < 30.0))
             # 1h down move, 4h still high, 1d downtrend
-            & ((rsi_3_1h > 3.0) | (stochrsi_k_4h < 50.0) | (roc_9_1d > -20.0))
+            & ((rsi_3_1h > 3.0) | (stochrsi_k_4h < 50.0) | (roc_9_1d_gt_neg_20))
             # 1h down move, 4h high
             & ((rsi_3_1h > 3.0) | (stochrsi_k_4h < 70.0))
             # 1h & 4h down move, 1d high
@@ -19511,7 +19517,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1d high, 4h downtrend
             & ((rsi_3_1h > 5.0) | (aroonu_14_1d < 90.0) | (roc_9_4h > -30.0))
             # 1h down move, 4h downtrend
-            & ((rsi_3_1h > 5.0) | (roc_9_4h > -20.0))
+            & ((rsi_3_1h > 5.0) | (roc_9_4h_gt_neg_20))
             # 1h, 1d downtrend
             & ((rsi_3_1h > 5.0) | roc_9_1d_gt_neg_50)
             # 1h & 4h down move, 4h still not low enough
@@ -19587,7 +19593,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 4h high
             & ((rsi_3_1h > 25.0) | (rsi_3_4h > 50.0) | (aroonu_14_4h < 85.0))
             # 1h & 4h down move, 1d overbought
-            & ((rsi_3_1h > 25.0) | (rsi_3_4h > 50.0) | (roc_9_1d < 100.0))
+            & ((rsi_3_1h > 25.0) | (rsi_3_4h > 50.0) | (roc_9_1d_lt_100))
             # 1h down move, 1h still not low enough, 4h still high
             & ((rsi_3_1h > 25.0) | (stochrsi_k_1h < 30.0) | (stochrsi_k_4h < 50.0))
             # 1h down move, 4h high, 1d downtrend
@@ -19595,11 +19601,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h still high, 1h downtrend
             & ((rsi_3_1h > 25.0) | (aroonu_14_1h < 40.0) | (roc_9_1h > -50.0))
             # 1h down move, 4h high & overbought
-            & ((rsi_3_1h > 25.0) | (aroonu_14_4h < 90.0) | (roc_9_4h < 20.0))
+            & ((rsi_3_1h > 25.0) | (aroonu_14_4h < 90.0) | (roc_9_4h_lt_20))
             # 1h down move, 1h still high, 1d overbought
             & ((rsi_3_1h > 25.0) | (stochrsi_k_1h < 50.0) | (roc_9_1d < 40.0))
             # 1h down move, 4h high & overbought
-            & ((rsi_3_1h > 25.0) | (stochrsi_k_4h < 80.0) | (roc_9_4h < 20.0))
+            & ((rsi_3_1h > 25.0) | (stochrsi_k_4h < 80.0) | (roc_9_4h_lt_20))
             # 1h down move, 4h high, 1d overbought
             & ((rsi_3_1h > 25.0) | (stochrsi_k_4h < 80.0) | (roc_9_1d < 70.0))
             # 1h & 4h down move, 1h high
@@ -19615,7 +19621,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h high
             & ((rsi_3_1h > 30.0) | (aroonu_14_1h < 80.0))
             # 1h down move, 4h high & overbought
-            & ((rsi_3_1h > 30.0) | (aroonu_14_4h < 90.0) | (roc_9_4h < 20.0))
+            & ((rsi_3_1h > 30.0) | (aroonu_14_4h < 90.0) | (roc_9_4h_lt_20))
             # 1h down move, 1d high & overbought
             & ((rsi_3_1h > 30.0) | (aroonu_14_1d < 80.0) | (roc_9_1d < 200.0))
             # 1h down move, 1d high, 4h downtrend
@@ -19651,7 +19657,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h high, 1d overbought
             & ((rsi_3_1h > 40.0) | (aroonu_14_1h < 80.0) | (roc_9_1d < 80.0))
             # 1h down move, 1h high, 4h overbought
-            & ((rsi_3_1h > 40.0) | (stochrsi_k_1h < 80.0) | (roc_9_4h < 20.0))
+            & ((rsi_3_1h > 40.0) | (stochrsi_k_1h < 80.0) | (roc_9_4h_lt_20))
             # 1h down move, 1h & 4h overbought
             & ((rsi_3_1h > 40.0) | (roc_9_1h < 10.0) | (roc_9_4h < 10.0))
             # 1h & 4h down move, 1d overbought
@@ -19661,7 +19667,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 4h high & overbought
             & ((rsi_3_1h > 45.0) | (aroonu_14_4h < 100.0) | (roc_9_4h < 40.0))
             # 1h down move, 1h high, 1d downtrend
-            & ((rsi_3_1h > 50.0) | (aroonu_14_1h < 90.0) | (roc_9_1d > -30.0))
+            & ((rsi_3_1h > 50.0) | (aroonu_14_1h < 90.0) | (roc_9_1d_gt_neg_30))
             # 1h down move, 4h high & overbought
             & ((rsi_3_1h > 50.0) | (aroonu_14_4h < 100.0) | (roc_9_4h < 100.0))
             # 1h down move, 4h high, 1d downtrend
@@ -19679,7 +19685,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 1h still high
             & ((rsi_3_4h > 5.0) | (stochrsi_k_1h < 50.0))
             # 4h down move, 4h & 1d downtrend
-            & ((rsi_3_4h > 5.0) | (roc_9_4h > -15.0) | (roc_9_1d > -20.0))
+            & ((rsi_3_4h > 5.0) | (roc_9_4h > -15.0) | (roc_9_1d_gt_neg_20))
             # 4h & 1d down move, 1d overbought
             & ((rsi_3_4h > 10.0) | (rsi_3_1d > 45.0) | (roc_9_1d < 10.0))
             # 4h down move, 1d still high, 1d downtrend
@@ -19709,7 +19715,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 15m still high
             & (rsi_3_4h_gt_20 | (aroonu_14_15m < 45.0))
             # 4h down move, 1h still not low enough, 1d downtrend
-            & (rsi_3_4h_gt_20 | (aroonu_14_1h < 30.0) | (roc_9_1d > -20.0))
+            & (rsi_3_4h_gt_20 | (aroonu_14_1h < 30.0) | (roc_9_1d_gt_neg_20))
             # 4h down move, 4h still high, 1d high
             & (rsi_3_4h_gt_20 | (aroonu_14_4h < 50.0) | (aroonu_14_1d < 100.0))
             # 4h down move, 1d high & overbought
@@ -19719,7 +19725,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 1h & 4h still high
             & ((rsi_3_4h > 25.0) | (stochrsi_k_1h < 40.0) | (stochrsi_k_4h < 40.0))
             # 4h dowqn move, 4h still high, 1d downtrend
-            & ((rsi_3_4h > 25.0) | (stochrsi_k_4h < 30.0) | (roc_9_1d > -30.0))
+            & ((rsi_3_4h > 25.0) | (stochrsi_k_4h < 30.0) | (roc_9_1d_gt_neg_30))
             # 4h down move, 4h high, 1d overbought
             & ((rsi_3_4h > 30.0) | (aroonu_14_4h < 80.0) | roc_9_1d_lt_50)
             # 4h down move, 1h high, 4h downtrend
@@ -19729,19 +19735,19 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 1d high & overbought
             & ((rsi_3_4h > 40.0) | (aroonu_14_1d < 90.0) | (roc_9_1d < 80.0))
             # 4h down move, 1h high, 1d downtrend
-            & ((rsi_3_4h > 40.0) | (stochrsi_k_1h < 80.0) | (roc_9_1d > -20.0))
+            & ((rsi_3_4h > 40.0) | (stochrsi_k_1h < 80.0) | (roc_9_1d_gt_neg_20))
             # 4h down move, 4h & 1d overbought
             & ((rsi_3_4h > 40.0) | (roc_9_4h < 10.0) | roc_9_1d_lt_50)
             # 4h down move, 4h still high, 1d downtrend
-            & ((rsi_3_4h > 50.0) | (rsi_14_4h < 40.0) | (roc_9_1d > -30.0))
+            & ((rsi_3_4h > 50.0) | (rsi_14_4h < 40.0) | (roc_9_1d_gt_neg_30))
             # 4h down move, 4h high, 1d overbought
             & ((rsi_3_4h > 50.0) | aroonu_14_4h_lt_70 | (roc_9_1d < 40.0))
             # 4h down move, 4h still high, 1d downtrend
-            & ((rsi_3_4h > 50.0) | (stochrsi_k_4h < 50.0) | (roc_9_1d > -30.0))
+            & ((rsi_3_4h > 50.0) | (stochrsi_k_4h < 50.0) | (roc_9_1d_gt_neg_30))
             # 4h down move, 1h high, 1d overbought
             & ((rsi_3_4h > 60.0) | (stochrsi_k_1h < 90.0) | (roc_9_1d < 30.0))
             # 4h down move, 4h high & overbought
-            & ((rsi_3_4h > 60.0) | (stochrsi_k_4h < 70.0) | (roc_9_4h < 20.0))
+            & ((rsi_3_4h > 60.0) | (stochrsi_k_4h < 70.0) | (roc_9_4h_lt_20))
             # 1d down move, 1h high & overbought
             & ((rsi_3_1d > 35.0) | (stochrsi_k_1h < 90.0) | (roc_9_1h < 10.0))
             # 1d down move, 1h high & overbought
@@ -19753,7 +19759,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h & 1d downtrend, 1d high
             & ((cmf_20_4h > -0.30) | (cmf_20_1d > -0.30) | (stochrsi_k_1d < 60.0))
             # 1d downtrend, 1d high & overbought
-            & ((cmf_20_1d > -0.30) | (aroonu_14_1d < 85.0) | (roc_9_1d < 100.0))
+            & ((cmf_20_1d > -0.30) | (aroonu_14_1d < 85.0) | (roc_9_1d_lt_100))
             # 1d downtrend, 1d high & overbought
             & ((cmf_20_1d > -0.40) | (aroonu_14_1d < 85.0) | (roc_9_1d < 20.0))
             # 15m still high, 1h overbought
@@ -19765,9 +19771,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m still high, 4h high & overbought
             & ((aroonu_14_15m < 50.0) | aroonu_14_4h_lt_70 | (roc_9_4h < 30.0))
             # 15m still high, 4h downtrend, 1d overbought
-            & ((aroonu_14_15m < 50.0) | (roc_9_4h > -20.0) | (roc_9_1d < 40.0))
+            & ((aroonu_14_15m < 50.0) | (roc_9_4h_gt_neg_20) | (roc_9_1d < 40.0))
             # 1h still high, 4h & 1d downtrend
-            & ((aroonu_14_1h < 40.0) | (roc_9_4h > -20.0) | (roc_9_1d > -40.0))
+            & ((aroonu_14_1h < 40.0) | (roc_9_4h_gt_neg_20) | (roc_9_1d > -40.0))
             # 1h high, 4h high, 1h overbought
             & ((aroonu_14_1h < 70.0) | (aroonu_14_4h < 100.0) | (roc_9_1h < 20.0))
             # 1h & 4h high, 4h overbought
@@ -19779,11 +19785,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h high, 1d downtrend
             & ((aroonu_14_1h < 80.0) | (roc_9_1d > -40.0))
             # 4h still not low enough, 4h & 1d downtrend
-            & ((aroonu_14_4h < 30.0) | (roc_9_4h > -20.0) | (roc_9_1d > -25.0))
+            & ((aroonu_14_4h < 30.0) | (roc_9_4h_gt_neg_20) | (roc_9_1d > -25.0))
             # 4h still high, 1d high, 4h downtrend
             & ((aroonu_14_4h < 50.0) | (aroonu_14_1d < 100.0) | (roc_9_4h > -30.0))
             # 4h high, 1h & 1d downtrend
-            & (aroonu_14_4h_lt_70 | (roc_9_1h > -20.0) | (roc_9_1d > -20.0))
+            & (aroonu_14_4h_lt_70 | (roc_9_1h > -20.0) | (roc_9_1d_gt_neg_20))
             # 4h & 1d high, 1d overbought
             & ((aroonu_14_4h < 80.0) | (aroonu_14_1d < 100.0) | roc_9_1d_lt_50)
             # 4h & 1d high, 4h overbought
@@ -19791,23 +19797,23 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h high, 1h & 4h overbought
             & ((aroonu_14_4h < 100.0) | (roc_9_1h < 10.0) | (roc_9_4h < 40.0))
             # 1d high, 4h & 1d downtrend
-            & ((aroonu_14_1d < 80.0) | (roc_9_4h > -20.0) | (roc_9_1d > -20.0))
+            & ((aroonu_14_1d < 80.0) | (roc_9_4h_gt_neg_20) | (roc_9_1d_gt_neg_20))
             # 1d high, 1h & 4h downtrend
             & ((aroonu_14_1d < 85.0) | (roc_9_1h > -30.0) | (roc_9_4h > -50.0))
             # 1d high, 1h & 1d overbought
-            & ((aroonu_14_1d < 85.0) | (roc_9_1h < 20.0) | (roc_9_1d < 100.0))
+            & ((aroonu_14_1d < 85.0) | (roc_9_1h < 20.0) | (roc_9_1d_lt_100))
             # 1d high, 1h & 4h down move
             & ((aroonu_14_1d < 100.0) | (roc_9_1h < 25.0) | (roc_9_4h < 60.0))
             # 1d high, 4h & 1d overbought
             & ((aroonu_14_1d < 100.0) | (roc_9_4h < 20.0) | (roc_9_1d < 30.0))
             # 1h high, 4h & 1d overbought
-            & ((stochrsi_k_1h < 90.0) | (roc_9_4h < 20.0) | (roc_9_1d < 100.0))
+            & ((stochrsi_k_1h < 90.0) | (roc_9_4h_lt_20) | (roc_9_1d_lt_100))
             # 4h still high, 4h & 1d downtrend
-            & ((stochrsi_k_4h < 40.0) | (roc_9_4h > -20.0) | (roc_9_1d > -40.0))
+            & ((stochrsi_k_4h < 40.0) | (roc_9_4h_gt_neg_20) | (roc_9_1d > -40.0))
             # 4h high, 1h & 1d downtrend
-            & ((stochrsi_k_4h < 70.0) | (roc_9_1h > -20.0) | (roc_9_1d > -20.0))
+            & ((stochrsi_k_4h < 70.0) | (roc_9_1h > -20.0) | (roc_9_1d_gt_neg_20))
             # 4h high, 4h & 1d overbought
-            & ((stochrsi_k_4h < 70.0) | (roc_9_4h < 20.0) | (roc_9_1d < 30.0))
+            & ((stochrsi_k_4h < 70.0) | (roc_9_4h_lt_20) | (roc_9_1d < 30.0))
             # 4h high, 1h overbought, 1d downtrend
             & ((stochrsi_k_4h < 80.0) | (roc_9_1h < 40.0) | (roc_9_1d > -70.0))
             # 4h high, 4h overbought
@@ -19815,7 +19821,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h high, 1h & 4h overbought
             & ((stochrsi_k_4h < 90.0) | (roc_9_1h < 20.0) | (roc_9_4h < 50.0))
             # 1d high, 4h & 1d overbought
-            & ((stochrsi_k_1d < 90.0) | (roc_9_4h < 40.0) | (roc_9_1d < 100.0))
+            & ((stochrsi_k_1d < 90.0) | (roc_9_4h < 40.0) | (roc_9_1d_lt_100))
             # 1h & 4h overbought
             & ((roc_9_1h < 30.0) | (roc_9_4h < 80.0))
             # 1d green with top wick, 4h high
@@ -19976,7 +19982,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m down move, 1d high & overbought
           long_entry_logic.append((rsi_3_15m > 20.0) | (aroonu_14_1d < 100.0) | (roc_9_1d < 20.0))
           # 15m down move, 1h high, 1d downtrend
-          long_entry_logic.append((rsi_3_15m > 20.0) | (stochrsi_k_1h < 80.0) | (roc_9_1d > -20.0))
+          long_entry_logic.append((rsi_3_15m > 20.0) | (stochrsi_k_1h < 80.0) | (roc_9_1d_gt_neg_20))
           # 15m down move, 1d high & overbought
           long_entry_logic.append((rsi_3_15m > 20.0) | (stochrsi_k_1h < 80.0) | (roc_9_1d < 20.0))
           # 15m & 1h down move, 1h high
@@ -19996,7 +20002,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1h & 4h down move, 4h high
           long_entry_logic.append((rsi_3_1h > 3.0) | (rsi_3_4h > 50.0) | aroonu_14_4h_lt_70)
           # 1h & 4h down move, 4h downtrend
-          long_entry_logic.append((rsi_3_1h > 5.0) | (rsi_3_4h > 5.0) | (roc_9_4h > -20.0))
+          long_entry_logic.append((rsi_3_1h > 5.0) | (rsi_3_4h > 5.0) | (roc_9_4h_gt_neg_20))
           # 1h & 4h down move, 4h downtrend
           long_entry_logic.append((rsi_3_1h > 5.0) | (rsi_3_4h > 15.0) | (roc_9_4h > -30.0))
           # 1h & 4h down move, 4h still not low enough
@@ -20064,9 +20070,9 @@ class NostalgiaForInfinityX7(IStrategy):
           # 4h down move, 4h & 1d downtrend
           long_entry_logic.append((rsi_3_4h > 15.0) | (roc_9_4h > -10.0) | (roc_9_1d > -15.0))
           # 4h down move, 4h & 1d downtrend
-          long_entry_logic.append(rsi_3_4h_gt_20 | (roc_9_4h > -20.0) | (roc_9_1d > -30.0))
+          long_entry_logic.append(rsi_3_4h_gt_20 | (roc_9_4h_gt_neg_20) | (roc_9_1d_gt_neg_30))
           # 4h dowqn move, 4h still high, 1d downtrend
-          long_entry_logic.append((rsi_3_4h > 25.0) | (stochrsi_k_4h < 50.0) | (roc_9_1d > -30.0))
+          long_entry_logic.append((rsi_3_4h > 25.0) | (stochrsi_k_4h < 50.0) | (roc_9_1d_gt_neg_30))
           # 4h down move, 4h & 1d high
           long_entry_logic.append((rsi_3_4h > 35.0) | (aroonu_14_4h < 80.0) | (aroonu_14_1d < 100.0))
           # 4h & 1d down move, 4h still high
@@ -20076,7 +20082,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 4h down move, 4h still high
           long_entry_logic.append((rsi_3_4h > 60.0) | (stochrsi_k_4h < 40.0))
           # 4h down move, 4h overbought
-          long_entry_logic.append((rsi_3_4h > 60.0) | (roc_9_4h < 20.0))
+          long_entry_logic.append((rsi_3_4h > 60.0) | (roc_9_4h_lt_20))
           # 1d down move, 1h still high, 4h high
           long_entry_logic.append((rsi_3_1d > 20.0) | (aroonu_14_1h < 50.0) | (aroonu_14_4h < 85.0))
           # 1d down move, 1h high & overbought
@@ -20086,13 +20092,13 @@ class NostalgiaForInfinityX7(IStrategy):
           # 4h still high, 4h moving lower, 4h overbought
           long_entry_logic.append((aroonu_14_4h < 50.0) | (aroonu_14_4h > aroonu_14_4h.shift(48)) | (roc_9_4h < 40.0))
           # 1h high, 1d downtrend
-          long_entry_logic.append((aroonu_14_1d < 70.0) | (roc_9_1d > -30.0))
+          long_entry_logic.append((aroonu_14_1d < 70.0) | (roc_9_1d_gt_neg_30))
           # 1d high, 4h & 1d overbought
           long_entry_logic.append((aroonu_14_1d < 85.0) | (roc_9_4h < 60.0) | (roc_9_1d < 60.0))
           # 1d high, 4h & 1d overbought
           long_entry_logic.append((aroonu_14_1d < 100.0) | (roc_9_4h < 10.0) | (roc_9_1d < 20.0))
           # 1h high, 4h downtrend
-          long_entry_logic.append((stochrsi_k_1h < 80.0) | (roc_9_4h > -20.0))
+          long_entry_logic.append((stochrsi_k_1h < 80.0) | (roc_9_4h_gt_neg_20))
           # 1h high, 4h overbought
           long_entry_logic.append((stochrsi_k_1h < 80.0) | (roc_9_4h < 80.0))
           # 4h high, 4h & 1d overbought
@@ -20297,7 +20303,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m down move, 15m still not low enough, 4h high
           long_entry_logic.append((rsi_3_15m > 20.0) | (aroonu_14_15m < 30.0) | (stochrsi_k_4h < 70.0))
           # 15m down move, 15m still high, 4d downtrend
-          long_entry_logic.append((rsi_3_15m > 20.0) | (aroonu_14_15m < 40.0) | (roc_9_4h > -20.0))
+          long_entry_logic.append((rsi_3_15m > 20.0) | (aroonu_14_15m < 40.0) | (roc_9_4h_gt_neg_20))
           # 15m down move, 15m still not low enough, 1h still high
           long_entry_logic.append((rsi_3_15m > 20.0) | (stochrsi_k_15m < 30.0) | (aroonu_14_1h < 50.0))
           # 15m down move, 15m & 1h still high
@@ -20323,7 +20329,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m down move, 15m still high, 4h high
           long_entry_logic.append((rsi_3_15m > 25.0) | (aroonu_14_15m < 50.0) | (stochrsi_k_4h < 70.0))
           # 15m down move, 15m high, 1d overbought
-          long_entry_logic.append((rsi_3_15m > 25.0) | (aroonu_14_15m < 70.0) | (roc_9_1d < 100.0))
+          long_entry_logic.append((rsi_3_15m > 25.0) | (aroonu_14_15m < 70.0) | (roc_9_1d_lt_100))
           # 15m down move, 15m high
           long_entry_logic.append((rsi_3_15m > 25.0) | (aroonu_14_15m < 85.0))
           # 15m down move, 1h & 4h high
@@ -20347,7 +20353,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m down move, 15m high
           long_entry_logic.append((rsi_3_15m > 35.0) | (aroonu_14_15m < 80.0))
           # 15m down move, 4h still high, 4h overbought
-          long_entry_logic.append((rsi_3_15m > 35.0) | (stochrsi_k_4h < 50.0) | (roc_9_4h < 20.0))
+          long_entry_logic.append((rsi_3_15m > 35.0) | (stochrsi_k_4h < 50.0) | (roc_9_4h_lt_20))
           # 15m down move, 15m still high, 1h high
           long_entry_logic.append((rsi_3_15m > 40.0) | (rsi_14_15m < 50.0) | (aroonu_14_1h < 80.0))
           # 15m down move, 15m high, 1h high
@@ -20371,7 +20377,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1h down move, 1h still not low enough, 4h high
           long_entry_logic.append((rsi_3_1h > 25.0) | (stochrsi_k_1h < 30.0) | (stochrsi_k_4h < 70.0))
           # 1h down move, 1d still high, 1d downtrend
-          long_entry_logic.append((rsi_3_1h > 25.0) | (stochrsi_k_1d < 50.0) | (roc_9_1d > -20.0))
+          long_entry_logic.append((rsi_3_1h > 25.0) | (stochrsi_k_1d < 50.0) | (roc_9_1d_gt_neg_20))
           # 1h down move, 4h high & overbought
           long_entry_logic.append((rsi_3_1h > 30.0) | aroonu_14_4h_lt_70 | (roc_9_4h < 10.0))
           # 1h down move, 4h high, 1d downtrend
@@ -20385,7 +20391,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1h down move, 1h high, 1d overbought
           long_entry_logic.append((rsi_3_1h > 35.0) | (aroonu_14_1h < 70.0) | (roc_9_1d < 20.0))
           # 1h down move, 4h high, 1d overbought
-          long_entry_logic.append((rsi_3_1h > 40.0) | (rsi_14_4h < 75.0) | (roc_9_1d < 100.0))
+          long_entry_logic.append((rsi_3_1h > 40.0) | (rsi_14_4h < 75.0) | (roc_9_1d_lt_100))
           # 1h down move, 1h still high, 1d high
           long_entry_logic.append((rsi_3_1h > 40.0) | (aroonu_14_1h < 50.0) | (aroonu_14_1d < 85.0))
           # 1h down move, 1h still high, 1d overbought
@@ -20403,33 +20409,33 @@ class NostalgiaForInfinityX7(IStrategy):
           # 4h & 1d down move, 15m still not low enough
           long_entry_logic.append(rsi_3_4h_gt_20 | (rsi_3_1d > 20.0) | (stochrsi_k_15m < 30.0))
           # 4h down move, 4h still not low enough, 1d downtrend
-          long_entry_logic.append(rsi_3_4h_gt_20 | (stochrsi_k_4h < 30.0) | (roc_9_1d > -20.0))
+          long_entry_logic.append(rsi_3_4h_gt_20 | (stochrsi_k_4h < 30.0) | (roc_9_1d_gt_neg_20))
           # 4h down move, 1d high, 4h downtrend
-          long_entry_logic.append((rsi_3_4h > 30.0) | (stochrsi_k_1d < 90.0) | (roc_9_4h > -20.0))
+          long_entry_logic.append((rsi_3_4h > 30.0) | (stochrsi_k_1d < 90.0) | (roc_9_4h_gt_neg_20))
           # 4h down move, 4h high, 1d downtrend
-          long_entry_logic.append((rsi_3_4h > 35.0) | (stochrsi_k_4h < 70.0) | (roc_9_1d > -30.0))
+          long_entry_logic.append((rsi_3_4h > 35.0) | (stochrsi_k_4h < 70.0) | (roc_9_1d_gt_neg_30))
           # 4h & 1d down move, 1d high
           long_entry_logic.append((rsi_3_4h > 40.0) | (rsi_3_1d > 60.0) | (aroonu_14_1d < 100.0))
           # 4h down move, 4h high, 1d downtrend
-          long_entry_logic.append((rsi_3_4h > 60.0) | (stochrsi_k_4h < 80.0) | (roc_9_1d > -20.0))
+          long_entry_logic.append((rsi_3_4h > 60.0) | (stochrsi_k_4h < 80.0) | (roc_9_1d_gt_neg_20))
           # 4h down move, 15m high, 4h overbought
-          long_entry_logic.append((rsi_3_4h > 60.0) | (stochrsi_k_15m < 80.0) | (roc_9_4h < 20.0))
+          long_entry_logic.append((rsi_3_4h > 60.0) | (stochrsi_k_15m < 80.0) | (roc_9_4h_lt_20))
           # 4h down move, 4h & 1d overbought
-          long_entry_logic.append((rsi_3_4h > 60.0) | (roc_9_4h < 20.0) | (roc_9_1d < 20.0))
+          long_entry_logic.append((rsi_3_4h > 60.0) | (roc_9_4h_lt_20) | (roc_9_1d < 20.0))
           # 1d down move, 1h high, 1d downtrend
-          long_entry_logic.append((rsi_3_1d > 10.0) | (aroonu_14_1h < 85.0) | (roc_9_1d > -30.0))
+          long_entry_logic.append((rsi_3_1d > 10.0) | (aroonu_14_1h < 85.0) | (roc_9_1d_gt_neg_30))
           # 1d down move, 15m still not low enough, 1h still high
           long_entry_logic.append((rsi_3_1d > 15.0) | (aroonu_14_15m < 30.0) | (stochrsi_k_1h < 50.0))
           # 15m still not low enough, 1h high, 1d overbought
-          long_entry_logic.append((aroonu_14_15m < 30.0) | (stochrsi_k_1h < 80.0) | (roc_9_1d < 100.0))
+          long_entry_logic.append((aroonu_14_15m < 30.0) | (stochrsi_k_1h < 80.0) | (roc_9_1d_lt_100))
           # 15m still high, 4h high & overbought
           long_entry_logic.append((aroonu_14_15m < 40.0) | (stochrsi_k_4h < 80.0) | (roc_9_4h < 30.0))
           # 15m & 1h & 4h high
           long_entry_logic.append((aroonu_14_15m < 70.0) | (aroonu_14_1h < 80.0) | (aroonu_14_4h < 90.0))
           # 15m & 1h high, 4h overbought
-          long_entry_logic.append((aroonu_14_15m < 70.0) | (aroonu_14_1h < 90.0) | (roc_9_4h < 20.0))
+          long_entry_logic.append((aroonu_14_15m < 70.0) | (aroonu_14_1h < 90.0) | (roc_9_4h_lt_20))
           # 15m & 1d high, 1d overbought
-          long_entry_logic.append((aroonu_14_15m < 70.0) | (aroonu_14_1d < 90.0) | (roc_9_1d < 100.0))
+          long_entry_logic.append((aroonu_14_15m < 70.0) | (aroonu_14_1d < 90.0) | (roc_9_1d_lt_100))
           # 15m high
           long_entry_logic.append((aroonu_14_15m < 80.0) | (stochrsi_k_15m < 60.0))
           # 15m & 4h high
@@ -20447,7 +20453,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1h & 1d high, 1d overbought
           long_entry_logic.append((aroonu_14_1h < 80.0) | (aroonu_14_1d < 100.0) | (roc_9_1d < 30.0))
           # 1h high, 4h & 1d overbought
-          long_entry_logic.append((aroonu_14_1h < 90.0) | (roc_9_4h < 20.0) | (roc_9_1d < 40.0))
+          long_entry_logic.append((aroonu_14_1h < 90.0) | (roc_9_4h_lt_20) | (roc_9_1d < 40.0))
           # 4h & 1d high, 4h overbought
           long_entry_logic.append((aroonu_14_4h < 80.0) | (aroonu_14_1d < 100.0) | (roc_9_4h < 30.0))
           # 4h & 1d high, 1d overbought
@@ -20595,7 +20601,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 4h down move, 1h & 4h downtrend
           long_entry_logic.append((rsi_3_4h > 5.0) | (roc_9_1h > -30.0) | (roc_9_4h > -30.0))
           # 1h down move, 4h high & overbought
-          long_entry_logic.append((rsi_3_1h > 50.0) | (stochrsi_k_4h < 90.0) | (roc_9_4h < 20.0))
+          long_entry_logic.append((rsi_3_1h > 50.0) | (stochrsi_k_4h < 90.0) | (roc_9_4h_lt_20))
           # 4h down move, 4h still high, 1d downtrend
           long_entry_logic.append(rsi_3_4h_gt_20 | (aroonu_14_4h < 50.0) | (roc_9_1d > -40.0))
           # 1h down move, 15m & 1h still high
@@ -20607,11 +20613,11 @@ class NostalgiaForInfinityX7(IStrategy):
           # 4h down move, 1h high, 4h downtrend
           long_entry_logic.append((rsi_3_4h > 30.0) | (aroonu_14_1h < 70.0) | (roc_9_4h > -10.0))
           # 4h down move, 4h still high, 1d downtrend
-          long_entry_logic.append((rsi_3_4h > 50.0) | (rsi_14_4h < 40.0) | (roc_9_1d > -30.0))
+          long_entry_logic.append((rsi_3_4h > 50.0) | (rsi_14_4h < 40.0) | (roc_9_1d_gt_neg_30))
           # 4h down move, 4h high & overbought
           long_entry_logic.append((rsi_3_4h > 50.0) | (aroonu_14_4h < 80.0) | (roc_9_4h < 20.0))
           # 4h down move, 4h still high, 1d downtrend
-          long_entry_logic.append((rsi_3_4h > 50.0) | (stochrsi_k_4h < 50.0) | (roc_9_1d > -30.0))
+          long_entry_logic.append((rsi_3_4h > 50.0) | (stochrsi_k_4h < 50.0) | (roc_9_1d_gt_neg_30))
           # 4h down move, 15m still high, 1h high
           long_entry_logic.append((rsi_3_4h > 60.0) | (aroonu_14_15m < 50.0) | (aroonu_14_1h < 90.0))
           # 4h down move, 1h high, 1d overbought
@@ -20639,7 +20645,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m & 1h & 4h high
           long_entry_logic.append((aroonu_14_15m < 70.0) | (stochrsi_k_1h < 70.0) | (aroonu_14_4h < 90.0))
           # 1h & 1d high, 4h downtrend
-          long_entry_logic.append((aroonu_14_1h < 40.0) | (aroonu_14_1d < 70.0) | (roc_9_4h > -20.0))
+          long_entry_logic.append((aroonu_14_1h < 40.0) | (aroonu_14_1d < 70.0) | (roc_9_4h_gt_neg_20))
           # 1h & 4h high, 4h overbought
           long_entry_logic.append((aroonu_14_1h < 70.0) | (aroonu_14_4h < 90.0) | (roc_9_4h < 10.0))
           # 1h high, 1h & 1d overbought
@@ -20655,7 +20661,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m still high, 1d high
           long_entry_logic.append((stochrsi_k_15m < 50.0) | (stochrsi_k_1d < 90.0))
           # 4h high, 4h & 1d overbought
-          long_entry_logic.append((stochrsi_k_4h < 80.0) | (roc_9_4h < 40.0) | (roc_9_1d < 100.0))
+          long_entry_logic.append((stochrsi_k_4h < 80.0) | (roc_9_4h < 40.0) | (roc_9_1d_lt_100))
           # 1d green, 4h down move, 4h still high
           long_entry_logic.append((change_pct_1d < 40.0) | (rsi_3_4h > 35.0) | (aroonu_14_4h < 40.0))
           # 1d top wick, 4h high
@@ -20761,7 +20767,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m & 1h down move, 1h still high
           long_entry_logic.append((rsi_3_15m > 15.0) | (rsi_3_1h > 30.0) | (aroonu_14_1h < 40.0))
           # 15m down move, 4h still high, 4h downtrend
-          long_entry_logic.append((rsi_3_15m > 15.0) | (aroonu_14_4h < 40.0) | (roc_9_4h > -20.0))
+          long_entry_logic.append((rsi_3_15m > 15.0) | (aroonu_14_4h < 40.0) | (roc_9_4h_gt_neg_20))
           # 15m down move, 1d high, 4h overbought
           long_entry_logic.append((rsi_3_15m > 15.0) | (aroonu_14_1d < 100.0) | (roc_9_4h < 50.0))
           # 15m & 3h down move, 15m still not low enough
@@ -20829,7 +20835,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1h down move, 1h & 1d high
           long_entry_logic.append((rsi_3_1h > 25.0) | (aroonu_14_1h < 70.0) | (aroonu_14_1d < 90.0))
           # 1h down move, 4h still high, 1d downtrend
-          long_entry_logic.append((rsi_3_1h > 25.0) | (aroonu_14_4h < 40.0) | (roc_9_1d > -20.0))
+          long_entry_logic.append((rsi_3_1h > 25.0) | (aroonu_14_4h < 40.0) | (roc_9_1d_gt_neg_20))
           # 1h down move, 1h still high, 1d overbought
           long_entry_logic.append((rsi_3_1h > 25.0) | (stochrsi_k_1h < 50.0) | (roc_9_1d < 40.0))
           # 1h & 4h down move, 4h high
@@ -20839,25 +20845,25 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1h down move, 4h still not low enough, 1d overbought
           long_entry_logic.append((rsi_3_1h > 30.0) | (aroonu_14_4h < 30.0) | roc_9_1d_lt_50)
           # 1h down move, 1h still not low enough, 4h downtrend
-          long_entry_logic.append((rsi_3_1h > 35.0) | (stochrsi_k_1h < 30.0) | (roc_9_4h > -20.0))
+          long_entry_logic.append((rsi_3_1h > 35.0) | (stochrsi_k_1h < 30.0) | (roc_9_4h_gt_neg_20))
           # 1h down move, 4h still high, 1d downtrend
-          long_entry_logic.append((rsi_3_1h > 35.0) | (stochrsi_k_4h < 50.0) | (roc_9_1d > -20.0))
+          long_entry_logic.append((rsi_3_1h > 35.0) | (stochrsi_k_4h < 50.0) | (roc_9_1d_gt_neg_20))
           # 1h down move, 4h & 1d overbought
           long_entry_logic.append((rsi_3_1h > 40.0) | (roc_9_4h < 10.0) | roc_9_1d_lt_50)
           # 1h down move, 4h high & overbought
-          long_entry_logic.append((rsi_3_1h > 50.0) | (aroonu_14_4h < 90.0) | (roc_9_4h < 20.0))
+          long_entry_logic.append((rsi_3_1h > 50.0) | (aroonu_14_4h < 90.0) | (roc_9_4h_lt_20))
           # 1h down move, 4h high & overbought
-          long_entry_logic.append((rsi_3_1h > 50.0) | (stochrsi_k_4h < 80.0) | (roc_9_4h < 20.0))
+          long_entry_logic.append((rsi_3_1h > 50.0) | (stochrsi_k_4h < 80.0) | (roc_9_4h_lt_20))
           # 4h down move, 15m not low enough, 1h still high
           long_entry_logic.append((rsi_3_4h > 3.0) | (stochrsi_k_15m < 20.0) | (stochrsi_k_1h < 40.0))
           # 4h & 1d down move, 4h downtrend
-          long_entry_logic.append((rsi_3_4h > 5.0) | (rsi_3_1d > 20.0) | (roc_9_4h > -20.0))
+          long_entry_logic.append((rsi_3_4h > 5.0) | (rsi_3_1d > 20.0) | (roc_9_4h_gt_neg_20))
           # 4h & 1d down move, 1d high
           long_entry_logic.append((rsi_3_4h > 5.0) | (rsi_3_1d > 30.0) | (aroonu_14_1d < 70.0))
           # 4h down move, 4h still high, 1d downtrend
-          long_entry_logic.append((rsi_3_4h > 5.0) | (stochrsi_k_4h < 40.0) | (roc_9_1d > -20.0))
+          long_entry_logic.append((rsi_3_4h > 5.0) | (stochrsi_k_4h < 40.0) | (roc_9_1d_gt_neg_20))
           # 4h down move, 1d still not low enough, 1d downtrend
-          long_entry_logic.append((rsi_3_4h > 5.0) | (stochrsi_k_1d < 30.0) | (roc_9_1d > -20.0))
+          long_entry_logic.append((rsi_3_4h > 5.0) | (stochrsi_k_1d < 30.0) | (roc_9_1d_gt_neg_20))
           # 4h down move, 1h downtrend, 1h still not low enough
           long_entry_logic.append((rsi_3_4h > 10.0) | (cmf_20_1h > -0.25) | (aroonu_14_1h < 30.0))
           # 4h down move, 1h & 1d downtrend
@@ -20869,13 +20875,13 @@ class NostalgiaForInfinityX7(IStrategy):
           # 4h down move, 1d high & overbought
           long_entry_logic.append(rsi_3_4h_gt_20 | (aroonu_14_1d < 70.0) | roc_9_1d_lt_50)
           # 4h down move, 1h still high, 1d downtrend
-          long_entry_logic.append(rsi_3_4h_gt_20 | (stochrsi_k_1h < 50.0) | (roc_9_1d > -20.0))
+          long_entry_logic.append(rsi_3_4h_gt_20 | (stochrsi_k_1h < 50.0) | (roc_9_1d_gt_neg_20))
           # 4h down move, 1h high
           long_entry_logic.append(rsi_3_4h_gt_20 | (stochrsi_k_1h < 80.0))
           # 4h down move, 1d high, 1h downtrend
           long_entry_logic.append(rsi_3_4h_gt_20 | (stochrsi_k_1d < 70.0) | (roc_9_1h > -10.0))
           # 4h down move, 4h still high, 1d overbought
-          long_entry_logic.append((rsi_3_4h > 30.0) | (aroonu_14_4h < 40.0) | (roc_9_1d < 100.0))
+          long_entry_logic.append((rsi_3_4h > 30.0) | (aroonu_14_4h < 40.0) | (roc_9_1d_lt_100))
           # 4h down move, 4h high, 1h downtrend
           long_entry_logic.append((rsi_3_4h > 30.0) | (aroonu_14_4h < 80.0) | (roc_9_1h > -30.0))
           # 4h down move, 4h still high, 1d overbought
@@ -21099,7 +21105,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 15m high, 1h high
             & ((rsi_3_15m > 10.0) | (aroonu_14_15m < 70.0) | (stochrsi_k_1h < 80.0))
             # 15m down move, 4h high, 1d overbought
-            & ((rsi_3_15m > 10.0) | aroonu_14_4h_lt_70 | (roc_9_1d < 100.0))
+            & ((rsi_3_15m > 10.0) | aroonu_14_4h_lt_70 | (roc_9_1d_lt_100))
             # 15m down move, 1d high & overbought
             & ((rsi_3_15m > 10.0) | (aroonu_14_1d < 85.0) | (roc_9_1d < 20.0))
             # 15m down move, 1h high, 1d overbought
@@ -21133,13 +21139,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 1h & 4h high
             & ((rsi_3_15m > 15.0) | (aroonu_14_1h < 100.0) | (aroonu_14_4h < 100.0))
             # 15m down move, 4h & 1d overbought
-            & ((rsi_3_15m > 15.0) | (roc_9_4h < 20.0) | (roc_9_1d < 80.0))
+            & ((rsi_3_15m > 15.0) | (roc_9_4h_lt_20) | (roc_9_1d < 80.0))
             # 15m down move, 1h high, 1d overbought
             & ((rsi_3_15m > 20.0) | (aroonu_14_1h < 80.0) | (roc_9_1d < 10.0))
             # 15m down move, 1h high, 1d downtrend
-            & ((rsi_3_15m > 20.0) | (stochrsi_k_1h < 80.0) | (roc_9_1d > -20.0))
+            & ((rsi_3_15m > 20.0) | (stochrsi_k_1h < 80.0) | (roc_9_1d_gt_neg_20))
             # 15m down move, 4h high, 1d downtrend
-            & ((rsi_3_15m > 20.0) | (stochrsi_k_4h < 80.0) | (roc_9_1d > -30.0))
+            & ((rsi_3_15m > 20.0) | (stochrsi_k_4h < 80.0) | (roc_9_1d_gt_neg_30))
             # 15m & 4h down move, 15m high
             & ((rsi_3_15m > 25.0) | (rsi_3_4h > 30.0) | (stochrsi_k_15m < 70.0))
             # 15m down move, 15m & 1h high
@@ -21215,13 +21221,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 1d high
             & (rsi_3_1h_gt_20 | (rsi_3_4h > 25.0) | (aroonu_14_1d < 80.0))
             # 1h & 4h down move, 1d overbought
-            & (rsi_3_1h_gt_20 | (rsi_3_4h > 30.0) | (roc_9_1d < 100.0))
+            & (rsi_3_1h_gt_20 | (rsi_3_4h > 30.0) | (roc_9_1d_lt_100))
             # 1h & 4h down move, 1h high
             & (rsi_3_1h_gt_20 | (rsi_3_4h > 35.0) | (aroonu_14_1h < 70.0))
             # 1h & 4h down move, 4h high
             & (rsi_3_1h_gt_20 | (rsi_3_4h > 50.0) | (aroonu_14_4h < 100.0))
             # 1h & 4h down move, 1d downtrend
-            & (rsi_3_1h_gt_20 | (rsi_3_1d > 25.0) | (roc_9_1d > -30.0))
+            & (rsi_3_1h_gt_20 | (rsi_3_1d > 25.0) | (roc_9_1d_gt_neg_30))
             # 1h down move, 15m still high, 1d high
             & (rsi_3_1h_gt_20 | (aroonu_14_15m < 40.0) | (aroonu_14_1d < 90.0))
             # 1h down move, 1h high, 1d overbought
@@ -21249,7 +21255,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h high , 1d overbought
             & ((rsi_3_1h > 35.0) | (stochrsi_k_1h < 80.0) | (roc_9_1d < 30.0))
             # 1h down move, 4h high, 1d overbought
-            & ((rsi_3_1h > 35.0) | aroonu_14_4h_lt_70 | (roc_9_1d < 100.0))
+            & ((rsi_3_1h > 35.0) | aroonu_14_4h_lt_70 | (roc_9_1d_lt_100))
             # 1h & 1d down move, 1h high
             & ((rsi_3_1h > 45.0) | (rsi_3_1d > 45.0) | (aroonu_14_1h < 80.0))
             # 1h down move, 1h & 4h high
@@ -21311,13 +21317,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 1h downtrend, 1d overbought
             & ((rsi_3_4h > 15.0) | (roc_9_1h > -10.0) | (roc_9_1d < 200.0))
             # 4h down move, 4h high, 4h downtrend
-            & (rsi_3_4h_gt_20 | (aroonu_14_4h < 60.0) | (roc_9_4h > -20.0))
+            & (rsi_3_4h_gt_20 | (aroonu_14_4h < 60.0) | (roc_9_4h_gt_neg_20))
             # 4h down move, 1d high & overbought
             & (rsi_3_4h_gt_20 | (aroonu_14_1d < 80.0) | (roc_9_1d < 70.0))
             # 4h down move, 4h & 1d downtrend
             & ((rsi_3_4h > 25.0) | (roc_9_4h > -10.0) | (roc_9_1d > -10.0))
             # 1h down move, 4h still not low enough, 1d downtrend
-            & (rsi_3_4h_gt_20 | (stochrsi_k_4h < 30.0) | (roc_9_1d > -20.0))
+            & (rsi_3_4h_gt_20 | (stochrsi_k_4h < 30.0) | (roc_9_1d_gt_neg_20))
             # 4h & 1d down move, 1h high
             & ((rsi_3_4h > 25.0) | (rsi_3_1d > 25.0) | (stochrsi_k_1h < 80.0))
             # 4h down move, 1h high
@@ -21333,9 +21339,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 1h high, 1d downtrend
             & ((rsi_3_4h > 30.0) | (stochrsi_k_1h < 80.0) | (roc_9_1d > -40.0))
             # 4h down move, 4h & 1d downtrend
-            & ((rsi_3_4h > 30.0) | (roc_9_4h > -20.0) | (roc_9_1d > -40.0))
+            & ((rsi_3_4h > 30.0) | (roc_9_4h_gt_neg_20) | (roc_9_1d > -40.0))
             # 4h down move, 4h still high, 1d downtrend
-            & ((rsi_3_4h > 35.0) | (stochrsi_k_4h < 40.0) | (roc_9_1d > -30.0))
+            & ((rsi_3_4h > 35.0) | (stochrsi_k_4h < 40.0) | (roc_9_1d_gt_neg_30))
             # 4h down move, 1d high & overbought
             & ((rsi_3_4h > 35.0) | (stochrsi_k_1d < 80.0) | (roc_9_1d < 20.0))
             # 4h down move, 15m still high, 1h high
@@ -21359,7 +21365,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h high, 4h overbought
             & ((aroonu_14_15m < 70.0) | (aroonu_14_1h < 100.0) | (roc_9_4h < 15.0))
             # 15m & 1h high, 1d overbought
-            & ((aroonu_14_15m < 70.0) | (aroonu_14_1h < 100.0) | (roc_9_1d < 100.0))
+            & ((aroonu_14_15m < 70.0) | (aroonu_14_1h < 100.0) | (roc_9_1d_lt_100))
             # 15m & 1h high, 1d downtrend
             & ((aroonu_14_15m < 70.0) | (aroonu_14_1h < 100.0) | (roc_9_1d > -10.0))
             # 15m high, 1d high & overbought
@@ -21367,7 +21373,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m high, 1d high & overbought
             & ((aroonu_14_15m < 70.0) | (aroonu_14_1d < 100.0) | (roc_9_1d < 20.0))
             # 15m high, 1h high, 1d downtrend
-            & ((aroonu_14_15m < 70.0) | (stochrsi_k_1h < 80.0) | (roc_9_1d > -20.0))
+            & ((aroonu_14_15m < 70.0) | (stochrsi_k_1h < 80.0) | (roc_9_1d_gt_neg_20))
             # 1h & 4h high, 4h overbought
             & ((aroonu_14_1h < 90.0) | (aroonu_14_4h < 90.0) | (roc_9_4h < 10.0))
             # 1h & 4h high, 1d overbought
@@ -21379,7 +21385,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h & 1d high, 1d overbought
             & ((aroonu_14_4h < 90.0) | (aroonu_14_1d < 100.0) | roc_9_1d_lt_50)
             # 1h high, 1h & 4h overbought
-            & ((stochrsi_k_1h < 80.0) | (roc_9_1h < 20.0) | (roc_9_4h < 20.0))
+            & ((stochrsi_k_1h < 80.0) | (roc_9_1h < 20.0) | (roc_9_4h_lt_20))
             # 4h & 1d overbought
             & ((roc_9_4h < 100.0) | (roc_9_1d < 200.0))
           )
@@ -21502,7 +21508,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 15m high, 1h high
             & ((rsi_3_15m > 10.0) | (aroonu_14_15m < 70.0) | (stochrsi_k_1h < 80.0))
             # 15m down move, 4h high, 1d overbought
-            & ((rsi_3_15m > 10.0) | aroonu_14_4h_lt_70 | (roc_9_1d < 100.0))
+            & ((rsi_3_15m > 10.0) | aroonu_14_4h_lt_70 | (roc_9_1d_lt_100))
             # 15m down move, 1d high & overbought
             & ((rsi_3_15m > 10.0) | (aroonu_14_1d < 85.0) | (roc_9_1d < 20.0))
             # 15m down move, 1h high, 1d overbought
@@ -21544,7 +21550,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 15m high, 1d high
             & ((rsi_3_15m > 20.0) | (aroonu_14_15m < 90.0) | (aroonu_14_1d < 100.0))
             # 15m down move, 1h high, 1d downtrend
-            & ((rsi_3_15m > 20.0) | (stochrsi_k_1h < 80.0) | (roc_9_1d > -20.0))
+            & ((rsi_3_15m > 20.0) | (stochrsi_k_1h < 80.0) | (roc_9_1d_gt_neg_20))
             # 15m down move, 1h high & overbought
             & ((rsi_3_15m > 20.0) | (stochrsi_k_1h < 90.0) | (roc_9_1h < 10.0))
             # 15m down move, 15m still high, 4h high
@@ -21614,7 +21620,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 1d high
             & (rsi_3_1h_gt_20 | (rsi_3_4h > 25.0) | (aroonu_14_1d < 80.0))
             # 1h & 4h down move, 1d overbought
-            & (rsi_3_1h_gt_20 | (rsi_3_4h > 30.0) | (roc_9_1d < 100.0))
+            & (rsi_3_1h_gt_20 | (rsi_3_4h > 30.0) | (roc_9_1d_lt_100))
             # 1h & 4h down move, 1h high
             & (rsi_3_1h_gt_20 | (rsi_3_4h > 35.0) | (aroonu_14_1h < 70.0))
             # 1h & 4h down move, 4h high
@@ -21634,11 +21640,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 15m still high, 1h high
             & ((rsi_3_1h > 30.0) | (aroonu_14_15m < 50.0) | (aroonu_14_1h < 85.0))
             # 1h down move, 4h high, 1d overbought
-            & ((rsi_3_1h > 35.0) | aroonu_14_4h_lt_70 | (roc_9_1d < 100.0))
+            & ((rsi_3_1h > 35.0) | aroonu_14_4h_lt_70 | (roc_9_1d_lt_100))
             # 1h down move, 4h & 1d high
             & ((rsi_3_1h > 35.0) | (aroonu_14_4h < 100.0) | (aroonu_14_1d < 100.0))
             # 1h down move, 1h still high, 1d downtrend
-            & ((rsi_3_1h > 35.0) | (stochrsi_k_1h < 50.0) | (roc_9_1d > -30.0))
+            & ((rsi_3_1h > 35.0) | (stochrsi_k_1h < 50.0) | (roc_9_1d_gt_neg_30))
             # 1h & 1d down move, 1h high
             & ((rsi_3_1h > 45.0) | (rsi_3_1d > 45.0) | (aroonu_14_1h < 80.0))
             # 1h down move, 1h & 4h high
@@ -21646,7 +21652,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 4h high & overbought
             & ((rsi_3_1h > 50.0) | (stochrsi_k_4h < 90.0) | (roc_9_4h < 25.0))
             # 4h & 1d down move, 1d downtrend
-            & ((rsi_3_4h > 3.0) | (rsi_3_1d > 10.0) | (roc_9_1d > -20.0))
+            & ((rsi_3_4h > 3.0) | (rsi_3_1d > 10.0) | (roc_9_1d_gt_neg_20))
             # 4h & 1d down move, 1d still high
             & ((rsi_3_4h > 3.0) | (rsi_3_1d > 20.0) | (rsi_14_1d < 40.0))
             # 4h & 1d down move, 1d high
@@ -21698,9 +21704,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 1d high & overbought
             & (rsi_3_4h_gt_20 | (aroonu_14_1d < 80.0) | (roc_9_1d < 70.0))
             # 4h down move, 4h still high, 4h downtrend
-            & (rsi_3_4h_gt_20 | (stochrsi_k_4h < 50.0) | (roc_9_4h > -20.0))
+            & (rsi_3_4h_gt_20 | (stochrsi_k_4h < 50.0) | (roc_9_4h_gt_neg_20))
             # 4h down move, 4h high, 1d downtrend
-            & (rsi_3_4h_gt_20 | (stochrsi_k_4h < 70.0) | (roc_9_1d > -20.0))
+            & (rsi_3_4h_gt_20 | (stochrsi_k_4h < 70.0) | (roc_9_1d_gt_neg_20))
             # 4h down move, 1d overbought
             & (rsi_3_4h_gt_20 | (roc_9_1d < 80.0))
             # 4h & 1d down move, 4h overbought
@@ -21718,13 +21724,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 4h high, 1d high
             & ((rsi_3_4h > 30.0) | aroonu_14_4h_lt_70 | (stochrsi_k_1d < 80.0))
             # 4h down move, 1d stil high, 1d downtrend
-            & ((rsi_3_4h > 30.0) | (aroonu_14_1d < 40.0) | (roc_9_1d > -30.0))
+            & ((rsi_3_4h > 30.0) | (aroonu_14_1d < 40.0) | (roc_9_1d_gt_neg_30))
             # 4h down move, 1h high, 1d downtrend
             & ((rsi_3_4h > 30.0) | (stochrsi_k_1h < 80.0) | (roc_9_1d > -40.0))
             # 4h down move, 15m still high, 1h high
             & ((rsi_3_4h > 35.0) | (aroonu_14_15m < 50.0) | (aroonu_14_1h < 100.0))
             # 4h down move, 4h still high, 1d downtrend
-            & ((rsi_3_4h > 35.0) | (stochrsi_k_4h < 40.0) | (roc_9_1d > -30.0))
+            & ((rsi_3_4h > 35.0) | (stochrsi_k_4h < 40.0) | (roc_9_1d_gt_neg_30))
             # 4h down move, 1d high & overbought
             & ((rsi_3_4h > 35.0) | (stochrsi_k_1d < 80.0) | (roc_9_1d < 20.0))
             # 4h down move, 1h high
@@ -21746,13 +21752,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1d down move, 1d high, 4h downtrend
             & ((rsi_3_1d > 15.0) | (aroonu_14_1d < 70.0) | (roc_9_4h > -40.0))
             # 1d down move, 1d high, 1d downtrend
-            & ((rsi_3_1d > 15.0) | (aroonu_14_1d < 70.0) | (roc_9_1d > -20.0))
+            & ((rsi_3_1d > 15.0) | (aroonu_14_1d < 70.0) | (roc_9_1d_gt_neg_20))
             # 1d down move, 1h & 4h high
             & ((rsi_3_1d > 30.0) | (aroonu_14_1h < 70.0) | (aroonu_14_4h < 100.0))
             # 15m & 1h high, 4h overbought
             & ((aroonu_14_15m < 70.0) | (aroonu_14_1h < 100.0) | (roc_9_4h < 15.0))
             # 15m & 1h high, 1d overbought
-            & ((aroonu_14_15m < 70.0) | (aroonu_14_1h < 100.0) | (roc_9_1d < 100.0))
+            & ((aroonu_14_15m < 70.0) | (aroonu_14_1h < 100.0) | (roc_9_1d_lt_100))
             # 15m & 1h high, 1d downtrend
             & ((aroonu_14_15m < 70.0) | (aroonu_14_1h < 100.0) | (roc_9_1d > -10.0))
             # 15m & 4h & 1d high
@@ -21762,7 +21768,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m high, 1h & 4h overbought
             & ((aroonu_14_15m < 70.0) | (roc_9_1h < 10.0) | (roc_9_4h < 10.0))
             # 15m high, 4h overbought, 1d downtrend
-            & ((aroonu_14_15m < 80.0) | (roc_9_4h < 20.0) | (roc_9_1d > -30.0))
+            & ((aroonu_14_15m < 80.0) | (roc_9_4h_lt_20) | (roc_9_1d_gt_neg_30))
             # 15m & 1h high
             & ((aroonu_14_15m < 90.0) | (aroonu_14_1h < 100.0))
             # 15m & 4h high
@@ -21780,17 +21786,17 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h high, 1h & 4h overbought
             & ((aroonu_14_4h < 100.0) | (roc_9_1h < 20.0) | (roc_9_4h < 40.0))
             # 1d high, 4h & 1d downtrend
-            & ((aroonu_14_1d < 60.0) | (roc_9_4h > -20.0) | (roc_9_1d > -30.0))
+            & ((aroonu_14_1d < 60.0) | (roc_9_4h_gt_neg_20) | (roc_9_1d_gt_neg_30))
             # 1d high, 4h & 1d overbought
             & ((aroonu_14_1d < 100.0) | (roc_9_4h < 60.0) | (roc_9_1d < 100.0))
             # 15m high, 4h & 1d overbought
-            & ((stochrsi_k_15m < 70.0) | (roc_9_4h < 20.0) | (roc_9_1d < 20.0))
+            & ((stochrsi_k_15m < 70.0) | (roc_9_4h_lt_20) | (roc_9_1d < 20.0))
             # 1h high, 1h & 1d overbought
-            & ((stochrsi_k_1h < 80.0) | (roc_9_1h < 20.0) | (roc_9_1d < 100.0))
+            & ((stochrsi_k_1h < 80.0) | (roc_9_1h < 20.0) | (roc_9_1d_lt_100))
             # 4h high, 4h overbought, 1d downtrend
-            & ((stochrsi_k_4h < 90.0) | (roc_9_4h < 20.0) | (roc_9_1d > -20.0))
+            & ((stochrsi_k_4h < 90.0) | (roc_9_4h_lt_20) | (roc_9_1d_gt_neg_20))
             # 1d high, 1h & 4h overbought
-            & ((stochrsi_k_1d < 80.0) | (roc_9_1h < 20.0) | (roc_9_4h < 20.0))
+            & ((stochrsi_k_1d < 80.0) | (roc_9_1h < 20.0) | (roc_9_4h_lt_20))
           )
 
           # Logic
@@ -21829,7 +21835,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 15m high
             & (rsi_3_15m_gt_3 | (rsi_3_1h > 30.0) | (aroonu_14_15m < 70.0))
             # 15m & 1h down move, 1d downtrend
-            & (rsi_3_15m_gt_3 | (rsi_3_1h > 35.0) | (roc_9_1d > -30.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h > 35.0) | (roc_9_1d_gt_neg_30))
             # 15m & 1h down move, 4h high
             & (rsi_3_15m_gt_3 | (rsi_3_1h > 40.0) | (aroonu_14_1h < 85.0))
             # 15m & 4h down move, 4h still high
@@ -21859,9 +21865,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 1h high, 4h overbought
             & (rsi_3_15m_gt_3 | (aroonu_14_1h < 70.0) | (roc_9_4h < 10.0))
             # 15m down move, 4h high, 1d downtrend
-            & (rsi_3_15m_gt_3 | (stochrsi_k_4h < 70.0) | (roc_9_1d > -20.0))
+            & (rsi_3_15m_gt_3 | (stochrsi_k_4h < 70.0) | (roc_9_1d_gt_neg_20))
             # 15m down move, 15m still high, 1d downtrend
-            & ((rsi_3_15m > 5.0) | (aroonu_14_15m < 50.0) | (roc_9_1d > -20.0))
+            & ((rsi_3_15m > 5.0) | (aroonu_14_15m < 50.0) | (roc_9_1d_gt_neg_20))
             # 15m down move, 1h high, 1d overbought
             & ((rsi_3_15m > 5.0) | (stochrsi_k_1h < 50.0) | (roc_9_1d < 40.0))
             # 15m & 1h down move, 1h high
@@ -21891,15 +21897,15 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 1h & 1d high
             & ((rsi_3_15m > 10.0) | (aroonu_14_1h < 90.0) | (aroonu_14_1d < 100.0))
             # 15m down move, 4h high, 1d overbought
-            & ((rsi_3_15m > 10.0) | aroonu_14_4h_lt_70 | (roc_9_1d < 100.0))
+            & ((rsi_3_15m > 10.0) | aroonu_14_4h_lt_70 | (roc_9_1d_lt_100))
             # 15m down move, 1h still high, 1d downtrend
-            & ((rsi_3_15m > 10.0) | (stochrsi_k_1h < 50.0) | (roc_9_1d > -20.0))
+            & ((rsi_3_15m > 10.0) | (stochrsi_k_1h < 50.0) | (roc_9_1d_gt_neg_20))
             # 15m & 4h down move, 1h high
             & ((rsi_3_15m > 15.0) | (rsi_3_4h > 35.0) | (aroonu_14_1h < 90.0))
             # 1h & 1d down move, 1d still high
             & ((rsi_3_1h > 3.0) | (rsi_3_1d > 25.0) | (stochrsi_k_1d < 40.0))
             # 1h & 4h down move, 1d downtrend
-            & ((rsi_3_1h > 5.0) | (rsi_3_4h > 5.0) | (roc_9_1d > -30.0))
+            & ((rsi_3_1h > 5.0) | (rsi_3_4h > 5.0) | (roc_9_1d_gt_neg_30))
             # 1h & 4h down move, 1d still high
             & ((rsi_3_1h > 5.0) | (rsi_3_4h > 10.0) | (aroonu_14_1d < 50.0))
             # 1h & 4h & 1d down move
@@ -21907,7 +21913,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 4h still not low enough
             & ((rsi_3_1h > 5.0) | (rsi_3_4h > 15.0) | (aroonu_14_4h < 30.0))
             # 1h down move, 4h & 1d downtrend
-            & ((rsi_3_1h > 5.0) | (roc_9_4h > -10.0) | (roc_9_1d > -20.0))
+            & ((rsi_3_1h > 5.0) | (roc_9_4h > -10.0) | (roc_9_1d_gt_neg_20))
             # 1h & 4h down move, 1d still not low enough
             & ((rsi_3_1h > 10.0) | (rsi_3_4h > 10.0) | (stochrsi_k_1d < 20.0))
             # 1h & 4h down move, 15m still not low enough
@@ -21931,11 +21937,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 1d down move, 1d overbought
             & (rsi_3_1h_gt_20 | (rsi_3_1d > 40.0) | (roc_9_1d < 30.0))
             # 1h down move, 1d high, 1d downtrend
-            & (rsi_3_1h_gt_20 | (aroonu_14_1d < 70.0) | (roc_9_1d > -20.0))
+            & (rsi_3_1h_gt_20 | (aroonu_14_1d < 70.0) | (roc_9_1d_gt_neg_20))
             # 1h down move, 1h & 4h high
             & ((rsi_3_1h > 25.0) | (aroonu_14_1h < 80.0) | (aroonu_14_4h < 100.0))
             # 1h down move, 4h & 1d overbought
-            & ((rsi_3_1h > 25.0) | (roc_9_4h < 20.0) | (roc_9_1d < 30.0))
+            & ((rsi_3_1h > 25.0) | (roc_9_4h_lt_20) | (roc_9_1d < 30.0))
             # 1h & 4h down move, 1h high
             & ((rsi_3_1h > 30.0) | (rsi_3_4h > 30.0) | (stochrsi_k_1h < 60.0))
             # 1h down move, 15m still high, 1h high
@@ -21947,11 +21953,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h & 1d down move, 1d high
             & ((rsi_3_4h > 3.0) | (rsi_3_1d > 25.0) | (aroonu_14_1d < 70.0))
             # 4h & 1d down move, 1d downtrend
-            & ((rsi_3_4h > 5.0) | (rsi_3_1d > 5.0) | (roc_9_1d > -30.0))
+            & ((rsi_3_4h > 5.0) | (rsi_3_1d > 5.0) | (roc_9_1d_gt_neg_30))
             # 4h & 1d down move, 1h still high
             & ((rsi_3_4h > 5.0) | (rsi_3_1d > 10.0) | (stochrsi_k_1h < 50.0))
             # 4h down move, 4h still high, 1d downtrend
-            & ((rsi_3_4h > 5.0) | (stochrsi_k_4h < 40.0) | (roc_9_1d > -20.0))
+            & ((rsi_3_4h > 5.0) | (stochrsi_k_4h < 40.0) | (roc_9_1d_gt_neg_20))
             # 4h & 1d down move, 1d high
             & ((rsi_3_4h > 10.0) | (rsi_3_1d > 15.0) | (aroonu_14_1d < 70.0))
             # 4h & 1d down move, 15m still high
@@ -21985,25 +21991,25 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 1d high & overbought
             & (rsi_3_4h_gt_20 | (aroonu_14_1d < 80.0) | (roc_9_1d < 70.0))
             # 4h down move, 4h high, 1d downtrend
-            & (rsi_3_4h_gt_20 | (stochrsi_k_4h < 60.0) | (roc_9_1d > -20.0))
+            & (rsi_3_4h_gt_20 | (stochrsi_k_4h < 60.0) | (roc_9_1d_gt_neg_20))
             # 4h & 1d down move, 1d overbought
             & ((rsi_3_4h > 25.0) | (rsi_3_1d > 40.0) | (roc_9_1d < 30.0))
             # 4h down move, 1h high, 1d downtrend
-            & ((rsi_3_4h > 25.0) | (stochrsi_k_1h < 60.0) | (roc_9_1d > -20.0))
+            & ((rsi_3_4h > 25.0) | (stochrsi_k_1h < 60.0) | (roc_9_1d_gt_neg_20))
             # 4h down move, 15m still high, 1h high
             & ((rsi_3_4h > 35.0) | (aroonu_14_15m < 50.0) | (aroonu_14_1h < 100.0))
             # 4h down move, 1h high
             & ((rsi_3_4h > 40.0) | (aroonu_14_1h < 80.0))
             # 4h down move, 4h high, 1d downtrend
-            & ((rsi_3_4h > 45.0) | (stochrsi_k_4h < 80.0) | (roc_9_1d > -20.0))
+            & ((rsi_3_4h > 45.0) | (stochrsi_k_4h < 80.0) | (roc_9_1d_gt_neg_20))
             # 1h high, 4h & 1d overbought
             & ((aroonu_14_1h < 70.0) | (roc_9_4h < 40.0) | (roc_9_1d < 80.0))
             # 1h & 4h high, 1d overbought
             & ((aroonu_14_1h < 85.0) | (aroonu_14_4h < 100.0) | (roc_9_1d < 40.0))
             # 1d high, 4h & 1d downtrend
-            & ((aroonu_14_1d < 60.0) | (roc_9_4h > -20.0) | (roc_9_1d > -30.0))
+            & ((aroonu_14_1d < 60.0) | (roc_9_4h_gt_neg_20) | (roc_9_1d_gt_neg_30))
             # 4h high, 4h & 1d overbought
-            & ((stochrsi_k_4h < 90.0) | (roc_9_4h < 20.0) | (roc_9_1d < 20.0))
+            & ((stochrsi_k_4h < 90.0) | (roc_9_4h_lt_20) | (roc_9_1d < 20.0))
           )
 
           # Logic
@@ -22042,7 +22048,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 1d overbought
             & ((rsi_3_15m > 5.0) | (rsi_3_1h > 30.0) | (roc_9_1d < 30.0))
             # 15m & 4h down move, 4h downtrend
-            & ((rsi_3_15m > 5.0) | (rsi_3_4h > 5.0) | (roc_9_4h > -20.0))
+            & ((rsi_3_15m > 5.0) | (rsi_3_4h > 5.0) | (roc_9_4h_gt_neg_20))
             # 15m & 4h down move, 4h still high
             & ((rsi_3_15m > 5.0) | (rsi_3_4h > 30.0) | (stochrsi_k_4h < 40.0))
             # 15m down move, 1d high & overbought
@@ -22062,17 +22068,17 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 4h down move, 15m still high
             & ((rsi_3_15m > 15.0) | (rsi_3_4h > 15.0) | (aroonu_14_15m < 40.0))
             # 15m down move, 4h & 1d overbought
-            & ((rsi_3_15m > 15.0) | (roc_9_4h < 20.0) | (roc_9_1d < 200.0))
+            & ((rsi_3_15m > 15.0) | (roc_9_4h_lt_20) | (roc_9_1d < 200.0))
             # 15m & 1h down move, 4h high
             & ((rsi_3_15m > 25.0) | (rsi_3_1h > 30.0) | (aroonu_14_4h < 100.0))
             # 15m & 1h down move, 4h high
             & ((rsi_3_15m > 25.0) | (rsi_3_1h > 40.0) | (stochrsi_k_4h < 90.0))
             # 15m down move, 4h high, 1d downtrend
-            & ((rsi_3_15m > 25.0) | (stochrsi_k_4h < 80.0) | (roc_9_1d > -30.0))
+            & ((rsi_3_15m > 25.0) | (stochrsi_k_4h < 80.0) | (roc_9_1d_gt_neg_30))
             # 15m & 1h down move, 15m high
             & ((rsi_3_15m > 45.0) | (rsi_3_1h > 45.0) | (stochrsi_k_15m < 70.0))
             # 15m down move, 4h high, 1d overbought
-            & ((rsi_3_15m > 10.0) | aroonu_14_4h_lt_70 | (roc_9_1d < 100.0))
+            & ((rsi_3_15m > 10.0) | aroonu_14_4h_lt_70 | (roc_9_1d_lt_100))
             # 15m & 4h down move, 1d downtrend
             & ((rsi_3_15m > 15.0) | (rsi_3_4h > 15.0) | (roc_9_1d > -20.0))
             # 15m & 1h down move, 4h high
@@ -22082,9 +22088,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 15m still high, 4h high
             & ((rsi_3_15m > 25.0) | (aroonu_14_15m < 50.0) | (aroonu_14_4h < 80.0))
             # 15m down move, 4h high & overbought
-            & ((rsi_3_15m > 25.0) | (stochrsi_k_4h < 80.0) | (roc_9_4h < 20.0))
+            & ((rsi_3_15m > 25.0) | (stochrsi_k_4h < 80.0) | (roc_9_4h_lt_20))
             # 15m down move, 4h high, 1d downtrend
-            & ((rsi_3_15m > 25.0) | (stochrsi_k_4h < 90.0) | (roc_9_1d > -30.0))
+            & ((rsi_3_15m > 25.0) | (stochrsi_k_4h < 90.0) | (roc_9_1d_gt_neg_30))
             # 15m down move, 1h & 4h overbought
             & ((rsi_3_15m > 25.0) | (roc_9_1h < 10.0) | (roc_9_4h < 30.0))
             # 15m down move, 1h & 4h high
@@ -22166,7 +22172,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 4h still not low enough
             & ((rsi_3_1h > 25.0) | (rsi_3_4h > 25.0) | (stochrsi_k_4h < 30.0))
             # 1h & 4h down move, 1d overbought
-            & ((rsi_3_1h > 25.0) | (rsi_3_4h > 25.0) | (roc_9_1d < 100.0))
+            & ((rsi_3_1h > 25.0) | (rsi_3_4h > 25.0) | (roc_9_1d_lt_100))
             # 1h & 4h down move, 4h high
             & ((rsi_3_1h > 25.0) | (rsi_3_4h > 30.0) | (aroonu_14_4h < 60.0))
             # 1h & 1d down move, 1d high
@@ -22220,7 +22226,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 15m high
             & ((rsi_3_4h > 15.0) | (stochrsi_k_15m < 70.0))
             # 4h & 1d down move, 1d downtrend
-            & (rsi_3_4h_gt_20 | (rsi_3_1d > 25.0) | (roc_9_1d > -30.0))
+            & (rsi_3_4h_gt_20 | (rsi_3_1d > 25.0) | (roc_9_1d_gt_neg_30))
             # 4h down move, 1d high & overbought
             & (rsi_3_4h_gt_20 | (aroonu_14_1d < 80.0) | (roc_9_1d < 70.0))
             # 4h & 1d down move, 4h overbought
@@ -22232,19 +22238,19 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 4h high, 1d high
             & ((rsi_3_4h > 30.0) | aroonu_14_4h_lt_70 | (stochrsi_k_1d < 80.0))
             # 4h down move, 1d stil high, 1d downtrend
-            & ((rsi_3_4h > 30.0) | (aroonu_14_1d < 40.0) | (roc_9_1d > -30.0))
+            & ((rsi_3_4h > 30.0) | (aroonu_14_1d < 40.0) | (roc_9_1d_gt_neg_30))
             # 4h down move, 4h still high, 4h downtrend
             & ((rsi_3_4h > 30.0) | (stochrsi_k_4h < 40.0) | (roc_9_4h > -15.0))
             # 4h down move, 4h still high, 1d downtrend
-            & ((rsi_3_4h > 35.0) | (stochrsi_k_4h < 40.0) | (roc_9_1d > -20.0))
+            & ((rsi_3_4h > 35.0) | (stochrsi_k_4h < 40.0) | (roc_9_1d_gt_neg_20))
             # 4h down move, 1d high & overbought
-            & ((rsi_3_4h > 55.0) | (stochrsi_k_1d < 90.0) | (roc_9_1d < 100.0))
+            & ((rsi_3_4h > 55.0) | (stochrsi_k_1d < 90.0) | (roc_9_1d_lt_100))
             # 1d down move, 4h still not low enough, 4h downtrend
             & ((rsi_3_1d > 10.0) | (stochrsi_k_4h < 30.0) | (roc_9_4h > -15.0))
             # 1d down move, 4h & 1d downtrend
-            & ((rsi_3_1d > 10.0) | (roc_9_4h > -20.0) | (roc_9_1d > -20.0))
+            & ((rsi_3_1d > 10.0) | (roc_9_4h_gt_neg_20) | (roc_9_1d_gt_neg_20))
             # 1d down move, 1d high, 4h downtrend
-            & ((rsi_3_1d > 15.0) | (aroonu_14_1d < 70.0) | (roc_9_4h > -20.0))
+            & ((rsi_3_1d > 15.0) | (aroonu_14_1d < 70.0) | (roc_9_4h_gt_neg_20))
             # 1d down move, 1h & 4h high
             & ((rsi_3_1d > 25.0) | (aroonu_14_1h < 70.0) | (aroonu_14_4h < 100.0))
             # 1d down move, 1h & 4h high
@@ -22256,13 +22262,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h high, 4h & 1d overbought
             & ((aroonu_14_4h < 90.0) | (roc_9_4h < 30.0) | (roc_9_1d < 60.0))
             # 15m high, 4h & 1d overbought
-            & ((stochrsi_k_15m < 80.0) | (roc_9_4h < 20.0) | (roc_9_1d < 20.0))
+            & ((stochrsi_k_15m < 80.0) | (roc_9_4h_lt_20) | (roc_9_1d < 20.0))
             # 15m still high, 4h & 1d overbought
-            & ((stochrsi_k_15m < 50.0) | (roc_9_4h < 40.0) | (roc_9_1d < 100.0))
+            & ((stochrsi_k_15m < 50.0) | (roc_9_4h < 40.0) | (roc_9_1d_lt_100))
             # 4h high, 4h & 1d overbought
             & ((stochrsi_k_4h < 90.0) | (roc_9_4h < 30.0) | (roc_9_1d < 60.0))
             # 1d high, 4h & 1d overbought
-            & ((stochrsi_k_1d < 90.0) | (roc_9_4h < 30.0) | (roc_9_1d < 100.0))
+            & ((stochrsi_k_1d < 90.0) | (roc_9_4h < 30.0) | (roc_9_1d_lt_100))
             # 4h & 1d overbought
             & ((roc_9_4h < 100.0) | (roc_9_1d < 200.0))
             # 1d P&D, 4h overbought
@@ -22288,7 +22294,7 @@ class NostalgiaForInfinityX7(IStrategy):
 
           long_entry_logic.append(
             # 5m & 4h down move, 1d downtrend
-            ((rsi_3 > 3.0) | (rsi_3_4h > 3.0) | (roc_9_1d > -20.0))
+            ((rsi_3 > 3.0) | (rsi_3_4h > 3.0) | (roc_9_1d_gt_neg_20))
             # 5m down move, 15m & 1h high
             & ((rsi_3 > 10.0) | (aroonu_14_15m < 85.0) | (aroonu_14_1h < 100.0))
             # 15m & 1h & 4h down move
@@ -22316,9 +22322,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 15m still high, 4h high
             & ((rsi_3_15m > 15.0) | (aroonu_14_15m < 40.0) | (stochrsi_k_4h < 60.0))
             # 15m down move, 1h high, 1d downtrend
-            & ((rsi_3_15m > 15.0) | (aroonu_14_1h < 90.0) | (roc_9_1d > -30.0))
+            & ((rsi_3_15m > 15.0) | (aroonu_14_1h < 90.0) | (roc_9_1d_gt_neg_30))
             # 15m & 1h down move, 1d downtrend
-            & ((rsi_3_15m > 20.0) | rsi_3_1h_gt_20 | (roc_9_1d > -30.0))
+            & ((rsi_3_15m > 20.0) | rsi_3_1h_gt_20 | (roc_9_1d_gt_neg_30))
             # 15m & 4h down move, 15m still high
             & ((rsi_3_15m > 20.0) | rsi_3_4h_gt_20 | (stochrsi_k_15m < 50.0))
             # 15m down move, 15m & 1h high
@@ -22402,7 +22408,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 4h high & overbought
             & (rsi_3_1h_gt_20 | (aroonu_14_4h < 80.0) | (roc_9_4h < 60.0))
             # 1h down move, 1h still not low enough, 1d downtrend
-            & (rsi_3_1h_gt_20 | (stochrsi_k_1h < 30.0) | (roc_9_1d > -30.0))
+            & (rsi_3_1h_gt_20 | (stochrsi_k_1h < 30.0) | (roc_9_1d_gt_neg_30))
             # 1h & 4h down move, 1h high
             & ((rsi_3_1h > 25.0) | (rsi_3_4h > 35.0) | (aroonu_14_1h < 70.0))
             # 1h & 4h down move, 1d overbought
@@ -22412,7 +22418,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h high, 1d overbought
             & ((rsi_3_1h > 25.0) | (aroonu_14_1h < 80.0) | (roc_9_1d < 30.0))
             # 1h down move, 1h still high, 4h downtrend
-            & ((rsi_3_1h > 25.0) | (stochrsi_k_1h < 50.0) | (roc_9_4h > -20.0))
+            & ((rsi_3_1h > 25.0) | (stochrsi_k_1h < 50.0) | (roc_9_4h_gt_neg_20))
             # 1h down move, 1d overbought
             & ((rsi_3_1h > 25.0) | (roc_9_1d < 80.0))
             # 1h down move, 1h high, 1d overbought
@@ -22424,11 +22430,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 4h high & overbought
             & ((rsi_3_1h > 35.0) | (aroonu_14_4h < 90.0) | (roc_9_4h < 60.0))
             # 1h down move, 4h high, 1d downtrend
-            & ((rsi_3_1h > 35.0) | (stochrsi_k_4h < 90.0) | (roc_9_1d > -20.0))
+            & ((rsi_3_1h > 35.0) | (stochrsi_k_4h < 90.0) | (roc_9_1d_gt_neg_20))
             # 1h down move, 1h high, 1d downtrend
             & ((rsi_3_1h > 40.0) | (aroonu_14_1h < 70.0) | (roc_9_1d > -30.0))
             # 1h down move, 1h high, 1d downtrend
-            & ((rsi_3_1h > 40.0) | (stochrsi_k_1h < 70.0) | (roc_9_1d > -30.0))
+            & ((rsi_3_1h > 40.0) | (stochrsi_k_1h < 70.0) | (roc_9_1d_gt_neg_30))
             # 1h down move, 1h & 4h high
             & ((rsi_3_1h > 45.0) | (aroonu_14_1h < 80.0) | (aroonu_14_4h < 100.0))
             # 1h down move, 1h high, 4h overbought
@@ -22436,7 +22442,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 4h high & overbought
             & ((rsi_3_1h > 50.0) | (stochrsi_k_4h < 90.0) | (roc_9_4h < 25.0))
             # 4h down move, 4h & 1d downtrend
-            & ((rsi_3_4h > 5.0) | (roc_9_4h > -15.0) | (roc_9_1d > -20.0))
+            & ((rsi_3_4h > 5.0) | (roc_9_4h > -15.0) | (roc_9_1d_gt_neg_20))
             # 4h & 1d down move, 1d still high
             & ((rsi_3_4h > 10.0) | (rsi_3_1d > 30.0) | (stochrsi_k_1d < 50.0))
             # 4h down move, 4h & 1d high
@@ -22468,7 +22474,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 15m high, 1d overbought
             & ((rsi_3_4h > 30.0) | (stochrsi_k_15m < 90.0) | (roc_9_1d < 10.0))
             # 4h down move, 4h still high, 1d downtrend
-            & ((rsi_3_4h > 35.0) | (stochrsi_k_4h < 40.0) | (roc_9_1d > -30.0))
+            & ((rsi_3_4h > 35.0) | (stochrsi_k_4h < 40.0) | (roc_9_1d_gt_neg_30))
             # 4h down move, 4h high, 1d overbought
             & ((rsi_3_4h > 40.0) | (aroonu_14_4h < 60.0) | (roc_9_1d < 40.0))
             # 4h & 1d down move, 1h high
@@ -22476,11 +22482,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 1d high & overbought
             & ((rsi_3_4h > 55.0) | (stochrsi_k_1d < 90.0) | (roc_9_1d < 80.0))
             # 1d down move, 1d high, 1d downtrend
-            & ((rsi_3_1d > 15.0) | (aroonu_14_1d < 70.0) | (roc_9_1d > -20.0))
+            & ((rsi_3_1d > 15.0) | (aroonu_14_1d < 70.0) | (roc_9_1d_gt_neg_20))
             # 1d down move, 1h high
             & ((rsi_3_1d > 20.0) | (stochrsi_k_1h < 70.0))
             # 1d down move, 1h high, 1d downtrend
-            & ((rsi_3_1d > 25.0) | (stochrsi_k_1h < 60.0) | (roc_9_1d > -30.0))
+            & ((rsi_3_1d > 25.0) | (stochrsi_k_1h < 60.0) | (roc_9_1d_gt_neg_30))
             # 1d down move, 1d high, 4h downtrend
             & ((rsi_3_1d > 35.0) | (aroonu_14_1d < 70.0) | (roc_9_4h > -10.0))
             # 1d down move, 4h high, 1d overbought
@@ -22488,7 +22494,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m high, 1d high & overbought
             & ((aroonu_14_15m < 70.0) | (aroonu_14_1d < 100.0) | (roc_9_1d < 100.0))
             # 15m high, 4h overbought, 1d downtrend
-            & ((aroonu_14_15m < 80.0) | (roc_9_4h < 20.0) | (roc_9_1d > -30.0))
+            & ((aroonu_14_15m < 80.0) | (roc_9_4h_lt_20) | (roc_9_1d_gt_neg_30))
             # 1h & 4h high, 4h overbought
             & ((aroonu_14_1h < 70.0) | (aroonu_14_4h < 100.0) | (roc_9_4h < 10.0))
             # 1h high, 1d overbought
@@ -22548,7 +22554,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m down move, 15m & 1h still high
           long_entry_logic.append((rsi_3_15m > 40.0) | (stochrsi_k_15m < 50.0) | (stochrsi_k_1h < 50.0))
           # 15m down move, 4h still high, 1d overbought
-          long_entry_logic.append((rsi_3_15m > 40.0) | (aroonu_14_4h < 50.0) | (roc_9_1d < 100.0))
+          long_entry_logic.append((rsi_3_15m > 40.0) | (aroonu_14_4h < 50.0) | (roc_9_1d_lt_100))
           # 15m & 1h down move, 1h still high
           long_entry_logic.append((rsi_3_15m > 45.0) | (rsi_3_1h > 45.0) | (stochrsi_k_1h < 40.0))
           # 15m down move, 15m high, 1d overbought
@@ -22781,13 +22787,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 4h high
             & ((rsi_3_15m > 15.0) | (rsi_3_1h > 35.0) | (stochrsi_k_4h < 90.0))
             # 15m down move, 4h high, 4h downtrend
-            & ((rsi_3_15m > 15.0) | (aroonu_14_4h < 60.0) | (roc_9_4h > -20.0))
+            & ((rsi_3_15m > 15.0) | (aroonu_14_4h < 60.0) | (roc_9_4h_gt_neg_20))
             # 15m down move, 4h & 1d downtrend
             & ((rsi_3_15m > 15.0) | (roc_9_4h > -10.0) | (roc_9_1d > -40.0))
             # 15m & 1h down move, 1h high
             & ((rsi_3_15m > 20.0) | (rsi_3_1h > 25.0) | (aroonu_14_1h < 70.0))
             # 15m down move, 4h high & overbought
-            & ((rsi_3_15m > 20.0) | aroonu_14_4h_lt_70 | (roc_9_4h < 20.0))
+            & ((rsi_3_15m > 20.0) | aroonu_14_4h_lt_70 | (roc_9_4h_lt_20))
             # 15m & 1h down move, 4h high
             & ((rsi_3_15m > 25.0) | (rsi_3_1h > 25.0) | (stochrsi_k_4h < 90.0))
             # 15m down move, 15m high, 1d overbought
@@ -22823,7 +22829,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1d high & overbought
             & ((rsi_3_1h > 15.0) | (stochrsi_k_1d < 90.0) | (roc_9_1d < 40.0))
             # 1h down move, 1h high, 1d overbought
-            & ((rsi_3_1h > 25.0) | (aroonu_14_1h < 60.0) | (roc_9_1d < 100.0))
+            & ((rsi_3_1h > 25.0) | (aroonu_14_1h < 60.0) | (roc_9_1d_lt_100))
             # 1h down move, 1h high
             & ((rsi_3_1h > 25.0) | (aroonu_14_1h < 90.0))
             # 1h & 4h down move, 4h high
@@ -22833,7 +22839,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 4h high & overbought
             & ((rsi_3_1h > 35.0) | (stochrsi_k_4h < 80.0) | (roc_9_4h < 30.0))
             # 1h down move, 1h high, 4h downtrend
-            & ((rsi_3_1h > 40.0) | (stochrsi_k_1h < 80.0) | (roc_9_4h > -20.0))
+            & ((rsi_3_1h > 40.0) | (stochrsi_k_1h < 80.0) | (roc_9_4h_gt_neg_20))
             # 1h down move, 15m still high, 1d overbought
             & ((rsi_3_1h > 45.0) | (aroonu_14_15m < 50.0) | roc_9_1d_lt_50)
             # 1h down move, 4h & 1d overbought
@@ -22873,7 +22879,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1d down move, 4h high
             & ((rsi_3_1d > 20.0) | (rsi_14_4h < 80.0))
             # 1d downtrend, 1d high & overbought
-            & ((cmf_20_1d > -0.30) | (aroonu_14_1d < 85.0) | (roc_9_1d < 100.0))
+            & ((cmf_20_1d > -0.30) | (aroonu_14_1d < 85.0) | (roc_9_1d_lt_100))
             # 1h & 4h high, 1d overbought
             & ((aroonu_14_1h < 70.0) | aroonu_14_4h_lt_70 | (roc_9_1d < 30.0))
             # 1h & 4h high, 1d overbought
@@ -22885,7 +22891,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h high, 4h & 1d overbought
             & ((aroonu_14_4h < 80.0) | (roc_9_4h < 20.0) | (roc_9_1d < 20.0))
             # 1d still high, 1h & 4h downtrend
-            & ((aroonu_14_1d < 50.0) | (roc_9_1h > -20.0) | (roc_9_4h > -20.0))
+            & ((aroonu_14_1d < 50.0) | (roc_9_1h > -20.0) | (roc_9_4h_gt_neg_20))
             # 1h high, 1h overbought
             & ((stochrsi_k_1h < 80.0) | (roc_9_1h < 50.0))
             # 1h high, 1d downtrend
@@ -23039,7 +23045,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 1h high, 1d overbought
             & ((rsi_3_15m > 15.0) | (aroonu_14_1h < 100.0) | (roc_9_1d < 40.0))
             # 15m down move, 4h still high, 4h downtrend
-            & ((rsi_3_15m > 15.0) | (aroonu_14_4h < 40.0) | (roc_9_4h > -20.0))
+            & ((rsi_3_15m > 15.0) | (aroonu_14_4h < 40.0) | (roc_9_4h_gt_neg_20))
             # 15m down move, 1d high & overbought
             & ((rsi_3_15m > 15.0) | (aroonu_14_1d < 100.0) | (roc_9_1d < 100.0))
             # 15m down move, 15m still not low enough, 4h high
@@ -23053,7 +23059,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 1h high & overbought
             & ((rsi_3_15m > 15.0) | (stochrsi_k_1h < 80.0) | (roc_9_1h < 20.0))
             # 15m down move, 1h high, 1d overbought
-            & ((rsi_3_15m > 15.0) | (stochrsi_k_1h < 80.0) | (roc_9_1d < 100.0))
+            & ((rsi_3_15m > 15.0) | (stochrsi_k_1h < 80.0) | (roc_9_1d_lt_100))
             # 15m down move, 4h high, 1d overbought
             & ((rsi_3_15m > 15.0) | (stochrsi_k_4h < 80.0) | (roc_9_1d < 25.0))
             # 15m down move, 4h high & overbought
@@ -23063,9 +23069,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 4h high and downtrend
             & ((rsi_3_15m > 15.0) | (cmf_20_4h > -0.2) | (aroonu_14_4h < 80.0))
             # 15m down move, 1h high, 4h overbought
-            & ((rsi_3_15m > 15.0) | (aroonu_14_1h < 90.0) | (roc_9_4h < 20.0))
+            & ((rsi_3_15m > 15.0) | (aroonu_14_1h < 90.0) | (roc_9_4h_lt_20))
             # 15m down move, 4h & 1d downtrend
-            & ((rsi_3_15m > 15.0) | (roc_9_4h > -20.0) | (roc_9_1d > -20.0))
+            & ((rsi_3_15m > 15.0) | (roc_9_4h_gt_neg_20) | (roc_9_1d_gt_neg_20))
             # 16m & 1h down move, 1h still high
             & ((rsi_3_15m > 20.0) | (rsi_3_1h > 25.0) | (stochrsi_k_1h < 40.0))
             # 15m & 1h down move, 1h downtrend, 1h downtrend, 15m still high, 1h high
@@ -23099,7 +23105,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1d down move, 1d high
             & ((rsi_3_15m > 25.0) | (rsi_3_1d > 40.0) | (aroonu_14_1d < 80.0))
             # 15m down move, 4h high, 1d downtrend
-            & ((rsi_3_15m > 25.0) | (stochrsi_k_4h < 90.0) | (roc_9_1d > -30.0))
+            & ((rsi_3_15m > 25.0) | (stochrsi_k_4h < 90.0) | (roc_9_1d_gt_neg_30))
             # 15m & 1h down move, 15m still not low enough, 1h & 4h high
             & (
               (rsi_3_15m > 30.0)
@@ -23130,13 +23136,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 4h downtrend, 4h high
             & ((rsi_3_1h > 25.0) | (cmf_20_4h > -0.25) | aroonu_14_4h_lt_70)
             # 1h down move, 15m still high, 1d downtrend
-            & ((rsi_3_1h > 25.0) | (aroonu_14_15m < 40.0) | (roc_9_1d > -20.0))
+            & ((rsi_3_1h > 25.0) | (aroonu_14_15m < 40.0) | (roc_9_1d_gt_neg_20))
             # 1h down move, 1h & 4h high
             & ((rsi_3_1h > 25.0) | (aroonu_14_1h < 60.0) | (aroonu_14_4h < 100.0))
             # 1h down move, 1h high, 1d downtrend
             & ((rsi_3_1h > 25.0) | (aroonu_14_1h < 90.0) | (cmf_20_1d > -0.2))
             # 1h down move, 4h high & overbought
-            & ((rsi_3_1h > 25.0) | (aroonu_14_4h < 90.0) | (roc_9_4h < 20.0))
+            & ((rsi_3_1h > 25.0) | (aroonu_14_4h < 90.0) | (roc_9_4h_lt_20))
             # 1h down move, 1h still not low enough, 1d downtrend
             & ((rsi_3_1h > 25.0) | (stochrsi_k_1h < 30.0) | (roc_9_1d > -40.0))
             # 1h down move, 4h high, 1d overbought
@@ -23176,7 +23182,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h & 1d high
             & ((rsi_3_1h > 35.0) | (aroonu_14_1h < 90.0) | (aroonu_14_1d < 90.0))
             # 1h down move, 4h & 1d overbought
-            & ((rsi_3_1h > 35.0) | (roc_9_4h < 20.0) | (roc_9_1d < 80.0))
+            & ((rsi_3_1h > 35.0) | (roc_9_4h_lt_20) | (roc_9_1d < 80.0))
             # 1h & 1d down move, 1d high
             & ((rsi_3_1h > 40.0) | (rsi_3_1d > 55.0) | (aroonu_14_1d < 100.0))
             # 1h down move, 1h high, 4h overbought
@@ -23206,7 +23212,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 15m & 1h high, 1d downtrend
             & ((rsi_3_1h > 60.0) | (aroonu_14_15m < 65.0) | (stochrsi_k_1h < 80.0) | (cmf_20_1d > -0.0))
             # 1h down move, 1h high, 1d downtrend
-            & ((rsi_3_1h > 60.0) | (stochrsi_k_1h < 90.0) | (roc_9_1d > -20.0))
+            & ((rsi_3_1h > 60.0) | (stochrsi_k_1h < 90.0) | (roc_9_1d_gt_neg_20))
             # 4h down move, 15m high
             & ((rsi_3_4h > 3.0) | (aroonu_14_15m < 50.0))
             # 4h & 1d down move, 1d high
@@ -23230,7 +23236,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h & 1d down move, 1h & 4h low
             & ((rsi_3_4h > 25.0) | (rsi_3_1d > 25.0) | (cmf_20_1h > -0.3) | (cmf_20_4h > -0.4))
             # 4h down move, 4h still high 1d downtrend
-            & ((rsi_3_4h > 25.0) | (aroonu_14_4h < 50.0) | (roc_9_1d > -20.0))
+            & ((rsi_3_4h > 25.0) | (aroonu_14_4h < 50.0) | (roc_9_1d_gt_neg_20))
             # 4h down move, 1d high & overbought
             & ((rsi_3_4h > 25.0) | (stochrsi_k_1d < 80.0) | (roc_9_1d < 25.0))
             # 4h down move, 4h & 1d high
@@ -23240,7 +23246,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 4h high, 1d overbought
             & ((rsi_3_4h > 40.0) | (aroonu_14_4h < 80.0) | (roc_9_1d < 20.0))
             # 4h down move, 1h high, 1d downtrend
-            & ((rsi_3_4h > 40.0) | (stochrsi_k_1h < 80.0) | (roc_9_1d > -20.0))
+            & ((rsi_3_4h > 40.0) | (stochrsi_k_1h < 80.0) | (roc_9_1d_gt_neg_20))
             # 4h down move, 4h & 1d overbought
             & ((rsi_3_4h > 40.0) | (roc_9_4h < 10.0) | roc_9_1d_lt_50)
             # 4h down move, 4h high, 1d overbought
@@ -23248,11 +23254,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 1d high, 4h overbought
             & ((rsi_3_4h > 45.0) | (aroonu_14_1d < 90.0) | (roc_9_4h < 10.0))
             # 4h down move, 4h still high, 1d downtrend
-            & ((rsi_3_4h > 50.0) | (rsi_14_4h < 40.0) | (roc_9_1d > -30.0))
+            & ((rsi_3_4h > 50.0) | (rsi_14_4h < 40.0) | (roc_9_1d_gt_neg_30))
             # 4h down move, 4h high & overbought
             & ((rsi_3_4h > 50.0) | aroonu_14_4h_lt_70 | (roc_9_4h < 10.0))
             # 4h down move, 15m still high, 1d overbought
-            & ((rsi_3_4h > 55.0) | (aroonu_14_15m < 40.0) | (roc_9_1d < 100.0))
+            & ((rsi_3_4h > 55.0) | (aroonu_14_15m < 40.0) | (roc_9_1d_lt_100))
             # 4h & 1d down move, 4h high, 1d overbought
             & ((rsi_3_4h > 60.0) | (rsi_3_1d > 60.0) | (aroonu_14_4h < 75.0) | (roc_9_1d < 40.0))
             # 4h down move, 4h & 1d high
@@ -23276,7 +23282,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1d down move, 1h high, 1d overbought
             & ((rsi_3_1d > 60.0) | (aroonu_14_1h < 80.0) | (roc_9_1d < 80.0))
             # 1d down move, 15m still high, 1d overbought
-            & ((rsi_3_1d > 65.0) | (aroonu_14_15m < 40.0) | (roc_9_1d < 100.0))
+            & ((rsi_3_1d > 65.0) | (aroonu_14_15m < 40.0) | (roc_9_1d_lt_100))
             # 1d down move, 4h & 1d high
             & ((rsi_3_1d > 65.0) | (roc_9_4h < 10.0) | (roc_9_1d < 10.0))
             # 5m still high, 1h down move, 15m still high, 1h high
@@ -23300,7 +23306,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h & 1d high, 1d overbought
             & ((aroonu_14_4h < 100.0) | (aroonu_14_1d < 100.0) | (roc_9_1d < 30.0))
             # 1d still high, 4h & 1d downtrend
-            & ((aroonu_14_1d < 50.0) | (roc_9_4h > -20.0) | (roc_9_1d > -30.0))
+            & ((aroonu_14_1d < 50.0) | (roc_9_4h_gt_neg_20) | (roc_9_1d_gt_neg_30))
             # 4h top wick, 15m & 1h down move
             & ((df["top_wick_pct_4h"] < 10.0) | (rsi_3_15m > 15.0) | (rsi_3_1h > 40.0))
             # 4h top wick, 1h down move, 1h high
@@ -23698,7 +23704,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m up move, 1h low
           short_entry_logic.append((rsi_3_15m < 80.0) | (aroonu_14_1h > 10.0))
           # 15m up move, 1h low, 1d uptrend
-          short_entry_logic.append((rsi_3_15m < 80.0) | (aroonu_14_1h > 40.0) | (roc_9_1d < 100.0))
+          short_entry_logic.append((rsi_3_15m < 80.0) | (aroonu_14_1h > 40.0) | (roc_9_1d_lt_100))
           # 15m up move, 4h low
           short_entry_logic.append((rsi_3_15m < 80.0) | (stochrsi_k_4h > 40.0))
           # 15m up move, 1h uptrend


### PR DESCRIPTION
## Summary
- Adds reusable ROC threshold masks for repeated entry-condition comparisons in X7.
- Keeps the branch independent on latest upstream main while avoiding original lines already touched by the open RSI and AROON entry-mask PRs.

## Safety
- Only replaces repeated Series comparisons with same-call boolean masks; indicator inputs, thresholds, condition order, candle selection, and return values are unchanged.
- Touched function: populate_entry_trend. No v3 grind-entry code, CMF formula, order classification, profit arithmetic, stake sizing, or leverage logic is touched.
- Conflict simulation checked the path where the open RSI and AROON entry-mask PRs are merged first.

## Backtest scope
- A full backtest was not required for this plumbing patch because it reuses already-read Series comparison results inside the same populate_entry_trend call without changing any trading condition values or ordering.

## Checks
- `python3 ~/.codex/skills/nfi-upstream-pr/scripts/validate_nfi_pr.py --base origin/main`
- `git merge-tree conflict simulation against origin/main`
- `temporary merge simulation with perf/x7-entry-rsi3-threshold-masks, perf/x7-short-entry-threshold-masks, and perf/x7-entry-aroon-roc-thresholds applied first`
- `targeted git diff origin/main...HEAD -- NostalgiaForInfinityX7.py review`
- `git diff --check`
- `ruff format --check NostalgiaForInfinityX7.py`
- `ruff check NostalgiaForInfinityX7.py`
- `PYTHONDONTWRITEBYTECODE=1 python3 -m py_compile NostalgiaForInfinityX7.py`
