### PR TITLE
Reuse X7 entry STOCHRSI threshold masks

### DIFF
--- a/NostalgiaForInfinityX7.py
+++ b/NostalgiaForInfinityX7.py
@@ -12621,6 +12621,11 @@ class NostalgiaForInfinityX7(IStrategy):
     roc_9_1h = df["ROC_9_1h"]
     stochrsi_k_15m = df["STOCHRSIk_14_14_3_3_15m"]
     stochrsi_k_1d = df["STOCHRSIk_14_14_3_3_1d"]
+    stochrsi_k_4h_lt_80 = stochrsi_k_4h < 80.0
+    stochrsi_k_1h_lt_50 = stochrsi_k_1h < 50.0
+    stochrsi_k_1h_lt_80 = stochrsi_k_1h < 80.0
+    stochrsi_k_1h_lt_70 = stochrsi_k_1h < 70.0
+    stochrsi_k_4h_lt_90 = stochrsi_k_4h < 90.0
     rsi_3 = df["RSI_3"]
     close = df["close"]
     roc_9_15m = df["ROC_9_15m"]
@@ -12751,7 +12756,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 5m & 1h down move, 15m still not low enough
             & ((rsi_3 > 5.0) | (rsi_3_1h > 10.0) | (aroonu_14_15m < 30.0))
             # 5m & 1h down move, 4h high
-            & ((rsi_3 > 3.0) | (rsi_3_1h > 25.0) | (stochrsi_k_4h < 80.0))
+            & ((rsi_3 > 3.0) | (rsi_3_1h > 25.0) | (stochrsi_k_4h_lt_80))
             # 15m & 1h down move, 1d still high
             & (rsi_3_15m_gt_3 | (rsi_3_1h > 3.0) | (stochrsi_k_1d < 50.0))
             # 5m & 1h down move, 15m still not low enough
@@ -12785,7 +12790,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 1h still high
             & (rsi_3_15m_gt_3 | (rsi_3_1h > 35.0) | (stochrsi_k_4h < 50.0))
             # 15m & 1h down move, 1h high
-            & (rsi_3_15m_gt_3 | (rsi_3_1h > 40.0) | (stochrsi_k_1h < 70.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h > 40.0) | (stochrsi_k_1h_lt_70))
             # 15m & 1h down move, 1h high
             & (rsi_3_15m_gt_3 | (rsi_3_1h > 45.0) | (aroonu_14_1h < 80.0))
             # 15m & 4h down move, 1d high
@@ -12809,7 +12814,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 1h high, 4h overbought
             & (rsi_3_15m_gt_3 | (stochrsi_k_1h < 90.0) | (roc_9_4h < 10.0))
             # 15m down move, 4h high & overbought
-            & (rsi_3_15m_gt_3 | (stochrsi_k_4h < 80.0) | (roc_9_4h < 30.0))
+            & (rsi_3_15m_gt_3 | (stochrsi_k_4h_lt_80) | (roc_9_4h < 30.0))
             # 15m down move, drop in last half hour, 15m downtrend
             & (rsi_3_15m_gt_3 | (close > (df["close_max_6"] * 0.75)) | (roc_9_15m > -20.0))
             # 15m & 1h down move, 1h still high
@@ -12865,7 +12870,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 4h down move, 1h high
             & ((rsi_3_15m > 10.0) | (rsi_3_4h > 30.0) | (aroonu_14_1h < 85.0))
             # 15m & 4h down move, 4h high
-            & ((rsi_3_15m > 10.0) | (rsi_3_4h > 60.0) | (stochrsi_k_4h < 90.0))
+            & ((rsi_3_15m > 10.0) | (rsi_3_4h > 60.0) | (stochrsi_k_4h_lt_90))
             # 15m & 1d down move, 1d high
             & ((rsi_3_15m > 10.0) | (rsi_3_1d > 50.0) | (stochrsi_k_1d < 80.0))
             # 15m down move & downtrend, 4h high
@@ -12879,9 +12884,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 1h high, 1d overbought
             & ((rsi_3_15m > 10.0) | (aroonu_14_1h < 100.0) | (roc_9_1d < 80.0))
             # 15m down move, 1h high, 4h downtrend
-            & ((rsi_3_15m > 10.0) | (stochrsi_k_1h < 70.0) | (roc_9_4h > -25.0))
+            & ((rsi_3_15m > 10.0) | (stochrsi_k_1h_lt_70) | (roc_9_4h > -25.0))
             # 15m down move, 1h high, 1d downtrend
-            & ((rsi_3_15m > 10.0) | (stochrsi_k_1h < 70.0) | roc_9_1d_gt_neg_50)
+            & ((rsi_3_15m > 10.0) | (stochrsi_k_1h_lt_70) | roc_9_1d_gt_neg_50)
             # 15m down move, 1h high & overbought
             & ((rsi_3_15m > 10.0) | (stochrsi_k_1h < 90.0) | (roc_9_1h < 20.0))
             # 15m down move, 1h & 1d overbought
@@ -12985,7 +12990,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h high, 15n downtrend
             & ((rsi_3_1h > 25.0) | (aroonu_14_1h < 70.0) | (roc_9_15m > -20.0))
             # 1h down move, 1h still high, 1d overbought
-            & ((rsi_3_1h > 25.0) | (stochrsi_k_1h < 50.0) | (roc_9_1d < 40.0))
+            & ((rsi_3_1h > 25.0) | (stochrsi_k_1h_lt_50) | (roc_9_1d < 40.0))
             # 1h down move, 4h & 1d overbought
             & ((rsi_3_1h > 25.0) | (roc_9_4h < 80.0) | (roc_9_1d < 100.0))
             # 1h & 4h down move, 4h downtrend
@@ -13083,7 +13088,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1d high, 4h & 1d overbought
             & ((aroonu_14_1d < 90.0) | (roc_9_4h < 40.0) | (roc_9_1d < 80.0))
             # 1h high, 4h overbought
-            & ((stochrsi_k_1h < 80.0) | (roc_9_4h < 80.0))
+            & ((stochrsi_k_1h_lt_80) | (roc_9_4h < 80.0))
             # 4h high, 1h downtrend
             & ((stochrsi_k_4h < 70.0) | (roc_9_1h > -15.0))
             # 4h high, 1d downtrend
@@ -13142,7 +13147,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 5m & 1h down move, 1d high
             & ((rsi_3 > 3.0) | rsi_3_1h_gt_20 | (aroonu_14_1d < 100.0))
             # 5m & 1h down move, 1h still high
-            & ((rsi_3 > 3.0) | (rsi_3_1h > 30.0) | (stochrsi_k_1h < 50.0))
+            & ((rsi_3 > 3.0) | (rsi_3_1h > 30.0) | (stochrsi_k_1h_lt_50))
             # 5m & 1h down move, 1d high
             & ((rsi_3 > 3.0) | (rsi_3_1h > 35.0) | (aroonu_14_1d < 100.0))
             # 5m & 4h down move, 15m still not low enough
@@ -13150,13 +13155,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 5m & 4h down move, 1d downtrend
             & ((rsi_3 > 3.0) | (rsi_3_4h > 15.0) | (roc_9_1d > -30.0))
             # 5m & 4h down move, 4h high
-            & ((rsi_3 > 3.0) | (rsi_3_4h > 45.0) | (stochrsi_k_4h < 80.0))
+            & ((rsi_3 > 3.0) | (rsi_3_4h > 45.0) | (stochrsi_k_4h_lt_80))
             # 5m & 4h down move, 15m still high
             & ((rsi_3 > 5.0) | (rsi_3_4h > 25.0) | (stochrsi_k_15m < 50.0))
             # 5m & 1d down move, 1h still high
             & ((rsi_3 > 3.0) | (rsi_3_1d > 10.0) | (aroonu_14_1h < 40.0))
             # 5m & 1d down move, 1h still high
-            & ((rsi_3 > 3.0) | (rsi_3_1d > 10.0) | (stochrsi_k_1h < 50.0))
+            & ((rsi_3 > 3.0) | (rsi_3_1d > 10.0) | (stochrsi_k_1h_lt_50))
             # 5m & 1d down move, 1d downtrend
             & ((rsi_3 > 3.0) | (rsi_3_1d > 15.0) | (cmf_20_1d > -0.25))
             # 5m & 1d down move, 15m still high
@@ -13174,7 +13179,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 5m & 15m down move, 15m still high
             & ((rsi_3 > 5.0) | (rsi_3_15m > 10.0) | (stochrsi_k_15m < 40.0))
             # 5m & 15m down move, 1h high
-            & ((rsi_3 > 5.0) | (rsi_3_15m > 30.0) | (stochrsi_k_1h < 80.0))
+            & ((rsi_3 > 5.0) | (rsi_3_15m > 30.0) | (stochrsi_k_1h_lt_80))
             # 5m & 4h down move, 1d downtrend
             & ((rsi_3 > 5.0) | (rsi_3_4h > 10.0) | (roc_9_1d > -20.0))
             # 5m & 4h down move, 4h still not low enough
@@ -13208,13 +13213,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 1h high
             & (rsi_3_15m_gt_3 | rsi_3_1h_gt_20 | (aroonu_14_1h < 70.0))
             # 15m & 1h down move, 1h still high
-            & (rsi_3_15m_gt_3 | rsi_3_1h_gt_20 | (stochrsi_k_1h < 50.0))
+            & (rsi_3_15m_gt_3 | rsi_3_1h_gt_20 | (stochrsi_k_1h_lt_50))
             # 15m & 1h down move, 4h high
             & (rsi_3_15m_gt_3 | rsi_3_1h_gt_20 | (stochrsi_k_4h < 60.0))
             # 15m & 1h down move, 1h high
             & (rsi_3_15m_gt_3 | (rsi_3_1h > 30.0) | (aroonu_14_1h < 60.0))
             # 15m & 1h down move, 1h high
-            & (rsi_3_15m_gt_3 | (rsi_3_1h > 30.0) | (stochrsi_k_1h < 70.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h > 30.0) | (stochrsi_k_1h_lt_70))
             # 15m & 1h down move, 1h still high
             & (rsi_3_15m_gt_3 | (rsi_3_1h > 35.0) | (aroonu_14_1h < 40.0))
             # 15m & 1h down move, 1d high
@@ -13222,11 +13227,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 1h high
             & (rsi_3_15m_gt_3 | (rsi_3_1h > 40.0) | (aroonu_14_1h < 70.0))
             # 15m & 1h down move, 4h high
-            & (rsi_3_15m_gt_3 | (rsi_3_1h > 40.0) | (stochrsi_k_4h < 80.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h > 40.0) | (stochrsi_k_4h_lt_80))
             # 15m & 1h down move, 1h high
             & (rsi_3_15m_gt_3 | (rsi_3_1h > 45.0) | (aroonu_14_1h < 85.0))
             # 15m & 1h down move, 1h high
-            & (rsi_3_15m_gt_3 | (rsi_3_1h > 60.0) | (stochrsi_k_1h < 80.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h > 60.0) | (stochrsi_k_1h_lt_80))
             # 15m & 4h down move, 4h still not low enough
             & (rsi_3_15m_gt_3 | (rsi_3_4h > 5.0) | (rsi_14_4h < 30.0))
             # 15m & 4h down move, 4h downtrend
@@ -13242,7 +13247,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 15m still not low enough, 1h high
             & (rsi_3_15m_gt_3 | (aroonu_14_15m < 20.0) | (stochrsi_k_1h < 60.0))
             # 15m down move, 15m still not low enough, 1h still high
-            & (rsi_3_15m_gt_3 | (aroonu_14_15m < 30.0) | (stochrsi_k_1h < 50.0))
+            & (rsi_3_15m_gt_3 | (aroonu_14_15m < 30.0) | (stochrsi_k_1h_lt_50))
             # 15m down move, 1h high, 1d overbought
             & (rsi_3_15m_gt_3 | (aroonu_14_1h < 70.0) | (roc_9_1d < 20.0))
             # 15m down move, 4h still high, 15m downtrend
@@ -13264,7 +13269,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1d down move, 1d still high, 4h still high
             & ((rsi_3_1d > 50.0) | (rsi_14_1d < 50.0) | (stochrsi_k_4h < 50.0))
             # 15m & 1h down move, 1h high
-            & ((rsi_3_15m > 5.0) | (rsi_3_1h > 40.0) | (stochrsi_k_4h < 80.0))
+            & ((rsi_3_15m > 5.0) | (rsi_3_1h > 40.0) | (stochrsi_k_4h_lt_80))
             # 15m & 1h down move, 1h high
             & ((rsi_3_15m > 5.0) | (rsi_3_1h > 45.0) | (aroonu_14_1h < 80.0))
             # 15m & 4h down move, 1d still high
@@ -13292,15 +13297,15 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 15m still not low enough, 4h high
             & ((rsi_3_15m > 5.0) | (aroonu_14_15m < 20.0) | (stochrsi_k_4h < 70.0))
             # 15m down move, 15m stil high, 1h still high
-            & ((rsi_3_15m > 5.0) | (aroonu_14_15m < 40.0) | (stochrsi_k_1h < 50.0))
+            & ((rsi_3_15m > 5.0) | (aroonu_14_15m < 40.0) | (stochrsi_k_1h_lt_50))
             # 15m down move, 1d high & overbought
             & ((rsi_3_15m > 5.0) | (aroonu_14_1d < 80.0) | (roc_9_1d < 20.0))
             # 15m down move, 15m still not low enough, 1h still high
-            & ((rsi_3_15m > 5.0) | (stochrsi_k_15m < 20.0) | (stochrsi_k_1h < 50.0))
+            & ((rsi_3_15m > 5.0) | (stochrsi_k_15m < 20.0) | (stochrsi_k_1h_lt_50))
             # 15m down move, 1h still high, 4h overbought
-            & ((rsi_3_15m > 5.0) | (stochrsi_k_1h < 50.0) | (roc_9_4h < 30.0))
+            & ((rsi_3_15m > 5.0) | (stochrsi_k_1h_lt_50) | (roc_9_4h < 30.0))
             # 15m down move, 1h high & overbought
-            & ((rsi_3_15m > 5.0) | (stochrsi_k_1h < 80.0) | (roc_9_1h < 20.0))
+            & ((rsi_3_15m > 5.0) | (stochrsi_k_1h_lt_80) | (roc_9_1h < 20.0))
             # 15m & 1h down move, 15m high
             & ((rsi_3_15m > 10.0) | (rsi_3_1h > 10.0) | (stochrsi_k_15m < 50.0))
             # 15m & 1h down move, 1h still high
@@ -13326,15 +13331,15 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 1h high
             & ((rsi_3_15m > 10.0) | (rsi_3_1h > 35.0) | (stochrsi_k_1h < 60.0))
             # 15m & 1h down move, 4h high
-            & ((rsi_3_15m > 10.0) | (rsi_3_1h > 40.0) | (stochrsi_k_4h < 80.0))
+            & ((rsi_3_15m > 10.0) | (rsi_3_1h > 40.0) | (stochrsi_k_4h_lt_80))
             # 15m & 1h down move, 1h high
-            & ((rsi_3_15m > 10.0) | (rsi_3_1h > 50.0) | (stochrsi_k_1h < 70.0))
+            & ((rsi_3_15m > 10.0) | (rsi_3_1h > 50.0) | (stochrsi_k_1h_lt_70))
             # 15m & 1h down move, 4h high
-            & ((rsi_3_15m > 10.0) | (rsi_3_1h > 50.0) | (stochrsi_k_4h < 80.0))
+            & ((rsi_3_15m > 10.0) | (rsi_3_1h > 50.0) | (stochrsi_k_4h_lt_80))
             # 16m & 1h down move, 1h high
-            & ((rsi_3_15m > 10.0) | (rsi_3_1h > 55.0) | (stochrsi_k_1h < 70.0))
+            & ((rsi_3_15m > 10.0) | (rsi_3_1h > 55.0) | (stochrsi_k_1h_lt_70))
             # 15m & 1h down move, 4h high
-            & ((rsi_3_15m > 10.0) | (rsi_3_1h > 55.0) | (stochrsi_k_4h < 90.0))
+            & ((rsi_3_15m > 10.0) | (rsi_3_1h > 55.0) | (stochrsi_k_4h_lt_90))
             # 15m & 1h down move, 1h high
             & ((rsi_3_15m > 10.0) | (rsi_3_1h > 40.0) | (aroonu_14_1h < 70.0))
             # 15m & 4h down move, 4h still not low enough
@@ -13358,7 +13363,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1d down move, 1h high
             & ((rsi_3_15m > 10.0) | (rsi_3_1d > 10.0) | (stochrsi_k_1h < 90.0))
             # 15m & 1d down move, 4h high
-            & ((rsi_3_15m > 10.0) | (rsi_3_1d > 15.0) | (stochrsi_k_4h < 90.0))
+            & ((rsi_3_15m > 10.0) | (rsi_3_1d > 15.0) | (stochrsi_k_4h_lt_90))
             # 15m down move, 15m downtrend, 1h high
             & ((rsi_3_15m > 10.0) | (cmf_20_15m > -0.40) | (aroonu_14_1h < 80.0))
             # 15m down move, 1h high, 1d overbought
@@ -13428,13 +13433,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 15m high
             & ((rsi_3_15m > 20.0) | (rsi_3_1h > 25.0) | (stochrsi_k_15m < 80.0))
             # 15m & 1h down move, 4h high
-            & ((rsi_3_15m > 20.0) | (rsi_3_1h > 25.0) | (stochrsi_k_4h < 80.0))
+            & ((rsi_3_15m > 20.0) | (rsi_3_1h > 25.0) | (stochrsi_k_4h_lt_80))
             # 15m & 1h down move, 1h high
             & ((rsi_3_15m > 20.0) | (rsi_3_1h > 30.0) | (aroonu_14_1h < 70.0))
             # 15m & 1h down move, 1h high
-            & ((rsi_3_15m > 20.0) | (rsi_3_1h > 45.0) | (stochrsi_k_1h < 80.0))
+            & ((rsi_3_15m > 20.0) | (rsi_3_1h > 45.0) | (stochrsi_k_1h_lt_80))
             # 15m & 4h down move, 1h high
-            & ((rsi_3_15m > 20.0) | rsi_3_4h_gt_20 | (stochrsi_k_1h < 80.0))
+            & ((rsi_3_15m > 20.0) | rsi_3_4h_gt_20 | (stochrsi_k_1h_lt_80))
             # 15m & 4h down move, 4h high
             & ((rsi_3_15m > 20.0) | (rsi_3_4h > 40.0) | (aroonu_14_4h < 80.0))
             # 15m down move, 1h & 4h high
@@ -13468,7 +13473,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 1h high, 1d downtrend
             & ((rsi_3_15m > 30.0) | (stochrsi_k_1h < 80.0) | (roc_9_1d > -20.0))
             # 15m down move, 4h high & overbought
-            & ((rsi_3_15m > 30.0) | (stochrsi_k_4h < 80.0) | (roc_9_4h < 30.0))
+            & ((rsi_3_15m > 30.0) | (stochrsi_k_4h_lt_80) | (roc_9_4h < 30.0))
             # 15m down move, 1h high, 4h overbought
             & ((rsi_3_15m > 35.0) | (aroonu_14_1h < 80.0) | (roc_9_4h < 80.0))
             # 15m down move, 4h high & overbought
@@ -13476,7 +13481,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 4h high, 1d overbought
             & ((rsi_3_15m > 35.0) | (aroonu_14_4h < 100.0) | (roc_9_1h < 20.0))
             # 15m down move, 1h high, 1d overbought
-            & ((rsi_3_15m > 35.0) | (stochrsi_k_1h < 80.0) | (roc_9_1d < 80.0))
+            & ((rsi_3_15m > 35.0) | (stochrsi_k_1h_lt_80) | (roc_9_1d < 80.0))
             # 15m down move, 4h high & overbought
             & ((rsi_3_15m > 40.0) | (aroonu_14_4h < 100.0) | (roc_9_4h < 40.0))
             # 1h & 4h down move, 1d downtrend
@@ -13582,7 +13587,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 4h high
             & (rsi_3_1h_gt_20 | (rsi_3_4h > 50.0) | (aroonu_14_4h < 85.0))
             # 1h & 1d down move, 1h still high
-            & (rsi_3_1h_gt_20 | (rsi_3_1d > 30.0) | (stochrsi_k_1h < 50.0))
+            & (rsi_3_1h_gt_20 | (rsi_3_1d > 30.0) | (stochrsi_k_1h_lt_50))
             # 1h down move, 1h high, 4h downtrend
             & (rsi_3_1h_gt_20 | (aroonu_14_1h < 70.0) | (roc_9_4h > -10.0))
             # 1h down move, 1h high, 4h overbought
@@ -13634,7 +13639,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1d high, 4h overbought
             & ((rsi_3_1h > 35.0) | (aroonu_14_1d < 100.0) | (roc_9_4h < 40.0))
             # 1h down move, 1h still high, 1d overbought
-            & ((rsi_3_1h > 35.0) | (stochrsi_k_1h < 50.0) | (roc_9_1d < 200.0))
+            & ((rsi_3_1h > 35.0) | (stochrsi_k_1h_lt_50) | (roc_9_1d < 200.0))
             # 1h down move, 1h & 4h high
             & ((rsi_3_1h > 40.0) | (aroonu_14_1h < 70.0) | (aroonu_14_4h < 100.0))
             # 1h down move, 1h & 1d high
@@ -13654,7 +13659,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 4h high, 1d downtrend
             & ((rsi_3_1h > 50.0) | (stochrsi_k_4h < 60.0) | (roc_9_1d > -60.0))
             # 1h down move, 4h high & overbought
-            & ((rsi_3_1h > 50.0) | (stochrsi_k_4h < 80.0) | (roc_9_4h < 100.0))
+            & ((rsi_3_1h > 50.0) | (stochrsi_k_4h_lt_80) | (roc_9_4h < 100.0))
             # 1h down move, 1h & 4h overbought
             & ((rsi_3_1h > 50.0) | (roc_9_1h < 10.0) | (roc_9_4h < 100.0))
             # 1h down move, 1h high & overbought
@@ -13662,7 +13667,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 4h high & overbought
             & ((rsi_3_1h > 55.0) | (aroonu_14_4h < 100.0) | (roc_9_4h < 10.0))
             # 1h down move, 1h high & overbought
-            & ((rsi_3_1h > 55.0) | (stochrsi_k_1h < 80.0) | (roc_9_1h < 10.0))
+            & ((rsi_3_1h > 55.0) | (stochrsi_k_1h_lt_80) | (roc_9_1h < 10.0))
             # 4h & 1d down move, 1d still high
             & ((rsi_3_4h > 3.0) | (rsi_3_1d > 15.0) | (aroonu_14_1d < 40.0))
             # 4h & 1d down move, 1d still high
@@ -13764,7 +13769,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1d down move, 1h high & overbought
             & ((rsi_3_1d > 40.0) | (aroonu_14_1d < 70.0) | (roc_9_1d < 80.0))
             # 1d down move, 4h high & overbought
-            & ((rsi_3_1d > 45.0) | (stochrsi_k_4h < 90.0) | (roc_9_4h < 60.0))
+            & ((rsi_3_1d > 45.0) | (stochrsi_k_4h_lt_90) | (roc_9_4h < 60.0))
             # 1d downtrend, 1d high & overbought
             & ((cmf_20_1d > -0.40) | (aroonu_14_1d < 85.0) | (roc_9_1d < 20.0))
             # 1h high, 4h & 1d overbought
@@ -13808,13 +13813,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m high, 1d overbought
             & ((stochrsi_k_15m < 70.0) | (roc_9_1d < 60.0))
             # 1h high, 1d downtrend
-            & ((stochrsi_k_1h < 70.0) | roc_9_1d_gt_neg_50)
+            & ((stochrsi_k_1h_lt_70) | roc_9_1d_gt_neg_50)
             # 1h high, 1d overbought
-            & ((stochrsi_k_1h < 70.0) | (roc_9_1d < 40.0))
+            & ((stochrsi_k_1h_lt_70) | (roc_9_1d < 40.0))
             # 1h high, 4h downtrend
             & ((stochrsi_k_1h < 80.0) | (roc_9_4h > -20.0))
             # 1h high, 4h overbought
-            & ((stochrsi_k_1h < 80.0) | (roc_9_4h < 80.0))
+            & ((stochrsi_k_1h_lt_80) | (roc_9_4h < 80.0))
             # 4h high, 1h & 4h overbought
             & ((stochrsi_k_4h < 80.0) | (roc_9_1h < 10.0) | (roc_9_4h < 20.0))
             # 1d high, 1h & 1d overbought
@@ -13826,7 +13831,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # drop in last 20 days, 1h high, 1d downtrend
             & ((close > (high_max_20_1d * 0.20)) | (aroonu_14_1h < 70.0) | (roc_9_1d > -70.0))
             # drop in last 20 days. 4h high
-            & ((close > (high_max_20_1d * 0.10)) | (stochrsi_k_4h < 90.0))
+            & ((close > (high_max_20_1d * 0.10)) | (stochrsi_k_4h_lt_90))
           )
 
           # Logic
@@ -13853,7 +13858,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 5m down move, 15m still high, 1d downtrend
             & ((rsi_3 > 5.0) | (stochrsi_k_15m < 50.0) | (roc_9_1d > -20.0))
             # 5m down move, 1h still high, 4h downtrend
-            & ((rsi_3 > 5.0) | (stochrsi_k_1h < 50.0) | (roc_9_4h > -10.0))
+            & ((rsi_3 > 5.0) | (stochrsi_k_1h_lt_50) | (roc_9_4h > -10.0))
             # 5m down move, 1h high. 1d downtrend
             & ((rsi_3 > 5.0) | (stochrsi_k_1h < 80.0) | (roc_9_1d > -30.0))
             # 5m down move, 15m & 1h high
@@ -13875,7 +13880,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 15m still high, 1h high
             & ((rsi_3_15m > 10.0) | (aroonu_14_15m < 40.0) | (stochrsi_k_1h < 90.0))
             # 15m down move, 15m still high, 1h high
-            & ((rsi_3_15m > 10.0) | (aroonu_14_15m < 50.0) | (stochrsi_k_1h < 80.0))
+            & ((rsi_3_15m > 10.0) | (aroonu_14_15m < 50.0) | (stochrsi_k_1h_lt_80))
             # 15m down move, 15m still high, 1d overbought
             & ((rsi_3_15m > 10.0) | (aroonu_14_15m < 50.0) | (roc_9_1d < 100.0))
             # 15m down move, 15m high, 1d overbought
@@ -13887,7 +13892,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 1h high
             & ((rsi_3_15m > 15.0) | (rsi_3_1h > 35.0) | (stochrsi_k_1h < 60.0))
             # 15m & 1h down move, 1h high
-            & ((rsi_3_15m > 15.0) | (rsi_3_1h > 45.0) | (stochrsi_k_1h < 80.0))
+            & ((rsi_3_15m > 15.0) | (rsi_3_1h > 45.0) | (stochrsi_k_1h_lt_80))
             # 15m & 1h down move, 1h high
             & ((rsi_3_15m > 15.0) | (rsi_3_1h > 50.0) | (aroonu_14_1h < 75.0))
             # 15m & 4h down move, 4h high
@@ -13917,13 +13922,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 15m & 1d high
             & ((rsi_3_15m > 15.0) | (aroonu_14_15m < 70.0) | (aroonu_14_1d < 100.0))
             # 15m down move, 15m still high, 4h high
-            & ((rsi_3_15m > 15.0) | (aroonu_14_15m < 70.0) | (stochrsi_k_4h < 80.0))
+            & ((rsi_3_15m > 15.0) | (aroonu_14_15m < 70.0) | (stochrsi_k_4h_lt_80))
             # 15m down move, 15m high, 1d overbought
             & ((rsi_3_15m > 15.0) | (aroonu_14_15m < 70.0) | roc_9_1d_lt_50)
             # 15m down move, 4h high, 1d downtrend
             & ((rsi_3_15m > 15.0) | (aroonu_14_4h < 50.0) | (roc_9_1d > -40.0))
             # 15m down move, 1h high, 1d overbought
-            & ((rsi_3_15m > 15.0) | (stochrsi_k_1h < 80.0) | (roc_9_1d < 20.0))
+            & ((rsi_3_15m > 15.0) | (stochrsi_k_1h_lt_80) | (roc_9_1d < 20.0))
             # 15m down move, 4h & 1d overbought
             & ((rsi_3_15m > 15.0) | (roc_9_4h < 25.0) | (roc_9_1d < 100.0))
             # 15m & 1h down move, 1h still high
@@ -13945,7 +13950,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 15m still high
             & ((rsi_3_15m > 20.0) | (rsi_3_1d > 25.0) | (stochrsi_k_15m < 50.0))
             # 15m & 1d down move, 1h still high
-            & ((rsi_3_15m > 20.0) | (rsi_3_1d > 25.0) | (stochrsi_k_1h < 50.0))
+            & ((rsi_3_15m > 20.0) | (rsi_3_1d > 25.0) | (stochrsi_k_1h_lt_50))
             # 15m & 1d down move, 1h high
             & ((rsi_3_15m > 20.0) | (rsi_3_1d > 40.0) | (aroonu_14_1h < 90.0))
             # 15m &1d down move, 1d overbought
@@ -13953,7 +13958,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 15m still not low enough, 4h overbought
             & ((rsi_3_15m > 20.0) | (aroonu_14_15m < 30.0) | (roc_9_4h < 60.0))
             # 15m down move, 15m still high, 4h high
-            & ((rsi_3_15m > 20.0) | (aroonu_14_15m < 40.0) | (stochrsi_k_4h < 90.0))
+            & ((rsi_3_15m > 20.0) | (aroonu_14_15m < 40.0) | (stochrsi_k_4h_lt_90))
             # 15m down move, 15m still high, 1h high
             & ((rsi_3_15m > 20.0) | (aroonu_14_15m < 50.0) | (aroonu_14_1h < 100.0))
             # 15m down move, 15m still high, 4h high
@@ -13979,7 +13984,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 1h high, 4h downtrend
             & ((rsi_3_15m > 20.0) | (stochrsi_k_1h < 60.0) | (roc_9_4h > -20.0))
             # 15m down move, 1h high, 1d overbought
-            & ((rsi_3_15m > 20.0) | (stochrsi_k_1h < 80.0) | (roc_9_1d < 30.0))
+            & ((rsi_3_15m > 20.0) | (stochrsi_k_1h_lt_80) | (roc_9_1d < 30.0))
             # 15m down move, 1h high
             & ((rsi_3_15m > 20.0) | (stochrsi_k_1h < 90.0))
             # 15m down move, 4h still high, 1d downtrend
@@ -14047,7 +14052,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 1h high, 1d overbought
             & ((rsi_3_15m > 30.0) | (stochrsi_k_1h < 90.0) | roc_9_1d_lt_50)
             # 15m down move, 15m high, 4h high
-            & ((rsi_3_15m > 35.0) | (aroonu_14_15m < 60.0) | (stochrsi_k_4h < 90.0))
+            & ((rsi_3_15m > 35.0) | (aroonu_14_15m < 60.0) | (stochrsi_k_4h_lt_90))
             # 15m down move, 15m high, 4h overbought
             & ((rsi_3_15m > 35.0) | (aroonu_14_15m < 70.0) | (roc_9_4h < 80.0))
             # 15m down move, 1h high, 4h overbought
@@ -14063,7 +14068,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 15m & 4h high
             & ((rsi_3_15m > 40.0) | (aroonu_14_15m < 75.0) | (aroonu_14_4h < 75.0))
             # 15m down move, 4h high & overbought
-            & ((rsi_3_15m > 40.0) | (stochrsi_k_4h < 80.0) | (roc_9_4h < 30.0))
+            & ((rsi_3_15m > 40.0) | (stochrsi_k_4h_lt_80) | (roc_9_4h < 30.0))
             # 1h & 4h down move, 15m still high
             & ((rsi_3_1h > 5.0) | (rsi_3_4h > 10.0) | (stochrsi_k_15m < 50.0))
             # 1h & 4h down move, 4h still high
@@ -14135,9 +14140,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h high, 1d overbought
             & ((rsi_3_1h > 35.0) | (aroonu_14_1h < 80.0) | roc_9_1d_lt_50)
             # 1h down move, 4h high, 1d downtrend
-            & ((rsi_3_1h > 35.0) | (stochrsi_k_4h < 80.0) | roc_9_1d_gt_neg_50)
+            & ((rsi_3_1h > 35.0) | (stochrsi_k_4h_lt_80) | roc_9_1d_gt_neg_50)
             # 1h & 4h down move, 1h high
-            & ((rsi_3_1h > 40.0) | (rsi_3_4h > 50.0) | (stochrsi_k_1h < 70.0))
+            & ((rsi_3_1h > 40.0) | (rsi_3_4h > 50.0) | (stochrsi_k_1h_lt_70))
             # 1h & 4h down move, 4h high
             & ((rsi_3_1h > 40.0) | (rsi_3_4h > 50.0) | (stochrsi_k_4h < 60.0))
             # 1h down move, 15m still high, 4h downtrend
@@ -14147,7 +14152,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 15m & 4h high
             & ((rsi_3_1h > 40.0) | (aroonu_14_15m < 70.0) | aroonu_14_4h_lt_70)
             # 1h down move, 1h still high, 4h high
-            & ((rsi_3_1h > 40.0) | (aroonu_14_1h < 50.0) | (stochrsi_k_4h < 80.0))
+            & ((rsi_3_1h > 40.0) | (aroonu_14_1h < 50.0) | (stochrsi_k_4h_lt_80))
             # 1h down move, 1h still high, 1d overbought
             & ((rsi_3_1h > 40.0) | (aroonu_14_1h < 50.0) | (roc_9_1d < 100.0))
             # 1h down move, 1h high, 4h overbought
@@ -14157,7 +14162,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h & 4h high
             & ((rsi_3_1h > 40.0) | (aroonu_14_1h < 90.0) | (aroonu_14_4h < 100.0))
             # 1h down move, 1h high, 1d downtrend
-            & ((rsi_3_1h > 40.0) | (stochrsi_k_1h < 80.0) | (cmf_20_1d > -0.20))
+            & ((rsi_3_1h > 40.0) | (stochrsi_k_1h_lt_80) | (cmf_20_1d > -0.20))
             # 1h down move, 4h & 1d overbought
             & ((rsi_3_1h > 40.0) | (roc_9_4h < 10.0) | roc_9_1d_lt_50)
             # 1h down move, 15m high, 4h overbought
@@ -14191,21 +14196,21 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h high, 1d downtrend
             & ((rsi_3_1h > 55.0) | (stochrsi_k_1h < 80.0) | (roc_9_1d > -30.0))
             # 1h down move, 4h high & overbought
-            & ((rsi_3_1h > 55.0) | (stochrsi_k_4h < 80.0) | (roc_9_4h < 100.0))
+            & ((rsi_3_1h > 55.0) | (stochrsi_k_4h_lt_80) | (roc_9_4h < 100.0))
             # 1h down move, 1h high, 1d overbought
             & ((rsi_3_1h > 60.0) | (stochrsi_k_1h < 80.0) | (roc_9_1d < 100.0))
             # 1h down move, 15m & 1h high
             & ((rsi_3_1h > 65.0) | (aroonu_14_15m < 70.0) | (aroonu_14_1h < 100.0))
             # 1h down move, 1h high & overbought
-            & ((rsi_3_1h > 65.0) | (stochrsi_k_1h < 80.0) | (roc_9_1h < 10.0))
+            & ((rsi_3_1h > 65.0) | (stochrsi_k_1h_lt_80) | (roc_9_1h < 10.0))
             # 4h down move, 1h still high, 1d downtrend
             & ((rsi_3_4h > 3.0) | (stochrsi_k_1h < 40.0) | (roc_9_1d > -30.0))
             # 4h down move, 1h still high, 4h downtrend
-            & ((rsi_3_4h > 3.0) | (stochrsi_k_1h < 50.0) | (roc_9_4h > -30.0))
+            & ((rsi_3_4h > 3.0) | (stochrsi_k_1h_lt_50) | (roc_9_4h > -30.0))
             # 4h down move, 4h & 1d downtrend
             & ((rsi_3_4h > 3.0) | (roc_9_4h > -20.0) | (roc_9_1d > -20.0))
             # 4h down move, 15m high, 1h still high
-            & ((rsi_3_4h > 5.0) | (aroonu_14_15m < 70.0) | (stochrsi_k_1h < 50.0))
+            & ((rsi_3_4h > 5.0) | (aroonu_14_15m < 70.0) | (stochrsi_k_1h_lt_50))
             # 4h down move, 15m high
             & ((rsi_3_4h > 5.0) | (stochrsi_k_15m < 70.0))
             # 4h down move, 4h still high, 1d downtrend
@@ -14285,7 +14290,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 1h still high, 1d overbought
             & ((rsi_3_4h > 25.0) | (stochrsi_k_1h < 50.0) | (roc_9_1d < 100.0))
             # 4h down move, 4h high, 1d downtrend
-            & ((rsi_3_4h > 25.0) | (stochrsi_k_4h < 80.0) | roc_9_1d_gt_neg_50)
+            & ((rsi_3_4h > 25.0) | (stochrsi_k_4h_lt_80) | roc_9_1d_gt_neg_50)
             # 4h down move, 1h high, 1h downtrend
             & ((rsi_3_4h > 30.0) | (aroonu_14_1h < 70.0) | (roc_9_1h > -10.0))
             # 4h & 1d down move, 1d overbought
@@ -14297,7 +14302,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 1h high, 1d downtrend
             & ((rsi_3_4h > 30.0) | (aroonu_14_1h < 90.0) | (roc_9_1d > -20.0))
             # 4h down move, 1h high, 1d downtrend
-            & ((rsi_3_4h > 30.0) | (stochrsi_k_1h < 80.0) | (roc_9_1d > -40.0))
+            & ((rsi_3_4h > 30.0) | (stochrsi_k_1h_lt_80) | (roc_9_1d > -40.0))
             # 4h down move, 1h high, 1d overbought
             & ((rsi_3_4h > 30.0) | (stochrsi_k_1h < 90.0) | roc_9_1d_lt_50)
             # 4h down move, 1d high & overbought
@@ -14307,7 +14312,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 15m still high, 4h high
             & ((rsi_3_4h > 35.0) | (aroonu_14_15m < 50.0) | (aroonu_14_4h < 80.0))
             # 4h down move, 15m high, 1h high
-            & ((rsi_3_4h > 35.0) | (aroonu_14_15m < 70.0) | (stochrsi_k_1h < 70.0))
+            & ((rsi_3_4h > 35.0) | (aroonu_14_15m < 70.0) | (stochrsi_k_1h_lt_70))
             # 4h down move, 4h & 1d high
             & ((rsi_3_4h > 35.0) | (aroonu_14_4h < 80.0) | (aroonu_14_1d < 100.0))
             # 4h down move, 1d high, 1d downtrend
@@ -14325,13 +14330,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 15m high, 1h high
             & ((rsi_3_4h > 40.0) | (stochrsi_k_15m < 70.0) | (aroonu_14_1h < 100.0))
             # 4h down move, 1h high, 1d overbought
-            & ((rsi_3_4h > 40.0) | (stochrsi_k_1h < 70.0) | (roc_9_1d < 60.0))
+            & ((rsi_3_4h > 40.0) | (stochrsi_k_1h_lt_70) | (roc_9_1d < 60.0))
             # 4h down move, 4h & 1d overbought
             & ((rsi_3_4h > 40.0) | (roc_9_4h < 10.0) | (roc_9_1d < 30.0))
             # 4h down move, 15m still high, 4h high
             & ((rsi_3_4h > 45.0) | (aroonu_14_15m < 40.0) | (aroonu_14_4h < 90.0))
             # 45 down move, 15m high, 1h high
-            & ((rsi_3_4h > 45.0) | (aroonu_14_15m < 70.0) | (stochrsi_k_1h < 70.0))
+            & ((rsi_3_4h > 45.0) | (aroonu_14_15m < 70.0) | (stochrsi_k_1h_lt_70))
             # 4h down move, 15m high, 4h high
             & ((rsi_3_4h > 45.0) | (aroonu_14_15m < 70.0) | (stochrsi_k_4h < 70.0))
             # 4h down move, 4h high, 1d overbought
@@ -14351,7 +14356,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 15m & 1h high
             & ((rsi_3_4h > 50.0) | (aroonu_14_15m < 70.0) | (aroonu_14_1h < 100.0))
             # 4h down move, 4h still high, 1h high
-            & ((rsi_3_4h > 50.0) | (aroonu_14_4h < 40.0) | (stochrsi_k_1h < 70.0))
+            & ((rsi_3_4h > 50.0) | (aroonu_14_4h < 40.0) | (stochrsi_k_1h_lt_70))
             # 4h down move, 4h high, 1d overbought
             & ((rsi_3_4h > 50.0) | aroonu_14_4h_lt_70 | (roc_9_1d < 40.0))
             # 4h down move, 1d high & overbought
@@ -14369,7 +14374,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 1d high & overbought
             & ((rsi_3_4h > 55.0) | (aroonu_14_1d < 90.0) | (roc_9_1d < 60.0))
             # 4h down move, 4h high & overbought
-            & ((rsi_3_4h > 55.0) | (stochrsi_k_4h < 80.0) | (roc_9_4h < 10.0))
+            & ((rsi_3_4h > 55.0) | (stochrsi_k_4h_lt_80) | (roc_9_4h < 10.0))
             # 4h down move, 15m high, 1h high
             & ((rsi_3_4h > 60.0) | (aroonu_14_15m < 60.0) | (stochrsi_k_1h < 90.0))
             # 4h down move, 4h high & overbought
@@ -14385,7 +14390,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1d down move, 4h & 1d downtrend
             & ((rsi_3_1d > 3.0) | (roc_9_4h > -40.0) | roc_9_1d_gt_neg_50)
             # 1d down move, 15m still high, 4h high
-            & ((rsi_3_1d > 10.0) | (aroonu_14_15m < 70.0) | (stochrsi_k_4h < 80.0))
+            & ((rsi_3_1d > 10.0) | (aroonu_14_15m < 70.0) | (stochrsi_k_4h_lt_80))
             # 1d down move, 4h & 1d downtrend
             & ((rsi_3_1d > 10.0) | (roc_9_4h > -20.0) | (roc_9_1d > -60.0))
             # 1d down move, 4h & 1d downtrend
@@ -14395,13 +14400,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1d down move, 4h & 1d downtrend
             & ((rsi_3_1d > 15.0) | (roc_9_4h > -10.0) | (roc_9_1d > -40.0))
             # 1d down move, 15m high, 1h high
-            & ((rsi_3_1d > 20.0) | (aroonu_14_15m < 60.0) | (stochrsi_k_1h < 80.0))
+            & ((rsi_3_1d > 20.0) | (aroonu_14_15m < 60.0) | (stochrsi_k_1h_lt_80))
             # 1d down move, 15m high, 1h high
             & ((rsi_3_1d > 20.0) | (aroonu_14_15m < 70.0) | (aroonu_14_1h < 100.0))
             # 1d down move, 4h high, 4h downtrend
             & ((rsi_3_1d > 20.0) | (stochrsi_k_4h < 70.0) | (roc_9_4h > -20.0))
             # 1d down move, 15m high, 4h high
-            & ((rsi_3_1d > 25.0) | (aroonu_14_15m < 70.0) | (stochrsi_k_4h < 80.0))
+            & ((rsi_3_1d > 25.0) | (aroonu_14_15m < 70.0) | (stochrsi_k_4h_lt_80))
             # 1d down move, 15m high, 4h downtrend
             & ((rsi_3_1d > 25.0) | (aroonu_14_15m < 70.0) | (roc_9_4h > -30.0))
             # 1d down move, 1h & 1d high
@@ -14411,7 +14416,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1d down move, 1d high & overbought
             & ((rsi_3_1d > 30.0) | (aroonu_14_1d < 60.0) | (roc_9_1d < 10.0))
             # 1d down move, 1h high, 1d downtrend
-            & ((rsi_3_1d > 30.0) | (stochrsi_k_1h < 70.0) | (roc_9_1d < 20.0))
+            & ((rsi_3_1d > 30.0) | (stochrsi_k_1h_lt_70) | (roc_9_1d < 20.0))
             # 1d down move, 1h & 1d high
             & ((rsi_3_1d > 35.0) | (aroonu_14_1h < 70.0) | (aroonu_14_1d < 90.0))
             # 1d down move, 1h high, 1d overbought
@@ -14421,7 +14426,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1d down move, 1d high & overbought
             & ((rsi_3_1d > 40.0) | (aroonu_14_1d < 80.0) | (roc_9_1d < 10.0))
             # 1d down move, 1h high, 1d overbought
-            & ((rsi_3_1d > 40.0) | (stochrsi_k_1h < 70.0) | roc_9_1d_lt_50)
+            & ((rsi_3_1d > 40.0) | (stochrsi_k_1h_lt_70) | roc_9_1d_lt_50)
             # 15m still high, 4h high, 1d overbought
             & ((aroonu_14_15m < 50.0) | (rsi_14_4h < 60.0) | (roc_9_1d < 70.0))
             # 15m still high, 1h downtrend, 4h overbought
@@ -14471,13 +14476,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1d high, 4h & 1d overbought
             & ((aroonu_14_1d < 100.0) | (roc_9_4h < 30.0) | (roc_9_1d < 40.0))
             # 15m & 1h high, 1d overbought
-            & ((stochrsi_k_15m < 70.0) | (stochrsi_k_1h < 70.0) | roc_9_1d_lt_50)
+            & ((stochrsi_k_15m < 70.0) | (stochrsi_k_1h_lt_70) | roc_9_1d_lt_50)
             # 15m & 1d high
             & ((stochrsi_k_15m < 90.0) | (stochrsi_k_1d < 90.0))
             # 1h high, 4h & 1d downtrend
             & ((stochrsi_k_1h < 60.0) | (roc_9_4h > -30.0) | (roc_9_1d > -30.0))
             # 1h high, 4h downtrend
-            & ((stochrsi_k_1h < 70.0) | (roc_9_4h > -30.0))
+            & ((stochrsi_k_1h_lt_70) | (roc_9_4h > -30.0))
             # 1h high, 1d downtrend
             & ((stochrsi_k_1h < 70.0) | (roc_9_1d > -20.0))
             # 4h high, 4h overbought, 1d downtrend
@@ -14536,7 +14541,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 5m & 1h down move, 1h high
             & ((rsi_3 > 3.0) | (rsi_3_1h > 50.0) | (aroonu_14_1h < 70.0))
             # 5m & 1h down move, 1h still high
-            & ((rsi_3 > 3.0) | (rsi_3_1h > 30.0) | (stochrsi_k_1h < 50.0))
+            & ((rsi_3 > 3.0) | (rsi_3_1h > 30.0) | (stochrsi_k_1h_lt_50))
             # 5m & 1h down move, 1d downtrend
             & ((rsi_3 > 3.0) | (rsi_3_4h > 15.0) | (roc_9_1d > -30.0))
             # 5m & 4h down move, 4h high
@@ -14584,9 +14589,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 4h & 1d high
             & ((rsi_3_15m > 10.0) | (aroonu_14_4h < 90.0) | (aroonu_14_1d < 100.0))
             # 15m down move, 1h high, 1d downtrend
-            & ((rsi_3_15m > 10.0) | (stochrsi_k_1h < 70.0) | roc_9_1d_gt_neg_50)
+            & ((rsi_3_15m > 10.0) | (stochrsi_k_1h_lt_70) | roc_9_1d_gt_neg_50)
             # 15m down move, 1h high
-            & ((rsi_3_15m > 10.0) | (stochrsi_k_1h < 80.0))
+            & ((rsi_3_15m > 10.0) | (stochrsi_k_1h_lt_80))
             # 15m & 1h down move, 1h still high
             & ((rsi_3_15m > 15.0) | (rsi_3_1h > 25.0) | (stochrsi_k_1h < 40.0))
             # 15m & 4h down move, 1d high
@@ -14594,7 +14599,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 4h high & overbought
             & ((rsi_3_15m > 15.0) | aroonu_14_4h_lt_70 | (roc_9_4h < 20.0))
             # 15m down move, 4h high & overbought
-            & ((rsi_3_15m > 15.0) | (stochrsi_k_4h < 90.0) | (roc_9_4h < 10.0))
+            & ((rsi_3_15m > 15.0) | (stochrsi_k_4h_lt_90) | (roc_9_4h < 10.0))
             # 15m down move, 4h & 1d downtrend
             & ((rsi_3_15m > 15.0) | (roc_9_4h > -10.0) | (roc_9_1d > -40.0))
             # 15m & 1h down move, 1h high
@@ -14606,7 +14611,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 1h high & overbought
             & ((rsi_3_15m > 20.0) | (stochrsi_k_1h < 90.0) | (roc_9_1h < 10.0))
             # 15m & 4h down move, 4h high
-            & ((rsi_3_15m > 25.0) | (rsi_3_4h > 50.0) | (stochrsi_k_4h < 80.0))
+            & ((rsi_3_15m > 25.0) | (rsi_3_4h > 50.0) | (stochrsi_k_4h_lt_80))
             # 15m down move, 4h high, 4h overbought
             & ((rsi_3_15m > 25.0) | (aroonu_14_4h < 60.0) | (roc_9_4h < 50.0))
             # 15m & 1h down move, 4h high
@@ -14682,7 +14687,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 1d overbought
             & ((rsi_3_1h > 25.0) | (rsi_3_4h > 25.0) | (roc_9_1d < 20.0))
             # 1h down move, 1h still high, 1d overbought
-            & ((rsi_3_1h > 25.0) | (stochrsi_k_1h < 50.0) | (roc_9_1d < 40.0))
+            & ((rsi_3_1h > 25.0) | (stochrsi_k_1h_lt_50) | (roc_9_1d < 40.0))
             # 1h down move, 1h & 4h high
             & ((rsi_3_1h > 30.0) | (aroonu_14_1h < 70.0) | aroonu_14_4h_lt_70)
             # 1h down move, 4h high, 1d overbought
@@ -14694,7 +14699,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 15m high
             & ((rsi_3_1h > 30.0) | (rsi_3_4h > 40.0) | (stochrsi_k_15m < 80.0))
             # 1h & 4h down move, 1h high
-            & ((rsi_3_1h > 30.0) | (rsi_3_4h > 50.0) | (stochrsi_k_1h < 70.0))
+            & ((rsi_3_1h > 30.0) | (rsi_3_4h > 50.0) | (stochrsi_k_1h_lt_70))
             # 1h down move, 15m still high, 1h high
             & ((rsi_3_1h > 30.0) | (stochrsi_k_15m < 40.0) | (aroonu_14_1h < 60.0))
             # 1h down move, 1h still high, 4h high
@@ -14708,7 +14713,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 4h high, 1d overbought
             & ((rsi_3_1h > 35.0) | (aroonu_14_4h < 85.0) | (roc_9_1d < 100.0))
             # 1h down move, 1h still high, 1d overbought
-            & ((rsi_3_1h > 35.0) | (stochrsi_k_1h < 50.0) | (roc_9_1d < 200.0))
+            & ((rsi_3_1h > 35.0) | (stochrsi_k_1h_lt_50) | (roc_9_1d < 200.0))
             # 1h down move, 1h high, 4h downtrend
             & ((rsi_3_1h > 35.0) | (stochrsi_k_1h < 70.0) | (roc_9_4h > -20.0))
             # 1h down move, 1h high, 4h overbought
@@ -14718,9 +14723,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 4h high, 1d downtrend
             & ((rsi_3_1h > 50.0) | (stochrsi_k_4h < 60.0) | (roc_9_1d > -60.0))
             # 1h down move, 4h high & overbought
-            & ((rsi_3_1h > 50.0) | (stochrsi_k_4h < 90.0) | (roc_9_4h < 40.0))
+            & ((rsi_3_1h > 50.0) | (stochrsi_k_4h_lt_90) | (roc_9_4h < 40.0))
             # 1h down move, 1h high & overbought
-            & ((rsi_3_1h > 55.0) | (stochrsi_k_1h < 80.0) | (roc_9_1h < 10.0))
+            & ((rsi_3_1h > 55.0) | (stochrsi_k_1h_lt_80) | (roc_9_1h < 10.0))
             # 1h down move, 4h & 1d overbought
             & ((rsi_3_1h > 60.0) | (roc_9_4h < 30.0) | (roc_9_1d < 60.0))
             # 4h down move, 4h high, 4h downtrend
@@ -14790,7 +14795,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1d high, 4h & 1d overbought
             & ((aroonu_14_1d < 90.0) | (roc_9_4h < 20.0) | roc_9_1d_lt_50)
             # 1h high, 4h overbought
-            & ((stochrsi_k_1h < 80.0) | (roc_9_4h < 80.0))
+            & ((stochrsi_k_1h_lt_80) | (roc_9_4h < 80.0))
             # 4h & 1d overbought
             & ((roc_9_4h < 100.0) | (roc_9_1d < 200.0))
             # big drop in the last 20 days, 1d high, 1d downtrend
@@ -14817,15 +14822,15 @@ class NostalgiaForInfinityX7(IStrategy):
             # 5m & 1h down move, 1d high
             & ((rsi_3 > 3.0) | rsi_3_1h_gt_20 | (aroonu_14_1d < 100.0))
             # 5m & 1h down move, 1h still high
-            & ((rsi_3 > 3.0) | (rsi_3_1h > 30.0) | (stochrsi_k_1h < 50.0))
+            & ((rsi_3 > 3.0) | (rsi_3_1h > 30.0) | (stochrsi_k_1h_lt_50))
             # 5m & 4h down move, 15m still high
             & ((rsi_3 > 3.0) | (rsi_3_4h > 3.0) | (stochrsi_k_15m < 40.0))
             # 15m & 1h down move, 4h high
             & ((rsi_3_15m > 10.0) | (rsi_3_1h > 30.0) | (stochrsi_k_4h < 60.0))
             # 15m & 1h down move, 1h still high
-            & ((rsi_3_15m > 25.0) | (rsi_3_1h > 25.0) | (stochrsi_k_1h < 50.0))
+            & ((rsi_3_15m > 25.0) | (rsi_3_1h > 25.0) | (stochrsi_k_1h_lt_50))
             # 1h & 4h down move, 4h high
-            & ((rsi_3_15m > 25.0) | (rsi_3_1h > 25.0) | (stochrsi_k_4h < 80.0))
+            & ((rsi_3_15m > 25.0) | (rsi_3_1h > 25.0) | (stochrsi_k_4h_lt_80))
             # 15m & 1h down move, 4h overbought
             & ((rsi_3_15m > 25.0) | (rsi_3_1h > 30.0) | (roc_9_4h < 70.0))
             # 15m & 1h down move, 1h high
@@ -14833,11 +14838,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 1h high
             & ((rsi_3_15m > 25.0) | (rsi_3_1h > 50.0) | (aroonu_14_1h < 85.0))
             # 15m & 1h down move, 1h high
-            & ((rsi_3_15m > 25.0) | (rsi_3_1h > 55.0) | (stochrsi_k_1h < 80.0))
+            & ((rsi_3_15m > 25.0) | (rsi_3_1h > 55.0) | (stochrsi_k_1h_lt_80))
             # 15m down move, 15m stil not low enough, 4h high
             & ((rsi_3_15m > 25.0) | (aroonu_14_15m < 30.0) | (aroonu_14_4h < 60.0))
             # 15m down move, 15m high, 1h high
-            & ((rsi_3_15m > 25.0) | (aroonu_14_15m < 60.0) | (stochrsi_k_1h < 70.0))
+            & ((rsi_3_15m > 25.0) | (aroonu_14_15m < 60.0) | (stochrsi_k_1h_lt_70))
             # 15m down move, 1h & 4h overbought
             & ((rsi_3_15m > 25.0) | (roc_9_1h < 40.0) | (roc_9_4h < 40.0))
             # 15m down move, 4h & 1d overbought
@@ -14859,7 +14864,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 4h high & overbought
             & ((rsi_3_15m > 30.0) | (aroonu_14_4h < 100.0) | (roc_9_4h < 25.0))
             # 15m & 4h down move, 4h high
-            & ((rsi_3_15m > 35.0) | (rsi_3_4h > 35.0) | (stochrsi_k_4h < 80.0))
+            & ((rsi_3_15m > 35.0) | (rsi_3_4h > 35.0) | (stochrsi_k_4h_lt_80))
             # 15m down move, 15m high, 4h overbought
             & ((rsi_3_15m > 35.0) | (aroonu_14_15m < 70.0) | (roc_9_4h < 10.0))
             # 15m down move, 1h high, 4h overbought
@@ -14943,7 +14948,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 4h high
             & (rsi_3_1h_gt_20 | (rsi_3_4h > 40.0) | (aroonu_14_4h < 80.0))
             # 1h & 1d down move, 1h still high
-            & (rsi_3_1h_gt_20 | (rsi_3_1d > 30.0) | (stochrsi_k_1h < 50.0))
+            & (rsi_3_1h_gt_20 | (rsi_3_1d > 30.0) | (stochrsi_k_1h_lt_50))
             # 1h & 4h down move, 15m high
             & ((rsi_3_1h > 25.0) | (rsi_3_4h > 25.0) | (aroonu_14_15m < 70.0))
             # 1h down move, 4h downtrend, 4h high
@@ -14965,9 +14970,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 15m still high, 1h high
             & ((rsi_3_1h > 30.0) | (stochrsi_k_15m < 40.0) | (aroonu_14_1h < 60.0))
             # 1h down move, 1h high, 1d downtrend
-            & ((rsi_3_1h > 30.0) | (stochrsi_k_1h < 70.0) | (roc_9_1d > -40.0))
+            & ((rsi_3_1h > 30.0) | (stochrsi_k_1h_lt_70) | (roc_9_1d > -40.0))
             # 1h down move, 4h high, 1d downtrend
-            & ((rsi_3_1h > 30.0) | (stochrsi_k_4h < 90.0) | roc_9_1d_gt_neg_50)
+            & ((rsi_3_1h > 30.0) | (stochrsi_k_4h_lt_90) | roc_9_1d_gt_neg_50)
             # 1h down move, 4h downtrend, 1d over
             & ((rsi_3_1h > 30.0) | (roc_9_4h > -30.0) | roc_9_1d_lt_50)
             # 1h down move, 1h still high, 1d overbought
@@ -14979,7 +14984,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h high, 4h downtrend
             & ((rsi_3_1h > 35.0) | (aroonu_14_1h < 80.0) | (roc_9_4h > -20.0))
             # 1h down move, 1h still high, 1d overbought
-            & ((rsi_3_1h > 35.0) | (stochrsi_k_1h < 50.0) | (roc_9_1d < 200.0))
+            & ((rsi_3_1h > 35.0) | (stochrsi_k_1h_lt_50) | (roc_9_1d < 200.0))
             # 1h down move, 15m high, 1h high
             & ((rsi_3_1h > 40.0) | (aroonu_14_15m < 60.0) | (aroonu_14_1h < 70.0))
             # 1h down move, 1h still high, 1d overbought
@@ -15001,7 +15006,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h high, 4h overbought
             & ((rsi_3_1h > 45.0) | (aroonu_14_1h < 80.0) | (roc_9_4h < 50.0))
             # 1h down move, 1h high, 1d overbought
-            & ((rsi_3_1h > 45.0) | (stochrsi_k_1h < 70.0) | roc_9_1d_lt_50)
+            & ((rsi_3_1h > 45.0) | (stochrsi_k_1h_lt_70) | roc_9_1d_lt_50)
             # 1h down move, 1h high, 1d downtrend
             & ((rsi_3_1h > 50.0) | (aroonu_14_1h < 90.0) | (roc_9_1d > -30.0))
             # 1h down move, 4h high, 1h overbought
@@ -15013,7 +15018,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 4h & 1d overbought
             & ((rsi_3_1h > 50.0) | (roc_9_4h < 20.0) | (roc_9_1d < 80.0))
             # 1h down move, 15m high, 1h high
-            & ((rsi_3_1h > 55.0) | (aroonu_14_15m < 60.0) | (stochrsi_k_1h < 80.0))
+            & ((rsi_3_1h > 55.0) | (aroonu_14_15m < 60.0) | (stochrsi_k_1h_lt_80))
             # 1h down move, 1h high & overbought
             & ((rsi_3_1h > 55.0) | (stochrsi_k_1h < 60.0) | (roc_9_1d < 10.0))
             # 1h down move, 4h & 1d overbought
@@ -15121,13 +15126,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h high, 4h & 1d overbought
             & ((stochrsi_k_1h < 90.0) | (roc_9_4h < 20.0) | (roc_9_1d < 100.0))
             # 4h high, 1h overbought, 1d downtrend
-            & ((stochrsi_k_4h < 80.0) | (roc_9_1h < 40.0) | (roc_9_1d > -70.0))
+            & ((stochrsi_k_4h_lt_80) | (roc_9_1h < 40.0) | (roc_9_1d > -70.0))
             # 4h high, 4h & 1d overbought
             & ((stochrsi_k_4h < 80.0) | (roc_9_4h < 80.0) | (roc_9_1d < 100.0))
             # 4h high, 1h & 4h overbought
-            & ((stochrsi_k_4h < 90.0) | (roc_9_1h < 10.0) | (roc_9_4h < 80.0))
+            & ((stochrsi_k_4h_lt_90) | (roc_9_1h < 10.0) | (roc_9_4h < 80.0))
             # 4h high, 1h & 4h overbought
-            & ((stochrsi_k_4h < 90.0) | (roc_9_1h < 20.0) | (roc_9_4h < 50.0))
+            & ((stochrsi_k_4h_lt_90) | (roc_9_1h < 20.0) | (roc_9_4h < 50.0))
             # 1d high, 4h & 1d overbought
             & ((stochrsi_k_1d < 90.0) | (roc_9_4h < 40.0) | (roc_9_1d < 100.0))
             # 1d P&D, dh downtrend
@@ -15137,7 +15142,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # drop in last 20 days, 1h high, 1d downtrend
             & ((close > (high_max_20_1d * 0.20)) | (aroonu_14_1h < 70.0) | (roc_9_1d > -70.0))
             # drop in last 20 days. 4h high
-            & ((close > (high_max_20_1d * 0.10)) | (stochrsi_k_4h < 90.0))
+            & ((close > (high_max_20_1d * 0.10)) | (stochrsi_k_4h_lt_90))
           )
 
           # Logic
@@ -15168,7 +15173,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 5m & 1h down move, 1h still not low enough
             & ((rsi_3 > 3.0) | rsi_3_1h_gt_20 | (aroonu_14_1h < 30.0))
             # 5m & 1h down move, 1h still high
-            & ((rsi_3 > 3.0) | (rsi_3_1h > 30.0) | (stochrsi_k_1h < 50.0))
+            & ((rsi_3 > 3.0) | (rsi_3_1h > 30.0) | (stochrsi_k_1h_lt_50))
             # 5m & 4h down move, 4h still high
             & ((rsi_3 > 3.0) | (rsi_3_4h > 15.0) | (stochrsi_k_4h < 50.0))
             # 5m & 4h & 1d down move
@@ -15202,7 +15207,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 5m down move, 4h high & overbought
             & ((rsi_3 > 5.0) | (aroonu_14_4h < 100.0) | (roc_9_4h < 25.0))
             # 5m down move, 1h high
-            & ((rsi_3 > 5.0) | (stochrsi_k_1h < 80.0))
+            & ((rsi_3 > 5.0) | (stochrsi_k_1h_lt_80))
             # 5m & 1d down move, 1d still high
             & ((rsi_3 > 10.0) | (rsi_3_1d > 15.0) | (stochrsi_k_1d < 40.0))
             # 15m & 1h down move, 1h still high
@@ -15246,7 +15251,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h & 4h down move, 15m downtrend
             & ((rsi_3_15m > 5.0) | (rsi_3_1h > 40.0) | (rsi_3_4h > 50.0) | (cmf_20_15m > -0.30))
             # 15m & 1h down move, 1h still high
-            & ((rsi_3_15m > 5.0) | (rsi_3_1h > 40.0) | (stochrsi_k_1h < 50.0))
+            & ((rsi_3_15m > 5.0) | (rsi_3_1h > 40.0) | (stochrsi_k_1h_lt_50))
             # 15m & 1h down move, 4h high
             & ((rsi_3_15m > 5.0) | (rsi_3_1h > 55.0) | (aroonu_14_4h < 100.0))
             # 15m & 4h down move, 15m still not low enough
@@ -15254,7 +15259,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 4h down move, 4h high
             & ((rsi_3_15m > 5.0) | (rsi_3_4h > 35.0) | (stochrsi_k_4h < 60.0))
             # 15m down move, 15m still high, 1h still high
-            & ((rsi_3_15m > 5.0) | (aroonu_14_15m < 30.0) | (stochrsi_k_1h < 50.0))
+            & ((rsi_3_15m > 5.0) | (aroonu_14_15m < 30.0) | (stochrsi_k_1h_lt_50))
             # 15m down move, 1h still high, 1d high
             & ((rsi_3_15m > 5.0) | (stochrsi_k_1h < 40.0) | (aroonu_14_1d < 70.0))
             # 15m down move, 1h & 4h high
@@ -15262,7 +15267,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 15m & 1h still not low enough
             & ((rsi_3_15m > 5.0) | (stochrsi_k_15m < 30.0) | (stochrsi_k_1h < 30.0))
             # 15m & 1h down move, 1h still high
-            & ((rsi_3_15m > 10.0) | rsi_3_1h_gt_20 | (stochrsi_k_1h < 50.0))
+            & ((rsi_3_15m > 10.0) | rsi_3_1h_gt_20 | (stochrsi_k_1h_lt_50))
             # 15m & 1h down move, 4h still high
             & ((rsi_3_15m > 10.0) | rsi_3_1h_gt_20 | (aroonu_14_4h < 40.0))
             # 15m & 1h down move, 4h high
@@ -15284,7 +15289,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 1d overbought
             & ((rsi_3_15m > 10.0) | (rsi_3_1h > 45.0) | (roc_9_1d < 150.0))
             # 15m & 1h down move, 4h high
-            & ((rsi_3_15m > 10.0) | (rsi_3_1h > 50.0) | (stochrsi_k_4h < 80.0))
+            & ((rsi_3_15m > 10.0) | (rsi_3_1h > 50.0) | (stochrsi_k_4h_lt_80))
             # 15m & 1h down move, 1h high
             & ((rsi_3_15m > 10.0) | (rsi_3_1h > 55.0) | (stochrsi_k_1h < 60.0))
             # 15m & 1h down move, 1h high
@@ -15302,7 +15307,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 4h down move, 1d high
             & ((rsi_3_15m > 10.0) | rsi_3_4h_gt_20 | (aroonu_14_1d < 90.0))
             # 15m & 4h down move, 1h still high
-            & ((rsi_3_15m > 10.0) | rsi_3_4h_gt_20 | (stochrsi_k_1h < 50.0))
+            & ((rsi_3_15m > 10.0) | rsi_3_4h_gt_20 | (stochrsi_k_1h_lt_50))
             # 15m & 4h down move, 4h still high
             & ((rsi_3_15m > 10.0) | rsi_3_4h_gt_20 | (stochrsi_k_4h < 40.0))
             # 15m & 4h down move, 1d high
@@ -15320,7 +15325,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 4h down move, 4h high
             & ((rsi_3_15m > 10.0) | (rsi_3_4h > 50.0) | (aroonu_14_4h < 75.0))
             # 15m & 4h down move, 4h high
-            & ((rsi_3_15m > 10.0) | (rsi_3_4h > 60.0) | (stochrsi_k_4h < 80.0))
+            & ((rsi_3_15m > 10.0) | (rsi_3_4h > 60.0) | (stochrsi_k_4h_lt_80))
             # 15m & 1d down move, 1h still high
             & ((rsi_3_15m > 10.0) | (rsi_3_1d > 10.0) | (stochrsi_k_1h < 40.0))
             # 15m & 1d down move, 1d high
@@ -15334,7 +15339,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 15m still not low enough, 4h high
             & ((rsi_3_15m > 10.0) | (aroonu_14_15m < 30.0) | (aroonu_14_4h < 60.0))
             # 15m down move, 15m still high, 1h still high
-            & ((rsi_3_15m > 10.0) | (aroonu_14_15m < 40.0) | (stochrsi_k_1h < 50.0))
+            & ((rsi_3_15m > 10.0) | (aroonu_14_15m < 40.0) | (stochrsi_k_1h_lt_50))
             # 15m down move, 4h high & overbought
             & ((rsi_3_15m > 10.0) | (aroonu_14_4h < 90.0) | (roc_9_4h < 20.0))
             # 15m down move, 1h still not low enough, 1d overbought
@@ -15386,11 +15391,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1d down move, 1h still high
             & ((rsi_3_15m > 15.0) | (rsi_3_1d > 15.0) | (stochrsi_k_1h < 30.0))
             # 15m & 1d down move, 1h still high
-            & ((rsi_3_15m > 15.0) | (rsi_3_1d > 20.0) | (stochrsi_k_1h < 50.0))
+            & ((rsi_3_15m > 15.0) | (rsi_3_1d > 20.0) | (stochrsi_k_1h_lt_50))
             # 15m & 1d down move, 1d overbought
             & ((rsi_3_15m > 15.0) | (rsi_3_1d > 30.0) | (roc_9_1d < 10.0))
             # 15m down move, 15m still not low enough, 1h high
-            & ((rsi_3_15m > 15.0) | (aroonu_14_15m < 25.0) | (stochrsi_k_1h < 80.0))
+            & ((rsi_3_15m > 15.0) | (aroonu_14_15m < 25.0) | (stochrsi_k_1h_lt_80))
             # 15m down move, 15m still high, 4h high
             & ((rsi_3_15m > 15.0) | (aroonu_14_15m < 40.0) | aroonu_14_4h_lt_70)
             # 15m down move, 1h still high, 1d overbought
@@ -15402,7 +15407,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 1h & 1d high
             & ((rsi_3_15m > 15.0) | (aroonu_14_1h < 70.0) | (aroonu_14_1d < 70.0))
             # 15m down move, 1h & 4h high
-            & ((rsi_3_15m > 15.0) | (aroonu_14_1h < 85.0) | (stochrsi_k_4h < 90.0))
+            & ((rsi_3_15m > 15.0) | (aroonu_14_1h < 85.0) | (stochrsi_k_4h_lt_90))
             # 15m down move, 4h high, 4h downtrend
             & ((rsi_3_15m > 15.0) | (aroonu_14_4h < 60.0) | (roc_9_4h > -20.0))
             # 15m down move, 4h & 1d high
@@ -15414,7 +15419,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 4h high, 1h overbought
             & ((rsi_3_15m > 15.0) | (aroonu_14_4h < 100.0) | (roc_9_1h < 10.0))
             # 15m down move, 1h still high, 4h overbought
-            & ((rsi_3_15m > 15.0) | (stochrsi_k_1h < 50.0) | (roc_9_4h < 10.0))
+            & ((rsi_3_15m > 15.0) | (stochrsi_k_1h_lt_50) | (roc_9_4h < 10.0))
             # 15m down move, 1h high, 4h downtrend
             & ((rsi_3_15m > 15.0) | (stochrsi_k_1h < 80.0) | (roc_9_4h > -20.0))
             # 15m down move, 4h high & overbought
@@ -15426,7 +15431,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 1h overbought
             & ((rsi_3_15m > 20.0) | (rsi_3_1h > 50.0) | (roc_9_1h < 10.0))
             # 15m & 1h down move, 4h high
-            & ((rsi_3_15m > 20.0) | (rsi_3_1h > 25.0) | (stochrsi_k_4h < 80.0))
+            & ((rsi_3_15m > 20.0) | (rsi_3_1h > 25.0) | (stochrsi_k_4h_lt_80))
             # 15m & 1h down move, 1d high
             & ((rsi_3_15m > 20.0) | (rsi_3_1h > 35.0) | (aroonu_14_1d < 100.0))
             # 15m & 1h down move, 1h high
@@ -15434,7 +15439,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 1h high
             & ((rsi_3_15m > 20.0) | (rsi_3_1h > 60.0) | (aroonu_14_1h < 90.0))
             # 15m & 1h down move, 4h high
-            & ((rsi_3_15m > 20.0) | (rsi_3_1h > 60.0) | (stochrsi_k_4h < 90.0))
+            & ((rsi_3_15m > 20.0) | (rsi_3_1h > 60.0) | (stochrsi_k_4h_lt_90))
             # 15m & 4h & 1d down move
             & ((rsi_3_15m > 20.0) | rsi_3_4h_gt_20 | (rsi_3_1d > 20.0))
             # 15m & 4h down move, 1d high
@@ -15468,13 +15473,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 15m high, 4h downtrend
             & ((rsi_3_15m > 20.0) | (stochrsi_k_15m < 60.0) | (roc_9_4h > -50.0))
             # 15 down move, 1h high, 1d overbought
-            & ((rsi_3_15m > 20.0) | (stochrsi_k_1h < 70.0) | (roc_9_1d < 10.0))
+            & ((rsi_3_15m > 20.0) | (stochrsi_k_1h_lt_70) | (roc_9_1d < 10.0))
             # 15m down move, 4h high, 15m downtrend
             & ((rsi_3_15m > 20.0) | (stochrsi_k_4h < 70.0) | (cmf_20_15m > -0.40))
             # 15m & 1h down move, 15m high
             & ((rsi_3_15m > 25.0) | (rsi_3_1h > 25.0) | (stochrsi_k_15m < 70.0))
             # 15m & 1h down move, 1h still high
-            & ((rsi_3_15m > 25.0) | (rsi_3_1h > 35.0) | (stochrsi_k_1h < 50.0))
+            & ((rsi_3_15m > 25.0) | (rsi_3_1h > 35.0) | (stochrsi_k_1h_lt_50))
             # 15m & 1h down move, 1d high
             & ((rsi_3_15m > 25.0) | (rsi_3_1h > 40.0) | (stochrsi_k_1d < 90.0))
             # 15m & 1h down move, 1d overbought
@@ -15484,7 +15489,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 4h high
             & ((rsi_3_15m > 25.0) | (rsi_3_1h > 60.0) | (aroonu_14_4h < 100.0))
             # 15m & 1h down move, 4h high
-            & ((rsi_3_15m > 25.0) | (rsi_3_1h > 60.0) | (stochrsi_k_4h < 90.0))
+            & ((rsi_3_15m > 25.0) | (rsi_3_1h > 60.0) | (stochrsi_k_4h_lt_90))
             # 15m & 4h down move, 4h overbought
             & ((rsi_3_15m > 25.0) | (rsi_3_4h > 55.0) | (roc_9_4h < 30.0))
             # 15m & 1d down move, 1h high
@@ -15492,7 +15497,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 15m still not low enough, 1h high
             & ((rsi_3_15m > 25.0) | (aroonu_14_15m < 25.0) | (stochrsi_k_1h < 90.0))
             # 15m down move, 15m still high, 1h high
-            & ((rsi_3_15m > 25.0) | (aroonu_14_15m < 40.0) | (stochrsi_k_1h < 80.0))
+            & ((rsi_3_15m > 25.0) | (aroonu_14_15m < 40.0) | (stochrsi_k_1h_lt_80))
             # 15m down move, 1h high, 1d overbought
             & ((rsi_3_15m > 25.0) | (aroonu_14_1h < 60.0) | (roc_9_1d < 60.0))
             # 15m down move, 1h high, 4h overbought
@@ -15510,11 +15515,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 1h high & overbought
             & ((rsi_3_15m > 25.0) | (stochrsi_k_1h < 90.0) | (roc_9_1h < 20.0))
             # 15m down move, 4h high & overbought
-            & ((rsi_3_15m > 25.0) | (stochrsi_k_4h < 90.0) | (roc_9_4h < 30.0))
+            & ((rsi_3_15m > 25.0) | (stochrsi_k_4h_lt_90) | (roc_9_4h < 30.0))
             # 15m & 1h down move, 1h high
             & ((rsi_3_15m > 30.0) | (rsi_3_1h > 35.0) | (aroonu_14_1h < 80.0))
             # 15m & 1h down move, 1h high
-            & ((rsi_3_15m > 30.0) | (rsi_3_1h > 55.0) | (stochrsi_k_1h < 80.0))
+            & ((rsi_3_15m > 30.0) | (rsi_3_1h > 55.0) | (stochrsi_k_1h_lt_80))
             # 15m & 4h down move, 15m high
             & ((rsi_3_15m > 30.0) | (rsi_3_4h > 30.0) | (stochrsi_k_15m < 70.0))
             # 15m down move, 1h high & overbought
@@ -15524,17 +15529,17 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 4h high & overbought
             & ((rsi_3_15m > 30.0) | (aroonu_14_4h < 100.0) | (roc_9_4h < 40.0))
             # 15m down move, 4h high & overbought
-            & ((rsi_3_15m > 30.0) | (stochrsi_k_4h < 90.0) | (roc_9_4h < 40.0))
+            & ((rsi_3_15m > 30.0) | (stochrsi_k_4h_lt_90) | (roc_9_4h < 40.0))
             # 15m & 1h down move, 1h high
-            & ((rsi_3_15m > 35.0) | (rsi_3_1h > 40.0) | (stochrsi_k_1h < 70.0))
+            & ((rsi_3_15m > 35.0) | (rsi_3_1h > 40.0) | (stochrsi_k_1h_lt_70))
             # 15m & 1h down move, 1h high
             & ((rsi_3_15m > 35.0) | (rsi_3_1h > 65.0) | (aroonu_14_1h < 80.0))
             # 15m & 4h down move, 4h high
-            & ((rsi_3_15m > 35.0) | (rsi_3_4h > 35.0) | (stochrsi_k_4h < 80.0))
+            & ((rsi_3_15m > 35.0) | (rsi_3_4h > 35.0) | (stochrsi_k_4h_lt_80))
             # 15m down move, 15m still not low enough, 1h high
             & ((rsi_3_15m > 35.0) | (aroonu_14_15m < 25.0) | (aroonu_14_1h < 80.0))
             # 15m down move, 15m still not low enough, 1h high
-            & ((rsi_3_15m > 35.0) | (aroonu_14_15m < 25.0) | (stochrsi_k_1h < 80.0))
+            & ((rsi_3_15m > 35.0) | (aroonu_14_15m < 25.0) | (stochrsi_k_1h_lt_80))
             # 15m down move, 1m still high, 4h overbought
             & ((rsi_3_15m > 35.0) | (aroonu_14_15m < 40.0) | (roc_9_4h < 50.0))
             # 15m down move, 1h high, 4h overbought
@@ -15552,7 +15557,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 4h high & overbought
             & ((rsi_3_15m > 40.0) | (aroonu_14_4h < 100.0) | (roc_9_4h < 40.0))
             # 15m down move, 1h high, 4h overbought
-            & ((rsi_3_15m > 50.0) | (stochrsi_k_1h < 80.0) | (roc_9_4h < 40.0))
+            & ((rsi_3_15m > 50.0) | (stochrsi_k_1h_lt_80) | (roc_9_4h < 40.0))
             # 1h & 4h down move, 1d high
             & ((rsi_3_1h > 3.0) | (rsi_3_4h > 15.0) | (stochrsi_k_1d < 70.0))
             # 1h & 4h down move, 4h high
@@ -15618,7 +15623,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 4h high
             & ((rsi_3_1h > 30.0) | (rsi_3_4h > 40.0) | (aroonu_14_4h < 60.0))
             # 1h & 4h down move, 4h high
-            & ((rsi_3_1h > 30.0) | (rsi_3_4h > 60.0) | (stochrsi_k_4h < 80.0))
+            & ((rsi_3_1h > 30.0) | (rsi_3_4h > 60.0) | (stochrsi_k_4h_lt_80))
             # 1h & 1d down move, 1h high
             & ((rsi_3_1h > 30.0) | (rsi_3_1d > 30.0) | (aroonu_14_1h < 60.0))
             # 1h down move, 4h & 1d down move
@@ -15674,13 +15679,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1d high, 4h overbought
             & ((rsi_3_1h > 50.0) | (aroonu_14_1d < 90.0) | (roc_9_4h < 20.0))
             # 1h down move, 1h high & overbought
-            & ((rsi_3_1h > 50.0) | (stochrsi_k_1h < 80.0) | (roc_9_1h < 10.0))
+            & ((rsi_3_1h > 50.0) | (stochrsi_k_1h_lt_80) | (roc_9_1h < 10.0))
             # 1h down move, 1h & 4h overbought
             & ((rsi_3_1h > 50.0) | (roc_9_1h < 10.0) | (roc_9_4h < 100.0))
             # 1h down move, 4h & 1d overbought
             & ((rsi_3_1h > 50.0) | (roc_9_4h < 20.0) | (roc_9_1d < 20.0))
             # 1h & 4h down move, 1h high
-            & ((rsi_3_1h > 55.0) | (rsi_3_4h > 55.0) | (stochrsi_k_1h < 70.0))
+            & ((rsi_3_1h > 55.0) | (rsi_3_4h > 55.0) | (stochrsi_k_1h_lt_70))
             # 1h down move, 1h high, 4h overbought
             & ((rsi_3_1h > 55.0) | (aroonu_14_1h < 80.0) | (roc_9_4h < 10.0))
             # 1h down move, 4h high & overbought
@@ -15692,7 +15697,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1d high, 1h overbought
             & ((rsi_3_1h > 60.0) | (aroonu_14_1d < 90.0) | (roc_9_1h < 10.0))
             # 1h down move, 1h high, 1d downtrend
-            & ((rsi_3_1h > 60.0) | (stochrsi_k_1h < 70.0) | (roc_9_1d > -10.0))
+            & ((rsi_3_1h > 60.0) | (stochrsi_k_1h_lt_70) | (roc_9_1d > -10.0))
             # 1h down move, 1h high, 1d overbought
             & ((rsi_3_1h > 60.0) | (stochrsi_k_1h < 80.0) | (roc_9_1d < 100.0))
             # 1h down move, 1h high, 4h overbought
@@ -15770,7 +15775,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 4h high & overbought
             & ((rsi_3_4h > 45.0) | (stochrsi_k_4h < 60.0) | (roc_9_4h < 20.0))
             # 4h down move, 4h high, 1d overbought
-            & ((rsi_3_4h > 45.0) | (stochrsi_k_4h < 80.0) | (roc_9_1d < 10.0))
+            & ((rsi_3_4h > 45.0) | (stochrsi_k_4h_lt_80) | (roc_9_1d < 10.0))
             # 4h down move, 4h high & overbought
             & ((rsi_3_4h > 50.0) | (aroonu_14_4h < 80.0) | (roc_9_4h < 10.0))
             # 4h down move, 1h high, 1d downtrend
@@ -15860,11 +15865,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m still not low enough, 4h high, 1d overbought
             & ((stochrsi_k_15m < 30.0) | (aroonu_14_4h < 100.0) | (roc_9_1d < 30.0))
             # 15m still high, 4h high & overbought
-            & ((stochrsi_k_15m < 40.0) | (stochrsi_k_4h < 80.0) | (roc_9_4h < 30.0))
+            & ((stochrsi_k_15m < 40.0) | (stochrsi_k_4h_lt_80) | (roc_9_4h < 30.0))
             # 1h high, 1d overbought
-            & ((stochrsi_k_1h < 70.0) | (roc_9_1d < 40.0))
+            & ((stochrsi_k_1h_lt_70) | (roc_9_1d < 40.0))
             # 1h high, 1h overbought, 4h downtrend
-            & ((stochrsi_k_1h < 80.0) | (roc_9_1h < 10.0) | (roc_9_4h > -10.0))
+            & ((stochrsi_k_1h_lt_80) | (roc_9_1h < 10.0) | (roc_9_4h > -10.0))
             # 1h high, 4h & 1d downtrend
             & ((stochrsi_k_1h < 80.0) | (roc_9_4h > -20.0) | (roc_9_1d > -80.0))
             # 1h down move, 1h & 1d overbought
@@ -15876,13 +15881,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h high, 1h & 1d overbought
             & ((stochrsi_k_4h < 70.0) | (roc_9_1h < 20.0) | (roc_9_1d < 200.0))
             # 4h high, 4h & 1d overbought
-            & ((stochrsi_k_4h < 80.0) | (roc_9_4h < 30.0) | (roc_9_1d < 30.0))
+            & ((stochrsi_k_4h_lt_80) | (roc_9_4h < 30.0) | (roc_9_1d < 30.0))
             # 4h high, 1d downtrend
-            & ((stochrsi_k_4h < 80.0) | roc_9_1d_gt_neg_50)
+            & ((stochrsi_k_4h_lt_80) | roc_9_1d_gt_neg_50)
             # 4h high, 1h & 1d overbought
-            & ((stochrsi_k_4h < 90.0) | (roc_9_1h < 20.0) | (roc_9_1d < 20.0))
+            & ((stochrsi_k_4h_lt_90) | (roc_9_1h < 20.0) | (roc_9_1d < 20.0))
             # 4h high, 4h & 1d overbought
-            & ((stochrsi_k_4h < 90.0) | (roc_9_4h < 10.0) | (roc_9_1d < 10.0))
+            & ((stochrsi_k_4h_lt_90) | (roc_9_4h < 10.0) | (roc_9_1d < 10.0))
             # 1d hihg, 1h & 1d overbought
             & ((stochrsi_k_1d < 90.0) | (roc_9_1h < 30.0) | (roc_9_1d < 100.0))
             # 1d P&D, dh downtrend
@@ -15892,7 +15897,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # drop in last 20 days, 1h high, 1d downtrend
             & ((close > (high_max_20_1d * 0.20)) | (aroonu_14_1h < 70.0) | (roc_9_1d > -70.0))
             # drop in last 20 days. 4h high
-            & ((close > (high_max_20_1d * 0.10)) | (stochrsi_k_4h < 90.0))
+            & ((close > (high_max_20_1d * 0.10)) | (stochrsi_k_4h_lt_90))
           )
 
           # Logic
@@ -15921,7 +15926,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 1h high
             & ((rsi_3_15m > 10.0) | (rsi_3_1h > 35.0) | (aroonu_14_1h < 80.0))
             # 15m & 1h down move, 1h high
-            & ((rsi_3_15m > 10.0) | (rsi_3_1h > 35.0) | (stochrsi_k_1h < 80.0))
+            & ((rsi_3_15m > 10.0) | (rsi_3_1h > 35.0) | (stochrsi_k_1h_lt_80))
             # 15m & 1h down move, 4h overbought
             & ((rsi_3_15m > 10.0) | (rsi_3_1h > 45.0) | (roc_9_4h < 50.0))
             # 15m & 1h down move, 4h overbought
@@ -15931,9 +15936,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 4h high & overbought
             & ((rsi_3_15m > 10.0) | (aroonu_14_4h < 100.0) | (roc_9_4h < 80.0))
             # 15m down move, 1h high, 1d downtrend
-            & ((rsi_3_15m > 10.0) | (stochrsi_k_1h < 70.0) | roc_9_1d_gt_neg_50)
+            & ((rsi_3_15m > 10.0) | (stochrsi_k_1h_lt_70) | roc_9_1d_gt_neg_50)
             # 15m down move, 4h high & overbought
-            & ((rsi_3_15m > 10.0) | (stochrsi_k_4h < 80.0) | (roc_9_4h < 30.0))
+            & ((rsi_3_15m > 10.0) | (stochrsi_k_4h_lt_80) | (roc_9_4h < 30.0))
             # 15m down move, 1d high, 1d downtrend
             & ((rsi_3_15m > 10.0) | (stochrsi_k_1d < 70.0) | (roc_9_1d > -15.0))
             # 15m & 1h down move, 4h overbought
@@ -15955,7 +15960,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 1h & 4h high
             & ((rsi_3_15m > 20.0) | (aroonu_14_1h < 60.0) | (aroonu_14_4h < 100.0))
             # 15m down move, 4h high, 1h overbought
-            & ((rsi_3_15m > 20.0) | (stochrsi_k_4h < 80.0) | (roc_9_1h < 10.0))
+            & ((rsi_3_15m > 20.0) | (stochrsi_k_4h_lt_80) | (roc_9_1h < 10.0))
             # 15m down move, 4h & 1d overbought
             & ((rsi_3_15m > 20.0) | (roc_9_4h < 80.0) | (roc_9_1d < 200.0))
             # 15m & 1h down move, 1d overbought
@@ -15975,7 +15980,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 1h & 4h overbought
             & ((rsi_3_15m > 25.0) | (roc_9_1h < 40.0) | (roc_9_4h < 40.0))
             # 15m down move, 4h high & overbought
-            & ((rsi_3_15m > 30.0) | (stochrsi_k_4h < 90.0) | (roc_9_4h < 200.0))
+            & ((rsi_3_15m > 30.0) | (stochrsi_k_4h_lt_90) | (roc_9_4h < 200.0))
             # 15m down move, 1h & 4h overbought
             & ((rsi_3_15m > 30.0) | (roc_9_1h < 60.0) | (roc_9_4h < 80.0))
             # 15m down move, 4h & 1d overbought
@@ -16005,7 +16010,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h high, 1d downtrend
             & ((rsi_3_1h > 35.0) | (aroonu_14_1h < 80.0) | (roc_9_1d > -40.0))
             # 1h down move, 4h high, 1d downtrend
-            & ((rsi_3_1h > 35.0) | (stochrsi_k_4h < 80.0) | roc_9_1d_gt_neg_50)
+            & ((rsi_3_1h > 35.0) | (stochrsi_k_4h_lt_80) | roc_9_1d_gt_neg_50)
             # 1h down move, 1h & 1d overbought
             & ((rsi_3_1h > 40.0) | (roc_9_1h < 30.0) | (roc_9_1d < 60.0))
             # 1h down move, 1h high, 4h overbought
@@ -16109,9 +16114,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h high, 1h & 4h overbought
             & ((stochrsi_k_1h < 60.0) | (roc_9_1h < 40.0) | (roc_9_4h < 40.0))
             # 1h high, 1h overbought
-            & ((stochrsi_k_1h < 80.0) | (roc_9_1h < 10.0))
+            & ((stochrsi_k_1h_lt_80) | (roc_9_1h < 10.0))
             # 1h high, 4h overbought. 1d downtrend
-            & ((stochrsi_k_1h < 80.0) | (roc_9_4h < 40.0) | (cmf_20_1d > -0.25))
+            & ((stochrsi_k_1h_lt_80) | (roc_9_4h < 40.0) | (cmf_20_1d > -0.25))
             # 4h high, 1h & 4h overbought
             & ((stochrsi_k_4h < 90.0) | (roc_9_1h < 10.0) | (roc_9_4h < 20.0))
             # 4h high & 4h & 1d overbought
@@ -16163,9 +16168,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 1d still high
             & (rsi_3_15m_gt_3 | (rsi_3_1h > 30.0) | (aroonu_14_1d < 50.0))
             # 15m & 1h down move, 1h high
-            & (rsi_3_15m_gt_3 | (rsi_3_1h > 30.0) | (stochrsi_k_1h < 70.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h > 30.0) | (stochrsi_k_1h_lt_70))
             # 15m & 1h down move, 1h still high
-            & (rsi_3_15m_gt_3 | (rsi_3_1h > 30.0) | (stochrsi_k_1h < 50.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h > 30.0) | (stochrsi_k_1h_lt_50))
             # 15m & 1h down move, 1d high
             & (rsi_3_15m_gt_3 | (rsi_3_1h > 30.0) | (stochrsi_k_1d < 90.0))
             # 15m & 1h down move, 1h high
@@ -16187,11 +16192,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 4h & 1d high
             & (rsi_3_15m_gt_3 | (aroonu_14_4h < 80.0) | (aroonu_14_1d < 100.0))
             # 15m down move, 1h & 4h high
-            & (rsi_3_15m_gt_3 | (stochrsi_k_1h < 80.0) | (stochrsi_k_4h < 80.0))
+            & (rsi_3_15m_gt_3 | (stochrsi_k_1h_lt_80) | (stochrsi_k_4h_lt_80))
             # 15m down move, 1h high, 4h overbought
             & (rsi_3_15m_gt_3 | (stochrsi_k_1h < 90.0) | (roc_9_4h < 10.0))
             # 15m down move, 4h high & overbought
-            & (rsi_3_15m_gt_3 | (stochrsi_k_4h < 80.0) | (roc_9_4h < 10.0))
+            & (rsi_3_15m_gt_3 | (stochrsi_k_4h_lt_80) | (roc_9_4h < 10.0))
             # 15m down move, 4h & 1d downtrend
             & (rsi_3_15m_gt_3 | (roc_9_4h > -20.0) | (roc_9_1d > -20.0))
             # 15m & 1h down move, 1d downtrend
@@ -16205,19 +16210,19 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 4h high
             & ((rsi_3_15m > 5.0) | (rsi_3_1h > 30.0) | aroonu_14_4h_lt_70)
             # 15m & 4h down move, 1h still high
-            & ((rsi_3_15m > 5.0) | (rsi_3_4h > 5.0) | (stochrsi_k_1h < 50.0))
+            & ((rsi_3_15m > 5.0) | (rsi_3_4h > 5.0) | (stochrsi_k_1h_lt_50))
             # 15m & 4h down move, 1d downtrend
             & ((rsi_3_15m > 5.0) | (rsi_3_4h > 10.0) | (roc_9_1d > -20.0))
             # 15m & 4h down move, 1h high
-            & ((rsi_3_15m > 5.0) | rsi_3_4h_gt_20 | (stochrsi_k_1h < 80.0))
+            & ((rsi_3_15m > 5.0) | rsi_3_4h_gt_20 | (stochrsi_k_1h_lt_80))
             # 15m & 4h down move, 1d downtrend
             & ((rsi_3_15m > 5.0) | (rsi_3_4h > 25.0) | (roc_9_1d > -70.0))
             # 15m down move, 1h & 4h high
             & ((rsi_3_15m > 5.0) | (aroonu_14_1h < 100.0) | (aroonu_14_4h < 100.0))
             # 15m down move, 1h still high, 1d downtrend
-            & ((rsi_3_15m > 5.0) | (stochrsi_k_1h < 50.0) | (roc_9_1d > -40.0))
+            & ((rsi_3_15m > 5.0) | (stochrsi_k_1h_lt_50) | (roc_9_1d > -40.0))
             # 5m down move, 4h high, 1d downtrend
-            & ((rsi_3_15m > 5.0) | (stochrsi_k_4h < 80.0) | (roc_9_1d > -40.0))
+            & ((rsi_3_15m > 5.0) | (stochrsi_k_4h_lt_80) | (roc_9_1d > -40.0))
             # 15m down move, 1h & 4h overbought
             & ((rsi_3_15m > 5.0) | (roc_9_1h < 25.0) | (roc_9_4h < 25.0))
             # 15m down move, 4h & 1d overbought
@@ -16235,7 +16240,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 4h high
             & ((rsi_3_15m > 10.0) | (rsi_3_1h > 15.0) | (stochrsi_k_4h < 70.0))
             # 15m & 1h down move, 1h still high
-            & ((rsi_3_15m > 10.0) | rsi_3_1h_gt_20 | (stochrsi_k_1h < 50.0))
+            & ((rsi_3_15m > 10.0) | rsi_3_1h_gt_20 | (stochrsi_k_1h_lt_50))
             # 15m & 1h down move, 1d overbought
             & ((rsi_3_15m > 10.0) | (rsi_3_1h > 25.0) | (roc_9_1d < 20.0))
             # 15m & 1h down move, 1d overbought
@@ -16245,7 +16250,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1d down move, 4h high
             & ((rsi_3_15m > 10.0) | (rsi_3_1d > 25.0) | (aroonu_14_4h < 100.0))
             # 15m & 1d down move, 4h high
-            & ((rsi_3_15m > 10.0) | (rsi_3_1d > 25.0) | (stochrsi_k_4h < 80.0))
+            & ((rsi_3_15m > 10.0) | (rsi_3_1d > 25.0) | (stochrsi_k_4h_lt_80))
             # 15m down move, 15m still high, 1d overbought
             & ((rsi_3_15m > 10.0) | (aroonu_14_15m < 50.0) | (roc_9_1d < 30.0))
             # 15m down move, 15m high
@@ -16271,7 +16276,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 1d high, 1d downtrend
             & ((rsi_3_15m > 10.0) | (aroonu_14_1d < 85.0) | (cmf_20_1d > -0.40))
             # 15m down move, 1h high, 15m downtrend
-            & ((rsi_3_15m > 10.0) | (stochrsi_k_1h < 80.0) | (roc_9_15m > -10.0))
+            & ((rsi_3_15m > 10.0) | (stochrsi_k_1h_lt_80) | (roc_9_15m > -10.0))
             # 15m down move, 1h high, 1d downtrend
             & ((rsi_3_15m > 10.0) | (stochrsi_k_1h < 90.0) | (roc_9_1d > -30.0))
             # 15m down move, 1h high, 1d overbought
@@ -16285,7 +16290,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 1h high
             & ((rsi_3_15m > 15.0) | (rsi_3_1h > 35.0) | (aroonu_14_1h < 80.0))
             # 15m & 1d down move, 4h high
-            & ((rsi_3_15m > 15.0) | (rsi_3_1d > 20.0) | (stochrsi_k_4h < 90.0))
+            & ((rsi_3_15m > 15.0) | (rsi_3_1d > 20.0) | (stochrsi_k_4h_lt_90))
             # 15m & 1d down move, 4h high
             & ((rsi_3_15m > 15.0) | (rsi_3_1d > 25.0) | (aroonu_14_4h < 100.0))
             # 15m & 1d down move, 1d high
@@ -16293,7 +16298,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 15m still high, 1h high
             & ((rsi_3_15m > 15.0) | (aroonu_14_15m < 50.0) | (aroonu_14_1h < 90.0))
             # 15m down move, 15m still high, 1h high
-            & ((rsi_3_15m > 15.0) | (aroonu_14_15m < 50.0) | (stochrsi_k_1h < 80.0))
+            & ((rsi_3_15m > 15.0) | (aroonu_14_15m < 50.0) | (stochrsi_k_1h_lt_80))
             # 15m down move, 1h & 4h high
             & ((rsi_3_15m > 15.0) | (aroonu_14_1h < 80.0) | (aroonu_14_4h < 100.0))
             # 15m down move, 4h high, 4h downtrend
@@ -16301,11 +16306,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 4h & 1d high
             & ((rsi_3_15m > 15.0) | (aroonu_14_4h < 80.0) | (aroonu_14_1d < 100.0))
             # 15m down move, 1h high, 4h downtrend
-            & ((rsi_3_15m > 15.0) | (stochrsi_k_1h < 70.0) | (roc_9_4h > -30.0))
+            & ((rsi_3_15m > 15.0) | (stochrsi_k_1h_lt_70) | (roc_9_4h > -30.0))
             # 15m down move, 4h high & overbought
-            & ((rsi_3_15m > 15.0) | (stochrsi_k_4h < 80.0) | (roc_9_4h < 10.0))
+            & ((rsi_3_15m > 15.0) | (stochrsi_k_4h_lt_80) | (roc_9_4h < 10.0))
             # 15m down move, 4h high, 1d downtrend
-            & ((rsi_3_15m > 15.0) | (stochrsi_k_4h < 80.0) | roc_9_1d_gt_neg_50)
+            & ((rsi_3_15m > 15.0) | (stochrsi_k_4h_lt_80) | roc_9_1d_gt_neg_50)
             # 15m down move, 1d high, 4h overbought
             & ((rsi_3_15m > 15.0) | (stochrsi_k_1d < 90.0) | (roc_9_4h < 40.0))
             # 15m down move, 1h downtrend, 4h overbought
@@ -16383,7 +16388,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 4h high
             & ((rsi_3_1h > 5.0) | (rsi_3_4h > 50.0) | aroonu_14_4h_lt_70)
             # 1h & 1d down move, 1h still high
-            & ((rsi_3_1h > 5.0) | (rsi_3_1d > 10.0) | (stochrsi_k_1h < 50.0))
+            & ((rsi_3_1h > 5.0) | (rsi_3_1d > 10.0) | (stochrsi_k_1h_lt_50))
             # 1h down move, 1d high, 1h downtrend
             & ((rsi_3_1h > 5.0) | (aroonu_14_1d < 85.0) | (roc_9_1h > -50.0))
             # 1h down move, 1d high, 4h downtrend
@@ -16503,7 +16508,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1d high & overbought
             & (rsi_3_1h_gt_20 | (aroonu_14_1d < 100.0) | (roc_9_1d < 60.0))
             # 1h down move, 1h high, 4h overbought
-            & (rsi_3_1h_gt_20 | (stochrsi_k_1h < 70.0) | (roc_9_4h < 10.0))
+            & (rsi_3_1h_gt_20 | (stochrsi_k_1h_lt_70) | (roc_9_4h < 10.0))
             # 1h down move, 1d high, 1d downtrend
             & (rsi_3_1h_gt_20 | (stochrsi_k_1d < 80.0) | roc_9_1d_gt_neg_50)
             # 1h down move, 1d high & overbought
@@ -16527,9 +16532,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 4h high
             & ((rsi_3_1h > 25.0) | (aroonu_14_4h < 90.0))
             # 1h down move, 1h still high, 1d overbought
-            & ((rsi_3_1h > 25.0) | (stochrsi_k_1h < 50.0) | (roc_9_1d < 40.0))
+            & ((rsi_3_1h > 25.0) | (stochrsi_k_1h_lt_50) | (roc_9_1d < 40.0))
             # 1h down move, 4h high, 1d downtrend
-            & ((rsi_3_1h > 25.0) | (stochrsi_k_4h < 80.0) | (roc_9_1d > -40.0))
+            & ((rsi_3_1h > 25.0) | (stochrsi_k_4h_lt_80) | (roc_9_1d > -40.0))
             # 1h down move, 15m downtrend, 4h overbought
             & ((rsi_3_1h > 25.0) | (roc_9_15m > -25.0) | (roc_9_4h < 30.0))
             # 1h down move, 1h & 1d downtrend
@@ -16543,7 +16548,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 4h downtrend
             & ((rsi_3_1h > 30.0) | (rsi_3_4h > 30.0) | (roc_9_4h > -20.0))
             # 1h down move, 1h downtrend, 1h high
-            & ((rsi_3_1h > 30.0) | (cmf_20_1h > -0.25) | (stochrsi_k_1h < 70.0))
+            & ((rsi_3_1h > 30.0) | (cmf_20_1h > -0.25) | (stochrsi_k_1h_lt_70))
             # 1h down move, 4h downtrend, 4h high
             & ((rsi_3_1h > 30.0) | (cmf_20_4h > -0.50) | (aroonu_14_4h < 100.0))
             # 1h down move, 1h high & overbought
@@ -16573,7 +16578,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 4h high & overbought
             & ((rsi_3_1h > 35.0) | (aroonu_14_4h < 100.0) | (roc_9_4h < 20.0))
             # 1h down move, 4h high & overbought
-            & ((rsi_3_1h > 35.0) | (stochrsi_k_4h < 80.0) | (roc_9_4h < 30.0))
+            & ((rsi_3_1h > 35.0) | (stochrsi_k_4h_lt_80) | (roc_9_4h < 30.0))
             # 1h down move, 1h downtrend, 4h overbought
             & ((rsi_3_1h > 35.0) | (roc_9_1h > -30.0) | (roc_9_4h < 100.0))
             # 1h down move, 4h & 1d overbought
@@ -16587,7 +16592,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h high, 15m downtrend
             & ((rsi_3_1h > 40.0) | (aroonu_14_1h < 90.0) | (roc_9_15m > -10.0))
             # 1h down move, 1h  high & overbought
-            & ((rsi_3_1h > 40.0) | (stochrsi_k_1h < 80.0) | (roc_9_1h < 10.0))
+            & ((rsi_3_1h > 40.0) | (stochrsi_k_1h_lt_80) | (roc_9_1h < 10.0))
             # 1h down move, 4h & 1d overbought
             & ((rsi_3_1h > 40.0) | (roc_9_4h < 20.0) | (roc_9_1d < 100.0))
             # 1h down move, 4h & 1d overbought
@@ -16595,7 +16600,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h high, 1d overbought
             & ((rsi_3_1h > 45.0) | (aroonu_14_1h < 100.0) | (roc_9_1d < 200.0))
             # 1h down move, 4h high & overbought
-            & ((rsi_3_1h > 45.0) | (stochrsi_k_4h < 80.0) | (roc_9_4h < 100.0))
+            & ((rsi_3_1h > 45.0) | (stochrsi_k_4h_lt_80) | (roc_9_4h < 100.0))
             # 1h down move, 1h high, 1d downtrend
             & ((rsi_3_1h > 50.0) | (aroonu_14_1h < 60.0) | (roc_9_1d > -70.0))
             # 1h down move, 1h high, 1d overbought
@@ -16603,7 +16608,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 4h high, 1d downtrend
             & ((rsi_3_1h > 50.0) | (stochrsi_k_4h < 60.0) | (roc_9_1d > -60.0))
             # 1h down move, 1h high
-            & ((rsi_3_1h > 60.0) | (stochrsi_k_1h < 80.0))
+            & ((rsi_3_1h > 60.0) | (stochrsi_k_1h_lt_80))
             # 1h down move, 1h overbought
             & ((rsi_3_1h > 60.0) | (roc_9_1h < 30.0))
             # 1h down move, 4h & 1d overbought
@@ -16613,7 +16618,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 4h high, 1h downtrend
             & ((rsi_3_4h > 3.0) | aroonu_14_4h_lt_70 | (roc_9_1h > -40.0))
             # 4h down move, 1h still high, 4h downtrend
-            & ((rsi_3_4h > 3.0) | (stochrsi_k_1h < 50.0) | (roc_9_4h > -30.0))
+            & ((rsi_3_4h > 3.0) | (stochrsi_k_1h_lt_50) | (roc_9_4h > -30.0))
             # 4h & 1d down move, 1d still high
             & ((rsi_3_4h > 5.0) | (rsi_3_1d > 20.0) | (aroonu_14_1d < 50.0))
             # 4h down move, 15m still high, 1d downtrend
@@ -16673,13 +16678,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1d down move, 1d high, 1d downtrend
             & ((rsi_3_1d > 10.0) | (aroonu_14_1d < 70.0) | (roc_9_1d > -40.0))
             # 1d down move, 4h high, 1d downtrend
-            & ((rsi_3_1d > 10.0) | (stochrsi_k_4h < 90.0) | (roc_9_1d > -80.0))
+            & ((rsi_3_1d > 10.0) | (stochrsi_k_4h_lt_90) | (roc_9_1d > -80.0))
             # 1d down move, 1h & 4h high
             & ((rsi_3_1d > 15.0) | (aroonu_14_1h < 90.0) | (aroonu_14_4h < 100.0))
             # 1d down move, 1h high, 1d downtrend
             & ((rsi_3_1d > 20.0) | (aroonu_14_1h < 100.0) | (roc_9_1d > -30.0))
             # 1d down move, 1h still high, 4h downtrend
-            & ((rsi_3_1d > 25.0) | (stochrsi_k_1h < 50.0) | (roc_9_4h > -30.0))
+            & ((rsi_3_1d > 25.0) | (stochrsi_k_1h_lt_50) | (roc_9_4h > -30.0))
             # 1d down move, 1h high & overbought
             & ((rsi_3_1d > 35.0) | (stochrsi_k_1h < 90.0) | (roc_9_1h < 10.0))
             # 15m downtrend, 4h & 1d high
@@ -16731,13 +16736,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1d high, 4h & 1d overbought
             & ((aroonu_14_1d < 90.0) | (roc_9_4h < 10.0) | roc_9_1d_lt_50)
             # 1h high, 1d overbought
-            & ((stochrsi_k_1h < 70.0) | (roc_9_1d < 40.0))
+            & ((stochrsi_k_1h_lt_70) | (roc_9_1d < 40.0))
             # 1h high, 4h overbought
-            & ((stochrsi_k_1h < 80.0) | (roc_9_4h < 80.0))
+            & ((stochrsi_k_1h_lt_80) | (roc_9_4h < 80.0))
             # 1h high, 1h overbought, 4h downtrend
             & ((stochrsi_k_1h < 90.0) | (roc_9_1h < 10.0) | (roc_9_4h > -15.0))
             # 4h high, 1h & 4h overbought
-            & ((stochrsi_k_4h < 90.0) | (roc_9_1h < 20.0) | (roc_9_4h < 50.0))
+            & ((stochrsi_k_4h_lt_90) | (roc_9_1h < 20.0) | (roc_9_4h < 50.0))
             # 1d high, 4h & 1d overbought
             & ((stochrsi_k_1d < 90.0) | (roc_9_4h < 100.0) | (roc_9_1d < 100.0))
             # 1d P&D, 4h overbought
@@ -16845,9 +16850,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 15m still high, 4h high
             & ((rsi_3_15m > 25.0) | (aroonu_14_15m < 50.0) | (aroonu_14_4h < 80.0))
             # 15m down move, 4h high, 1d downtrend
-            & ((rsi_3_15m > 25.0) | (stochrsi_k_4h < 80.0) | (roc_9_1d > -40.0))
+            & ((rsi_3_15m > 25.0) | (stochrsi_k_4h_lt_80) | (roc_9_1d > -40.0))
             # 15m down move, 4h high, 1d downtrend
-            & ((rsi_3_15m > 25.0) | (stochrsi_k_4h < 90.0) | (roc_9_1d > -10.0))
+            & ((rsi_3_15m > 25.0) | (stochrsi_k_4h_lt_90) | (roc_9_1d > -10.0))
             # 15m down move, 15m still high, 4h high
             & ((rsi_3_15m > 35.0) | (aroonu_14_15m < 50.0) | (aroonu_14_4h < 80.0))
             # 1h & 4h down move
@@ -16987,7 +16992,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 1d overbought
             & (rsi_3_1h_gt_20 | rsi_3_4h_gt_20 | (roc_9_1d < 30.0))
             # 1h & 4h down move, 4h high
-            & (rsi_3_1h_gt_20 | (rsi_3_4h > 50.0) | (stochrsi_k_4h < 80.0))
+            & (rsi_3_1h_gt_20 | (rsi_3_4h > 50.0) | (stochrsi_k_4h_lt_80))
             # 1h & 1d down move, 1d high
             & (rsi_3_1h_gt_20 | (rsi_3_1d > 20.0) | (stochrsi_k_1d < 60.0))
             # 1h & 1d down move, 1d high
@@ -17065,7 +17070,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 4h high, 1d downtrend
             & ((rsi_3_1h > 35.0) | (aroonu_14_4h < 90.0) | (roc_9_1d > -20.0))
             # 1h down move, 4h high & overbought
-            & ((rsi_3_1h > 35.0) | (stochrsi_k_4h < 90.0) | (roc_9_4h < 10.0))
+            & ((rsi_3_1h > 35.0) | (stochrsi_k_4h_lt_90) | (roc_9_4h < 10.0))
             # 1h down move, 4h & 1d downtrend
             & ((rsi_3_1h > 35.0) | (roc_9_4h > -10.0) | (roc_9_1d > -60.0))
             # 1h down move, 4h high & overbought
@@ -17225,7 +17230,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 4h overbought
             & ((rsi_3_4h > 55.0) | (roc_9_4h < 30.0))
             # 4h down move, 4h high & overbought
-            & ((rsi_3_4h > 60.0) | (stochrsi_k_4h < 80.0) | (roc_9_4h < 10.0))
+            & ((rsi_3_4h > 60.0) | (stochrsi_k_4h_lt_80) | (roc_9_4h < 10.0))
             # 1d down move, 1d high, 1d downtrend
             & ((rsi_3_1d > 15.0) | (aroonu_14_1d < 70.0) | (roc_9_1d > -20.0))
             # 1d down move, 1d still high
@@ -17275,7 +17280,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m still high, 1h & 4h downtrend
             & ((stochrsi_k_15m < 50.0) | (roc_9_1h > -20.0) | (roc_9_4h > -20.0))
             # 4h high, 1h & 4h overbought
-            & ((stochrsi_k_4h < 90.0) | (roc_9_1h < 20.0) | (roc_9_4h < 30.0))
+            & ((stochrsi_k_4h_lt_90) | (roc_9_1h < 20.0) | (roc_9_4h < 30.0))
             # 4h high, 4h & 1d overbought
             & ((stochrsi_k_4h < 90.0) | (roc_9_4h < 20.0) | (roc_9_1d < 80.0))
             # 1d still high, 4h & 1d downtrend
@@ -17378,9 +17383,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 1h high, 1d downtrend
             & (rsi_3_15m_gt_3 | (stochrsi_k_1h < 80.0) | (roc_9_1d > -20.0))
             # 15m down move, 4h high & overbought
-            & (rsi_3_15m_gt_3 | (stochrsi_k_4h < 80.0) | (roc_9_4h < 40.0))
+            & (rsi_3_15m_gt_3 | (stochrsi_k_4h_lt_80) | (roc_9_4h < 40.0))
             # 15m down move, 4h high, 1d overbought
-            & (rsi_3_15m_gt_3 | (stochrsi_k_4h < 80.0) | (roc_9_1d < 10.0))
+            & (rsi_3_15m_gt_3 | (stochrsi_k_4h_lt_80) | (roc_9_1d < 10.0))
             # 15m down move, 1h downtrend, 4h overbought
             & (rsi_3_15m_gt_3 | (roc_9_1h > -30.0) | (roc_9_4h < 100.0))
             # 15m down move, 4h & 1d downtrend
@@ -17408,7 +17413,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 4h down move, 1d high
             & ((rsi_3_15m > 5.0) | rsi_3_4h_gt_20 | (aroonu_14_1d < 70.0))
             # 15m & 1d down move, 1h still high
-            & ((rsi_3_15m > 5.0) | (rsi_3_1d > 20.0) | (stochrsi_k_1h < 50.0))
+            & ((rsi_3_15m > 5.0) | (rsi_3_1d > 20.0) | (stochrsi_k_1h_lt_50))
             # 15m down move, 15m & 1h still high
             & ((rsi_3_15m > 5.0) | (aroonu_14_15m < 40.0) | (aroonu_14_1h < 50.0))
             # 15m down move, 1h high & overbought
@@ -17446,7 +17451,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 4h high
             & ((rsi_3_15m > 10.0) | (rsi_3_1h > 25.0) | (aroonu_14_4h < 90.0))
             # 15m & 1h down move, 4h high
-            & ((rsi_3_15m > 10.0) | (rsi_3_1h > 25.0) | (stochrsi_k_4h < 80.0))
+            & ((rsi_3_15m > 10.0) | (rsi_3_1h > 25.0) | (stochrsi_k_4h_lt_80))
             # 15m & 1h down move, 4h overbought
             & ((rsi_3_15m > 10.0) | (rsi_3_1h > 25.0) | (roc_9_4h < 20.0))
             # 15m & 1h down move, 1h high
@@ -17456,7 +17461,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 1h high
             & ((rsi_3_15m > 10.0) | (rsi_3_1h > 40.0) | (stochrsi_k_1h < 90.0))
             # 15m & 1h down move, 4h high
-            & ((rsi_3_15m > 10.0) | (rsi_3_1h > 50.0) | (stochrsi_k_4h < 90.0))
+            & ((rsi_3_15m > 10.0) | (rsi_3_1h > 50.0) | (stochrsi_k_4h_lt_90))
             # 15m & 4h down move, 15m still high
             & ((rsi_3_15m > 10.0) | (rsi_3_4h > 10.0) | (stochrsi_k_15m < 40.0))
             # 15m & 4h down move, 4h still high
@@ -17502,7 +17507,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 4h down move, 4h high
             & ((rsi_3_15m > 15.0) | (rsi_3_4h > 40.0) | aroonu_14_4h_lt_70)
             # 15m down move. 15m still high, 1h high
-            & ((rsi_3_15m > 15.0) | (aroonu_14_15m < 50.0) | (stochrsi_k_1h < 80.0))
+            & ((rsi_3_15m > 15.0) | (aroonu_14_15m < 50.0) | (stochrsi_k_1h_lt_80))
             # 15m down move, 15m & 4h high
             & ((rsi_3_15m > 15.0) | (aroonu_14_15m < 70.0) | (aroonu_14_4h < 100.0))
             # 15m down move, 1h high, 1d overbought
@@ -17514,19 +17519,19 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 4h high, 1d overbought
             & ((rsi_3_15m > 15.0) | (aroonu_14_4h < 100.0) | (roc_9_1d < 100.0))
             # 15m down move, 1h high, 4h downtrend
-            & ((rsi_3_15m > 15.0) | (stochrsi_k_1h < 70.0) | (roc_9_4h > -30.0))
+            & ((rsi_3_15m > 15.0) | (stochrsi_k_1h_lt_70) | (roc_9_4h > -30.0))
             # 15m down move, 4h high & overbought
-            & ((rsi_3_15m > 15.0) | (stochrsi_k_4h < 90.0) | (roc_9_4h < 25.0))
+            & ((rsi_3_15m > 15.0) | (stochrsi_k_4h_lt_90) | (roc_9_4h < 25.0))
             # 15m down move, 4h high, 1d downtrend
-            & ((rsi_3_15m > 15.0) | (stochrsi_k_4h < 90.0) | (roc_9_1d > -40.0))
+            & ((rsi_3_15m > 15.0) | (stochrsi_k_4h_lt_90) | (roc_9_1d > -40.0))
             # 15m down move, 4h high, 1d overbought
-            & ((rsi_3_15m > 15.0) | (stochrsi_k_4h < 90.0) | (roc_9_1d < 30.0))
+            & ((rsi_3_15m > 15.0) | (stochrsi_k_4h_lt_90) | (roc_9_1d < 30.0))
             # 15m down move, 1d high & overbought
             & ((rsi_3_15m > 15.0) | (stochrsi_k_1d < 90.0) | (roc_9_1d < 100.0))
             # 15m down move, 4h & 1d downtrend
             & ((rsi_3_15m > 15.0) | (roc_9_4h > -10.0) | (roc_9_1d > -40.0))
             # 15m & 1h down move, 4h high
-            & ((rsi_3_15m > 20.0) | rsi_3_1h_gt_20 | (stochrsi_k_4h < 80.0))
+            & ((rsi_3_15m > 20.0) | rsi_3_1h_gt_20 | (stochrsi_k_4h_lt_80))
             # 15m & 1h down move, 1d overbought
             & ((rsi_3_15m > 20.0) | (rsi_3_1h > 25.0) | (roc_9_1d < 100.0))
             # 15m & 1d down move, 4h high
@@ -17618,7 +17623,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 4h high & overbought
             & ((rsi_3_1h > 15.0) | (aroonu_14_4h < 80.0) | (roc_9_4h < 10.0))
             # 1h & 4h down move, 1h still high
-            & (rsi_3_1h_gt_20 | (rsi_3_4h > 30.0) | (stochrsi_k_1h < 50.0))
+            & (rsi_3_1h_gt_20 | (rsi_3_4h > 30.0) | (stochrsi_k_1h_lt_50))
             # 1h & 4h down move, 4h high
             & (rsi_3_1h_gt_20 | (rsi_3_4h > 50.0) | (aroonu_14_4h < 75.0))
             # 1h down move, 1h high, 4h overbought
@@ -17698,7 +17703,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 4h still high
             & ((rsi_3_4h > 3.0) | (aroonu_14_4h < 50.0))
             # 4h down move, 1h still high, 4h downtrend
-            & ((rsi_3_4h > 3.0) | (stochrsi_k_1h < 50.0) | (roc_9_4h > -30.0))
+            & ((rsi_3_4h > 3.0) | (stochrsi_k_1h_lt_50) | (roc_9_4h > -30.0))
             # 4h & 1d down move, 1d still high
             & ((rsi_3_4h > 5.0) | (rsi_3_1d > 30.0) | (stochrsi_k_1d < 40.0))
             # 4h down move, 1h & 4h downtrend
@@ -17782,13 +17787,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1d high, 4h & 1d overbought
             & ((aroonu_14_1d < 100.0) | (roc_9_4h < 20.0) | (roc_9_1d < 100.0))
             # 1h high, 1d overbought
-            & ((stochrsi_k_1h < 70.0) | (roc_9_1d < 40.0))
+            & ((stochrsi_k_1h_lt_70) | (roc_9_1d < 40.0))
             # 1h high, 4h overbought
-            & ((stochrsi_k_1h < 80.0) | (roc_9_4h < 80.0))
+            & ((stochrsi_k_1h_lt_80) | (roc_9_4h < 80.0))
             # 1h high, 4h & 1d downtrend
             & ((stochrsi_k_1h < 85.0) | (roc_9_4h > -70.0) | (roc_9_1d > -70.0))
             # 4h high, 1h & 4h overbought
-            & ((stochrsi_k_4h < 80.0) | (roc_9_1h < 40.0) | (roc_9_4h < 100.0))
+            & ((stochrsi_k_4h_lt_80) | (roc_9_1h < 40.0) | (roc_9_4h < 100.0))
             # 1d high, 4h & 1d overbought
             & ((stochrsi_k_1d < 90.0) | (roc_9_4h < 20.0) | (roc_9_1d < 100.0))
             # 1h & 4h overbought, 1d downtrend
@@ -17845,7 +17850,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 4h high & overbought
             & (rsi_3_15m_gt_3 | (aroonu_14_4h < 100.0) | (roc_9_4h < 100.0))
             # 15m down move, 1h high
-            & (rsi_3_15m_gt_3 | (stochrsi_k_1h < 70.0))
+            & (rsi_3_15m_gt_3 | (stochrsi_k_1h_lt_70))
             # 15m down move, 4h high, 15m downtrend
             & (rsi_3_15m_gt_3 | (stochrsi_k_4h < 70.0) | (roc_9_15m > -30.0))
             # 15m & 1h down move, 1h high
@@ -17985,7 +17990,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h still high, 4h downtrend
             & (rsi_3_1h_gt_20 | (aroonu_14_1h < 40.0) | (roc_9_4h > -30.0))
             # 1h down move, 4h high, 1d downtrend
-            & (rsi_3_1h_gt_20 | (stochrsi_k_4h < 80.0) | (roc_9_1d > -40.0))
+            & (rsi_3_1h_gt_20 | (stochrsi_k_4h_lt_80) | (roc_9_1d > -40.0))
             # 1h down move, 4h & 1d downtrend
             & (rsi_3_1h_gt_20 | (roc_9_4h > -30.0) | (roc_9_1d > -40.0))
             # 1h & 4h down ove, 4h high
@@ -17997,7 +18002,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1d high & overbought
             & ((rsi_3_1h > 25.0) | (aroonu_14_1d < 90.0) | (roc_9_1d < 100.0))
             # 1h down move, 1h still high, 1d overbought
-            & ((rsi_3_1h > 25.0) | (stochrsi_k_1h < 50.0) | (roc_9_1d < 40.0))
+            & ((rsi_3_1h > 25.0) | (stochrsi_k_1h_lt_50) | (roc_9_1d < 40.0))
             # 1h down move, 1h downtrend, 4h overbought
             & ((rsi_3_1h > 25.0) | (roc_9_1h > -20.0) | (roc_9_4h < 20.0))
             # 1h down move, 1d overbought
@@ -18005,7 +18010,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 4h high
             & ((rsi_3_1h > 30.0) | (aroonu_14_4h < 100.0))
             # 1h down move, 4h high & overbought
-            & ((rsi_3_1h > 30.0) | (stochrsi_k_4h < 80.0) | (roc_9_4h < 10.0))
+            & ((rsi_3_1h > 30.0) | (stochrsi_k_4h_lt_80) | (roc_9_4h < 10.0))
             # 4h down move, 4h still high, 1d high
             & ((rsi_3_4h > 3.0) | (aroonu_14_4h < 50.0) | (aroonu_14_1d < 100.0))
             # 4h down move, 1d still high, 4h downtrend
@@ -18093,7 +18098,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h still high, 4h & 1d downtrend
             & ((stochrsi_k_1h < 50.0) | (roc_9_4h > -20.0) | roc_9_1d_gt_neg_50)
             # 1h high, 15m downtrend
-            & ((stochrsi_k_1h < 70.0) | (roc_9_15m > -30.0))
+            & ((stochrsi_k_1h_lt_70) | (roc_9_15m > -30.0))
             # 4h high, 1d downtrend
             & ((stochrsi_k_4h < 70.0) | (roc_9_1d > -70.0))
             # 1d high, 1h downtrend
@@ -18142,7 +18147,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m & 1h down move
           long_entry_logic.append((rsi_3_15m > 5.0) | (rsi_3_1h > 15.0))
           # 15m & 1h down move, 4h high
-          long_entry_logic.append((rsi_3_15m > 5.0) | (rsi_3_1h > 40.0) | (stochrsi_k_4h < 80.0))
+          long_entry_logic.append((rsi_3_15m > 5.0) | (rsi_3_1h > 40.0) | (stochrsi_k_4h_lt_80))
           # 15m down move, 1h still not low enough
           long_entry_logic.append((rsi_3_15m > 5.0) | (aroonu_14_1h < 30.0))
           # 15m down move, 4h high
@@ -18154,7 +18159,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m & 1h down move, 1h high
           long_entry_logic.append((rsi_3_15m > 10.0) | (rsi_3_1h > 45.0) | (aroonu_14_1h < 80.0))
           # 15m & 1h down move, 1h high
-          long_entry_logic.append((rsi_3_15m > 10.0) | (rsi_3_1h > 65.0) | (stochrsi_k_1h < 80.0))
+          long_entry_logic.append((rsi_3_15m > 10.0) | (rsi_3_1h > 65.0) | (stochrsi_k_1h_lt_80))
           # 15m & 4h down move, 4h still not low enough
           long_entry_logic.append((rsi_3_15m > 10.0) | (rsi_3_4h > 10.0) | (stochrsi_k_4h < 30.0))
           # 15m & 4h down move, 1d high
@@ -18248,9 +18253,9 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1h down move, 1h high
           long_entry_logic.append((rsi_3_1h > 25.0) | (aroonu_14_1h < 70.0))
           # 1h down move, 4h high
-          long_entry_logic.append((rsi_3_1h > 25.0) | (stochrsi_k_4h < 80.0))
+          long_entry_logic.append((rsi_3_1h > 25.0) | (stochrsi_k_4h_lt_80))
           # 1h & 1d down move, 1h still high
-          long_entry_logic.append((rsi_3_1h > 30.0) | (rsi_3_1d > 50.0) | (stochrsi_k_1h < 50.0))
+          long_entry_logic.append((rsi_3_1h > 30.0) | (rsi_3_1d > 50.0) | (stochrsi_k_1h_lt_50))
           # 1h down move, 4h high
           long_entry_logic.append((rsi_3_1h > 30.0) | (rsi_14_4h < 80.0))
           # 14 down move, 1h high
@@ -18258,15 +18263,15 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1h down move, 4h high
           long_entry_logic.append((rsi_3_1h > 30.0) | (aroonu_14_4h < 80.0))
           # 1h down move, 4h high
-          long_entry_logic.append((rsi_3_1h > 30.0) | (stochrsi_k_4h < 80.0))
+          long_entry_logic.append((rsi_3_1h > 30.0) | (stochrsi_k_4h_lt_80))
           # 1h down move, 4h & 1d high
-          long_entry_logic.append((rsi_3_1h > 35.0) | (stochrsi_k_4h < 80.0) | (stochrsi_k_1d < 80.0))
+          long_entry_logic.append((rsi_3_1h > 35.0) | (stochrsi_k_4h_lt_80) | (stochrsi_k_1d < 80.0))
           # 1h down move, 1h still high, 1d overbought
           long_entry_logic.append((rsi_3_1h > 40.0) | (aroonu_14_1h < 50.0) | roc_9_1d_lt_50)
           # 1h down move, 1h & 4h high
           long_entry_logic.append((rsi_3_1h > 45.0) | (aroonu_14_1h < 70.0) | (aroonu_14_4h < 90.0))
           # 1h down move, 1h & 4h high
-          long_entry_logic.append((rsi_3_1h > 60.0) | (stochrsi_k_1h < 70.0) | (aroonu_14_4h < 90.0))
+          long_entry_logic.append((rsi_3_1h > 60.0) | (stochrsi_k_1h_lt_70) | (aroonu_14_4h < 90.0))
           # 4h down move, 1d high
           long_entry_logic.append((rsi_3_4h > 5.0) | (aroonu_14_1d < 100.0))
           # 4h & 1d down move, 1d still high
@@ -18292,13 +18297,13 @@ class NostalgiaForInfinityX7(IStrategy):
           # 4h down move, 4h & 1d high
           long_entry_logic.append((rsi_3_4h > 30.0) | (aroonu_14_4h < 80.0) | (aroonu_14_1d < 100.0))
           # 4h down move, 1h high
-          long_entry_logic.append((rsi_3_4h > 40.0) | (stochrsi_k_1h < 70.0))
+          long_entry_logic.append((rsi_3_4h > 40.0) | (stochrsi_k_1h_lt_70))
           # 4h down move, 4h still high
           long_entry_logic.append((rsi_3_4h > 50.0) | (stochrsi_k_4h < 50.0))
           # 4h down move, 1h high
-          long_entry_logic.append((rsi_3_4h > 60.0) | (stochrsi_k_1h < 80.0))
+          long_entry_logic.append((rsi_3_4h > 60.0) | (stochrsi_k_1h_lt_80))
           # 4h down move, 4h high
-          long_entry_logic.append((rsi_3_4h > 60.0) | (stochrsi_k_4h < 80.0))
+          long_entry_logic.append((rsi_3_4h > 60.0) | (stochrsi_k_4h_lt_80))
           # 1d down move, 1h still not low enough
           long_entry_logic.append((rsi_3_1d > 5.0) | (stochrsi_k_1h < 30.0))
           # 1d down move, 1h still not low enough
@@ -18322,13 +18327,13 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1d high, 4h & 1d downtrend
           long_entry_logic.append((aroonu_14_1d < 80.0) | (roc_9_4h > -20.0) | (roc_9_1d > -20.0))
           # 1h high, 4h overbought
-          long_entry_logic.append((stochrsi_k_1h < 80.0) | (roc_9_4h < 80.0))
+          long_entry_logic.append((stochrsi_k_1h_lt_80) | (roc_9_4h < 80.0))
           # 4h high, 1h & 1d downtrend
           long_entry_logic.append((stochrsi_k_4h < 70.0) | (roc_9_1h > -20.0) | (roc_9_1d > -20.0))
           # 4h high, 1h & 4h overbought
-          long_entry_logic.append((stochrsi_k_4h < 80.0) | (roc_9_1h < 10.0) | (roc_9_4h < 10.0))
+          long_entry_logic.append((stochrsi_k_4h_lt_80) | (roc_9_1h < 10.0) | (roc_9_4h < 10.0))
           # 4h high, 4h & 1d overbought
-          long_entry_logic.append((stochrsi_k_4h < 80.0) | (roc_9_4h < 30.0) | (roc_9_1d < 30.0))
+          long_entry_logic.append((stochrsi_k_4h_lt_80) | (roc_9_4h < 30.0) | (roc_9_1d < 30.0))
           # 1d top wick, 4h still high
           long_entry_logic.append((top_wick_pct_1d < 40.0) | (aroonu_14_4h < 50.0))
           # pump, 4h still high
@@ -18543,7 +18548,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1h down move, 4h high, 1d downtrend
           long_entry_logic.append((rsi_3_1h > 30.0) | (aroonu_14_4h < 100.0) | (roc_9_1d > -30.0))
           # 1h down move, 4h high
-          long_entry_logic.append((rsi_3_1h > 30.0) | (stochrsi_k_4h < 90.0))
+          long_entry_logic.append((rsi_3_1h > 30.0) | (stochrsi_k_4h_lt_90))
           # 1h & 4h down move, 4h high
           long_entry_logic.append((rsi_3_1h > 35.0) | (rsi_3_4h > 55.0) | (aroonu_14_4h < 80.0))
           # 1h down move, 1h & 4h high
@@ -18690,7 +18695,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 1h high
             & (rsi_3_15m_gt_3 | (rsi_3_1h > 45.0) | (aroonu_14_1h < 80.0))
             # 15m & 1h down move, 1h high
-            & (rsi_3_15m_gt_3 | (rsi_3_1h > 60.0) | (stochrsi_k_1h < 80.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h > 60.0) | (stochrsi_k_1h_lt_80))
             # 15m & 4h down move, 4h still high
             & (rsi_3_15m_gt_3 | (rsi_3_4h > 40.0) | (rsi_14_4h < 40.0))
             # 15m down move, 15m downtrend. 4h high
@@ -18704,13 +18709,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 1h still high
             & ((rsi_3_15m > 5.0) | rsi_3_1h_gt_20 | (stochrsi_k_1h < 40.0))
             # 15m & 1h down move, 1h high
-            & ((rsi_3_15m > 5.0) | (rsi_3_1h > 30.0) | (stochrsi_k_1h < 80.0))
+            & ((rsi_3_15m > 5.0) | (rsi_3_1h > 30.0) | (stochrsi_k_1h_lt_80))
             # 15m & 4h down move, 1h downtrend
             & ((rsi_3_15m > 5.0) | (rsi_3_4h > 10.0) | (roc_9_1h > -20.0))
             # 15m & 4h down move, 1d overbought
             & ((rsi_3_15m > 5.0) | (rsi_3_4h > 15.0) | (roc_9_1d < 70.0))
             # 15m & 4h down move, 1h high
-            & ((rsi_3_15m > 5.0) | rsi_3_4h_gt_20 | (stochrsi_k_1h < 80.0))
+            & ((rsi_3_15m > 5.0) | rsi_3_4h_gt_20 | (stochrsi_k_1h_lt_80))
             # 15m down move, 15m still low, 4h still high
             & ((rsi_3_15m > 5.0) | (aroonu_14_15m < 20.0) | (aroonu_14_4h < 50.0))
             # 15m down move, 15m still high
@@ -18780,9 +18785,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 4h high & overbought
             & ((rsi_3_15m > 20.0) | aroonu_14_4h_lt_70 | (roc_9_4h < 20.0))
             # 15m down move, 1h high
-            & ((rsi_3_15m > 20.0) | (stochrsi_k_1h < 80.0))
+            & ((rsi_3_15m > 20.0) | (stochrsi_k_1h_lt_80))
             # 15m down move, 4h high
-            & ((rsi_3_15m > 20.0) | (stochrsi_k_4h < 90.0))
+            & ((rsi_3_15m > 20.0) | (stochrsi_k_4h_lt_90))
             # 15m down move, 1h high, 1d overbought
             & ((rsi_3_15m > 25.0) | (aroonu_14_1h < 100.0) | (roc_9_1d < 20.0))
             # 15m & 1h down move, 1h high
@@ -18792,7 +18797,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 15m high, 4h high
             & ((rsi_3_15m > 30.0) | (aroonu_14_15m < 60.0) | (stochrsi_k_4h < 70.0))
             # 15m down move, 1h & 4h high
-            & ((rsi_3_15m > 30.0) | (stochrsi_k_1h < 70.0) | (stochrsi_k_4h < 80.0))
+            & ((rsi_3_15m > 30.0) | (stochrsi_k_1h_lt_70) | (stochrsi_k_4h_lt_80))
             # 1h & 4h down move, 4h still not low enough
             & ((rsi_3_1h > 3.0) | (rsi_3_4h > 5.0) | (stochrsi_k_4h < 20.0))
             # 1h & 4h down move, 15m stil high
@@ -18856,15 +18861,15 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h & 1d high
             & ((rsi_3_1h > 25.0) | (aroonu_14_1h < 70.0) | (aroonu_14_1d < 90.0))
             # 1h down move, 1h still high, 1d overbought
-            & ((rsi_3_1h > 25.0) | (stochrsi_k_1h < 50.0) | (roc_9_1d < 40.0))
+            & ((rsi_3_1h > 25.0) | (stochrsi_k_1h_lt_50) | (roc_9_1d < 40.0))
             # 1h down move, 4h high, 1d downtrend
-            & ((rsi_3_1h > 25.0) | (stochrsi_k_4h < 80.0) | (roc_9_1d > -40.0))
+            & ((rsi_3_1h > 25.0) | (stochrsi_k_4h_lt_80) | (roc_9_1d > -40.0))
             # 1h & 4h down move, 1h high
             & ((rsi_3_1h > 30.0) | (rsi_3_4h > 35.0) | (aroonu_14_1h < 75.0))
             # 1h down move, 1h high, 4h downtrend
             & ((rsi_3_1h > 35.0) | (aroonu_14_1h < 80.0) | (roc_9_4h > -40.0))
             # 1h down move, 1h still high, 1d overbought
-            & ((rsi_3_1h > 35.0) | (stochrsi_k_1h < 50.0) | (roc_9_1d < 200.0))
+            & ((rsi_3_1h > 35.0) | (stochrsi_k_1h_lt_50) | (roc_9_1d < 200.0))
             # 1h down move, 1h high, 4h downtrend
             & ((rsi_3_1h > 35.0) | (stochrsi_k_1h < 70.0) | (roc_9_4h > -20.0))
             # 1h down move, 4h & 1d overbought
@@ -18890,7 +18895,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 1d high
             & ((rsi_3_4h > 3.0) | (aroonu_14_1d < 90.0))
             # 4h down move, 1h still high, 4h downtrend
-            & ((rsi_3_4h > 3.0) | (stochrsi_k_1h < 50.0) | (roc_9_4h > -30.0))
+            & ((rsi_3_4h > 3.0) | (stochrsi_k_1h_lt_50) | (roc_9_4h > -30.0))
             # 4h down move, 1d high
             & ((rsi_3_4h > 3.0) | (stochrsi_k_1d < 90.0))
             # 4h down move, 1h & 4h downtrend
@@ -18968,11 +18973,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1d high, 4h & 1d overbought
             & ((aroonu_14_1d < 90.0) | (roc_9_4h < 30.0) | (roc_9_1d < 60.0))
             # 1h high, 1d overbought
-            & ((stochrsi_k_1h < 70.0) | (roc_9_1d < 40.0))
+            & ((stochrsi_k_1h_lt_70) | (roc_9_1d < 40.0))
             # 4h high, 1h overbought, 1d downtrend
-            & ((stochrsi_k_4h < 80.0) | (roc_9_1h < 40.0) | (roc_9_1d > -70.0))
+            & ((stochrsi_k_4h_lt_80) | (roc_9_1h < 40.0) | (roc_9_1d > -70.0))
             # 4h high, 1h & 4h overbought
-            & ((stochrsi_k_4h < 90.0) | (roc_9_1h < 20.0) | (roc_9_4h < 50.0))
+            & ((stochrsi_k_4h_lt_90) | (roc_9_1h < 20.0) | (roc_9_4h < 50.0))
             # 1h & 4h overbought
             & ((roc_9_1h < 100.0) | (roc_9_4h < 100.0))
             # big drop in the last 20 days, 1d high, 1d downtrend
@@ -19169,7 +19174,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 1d high
             & (rsi_3_1h_gt_20 | (rsi_3_4h > 45.0) | (aroonu_14_1d < 100.0))
             # 1h & 4h down move, 4h high
-            & (rsi_3_1h_gt_20 | (rsi_3_4h > 50.0) | (stochrsi_k_4h < 80.0))
+            & (rsi_3_1h_gt_20 | (rsi_3_4h > 50.0) | (stochrsi_k_4h_lt_80))
             # 1h down move, 1h high
             & (rsi_3_1h_gt_20 | (aroonu_14_1h < 70.0))
             # 1h down move, 4h still high, 1d downtrend
@@ -19183,7 +19188,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1d high, 4h downtrend
             & (rsi_3_1h_gt_20 | (stochrsi_k_1d < 80.0) | (roc_9_4h > -20.0))
             # 1h down move, 4h high
-            & (rsi_3_1h_gt_20 | (stochrsi_k_4h < 80.0))
+            & (rsi_3_1h_gt_20 | (stochrsi_k_4h_lt_80))
             # 1h & 4h down move, 1h still not low enough
             & ((rsi_3_1h > 25.0) | (rsi_3_4h > 25.0) | (stochrsi_k_1h < 20.0))
             # 1h & 4h down move, 1d overbought
@@ -19365,7 +19370,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 15m still high
             & ((rsi_3_15m > 10.0) | (rsi_3_1h > 30.0) | (aroonu_14_15m < 50.0))
             # 15m & 1h down move 1h still high
-            & ((rsi_3_15m > 10.0) | (rsi_3_1h > 30.0) | (stochrsi_k_1h < 50.0))
+            & ((rsi_3_15m > 10.0) | (rsi_3_1h > 30.0) | (stochrsi_k_1h_lt_50))
             # 15m & 1h down move, 4h overbought
             & ((rsi_3_15m > 10.0) | (rsi_3_1h > 30.0) | (roc_9_4h < 10.0))
             # 15m & 1h down move, 1h high
@@ -19381,7 +19386,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 15m still high
             & ((rsi_3_15m > 10.0) | (rsi_3_4h > 30.0) | (aroonu_14_15m < 50.0))
             # 15m & 4h down move, 4h high
-            & ((rsi_3_15m > 10.0) | (rsi_3_4h > 40.0) | (stochrsi_k_4h < 80.0))
+            & ((rsi_3_15m > 10.0) | (rsi_3_4h > 40.0) | (stochrsi_k_4h_lt_80))
             # 15m & 1d down move, 1d high
             & ((rsi_3_15m > 10.0) | (rsi_3_1d > 10.0) | (aroonu_14_1d < 70.0))
             # 15m & 1d down move, 1d high
@@ -19411,17 +19416,17 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1d down move, 4h high
             & ((rsi_3_15m > 15.0) | (rsi_3_1d > 25.0) | (aroonu_14_4h < 100.0))
             # 15m down move, 15m still high, 4h high
-            & ((rsi_3_15m > 15.0) | (aroonu_14_15m < 50.0) | (stochrsi_k_4h < 80.0))
+            & ((rsi_3_15m > 15.0) | (aroonu_14_15m < 50.0) | (stochrsi_k_4h_lt_80))
             # 15m down move, 4h high, 4h downtrend
             & ((rsi_3_15m > 15.0) | (aroonu_14_4h < 60.0) | (roc_9_4h > -20.0))
             # 15m down move, 4h & 1d high
             & ((rsi_3_15m > 15.0) | (aroonu_14_4h < 75.0) | (aroonu_14_1d < 100.0))
             # 15m down move, 15m still not low enough, 1h still high
-            & ((rsi_3_15m > 15.0) | (stochrsi_k_15m < 30.0) | (stochrsi_k_1h < 50.0))
+            & ((rsi_3_15m > 15.0) | (stochrsi_k_15m < 30.0) | (stochrsi_k_1h_lt_50))
             # 15m down move, 4h & 1d overbought
             & ((rsi_3_15m > 15.0) | (roc_9_4h < 20.0) | (roc_9_1d < 60.0))
             # 15m & 1h down move, 1h high
-            & ((rsi_3_15m > 20.0) | rsi_3_1h_gt_20 | (stochrsi_k_1h < 70.0))
+            & ((rsi_3_15m > 20.0) | rsi_3_1h_gt_20 | (stochrsi_k_1h_lt_70))
             # 15m & 4h down move, 4h high
             & ((rsi_3_15m > 20.0) | (rsi_3_4h > 50.0) | (aroonu_14_4h < 85.0))
             # 15m down move, 1h high
@@ -19445,7 +19450,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 1h high
             & ((rsi_3_15m > 30.0) | (rsi_3_1h > 40.0) | (aroonu_14_1h < 80.0))
             # 15m & 1h down move, 1h high
-            & ((rsi_3_15m > 30.0) | (rsi_3_1h > 45.0) | (stochrsi_k_1h < 80.0))
+            & ((rsi_3_15m > 30.0) | (rsi_3_1h > 45.0) | (stochrsi_k_1h_lt_80))
             # 15m down move, 15m downtrend, 4h high
             & ((rsi_3_15m > 30.0) | (cmf_20_15m > -0.30) | (aroonu_14_4h < 100.0))
             # 15m down move, 15m still high, 1d high
@@ -19455,11 +19460,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 4h high, 1h downtrend
             & ((rsi_3_15m < 30.0) | (aroonu_14_4h < 85.0) | (roc_9_1h > -40.0))
             # 15m down move, 4h high
-            & ((rsi_3_15m > 30.0) | (stochrsi_k_4h < 90.0))
+            & ((rsi_3_15m > 30.0) | (stochrsi_k_4h_lt_90))
             # 15m & 1h down move, 15m high
             & ((rsi_3_15m > 35.0) | (rsi_3_1h > 45.0) | (aroonu_14_15m < 70.0))
             # 15m & 4h down move, 4h high
-            & ((rsi_3_15m > 35.0) | (rsi_3_4h > 35.0) | (stochrsi_k_4h < 80.0))
+            & ((rsi_3_15m > 35.0) | (rsi_3_4h > 35.0) | (stochrsi_k_4h_lt_80))
             # 15m down move, 15m still high, 4h overbought
             & ((rsi_3_15m > 35.0) | (aroonu_14_15m < 40.0) | (roc_9_4h < 20.0))
             # 15m down move, 15m still high, 1d overbought
@@ -19591,17 +19596,17 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h still not low enough, 4h still high
             & ((rsi_3_1h > 25.0) | (stochrsi_k_1h < 30.0) | (stochrsi_k_4h < 50.0))
             # 1h down move, 4h high, 1d downtrend
-            & ((rsi_3_1h > 25.0) | (stochrsi_k_4h < 80.0) | (roc_9_1d > -40.0))
+            & ((rsi_3_1h > 25.0) | (stochrsi_k_4h_lt_80) | (roc_9_1d > -40.0))
             # 1h down move, 1h still high, 1h downtrend
             & ((rsi_3_1h > 25.0) | (aroonu_14_1h < 40.0) | (roc_9_1h > -50.0))
             # 1h down move, 4h high & overbought
             & ((rsi_3_1h > 25.0) | (aroonu_14_4h < 90.0) | (roc_9_4h < 20.0))
             # 1h down move, 1h still high, 1d overbought
-            & ((rsi_3_1h > 25.0) | (stochrsi_k_1h < 50.0) | (roc_9_1d < 40.0))
+            & ((rsi_3_1h > 25.0) | (stochrsi_k_1h_lt_50) | (roc_9_1d < 40.0))
             # 1h down move, 4h high & overbought
             & ((rsi_3_1h > 25.0) | (stochrsi_k_4h < 80.0) | (roc_9_4h < 20.0))
             # 1h down move, 4h high, 1d overbought
-            & ((rsi_3_1h > 25.0) | (stochrsi_k_4h < 80.0) | (roc_9_1d < 70.0))
+            & ((rsi_3_1h > 25.0) | (stochrsi_k_4h_lt_80) | (roc_9_1d < 70.0))
             # 1h & 4h down move, 1h high
             & ((rsi_3_1h > 30.0) | (rsi_3_4h > 30.0) | (stochrsi_k_1h < 60.0))
             # 1h & 4h down move, 4h still high
@@ -19643,7 +19648,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1d high & overbought
             & ((rsi_3_1h > 35.0) | (aroonu_14_1d < 100.0) | (roc_9_1d < 100.0))
             # 1h down move, 1h still high, 1d overbought
-            & ((rsi_3_1h > 35.0) | (stochrsi_k_1h < 50.0) | (roc_9_1d < 200.0))
+            & ((rsi_3_1h > 35.0) | (stochrsi_k_1h_lt_50) | (roc_9_1d < 200.0))
             # 1h down move, 1d high & overbought
             & ((rsi_3_1h > 40.0) | (rsi_14_1d < 80.0) | (roc_9_1d < 150.0))
             # 1h down move, 15m high, 1h high
@@ -19667,7 +19672,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 4h high, 1d downtrend
             & ((rsi_3_1h > 50.0) | (stochrsi_k_4h < 60.0) | (roc_9_1d > -60.0))
             # 1h down move, 15m high, 1h high
-            & ((rsi_3_1h > 55.0) | (aroonu_14_15m < 60.0) | (stochrsi_k_1h < 80.0))
+            & ((rsi_3_1h > 55.0) | (aroonu_14_15m < 60.0) | (stochrsi_k_1h_lt_80))
             # 1h down move, 1h high & overbought
             & ((rsi_3_1h > 55.0) | (aroonu_14_1h < 90.0) | (roc_9_1h < 10.0))
             # 4h down move, 1h still not low enough, 4h downtrend
@@ -19677,7 +19682,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 1d high, 4h downtrend
             & ((rsi_3_4h > 5.0) | (aroonu_14_1d < 80.0) | (roc_9_4h > -10.0))
             # 4h down move, 1h still high
-            & ((rsi_3_4h > 5.0) | (stochrsi_k_1h < 50.0))
+            & ((rsi_3_4h > 5.0) | (stochrsi_k_1h_lt_50))
             # 4h down move, 4h & 1d downtrend
             & ((rsi_3_4h > 5.0) | (roc_9_4h > -15.0) | (roc_9_1d > -20.0))
             # 4h & 1d down move, 1d overbought
@@ -19809,11 +19814,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h high, 4h & 1d overbought
             & ((stochrsi_k_4h < 70.0) | (roc_9_4h < 20.0) | (roc_9_1d < 30.0))
             # 4h high, 1h overbought, 1d downtrend
-            & ((stochrsi_k_4h < 80.0) | (roc_9_1h < 40.0) | (roc_9_1d > -70.0))
+            & ((stochrsi_k_4h_lt_80) | (roc_9_1h < 40.0) | (roc_9_1d > -70.0))
             # 4h high, 4h overbought
-            & ((stochrsi_k_4h < 80.0) | (roc_9_4h < 10.0))
+            & ((stochrsi_k_4h_lt_80) | (roc_9_4h < 10.0))
             # 4h high, 1h & 4h overbought
-            & ((stochrsi_k_4h < 90.0) | (roc_9_1h < 20.0) | (roc_9_4h < 50.0))
+            & ((stochrsi_k_4h_lt_90) | (roc_9_1h < 20.0) | (roc_9_4h < 50.0))
             # 1d high, 4h & 1d overbought
             & ((stochrsi_k_1d < 90.0) | (roc_9_4h < 40.0) | (roc_9_1d < 100.0))
             # 1h & 4h overbought
@@ -19823,7 +19828,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1d top wick, 4h down move, 1d overbought
             & ((top_wick_pct_1d < 50.0) | (rsi_3_4h > 35.0) | (roc_9_1d < 60.0))
             # drop in last 20 days, 4h high
-            & ((close > (high_max_20_1d * 0.10)) | (stochrsi_k_4h < 90.0))
+            & ((close > (high_max_20_1d * 0.10)) | (stochrsi_k_4h_lt_90))
             # drop in last 20 days, 1h high, 1d downtrend
             & ((close > (high_max_20_1d * 0.20)) | (aroonu_14_1h < 70.0) | (roc_9_1d > -70.0))
             # drop in last 20 days, 1d high, 1d downtrend
@@ -19890,13 +19895,13 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m & 1h down move, 1h still not low enough
           long_entry_logic.append((rsi_3_15m > 5.0) | (rsi_3_1h > 30.0) | (stochrsi_k_1h < 30.0))
           # 15m & 1h down move, 4h high
-          long_entry_logic.append((rsi_3_15m > 5.0) | (rsi_3_1h > 30.0) | (stochrsi_k_4h < 80.0))
+          long_entry_logic.append((rsi_3_15m > 5.0) | (rsi_3_1h > 30.0) | (stochrsi_k_4h_lt_80))
           # 15m & 1h down move, 4h high
-          long_entry_logic.append((rsi_3_15m > 5.0) | (rsi_3_1h > 40.0) | (stochrsi_k_4h < 80.0))
+          long_entry_logic.append((rsi_3_15m > 5.0) | (rsi_3_1h > 40.0) | (stochrsi_k_4h_lt_80))
           # 15m & 1h down move, 1h high
-          long_entry_logic.append((rsi_3_15m > 5.0) | (rsi_3_1h > 50.0) | (stochrsi_k_1h < 70.0))
+          long_entry_logic.append((rsi_3_15m > 5.0) | (rsi_3_1h > 50.0) | (stochrsi_k_1h_lt_70))
           # 15m & 1h down move, 4h high
-          long_entry_logic.append((rsi_3_15m > 5.0) | (rsi_3_1h > 50.0) | (stochrsi_k_4h < 90.0))
+          long_entry_logic.append((rsi_3_15m > 5.0) | (rsi_3_1h > 50.0) | (stochrsi_k_4h_lt_90))
           # 15m & 4h down move, 1d still high
           long_entry_logic.append((rsi_3_15m > 5.0) | (rsi_3_4h > 5.0) | (stochrsi_k_1d < 40.0))
           # 15m & 4h down move, 4h still high
@@ -19906,11 +19911,11 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m & 1d down move, 4h still not low enough
           long_entry_logic.append((rsi_3_15m > 5.0) | (rsi_3_1d > 30.0) | (stochrsi_k_4h < 30.0))
           # 15m down move, 1h still high, 4h high
-          long_entry_logic.append((rsi_3_15m > 5.0) | (aroonu_14_1h < 50.0) | (stochrsi_k_4h < 90.0))
+          long_entry_logic.append((rsi_3_15m > 5.0) | (aroonu_14_1h < 50.0) | (stochrsi_k_4h_lt_90))
           # 15m down move, 1h high & overbought
           long_entry_logic.append((rsi_3_15m > 5.0) | (aroonu_14_1h < 80.0) | (roc_9_1h < 10.0))
           # 15m down move, 1h high & overbought
-          long_entry_logic.append((rsi_3_15m > 5.0) | (stochrsi_k_1h < 80.0) | (roc_9_1h < 10.0))
+          long_entry_logic.append((rsi_3_15m > 5.0) | (stochrsi_k_1h_lt_80) | (roc_9_1h < 10.0))
           # 15m & 1h down move, 4h still high
           long_entry_logic.append((rsi_3_15m > 10.0) | rsi_3_1h_gt_20 | (stochrsi_k_4h < 50.0))
           # 15m & 1h down move, 1h still not low enough
@@ -19920,11 +19925,11 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m & 1h down move, 4h still high
           long_entry_logic.append((rsi_3_15m > 10.0) | (rsi_3_1h > 30.0) | (stochrsi_k_4h < 50.0))
           # 15m & 1h down move, 1h still high
-          long_entry_logic.append((rsi_3_15m > 10.0) | (rsi_3_1h > 35.0) | (stochrsi_k_1h < 50.0))
+          long_entry_logic.append((rsi_3_15m > 10.0) | (rsi_3_1h > 35.0) | (stochrsi_k_1h_lt_50))
           # 15m & 1h down move, 1h high
           long_entry_logic.append((rsi_3_15m > 10.0) | (rsi_3_1h > 50.0) | (aroonu_14_1h < 80.0))
           # 15m & 1h down move, 1h high
-          long_entry_logic.append((rsi_3_15m > 10.0) | (rsi_3_1h > 50.0) | (stochrsi_k_1h < 80.0))
+          long_entry_logic.append((rsi_3_15m > 10.0) | (rsi_3_1h > 50.0) | (stochrsi_k_1h_lt_80))
           # 15m & 4h down move, 15m still not low enough
           long_entry_logic.append((rsi_3_15m > 10.0) | (rsi_3_4h > 10.0) | (stochrsi_k_15m < 10.0))
           # 15m & 4h down move, 1d downtrend
@@ -19932,21 +19937,21 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m & 4h down move, 1d high
           long_entry_logic.append((rsi_3_15m > 10.0) | (rsi_3_4h > 25.0) | (aroonu_14_1d < 85.0))
           # 15m & 4h down move, 1h still high
-          long_entry_logic.append((rsi_3_15m > 10.0) | (rsi_3_4h > 30.0) | (stochrsi_k_1h < 50.0))
+          long_entry_logic.append((rsi_3_15m > 10.0) | (rsi_3_4h > 30.0) | (stochrsi_k_1h_lt_50))
           # 15m & 4h down move, 4h high
           long_entry_logic.append((rsi_3_15m > 10.0) | (rsi_3_4h > 30.0) | (stochrsi_k_4h < 70.0))
           # 15m & 1d down move, 1h still high
-          long_entry_logic.append((rsi_3_15m > 10.0) | (rsi_3_1d > 25.0) | (stochrsi_k_1h < 50.0))
+          long_entry_logic.append((rsi_3_15m > 10.0) | (rsi_3_1d > 25.0) | (stochrsi_k_1h_lt_50))
           # 15m down move, 15m still not low enough, 1h still high
-          long_entry_logic.append((rsi_3_15m > 10.0) | (aroonu_14_15m < 30.0) | (stochrsi_k_1h < 50.0))
+          long_entry_logic.append((rsi_3_15m > 10.0) | (aroonu_14_15m < 30.0) | (stochrsi_k_1h_lt_50))
           # 15m down move, 1h still high, 4h high
-          long_entry_logic.append((rsi_3_15m > 10.0) | (stochrsi_k_1h < 50.0) | (aroonu_14_4h < 85.0))
+          long_entry_logic.append((rsi_3_15m > 10.0) | (stochrsi_k_1h_lt_50) | (aroonu_14_4h < 85.0))
           # 15m down move, 1h & 4h high
-          long_entry_logic.append((rsi_3_15m > 10.0) | (stochrsi_k_1h < 70.0) | (stochrsi_k_4h < 75.0))
+          long_entry_logic.append((rsi_3_15m > 10.0) | (stochrsi_k_1h_lt_70) | (stochrsi_k_4h < 75.0))
           # 15m & 1h down move, 15m still not low enough
           long_entry_logic.append((rsi_3_15m > 15.0) | (rsi_3_1h > 15.0) | (stochrsi_k_15m < 30.0))
           # 15m & 1h down move, 4h high
-          long_entry_logic.append((rsi_3_15m > 15.0) | rsi_3_1h_gt_20 | (stochrsi_k_4h < 90.0))
+          long_entry_logic.append((rsi_3_15m > 15.0) | rsi_3_1h_gt_20 | (stochrsi_k_4h_lt_90))
           # 15m & 1h down move, 1h still high
           long_entry_logic.append((rsi_3_15m > 15.0) | (rsi_3_1h > 25.0) | (stochrsi_k_1h < 40.0))
           # 15m & 1h down move, 1h still high
@@ -19956,7 +19961,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m & 4h down move, 1h high
           long_entry_logic.append((rsi_3_15m > 15.0) | (rsi_3_4h > 15.0) | (stochrsi_k_1h < 80.0))
           # 15m & 4h down move, 1h still high
-          long_entry_logic.append((rsi_3_15m > 15.0) | rsi_3_4h_gt_20 | (stochrsi_k_1h < 50.0))
+          long_entry_logic.append((rsi_3_15m > 15.0) | rsi_3_4h_gt_20 | (stochrsi_k_1h_lt_50))
           # 15m & 4h down move, 15m still not low enough
           long_entry_logic.append((rsi_3_15m > 15.0) | (rsi_3_4h > 25.0) | (aroonu_14_15m < 30.0))
           # 15m & 4h down move, 4h still high
@@ -19964,21 +19969,21 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1h & 1d down move, 1d overbought
           long_entry_logic.append((rsi_3_1h > 15.0) | (rsi_3_1d > 35.0) | (roc_9_1d < 10.0))
           # 15m down move, 15m still not low enough, 1h high
-          long_entry_logic.append((rsi_3_15m > 15.0) | (aroonu_14_15m < 25.0) | (stochrsi_k_1h < 80.0))
+          long_entry_logic.append((rsi_3_15m > 15.0) | (aroonu_14_15m < 25.0) | (stochrsi_k_1h_lt_80))
           # 15m down move, 4h high & overbought
           long_entry_logic.append((rsi_3_15m > 15.0) | (aroonu_14_4h < 80.0) | (roc_9_4h < 40.0))
           # 15m down move, 1h & 4h high
-          long_entry_logic.append((rsi_3_15m > 15.0) | (stochrsi_k_1h < 70.0) | (aroonu_14_4h < 85.0))
+          long_entry_logic.append((rsi_3_15m > 15.0) | (stochrsi_k_1h_lt_70) | (aroonu_14_4h < 85.0))
           # 15m & 1h down move, 4h high
-          long_entry_logic.append((rsi_3_15m > 20.0) | (rsi_3_1h > 30.0) | (stochrsi_k_4h < 90.0))
+          long_entry_logic.append((rsi_3_15m > 20.0) | (rsi_3_1h > 30.0) | (stochrsi_k_4h_lt_90))
           # 15m & 1d down move, 1h high
-          long_entry_logic.append((rsi_3_15m > 20.0) | (rsi_3_1d > 20.0) | (stochrsi_k_1h < 70.0))
+          long_entry_logic.append((rsi_3_15m > 20.0) | (rsi_3_1d > 20.0) | (stochrsi_k_1h_lt_70))
           # 15m down move, 1d high & overbought
           long_entry_logic.append((rsi_3_15m > 20.0) | (aroonu_14_1d < 100.0) | (roc_9_1d < 20.0))
           # 15m down move, 1h high, 1d downtrend
           long_entry_logic.append((rsi_3_15m > 20.0) | (stochrsi_k_1h < 80.0) | (roc_9_1d > -20.0))
           # 15m down move, 1d high & overbought
-          long_entry_logic.append((rsi_3_15m > 20.0) | (stochrsi_k_1h < 80.0) | (roc_9_1d < 20.0))
+          long_entry_logic.append((rsi_3_15m > 20.0) | (stochrsi_k_1h_lt_80) | (roc_9_1d < 20.0))
           # 15m & 1h down move, 1h high
           long_entry_logic.append((rsi_3_15m > 25.0) | (rsi_3_1h > 25.0) | (stochrsi_k_1h < 60.0))
           # 15m & 1h down move, 1h high
@@ -20026,13 +20031,13 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1h down move, 1h still not low enough, 4h high
           long_entry_logic.append(rsi_3_1h_gt_20 | (stochrsi_k_1h < 20.0) | (aroonu_14_4h < 80.0))
           # 1h & 4h down move, 1h still high
-          long_entry_logic.append((rsi_3_1h > 25.0) | (rsi_3_4h > 25.0) | (stochrsi_k_1h < 50.0))
+          long_entry_logic.append((rsi_3_1h > 25.0) | (rsi_3_4h > 25.0) | (stochrsi_k_1h_lt_50))
           # 1h & 4h down move, 1d high
           long_entry_logic.append((rsi_3_1h > 25.0) | (rsi_3_4h > 30.0) | (stochrsi_k_1d < 80.0))
           # 1h & 4h down move, 1h high
-          long_entry_logic.append((rsi_3_1h > 25.0) | (rsi_3_4h > 60.0) | (stochrsi_k_4h < 80.0))
+          long_entry_logic.append((rsi_3_1h > 25.0) | (rsi_3_4h > 60.0) | (stochrsi_k_4h_lt_80))
           # 1h & 4h down move, 1h still high
-          long_entry_logic.append((rsi_3_1h > 30.0) | (rsi_3_4h > 40.0) | (stochrsi_k_1h < 50.0))
+          long_entry_logic.append((rsi_3_1h > 30.0) | (rsi_3_4h > 40.0) | (stochrsi_k_1h_lt_50))
           # 1h down move, 4h high, 1d overbought
           long_entry_logic.append((rsi_3_1h > 30.0) | (aroonu_14_4h < 90.0) | (roc_9_1d < 40.0))
           # 1h down move, 4h & 1d high
@@ -20044,7 +20049,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1h down move, 1h & 4h high
           long_entry_logic.append((rsi_3_1h > 40.0) | (aroonu_14_1h < 80.0) | (aroonu_14_4h < 100.0))
           # 1h down move, 1h high & overbought
-          long_entry_logic.append((rsi_3_1h > 55.0) | (stochrsi_k_1h < 80.0) | (roc_9_1h < 10.0))
+          long_entry_logic.append((rsi_3_1h > 55.0) | (stochrsi_k_1h_lt_80) | (roc_9_1h < 10.0))
           # 1h down move, 4h high
           long_entry_logic.append((rsi_3_1h > 60.0) | (aroonu_14_4h < 90.0))
           # 4h down move, 15m still high
@@ -20082,7 +20087,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1d down move, 1h high & overbought
           long_entry_logic.append((rsi_3_1d > 35.0) | (stochrsi_k_1h < 90.0) | (roc_9_1h < 10.0))
           # 1d down move, 4h high, 1d overbought
-          long_entry_logic.append((rsi_3_1d > 45.0) | (stochrsi_k_4h < 90.0) | (roc_9_1d < 10.0))
+          long_entry_logic.append((rsi_3_1d > 45.0) | (stochrsi_k_4h_lt_90) | (roc_9_1d < 10.0))
           # 4h still high, 4h moving lower, 4h overbought
           long_entry_logic.append((aroonu_14_4h < 50.0) | (aroonu_14_4h > aroonu_14_4h.shift(48)) | (roc_9_4h < 40.0))
           # 1h high, 1d downtrend
@@ -20094,13 +20099,13 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1h high, 4h downtrend
           long_entry_logic.append((stochrsi_k_1h < 80.0) | (roc_9_4h > -20.0))
           # 1h high, 4h overbought
-          long_entry_logic.append((stochrsi_k_1h < 80.0) | (roc_9_4h < 80.0))
+          long_entry_logic.append((stochrsi_k_1h_lt_80) | (roc_9_4h < 80.0))
           # 4h high, 4h & 1d overbought
-          long_entry_logic.append((stochrsi_k_4h < 80.0) | (roc_9_4h < 30.0) | (roc_9_1d < 30.0))
+          long_entry_logic.append((stochrsi_k_4h_lt_80) | (roc_9_4h < 30.0) | (roc_9_1d < 30.0))
           # 1d high, 4h & 1d overbought
           long_entry_logic.append((stochrsi_k_1d < 80.0) | (roc_9_4h < 60.0) | (roc_9_1d < 60.0))
           # 1d red, 4h down move, 1h still high
-          long_entry_logic.append((change_pct_1d > -30.0) | (rsi_3_4h > 30.0) | (stochrsi_k_1h < 50.0))
+          long_entry_logic.append((change_pct_1d > -30.0) | (rsi_3_4h > 30.0) | (stochrsi_k_1h_lt_50))
           # pump, drop but not yet near the previous lows
           long_entry_logic.append(
             (((high_max_24_4h - low_min_24_4h) / low_min_24_4h) < 2.0)
@@ -20130,7 +20135,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # big drop in the last 6 days, 1d down move
           long_entry_logic.append((close > (high_max_6_1d * 0.30)) | (rsi_3_1d > 15.0))
           # big drop in the last 12 days, 4h high
-          long_entry_logic.append((close > (high_max_12_1d * 0.50)) | (stochrsi_k_4h < 90.0))
+          long_entry_logic.append((close > (high_max_12_1d * 0.50)) | (stochrsi_k_4h_lt_90))
           # big drop in the last 30 days, 4h down move
           long_entry_logic.append((close > (high_max_20_1d * 0.10)) | (rsi_3_4h > 30.0))
           # big drop in the last 20 days, 1h still high
@@ -20183,9 +20188,9 @@ class NostalgiaForInfinityX7(IStrategy):
           # 5m down move, 15m still high, 1h high
           long_entry_logic.append((rsi_3 > 5.0) | (rsi_14_15m < 40.0) | (aroonu_14_1h < 80.0))
           # 5m down move, 15m still high, 1h high
-          long_entry_logic.append((rsi_3 > 5.0) | (aroonu_14_15m < 40.0) | (stochrsi_k_1h < 50.0))
+          long_entry_logic.append((rsi_3 > 5.0) | (aroonu_14_15m < 40.0) | (stochrsi_k_1h_lt_50))
           # 5m down move, 15m & 4h high
-          long_entry_logic.append((rsi_3 > 5.0) | (stochrsi_k_15m < 70.0) | (stochrsi_k_4h < 90.0))
+          long_entry_logic.append((rsi_3 > 5.0) | (stochrsi_k_15m < 70.0) | (stochrsi_k_4h_lt_90))
           # 5m & 15m down move, 4h high
           long_entry_logic.append((rsi_3 > 10.0) | (rsi_3_15m > 20.0) | (aroonu_14_4h < 90.0))
           # 5m & 15m down move, 1d high
@@ -20201,7 +20206,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 5m down move, 15m still high, 1h high
           long_entry_logic.append((rsi_3 > 15.0) | (rsi_14_15m < 40.0) | (stochrsi_k_1h < 90.0))
           # 5m down move, 15m still high, 4h high
-          long_entry_logic.append((rsi_3 > 15.0) | (rsi_14_15m < 40.0) | (stochrsi_k_4h < 90.0))
+          long_entry_logic.append((rsi_3 > 15.0) | (rsi_14_15m < 40.0) | (stochrsi_k_4h_lt_90))
           # 15m down move, 15m still not low enough, 1h high
           long_entry_logic.append(rsi_3_15m_gt_3 | (aroonu_14_15m < 20.0) | (stochrsi_k_1h < 60.0))
           # 15m & 1h down move, 1d high
@@ -20213,7 +20218,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m & 1h down move, 1h still high
           long_entry_logic.append((rsi_3_15m > 10.0) | (rsi_3_1h > 35.0) | (aroonu_14_1h < 50.0))
           # 15m & 1h down move, 1h still high
-          long_entry_logic.append((rsi_3_15m > 10.0) | (rsi_3_1h > 35.0) | (stochrsi_k_1h < 50.0))
+          long_entry_logic.append((rsi_3_15m > 10.0) | (rsi_3_1h > 35.0) | (stochrsi_k_1h_lt_50))
           # 15m & 1h down move, 4h still high
           long_entry_logic.append((rsi_3_15m > 10.0) | (rsi_3_1h > 35.0) | aroonu_14_4h_lt_70)
           # 15m & 4h down move, 4h still not low enough
@@ -20233,13 +20238,13 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m & 4h down move, 1d high
           long_entry_logic.append((rsi_3_15m > 10.0) | (rsi_3_4h > 25.0) | (aroonu_14_1d < 85.0))
           # 15m & 4h down move, 1h still high
-          long_entry_logic.append((rsi_3_15m > 10.0) | (rsi_3_4h > 30.0) | (stochrsi_k_1h < 50.0))
+          long_entry_logic.append((rsi_3_15m > 10.0) | (rsi_3_4h > 30.0) | (stochrsi_k_1h_lt_50))
           # 15m & 4h down move, 4h high
           long_entry_logic.append((rsi_3_15m > 10.0) | (rsi_3_4h > 30.0) | aroonu_14_4h_lt_70)
           # 15m & 1d down move, 1h still high
-          long_entry_logic.append((rsi_3_15m > 10.0) | (rsi_3_1d > 25.0) | (stochrsi_k_1h < 50.0))
+          long_entry_logic.append((rsi_3_15m > 10.0) | (rsi_3_1d > 25.0) | (stochrsi_k_1h_lt_50))
           # 15m down move, 15m still not low enough, 1h high
-          long_entry_logic.append((rsi_3_15m > 10.0) | (aroonu_14_15m < 30.0) | (stochrsi_k_1h < 80.0))
+          long_entry_logic.append((rsi_3_15m > 10.0) | (aroonu_14_15m < 30.0) | (stochrsi_k_1h_lt_80))
           # 15m down move, 1h high, 4h overbought
           long_entry_logic.append((rsi_3_15m > 10.0) | (aroonu_14_1h < 70.0) | (roc_9_4h < 50.0))
           # 15m down move, 1d high & overbought
@@ -20249,7 +20254,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m & 1h down move, 1h still high
           long_entry_logic.append((rsi_3_15m > 15.0) | (rsi_3_1h > 40.0) | (aroonu_14_1h < 50.0))
           # 15m & 1h down move, 1h still high
-          long_entry_logic.append((rsi_3_15m > 15.0) | (rsi_3_1h > 45.0) | (stochrsi_k_1h < 50.0))
+          long_entry_logic.append((rsi_3_15m > 15.0) | (rsi_3_1h > 45.0) | (stochrsi_k_1h_lt_50))
           # 15m & 1h down move, 4h high
           long_entry_logic.append((rsi_3_15m > 15.0) | (rsi_3_1h > 45.0) | (aroonu_14_4h < 80.0))
           # 15m & 1h down move, 15m still not low enough
@@ -20267,21 +20272,21 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m & 4h down move, 4h still high
           long_entry_logic.append((rsi_3_15m > 15.0) | (rsi_3_4h > 45.0) | (stochrsi_k_4h < 50.0))
           # 15m down move, 15m still not low enough, 4h high
-          long_entry_logic.append((rsi_3_15m > 15.0) | (rsi_14_15m < 35.0) | (stochrsi_k_4h < 90.0))
+          long_entry_logic.append((rsi_3_15m > 15.0) | (rsi_14_15m < 35.0) | (stochrsi_k_4h_lt_90))
           # 15m down move, 15m still not low enough, 4h high
-          long_entry_logic.append((rsi_3_15m > 15.0) | (aroonu_14_15m < 30.0) | (stochrsi_k_4h < 90.0))
+          long_entry_logic.append((rsi_3_15m > 15.0) | (aroonu_14_15m < 30.0) | (stochrsi_k_4h_lt_90))
           # 15m down move, 15m & 4h still high
           long_entry_logic.append((rsi_3_15m > 15.0) | (aroonu_14_15m < 50.0) | (aroonu_14_4h < 50.0))
           # 15m down move, 15m still high, 1h high
-          long_entry_logic.append((rsi_3_15m > 15.0) | (stochrsi_k_15m < 40.0) | (stochrsi_k_1h < 70.0))
+          long_entry_logic.append((rsi_3_15m > 15.0) | (stochrsi_k_15m < 40.0) | (stochrsi_k_1h_lt_70))
           # 15m down move, 1h still high, 4h high
-          long_entry_logic.append((rsi_3_15m > 15.0) | (stochrsi_k_1h < 50.0) | (stochrsi_k_4h < 60.0))
+          long_entry_logic.append((rsi_3_15m > 15.0) | (stochrsi_k_1h_lt_50) | (stochrsi_k_4h < 60.0))
           # 15m down move, 4h still high 1d overbought
           long_entry_logic.append((rsi_3_15m > 15.0) | (aroonu_14_4h < 50.0) | roc_9_1d_lt_50)
           # 15m & 1h down move, 15m still not low enough
           long_entry_logic.append((rsi_3_15m > 20.0) | rsi_3_1h_gt_20 | (aroonu_14_15m < 30.0))
           # 15m & 1h down move, 4h high
-          long_entry_logic.append((rsi_3_15m > 20.0) | (rsi_3_1h > 30.0) | (stochrsi_k_4h < 90.0))
+          long_entry_logic.append((rsi_3_15m > 20.0) | (rsi_3_1h > 30.0) | (stochrsi_k_4h_lt_90))
           # 15m & 1h down move, 15m high
           long_entry_logic.append((rsi_3_15m > 20.0) | (rsi_3_1h > 40.0) | (aroonu_14_15m < 60.0))
           # 15m & 4h down move, 1h high
@@ -20289,11 +20294,11 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m & 4h down move, 4h high
           long_entry_logic.append((rsi_3_15m > 20.0) | (rsi_3_4h > 60.0) | (aroonu_14_4h < 80.0))
           # 15m & 1d down move, 4h high
-          long_entry_logic.append((rsi_3_15m > 20.0) | (rsi_3_1d > 20.0) | (stochrsi_k_4h < 90.0))
+          long_entry_logic.append((rsi_3_15m > 20.0) | (rsi_3_1d > 20.0) | (stochrsi_k_4h_lt_90))
           # 15m down move, 15m still not low enough, 4h high
           long_entry_logic.append((rsi_3_15m > 20.0) | (rsi_14_15m < 35.0) | (rsi_14_4h < 85.0))
           # 15m down move, 15m still not low enough, 1h high
-          long_entry_logic.append((rsi_3_15m > 20.0) | (aroonu_14_15m < 30.0) | (stochrsi_k_1h < 80.0))
+          long_entry_logic.append((rsi_3_15m > 20.0) | (aroonu_14_15m < 30.0) | (stochrsi_k_1h_lt_80))
           # 15m down move, 15m still not low enough, 4h high
           long_entry_logic.append((rsi_3_15m > 20.0) | (aroonu_14_15m < 30.0) | (stochrsi_k_4h < 70.0))
           # 15m down move, 15m still high, 4d downtrend
@@ -20307,7 +20312,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m & 1h down move, 1h high
           long_entry_logic.append((rsi_3_15m > 25.0) | (rsi_3_1h > 25.0) | (aroonu_14_1h < 80.0))
           # 15m & 1h down move, 4h high
-          long_entry_logic.append((rsi_3_15m > 25.0) | (rsi_3_1h > 35.0) | (stochrsi_k_4h < 80.0))
+          long_entry_logic.append((rsi_3_15m > 25.0) | (rsi_3_1h > 35.0) | (stochrsi_k_4h_lt_80))
           # 15m & 1h down move, 1d high
           long_entry_logic.append((rsi_3_15m > 25.0) | (rsi_3_1h > 40.0) | (stochrsi_k_1d < 90.0))
           # 15m & 1h down move, 1h high
@@ -20317,9 +20322,9 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m & 1d down move, 4h high
           long_entry_logic.append((rsi_3_15m > 25.0) | (rsi_3_1d > 25.0) | (stochrsi_k_4h < 70.0))
           # 15m & 1d down move, 1h high
-          long_entry_logic.append((rsi_3_15m > 25.0) | (rsi_3_1d > 30.0) | (stochrsi_k_1h < 80.0))
+          long_entry_logic.append((rsi_3_15m > 25.0) | (rsi_3_1d > 30.0) | (stochrsi_k_1h_lt_80))
           # 15m down move, 15m & 1h still high
-          long_entry_logic.append((rsi_3_15m > 25.0) | (aroonu_14_15m < 50.0) | (stochrsi_k_1h < 50.0))
+          long_entry_logic.append((rsi_3_15m > 25.0) | (aroonu_14_15m < 50.0) | (stochrsi_k_1h_lt_50))
           # 15m down move, 15m still high, 4h high
           long_entry_logic.append((rsi_3_15m > 25.0) | (aroonu_14_15m < 50.0) | (stochrsi_k_4h < 70.0))
           # 15m down move, 15m high, 1d overbought
@@ -20329,7 +20334,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m down move, 1h & 4h high
           long_entry_logic.append((rsi_3_15m > 25.0) | (aroonu_14_1h < 80.0) | (aroonu_14_4h < 90.0))
           # 15m down move, 1h & 4h high
-          long_entry_logic.append((rsi_3_15m > 25.0) | (stochrsi_k_1h < 70.0) | (aroonu_14_4h < 90.0))
+          long_entry_logic.append((rsi_3_15m > 25.0) | (stochrsi_k_1h_lt_70) | (aroonu_14_4h < 90.0))
           # 15m down move, 4h high, 1d overbought
           long_entry_logic.append((rsi_3_15m > 25.0) | (aroonu_14_4h < 80.0) | roc_9_1d_lt_50)
           # 15m & 1h down move, 1h high
@@ -20337,13 +20342,13 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m down move, 15m high, 4h still high
           long_entry_logic.append((rsi_3_15m > 30.0) | (aroonu_14_15m < 70.0) | (aroonu_14_4h < 50.0))
           # 15m down move, 15m still not low enough, 1h high
-          long_entry_logic.append((rsi_3_15m > 30.0) | (stochrsi_k_15m < 30.0) | (stochrsi_k_1h < 80.0))
+          long_entry_logic.append((rsi_3_15m > 30.0) | (stochrsi_k_15m < 30.0) | (stochrsi_k_1h_lt_80))
           # 15m down move, 1h still high, 4h high
           long_entry_logic.append((rsi_3_15m > 30.0) | (aroonu_14_1h < 50.0) | (aroonu_14_4h < 90.0))
           # 15m down move, 15m & 1h high
-          long_entry_logic.append((rsi_3_15m > 35.0) | (aroonu_14_15m < 70.0) | (stochrsi_k_1h < 70.0))
+          long_entry_logic.append((rsi_3_15m > 35.0) | (aroonu_14_15m < 70.0) | (stochrsi_k_1h_lt_70))
           # 15m down move, 15m & 4h high
-          long_entry_logic.append((rsi_3_15m > 35.0) | (aroonu_14_15m < 70.0) | (stochrsi_k_4h < 90.0))
+          long_entry_logic.append((rsi_3_15m > 35.0) | (aroonu_14_15m < 70.0) | (stochrsi_k_4h_lt_90))
           # 15m down move, 15m high
           long_entry_logic.append((rsi_3_15m > 35.0) | (aroonu_14_15m < 80.0))
           # 15m down move, 4h still high, 4h overbought
@@ -20381,7 +20386,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1h down move, 4h & 1d overbought
           long_entry_logic.append((rsi_3_1h > 30.0) | (roc_9_4h < 10.0) | (roc_9_1d < 40.0))
           # 1h & 4h down move, 4h high
-          long_entry_logic.append((rsi_3_1h > 35.0) | (rsi_3_4h > 55.0) | (stochrsi_k_4h < 80.0))
+          long_entry_logic.append((rsi_3_1h > 35.0) | (rsi_3_4h > 55.0) | (stochrsi_k_4h_lt_80))
           # 1h down move, 1h high, 1d overbought
           long_entry_logic.append((rsi_3_1h > 35.0) | (aroonu_14_1h < 70.0) | (roc_9_1d < 20.0))
           # 1h down move, 4h high, 1d overbought
@@ -20393,7 +20398,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1h down move 1h high & overbought
           long_entry_logic.append((rsi_3_1h > 45.0) | (aroonu_14_1h < 90.0) | (roc_9_1h < 10.0))
           # 1h down move, 1h high & overbought
-          long_entry_logic.append((rsi_3_1h > 55.0) | (stochrsi_k_1h < 80.0) | (roc_9_1h < 10.0))
+          long_entry_logic.append((rsi_3_1h > 55.0) | (stochrsi_k_1h_lt_80) | (roc_9_1h < 10.0))
           # 1h down move, 1d high, 1h overbought
           long_entry_logic.append((rsi_3_1h > 60.0) | (aroonu_14_1d < 90.0) | (roc_9_1h < 10.0))
           # 4h down move, 4h still not low enough, 1d overbought
@@ -20419,11 +20424,11 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1d down move, 1h high, 1d downtrend
           long_entry_logic.append((rsi_3_1d > 10.0) | (aroonu_14_1h < 85.0) | (roc_9_1d > -30.0))
           # 1d down move, 15m still not low enough, 1h still high
-          long_entry_logic.append((rsi_3_1d > 15.0) | (aroonu_14_15m < 30.0) | (stochrsi_k_1h < 50.0))
+          long_entry_logic.append((rsi_3_1d > 15.0) | (aroonu_14_15m < 30.0) | (stochrsi_k_1h_lt_50))
           # 15m still not low enough, 1h high, 1d overbought
           long_entry_logic.append((aroonu_14_15m < 30.0) | (stochrsi_k_1h < 80.0) | (roc_9_1d < 100.0))
           # 15m still high, 4h high & overbought
-          long_entry_logic.append((aroonu_14_15m < 40.0) | (stochrsi_k_4h < 80.0) | (roc_9_4h < 30.0))
+          long_entry_logic.append((aroonu_14_15m < 40.0) | (stochrsi_k_4h_lt_80) | (roc_9_4h < 30.0))
           # 15m & 1h & 4h high
           long_entry_logic.append((aroonu_14_15m < 70.0) | (aroonu_14_1h < 80.0) | (aroonu_14_4h < 90.0))
           # 15m & 1h high, 4h overbought
@@ -20461,7 +20466,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 4h high, 4h & 1d overbought
           long_entry_logic.append((stochrsi_k_4h < 70.0) | (roc_9_4h < 30.0) | (roc_9_1d < 30.0))
           # 5m red, 1h still high
-          long_entry_logic.append((df["change_pct"] > -5.0) | (stochrsi_k_1h < 50.0))
+          long_entry_logic.append((df["change_pct"] > -5.0) | (stochrsi_k_1h_lt_50))
           # 1d top wick, 4h down move, 4h still high
           long_entry_logic.append((top_wick_pct_1d < 30.0) | (rsi_3_4h > 60.0) | (aroonu_14_4h < 50.0))
           # pump, drop but not yet near the previous lows
@@ -20472,7 +20477,7 @@ class NostalgiaForInfinityX7(IStrategy):
           )
           # 4h high, drop but not yet near the previous lows
           long_entry_logic.append(
-            (stochrsi_k_4h < 90.0) | (close > (close_max_48 * 0.85)) | (close < (df["low_min_24_1h"] * 1.25))
+            (stochrsi_k_4h_lt_90) | (close > (close_max_48 * 0.85)) | (close < (df["low_min_24_1h"] * 1.25))
           )
           # 4h high, drop but not yet near the previous lows
           long_entry_logic.append(
@@ -20489,7 +20494,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # big drop in the last 30 days, 4h down move, 4h still high
           long_entry_logic.append((close > (high_max_30_1d * 0.25)) | (rsi_3_4h > 45.0) | (rsi_14_4h < 40.0))
           # big drop in the last 30 days, 1h high
-          long_entry_logic.append((close > (high_max_30_1d * 0.20)) | (stochrsi_k_1h < 80.0))
+          long_entry_logic.append((close > (high_max_30_1d * 0.20)) | (stochrsi_k_1h_lt_80))
 
           # Logic
           long_entry_logic.append(willr_14 < -95.0)
@@ -20509,7 +20514,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m & 1h & 4h down move
           long_entry_logic.append((rsi_3_15m > 20.0) | (rsi_3_1h > 10.0) | rsi_3_4h_gt_20)
           # 15m & 4h down move, 1h still high
-          long_entry_logic.append((rsi_3_15m > 10.0) | rsi_3_4h_gt_20 | (stochrsi_k_1h < 50.0))
+          long_entry_logic.append((rsi_3_15m > 10.0) | rsi_3_4h_gt_20 | (stochrsi_k_1h_lt_50))
           # 15m & 1h down move, 1h high
           long_entry_logic.append((rsi_3_15m > 15.0) | (rsi_3_1h > 40.0) | (aroonu_14_1h < 70.0))
           # 15m down move, 4h high & overbought
@@ -20519,7 +20524,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m & 4h down move, 15m still high
           long_entry_logic.append((rsi_3_15m > 20.0) | rsi_3_4h_gt_20 | (stochrsi_k_15m < 50.0))
           # 15m down move, 15m still high, 1h high
-          long_entry_logic.append((rsi_3_15m > 20.0) | (rsi_14_15m < 40.0) | (stochrsi_k_1h < 70.0))
+          long_entry_logic.append((rsi_3_15m > 20.0) | (rsi_14_15m < 40.0) | (stochrsi_k_1h_lt_70))
           # 15m down move, 15m still high, 4h high
           long_entry_logic.append((rsi_3_15m > 20.0) | (rsi_14_15m < 40.0) | (aroonu_14_4h < 90.0))
           # 15m down move, 15m still high, 4h high
@@ -20529,7 +20534,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m down move, 15m high, 4h still high
           long_entry_logic.append((rsi_3_15m > 20.0) | (aroonu_14_15m < 70.0) | (aroonu_14_4h < 50.0))
           # 15m down move, 15m & 1h still high
-          long_entry_logic.append((rsi_3_15m > 20.0) | (stochrsi_k_15m < 50.0) | (stochrsi_k_1h < 50.0))
+          long_entry_logic.append((rsi_3_15m > 20.0) | (stochrsi_k_15m < 50.0) | (stochrsi_k_1h_lt_50))
           # 15m down move, 4h overbought
           long_entry_logic.append((rsi_3_15m > 20.0) | (roc_9_4h < 70.0))
           # 15m down move, 15m still high, 1h high
@@ -20537,21 +20542,21 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m down move, 4h & 1d high
           long_entry_logic.append((rsi_3_15m > 25.0) | (aroonu_14_4h < 90.0) | (stochrsi_k_1d < 90.0))
           # 15m down move, 1h & 1d high
-          long_entry_logic.append((rsi_3_15m > 25.0) | (stochrsi_k_1h < 80.0) | (stochrsi_k_1d < 90.0))
+          long_entry_logic.append((rsi_3_15m > 25.0) | (stochrsi_k_1h_lt_80) | (stochrsi_k_1d < 90.0))
           # 15m down move, 1h high & overbought
-          long_entry_logic.append((rsi_3_15m > 25.0) | (stochrsi_k_1h < 80.0) | (roc_9_1h < 20.0))
+          long_entry_logic.append((rsi_3_15m > 25.0) | (stochrsi_k_1h_lt_80) | (roc_9_1h < 20.0))
           # 15m & 1h down move, 15m high
           long_entry_logic.append((rsi_3_15m > 30.0) | (rsi_3_1h > 30.0) | (aroonu_14_15m < 70.0))
           # 15m down move, 15m & 1h high
           long_entry_logic.append((rsi_3_15m > 30.0) | (aroonu_14_15m < 70.0) | (aroonu_14_1h < 90.0))
           # 15m down move, 1h & 4h high
-          long_entry_logic.append((rsi_3_15m > 30.0) | (stochrsi_k_1h < 70.0) | (aroonu_14_4h < 90.0))
+          long_entry_logic.append((rsi_3_15m > 30.0) | (stochrsi_k_1h_lt_70) | (aroonu_14_4h < 90.0))
           # 15m & 1h down move, 1h high
-          long_entry_logic.append((rsi_3_15m > 35.0) | (rsi_3_1h > 45.0) | (stochrsi_k_1h < 80.0))
+          long_entry_logic.append((rsi_3_15m > 35.0) | (rsi_3_1h > 45.0) | (stochrsi_k_1h_lt_80))
           # 15m down move, 15m still high, 4h high
           long_entry_logic.append((rsi_3_15m > 35.0) | (aroonu_14_15m < 50.0) | (aroonu_14_4h < 80.0))
           # 15m down move, 15m & 1h high
-          long_entry_logic.append((rsi_3_15m > 35.0) | (aroonu_14_15m < 70.0) | (stochrsi_k_1h < 80.0))
+          long_entry_logic.append((rsi_3_15m > 35.0) | (aroonu_14_15m < 70.0) | (stochrsi_k_1h_lt_80))
           # 15m down move, 1h high, 4h overbought
           long_entry_logic.append((rsi_3_15m > 35.0) | (aroonu_14_1h < 85.0) | (roc_9_4h < 80.0))
           # 1h & 4h down move, 1h still high
@@ -20577,7 +20582,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1h down move, 4h & 1d overbought
           long_entry_logic.append((rsi_3_1h > 30.0) | (roc_9_4h < 30.0) | (roc_9_1d < 40.0))
           # 1h down move, 15m & 1h still high
-          long_entry_logic.append((rsi_3_1h > 40.0) | (aroonu_14_15m < 50.0) | (stochrsi_k_1h < 50.0))
+          long_entry_logic.append((rsi_3_1h > 40.0) | (aroonu_14_15m < 50.0) | (stochrsi_k_1h_lt_50))
           # 1h down move, 1h still high, 4h high
           long_entry_logic.append((rsi_3_1h > 40.0) | (aroonu_14_1h < 50.0) | (aroonu_14_4h < 90.0))
           # 1h down move, 1h high, 4h overbought
@@ -20591,7 +20596,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1h & 4h down move, 4h high
           long_entry_logic.append((rsi_3_1h > 60.0) | (rsi_3_4h > 60.0) | (aroonu_14_4h < 80.0))
           # 1h & 4h down move, 4h high
-          long_entry_logic.append((rsi_3_1h > 60.0) | (rsi_3_4h > 60.0) | (stochrsi_k_4h < 80.0))
+          long_entry_logic.append((rsi_3_1h > 60.0) | (rsi_3_4h > 60.0) | (stochrsi_k_4h_lt_80))
           # 4h down move, 1h & 4h downtrend
           long_entry_logic.append((rsi_3_4h > 5.0) | (roc_9_1h > -30.0) | (roc_9_4h > -30.0))
           # 1h down move, 4h high & overbought
@@ -20599,7 +20604,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 4h down move, 4h still high, 1d downtrend
           long_entry_logic.append(rsi_3_4h_gt_20 | (aroonu_14_4h < 50.0) | (roc_9_1d > -40.0))
           # 1h down move, 15m & 1h still high
-          long_entry_logic.append(rsi_3_4h_gt_20 | (stochrsi_k_15m < 40.0) | (stochrsi_k_1h < 50.0))
+          long_entry_logic.append(rsi_3_4h_gt_20 | (stochrsi_k_15m < 40.0) | (stochrsi_k_1h_lt_50))
           # 4h down move, 15m still high, 4h high
           long_entry_logic.append((rsi_3_4h > 25.0) | (stochrsi_k_15m < 50.0) | aroonu_14_4h_lt_70)
           # 4h down move, 15m still not low enough, 4h high
@@ -20619,7 +20624,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1d down move, 1h high, 1d downtrend
           long_entry_logic.append((rsi_3_1d > 10.0) | (aroonu_14_1h < 80.0) | (roc_9_1d > -10.0))
           # 1d down move, 4h high
-          long_entry_logic.append((rsi_3_1d > 10.0) | (stochrsi_k_4h < 80.0))
+          long_entry_logic.append((rsi_3_1d > 10.0) | (stochrsi_k_4h_lt_80))
           # 1d down move, 15m still high, 1h high
           long_entry_logic.append((rsi_3_1d > 15.0) | (aroonu_14_15m < 50.0) | (aroonu_14_1h < 85.0))
           # 1d down move, 1h & 1d overbought
@@ -20637,7 +20642,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m & 1h
           long_entry_logic.append((aroonu_14_15m < 70.0) | (aroonu_14_1h < 90.0))
           # 15m & 1h & 4h high
-          long_entry_logic.append((aroonu_14_15m < 70.0) | (stochrsi_k_1h < 70.0) | (aroonu_14_4h < 90.0))
+          long_entry_logic.append((aroonu_14_15m < 70.0) | (stochrsi_k_1h_lt_70) | (aroonu_14_4h < 90.0))
           # 1h & 1d high, 4h downtrend
           long_entry_logic.append((aroonu_14_1h < 40.0) | (aroonu_14_1d < 70.0) | (roc_9_4h > -20.0))
           # 1h & 4h high, 4h overbought
@@ -20701,7 +20706,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 5m & 4h down move, 1d downtrend
           long_entry_logic.append((rsi_3 > 5.0) | (rsi_3_4h > 10.0) | (roc_9_1d > -20.0))
           # 5m & 1h down move, 1h still high
-          long_entry_logic.append((rsi_3 > 5.0) | (rsi_3_1h > 30.0) | (stochrsi_k_1h < 50.0))
+          long_entry_logic.append((rsi_3 > 5.0) | (rsi_3_1h > 30.0) | (stochrsi_k_1h_lt_50))
           # 15m & 4h & 1d down move
           long_entry_logic.append(rsi_3_15m_gt_3 | (rsi_3_4h > 10.0) | (rsi_3_1d > 15.0))
           # 15m & 1h down move
@@ -20721,7 +20726,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m & 1h down move, 4h still not low enough
           long_entry_logic.append((rsi_3_15m > 5.0) | rsi_3_1h_gt_20 | (aroonu_14_4h < 20.0))
           # 15m & 1h down move, 1h high
-          long_entry_logic.append((rsi_3_15m > 5.0) | (rsi_3_1h > 30.0) | (stochrsi_k_1h < 50.0))
+          long_entry_logic.append((rsi_3_15m > 5.0) | (rsi_3_1h > 30.0) | (stochrsi_k_1h_lt_50))
           # 15m & 4h down move, 4h still high
           long_entry_logic.append((rsi_3_15m > 5.0) | (rsi_3_4h > 15.0) | (aroonu_14_4h < 50.0))
           # 15m & 1h down move, 15m & 1h downtrend
@@ -20743,7 +20748,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m & 4h down move, 1d high
           long_entry_logic.append((rsi_3_15m > 10.0) | (rsi_3_4h > 15.0) | (stochrsi_k_1d < 90.0))
           # 15m & 4h down move, 1h high
-          long_entry_logic.append((rsi_3_15m > 10.0) | rsi_3_4h_gt_20 | (stochrsi_k_1h < 70.0))
+          long_entry_logic.append((rsi_3_15m > 10.0) | rsi_3_4h_gt_20 | (stochrsi_k_1h_lt_70))
           # 15m & 4h down move, 4h still high
           long_entry_logic.append((rsi_3_15m > 10.0) | rsi_3_4h_gt_20 | (stochrsi_k_4h < 40.0))
           # 15m & 4h down move, 1d downtrend
@@ -20817,7 +20822,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1h & 4h down move, 1d overbought
           long_entry_logic.append(rsi_3_1h_gt_20 | rsi_3_4h_gt_20 | roc_9_1d_lt_50)
           # 1h & 4h down move, 1h still high
-          long_entry_logic.append(rsi_3_1h_gt_20 | (rsi_3_4h > 25.0) | (stochrsi_k_1h < 50.0))
+          long_entry_logic.append(rsi_3_1h_gt_20 | (rsi_3_4h > 25.0) | (stochrsi_k_1h_lt_50))
           # 1h & 1d down move, 1d high
           long_entry_logic.append(rsi_3_1h_gt_20 | (rsi_3_1d > 20.0) | (aroonu_14_1d < 70.0))
           # 4h & 1d down move, 1d high
@@ -20825,13 +20830,13 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1h down move, 1h still high, 4h high
           long_entry_logic.append(rsi_3_1h_gt_20 | (aroonu_14_1h < 50.0) | aroonu_14_4h_lt_70)
           # 1h down move, 4h high
-          long_entry_logic.append(rsi_3_1h_gt_20 | (stochrsi_k_4h < 90.0))
+          long_entry_logic.append(rsi_3_1h_gt_20 | (stochrsi_k_4h_lt_90))
           # 1h down move, 1h & 1d high
           long_entry_logic.append((rsi_3_1h > 25.0) | (aroonu_14_1h < 70.0) | (aroonu_14_1d < 90.0))
           # 1h down move, 4h still high, 1d downtrend
           long_entry_logic.append((rsi_3_1h > 25.0) | (aroonu_14_4h < 40.0) | (roc_9_1d > -20.0))
           # 1h down move, 1h still high, 1d overbought
-          long_entry_logic.append((rsi_3_1h > 25.0) | (stochrsi_k_1h < 50.0) | (roc_9_1d < 40.0))
+          long_entry_logic.append((rsi_3_1h > 25.0) | (stochrsi_k_1h_lt_50) | (roc_9_1d < 40.0))
           # 1h & 4h down move, 4h high
           long_entry_logic.append((rsi_3_1h > 30.0) | (rsi_3_4h > 45.0) | (aroonu_14_4h < 80.0))
           # 1h & dh down move, 4h high
@@ -20871,7 +20876,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 4h down move, 1h still high, 1d downtrend
           long_entry_logic.append(rsi_3_4h_gt_20 | (stochrsi_k_1h < 50.0) | (roc_9_1d > -20.0))
           # 4h down move, 1h high
-          long_entry_logic.append(rsi_3_4h_gt_20 | (stochrsi_k_1h < 80.0))
+          long_entry_logic.append(rsi_3_4h_gt_20 | (stochrsi_k_1h_lt_80))
           # 4h down move, 1d high, 1h downtrend
           long_entry_logic.append(rsi_3_4h_gt_20 | (stochrsi_k_1d < 70.0) | (roc_9_1h > -10.0))
           # 4h down move, 4h still high, 1d overbought
@@ -20893,7 +20898,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 4h & 1d high,1d overbought
           long_entry_logic.append(aroonu_14_4h_lt_70 | (aroonu_14_1d < 100.0) | roc_9_1d_lt_50)
           # 1d red, 4h down move, 1h still high
-          long_entry_logic.append((change_pct_1d > -30.0) | (rsi_3_4h > 30.0) | (stochrsi_k_1h < 50.0))
+          long_entry_logic.append((change_pct_1d > -30.0) | (rsi_3_4h > 30.0) | (stochrsi_k_1h_lt_50))
           # pump, drop but not yet near the previous lows
           long_entry_logic.append(
             (((high_max_24_4h - low_min_24_4h) / low_min_24_4h) < 2.0)
@@ -20969,7 +20974,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 5m & 1h down move, 15m still high
             & ((rsi_3 > 3.0) | (rsi_3_1h > 15.0) | (aroonu_14_15m < 40.0))
             # 5m & 1h down move, 1h high
-            & ((rsi_3 > 3.0) | (rsi_3_1h > 45.0) | (stochrsi_k_1h < 80.0))
+            & ((rsi_3 > 3.0) | (rsi_3_1h > 45.0) | (stochrsi_k_1h_lt_80))
             # 5m & 4h down move, 15m still high
             & ((rsi_3 > 3.0) | (rsi_3_4h > 5.0) | (aroonu_14_15m < 40.0))
             # 5m & 4h down move, 15m still high
@@ -20977,7 +20982,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 5m & 4h down move, 15m still high
             & ((rsi_3 > 3.0) | rsi_3_4h_gt_20 | (stochrsi_k_15m < 50.0))
             # 5m & 4h down move, 1h high
-            & ((rsi_3 > 3.0) | (rsi_3_4h > 45.0) | (stochrsi_k_1h < 80.0))
+            & ((rsi_3 > 3.0) | (rsi_3_4h > 45.0) | (stochrsi_k_1h_lt_80))
             # 5m & 1d down move, 15m high
             & ((rsi_3 > 3.0) | (rsi_3_1d > 10.0) | (aroonu_14_15m < 70.0))
             # 5m & 1d down move, 15m stil high
@@ -21011,9 +21016,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 4h high
             & (rsi_3_15m_gt_3 | (rsi_3_1h > 40.0) | (aroonu_14_1h < 85.0))
             # 15m & 1h down move, 1h high
-            & (rsi_3_15m_gt_3 | (rsi_3_1h > 40.0) | (stochrsi_k_1h < 80.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h > 40.0) | (stochrsi_k_1h_lt_80))
             # 15m & 1h down move, 1h high
-            & (rsi_3_15m_gt_3 | (rsi_3_1h > 45.0) | (stochrsi_k_1h < 80.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h > 45.0) | (stochrsi_k_1h_lt_80))
             # 15m & 1h down move, 1d high
             & (rsi_3_15m_gt_3 | (rsi_3_1h > 45.0) | (stochrsi_k_1d < 80.0))
             # 15m & 4h down move, 15m downtrend
@@ -21027,9 +21032,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 4h still high
             & ((rsi_3_15m > 5.0) | (rsi_3_1h > 10.0) | (stochrsi_k_4h < 50.0))
             # 15m & 1h down move, 1h still high
-            & ((rsi_3_15m > 5.0) | (rsi_3_1h > 25.0) | (stochrsi_k_1h < 50.0))
+            & ((rsi_3_15m > 5.0) | (rsi_3_1h > 25.0) | (stochrsi_k_1h_lt_50))
             # 15m & 1h down move, 1h high
-            & ((rsi_3_15m > 5.0) | (rsi_3_1h > 30.0) | (stochrsi_k_1h < 80.0))
+            & ((rsi_3_15m > 5.0) | (rsi_3_1h > 30.0) | (stochrsi_k_1h_lt_80))
             # 15m & 4h down move, 1d high
             & ((rsi_3_15m > 5.0) | (rsi_3_4h > 15.0) | (aroonu_14_1d < 70.0))
             # 15m & 4h down move, 1d high
@@ -21055,7 +21060,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 1h high
             & ((rsi_3_15m > 10.0) | rsi_3_1h_gt_20 | (aroonu_14_1h < 80.0))
             # 15m & 1h down move, 1h high
-            & ((rsi_3_15m > 10.0) | (rsi_3_1h > 30.0) | (stochrsi_k_1h < 70.0))
+            & ((rsi_3_15m > 10.0) | (rsi_3_1h > 30.0) | (stochrsi_k_1h_lt_70))
             # 15m & 1h down move, 1d overbought
             & ((rsi_3_15m > 10.0) | (rsi_3_1h > 30.0) | (roc_9_1d < 60.0))
             # 15m & 4h down move, 15m still high
@@ -21075,7 +21080,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 4h down move, 1d high
             & ((rsi_3_15m > 10.0) | rsi_3_4h_gt_20 | (aroonu_14_1d < 80.0))
             # 15m & 4h down move, 1h high
-            & ((rsi_3_15m > 10.0) | rsi_3_4h_gt_20 | (stochrsi_k_1h < 70.0))
+            & ((rsi_3_15m > 10.0) | rsi_3_4h_gt_20 | (stochrsi_k_1h_lt_70))
             # 15m & 4h down move, 1d high
             & ((rsi_3_15m > 10.0) | rsi_3_4h_gt_20 | (stochrsi_k_1d < 80.0))
             # 15m & 4h down move, 1d overbought
@@ -21089,7 +21094,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 1h high
             & ((rsi_3_15m > 10.0) | (stochrsi_k_1h < 90.0))
             # 15m & 1d down move, 1h still high
-            & ((rsi_3_15m > 10.0) | (rsi_3_1d > 10.0) | (stochrsi_k_1h < 50.0))
+            & ((rsi_3_15m > 10.0) | (rsi_3_1d > 10.0) | (stochrsi_k_1h_lt_50))
             # 15m & 1d down move, 1d high
             & ((rsi_3_15m > 10.0) | (rsi_3_1d > 30.0) | (stochrsi_k_1d < 60.0))
             # 15m down move, 15m & 1h high
@@ -21097,13 +21102,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 15m & 4h high
             & ((rsi_3_15m > 10.0) | (aroonu_14_15m < 60.0) | aroonu_14_4h_lt_70)
             # 15m down move, 15m high, 1h high
-            & ((rsi_3_15m > 10.0) | (aroonu_14_15m < 70.0) | (stochrsi_k_1h < 80.0))
+            & ((rsi_3_15m > 10.0) | (aroonu_14_15m < 70.0) | (stochrsi_k_1h_lt_80))
             # 15m down move, 4h high, 1d overbought
             & ((rsi_3_15m > 10.0) | aroonu_14_4h_lt_70 | (roc_9_1d < 100.0))
             # 15m down move, 1d high & overbought
             & ((rsi_3_15m > 10.0) | (aroonu_14_1d < 85.0) | (roc_9_1d < 20.0))
             # 15m down move, 1h high, 1d overbought
-            & ((rsi_3_15m > 10.0) | (stochrsi_k_1h < 50.0) | (roc_9_1d < 40.0))
+            & ((rsi_3_15m > 10.0) | (stochrsi_k_1h_lt_50) | (roc_9_1d < 40.0))
             # 15m & 1h down move, 1h high
             & ((rsi_3_15m > 15.0) | (rsi_3_1h > 15.0) | (aroonu_14_1h < 70.0))
             # 15m & 1h down move, 4h high
@@ -21127,7 +21132,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 15m downtrend, 1h high
             & ((rsi_3_15m > 15.0) | (cmf_20_15m > -0.40) | (aroonu_14_1h < 60.0))
             # 15m down move, 15m still high, 4h high
-            & ((rsi_3_15m > 15.0) | (aroonu_14_15m < 50.0) | (stochrsi_k_4h < 80.0))
+            & ((rsi_3_15m > 15.0) | (aroonu_14_15m < 50.0) | (stochrsi_k_4h_lt_80))
             # 15m down move, 15m high, 1d overbought
             & ((rsi_3_15m > 15.0) | (aroonu_14_15m < 70.0) | (roc_9_1d < 20.0))
             # 15m down move, 1h & 4h high
@@ -21145,15 +21150,15 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 15m & 1h high
             & ((rsi_3_15m > 25.0) | (aroonu_14_15m < 70.0) | (aroonu_14_1h < 100.0))
             # 15m & 4h down mve, 1h high
-            & ((rsi_3_15m > 30.0) | (rsi_3_4h > 30.0) | (stochrsi_k_1h < 80.0))
+            & ((rsi_3_15m > 30.0) | (rsi_3_4h > 30.0) | (stochrsi_k_1h_lt_80))
             # 15m & 4h down move, 4h high
-            & ((rsi_3_15m > 30.0) | (rsi_3_4h > 45.0) | (stochrsi_k_4h < 80.0))
+            & ((rsi_3_15m > 30.0) | (rsi_3_4h > 45.0) | (stochrsi_k_4h_lt_80))
             # 15m down move, 15m & 1h high
             & ((rsi_3_15m > 30.0) | (aroonu_14_15m < 70.0) | (aroonu_14_1h < 90.0))
             # 15m down move, 1h high, 1d downtrend
             & ((rsi_3_15m > 30.0) | (aroonu_14_1h < 90.0) | (roc_9_1d > -10.0))
             # 15m down move, 15m high, 4h high
-            & ((rsi_3_15m > 35.0) | (aroonu_14_15m < 70.0) | (stochrsi_k_4h < 80.0))
+            & ((rsi_3_15m > 35.0) | (aroonu_14_15m < 70.0) | (stochrsi_k_4h_lt_80))
             # 15m down move, 15m & 4h high
             & ((rsi_3_15m > 35.0) | (aroonu_14_15m < 70.0) | (aroonu_14_4h < 90.0))
             # 1h & 4h down move, 4h still not low enough
@@ -21243,11 +21248,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 4h high, 1d overbought
             & ((rsi_3_1h > 30.0) | (aroonu_14_4h < 90.0) | (roc_9_1d < 40.0))
             # 1h & 4h down move, 1h still high
-            & ((rsi_3_1h > 35.0) | (rsi_3_4h > 35.0) | (stochrsi_k_1h < 50.0))
+            & ((rsi_3_1h > 35.0) | (rsi_3_4h > 35.0) | (stochrsi_k_1h_lt_50))
             # 1h & 4h down move, 4h high
             & ((rsi_3_1h > 35.0) | (rsi_3_4h > 50.0) | (aroonu_14_4h < 80.0))
             # 1h down move, 1h high , 1d overbought
-            & ((rsi_3_1h > 35.0) | (stochrsi_k_1h < 80.0) | (roc_9_1d < 30.0))
+            & ((rsi_3_1h > 35.0) | (stochrsi_k_1h_lt_80) | (roc_9_1d < 30.0))
             # 1h down move, 4h high, 1d overbought
             & ((rsi_3_1h > 35.0) | aroonu_14_4h_lt_70 | (roc_9_1d < 100.0))
             # 1h & 1d down move, 1h high
@@ -21255,7 +21260,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h & 4h high
             & ((rsi_3_1h > 45.0) | (aroonu_14_1h < 75.0) | (aroonu_14_4h < 100.0))
             # 1h down move, 4h high & overbought
-            & ((rsi_3_1h > 50.0) | (stochrsi_k_4h < 90.0) | (roc_9_4h < 25.0))
+            & ((rsi_3_1h > 50.0) | (stochrsi_k_4h_lt_90) | (roc_9_4h < 25.0))
             # 1h & 1d down move, 1h high
             & ((rsi_3_1h > 60.0) | (rsi_3_1d > 60.0) | (aroonu_14_1h < 70.0))
             # 4h & 1d down move, 1d still high
@@ -21319,9 +21324,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 4h still not low enough, 1d downtrend
             & (rsi_3_4h_gt_20 | (stochrsi_k_4h < 30.0) | (roc_9_1d > -20.0))
             # 4h & 1d down move, 1h high
-            & ((rsi_3_4h > 25.0) | (rsi_3_1d > 25.0) | (stochrsi_k_1h < 80.0))
+            & ((rsi_3_4h > 25.0) | (rsi_3_1d > 25.0) | (stochrsi_k_1h_lt_80))
             # 4h down move, 1h high
-            & ((rsi_3_4h > 25.0) | (stochrsi_k_1h < 70.0))
+            & ((rsi_3_4h > 25.0) | (stochrsi_k_1h_lt_70))
             # 4h & 1d down move, 1d overbought
             & ((rsi_3_4h > 25.0) | (rsi_3_1d > 40.0) | (roc_9_1d < 30.0))
             # 4h & 1d down move, 4h still high
@@ -21331,7 +21336,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 15m & 4h high
             & ((rsi_3_4h > 30.0) | (aroonu_14_15m < 70.0) | aroonu_14_4h_lt_70)
             # 4h down move, 1h high, 1d downtrend
-            & ((rsi_3_4h > 30.0) | (stochrsi_k_1h < 80.0) | (roc_9_1d > -40.0))
+            & ((rsi_3_4h > 30.0) | (stochrsi_k_1h_lt_80) | (roc_9_1d > -40.0))
             # 4h down move, 4h & 1d downtrend
             & ((rsi_3_4h > 30.0) | (roc_9_4h > -20.0) | (roc_9_1d > -40.0))
             # 4h down move, 4h still high, 1d downtrend
@@ -21351,7 +21356,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1d down move, 1h & 4h high
             & ((rsi_3_1d > 30.0) | (aroonu_14_1h < 70.0) | (aroonu_14_4h < 100.0))
             # 1d down move, 4h high, 1d overbought
-            & ((rsi_3_1d > 45.0) | (stochrsi_k_4h < 90.0) | (roc_9_1d < 10.0))
+            & ((rsi_3_1d > 45.0) | (stochrsi_k_4h_lt_90) | (roc_9_1d < 10.0))
             # 1d down move, 1d high & overbought
             & ((rsi_3_1d > 55.0) | (stochrsi_k_1d < 80.0) | (roc_9_1d < 10.0))
             # 1d down move, 1d overbought
@@ -21434,7 +21439,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 1h high, 1d overbought
             & (rsi_3_15m_gt_3 | (stochrsi_k_1h < 60.0) | (roc_9_1d < 20.0))
             # 15m down move, 4h high
-            & (rsi_3_15m_gt_3 | (stochrsi_k_4h < 80.0))
+            & (rsi_3_15m_gt_3 | (stochrsi_k_4h_lt_80))
             # 15m & 1h down move, 15m still not low enough
             & ((rsi_3_15m > 5.0) | (rsi_3_1h > 5.0) | (stochrsi_k_15m < 30.0))
             # 15m & 1h down move, 4h still high
@@ -21464,7 +21469,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 15m still high
             & ((rsi_3_15m > 10.0) | (rsi_3_1h > 25.0) | (aroonu_14_15m < 40.0))
             # 15m & 1h down move, 1h high
-            & ((rsi_3_15m > 10.0) | (rsi_3_1h > 30.0) | (stochrsi_k_1h < 70.0))
+            & ((rsi_3_15m > 10.0) | (rsi_3_1h > 30.0) | (stochrsi_k_1h_lt_70))
             # 15m & 1h down move, 1d overbought
             & ((rsi_3_15m > 10.0) | (rsi_3_1h > 30.0) | (roc_9_1d < 60.0))
             # 15m & 4h down move, 1d still high
@@ -21482,7 +21487,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 14m & 4h down move, 1d high
             & ((rsi_3_15m > 10.0) | rsi_3_4h_gt_20 | (aroonu_14_1d < 80.0))
             # 15m & 4h down move, 1h high
-            & ((rsi_3_15m > 10.0) | rsi_3_4h_gt_20 | (stochrsi_k_1h < 70.0))
+            & ((rsi_3_15m > 10.0) | rsi_3_4h_gt_20 | (stochrsi_k_1h_lt_70))
             # 15m & 4h down move, 1d high
             & ((rsi_3_15m > 10.0) | rsi_3_4h_gt_20 | (stochrsi_k_1d < 80.0))
             # 15m & 4h down move, 1d overbought
@@ -21498,15 +21503,15 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 4h down move, 15m high
             & ((rsi_3_15m > 10.0) | (rsi_3_4h > 40.0) | (aroonu_14_15m < 70.0))
             # 15m & 1d down move, 1h still high
-            & ((rsi_3_15m > 10.0) | (rsi_3_1d > 10.0) | (stochrsi_k_1h < 50.0))
+            & ((rsi_3_15m > 10.0) | (rsi_3_1d > 10.0) | (stochrsi_k_1h_lt_50))
             # 15m down move, 15m high, 1h high
-            & ((rsi_3_15m > 10.0) | (aroonu_14_15m < 70.0) | (stochrsi_k_1h < 80.0))
+            & ((rsi_3_15m > 10.0) | (aroonu_14_15m < 70.0) | (stochrsi_k_1h_lt_80))
             # 15m down move, 4h high, 1d overbought
             & ((rsi_3_15m > 10.0) | aroonu_14_4h_lt_70 | (roc_9_1d < 100.0))
             # 15m down move, 1d high & overbought
             & ((rsi_3_15m > 10.0) | (aroonu_14_1d < 85.0) | (roc_9_1d < 20.0))
             # 15m down move, 1h high, 1d overbought
-            & ((rsi_3_15m > 10.0) | (stochrsi_k_1h < 50.0) | (roc_9_1d < 40.0))
+            & ((rsi_3_15m > 10.0) | (stochrsi_k_1h_lt_50) | (roc_9_1d < 40.0))
             # 15m & 1h down move, 1h high
             & ((rsi_3_15m > 15.0) | (rsi_3_1h > 15.0) | (aroonu_14_1h < 70.0))
             # 15m & 1h down move, 4h high
@@ -21522,11 +21527,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 4h down move, 1h high
             & ((rsi_3_15m > 15.0) | (rsi_3_4h > 35.0) | (aroonu_14_1h < 90.0))
             # 15m & 1d down move, 4h high
-            & ((rsi_3_15m > 15.0) | (rsi_3_1d > 20.0) | (stochrsi_k_4h < 80.0))
+            & ((rsi_3_15m > 15.0) | (rsi_3_1d > 20.0) | (stochrsi_k_4h_lt_80))
             # 15m down move, 15m downtrend, 1h high
             & ((rsi_3_15m > 15.0) | (cmf_20_15m > -0.40) | (aroonu_14_1h < 60.0))
             # 15m down move, 15m still high, 4h high
-            & ((rsi_3_15m > 15.0) | (aroonu_14_15m < 50.0) | (stochrsi_k_4h < 80.0))
+            & ((rsi_3_15m > 15.0) | (aroonu_14_15m < 50.0) | (stochrsi_k_4h_lt_80))
             # 15m down move, 15m high, 1d overbought
             & ((rsi_3_15m > 15.0) | (aroonu_14_15m < 70.0) | (roc_9_1d < 10.0))
             # 15m down move, 1h & 4h high
@@ -21550,13 +21555,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 15m still high, 4h high
             & ((rsi_3_15m > 25.0) | (aroonu_14_15m < 50.0) | (aroonu_14_4h < 80.0))
             # 15m & 4h down mve, 1h high
-            & ((rsi_3_15m > 30.0) | (rsi_3_4h > 30.0) | (stochrsi_k_1h < 80.0))
+            & ((rsi_3_15m > 30.0) | (rsi_3_4h > 30.0) | (stochrsi_k_1h_lt_80))
             # 15m & 4h down move, 4h high
-            & ((rsi_3_15m > 30.0) | (rsi_3_4h > 45.0) | (stochrsi_k_4h < 80.0))
+            & ((rsi_3_15m > 30.0) | (rsi_3_4h > 45.0) | (stochrsi_k_4h_lt_80))
             # 15m down move, 1h high, 1d downtrend
             & ((rsi_3_15m > 30.0) | (aroonu_14_1h < 90.0) | (roc_9_1d > -10.0))
             # 15m down move, 15m high, 4h high
-            & ((rsi_3_15m > 35.0) | (aroonu_14_15m < 70.0) | (stochrsi_k_4h < 80.0))
+            & ((rsi_3_15m > 35.0) | (aroonu_14_15m < 70.0) | (stochrsi_k_4h_lt_80))
             # 15m down move, 15m & 4h high
             & ((rsi_3_15m > 35.0) | (aroonu_14_15m < 70.0) | (aroonu_14_4h < 90.0))
             # 15m down move, 15m high, 1d overbought
@@ -21644,7 +21649,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h & 4h high
             & ((rsi_3_1h > 45.0) | (aroonu_14_1h < 75.0) | (aroonu_14_4h < 100.0))
             # 1h down move, 4h high & overbought
-            & ((rsi_3_1h > 50.0) | (stochrsi_k_4h < 90.0) | (roc_9_4h < 25.0))
+            & ((rsi_3_1h > 50.0) | (stochrsi_k_4h_lt_90) | (roc_9_4h < 25.0))
             # 4h & 1d down move, 1d downtrend
             & ((rsi_3_4h > 3.0) | (rsi_3_1d > 10.0) | (roc_9_1d > -20.0))
             # 4h & 1d down move, 1d still high
@@ -21720,7 +21725,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 1d stil high, 1d downtrend
             & ((rsi_3_4h > 30.0) | (aroonu_14_1d < 40.0) | (roc_9_1d > -30.0))
             # 4h down move, 1h high, 1d downtrend
-            & ((rsi_3_4h > 30.0) | (stochrsi_k_1h < 80.0) | (roc_9_1d > -40.0))
+            & ((rsi_3_4h > 30.0) | (stochrsi_k_1h_lt_80) | (roc_9_1d > -40.0))
             # 4h down move, 15m still high, 1h high
             & ((rsi_3_4h > 35.0) | (aroonu_14_15m < 50.0) | (aroonu_14_1h < 100.0))
             # 4h down move, 4h still high, 1d downtrend
@@ -21855,7 +21860,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1d down move, 1h still high
             & ((rsi_3_15m > 5.0) | (rsi_3_1d > 10.0) | (aroonu_14_1h < 50.0))
             # 15m & 1d down move, 1h still high
-            & (rsi_3_15m_gt_3 | (rsi_3_1d > 25.0) | (stochrsi_k_1h < 50.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1d > 25.0) | (stochrsi_k_1h_lt_50))
             # 15m down move, 1h high, 4h overbought
             & (rsi_3_15m_gt_3 | (aroonu_14_1h < 70.0) | (roc_9_4h < 10.0))
             # 15m down move, 4h high, 1d downtrend
@@ -21863,7 +21868,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 15m still high, 1d downtrend
             & ((rsi_3_15m > 5.0) | (aroonu_14_15m < 50.0) | (roc_9_1d > -20.0))
             # 15m down move, 1h high, 1d overbought
-            & ((rsi_3_15m > 5.0) | (stochrsi_k_1h < 50.0) | (roc_9_1d < 40.0))
+            & ((rsi_3_15m > 5.0) | (stochrsi_k_1h_lt_50) | (roc_9_1d < 40.0))
             # 15m & 1h down move, 1h high
             & ((rsi_3_15m > 10.0) | (rsi_3_1h > 10.0) | (aroonu_14_1h < 60.0))
             # 15m & 1h down move, 4h high
@@ -21871,17 +21876,17 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 1h high
             & ((rsi_3_15m > 10.0) | rsi_3_1h_gt_20 | (aroonu_14_1h < 80.0))
             # 15m & 1h down move, 1h high
-            & ((rsi_3_15m > 10.0) | (rsi_3_1h > 25.0) | (stochrsi_k_1h < 70.0))
+            & ((rsi_3_15m > 10.0) | (rsi_3_1h > 25.0) | (stochrsi_k_1h_lt_70))
             # 15m & 1h down move, 1h high
-            & ((rsi_3_15m > 10.0) | (rsi_3_1h > 30.0) | (stochrsi_k_1h < 70.0))
+            & ((rsi_3_15m > 10.0) | (rsi_3_1h > 30.0) | (stochrsi_k_1h_lt_70))
             # 15m & 4h down move, 1h still high
             & ((rsi_3_15m > 10.0) | (rsi_3_4h > 10.0) | (stochrsi_k_1h < 50.0))
             # 15m & 4h down move, 1h high
-            & ((rsi_3_15m > 10.0) | rsi_3_4h_gt_20 | (stochrsi_k_1h < 70.0))
+            & ((rsi_3_15m > 10.0) | rsi_3_4h_gt_20 | (stochrsi_k_1h_lt_70))
             # 15m & 4h down move, 4h overbought
             & ((rsi_3_15m > 10.0) | (rsi_3_4h > 35.0) | (roc_9_4h < 10.0))
             # 15m & 1d down move, 1h high
-            & ((rsi_3_15m > 10.0) | (rsi_3_1d > 10.0) | (stochrsi_k_1h < 70.0))
+            & ((rsi_3_15m > 10.0) | (rsi_3_1d > 10.0) | (stochrsi_k_1h_lt_70))
             # 15m & 1d down move, 4h still high
             & ((rsi_3_15m > 10.0) | (rsi_3_1d > 10.0) | (stochrsi_k_4h < 40.0))
             # 15m & 4h down move, 15m high
@@ -21949,7 +21954,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h & 1d down move, 1d downtrend
             & ((rsi_3_4h > 5.0) | (rsi_3_1d > 5.0) | (roc_9_1d > -30.0))
             # 4h & 1d down move, 1h still high
-            & ((rsi_3_4h > 5.0) | (rsi_3_1d > 10.0) | (stochrsi_k_1h < 50.0))
+            & ((rsi_3_4h > 5.0) | (rsi_3_1d > 10.0) | (stochrsi_k_1h_lt_50))
             # 4h down move, 4h still high, 1d downtrend
             & ((rsi_3_4h > 5.0) | (stochrsi_k_4h < 40.0) | (roc_9_1d > -20.0))
             # 4h & 1d down move, 1d high
@@ -22066,7 +22071,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 4h high
             & ((rsi_3_15m > 25.0) | (rsi_3_1h > 30.0) | (aroonu_14_4h < 100.0))
             # 15m & 1h down move, 4h high
-            & ((rsi_3_15m > 25.0) | (rsi_3_1h > 40.0) | (stochrsi_k_4h < 90.0))
+            & ((rsi_3_15m > 25.0) | (rsi_3_1h > 40.0) | (stochrsi_k_4h_lt_90))
             # 15m down move, 4h high, 1d downtrend
             & ((rsi_3_15m > 25.0) | (stochrsi_k_4h < 80.0) | (roc_9_1d > -30.0))
             # 15m & 1h down move, 15m high
@@ -22076,7 +22081,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 4h down move, 1d downtrend
             & ((rsi_3_15m > 15.0) | (rsi_3_4h > 15.0) | (roc_9_1d > -20.0))
             # 15m & 1h down move, 4h high
-            & ((rsi_3_15m > 15.0) | (rsi_3_1h > 30.0) | (stochrsi_k_4h < 80.0))
+            & ((rsi_3_15m > 15.0) | (rsi_3_1h > 30.0) | (stochrsi_k_4h_lt_80))
             # 15m down move, 4h high & overbought
             & ((rsi_3_15m > 20.0) | (aroonu_14_4h < 100.0) | (roc_9_4h < 30.0))
             # 15m down move, 15m still high, 4h high
@@ -22260,7 +22265,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m still high, 4h & 1d overbought
             & ((stochrsi_k_15m < 50.0) | (roc_9_4h < 40.0) | (roc_9_1d < 100.0))
             # 4h high, 4h & 1d overbought
-            & ((stochrsi_k_4h < 90.0) | (roc_9_4h < 30.0) | (roc_9_1d < 60.0))
+            & ((stochrsi_k_4h_lt_90) | (roc_9_4h < 30.0) | (roc_9_1d < 60.0))
             # 1d high, 4h & 1d overbought
             & ((stochrsi_k_1d < 90.0) | (roc_9_4h < 30.0) | (roc_9_1d < 100.0))
             # 4h & 1d overbought
@@ -22328,13 +22333,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 15m still high, 1d overbought
             & ((rsi_3_15m > 25.0) | (stochrsi_k_15m < 50.0) | (roc_9_1d < 30.0))
             # 15m & 4h down move, 1h high
-            & ((rsi_3_15m > 30.0) | (rsi_3_4h > 30.0) | (stochrsi_k_1h < 70.0))
+            & ((rsi_3_15m > 30.0) | (rsi_3_4h > 30.0) | (stochrsi_k_1h_lt_70))
             # 15m down move, 15m & 4h high
             & ((rsi_3_15m > 30.0) | (aroonu_14_15m < 70.0) | aroonu_14_4h_lt_70)
             # 15m down move, 15m high, 1h high
-            & ((rsi_3_15m > 30.0) | (aroonu_14_15m < 70.0) | (stochrsi_k_1h < 70.0))
+            & ((rsi_3_15m > 30.0) | (aroonu_14_15m < 70.0) | (stochrsi_k_1h_lt_70))
             # 15m down move, 15m high, 4h high
-            & ((rsi_3_15m > 30.0) | (aroonu_14_15m < 70.0) | (stochrsi_k_4h < 80.0))
+            & ((rsi_3_15m > 30.0) | (aroonu_14_15m < 70.0) | (stochrsi_k_4h_lt_80))
             # 15m down move, 1h high, 1d overbought
             & ((rsi_3_15m > 30.0) | (aroonu_14_1h < 80.0) | (roc_9_1d < 20.0))
             # 15m down move, 4h & 1d overbought
@@ -22390,7 +22395,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 4h high
             & (rsi_3_1h_gt_20 | (rsi_3_4h > 35.0) | aroonu_14_4h_lt_70)
             # 1h & 4h down move, 4h high
-            & (rsi_3_1h_gt_20 | (rsi_3_4h > 45.0) | (stochrsi_k_4h < 80.0))
+            & (rsi_3_1h_gt_20 | (rsi_3_4h > 45.0) | (stochrsi_k_4h_lt_80))
             # 1h & 1d down move, 4h still high
             & (rsi_3_1h_gt_20 | (rsi_3_1d > 20.0) | (stochrsi_k_4h < 50.0))
             # 1h & 1d down move, 1h still high
@@ -22418,7 +22423,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h high, 1d overbought
             & ((rsi_3_1h > 30.0) | (aroonu_14_1h < 70.0) | (roc_9_1d < 40.0))
             # 1h & 4h down move, 4h high
-            & ((rsi_3_1h > 35.0) | (rsi_3_4h > 40.0) | (stochrsi_k_4h < 80.0))
+            & ((rsi_3_1h > 35.0) | (rsi_3_4h > 40.0) | (stochrsi_k_4h_lt_80))
             # 1h down move, 1h still high, 1d overbought
             & ((rsi_3_1h > 35.0) | (aroonu_14_1h < 40.0) | (roc_9_1d < 40.0))
             # 1h down move, 4h high & overbought
@@ -22434,7 +22439,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h high, 4h overbought
             & ((rsi_3_1h > 50.0) | (aroonu_14_1h < 80.0) | (roc_9_4h < 10.0))
             # 1h down move, 4h high & overbought
-            & ((rsi_3_1h > 50.0) | (stochrsi_k_4h < 90.0) | (roc_9_4h < 25.0))
+            & ((rsi_3_1h > 50.0) | (stochrsi_k_4h_lt_90) | (roc_9_4h < 25.0))
             # 4h down move, 4h & 1d downtrend
             & ((rsi_3_4h > 5.0) | (roc_9_4h > -15.0) | (roc_9_1d > -20.0))
             # 4h & 1d down move, 1d still high
@@ -22472,13 +22477,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 4h high, 1d overbought
             & ((rsi_3_4h > 40.0) | (aroonu_14_4h < 60.0) | (roc_9_1d < 40.0))
             # 4h & 1d down move, 1h high
-            & ((rsi_3_4h > 45.0) | (rsi_3_1d > 45.0) | (stochrsi_k_1h < 70.0))
+            & ((rsi_3_4h > 45.0) | (rsi_3_1d > 45.0) | (stochrsi_k_1h_lt_70))
             # 4h down move, 1d high & overbought
             & ((rsi_3_4h > 55.0) | (stochrsi_k_1d < 90.0) | (roc_9_1d < 80.0))
             # 1d down move, 1d high, 1d downtrend
             & ((rsi_3_1d > 15.0) | (aroonu_14_1d < 70.0) | (roc_9_1d > -20.0))
             # 1d down move, 1h high
-            & ((rsi_3_1d > 20.0) | (stochrsi_k_1h < 70.0))
+            & ((rsi_3_1d > 20.0) | (stochrsi_k_1h_lt_70))
             # 1d down move, 1h high, 1d downtrend
             & ((rsi_3_1d > 25.0) | (stochrsi_k_1h < 60.0) | (roc_9_1d > -30.0))
             # 1d down move, 1d high, 4h downtrend
@@ -22498,7 +22503,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h & 1d high, 1d overbought
             & ((aroonu_14_4h < 100.0) | (aroonu_14_1d < 100.0) | (roc_9_1d < 60.0))
             # 1h high, 4h & 1d downtrend
-            & ((stochrsi_k_1h < 80.0) | (roc_9_4h > -10.0) | (roc_9_1d > -25.0))
+            & ((stochrsi_k_1h_lt_80) | (roc_9_4h > -10.0) | (roc_9_1d > -25.0))
           )
 
           # Logic
@@ -22536,7 +22541,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m & 1h down move, 1h high
           long_entry_logic.append((rsi_3_15m > 40.0) | (rsi_3_1h > 40.0) | (aroonu_14_1h < 70.0))
           # 15m & 1h down move, 1h still high
-          long_entry_logic.append((rsi_3_15m > 40.0) | (rsi_3_1h > 40.0) | (stochrsi_k_1h < 50.0))
+          long_entry_logic.append((rsi_3_15m > 40.0) | (rsi_3_1h > 40.0) | (stochrsi_k_1h_lt_50))
           # 15m & 1h down move, 4h high
           long_entry_logic.append((rsi_3_15m > 40.0) | (rsi_3_1h > 60.0) | (aroonu_14_4h < 80.0))
           # 15m & 4h down move, 15m high
@@ -22544,9 +22549,9 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m & 4h down move, 15m high
           long_entry_logic.append((rsi_3_15m > 40.0) | (rsi_3_4h > 60.0) | (stochrsi_k_15m < 70.0))
           # 15m down move, 15m & 1h still high
-          long_entry_logic.append((rsi_3_15m > 40.0) | (aroonu_14_15m < 50.0) | (stochrsi_k_1h < 50.0))
+          long_entry_logic.append((rsi_3_15m > 40.0) | (aroonu_14_15m < 50.0) | (stochrsi_k_1h_lt_50))
           # 15m down move, 15m & 1h still high
-          long_entry_logic.append((rsi_3_15m > 40.0) | (stochrsi_k_15m < 50.0) | (stochrsi_k_1h < 50.0))
+          long_entry_logic.append((rsi_3_15m > 40.0) | (stochrsi_k_15m < 50.0) | (stochrsi_k_1h_lt_50))
           # 15m down move, 4h still high, 1d overbought
           long_entry_logic.append((rsi_3_15m > 40.0) | (aroonu_14_4h < 50.0) | (roc_9_1d < 100.0))
           # 15m & 1h down move, 1h still high
@@ -22560,15 +22565,15 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m down move, 15m & 1h still high
           long_entry_logic.append((rsi_3_15m > 45.0) | (stochrsi_k_15m < 45.0) | (stochrsi_k_1h < 40.0))
           # 15m down move, 15m still not low enough, 4h high
-          long_entry_logic.append((rsi_3_15m > 50.0) | (stochrsi_k_15m < 30.0) | (stochrsi_k_4h < 90.0))
+          long_entry_logic.append((rsi_3_15m > 50.0) | (stochrsi_k_15m < 30.0) | (stochrsi_k_4h_lt_90))
           # 15m down move, 15m still high, 1d overbought
           long_entry_logic.append((rsi_3_15m > 50.0) | (aroonu_14_15m < 50.0) | roc_9_1d_lt_50)
           # 15m down move, 15m still high, 1h high
-          long_entry_logic.append((rsi_3_15m > 55.0) | (stochrsi_k_15m < 40.0) | (stochrsi_k_1h < 70.0))
+          long_entry_logic.append((rsi_3_15m > 55.0) | (stochrsi_k_15m < 40.0) | (stochrsi_k_1h_lt_70))
           # 15m down move, 15m still high, 4h high
           long_entry_logic.append((rsi_3_15m > 55.0) | (stochrsi_k_15m < 50.0) | (aroonu_14_4h < 85.0))
           # 15m down move, 15m & 1h still high
-          long_entry_logic.append((rsi_3_15m > 55.0) | (stochrsi_k_15m < 50.0) | (stochrsi_k_1h < 50.0))
+          long_entry_logic.append((rsi_3_15m > 55.0) | (stochrsi_k_15m < 50.0) | (stochrsi_k_1h_lt_50))
           # 1h down move, 4h still high, 1d high
           long_entry_logic.append((rsi_3_1h > 25.0) | (aroonu_14_4h < 50.0) | (stochrsi_k_1d < 90.0))
           # 1h & 4h down move, 1h still high
@@ -22577,11 +22582,11 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1h & 4h down move, 4h still high
           long_entry_logic.append((rsi_3_1h > 35.0) | (rsi_3_4h > 55.0) | (stochrsi_k_4h < 50.0))
           # 1h & 4h down move, 4h high
-          long_entry_logic.append((rsi_3_1h > 35.0) | (rsi_3_4h > 60.0) | (stochrsi_k_4h < 80.0))
+          long_entry_logic.append((rsi_3_1h > 35.0) | (rsi_3_4h > 60.0) | (stochrsi_k_4h_lt_80))
           # 1h down move, 15m & 1h still high
-          long_entry_logic.append((rsi_3_1h > 40.0) | (stochrsi_k_15m < 50.0) | (stochrsi_k_1h < 50.0))
+          long_entry_logic.append((rsi_3_1h > 40.0) | (stochrsi_k_15m < 50.0) | (stochrsi_k_1h_lt_50))
           # 1h down move, 1h still high, 4h high
-          long_entry_logic.append((rsi_3_1h > 40.0) | (stochrsi_k_1h < 50.0) | (stochrsi_k_4h < 70.0))
+          long_entry_logic.append((rsi_3_1h > 40.0) | (stochrsi_k_1h_lt_50) | (stochrsi_k_4h < 70.0))
           # 1h down move, 1h high
           long_entry_logic.append((rsi_3_1h > 40.0) | (stochrsi_k_1h < 60.0))
           # 1h down move, 4h & 1d high
@@ -22599,7 +22604,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1h down move, 15m high, 1h still high
           long_entry_logic.append((rsi_3_1h > 50.0) | (aroonu_14_15m < 70.0) | (stochrsi_k_1h < 40.0))
           # 1h down move, 15m still high, 4h high
-          long_entry_logic.append((rsi_3_1h > 50.0) | (stochrsi_k_15m < 50.0) | (stochrsi_k_4h < 80.0))
+          long_entry_logic.append((rsi_3_1h > 50.0) | (stochrsi_k_15m < 50.0) | (stochrsi_k_4h_lt_80))
           # 1h down move, 15m & 1h high
           long_entry_logic.append((rsi_3_1h > 50.0) | (stochrsi_k_15m < 60.0) | (aroonu_14_1h < 60.0))
           # 1h down move, 1h & 1d high
@@ -22613,9 +22618,9 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1h down move, 1h & 4h high
           long_entry_logic.append((rsi_3_1h > 55.0) | (aroonu_14_1h < 70.0) | (aroonu_14_4h < 100.0))
           # 1h down move, 5m up move, 1h still high
-          long_entry_logic.append((rsi_3_1h > 60.0) | (rsi_3 < 60.0) | (stochrsi_k_1h < 50.0))
+          long_entry_logic.append((rsi_3_1h > 60.0) | (rsi_3 < 60.0) | (stochrsi_k_1h_lt_50))
           # 1h down move, 15m still not low enough, 4h high
-          long_entry_logic.append((rsi_3_1h > 60.0) | (aroonu_14_15m < 70.0) | (stochrsi_k_4h < 90.0))
+          long_entry_logic.append((rsi_3_1h > 60.0) | (aroonu_14_15m < 70.0) | (stochrsi_k_4h_lt_90))
           # 1h down move, 15m still not low enough, 1h high
           long_entry_logic.append((rsi_3_1h > 60.0) | (stochrsi_k_15m < 30.0) | (aroonu_14_1h < 70.0))
           # 1h down move, 15m still not low enough, 1h high
@@ -22625,13 +22630,13 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1h down move, 15m & 1h high
           long_entry_logic.append((rsi_3_1h > 60.0) | (aroonu_14_15m < 70.0) | (aroonu_14_1h < 90.0))
           # 1h down move, 1h still high, 4h high
-          long_entry_logic.append((rsi_3_1h > 60.0) | (aroonu_14_1h < 50.0) | (stochrsi_k_4h < 90.0))
+          long_entry_logic.append((rsi_3_1h > 60.0) | (aroonu_14_1h < 50.0) | (stochrsi_k_4h_lt_90))
           # 1h down move, 1h high, 4h still high
           long_entry_logic.append((rsi_3_1h > 60.0) | (aroonu_14_1h < 80.0) | (aroonu_14_4h < 40.0))
           # 1h down move, 1h still high, 4h high
           long_entry_logic.append((rsi_3_1h > 60.0) | (stochrsi_k_1h < 40.0) | aroonu_14_4h_lt_70)
           # 1h down move, 1h & 1d high
-          long_entry_logic.append((rsi_3_1h > 60.0) | (stochrsi_k_1h < 70.0) | (aroonu_14_1d < 90.0))
+          long_entry_logic.append((rsi_3_1h > 60.0) | (stochrsi_k_1h_lt_70) | (aroonu_14_1d < 90.0))
           # 1h down move, 4h & 1d high
           long_entry_logic.append((rsi_3_1h > 60.0) | (rsi_14_4h < 70.0) | (rsi_14_1d < 80.0))
           # 15m & 1h & 4h down move, 4h high
@@ -22639,25 +22644,25 @@ class NostalgiaForInfinityX7(IStrategy):
           # 4h down move, 15m high
           long_entry_logic.append(rsi_3_4h_gt_20 | (aroonu_14_15m < 80.0))
           # 4h down move, 1h high
-          long_entry_logic.append((rsi_3_4h > 25.0) | (stochrsi_k_1h < 80.0))
+          long_entry_logic.append((rsi_3_4h > 25.0) | (stochrsi_k_1h_lt_80))
           # 4h down move, 15m & 4h still high
           long_entry_logic.append((rsi_3_4h > 30.0) | (aroonu_14_15m < 50.0) | (aroonu_14_4h < 50.0))
           # 4h down move, 15m still high, 1d overbought
           long_entry_logic.append((rsi_3_4h > 30.0) | (stochrsi_k_15m < 50.0) | (roc_9_1d < 10.0))
           # 4h down move, 1h & 4h still high
-          long_entry_logic.append((rsi_3_4h > 35.0) | (stochrsi_k_1h < 50.0) | (aroonu_14_4h < 50.0))
+          long_entry_logic.append((rsi_3_4h > 35.0) | (stochrsi_k_1h_lt_50) | (aroonu_14_4h < 50.0))
           # 4h down move, 1d high & overbought
           long_entry_logic.append((rsi_3_4h > 35.0) | (stochrsi_k_1d < 80.0) | (roc_9_1d < 40.0))
           # 4h down move, 15m & 1h high
-          long_entry_logic.append((rsi_3_4h > 40.0) | (aroonu_14_15m < 80.0) | (stochrsi_k_1h < 70.0))
+          long_entry_logic.append((rsi_3_4h > 40.0) | (aroonu_14_15m < 80.0) | (stochrsi_k_1h_lt_70))
           # 4h down move, 1d high & overbought
           long_entry_logic.append((rsi_3_4h > 40.0) | (aroonu_14_1d < 80.0) | (roc_9_1d < 20.0))
           # 4h down move, 15m still high, 1h high
-          long_entry_logic.append((rsi_3_4h > 40.0) | (stochrsi_k_15m < 40.0) | (stochrsi_k_1h < 80.0))
+          long_entry_logic.append((rsi_3_4h > 40.0) | (stochrsi_k_15m < 40.0) | (stochrsi_k_1h_lt_80))
           # 4h down move, 1h & 4h still high
-          long_entry_logic.append((rsi_3_4h > 40.0) | (stochrsi_k_1h < 50.0) | (rsi_14_4h < 50.0))
+          long_entry_logic.append((rsi_3_4h > 40.0) | (stochrsi_k_1h_lt_50) | (rsi_14_4h < 50.0))
           # 4h down move, 1h still high, 4h still moving down
-          long_entry_logic.append((rsi_3_4h > 40.0) | (stochrsi_k_1h < 50.0) | (cci_20_change_pct_4h > -0.0))
+          long_entry_logic.append((rsi_3_4h > 40.0) | (stochrsi_k_1h_lt_50) | (cci_20_change_pct_4h > -0.0))
           # 4h down move, 1d high & overbought
           long_entry_logic.append((rsi_3_4h > 40.0) | (stochrsi_k_1d < 80.0) | (roc_9_1d < 10.0))
           # 4h down move, 1h high, 4h still high
@@ -22665,13 +22670,13 @@ class NostalgiaForInfinityX7(IStrategy):
           # 4h down move, 15m high, 4h still high
           long_entry_logic.append((rsi_3_4h > 50.0) | (aroonu_14_15m < 70.0) | (stochrsi_k_4h < 40.0))
           # 4h down move, 15m still high, 1h high
-          long_entry_logic.append((rsi_3_4h > 50.0) | (stochrsi_k_15m < 40.0) | (stochrsi_k_1h < 70.0))
+          long_entry_logic.append((rsi_3_4h > 50.0) | (stochrsi_k_15m < 40.0) | (stochrsi_k_1h_lt_70))
           # 4h down move, 15m & 4h still high
           long_entry_logic.append((rsi_3_4h > 50.0) | (stochrsi_k_15m < 50.0) | (aroonu_14_4h < 50.0))
           # 4h down move, 15m high, 4h still not low enough
           long_entry_logic.append((rsi_3_4h > 50.0) | (stochrsi_k_15m < 70.0) | (stochrsi_k_4h < 30.0))
           # 4h down move, 1h still high, 4h high
-          long_entry_logic.append((rsi_3_4h > 50.0) | (stochrsi_k_1h < 50.0) | aroonu_14_4h_lt_70)
+          long_entry_logic.append((rsi_3_4h > 50.0) | (stochrsi_k_1h_lt_50) | aroonu_14_4h_lt_70)
           # 4h down move, 15m & 1d high
           long_entry_logic.append((rsi_3_4h > 50.0) | (aroonu_14_15m < 70.0) | (aroonu_14_1d < 90.0))
           # 4h down move, 1d high & overbought
@@ -22687,7 +22692,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 4h down move, 15m & 4h high
           long_entry_logic.append((rsi_3_4h > 60.0) | (stochrsi_k_15m < 70.0) | (stochrsi_k_4h < 60.0))
           # 4h down move, 1h & 4h high
-          long_entry_logic.append((rsi_3_4h > 60.0) | (stochrsi_k_1h < 70.0) | aroonu_14_4h_lt_70)
+          long_entry_logic.append((rsi_3_4h > 60.0) | (stochrsi_k_1h_lt_70) | aroonu_14_4h_lt_70)
           # 4h down move, 4h still high, 1d high
           long_entry_logic.append((rsi_3_4h > 60.0) | (stochrsi_k_4h < 50.0) | (stochrsi_k_1d < 80.0))
           # 15m still high, 1d high & overbought
@@ -22775,11 +22780,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 15m still not low enough
             & ((rsi_3_15m > 15.0) | rsi_3_1h_gt_20 | (stochrsi_k_15m < 30.0))
             # 15m & 1h down nove, 1h still high
-            & ((rsi_3_15m > 15.0) | rsi_3_1h_gt_20 | (stochrsi_k_1h < 50.0))
+            & ((rsi_3_15m > 15.0) | rsi_3_1h_gt_20 | (stochrsi_k_1h_lt_50))
             # 15m & 1h down move, 4h high
             & ((rsi_3_15m > 15.0) | (rsi_3_1h > 30.0) | (aroonu_14_4h < 100.0))
             # 15m & 1h down move, 4h high
-            & ((rsi_3_15m > 15.0) | (rsi_3_1h > 35.0) | (stochrsi_k_4h < 90.0))
+            & ((rsi_3_15m > 15.0) | (rsi_3_1h > 35.0) | (stochrsi_k_4h_lt_90))
             # 15m down move, 4h high, 4h downtrend
             & ((rsi_3_15m > 15.0) | (aroonu_14_4h < 60.0) | (roc_9_4h > -20.0))
             # 15m down move, 4h & 1d downtrend
@@ -22789,7 +22794,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 4h high & overbought
             & ((rsi_3_15m > 20.0) | aroonu_14_4h_lt_70 | (roc_9_4h < 20.0))
             # 15m & 1h down move, 4h high
-            & ((rsi_3_15m > 25.0) | (rsi_3_1h > 25.0) | (stochrsi_k_4h < 90.0))
+            & ((rsi_3_15m > 25.0) | (rsi_3_1h > 25.0) | (stochrsi_k_4h_lt_90))
             # 15m down move, 15m high, 1d overbought
             & ((rsi_3_15m > 25.0) | (aroonu_14_15m < 60.0) | (roc_9_1d < 150.0))
             # 15m down move, 1h & 4h high
@@ -22831,7 +22836,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h high, 4h overbought
             & ((rsi_3_1h > 30.0) | (aroonu_14_1h < 60.0) | (roc_9_4h < 50.0))
             # 1h down move, 4h high & overbought
-            & ((rsi_3_1h > 35.0) | (stochrsi_k_4h < 80.0) | (roc_9_4h < 30.0))
+            & ((rsi_3_1h > 35.0) | (stochrsi_k_4h_lt_80) | (roc_9_4h < 30.0))
             # 1h down move, 1h high, 4h downtrend
             & ((rsi_3_1h > 40.0) | (stochrsi_k_1h < 80.0) | (roc_9_4h > -20.0))
             # 1h down move, 15m still high, 1d overbought
@@ -22839,7 +22844,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 4h & 1d overbought
             & ((rsi_3_1h > 45.0) | (roc_9_4h < 10.0) | roc_9_1d_lt_50)
             # 1h down move,  4h high, 1d overbought
-            & ((rsi_3_1h > 50.0) | (stochrsi_k_4h < 90.0) | (roc_9_1d < 150.0))
+            & ((rsi_3_1h > 50.0) | (stochrsi_k_4h_lt_90) | (roc_9_1d < 150.0))
             # 4h down move, 1d high
             & ((rsi_3_4h > 3.0) | (aroonu_14_1d < 90.0))
             # 4h down move, 15m still high
@@ -22863,11 +22868,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 4h & 1d overbought
             & ((rsi_3_4h > 40.0) | (roc_9_4h < 10.0) | roc_9_1d_lt_50)
             # 1d down move, 1h high
-            & ((rsi_3_1d > 3.0) | (stochrsi_k_1h < 70.0))
+            & ((rsi_3_1d > 3.0) | (stochrsi_k_1h_lt_70))
             # 1d down move, 15m still high
             & ((rsi_3_1d > 3.0) | (aroonu_14_15m < 50.0))
             # 1d down move, 15m still high, 1h high
-            & ((rsi_3_1d > 10.0) | (aroonu_14_15m < 40.0) | (stochrsi_k_1h < 70.0))
+            & ((rsi_3_1d > 10.0) | (aroonu_14_15m < 40.0) | (stochrsi_k_1h_lt_70))
             # 1d down move, 1h & 4h high
             & ((rsi_3_1d > 10.0) | (aroonu_14_1h < 70.0) | (aroonu_14_4h < 90.0))
             # 1d down move, 4h high
@@ -22887,13 +22892,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1d still high, 1h & 4h downtrend
             & ((aroonu_14_1d < 50.0) | (roc_9_1h > -20.0) | (roc_9_4h > -20.0))
             # 1h high, 1h overbought
-            & ((stochrsi_k_1h < 80.0) | (roc_9_1h < 50.0))
+            & ((stochrsi_k_1h_lt_80) | (roc_9_1h < 50.0))
             # 1h high, 1d downtrend
-            & ((stochrsi_k_1h < 80.0) | (roc_9_1d > -60.0))
+            & ((stochrsi_k_1h_lt_80) | (roc_9_1d > -60.0))
             # 4h high, 1h overbought, 1d downtrend
-            & ((stochrsi_k_4h < 80.0) | (roc_9_1h < 10.0) | (roc_9_1d > -70.0))
+            & ((stochrsi_k_4h_lt_80) | (roc_9_1h < 10.0) | (roc_9_1d > -70.0))
             # 4h high, 1h & 4h overbought
-            & ((stochrsi_k_4h < 90.0) | (roc_9_1h < 20.0) | (roc_9_4h < 50.0))
+            & ((stochrsi_k_4h_lt_90) | (roc_9_1h < 20.0) | (roc_9_4h < 50.0))
             # 1h & 4h overbought
             & ((roc_9_1h < 100.0) | (roc_9_4h < 100.0))
             # 1h P&D, 1h down move
@@ -22979,7 +22984,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 1h high
             & ((rsi_3_15m > 15.0) | (rsi_3_1h > 30.0) | (aroonu_14_1h < 70.0))
             # 15m & 1h down move, 1h high
-            & ((rsi_3_15m > 15.0) | (rsi_3_1h > 30.0) | (stochrsi_k_1h < 70.0))
+            & ((rsi_3_15m > 15.0) | (rsi_3_1h > 30.0) | (stochrsi_k_1h_lt_70))
             # 15m & 1h down move, 1d overbought
             & ((rsi_3_15m > 15.0) | (rsi_3_1h > 30.0) | (roc_9_1d < 30.0))
             # 15m & 1h & 4h down move, 4h high
@@ -23013,7 +23018,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 4h down move, 1h high
             & ((rsi_3_15m > 15.0) | (rsi_3_4h > 35.0) | (stochrsi_k_1h < 60.0))
             # 15m & 4h down move, 1h high
-            & ((rsi_3_15m > 15.0) | (rsi_3_4h > 50.0) | (stochrsi_k_1h < 80.0))
+            & ((rsi_3_15m > 15.0) | (rsi_3_4h > 50.0) | (stochrsi_k_1h_lt_80))
             # 15m down move, 4h & 1d up move, 1d downtrend
             & ((rsi_3_15m > 15.0) | (rsi_3_4h < 90.0) | (rsi_3_1d < 80.0) | (cmf_20_1d > -0.2))
             # 15m & 1d down move, 4h high
@@ -23045,21 +23050,21 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 15m still not low enough, 4h high
             & ((rsi_3_15m > 15.0) | (stochrsi_k_15m < 30.0) | (stochrsi_k_4h < 50.0))
             # 15m down move, 15m & 1h high
-            & ((rsi_3_15m > 15.0) | (stochrsi_k_15m < 50.0) | (stochrsi_k_1h < 50.0))
+            & ((rsi_3_15m > 15.0) | (stochrsi_k_15m < 50.0) | (stochrsi_k_1h_lt_50))
             # 15m down move, 1h high, 1d overbought
-            & ((rsi_3_15m > 15.0) | (stochrsi_k_1h < 70.0) | (roc_9_1d < 30.0))
+            & ((rsi_3_15m > 15.0) | (stochrsi_k_1h_lt_70) | (roc_9_1d < 30.0))
             # 15m down move, 1h high, 1d overbought
-            & ((rsi_3_15m > 15.0) | (stochrsi_k_1h < 70.0) | (roc_9_1d < 150.0))
+            & ((rsi_3_15m > 15.0) | (stochrsi_k_1h_lt_70) | (roc_9_1d < 150.0))
             # 15m down move, 1h high & overbought
-            & ((rsi_3_15m > 15.0) | (stochrsi_k_1h < 80.0) | (roc_9_1h < 20.0))
+            & ((rsi_3_15m > 15.0) | (stochrsi_k_1h_lt_80) | (roc_9_1h < 20.0))
             # 15m down move, 1h high, 1d overbought
             & ((rsi_3_15m > 15.0) | (stochrsi_k_1h < 80.0) | (roc_9_1d < 100.0))
             # 15m down move, 4h high, 1d overbought
-            & ((rsi_3_15m > 15.0) | (stochrsi_k_4h < 80.0) | (roc_9_1d < 25.0))
+            & ((rsi_3_15m > 15.0) | (stochrsi_k_4h_lt_80) | (roc_9_1d < 25.0))
             # 15m down move, 4h high & overbought
-            & ((rsi_3_15m > 15.0) | (stochrsi_k_4h < 90.0) | (roc_9_4h < 25.0))
+            & ((rsi_3_15m > 15.0) | (stochrsi_k_4h_lt_90) | (roc_9_4h < 25.0))
             # 15m down move, 4h high
-            & ((rsi_3_15m > 15.0) | (rsi_14_4h < 70.0) | (stochrsi_k_4h < 90.0) | (ema_9 < (ema_26 * 0.972)))
+            & ((rsi_3_15m > 15.0) | (rsi_14_4h < 70.0) | (stochrsi_k_4h_lt_90) | (ema_9 < (ema_26 * 0.972)))
             # 15m down move, 4h high and downtrend
             & ((rsi_3_15m > 15.0) | (cmf_20_4h > -0.2) | (aroonu_14_4h < 80.0))
             # 15m down move, 1h high, 4h overbought
@@ -23095,7 +23100,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 1d high, 4h overbought
             & ((rsi_3_15m > 20.0) | (aroonu_14_1d < 100.0) | (roc_9_4h < 30.0))
             # 15m down move, 1h high & overbought
-            & ((rsi_3_15m > 20.0) | (stochrsi_k_1h < 80.0) | (roc_9_1h < 10.0))
+            & ((rsi_3_15m > 20.0) | (stochrsi_k_1h_lt_80) | (roc_9_1h < 10.0))
             # 15m & 1d down move, 1d high
             & ((rsi_3_15m > 25.0) | (rsi_3_1d > 40.0) | (aroonu_14_1d < 80.0))
             # 15m down move, 4h high, 1d downtrend
@@ -23114,13 +23119,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 4h down move, 4h overbought
             & ((rsi_3_15m > 30.0) | (rsi_3_4h > 60.0) | (roc_9_4h < 60.0))
             # 15m & 4h down move, 4h high
-            & ((rsi_3_15m > 35.0) | (rsi_3_4h > 35.0) | (stochrsi_k_4h < 80.0))
+            & ((rsi_3_15m > 35.0) | (rsi_3_4h > 35.0) | (stochrsi_k_4h_lt_80))
             # 1h & 4h down move, 1d high
             & ((rsi_3_1h > 25.0) | (rsi_3_4h > 30.0) | (stochrsi_k_1d < 80.0))
             # 1h & 4h down move, 4h high
             & ((rsi_3_1h > 25.0) | (rsi_3_4h > 40.0) | aroonu_14_4h_lt_70)
             # 1h & 4h down move, 4h high
-            & ((rsi_3_1h > 25.0) | (rsi_3_4h > 45.0) | (stochrsi_k_4h < 80.0))
+            & ((rsi_3_1h > 25.0) | (rsi_3_4h > 45.0) | (stochrsi_k_4h_lt_80))
             # 1h & 4h down move, 1d high
             & ((rsi_3_1h > 25.0) | (rsi_3_4h > 65.0) | (aroonu_14_1d < 100.0))
             # 1h & 1d down move, 1d high
@@ -23140,7 +23145,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h still not low enough, 1d downtrend
             & ((rsi_3_1h > 25.0) | (stochrsi_k_1h < 30.0) | (roc_9_1d > -40.0))
             # 1h down move, 4h high, 1d overbought
-            & ((rsi_3_1h > 25.0) | (stochrsi_k_4h < 90.0) | (roc_9_1d < 25.0))
+            & ((rsi_3_1h > 25.0) | (stochrsi_k_4h_lt_90) | (roc_9_1d < 25.0))
             # 1h & 4h down move, 1h still high
             & ((rsi_3_1h > 30.0) | (rsi_3_4h > 30.0) | (aroonu_14_1h < 40.0))
             # 1h & 1d down move, 1d still high
@@ -23188,23 +23193,23 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h high, 15m downtrend
             & ((rsi_3_1h > 40.0) | (aroonu_14_1h < 90.0) | (roc_9_15m > -10.0))
             # 1h down move, 1h high, 1d downtrend
-            & ((rsi_3_1h > 40.0) | (stochrsi_k_1h < 80.0) | (roc_9_1d > -40.0))
+            & ((rsi_3_1h > 40.0) | (stochrsi_k_1h_lt_80) | (roc_9_1d > -40.0))
             # 1h & 4h down move, 1d overbought
             & ((rsi_3_1h > 45.0) | (rsi_3_4h > 65.0) | (roc_9_1d < 200.0))
             # 1h & 1d down move, 4h high
-            & ((rsi_3_1h > 45.0) | (rsi_3_1d > 50.0) | (stochrsi_k_4h < 90.0))
+            & ((rsi_3_1h > 45.0) | (rsi_3_1d > 50.0) | (stochrsi_k_4h_lt_90))
             # 1h down move, 1h high, 4h overbought
             & ((rsi_3_1h > 45.0) | (aroonu_14_1h < 100.0) | (roc_9_4h < 10.0))
             # 1h & 4h down move, 1h & 4h high
             & ((rsi_3_1h > 50.0) | (rsi_3_4h > 65.0) | (aroonu_14_1h < 85.0) | (aroonu_14_4h < 100.0))
             # 1h down move, 15m & 1h high
-            & ((rsi_3_1h > 50.0) | (aroonu_14_15m < 60.0) | (stochrsi_k_1h < 80.0))
+            & ((rsi_3_1h > 50.0) | (aroonu_14_15m < 60.0) | (stochrsi_k_1h_lt_80))
             # 1h down move, 4h & 1d high
             & ((rsi_3_1h > 50.0) | (aroonu_14_4h < 90.0) | (aroonu_14_1d < 90.0))
             # 1h down move, 4h high, 1h overbought
             & ((rsi_3_1h > 55.0) | (aroonu_14_4h < 100.0) | (roc_9_1h < 20.0))
             # 1h down move, 15m & 1h high, 1d downtrend
-            & ((rsi_3_1h > 60.0) | (aroonu_14_15m < 65.0) | (stochrsi_k_1h < 80.0) | (cmf_20_1d > -0.0))
+            & ((rsi_3_1h > 60.0) | (aroonu_14_15m < 65.0) | (stochrsi_k_1h_lt_80) | (cmf_20_1d > -0.0))
             # 1h down move, 1h high, 1d downtrend
             & ((rsi_3_1h > 60.0) | (stochrsi_k_1h < 90.0) | (roc_9_1d > -20.0))
             # 4h down move, 15m high
@@ -23260,15 +23265,15 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1d down move, 4h high
             & ((rsi_3_1d > 3.0) | (stochrsi_k_4h < 60.0))
             # 1d down move, 1h high
-            & ((rsi_3_1d > 5.0) | (stochrsi_k_1h < 80.0))
+            & ((rsi_3_1d > 5.0) | (stochrsi_k_1h_lt_80))
             # 1d down move, 15m & 1h still high
-            & ((rsi_3_1d > 10.0) | (rsi_14_15m < 40.0) | (stochrsi_k_1h < 50.0))
+            & ((rsi_3_1d > 10.0) | (rsi_14_15m < 40.0) | (stochrsi_k_1h_lt_50))
             # 1d down move, 1h & 4h high
             & ((rsi_3_1d > 10.0) | (aroonu_14_1h < 80.0) | (aroonu_14_4h < 90.0))
             # 1d down move, 1h & 4h still high
             & ((rsi_3_1d > 10.0) | (stochrsi_k_1h < 40.0) | (aroonu_14_4h < 40.0))
             # 1d down move, 1h high & overbought
-            & ((rsi_3_1d > 20.0) | (stochrsi_k_1h < 80.0) | (roc_9_1h < 20.0))
+            & ((rsi_3_1d > 20.0) | (stochrsi_k_1h_lt_80) | (roc_9_1h < 20.0))
             # 1d down move, 1d high & overbought
             & ((rsi_3_1d > 40.0) | (aroonu_14_1d < 70.0) | (roc_9_1d < 20.0))
             # 1d down move, 4h high & overbought
@@ -23286,11 +23291,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 5m still high, 1h down move, 4h high
             & ((rsi_3 < 50.0) | (rsi_3_1h > 30.0) | (aroonu_14_4h < 100.0))
             # 15m down move, 1h high
-            & ((rsi_14_15m > 25.0) | (stochrsi_k_1h < 80.0))
+            & ((rsi_14_15m > 25.0) | (stochrsi_k_1h_lt_80))
             # 15m down move, 4h & 1d high
-            & ((rsi_14_15m > 30.0) | (stochrsi_k_4h < 90.0) | (stochrsi_k_1d < 70.0))
+            & ((rsi_14_15m > 30.0) | (stochrsi_k_4h_lt_90) | (stochrsi_k_1d < 70.0))
             # 1h downtrend, 4h high, 1d downtrend
-            & ((cmf_20_1h > -0.2) | (stochrsi_k_4h < 90.0) | (cmf_20_1d > -0.25))
+            & ((cmf_20_1h > -0.2) | (stochrsi_k_4h_lt_90) | (cmf_20_1d > -0.25))
             # 15m & 1h high, 1d overbought
             & ((aroonu_14_15m < 60.0) | (aroonu_14_1h < 100.0) | (roc_9_1d < 20.0))
             # 4h high, 4h & 1d overbought
@@ -23308,13 +23313,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1d red, 1h down move, 1h still high
             & ((change_pct_1d > -15.0) | (rsi_3_1h > 25.0) | (aroonu_14_1h < 50.0))
             # 1d P&D, 1h high
-            & ((change_pct_1d > -15.0) | (change_pct_1d.shift(288) < 15.0) | (stochrsi_k_1h < 80.0))
+            & ((change_pct_1d > -15.0) | (change_pct_1d.shift(288) < 15.0) | (stochrsi_k_1h_lt_80))
             # 1d P&D, 1d downtrend
             & ((change_pct_1d > -5.0) | (change_pct_1d.shift(288) < 30.0) | (cmf_20_1d > -0.1))
             # 1d P&D, 15m high
             & ((change_pct_1d > -10.0) | (change_pct_1d.shift(288) < 40.0) | (aroonu_14_15m < 50.0))
             # 1d P&D, 1h high
-            & ((change_pct_1d > -10.0) | (change_pct_1d.shift(288) < 40.0) | (stochrsi_k_1h < 70.0))
+            & ((change_pct_1d > -10.0) | (change_pct_1d.shift(288) < 40.0) | (stochrsi_k_1h_lt_70))
             # 1d red with top wick, 1h high
             & ((change_pct_1d > -10.0) | (top_wick_pct_1d < 10.0) | (aroonu_14_1h < 80.0))
             # 1d green, 4m down move, 4h high


### PR DESCRIPTION
## Summary
- Reuse common STOCHRSI threshold masks inside X7 `populate_entry_trend()`.
- Replace repeated same-call Series comparisons for five frequently reused STOCHRSI entry thresholds.
- Keep the existing entry conditions, thresholds, and ordering unchanged.

## Safety
- This only names boolean masks for existing comparisons such as `stochrsi_k_4h < 80.0` and reuses them in the same function call.
- No indicator formula, CMF/math path, candle selection, order/profit/stake/leverage logic, or grind-entry v3 logic changed.
- I also simulated applying this after the current overlapping entry-mask PRs to check for maintainer-side merge conflicts.

## Backtest scope
- No backtest was run for this patch because it is a same-dataframe boolean mask reuse inside `populate_entry_trend()`.
- The expected output is unchanged; this is intended to reduce repeated Series comparison work, not alter signals.

## Checks
- `python3 ~/.codex/skills/nfi-upstream-pr/scripts/validate_nfi_pr.py --base origin/main`
- `git diff --check`
- `ruff format --check NostalgiaForInfinityX7.py`
- `ruff check NostalgiaForInfinityX7.py`
- `PYTHONDONTWRITEBYTECODE=1 python3 -m py_compile NostalgiaForInfinityX7.py`
- Merge simulation after #960/#962/#967/#968: automatic merges succeeded, conflict marker scan clean, `py_compile` passed.
