### PR TITLE
Reuse X7 v2 exit candle reads

### DIFF
--- a/NostalgiaForInfinityX7.py
+++ b/NostalgiaForInfinityX7.py
@@ -41716,13 +41716,16 @@ class NostalgiaForInfinityX7(IStrategy):
     last_rsi_3 = last_candle["RSI_3"]
     last_rsi_14 = last_candle["RSI_14"]
     last_willr_14 = last_candle["WILLR_14"]
+    last_stochrsi_k = last_candle["STOCHRSIk_14_14_3_3"]
+    last_close = last_candle["close"]
+    last_bbu_20 = last_candle["BBU_20_2.0"]
 
     if (
       (last_rsi_3 > 99.0)
       or (last_rsi_14 > 70.0)
       or (last_willr_14 > -0.1)
-      or (last_candle["STOCHRSIk_14_14_3_3"] > 95.0)
-      or (last_candle["close"] > (last_candle["BBU_20_2.0"] * 1.01))
+      or (last_stochrsi_k > 95.0)
+      or (last_close > (last_bbu_20 * 1.01))
       or ((last_rsi_3 > 90.0) and (last_rsi_14 < 50.0))
     ):
       return True
@@ -41735,13 +41738,16 @@ class NostalgiaForInfinityX7(IStrategy):
     last_rsi_3 = last_candle["RSI_3"]
     last_rsi_14 = last_candle["RSI_14"]
     last_willr_14 = last_candle["WILLR_14"]
+    last_stochrsi_k = last_candle["STOCHRSIk_14_14_3_3"]
+    last_close = last_candle["close"]
+    last_bbu_20 = last_candle["BBU_20_2.0"]
 
     if (
       (last_rsi_3 > 99.0)
       or (last_rsi_14 > 70.0)
       or (last_willr_14 > -0.1)
-      or (last_candle["STOCHRSIk_14_14_3_3"] > 95.0)
-      or (last_candle["close"] > (last_candle["BBU_20_2.0"] * 1.01))
+      or (last_stochrsi_k > 95.0)
+      or (last_close > (last_bbu_20 * 1.01))
       or ((last_rsi_3 > 90.0) and (last_rsi_14 < 50.0))
     ):
       return True
@@ -64826,13 +64832,17 @@ class NostalgiaForInfinityX7(IStrategy):
   ) -> float:
     last_rsi_3 = last_candle["RSI_3"]
     last_rsi_14 = last_candle["RSI_14"]
+    last_willr_14 = last_candle["WILLR_14"]
+    last_stochrsi_k = last_candle["STOCHRSIk_14_14_3_3"]
+    last_close = last_candle["close"]
+    last_bbl_20 = last_candle["BBL_20_2.0"]
 
     if (
       (last_rsi_3 < 1.0)
       or (last_rsi_14 < 30.0)
-      or (last_candle["WILLR_14"] < -99.9)
-      or (last_candle["STOCHRSIk_14_14_3_3"] > 5.0)
-      or (last_candle["close"] < (last_candle["BBL_20_2.0"] * 0.99))
+      or (last_willr_14 < -99.9)
+      or (last_stochrsi_k > 5.0)
+      or (last_close < (last_bbl_20 * 0.99))
       or ((last_rsi_3 < 10.0) and (last_rsi_14 > 50.0))
     ):
       return True
@@ -64844,13 +64854,17 @@ class NostalgiaForInfinityX7(IStrategy):
   ) -> float:
     last_rsi_3 = last_candle["RSI_3"]
     last_rsi_14 = last_candle["RSI_14"]
+    last_willr_14 = last_candle["WILLR_14"]
+    last_stochrsi_k = last_candle["STOCHRSIk_14_14_3_3"]
+    last_close = last_candle["close"]
+    last_bbl_20 = last_candle["BBL_20_2.0"]
 
     if (
       (last_rsi_3 < 1.0)
       or (last_rsi_14 < 30.0)
-      or (last_candle["WILLR_14"] < -99.9)
-      or (last_candle["STOCHRSIk_14_14_3_3"] < 5.0)
-      or (last_candle["close"] < (last_candle["BBL_20_2.0"] * 0.99))
+      or (last_willr_14 < -99.9)
+      or (last_stochrsi_k < 5.0)
+      or (last_close < (last_bbl_20 * 0.99))
       or ((last_rsi_3 < 10.0) and (last_rsi_14 > 50.0))
     ):
       return True


### PR DESCRIPTION
## Summary
- Reuse local candle values in the X7 v2 buyback/grind exit helpers.
- Keep the existing boolean order, thresholds, and return values unchanged.

## Safety
- Behavior is preserved because the patch only reuses already-read RSI, WILLR, STOCHRSI, close, and Bollinger values inside the same helper call.
- Touched functions: long_buyback_exit_v2, long_grind_exit_v2, short_buyback_exit_v2, short_grind_exit_v2; these are active runtime paths and were reviewed as lookup-only changes.
- Indicators, candle selection, order classification, profit arithmetic, thresholds, condition order, and return values are unchanged. No v3 grind-entry code is touched.

## Backtest scope
- Full backtesting was not required for this lookup-reuse patch because it only replaces repeated same-candle reads with local variables inside the same calls; trading conditions and outputs are unchanged.

## Checks
- `python3 ~/.codex/skills/nfi-upstream-pr/scripts/validate_nfi_pr.py --base origin/main`
- `git merge-tree conflict simulation against origin/main`
- `targeted git diff origin/main...HEAD -- NostalgiaForInfinityX7.py review`
- `git diff --check`
- `ruff format --check NostalgiaForInfinityX7.py`
- `ruff check NostalgiaForInfinityX7.py`
- `PYTHONDONTWRITEBYTECODE=1 python3 -m py_compile NostalgiaForInfinityX7.py`
