### PR TITLE
Reuse X7 entry open series

### DIFF
--- a/NostalgiaForInfinityX7.py
+++ b/NostalgiaForInfinityX7.py
@@ -12598,6 +12598,7 @@ class NostalgiaForInfinityX7(IStrategy):
     stochrsi_k_4h_lt_90 = stochrsi_k_4h < 90.0
     rsi_3 = df["RSI_3"]
     close = df["close"]
+    open_rate = df["open"]
     roc_9_15m = df["ROC_9_15m"]
     rsi_14_4h = df["RSI_14_4h"]
 
@@ -13115,8 +13116,8 @@ class NostalgiaForInfinityX7(IStrategy):
           # Logic
           long_entry_logic.append(
             (ema_26 > ema_12)
-            & ((ema_26 - ema_12) > (df["open"] * 0.034))
-            & ((ema_26.shift() - ema_12.shift()) > (df["open"] / 100.0))
+            & ((ema_26 - ema_12) > (open_rate * 0.034))
+            & ((ema_26.shift() - ema_12.shift()) > (open_rate / 100.0))
             & (close < (df["BBL_20_2.0"] * 0.999))
           )
 
@@ -15136,8 +15137,8 @@ class NostalgiaForInfinityX7(IStrategy):
             & (aroonu_14 < 25.0)
             & (stochrsi_k < 30.0)
             & (ema_26 > ema_12)
-            & ((ema_26 - ema_12) > (df["open"] * 0.020))
-            & ((ema_26.shift() - ema_12.shift()) > (df["open"] / 100.0))
+            & ((ema_26 - ema_12) > (open_rate * 0.020))
+            & ((ema_26.shift() - ema_12.shift()) > (open_rate / 100.0))
           )
 
         # Condition #6 - Normal mode (Long).
@@ -17793,8 +17794,8 @@ class NostalgiaForInfinityX7(IStrategy):
             & (df["MFI_14"] < 40.0)
             & (aroonu_14 < 25.0)
             & (ema_26 > ema_12)
-            & ((ema_26 - ema_12) > (df["open"] * 0.024))
-            & ((ema_26.shift() - ema_12.shift()) > (df["open"] / 100.0))
+            & ((ema_26 - ema_12) > (open_rate * 0.024))
+            & ((ema_26.shift() - ema_12.shift()) > (open_rate / 100.0))
             & (close < (ema_20 * 0.960))
             & (close < (df["BBL_20_2.0"] * 0.999))
           )
@@ -18975,8 +18976,8 @@ class NostalgiaForInfinityX7(IStrategy):
             & (aroonu_14 < 25.0)
             & (stochrsi_k < 30.0)
             & (ema_26 > ema_12)
-            & ((ema_26 - ema_12) > (df["open"] * 0.030))
-            & ((ema_26.shift() - ema_12.shift()) > (df["open"] / 100.0))
+            & ((ema_26 - ema_12) > (open_rate * 0.030))
+            & ((ema_26.shift() - ema_12.shift()) > (open_rate / 100.0))
           )
 
         # Condition #62 - Rebuy mode (Long).
@@ -19826,8 +19827,8 @@ class NostalgiaForInfinityX7(IStrategy):
             & (rsi_3 < 50.0)
             & (aroonu_14 < 25.0)
             & (ema_26 > ema_12)
-            & ((ema_26 - ema_12) > (df["open"] * 0.022))
-            & ((ema_26.shift() - ema_12.shift()) > (df["open"] / 100.0))
+            & ((ema_26 - ema_12) > (open_rate * 0.022))
+            & ((ema_26.shift() - ema_12.shift()) > (open_rate / 100.0))
           )
 
         # Condition #101 - Rapid mode (Long).
@@ -22001,8 +22002,8 @@ class NostalgiaForInfinityX7(IStrategy):
             (rsi_3 < 40.0)
             & (stochrsi_k < 20.0)
             & (ema_26 > ema_12)
-            & ((ema_26 - ema_12) > (df["open"] * 0.020))
-            & ((ema_26.shift() - ema_12.shift()) > (df["open"] / 100.0))
+            & ((ema_26 - ema_12) > (open_rate * 0.020))
+            & ((ema_26.shift() - ema_12.shift()) > (open_rate / 100.0))
           )
 
         # Condition #144 - Top Coins mode (Long).
@@ -22922,8 +22923,8 @@ class NostalgiaForInfinityX7(IStrategy):
             & (aroond_14 > 75.0)
             & (stochrsi_k < 30.0)
             & (ema_26 > ema_12)
-            & ((ema_26 - ema_12) > (df["open"] * 0.030))
-            & ((ema_26.shift() - ema_12.shift()) > (df["open"] / 100.0))
+            & ((ema_26 - ema_12) > (open_rate * 0.030))
+            & ((ema_26.shift() - ema_12.shift()) > (open_rate / 100.0))
             & (close < df["SMA_9"])
           )
 
@@ -23633,8 +23634,8 @@ class NostalgiaForInfinityX7(IStrategy):
 
           # Logic
           short_entry_logic.append(ema_12 > ema_26)
-          short_entry_logic.append((ema_12 - ema_26) > (df["open"] * 0.030))
-          short_entry_logic.append((ema_12.shift() - ema_26.shift()) > (df["open"] / 100.0))
+          short_entry_logic.append((ema_12 - ema_26) > (open_rate * 0.030))
+          short_entry_logic.append((ema_12.shift() - ema_26.shift()) > (open_rate / 100.0))
           short_entry_logic.append(close > (df["BBU_20_2.0"] * 1.004))
 
         # Condition #502 - Normal mode (Short).
@@ -24332,8 +24333,8 @@ class NostalgiaForInfinityX7(IStrategy):
           short_entry_logic.append(df["MFI_14"] > 60.0)
           short_entry_logic.append(aroond_14 < 25.0)
           short_entry_logic.append(ema_26 < ema_12)
-          short_entry_logic.append((ema_26 - ema_12) > (df["open"] * 0.024))
-          short_entry_logic.append((ema_26.shift() - ema_12.shift()) > (df["open"] / 100.0))
+          short_entry_logic.append((ema_26 - ema_12) > (open_rate * 0.024))
+          short_entry_logic.append((ema_26.shift() - ema_12.shift()) > (open_rate / 100.0))
           short_entry_logic.append(close < (ema_20 * 0.958))
           short_entry_logic.append(close < (df["BBL_20_2.0"] * 0.992))
 


### PR DESCRIPTION
## Summary
- Reuses the entry open-price Series across EMA gap checks in populate_entry_trend.
- Branch is independent on latest upstream main.

## Safety
- Only repeated DataFrame column lookup reuse is changed inside populate_entry_trend.
- Entry conditions, indicators, thresholds, condition order, signal tags, and return values are unchanged.
- No v3 grind-entry code is touched.

## Backtest scope
- A full backtest was not required for this plumbing patch because it only reuses the same df["open"] Series within the same entry-signal calculation; targeted diff review and static checks cover the risk.

## Checks
- `python3 ~/.codex/skills/nfi-upstream-pr/scripts/validate_nfi_pr.py --base origin/main`
- `git merge-tree conflict simulation against origin/main`
- `targeted git diff origin/main...HEAD -- NostalgiaForInfinityX7.py review`
- `git diff --check`
- `ruff format --check NostalgiaForInfinityX7.py`
- `ruff check NostalgiaForInfinityX7.py`
- `PYTHONDONTWRITEBYTECODE=1 python3 -m py_compile NostalgiaForInfinityX7.py`
