### PR TITLE
Reuse X7 entry oscillator series

### DIFF
--- a/NostalgiaForInfinityX7.py
+++ b/NostalgiaForInfinityX7.py
@@ -12600,6 +12600,10 @@ class NostalgiaForInfinityX7(IStrategy):
     close = df["close"]
     roc_9_15m = df["ROC_9_15m"]
     rsi_14_4h = df["RSI_14_4h"]
+    roc_2_1d = df["ROC_2_1d"]
+    uo_7_14_28_4h = df["UO_7_14_28_4h"]
+    willr_84_1h = df["WILLR_84_1h"]
+    mfi_14 = df["MFI_14"]
 
     # Reused entry Series and comparison masks
     aroond_14 = df["AROOND_14"]
@@ -17278,7 +17282,7 @@ class NostalgiaForInfinityX7(IStrategy):
           long_entry_logic.append(
             (willr_14 < -50.0)
             & (stochrsi_k < 20.0)
-            & (df["WILLR_84_1h"] < -70.0)
+            & (willr_84_1h < -70.0)
             & (stochrsi_k_1h < 20.0)
             & (bbb_20_2_0_1h > 16.0)
             & (close_max_48 >= (close * 1.10))
@@ -17790,7 +17794,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # Logic
           long_entry_logic.append(
             (rsi_14 < 40.0)
-            & (df["MFI_14"] < 40.0)
+            & (mfi_14 < 40.0)
             & (aroonu_14 < 25.0)
             & (ema_26 > ema_12)
             & ((ema_26 - ema_12) > (df["open"] * 0.024))
@@ -18633,7 +18637,7 @@ class NostalgiaForInfinityX7(IStrategy):
           long_entry_logic.append(df["WILLR_14_15m"] < -50.0)
           long_entry_logic.append(aroonu_14_15m < 25.0)
           long_entry_logic.append(stochrsi_k_15m < 20.0)
-          long_entry_logic.append(df["WILLR_84_1h"] < -70.0)
+          long_entry_logic.append(willr_84_1h < -70.0)
           long_entry_logic.append(stochrsi_k_1h < 20.0)
           long_entry_logic.append(bbb_20_2_0_1h > 12.0)
           long_entry_logic.append(close_max_48 >= (close * 1.10))
@@ -19324,7 +19328,7 @@ class NostalgiaForInfinityX7(IStrategy):
             & (aroonu_14 < 30.0)
             & (stochrsi_k < 20.0)
             & (stochrsi_k_15m < 70.0)
-            & (df["WILLR_84_1h"] < -70.0)
+            & (willr_84_1h < -70.0)
             & (stochrsi_k_1h < 30.0)
             & (bbb_20_2_0_1h > 12.0)
             & (close_max_48 >= (close * 1.10))
@@ -23519,7 +23523,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1h up move, 4h low
           short_entry_logic.append((rsi_3_1h_lt_95) | (stochrsi_k_4h_gt_30))
           # 1h & 4h up move, 4h still not high enough
-          short_entry_logic.append((rsi_3_1h_lt_95) | (rsi_3_4h_lt_95) | (df["UO_7_14_28_4h"] > 60.0))
+          short_entry_logic.append((rsi_3_1h_lt_95) | (rsi_3_4h_lt_95) | (uo_7_14_28_4h > 60.0))
           # 1h & 4h up move, 4h still low
           short_entry_logic.append((rsi_3_1h_lt_95) | (rsi_3_4h_lt_85) | (stochrsi_k_4h_gt_50))
           # 1h & 4h up move, 4h uptrend
@@ -23831,7 +23835,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 5m strong down move
           short_entry_logic.append((rsi_3 < 98.0) | (roc_9 < 50.0))
           # 5m down move, 4h still high
-          short_entry_logic.append((rsi_3_lt_90) | (df["MFI_14"] > 10.0) | (stochrsi_k_4h_gt_30))
+          short_entry_logic.append((rsi_3_lt_90) | (mfi_14 > 10.0) | (stochrsi_k_4h_gt_30))
           # 5m & 1h down move, 1h still high
           short_entry_logic.append((rsi_3_lt_90) | (rsi_3_1h_lt_90) | (stochrsi_k_1h_gt_70))
           # 5m down move, 4h downtrend, 1h still high
@@ -23895,7 +23899,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m strong down move
           short_entry_logic.append((rsi_3_15m_lt_90) | (mfi_14_15m < 85.0) | (aroond_14_15m < 25.0))
           # 14m down move, 4h still high
-          short_entry_logic.append((rsi_3_15m < 80.0) | (aroond_14_15m < 50.0) | (df["UO_7_14_28_4h"] > 50.0))
+          short_entry_logic.append((rsi_3_15m < 80.0) | (aroond_14_15m < 50.0) | (uo_7_14_28_4h > 50.0))
           # 15m down move, 1h stil high, 1d overbought
           short_entry_logic.append((rsi_3_15m_lt_85) | (aroond_14_1h < 25.0) | (roc_9_1d > -80.0))
           # 15m down move, 1h high, 1d overbought
@@ -23915,7 +23919,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1h down move, 4h still high, 1d downtrend
           short_entry_logic.append((rsi_3_change_pct_1h > -65.0) | (stochrsi_k_4h_gt_30) | roc_9_1d_lt_50)
           # 4h & 1d down move, 1h still high
-          short_entry_logic.append((rsi_3_4h_lt_90) | (df["ROC_2_1d"] < 20.0) | (stochrsi_k_1h_gt_50))
+          short_entry_logic.append((rsi_3_4h_lt_90) | (roc_2_1d < 20.0) | (stochrsi_k_1h_gt_50))
           # 15m still high, 1h down move, 4h high
           short_entry_logic.append((aroond_14_15m < 50.0) | (rsi_3_change_pct_1h < 50.0) | (stochrsi_k_4h_gt_30))
           # 15m still high, 1h & 4h down move, 4h still high
@@ -23927,15 +23931,15 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m still high, 1h down move, 1d downtrend
           short_entry_logic.append((stochrsi_k_15m > 30.0) | (rsi_3_4h_lt_90) | roc_9_1d_lt_50)
           # 1h & 4h still high, 1d strong down move
-          short_entry_logic.append((stochrsi_k_1h_gt_50) | (df["UO_7_14_28_4h"] > 55.0) | (rsi_3_1d < 90.0))
+          short_entry_logic.append((stochrsi_k_1h_gt_50) | (uo_7_14_28_4h > 55.0) | (rsi_3_1d < 90.0))
           # 1h still high, 4h & 1d downtrend
           short_entry_logic.append((aroond_14_1h < 25.0) | (roc_9_4h_lt_20) | roc_9_1d_lt_50)
           # 4h moving down, 1d P&D
           short_entry_logic.append((roc_9_4h < 30.0) | (df["RSI_3_change_pct_1d"] < 50.0) | roc_9_1d_gt_neg_50)
           # 1d strong downtrend, 4h still high
-          short_entry_logic.append((df["ROC_2_1d"] < 20.0) | roc_9_1d_lt_50 | (stochrsi_k_4h_gt_70))
+          short_entry_logic.append((roc_2_1d < 20.0) | roc_9_1d_lt_50 | (stochrsi_k_4h_gt_70))
           # 1d P&D, 1d overbought
-          short_entry_logic.append((df["ROC_2_1d"] < 10.0) | roc_9_1d_gt_neg_50 | (stochrsi_k_1h > 5.0))
+          short_entry_logic.append((roc_2_1d < 10.0) | roc_9_1d_gt_neg_50 | (stochrsi_k_1h > 5.0))
           # 1h red, previous 1h green, 1h overbought
           short_entry_logic.append(
             (change_pct_1h < 1.0) | (change_pct_1h.shift(12) > -5.0) | (rsi_14_1h.shift(12) < 80.0)
@@ -24066,7 +24070,7 @@ class NostalgiaForInfinityX7(IStrategy):
             (rsi_3_1h_lt_90) | (rsi_3_change_pct_4h < 50.0) | (aroond_14_4h < 25.0) | (stochrsi_k_1d > 60.0)
           )
           # 1h down move, 1h still high, 1d going down
-          short_entry_logic.append((rsi_3_1h_lt_85) | (stochrsi_k_1h_gt_50) | (df["ROC_2_1d"] > -50.0))
+          short_entry_logic.append((rsi_3_1h_lt_85) | (stochrsi_k_1h_gt_50) | (roc_2_1d > -50.0))
           # 4h downtrend, 4h still high, 1d strong downtrend
           short_entry_logic.append((rsi_3_4h_lt_85) | (stochrsi_k_4h_gt_70) | (roc_9_1d < 60.0))
           # 15m down move, 1h strong down move, 1d overbought
@@ -24087,7 +24091,7 @@ class NostalgiaForInfinityX7(IStrategy):
           short_entry_logic.append((roc_9_1h < 40.0) | (rsi_3_4h_lt_90) | roc_9_1d_lt_50)
           short_entry_logic.append((roc_9_4h > -200.0) | (rsi_14_4h > 20.0))
           # 4h down move, 1d P&D
-          short_entry_logic.append((roc_9_4h_lt_20) | (df["ROC_2_1d"] < 20.0) | roc_9_1d_gt_neg_50)
+          short_entry_logic.append((roc_9_4h_lt_20) | (roc_2_1d < 20.0) | roc_9_1d_gt_neg_50)
           # 1h P&D, 4h overbought
           short_entry_logic.append((change_pct_1h < 2.0) | (change_pct_1h.shift(12) > 2.0) | (rsi_14_4h > 20.0))
           # 1h P&D, 1d overbought
@@ -24251,7 +24255,7 @@ class NostalgiaForInfinityX7(IStrategy):
           short_entry_logic.append(aroonu_14 > 75.0)
           short_entry_logic.append(aroond_14 < 25.0)
           short_entry_logic.append(stochrsi_k > 80.0)
-          short_entry_logic.append(df["WILLR_84_1h"] > -30.0)
+          short_entry_logic.append(willr_84_1h > -30.0)
           short_entry_logic.append(stochrsi_k_1h > 80.0)
           short_entry_logic.append(bbb_20_2_0_1h > 20.0)
           short_entry_logic.append(df["close_min_48"] <= (close * 0.90))
@@ -24285,9 +24289,7 @@ class NostalgiaForInfinityX7(IStrategy):
             (rsi_3_15m_lt_95) | (rsi_3_1h_lt_80) | (stochrsi_k_4h_gt_70) | (aroond_14_4h < 50.0)
           )
           # 15m & 1h down move, 4h still high, 4h downtrend
-          short_entry_logic.append(
-            (rsi_3_15m_lt_95) | (rsi_3_1h_lt_90) | (df["UO_7_14_28_4h"] > 60.0) | (roc_9_4h_lt_20)
-          )
+          short_entry_logic.append((rsi_3_15m_lt_95) | (rsi_3_1h_lt_90) | (uo_7_14_28_4h > 60.0) | (roc_9_4h_lt_20))
           # 15m & 1h down move, 1d strong downtrend
           short_entry_logic.append((rsi_3_15m_lt_95) | (rsi_3_1h_lt_90) | roc_9_1d_lt_50)
           # 15m & 4h down move, 4h still not low enough
@@ -24329,7 +24331,7 @@ class NostalgiaForInfinityX7(IStrategy):
 
           # Logic
           short_entry_logic.append(rsi_14 > 60.0)
-          short_entry_logic.append(df["MFI_14"] > 60.0)
+          short_entry_logic.append(mfi_14 > 60.0)
           short_entry_logic.append(aroond_14 < 25.0)
           short_entry_logic.append(ema_26 < ema_12)
           short_entry_logic.append((ema_26 - ema_12) > (df["open"] * 0.024))


### PR DESCRIPTION
## Summary
- Reuses repeated oscillator Series lookups in populate_entry_trend.
- Branch is independent on latest upstream main.

## Safety
- Only repeated DataFrame column lookup reuse is changed for existing entry-signal conditions.
- Entry conditions, indicators, thresholds, condition order, signal tags, and return values are unchanged.
- No v3 grind-entry code is touched.

## Backtest scope
- A full backtest was not required for this plumbing patch because it only reuses the same DataFrame Series within the same entry-signal calculation; targeted diff review and static checks cover the risk.

## Checks
- `python3 ~/.codex/skills/nfi-upstream-pr/scripts/validate_nfi_pr.py --base origin/main`
- `git merge-tree conflict simulation against origin/main`
- `targeted git diff origin/main...HEAD -- NostalgiaForInfinityX7.py review`
- `git diff --check`
- `ruff format --check NostalgiaForInfinityX7.py`
- `ruff check NostalgiaForInfinityX7.py`
- `PYTHONDONTWRITEBYTECODE=1 python3 -m py_compile NostalgiaForInfinityX7.py`
