### PR TITLE
Reuse X7 short grind v2 order refs

### DIFF
--- a/NostalgiaForInfinityX7.py
+++ b/NostalgiaForInfinityX7.py
@@ -62523,10 +62523,15 @@ class NostalgiaForInfinityX7(IStrategy):
       profit_values = self.calc_total_profit(trade, filled_entries, filled_exits, exit_rate)
     profit_stake, profit_ratio, profit_current_stake_ratio, profit_init_ratio = profit_values
 
+    first_filled_order = filled_orders[0]
+    last_filled_order = filled_orders[-1]
+    first_filled_entry = filled_entries[0]
+    last_filled_entry = filled_entries[-1]
+
     current_stake_amount = trade_amount * exit_rate
-    slice_amount = filled_entries[0].cost
-    slice_profit = (exit_rate - filled_orders[-1].safe_price) / filled_orders[-1].safe_price
-    slice_profit_entry = (exit_rate - filled_entries[-1].safe_price) / filled_entries[-1].safe_price
+    slice_amount = first_filled_entry.cost
+    slice_profit = (exit_rate - last_filled_order.safe_price) / last_filled_order.safe_price
+    slice_profit_entry = (exit_rate - last_filled_entry.safe_price) / last_filled_entry.safe_price
     slice_profit_exit = (
       ((exit_rate - filled_exits[-1].safe_price) / filled_exits[-1].safe_price) if count_of_exits > 0 else 0.0
     )
@@ -62536,7 +62541,7 @@ class NostalgiaForInfinityX7(IStrategy):
       and all(c in (short_rebuy_mode_tags + short_grind_mode_tags) for c in enter_tags)
     )
 
-    has_order_tags = hasattr(filled_orders[0], "ft_order_tag")
+    has_order_tags = hasattr(first_filled_order, "ft_order_tag")
 
     fee_open_rate = trade_fee_open if self.custom_fee_open_rate is None else self.custom_fee_open_rate
     fee_close_rate = trade_fee_close if self.custom_fee_close_rate is None else self.custom_fee_close_rate
@@ -62769,7 +62774,7 @@ class NostalgiaForInfinityX7(IStrategy):
     grind_5_exit_order = None
     grind_5_exit_distance_ratio = 0.0
     for order in reversed(filled_orders):
-      if (order.ft_order_side == "sell") and (order is not filled_orders[0]):
+      if (order.ft_order_side == "sell") and (order is not first_filled_order):
         order_tag = ""
         if has_order_tags:
           if order.ft_order_tag is not None:
@@ -63004,11 +63009,11 @@ class NostalgiaForInfinityX7(IStrategy):
     )
 
     is_short_extra_checks_entry = (
-      (current_time - timedelta(minutes=5) > filled_entries[-1].order_filled_utc)
-      and ((current_time - timedelta(hours=2) > filled_orders[-1].order_filled_utc) or (slice_profit > 0.06))
+      (current_time - timedelta(minutes=5) > last_filled_entry.order_filled_utc)
+      and ((current_time - timedelta(hours=2) > last_filled_order.order_filled_utc) or (slice_profit > 0.06))
       and (
-        (current_stake_amount < (filled_entries[0].cost * 0.50))
-        or (current_time - timedelta(hours=6) > filled_orders[-1].order_filled_utc)
+        (current_stake_amount < (first_filled_entry.cost * 0.50))
+        or (current_time - timedelta(hours=6) > last_filled_order.order_filled_utc)
         or (slice_profit > 0.06)
       )
     )
@@ -63106,7 +63111,7 @@ class NostalgiaForInfinityX7(IStrategy):
     ):
       sell_amount = (
         (
-          filled_entries[0].safe_filled
+          first_filled_entry.safe_filled
           * (
             self.grinding_v2_derisk_level_1_stake_futures if is_futures else self.grinding_v2_derisk_level_1_stake_spot
           )
@@ -63193,7 +63198,7 @@ class NostalgiaForInfinityX7(IStrategy):
     ):
       sell_amount = (
         (
-          filled_entries[0].safe_filled
+          first_filled_entry.safe_filled
           * (
             self.grinding_v2_derisk_level_2_stake_futures if is_futures else self.grinding_v2_derisk_level_2_stake_spot
           )
@@ -63280,7 +63285,7 @@ class NostalgiaForInfinityX7(IStrategy):
     ):
       sell_amount = (
         (
-          filled_entries[0].safe_filled
+          first_filled_entry.safe_filled
           * (
             self.grinding_v2_derisk_level_3_stake_futures if is_futures else self.grinding_v2_derisk_level_3_stake_spot
           )


### PR DESCRIPTION
## Summary
- Reuses the first and latest filled order/entry references inside short_grind_adjust_trade_position_v2.
- Branch is independent on latest upstream main.

## Safety
- Only repeated list indexing for already-read filled order and entry objects is changed.
- Order classification, profit arithmetic, stake sizing, thresholds, condition order, return values, and exit-list handling are unchanged.
- Touched active runtime function: short_grind_adjust_trade_position_v2.
- No v3 grind-entry code is touched.

## Backtest scope
- Full backtesting was not required because this patch only reuses the same filled order and entry objects after the existing snapshot call. Order classification, profit arithmetic, stake sizing, thresholds, and return values are unchanged; targeted diff review and static checks cover the risk.

## Checks
- `python3 ~/.codex/skills/nfi-upstream-pr/scripts/validate_nfi_pr.py --base origin/main`
- `AST undefined-local scan for local-read aliases via validate_nfi_pr.py`
- `git merge-tree conflict simulation against origin/main`
- `targeted git diff origin/main...HEAD -- NostalgiaForInfinityX7.py review`
- `git diff --check`
- `ruff format --check NostalgiaForInfinityX7.py`
- `ruff check NostalgiaForInfinityX7.py`
- `PYTHONDONTWRITEBYTECODE=1 python3 -m py_compile NostalgiaForInfinityX7.py`
