### PR TITLE
Reuse X7 protection RSI series

### DIFF
--- a/NostalgiaForInfinityX7.py
+++ b/NostalgiaForInfinityX7.py
@@ -4491,7 +4491,8 @@ class NostalgiaForInfinityX7(IStrategy):
     # df["WILLR_480_1h"] = df["WILLR_480_1h"].astype(np.float64).replace(to_replace=[np.nan, None], value=(-50.0))
     # df["WILLR_480_4h"] = df["WILLR_480_4h"].astype(np.float64).replace(to_replace=[np.nan, None], value=(-50.0))
     # df["RSI_14_1d"] = df["RSI_14_1d"].astype(np.float64).replace(to_replace=[np.nan, None], value=(50.0))
-    df["RSI_14_1h"] = df["RSI_14_1h"].fillna(50.0)
+    rsi_14_1h = df["RSI_14_1h"].fillna(50.0)
+    df["RSI_14_1h"] = rsi_14_1h
 
     tok_before_protections = time.perf_counter()
 
@@ -4500,7 +4501,7 @@ class NostalgiaForInfinityX7(IStrategy):
     protection_rsi_3_1h = df["RSI_3_1h"].to_numpy(copy=False)
     protection_rsi_3_4h = df["RSI_3_4h"].to_numpy(copy=False)
     protection_rsi_3_1d = df["RSI_3_1d"].to_numpy(copy=False)
-    protection_rsi_14_1h = df["RSI_14_1h"].to_numpy(copy=False)
+    protection_rsi_14_1h = rsi_14_1h.to_numpy(copy=False)
     protection_rsi_14_4h = df["RSI_14_4h"].to_numpy(copy=False)
     protection_rsi_14_1d = df["RSI_14_1d"].to_numpy(copy=False)
     protection_cci_20_1h = df["CCI_20_1h"].to_numpy(copy=False)


### PR DESCRIPTION
## Summary
- Reuses the filled RSI_14_1h Series for the protection numpy view in populate_indicators.
- Branch is independent on latest upstream main.

## Safety
- The RSI_14_1h fillna value assignment is unchanged; the same filled Series is reused for to_numpy(copy=False).
- Indicator formulas, candle selection, thresholds, condition order, trading conditions, and return values are unchanged.
- Touched function: populate_indicators.
- No v3 grind-entry code is touched.

## Backtest scope
- Full backtesting was not required because this patch does not change indicator formulas or values; it only reuses the same filled RSI_14_1h Series already assigned to the dataframe before creating the protection numpy view.

## Checks
- `python3 ~/.codex/skills/nfi-upstream-pr/scripts/validate_nfi_pr.py --base origin/main`
- `AST undefined-local scan via validate_nfi_pr.py`
- `git merge-tree conflict simulation against origin/main`
- `targeted git diff origin/main...HEAD -- NostalgiaForInfinityX7.py review`
- `git diff --check`
- `ruff format --check NostalgiaForInfinityX7.py`
- `ruff check NostalgiaForInfinityX7.py`
- `PYTHONDONTWRITEBYTECODE=1 python3 -m py_compile NostalgiaForInfinityX7.py`
