### PR TITLE
Reuse X7 long rebuy v3 pair label

### DIFF
--- a/NostalgiaForInfinityX7.py
+++ b/NostalgiaForInfinityX7.py
@@ -47694,7 +47694,7 @@ class NostalgiaForInfinityX7(IStrategy):
           )
         )
         log.info(
-          f"Rebuy (r) [{current_time}] [{trade.pair}] | Rate: {current_rate} | Stake amount: {buy_amount} | Profit (stake): {profit_stake} | Profit: {(profit_ratio * 100.0):.2f}%"
+          f"Rebuy (r) [{current_time}] [{trade_pair}] | Rate: {current_rate} | Stake amount: {buy_amount} | Profit (stake): {profit_stake} | Profit: {(profit_ratio * 100.0):.2f}%"
         )
         if has_order_tags:
           return buy_amount, "r"
@@ -47715,14 +47715,14 @@ class NostalgiaForInfinityX7(IStrategy):
         grind_profit = 0.0
         dp.send_msg(
           f"❌​​ ​**Rebuy De-risk:** `Level 3`\n"
-          f"🪙​ **Pair:** `{trade.pair}`\n"
+          f"🪙​ **Pair:** `{trade_pair}`\n"
           f"〽️​ **Rate:** `{exit_rate}`\n"
           f"💰 **Stake amount:** `{sell_amount}`\n"
           f"💵​ **Profit (stake):** `{profit_stake}`\n"
           f"💸 **Profit (percent):** `{(profit_ratio * 100.0):.2f}%`"
         )
         log.info(
-          f"Rebuy De-risk Level 3 [{current_time}] [{trade.pair}] | Rate: {exit_rate} | Stake amount: {sell_amount} | Profit (stake): {profit_stake} | Profit: {(profit_ratio * 100.0):.2f}%"
+          f"Rebuy De-risk Level 3 [{current_time}] [{trade_pair}] | Rate: {exit_rate} | Stake amount: {sell_amount} | Profit (stake): {profit_stake} | Profit: {(profit_ratio * 100.0):.2f}%"
         )
         if has_order_tags:
           return -ft_sell_amount, "derisk_level_3"


### PR DESCRIPTION
## Summary
- Reuses the existing trade_pair label in long_rebuy_adjust_trade_position_v3 logs and messages.
- Branch is independent on latest upstream main.

## Safety
- Only repeated trade.pair reads are replaced with the already-bound trade_pair local.
- Trading conditions, profit arithmetic, stake sizing, thresholds, order handling, return values, and message contents are unchanged.
- Touched active runtime function: long_rebuy_adjust_trade_position_v3.
- No v3 grind-entry code is touched.

## Backtest scope
- Full backtesting was not required because this patch only reuses the existing trade_pair string in log and notification formatting. Trading conditions, arithmetic, stake sizing, order handling, and return values are unchanged.

## Checks
- `python3 ~/.codex/skills/nfi-upstream-pr/scripts/validate_nfi_pr.py --base origin/main`
- `AST undefined-local scan via validate_nfi_pr.py`
- `git merge-tree conflict simulation against origin/main`
- `targeted git diff origin/main...HEAD -- NostalgiaForInfinityX7.py review`
- `git diff --check`
- `ruff format --check NostalgiaForInfinityX7.py`
- `ruff check NostalgiaForInfinityX7.py`
- `PYTHONDONTWRITEBYTECODE=1 python3 -m py_compile NostalgiaForInfinityX7.py`
