### PR TITLE
Reuse X7 short rebuy v3 pair label

### DIFF
--- a/NostalgiaForInfinityX7.py
+++ b/NostalgiaForInfinityX7.py
@@ -70411,7 +70411,7 @@ class NostalgiaForInfinityX7(IStrategy):
           )
         )
         log.info(
-          f"Rebuy (r) [{current_time}] [{trade.pair}] | Rate: {current_rate} | Stake amount: {buy_amount} | Profit (stake): {profit_stake} | Profit: {(profit_ratio * 100.0):.2f}%"
+          f"Rebuy (r) [{current_time}] [{trade_pair}] | Rate: {current_rate} | Stake amount: {buy_amount} | Profit (stake): {profit_stake} | Profit: {(profit_ratio * 100.0):.2f}%"
         )
         if has_order_tags:
           return buy_amount, "r"


### PR DESCRIPTION
## Summary
- Reuses the existing trade_pair label in short_rebuy_adjust_trade_position_v3 logging.
- Branch is independent on latest upstream main.

## Safety
- Only a repeated trade.pair read is replaced with the already-bound trade_pair local.
- Trading conditions, indicator values, candle selection, profit arithmetic, stake sizing, order handling, thresholds, return values, and message contents are unchanged.
- Touched active runtime function: short_rebuy_adjust_trade_position_v3.
- No v3 grind-entry code is touched.

## Backtest scope
- Full backtesting was not required because this patch only reuses the existing trade_pair string in log formatting. Trading conditions, arithmetic, stake sizing, order handling, and return values are unchanged.

## Checks
- `python3 ~/.codex/skills/nfi-upstream-pr/scripts/validate_nfi_pr.py --base origin/main`
- `git merge-tree conflict simulation against origin/main`
- `targeted git diff origin/main...HEAD -- NostalgiaForInfinityX7.py review`
- `git diff --check origin/main...HEAD`
- `ruff format --check NostalgiaForInfinityX7.py`
- `ruff check NostalgiaForInfinityX7.py`
- `PYTHONDONTWRITEBYTECODE=1 python3 -m py_compile NostalgiaForInfinityX7.py`
