### PR TITLE
Reuse X7 confirm-entry side flags

### DIFF
--- a/NostalgiaForInfinityX7.py
+++ b/NostalgiaForInfinityX7.py
@@ -12170,6 +12170,8 @@ class NostalgiaForInfinityX7(IStrategy):
 
     # Mode Validation
     entry_tags = entry_tag.split()
+    is_long_side = side == "long"
+    is_short_side = side == "short"
     long_grind_mode_tags = self.long_grind_mode_tags
     long_top_coins_mode_tags = self.long_top_coins_mode_tags
     long_scalp_mode_tags = self.long_scalp_mode_tags
@@ -12183,9 +12185,9 @@ class NostalgiaForInfinityX7(IStrategy):
     # Long/Short Slot Validation (only in futures mode)
     if self.is_futures_mode:
       max_side_trades = 0
-      if side == "long":
+      if is_long_side:
         max_side_trades = self.futures_max_open_trades_long
-      elif side == "short":
+      elif is_short_side:
         max_side_trades = self.futures_max_open_trades_short
 
       if max_side_trades != 0:
@@ -12204,9 +12206,9 @@ class NostalgiaForInfinityX7(IStrategy):
     if len(df) >= 1:
       last_candle = df.iloc[-1]
       last_close = last_candle["close"]
-      if (side == "long" and rate > last_close) or (side == "short" and rate < last_close):
+      if (is_long_side and rate > last_close) or (is_short_side and rate < last_close):
         slippage = (rate / last_close) - 1.0
-        if (side == "long" and slippage < max_slippage) or (side == "short" and slippage > -max_slippage):
+        if (is_long_side and slippage < max_slippage) or (is_short_side and slippage > -max_slippage):
           return True
         else:
           log.warning(f"[{current_time}] Cancelling entry for {pair} due to slippage {(slippage * 100.0):.2f}%")


### PR DESCRIPTION
## Summary
- Reuses confirm_trade_entry side checks for futures slot and slippage validation.
- Branch is independent on latest upstream main.

## Safety
- Only repeated side == 'long' / side == 'short' comparisons are replaced with local booleans inside the same call.
- Entry mode validation, futures slot counts, candle selection, slippage arithmetic, thresholds, log text, and return values are unchanged.
- Touched active runtime function: confirm_trade_entry.
- No v3 grind-entry code is touched.

## Backtest scope
- Full backtesting was not required because this patch only reuses already-evaluated side flags inside confirm_trade_entry. Entry conditions, slippage math, slot counting, candle reads, and return values are unchanged.

## Checks
- `python3 ~/.codex/skills/nfi-upstream-pr/scripts/validate_nfi_pr.py --base origin/main`
- `git merge-tree conflict simulation against origin/main`
- `targeted git diff origin/main...HEAD -- NostalgiaForInfinityX7.py review`
- `git diff --check origin/main...HEAD`
- `ruff format --check NostalgiaForInfinityX7.py`
- `ruff check NostalgiaForInfinityX7.py`
- `PYTHONDONTWRITEBYTECODE=1 python3 -m py_compile NostalgiaForInfinityX7.py`
