### PR TITLE
Reuse X7 grind runmode value

### DIFF
--- a/NostalgiaForInfinityX7.py
+++ b/NostalgiaForInfinityX7.py
@@ -43757,7 +43757,8 @@ class NostalgiaForInfinityX7(IStrategy):
     trade_fee_open = trade.fee_open
     trade_fee_close = trade.fee_close
 
-    is_backtest = dp.runmode.value in ["backtest", "hyperopt"]
+    runmode_value = dp.runmode.value
+    is_backtest = runmode_value in ["backtest", "hyperopt"]
     trade_open_date = None if is_backtest else trade.open_date_utc.replace(tzinfo=None)
     # we already waiting for an order to get filled
     if trade.has_open_orders:
@@ -43792,7 +43793,7 @@ class NostalgiaForInfinityX7(IStrategy):
 
     has_order_tags = hasattr(filled_orders[0], "ft_order_tag")
 
-    if dp.runmode.value in ("live", "dry_run"):
+    if runmode_value in ("live", "dry_run"):
       ticker = dp.ticker(trade_pair)
       if ("bid" in ticker) and ("ask" in ticker):
         exit_price_side = self.config["exit_pricing"]["price_side"]
@@ -66564,7 +66565,8 @@ class NostalgiaForInfinityX7(IStrategy):
     trade_fee_open = trade.fee_open
     trade_fee_close = trade.fee_close
 
-    is_backtest = dp.runmode.value in ["backtest", "hyperopt"]
+    runmode_value = dp.runmode.value
+    is_backtest = runmode_value in ["backtest", "hyperopt"]
     trade_open_date = None if is_backtest else trade.open_date_utc.replace(tzinfo=None)
     # we already waiting for an order to get filled
     if trade.has_open_orders:
@@ -66599,7 +66601,7 @@ class NostalgiaForInfinityX7(IStrategy):
 
     has_order_tags = hasattr(filled_orders[0], "ft_order_tag")
 
-    if dp.runmode.value in ("live", "dry_run"):
+    if runmode_value in ("live", "dry_run"):
       ticker = dp.ticker(trade_pair)
       if ("bid" in ticker) and ("ask" in ticker):
         exit_price_side = self.config["exit_pricing"]["price_side"]


### PR DESCRIPTION
## Summary
- Reuses the runmode value in long and short grind adjust paths.
- Branch is independent on latest upstream main.

## Safety
- Only repeated dp.runmode.value reads are replaced with a local runmode_value inside each function.
- Backtest/hyperopt detection, live/dry_run price-side handling, candle selection, order classification, profit arithmetic, stake sizing, thresholds, order handling, and return values are unchanged.
- Touched active runtime functions: long_grind_adjust_trade_position and short_grind_adjust_trade_position.
- No v3 grind-entry code is touched.

## Backtest scope
- Full backtesting was not required because this patch only reuses the existing runmode value inside the same grind adjust call. Trading conditions, arithmetic, stake sizing, order handling, candle reads, and return values are unchanged.

## Checks
- `python3 ~/.codex/skills/nfi-upstream-pr/scripts/validate_nfi_pr.py --base origin/main`
- `git merge-tree conflict simulation against origin/main`
- `targeted git diff origin/main...HEAD -- NostalgiaForInfinityX7.py review`
- `git diff --check origin/main...HEAD`
- `ruff format --check NostalgiaForInfinityX7.py`
- `ruff check NostalgiaForInfinityX7.py`
- `PYTHONDONTWRITEBYTECODE=1 python3 -m py_compile NostalgiaForInfinityX7.py`
