### PR TITLE
Hoist X7 long dec low-profit thresholds

### DIFF
--- a/NostalgiaForInfinityX7.py
+++ b/NostalgiaForInfinityX7.py
@@ -28590,9 +28590,56 @@ class NostalgiaForInfinityX7(IStrategy):
     last_rsi_3_4h_lt_30 = last_rsi_3_4h < 30.0
 
     if 0.01 > current_profit >= 0.001:
+      # Reused long exit decision threshold checks for this profit bracket
+      last_rsi_3_gt_95 = last_rsi_3 > 95.0
+      last_rsi_3_gt_99 = last_rsi_3 > 99.0
+      last_rsi_3_gt_98 = last_rsi_3 > 98.0
+      last_rsi_14_lt_46 = last_rsi_14 < 46.0
+      last_rsi_3_4h_lt_20 = last_rsi_3_4h < 20.0
+      last_rsi_3_1h_lt_20 = last_rsi_3_1h < 20.0
+      last_rsi_3_4h_lt_10 = last_rsi_3_4h < 10.0
+      last_rsi_14_lt_44 = last_rsi_14 < 44.0
+      last_rsi_14_gt_78 = last_rsi_14 > 78.0
+      last_rsi_3_gt_90 = last_rsi_3 > 90.0
+      last_rsi_3_1h_lt_15 = last_rsi_3_1h < 15.0
+      last_rsi_3_1h_lt_50 = last_rsi_3_1h < 50.0
+      last_rsi_3_1h_lt_10 = last_rsi_3_1h < 10.0
+      last_rsi_3_1h_lt_25 = last_rsi_3_1h < 25.0
+      last_rsi_3_4h_lt_40 = last_rsi_3_4h < 40.0
+      last_rsi_3_4h_lt_25 = last_rsi_3_4h < 25.0
+      last_rsi_14_lt_40 = last_rsi_14 < 40.0
+      last_rsi_3_1d_lt_25 = last_rsi_3_1d < 25.0
+      last_aroonu_14_4h_gt_50 = last_aroonu_14_4h > 50.0
+      last_rsi_3_1h_lt_60 = last_rsi_3_1h < 60.0
+      last_stochrsi_k_4h_gt_30 = last_stochrsi_k_4h > 30.0
+      last_stochrsi_k_4h_gt_40 = last_stochrsi_k_4h > 40.0
+      last_rsi_14_lt_42 = last_rsi_14 < 42.0
+      last_stochrsi_k_4h_gt_20 = last_stochrsi_k_4h > 20.0
+      last_stochrsi_k_4h_gt_90 = last_stochrsi_k_4h > 90.0
+      last_rsi_3_4h_lt_15 = last_rsi_3_4h < 15.0
+      last_stochrsi_k_1h_gt_70 = last_stochrsi_k_1h > 70.0
+      last_rsi_3_gt_84 = last_rsi_3 > 84.0
+      last_rsi_3_gt_96 = last_rsi_3 > 96.0
+      last_stochrsi_k_1h_gt_80 = last_stochrsi_k_1h > 80.0
+      last_rsi_14_lt_48 = last_rsi_14 < 48.0
+      last_stochrsi_k_1h_gt_40 = last_stochrsi_k_1h > 40.0
+      last_aroonu_14_1h_gt_75 = last_aroonu_14_1h > 75.0
+      last_rsi_3_4h_lt_60 = last_rsi_3_4h < 60.0
+      last_stochrsi_k_gt_95 = last_stochrsi_k > 95.0
+      last_aroonu_14_4h_gt_25 = last_aroonu_14_4h > 25.0
+      last_aroonu_14_4h_gt_75 = last_aroonu_14_4h > 75.0
+      last_stochrsi_k_1h_gt_30 = last_stochrsi_k_1h > 30.0
+      last_stochrsi_k_4h_gt_25 = last_stochrsi_k_4h > 25.0
+      last_rsi_14_lt_38 = last_rsi_14 < 38.0
+      last_rsi_3_1h_lt_40 = last_rsi_3_1h < 40.0
+      last_rsi_3_1h_lt_45 = last_rsi_3_1h < 45.0
+      last_rsi_3_1h_lt_35 = last_rsi_3_1h < 35.0
+      last_rsi_3_gt_92 = last_rsi_3 > 92.0
+      last_rsi_14_4h_gt_70 = last_rsi_14_4h > 70.0
+      last_rsi_3_1d_lt_30 = last_rsi_3_1d < 30.0
       if (
         (last_willr_14 > -1.0)
-        and (last_rsi_14 > 78.0)
+        and (last_rsi_14_gt_78)
         and (isinstance(last_ema_200_1h, np.float64) and (last_ema_12_1h < last_ema_200_1h))
         and (isinstance(last_ema_200_4h, np.float64) and (last_ema_12_4h < last_ema_200_4h))
         and (last_kst_1h < last_ksts_9_1h)
@@ -28601,7 +28648,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_0_1"
       elif (
         (last_willr_14 > -1.0)
-        and (last_rsi_14 > 78.0)
+        and (last_rsi_14_gt_78)
         and (last_cmf_20_1h < -0.0)
         and (isinstance(last_ema_200_1h, np.float64) and (last_ema_12_1h < last_ema_200_1h))
         and (isinstance(last_ema_200_4h, np.float64) and (last_ema_12_4h < last_ema_200_4h))
@@ -28612,31 +28659,31 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_stochrsi_k > 99.0)
         and (last_cmf_20_1h < -0.0)
         and (last_cmf_20_4h < -0.0)
-        and ((last_stochrsi_k_4h > 20.0) and (last_stochrsi_k_change_pct_4h < -10.0))
+        and ((last_stochrsi_k_4h_gt_20) and (last_stochrsi_k_change_pct_4h < -10.0))
       ):
         return True, f"exit_{mode_name}_d_0_3"
       elif (
         (last_willr_14 > -1.0)
-        and (last_rsi_14 > 78.0)
-        and (last_stochrsi_k > 95.0)
+        and (last_rsi_14_gt_78)
+        and (last_stochrsi_k_gt_95)
         and (last_stochrsi_k_4h > 70.0)
         and (isinstance(last_ema_200_1h, np.float64) and (last_ema_12_1h < last_ema_200_1h))
         and (isinstance(last_ema_200_4h, np.float64) and (last_ema_12_4h < last_ema_200_4h))
       ):
         return True, f"exit_{mode_name}_d_0_4"
-      elif (last_willr_14 > -1.0) and (last_rsi_14 > 78.0) and (last_roc_9_1h < -5.0) and (last_roc_9_4h < -5.0):
+      elif (last_willr_14 > -1.0) and (last_rsi_14_gt_78) and (last_roc_9_1h < -5.0) and (last_roc_9_4h < -5.0):
         return True, f"exit_{mode_name}_d_0_5"
       elif (
-        (last_rsi_3 > 95.0)
-        and (last_stochrsi_k > 95.0)
-        and (last_rsi_14 < 40.0)
+        (last_rsi_3_gt_95)
+        and (last_stochrsi_k_gt_95)
+        and (last_rsi_14_lt_40)
         and (last_roc_9_1h < -10.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 50.0))
       ):
         return True, f"exit_{mode_name}_d_0_6"
       elif (
         (last_rsi_14_lt_50)
-        and (last_stochrsi_k > 95.0)
+        and (last_stochrsi_k_gt_95)
         and (last_stochrsi_k_4h_gt_50)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -40.0))
       ):
@@ -28652,7 +28699,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_0_8"
       elif (
         (last_willr_14 > -1.0)
-        and (last_rsi_3 > 99.0)
+        and (last_rsi_3_gt_99)
         and (last_change_pct_4h < -5.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
       ):
@@ -28666,7 +28713,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_0_10"
       elif (
-        (last_rsi_3 > 95.0)
+        (last_rsi_3_gt_95)
         and (last_rsi_14 < 45.0)
         and (last_roc_9_15m < -10.0)
         and (last_roc_9_1h < -10.0)
@@ -28674,108 +28721,108 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_0_11"
       elif (
-        (last_rsi_3 > 95.0)
+        (last_rsi_3_gt_95)
         and (last_rsi_14_lt_50)
-        and (last_rsi_3_4h < 10.0)
+        and (last_rsi_3_4h_lt_10)
         and (last_roc_9_1h < -20.0)
         and (last_roc_9_4h < -20.0)
       ):
         return True, f"exit_{mode_name}_d_0_12"
-      elif (last_rsi_3 > 99.0) and (last_rsi_3_4h < 5.0) and (last_roc_9_4h < -25.0):
+      elif (last_rsi_3_gt_99) and (last_rsi_3_4h < 5.0) and (last_roc_9_4h < -25.0):
         return True, f"exit_{mode_name}_d_0_13"
-      elif (last_rsi_3 > 99.0) and (last_willr_14 > -1.0) and (last_rsi_3_4h < 5.0) and (last_aroonu_14_4h > 25.0):
+      elif (last_rsi_3_gt_99) and (last_willr_14 > -1.0) and (last_rsi_3_4h < 5.0) and (last_aroonu_14_4h_gt_25):
         return True, f"exit_{mode_name}_d_0_14"
-      elif (last_rsi_3 > 99.0) and (last_rsi_14 > 78.0) and (last_roc_9_4h < -30.0):
+      elif (last_rsi_3_gt_99) and (last_rsi_14_gt_78) and (last_roc_9_4h < -30.0):
         return True, f"exit_{mode_name}_d_0_15"
       elif (
-        (last_rsi_3 > 99.0)
-        and (last_aroonu_14_4h > 25.0)
+        (last_rsi_3_gt_99)
+        and (last_aroonu_14_4h_gt_25)
         and (last_roc_9_4h < -25.0)
         and (last_aroonu_14_1d > 50.0)
         and (last_change_pct_1d < -15.0)
       ):
         return True, f"exit_{mode_name}_d_0_16"
       elif (
-        (last_rsi_3 > 99.0)
+        (last_rsi_3_gt_99)
         and (last_willr_14 > -1.0)
-        and (last_rsi_3_1h < 10.0)
-        and (last_stochrsi_k_4h > 90.0)
+        and (last_rsi_3_1h_lt_10)
+        and (last_stochrsi_k_4h_gt_90)
         and (last_roc_9_4h > 30.0)
       ):
         return True, f"exit_{mode_name}_d_0_17"
-      elif (last_rsi_3 > 95.0) and (last_rsi_14 > 75.0) and (last_rsi_3_4h < 20.0) and (last_roc_2_1d < -50.0):
+      elif (last_rsi_3_gt_95) and (last_rsi_14 > 75.0) and (last_rsi_3_4h_lt_20) and (last_roc_2_1d < -50.0):
         return True, f"exit_{mode_name}_d_0_18"
       elif (
-        (last_rsi_3 > 99.0)
-        and (last_rsi_14 > 78.0)
-        and (last_rsi_3_4h < 10.0)
+        (last_rsi_3_gt_99)
+        and (last_rsi_14_gt_78)
+        and (last_rsi_3_4h_lt_10)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d > 70.0))
       ):
         return True, f"exit_{mode_name}_d_0_19"
-      elif (last_rsi_3 > 90.0) and (last_rsi_14 < 40.0) and (last_rsi_3_1h < 10.0) and (last_aroonu_14_1h > 25.0):
+      elif (last_rsi_3_gt_90) and (last_rsi_14_lt_40) and (last_rsi_3_1h_lt_10) and (last_aroonu_14_1h > 25.0):
         return True, f"exit_{mode_name}_d_0_20"
-      elif (last_rsi_3 > 95.0) and (last_rsi_14 < 40.0) and (last_rsi_3_1h < 20.0) and (last_stochrsi_k_4h > 90.0):
+      elif (last_rsi_3_gt_95) and (last_rsi_14_lt_40) and (last_rsi_3_1h_lt_20) and (last_stochrsi_k_4h_gt_90):
         return True, f"exit_{mode_name}_d_0_21"
       elif (
-        (last_rsi_3 > 99.0)
+        (last_rsi_3_gt_99)
         and (last_willr_14 > -1.0)
         and (last_change_pct_4h < -5.0)
         and (last_stochrsi_k_4h_gt_50)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
       ):
         return True, f"exit_{mode_name}_d_0_22"
-      elif (last_rsi_3 > 98.0) and (last_willr_14 > -5.0) and (last_rsi_3_1h < 15.0) and (last_rsi_3_1d < 5.0):
+      elif (last_rsi_3_gt_98) and (last_willr_14 > -5.0) and (last_rsi_3_1h_lt_15) and (last_rsi_3_1d < 5.0):
         return True, f"exit_{mode_name}_d_0_23"
       elif (
-        (last_rsi_3 > 99.0)
-        and (last_rsi_14 > 78.0)
+        (last_rsi_3_gt_99)
+        and (last_rsi_14_gt_78)
         and (last_willr_14 > -5.0)
         and (last_rsi_3_4h_lt_30)
-        and (last_aroonu_14_4h > 75.0)
+        and (last_aroonu_14_4h_gt_75)
       ):
         return True, f"exit_{mode_name}_d_0_24"
       elif (
-        (last_rsi_3 > 95.0)
+        (last_rsi_3_gt_95)
         and (last_willr_14 > -2.0)
-        and (last_rsi_3_4h < 10.0)
+        and (last_rsi_3_4h_lt_10)
         and (last_roc_9_4h < -15.0)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d > 50.0))
       ):
         return True, f"exit_{mode_name}_d_0_25"
-      elif (last_rsi_3 > 95.0) and (last_willr_14 > -1.0) and (last_rsi_3_4h < 15.0) and (last_roc_9_4h < -20.0):
+      elif (last_rsi_3_gt_95) and (last_willr_14 > -1.0) and (last_rsi_3_4h_lt_15) and (last_roc_9_4h < -20.0):
         return True, f"exit_{mode_name}_d_0_26"
       elif (
-        (last_rsi_3 > 95.0)
+        (last_rsi_3_gt_95)
         and (last_rsi_14_lt_50)
-        and (last_rsi_3_1h < 20.0)
-        and (last_rsi_3_4h < 20.0)
-        and (last_stochrsi_k_4h > 20.0)
+        and (last_rsi_3_1h_lt_20)
+        and (last_rsi_3_4h_lt_20)
+        and (last_stochrsi_k_4h_gt_20)
       ):
         return True, f"exit_{mode_name}_d_0_27"
-      elif (last_rsi_3 > 95.0) and (last_rsi_14_lt_50) and (last_rsi_3_15m < 10.0) and (last_roc_9_4h > 50.0):
+      elif (last_rsi_3_gt_95) and (last_rsi_14_lt_50) and (last_rsi_3_15m < 10.0) and (last_roc_9_4h > 50.0):
         return True, f"exit_{mode_name}_d_0_28"
       elif (
-        (last_rsi_3 > 95.0)
+        (last_rsi_3_gt_95)
         and (last_rsi_14_lt_50)
-        and (last_rsi_3_1h < 20.0)
-        and (last_rsi_3_4h < 20.0)
-        and (last_stochrsi_k_1h > 30.0)
+        and (last_rsi_3_1h_lt_20)
+        and (last_rsi_3_4h_lt_20)
+        and (last_stochrsi_k_1h_gt_30)
       ):
         return True, f"exit_{mode_name}_d_0_29"
-      elif (last_rsi_3 > 99.0) and (last_rsi_3_1h < 25.0) and (last_rsi_3_4h < 10.0) and (last_stochrsi_k_1h > 70.0):
+      elif (last_rsi_3_gt_99) and (last_rsi_3_1h_lt_25) and (last_rsi_3_4h_lt_10) and (last_stochrsi_k_1h_gt_70):
         return True, f"exit_{mode_name}_d_0_30"
       elif (
-        (last_rsi_3 > 95.0)
+        (last_rsi_3_gt_95)
         and (last_rsi_14_lt_50)
-        and (last_rsi_3_1h < 15.0)
-        and (last_rsi_3_4h < 15.0)
+        and (last_rsi_3_1h_lt_15)
+        and (last_rsi_3_4h_lt_15)
         and (last_stochrsi_k_1h > 25.0)
       ):
         return True, f"exit_{mode_name}_d_0_31"
-      elif (last_rsi_3 > 95.0) and (last_rsi_3_1h < 15.0) and (last_roc_2_4h < -30.0) and (last_stochrsi_k_4h > 30.0):
+      elif (last_rsi_3_gt_95) and (last_rsi_3_1h_lt_15) and (last_roc_2_4h < -30.0) and (last_stochrsi_k_4h_gt_30):
         return True, f"exit_{mode_name}_d_0_32"
       elif (
-        (last_rsi_3 > 95.0)
+        (last_rsi_3_gt_95)
         and (last_willr_14 > -1.0)
         and (last_roc_2_1h < -10.0)
         and (last_roc_9_1h > 30.0)
@@ -28784,127 +28831,127 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_0_33"
       elif (last_rsi_3 > 65.0) and (last_rsi_3_15m < 30.0) and (last_rsi_14_1h > 80.0) and (last_roc_9_1h > 40.0):
         return True, f"exit_{mode_name}_d_0_34"
-      elif (last_rsi_3 > 95.0) and (last_willr_14 > -5.0) and (last_rsi_3_1d < 25.0) and (last_stochrsi_k_1h > 75.0):
+      elif (last_rsi_3_gt_95) and (last_willr_14 > -5.0) and (last_rsi_3_1d_lt_25) and (last_stochrsi_k_1h > 75.0):
         return True, f"exit_{mode_name}_d_0_35"
       elif (
-        (last_rsi_3 > 95.0)
+        (last_rsi_3_gt_95)
         and (last_willr_14 > -1.0)
         and (last_roc_9_4h < -25.0)
-        and (last_rsi_3_1d < 25.0)
+        and (last_rsi_3_1d_lt_25)
         and (last_stochrsi_k_1h_gt_50)
       ):
         return True, f"exit_{mode_name}_d_0_36"
       elif (
-        (last_rsi_3 > 84.0)
+        (last_rsi_3_gt_84)
         and (last_rsi_14_lt_50)
-        and (last_rsi_3_1h < 20.0)
-        and (last_rsi_3_1d < 25.0)
+        and (last_rsi_3_1h_lt_20)
+        and (last_rsi_3_1d_lt_25)
         and (last_stochrsi_k_4h_gt_50)
       ):
         return True, f"exit_{mode_name}_d_0_37"
-      elif (last_rsi_3 > 90.0) and (last_willr_14 > -10.0) and (last_rsi_3_4h < 10.0) and (last_stochrsi_k_4h > 20.0):
+      elif (last_rsi_3_gt_90) and (last_willr_14 > -10.0) and (last_rsi_3_4h_lt_10) and (last_stochrsi_k_4h_gt_20):
         return True, f"exit_{mode_name}_d_0_38"
-      elif (last_rsi_3 > 99.0) and (last_willr_14 > -1.0) and (last_cmf_20_4h < -0.0) and (last_rsi_3_4h < 10.0):
+      elif (last_rsi_3_gt_99) and (last_willr_14 > -1.0) and (last_cmf_20_4h < -0.0) and (last_rsi_3_4h_lt_10):
         return True, f"exit_{mode_name}_d_0_39"
       elif (
-        (last_rsi_3 > 98.0)
+        (last_rsi_3_gt_98)
         and (last_willr_14 > -2.0)
         and (last_rsi_3_1h_lt_30)
-        and (last_stochrsi_k_1h > 30.0)
+        and (last_stochrsi_k_1h_gt_30)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d > 90.0))
       ):
         return True, f"exit_{mode_name}_d_0_40"
       elif (
-        (last_rsi_3 > 98.0)
+        (last_rsi_3_gt_98)
         and (last_willr_14 > -5.0)
         and (last_rsi_3_1h_lt_30)
-        and (last_stochrsi_k_4h > 25.0)
+        and (last_stochrsi_k_4h_gt_25)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 50.0))
       ):
         return True, f"exit_{mode_name}_d_0_41"
       elif (
-        (last_rsi_3 > 95.0)
+        (last_rsi_3_gt_95)
         and (last_willr_14 > -2.0)
-        and (last_stochrsi_k_4h > 30.0)
+        and (last_stochrsi_k_4h_gt_30)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 40.0))
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d > 70.0))
       ):
         return True, f"exit_{mode_name}_d_0_42"
       elif (
-        (last_rsi_3 > 95.0)
+        (last_rsi_3_gt_95)
         and (last_rsi_14_lt_50)
-        and (last_rsi_3_1h < 15.0)
-        and (last_rsi_3_4h < 40.0)
+        and (last_rsi_3_1h_lt_15)
+        and (last_rsi_3_4h_lt_40)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d > 90.0))
       ):
         return True, f"exit_{mode_name}_d_0_43"
       elif (
-        (last_rsi_3 > 90.0)
+        (last_rsi_3_gt_90)
         and (last_willr_14 > -2.0)
         and (last_rsi_3_4h_lt_30)
-        and (last_rsi_3_1d < 25.0)
+        and (last_rsi_3_1d_lt_25)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
       ):
         return True, f"exit_{mode_name}_d_0_44"
-      elif (last_rsi_3 > 96.0) and (last_willr_14 > -4.0) and (last_rsi_3_1h < 10.0):
+      elif (last_rsi_3_gt_96) and (last_willr_14 > -4.0) and (last_rsi_3_1h_lt_10):
         return True, f"exit_{mode_name}_d_0_45"
-      elif (last_rsi_3 > 98.0) and (last_rsi_3_1h < 15.0) and (last_rsi_3_4h < 10.0) and (last_roc_2_1d < -20.0):
+      elif (last_rsi_3_gt_98) and (last_rsi_3_1h_lt_15) and (last_rsi_3_4h_lt_10) and (last_roc_2_1d < -20.0):
         return True, f"exit_{mode_name}_d_0_46"
       elif (
-        (last_rsi_3 > 98.0)
-        and (last_stochrsi_k_1h > 80.0)
-        and (last_stochrsi_k_4h > 40.0)
+        (last_rsi_3_gt_98)
+        and (last_stochrsi_k_1h_gt_80)
+        and (last_stochrsi_k_4h_gt_40)
         and (last_change_pct_1d < -5.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -5.0))
       ):
         return True, f"exit_{mode_name}_d_0_47"
       elif (
         (last_rsi_3 > 70.0)
-        and (last_rsi_14 < 42.0)
+        and (last_rsi_14_lt_42)
         and (last_rsi_3_1h_lt_30)
-        and (last_rsi_3_4h < 20.0)
+        and (last_rsi_3_4h_lt_20)
         and (last_stochrsi_k_1h_gt_50)
       ):
         return True, f"exit_{mode_name}_d_0_48"
       elif (
-        (last_rsi_3 > 95.0)
+        (last_rsi_3_gt_95)
         and (last_willr_14 > -2.0)
-        and (last_rsi_3_4h < 20.0)
+        and (last_rsi_3_4h_lt_20)
         and (last_change_pct_1d < -5.0)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d > 50.0))
       ):
         return True, f"exit_{mode_name}_d_0_49"
       elif (last_rsi_3 > 80.0) and (last_willr_14 > -2.0) and (last_rsi_3_1d < 10.0) and (last_stochrsi_k_1h > 90.0):
         return True, f"exit_{mode_name}_d_0_50"
-      elif (last_rsi_3 > 68.0) and (last_rsi_14 < 44.0) and (last_rsi_3_4h < 20.0) and (last_stochrsi_k_1h_gt_50):
+      elif (last_rsi_3 > 68.0) and (last_rsi_14_lt_44) and (last_rsi_3_4h_lt_20) and (last_stochrsi_k_1h_gt_50):
         return True, f"exit_{mode_name}_d_0_51"
       elif (
-        (last_rsi_3 > 95.0)
+        (last_rsi_3_gt_95)
         and (last_rsi_14 > 62.0)
         and (last_willr_14 > -10.0)
-        and (last_stochrsi_k_1h > 70.0)
+        and (last_stochrsi_k_1h_gt_70)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -15.0))
       ):
         return True, f"exit_{mode_name}_d_0_52"
       elif (
-        (last_rsi_3 > 95.0)
+        (last_rsi_3_gt_95)
         and (last_rsi_14_lt_50)
         and (last_willr_14 > -5.0)
-        and (last_rsi_3_1h < 20.0)
+        and (last_rsi_3_1h_lt_20)
         and (last_stochrsi_k_4h_gt_50)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d > 50.0))
       ):
         return True, f"exit_{mode_name}_d_0_53"
       elif (
         (last_rsi_3 > 80.0)
-        and (last_rsi_14 < 44.0)
+        and (last_rsi_14_lt_44)
         and (last_stochrsi_k_1h_gt_50)
         and (last_roc_9_4h < -10.0)
         and (last_change_pct_1d < -10.0)
       ):
         return True, f"exit_{mode_name}_d_0_54"
       elif (
-        (last_rsi_3 > 98.0)
+        (last_rsi_3_gt_98)
         and (last_willr_14 > -12.0)
         and (last_roc_9_4h < -5.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 10.0))
@@ -28912,10 +28959,10 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_0_55"
       elif (
-        (last_rsi_3 > 95.0)
+        (last_rsi_3_gt_95)
         and (last_rsi_14_lt_50)
         and (last_rsi_3_1h_lt_30)
-        and (last_rsi_3_4h < 25.0)
+        and (last_rsi_3_4h_lt_25)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
         and (last_stochrsi_k_4h > 10.0)
       ):
@@ -28928,7 +28975,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_0_57"
       elif (
-        (last_rsi_3 > 95.0)
+        (last_rsi_3_gt_95)
         and (last_rsi_3_1h_lt_30)
         and (last_rsi_3_4h_lt_30)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -15.0))
@@ -28936,158 +28983,156 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_0_58"
       elif (
-        (last_rsi_3 > 95.0)
+        (last_rsi_3_gt_95)
         and (last_willr_14 > -10.0)
-        and (last_rsi_3_4h < 25.0)
+        and (last_rsi_3_4h_lt_25)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -15.0))
-        and (last_stochrsi_k_4h > 40.0)
+        and (last_stochrsi_k_4h_gt_40)
       ):
         return True, f"exit_{mode_name}_d_0_59"
       elif (
-        (last_rsi_3 > 95.0)
-        and (last_rsi_14 < 38.0)
+        (last_rsi_3_gt_95)
+        and (last_rsi_14_lt_38)
         and (last_rsi_14_4h > 65.0)
         and (last_stochrsi_k_4h_gt_50)
         and (last_stochrsi_k_1d > 50.0)
       ):
         return True, f"exit_{mode_name}_d_0_60"
-      elif (last_rsi_3 > 98.0) and (last_willr_14 > -25.0) and (last_rsi_3_4h < 10.0) and (last_stochrsi_k_1h > 30.0):
+      elif (last_rsi_3_gt_98) and (last_willr_14 > -25.0) and (last_rsi_3_4h_lt_10) and (last_stochrsi_k_1h_gt_30):
         return True, f"exit_{mode_name}_d_0_61"
       elif (
         (last_rsi_3 > 88.0)
         and (last_willr_14 > -1.0)
         and (last_rsi_3_1h_lt_30)
-        and (last_rsi_3_4h < 20.0)
+        and (last_rsi_3_4h_lt_20)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 20.0))
         and (last_change_pct_1d < -5.0)
       ):
         return True, f"exit_{mode_name}_d_0_62"
-      elif (
-        (last_rsi_3 > 98.0) and (last_rsi_3_1d < 25.0) and (last_stochrsi_k_1h > 80.0) and (last_stochrsi_k_4h > 30.0)
-      ):
+      elif (last_rsi_3_gt_98) and (last_rsi_3_1d_lt_25) and (last_stochrsi_k_1h_gt_80) and (last_stochrsi_k_4h_gt_30):
         return True, f"exit_{mode_name}_d_0_63"
       elif (
-        (last_rsi_3 > 98.0)
+        (last_rsi_3_gt_98)
         and (last_rsi_3_1h_lt_30)
         and (last_rsi_3_4h_lt_30)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
       ):
         return True, f"exit_{mode_name}_d_0_64"
-      elif (last_rsi_3 > 90.0) and (last_rsi_14 < 40.0) and (last_rsi_3_1h < 20.0) and (last_rsi_3_4h < 15.0):
+      elif (last_rsi_3_gt_90) and (last_rsi_14_lt_40) and (last_rsi_3_1h_lt_20) and (last_rsi_3_4h_lt_15):
         return True, f"exit_{mode_name}_d_0_65"
-      elif (last_rsi_3 > 84.0) and (last_rsi_14 < 46.0) and (last_rsi_3_1h < 20.0) and (last_stochrsi_k_1h_gt_50):
+      elif (last_rsi_3_gt_84) and (last_rsi_14_lt_46) and (last_rsi_3_1h_lt_20) and (last_stochrsi_k_1h_gt_50):
         return True, f"exit_{mode_name}_d_0_66"
       elif (
         (last_rsi_3 > 50.0)
-        and (last_rsi_14 < 40.0)
+        and (last_rsi_14_lt_40)
         and (last_stochrsi_k_4h > 80.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -25.0))
       ):
         return True, f"exit_{mode_name}_d_0_67"
       elif (
         (last_rsi_3 > 86.0)
-        and (last_rsi_14 < 46.0)
-        and (last_rsi_3_1h < 25.0)
+        and (last_rsi_14_lt_46)
+        and (last_rsi_3_1h_lt_25)
         and (last_roc_2_4h < -30.0)
-        and (last_stochrsi_k_4h > 25.0)
+        and (last_stochrsi_k_4h_gt_25)
       ):
         return True, f"exit_{mode_name}_d_0_68"
       elif (
         (last_rsi_3 > 97.0) and (last_roc_9_4h > 20.0) and (last_stochrsi_k_4h_gt_50) and (last_change_pct_4h < -5.0)
       ):
         return True, f"exit_{mode_name}_d_0_69"
-      elif (last_rsi_3 > 95.0) and (last_rsi_14 < 38.0) and (last_rsi_3_1h < 25.0) and (last_stochrsi_k_4h > 20.0):
+      elif (last_rsi_3_gt_95) and (last_rsi_14_lt_38) and (last_rsi_3_1h_lt_25) and (last_stochrsi_k_4h_gt_20):
         return True, f"exit_{mode_name}_d_0_70"
-      elif (last_rsi_3 > 95.0) and (last_rsi_14 < 42.0) and (last_rsi_3_4h < 25.0) and (last_stochrsi_k_1h > 20.0):
+      elif (last_rsi_3_gt_95) and (last_rsi_14_lt_42) and (last_rsi_3_4h_lt_25) and (last_stochrsi_k_1h > 20.0):
         return True, f"exit_{mode_name}_d_0_71"
-      elif (last_rsi_3 > 95.0) and (last_rsi_14 < 40.0) and (last_rsi_3_1h < 10.0) and (last_aroonu_14_4h > 25.0):
+      elif (last_rsi_3_gt_95) and (last_rsi_14_lt_40) and (last_rsi_3_1h_lt_10) and (last_aroonu_14_4h_gt_25):
         return True, f"exit_{mode_name}_d_0_72"
       elif (
-        (last_rsi_3 > 95.0)
-        and (last_rsi_3_1h < 25.0)
-        and (last_rsi_3_4h < 15.0)
+        (last_rsi_3_gt_95)
+        and (last_rsi_3_1h_lt_25)
+        and (last_rsi_3_4h_lt_15)
         and (last_roc_9_4h < -20.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -25.0))
       ):
         return True, f"exit_{mode_name}_d_0_73"
       elif (
-        (last_rsi_3 > 99.0)
+        (last_rsi_3_gt_99)
         and (last_willr_14 > -10.0)
-        and (last_rsi_3_4h < 25.0)
-        and (last_rsi_3_1d < 25.0)
+        and (last_rsi_3_4h_lt_25)
+        and (last_rsi_3_1d_lt_25)
         and (last_stochrsi_k_1h_gt_50)
       ):
         return True, f"exit_{mode_name}_d_0_74"
       elif (
-        (last_rsi_3 > 98.0)
+        (last_rsi_3_gt_98)
         and (last_rsi_3_1h_lt_30)
-        and (last_rsi_3_4h < 20.0)
+        and (last_rsi_3_4h_lt_20)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d > 50.0))
       ):
         return True, f"exit_{mode_name}_d_0_75"
-      elif (last_rsi_3 > 95.0) and (last_rsi_14 < 48.0) and (last_roc_9_1h > 80.0) and (last_stochrsi_k_4h > 80.0):
+      elif (last_rsi_3_gt_95) and (last_rsi_14_lt_48) and (last_roc_9_1h > 80.0) and (last_stochrsi_k_4h > 80.0):
         return True, f"exit_{mode_name}_d_0_76"
       elif (
-        (last_rsi_3 > 95.0)
-        and (last_rsi_14 < 44.0)
+        (last_rsi_3_gt_95)
+        and (last_rsi_14_lt_44)
         and (last_rsi_3_1h_lt_30)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 50.0))
       ):
         return True, f"exit_{mode_name}_d_0_77"
       elif (
-        (last_rsi_3 > 98.0)
+        (last_rsi_3_gt_98)
         and (last_willr_14 > -14.0)
         and (last_rsi_3_1h_lt_30)
-        and (last_rsi_3_4h < 20.0)
+        and (last_rsi_3_4h_lt_20)
         and (last_rsi_3_1d < 20.0)
       ):
         return True, f"exit_{mode_name}_d_0_78"
-      elif (last_rsi_3 > 94.0) and (last_willr_14 > -1.0) and (last_rsi_3_1h_lt_30) and (last_rsi_3_4h < 10.0):
+      elif (last_rsi_3 > 94.0) and (last_willr_14 > -1.0) and (last_rsi_3_1h_lt_30) and (last_rsi_3_4h_lt_10):
         return True, f"exit_{mode_name}_d_0_79"
       elif (
         (last_rsi_3 > 74.0)
-        and (last_rsi_14 < 44.0)
+        and (last_rsi_14_lt_44)
         and (last_rsi_3_1h_lt_30)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 50.0))
-        and (last_stochrsi_k_4h > 25.0)
+        and (last_stochrsi_k_4h_gt_25)
       ):
         return True, f"exit_{mode_name}_d_0_80"
       elif (
-        (last_rsi_3 > 96.0)
+        (last_rsi_3_gt_96)
         and (last_willr_14 > -8.0)
-        and (last_rsi_3_1h < 25.0)
-        and (last_rsi_3_4h < 25.0)
+        and (last_rsi_3_1h_lt_25)
+        and (last_rsi_3_4h_lt_25)
         and (isinstance(last_rsi_14_1d, np.float64) and (last_rsi_14_1d > 50.0))
       ):
         return True, f"exit_{mode_name}_d_0_81"
       elif (
-        (last_rsi_3 > 84.0)
+        (last_rsi_3_gt_84)
         and (last_willr_14 > -8.0)
         and (last_rsi_3_4h_lt_30)
         and (last_rsi_3_1d < 15.0)
-        and (last_stochrsi_k_4h > 40.0)
+        and (last_stochrsi_k_4h_gt_40)
       ):
         return True, f"exit_{mode_name}_d_0_82"
       elif (
-        (last_rsi_3 > 95.0)
-        and (last_rsi_14 < 44.0)
-        and (last_rsi_3_1h < 40.0)
+        (last_rsi_3_gt_95)
+        and (last_rsi_14_lt_44)
+        and (last_rsi_3_1h_lt_40)
         and (last_stochrsi_k_1h_gt_50)
-        and (last_stochrsi_k_4h > 40.0)
+        and (last_stochrsi_k_4h_gt_40)
       ):
         return True, f"exit_{mode_name}_d_0_83"
-      elif (last_rsi_3 > 99.0) and (last_willr_14 > -1.0) and (last_rsi_3_4h_lt_30) and (last_stochrsi_k_1h > 20.0):
+      elif (last_rsi_3_gt_99) and (last_willr_14 > -1.0) and (last_rsi_3_4h_lt_30) and (last_stochrsi_k_1h > 20.0):
         return True, f"exit_{mode_name}_d_0_84"
       elif (
-        (last_rsi_3 > 99.0)
+        (last_rsi_3_gt_99)
         and (last_willr_14 > -6.0)
         and (last_rsi_3_1h_lt_30)
-        and (last_rsi_3_4h < 40.0)
+        and (last_rsi_3_4h_lt_40)
         and (last_stochrsi_k_4h_gt_50)
       ):
         return True, f"exit_{mode_name}_d_0_85"
       elif (
-        (last_rsi_3 > 96.0)
+        (last_rsi_3_gt_96)
         and (last_rsi_14_4h > 80.0)
         and (last_roc_2_1h < -5.0)
         and (last_roc_9_1h > 5.0)
@@ -29095,24 +29140,24 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_0_86"
       elif (
-        (last_rsi_3 > 95.0)
-        and (last_rsi_14 < 42.0)
-        and (last_rsi_3_1h < 45.0)
+        (last_rsi_3_gt_95)
+        and (last_rsi_14_lt_42)
+        and (last_rsi_3_1h_lt_45)
         and (last_rsi_3_4h < 50.0)
         and (last_stochrsi_k_4h_gt_50)
       ):
         return True, f"exit_{mode_name}_d_0_87"
       elif (
-        (last_rsi_3 > 95.0)
+        (last_rsi_3_gt_95)
         and (last_willr_14 > -2.0)
-        and (last_stochrsi_k_1h > 40.0)
+        and (last_stochrsi_k_1h_gt_40)
         and (last_stochrsi_k_4h_gt_50)
         and (last_change_pct_1h < -2.0)
       ):
         return True, f"exit_{mode_name}_d_0_88"
       elif (
-        (last_rsi_3 > 90.0)
-        and (last_rsi_14 < 38.0)
+        (last_rsi_3_gt_90)
+        and (last_rsi_14_lt_38)
         and (last_roc_9_1h < -5.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 25.0))
       ):
@@ -29120,284 +29165,282 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 94.0)
         and (last_willr_14 > -25.0)
-        and (last_rsi_3_1h < 50.0)
+        and (last_rsi_3_1h_lt_50)
         and (last_rsi_3_4h_lt_30)
-        and (last_aroonu_14_4h > 50.0)
+        and (last_aroonu_14_4h_gt_50)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 40.0))
       ):
         return True, f"exit_{mode_name}_d_0_90"
       elif (
-        (last_rsi_3 > 90.0)
-        and (last_rsi_14 < 44.0)
-        and (last_rsi_3_1h < 25.0)
-        and (last_rsi_3_4h < 25.0)
-        and (last_aroonu_14_4h > 50.0)
+        (last_rsi_3_gt_90)
+        and (last_rsi_14_lt_44)
+        and (last_rsi_3_1h_lt_25)
+        and (last_rsi_3_4h_lt_25)
+        and (last_aroonu_14_4h_gt_50)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d > 50.0))
       ):
         return True, f"exit_{mode_name}_d_0_91"
       elif (
-        (last_rsi_3 > 95.0)
-        and (last_rsi_14 < 46.0)
-        and (last_rsi_3_1h < 40.0)
+        (last_rsi_3_gt_95)
+        and (last_rsi_14_lt_46)
+        and (last_rsi_3_1h_lt_40)
         and (last_stochrsi_k_1h > 25.0)
         and (last_stochrsi_k_4h_gt_50)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -25.0))
       ):
         return True, f"exit_{mode_name}_d_0_92"
       elif (
-        (last_rsi_3 > 90.0)
-        and (last_rsi_14 < 48.0)
+        (last_rsi_3_gt_90)
+        and (last_rsi_14_lt_48)
         and (last_rsi_3_15m < 50.0)
-        and (last_aroonu_14_1h > 75.0)
-        and (last_stochrsi_k_1h > 70.0)
-        and (last_aroonu_14_4h > 50.0)
+        and (last_aroonu_14_1h_gt_75)
+        and (last_stochrsi_k_1h_gt_70)
+        and (last_aroonu_14_4h_gt_50)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d > 90.0))
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
       ):
         return True, f"exit_{mode_name}_d_0_93"
       elif (
-        (last_rsi_3 > 95.0)
-        and (last_rsi_14 < 48.0)
-        and (last_rsi_3_1h < 25.0)
+        (last_rsi_3_gt_95)
+        and (last_rsi_14_lt_48)
+        and (last_rsi_3_1h_lt_25)
         and (last_rsi_3_4h < 45.0)
-        and (last_aroonu_14_1h > 75.0)
+        and (last_aroonu_14_1h_gt_75)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d > 90.0))
       ):
         return True, f"exit_{mode_name}_d_0_94"
       elif (
-        (last_rsi_3 > 95.0)
+        (last_rsi_3_gt_95)
         and (last_willr_14 > -10.0)
-        and (last_rsi_3_1h < 45.0)
-        and (last_rsi_3_4h < 40.0)
+        and (last_rsi_3_1h_lt_45)
+        and (last_rsi_3_4h_lt_40)
         and (last_stochrsi_k_4h > 10.0)
         and (isinstance(last_aroonu_14_1d, np.float64) and (last_aroonu_14_1d > 75.0))
       ):
         return True, f"exit_{mode_name}_d_0_95"
       elif (
-        (last_rsi_3 > 90.0)
-        and (last_rsi_14 < 44.0)
-        and (last_rsi_3_1h < 45.0)
+        (last_rsi_3_gt_90)
+        and (last_rsi_14_lt_44)
+        and (last_rsi_3_1h_lt_45)
         and (last_rsi_3_1d < 45.0)
         and (last_stochrsi_k_1h_gt_50)
       ):
         return True, f"exit_{mode_name}_d_0_96"
       elif (
-        (last_rsi_3 > 84.0)
-        and (last_rsi_14 < 44.0)
-        and (last_rsi_3_1h < 35.0)
-        and (last_aroonu_14_4h > 50.0)
-        and (last_stochrsi_k_4h > 30.0)
+        (last_rsi_3_gt_84)
+        and (last_rsi_14_lt_44)
+        and (last_rsi_3_1h_lt_35)
+        and (last_aroonu_14_4h_gt_50)
+        and (last_stochrsi_k_4h_gt_30)
       ):
         return True, f"exit_{mode_name}_d_0_97"
       elif (
-        (last_rsi_3 > 92.0)
+        (last_rsi_3_gt_92)
         and (last_rsi_3_15m > 74.0)
-        and (last_rsi_3_1h < 60.0)
-        and (last_rsi_3_4h < 60.0)
+        and (last_rsi_3_1h_lt_60)
+        and (last_rsi_3_4h_lt_60)
         and (last_rsi_3_1d > 80.0)
         and (last_stochrsi_k_4h_gt_50)
       ):
         return True, f"exit_{mode_name}_d_0_98"
       elif (
-        (last_rsi_3 > 95.0)
+        (last_rsi_3_gt_95)
         and (last_rsi_14_lt_50)
         and (last_rsi_3_1h < 65.0)
-        and (last_rsi_3_4h < 60.0)
-        and (last_aroonu_14_4h > 50.0)
+        and (last_rsi_3_4h_lt_60)
+        and (last_aroonu_14_4h_gt_50)
         and (last_stoch_k_4h > 40.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 80.0))
       ):
         return True, f"exit_{mode_name}_d_0_99"
-      elif (last_rsi_3 > 99.0) and (last_rsi_14 > 78.0) and (last_rsi_3_15m > 70.0) and (last_rsi_3_4h < 80.0):
+      elif (last_rsi_3_gt_99) and (last_rsi_14_gt_78) and (last_rsi_3_15m > 70.0) and (last_rsi_3_4h < 80.0):
         return True, f"exit_{mode_name}_d_0_100"
       elif (
         (last_rsi_3 > 86.0)
         and (last_willr_14 > -14.0)
-        and (last_rsi_3_1h < 50.0)
-        and (last_stochrsi_k_4h > 40.0)
+        and (last_rsi_3_1h_lt_50)
+        and (last_stochrsi_k_4h_gt_40)
         and (isinstance(last_roc_9_4h, np.float64) and (last_roc_9_4h > 40.0))
       ):
         return True, f"exit_{mode_name}_d_0_101"
       elif (
-        (last_rsi_3 > 95.0)
-        and (last_rsi_14 < 46.0)
-        and (last_rsi_3_1h < 60.0)
-        and (last_rsi_3_4h < 40.0)
-        and (last_stochrsi_k_4h > 30.0)
+        (last_rsi_3_gt_95)
+        and (last_rsi_14_lt_46)
+        and (last_rsi_3_1h_lt_60)
+        and (last_rsi_3_4h_lt_40)
+        and (last_stochrsi_k_4h_gt_30)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 40.0))
       ):
         return True, f"exit_{mode_name}_d_0_102"
       elif (
-        (last_rsi_3 > 95.0)
+        (last_rsi_3_gt_95)
         and (last_rsi_14 < 54.0)
-        and (last_rsi_3_1h < 60.0)
-        and (last_rsi_14_4h > 70.0)
+        and (last_rsi_3_1h_lt_60)
+        and (last_rsi_14_4h_gt_70)
         and (isinstance(last_roc_9_4h, np.float64) and (last_roc_9_4h > 80.0))
       ):
         return True, f"exit_{mode_name}_d_0_103"
       elif (
-        (last_rsi_3 > 95.0)
-        and (last_rsi_14 < 46.0)
-        and (last_rsi_3_1h < 60.0)
-        and (last_stochrsi_k_1h > 40.0)
-        and (last_stochrsi_k_4h > 90.0)
+        (last_rsi_3_gt_95)
+        and (last_rsi_14_lt_46)
+        and (last_rsi_3_1h_lt_60)
+        and (last_stochrsi_k_1h_gt_40)
+        and (last_stochrsi_k_4h_gt_90)
         and (last_roc_9_4h > 40.0)
       ):
         return True, f"exit_{mode_name}_d_0_104"
       elif (
-        (last_rsi_3 > 95.0)
-        and (last_rsi_14 < 46.0)
+        (last_rsi_3_gt_95)
+        and (last_rsi_14_lt_46)
         and (last_rsi_3_15m < 55.0)
-        and (last_stochrsi_k_4h > 90.0)
+        and (last_stochrsi_k_4h_gt_90)
         and (last_roc_9_4h > 25.0)
       ):
         return True, f"exit_{mode_name}_d_0_105"
       elif (
-        (last_rsi_3 > 95.0)
-        and (last_rsi_14 < 46.0)
-        and (last_rsi_3_1h < 50.0)
+        (last_rsi_3_gt_95)
+        and (last_rsi_14_lt_46)
+        and (last_rsi_3_1h_lt_50)
         and (last_stochrsi_k_1h_gt_50)
-        and (last_rsi_14_4h > 70.0)
+        and (last_rsi_14_4h_gt_70)
         and (last_roc_9_4h > 40.0)
       ):
         return True, f"exit_{mode_name}_d_0_106"
       elif (
-        (last_rsi_3 > 95.0)
-        and (last_rsi_14 < 46.0)
-        and (last_rsi_3_1h < 50.0)
-        and (last_stochrsi_k_1h > 70.0)
+        (last_rsi_3_gt_95)
+        and (last_rsi_14_lt_46)
+        and (last_rsi_3_1h_lt_50)
+        and (last_stochrsi_k_1h_gt_70)
         and (last_rsi_14_4h > 50.0)
       ):
         return True, f"exit_{mode_name}_d_0_107"
-      elif (last_rsi_3 > 95.0) and (last_rsi_14 < 46.0) and (last_rsi_3_1h < 60.0) and (last_stochrsi_k_1h > 80.0):
+      elif (last_rsi_3_gt_95) and (last_rsi_14_lt_46) and (last_rsi_3_1h_lt_60) and (last_stochrsi_k_1h_gt_80):
         return True, f"exit_{mode_name}_d_0_108"
       elif (
-        (last_rsi_3 > 95.0)
+        (last_rsi_3_gt_95)
         and (last_willr_14 > -6.0)
-        and (last_rsi_3_1h < 50.0)
-        and (last_rsi_3_4h < 20.0)
+        and (last_rsi_3_1h_lt_50)
+        and (last_rsi_3_4h_lt_20)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 50.0))
       ):
         return True, f"exit_{mode_name}_d_0_109"
-      elif (last_rsi_3 > 95.0) and (last_rsi_3_4h < 65.0) and (last_stochrsi_k_4h_gt_50) and (last_roc_9_4h > 25.0):
+      elif (last_rsi_3_gt_95) and (last_rsi_3_4h < 65.0) and (last_stochrsi_k_4h_gt_50) and (last_roc_9_4h > 25.0):
         return True, f"exit_{mode_name}_d_0_110"
       elif (
-        (last_rsi_3 > 95.0)
-        and (last_rsi_14 < 42.0)
-        and (last_rsi_3_1h < 50.0)
-        and (last_rsi_14_4h > 70.0)
-        and (last_aroonu_14_1h > 75.0)
-        and (last_aroonu_14_4h > 75.0)
+        (last_rsi_3_gt_95)
+        and (last_rsi_14_lt_42)
+        and (last_rsi_3_1h_lt_50)
+        and (last_rsi_14_4h_gt_70)
+        and (last_aroonu_14_1h_gt_75)
+        and (last_aroonu_14_4h_gt_75)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 20.0))
       ):
         return True, f"exit_{mode_name}_d_0_111"
       elif (
-        (last_rsi_3 > 95.0)
+        (last_rsi_3_gt_95)
         and (last_willr_14 > -20.0)
         and (last_rsi_14_lt_50)
-        and (last_rsi_3_1h < 35.0)
+        and (last_rsi_3_1h_lt_35)
         and (last_rsi_3_4h < 35.0)
         and (last_rsi_3_1d < 60.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
       ):
         return True, f"exit_{mode_name}_d_0_112"
       elif (
-        (last_rsi_3 > 95.0)
+        (last_rsi_3_gt_95)
         and (last_willr_14 > -1.0)
-        and (last_rsi_3_1d < 30.0)
+        and (last_rsi_3_1d_lt_30)
         and (last_stochrsi_k_4h_gt_50)
         and (isinstance(last_roc_9_4h, np.float64) and (last_roc_9_4h > 10.0))
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -10.0))
       ):
         return True, f"exit_{mode_name}_d_0_113"
       elif (
-        (last_rsi_3 > 95.0)
-        and (last_rsi_14 < 48.0)
-        and (last_rsi_3_1h < 20.0)
+        (last_rsi_3_gt_95)
+        and (last_rsi_14_lt_48)
+        and (last_rsi_3_1h_lt_20)
         and (last_rsi_3_4h_lt_30)
-        and (last_rsi_3_1d < 30.0)
+        and (last_rsi_3_1d_lt_30)
       ):
         return True, f"exit_{mode_name}_d_0_114"
       elif (
-        (last_rsi_3 > 95.0)
-        and (last_rsi_14 < 46.0)
+        (last_rsi_3_gt_95)
+        and (last_rsi_14_lt_46)
         and (last_rsi_3_15m < 30.0)
         and (last_stochrsi_k_1h_gt_50)
         and (last_stochrsi_k_4h_gt_50)
       ):
         return True, f"exit_{mode_name}_d_0_115"
-      elif (last_rsi_3 > 92.0) and (last_rsi_3_1h < 15.0) and (last_rsi_3_4h < 40.0) and (last_aroonu_14_4h > 50.0):
+      elif (last_rsi_3_gt_92) and (last_rsi_3_1h_lt_15) and (last_rsi_3_4h_lt_40) and (last_aroonu_14_4h_gt_50):
         return True, f"exit_{mode_name}_d_0_116"
-      elif (
-        (last_rsi_3 > 95.0) and (last_rsi_3_1h < 50.0) and (last_aroonu_14_1h > 80.0) and (last_aroonu_14_4h > 80.0)
-      ):
+      elif (last_rsi_3_gt_95) and (last_rsi_3_1h_lt_50) and (last_aroonu_14_1h > 80.0) and (last_aroonu_14_4h > 80.0):
         return True, f"exit_{mode_name}_d_0_117"
-      elif (last_rsi_3 > 92.0) and (last_rsi_3_1h < 20.0) and (last_rsi_3_4h < 60.0) and (last_aroonu_14_4h > 40.0):
+      elif (last_rsi_3_gt_92) and (last_rsi_3_1h_lt_20) and (last_rsi_3_4h_lt_60) and (last_aroonu_14_4h > 40.0):
         return True, f"exit_{mode_name}_d_0_118"
       elif (
-        (last_rsi_3 > 95.0)
+        (last_rsi_3_gt_95)
         and (last_willr_14 > -20.0)
-        and (last_rsi_3_1h < 60.0)
-        and (last_rsi_3_4h < 60.0)
-        and (last_stochrsi_k_1h > 40.0)
+        and (last_rsi_3_1h_lt_60)
+        and (last_rsi_3_4h_lt_60)
+        and (last_stochrsi_k_1h_gt_40)
       ):
         return True, f"exit_{mode_name}_d_0_119"
-      elif (last_rsi_3 > 95.0) and (last_rsi_14 < 46.0) and (last_rsi_3_1h < 40.0) and (last_aroonu_14_4h > 75.0):
+      elif (last_rsi_3_gt_95) and (last_rsi_14_lt_46) and (last_rsi_3_1h_lt_40) and (last_aroonu_14_4h_gt_75):
         return True, f"exit_{mode_name}_d_0_120"
-      elif (last_rsi_3 > 95.0) and (last_rsi_14 < 44.0) and (last_rsi_3_1h < 50.0) and (last_rsi_14_4h > 85.0):
+      elif (last_rsi_3_gt_95) and (last_rsi_14_lt_44) and (last_rsi_3_1h_lt_50) and (last_rsi_14_4h > 85.0):
         return True, f"exit_{mode_name}_d_0_121"
-      elif (last_rsi_3 > 95.0) and (last_rsi_14 < 42.0) and (last_rsi_3_4h_lt_30) and (last_stochrsi_k_1h_gt_50):
+      elif (last_rsi_3_gt_95) and (last_rsi_14_lt_42) and (last_rsi_3_4h_lt_30) and (last_stochrsi_k_1h_gt_50):
         return True, f"exit_{mode_name}_d_0_122"
-      elif (last_rsi_3 > 95.0) and (last_willr_14 > -2.0) and (last_rsi_3_1h < 10.0) and (last_rsi_3_1d < 30.0):
+      elif (last_rsi_3_gt_95) and (last_willr_14 > -2.0) and (last_rsi_3_1h_lt_10) and (last_rsi_3_1d_lt_30):
         return True, f"exit_{mode_name}_d_0_123"
       elif (
-        (last_rsi_3 > 95.0)
-        and (last_rsi_3_1h < 15.0)
+        (last_rsi_3_gt_95)
+        and (last_rsi_3_1h_lt_15)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d > 80.0))
       ):
         return True, f"exit_{mode_name}_d_0_124"
       elif (
-        (last_rsi_3 > 95.0)
+        (last_rsi_3_gt_95)
         and (last_willr_14 > -2.0)
-        and (last_rsi_3_1h < 10.0)
-        and (last_rsi_3_4h < 40.0)
+        and (last_rsi_3_1h_lt_10)
+        and (last_rsi_3_4h_lt_40)
         and (last_rsi_3_1d < 40.0)
         and (last_close < (last_high_max_30_1d * 0.50))
       ):
         return True, f"exit_{mode_name}_d_0_125"
-      elif (last_rsi_3 > 95.0) and (last_rsi_3_1h < 15.0) and (last_rsi_3_4h < 40.0) and (last_stochrsi_k_4h_gt_50):
+      elif (last_rsi_3_gt_95) and (last_rsi_3_1h_lt_15) and (last_rsi_3_4h_lt_40) and (last_stochrsi_k_4h_gt_50):
         return True, f"exit_{mode_name}_d_0_126"
-      elif (last_rsi_3 > 95.0) and (last_rsi_3_1h < 10.0) and (last_rsi_3_4h_lt_30) and (last_rsi_3_1d < 40.0):
+      elif (last_rsi_3_gt_95) and (last_rsi_3_1h_lt_10) and (last_rsi_3_4h_lt_30) and (last_rsi_3_1d < 40.0):
         return True, f"exit_{mode_name}_d_0_127"
-      elif (last_rsi_3 > 96.0) and (last_rsi_3_4h_lt_30) and (last_aroonu_14_4h > 85.0):
+      elif (last_rsi_3_gt_96) and (last_rsi_3_4h_lt_30) and (last_aroonu_14_4h > 85.0):
         return True, f"exit_{mode_name}_d_0_128"
       elif (
-        (last_rsi_3 > 95.0)
-        and (last_rsi_3_4h < 25.0)
+        (last_rsi_3_gt_95)
+        and (last_rsi_3_4h_lt_25)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 80.0))
       ):
         return True, f"exit_{mode_name}_d_0_129"
       elif (
-        (last_rsi_3 > 95.0)
+        (last_rsi_3_gt_95)
         and (last_rsi_14_1h > 65.0)
-        and (last_stochrsi_k_1h > 80.0)
+        and (last_stochrsi_k_1h_gt_80)
         and (last_cci_20_change_pct_1h < -0.0)
       ):
         return True, f"exit_{mode_name}_d_0_130"
-      elif (last_rsi_14 < 36.0) and (last_rsi_3_1h < 20.0) and (last_rsi_3_4h_lt_30) and (last_stochrsi_k_4h_gt_50):
+      elif (last_rsi_14 < 36.0) and (last_rsi_3_1h_lt_20) and (last_rsi_3_4h_lt_30) and (last_stochrsi_k_4h_gt_50):
         return True, f"exit_{mode_name}_d_0_131"
       elif (
-        (last_rsi_3 > 95.0)
-        and (last_rsi_3_1h < 35.0)
+        (last_rsi_3_gt_95)
+        and (last_rsi_3_1h_lt_35)
         and (last_rsi_3_4h < 35.0)
         and (last_aroonu_14_1h > 50.0)
-        and (last_stochrsi_k_1h > 40.0)
+        and (last_stochrsi_k_1h_gt_40)
       ):
         return True, f"exit_{mode_name}_d_0_132"
       elif (
-        (last_rsi_3 > 95.0)
+        (last_rsi_3_gt_95)
         and (last_aroonu_14_15m > 75.0)
-        and (last_aroonu_14_1h > 75.0)
+        and (last_aroonu_14_1h_gt_75)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 25.0))
       ):
         return True, f"exit_{mode_name}_d_0_133"


### PR DESCRIPTION
## Summary
- Hoists repeated long `long_exit_dec` threshold checks for the 0.1-1% profit bracket into local boolean aliases.
- Keeps the branch independent on latest upstream `main`.

## Safety
- Only already-read scalar threshold comparisons inside the same current-profit branch are reused.
- Indicator formulas, candle selection, profit arithmetic, thresholds, condition order, return values, order classification, and stake logic are unchanged.
- Touched function: `long_exit_dec`. No v3 grind-entry code is touched.

## Backtest scope
- Full backtesting was not required because this patch only reuses already-read scalar threshold checks inside the same `long_exit_dec` current-profit branch. Trading conditions and output values are unchanged.

## Checks
- `python3 ~/.codex/skills/nfi-upstream-pr/scripts/validate_nfi_pr.py --base origin/main`
- `AST undefined-local scan from validator reported zero findings for introduced `last_*` aliases`
- `git merge-tree conflict simulation against origin/main`
- `targeted git diff origin/main...HEAD -- NostalgiaForInfinityX7.py review`
- `git diff --check`
- `ruff format --check NostalgiaForInfinityX7.py`
- `ruff check NostalgiaForInfinityX7.py`
- `PYTHONDONTWRITEBYTECODE=1 python3 -m py_compile NostalgiaForInfinityX7.py`
