### PR TITLE
Hoist X7 short dec low-profit thresholds

### DIFF
--- a/NostalgiaForInfinityX7.py
+++ b/NostalgiaForInfinityX7.py
@@ -51744,9 +51744,60 @@ class NostalgiaForInfinityX7(IStrategy):
     last_rsi_3_4h_gt_70 = last_rsi_3_4h > 70.0
 
     if 0.01 > current_profit >= 0.001:
+      # Reused short exit decision threshold checks for this profit bracket
+      last_rsi_3_lt_5 = last_rsi_3 < 5.0
+      last_rsi_3_lt_1 = last_rsi_3 < 1.0
+      last_rsi_3_lt_2 = last_rsi_3 < 2.0
+      last_rsi_14_gt_54 = last_rsi_14 > 54.0
+      last_rsi_3_4h_gt_80 = last_rsi_3_4h > 80.0
+      last_rsi_3_4h_gt_90 = last_rsi_3_4h > 90.0
+      last_rsi_3_1h_gt_80 = last_rsi_3_1h > 80.0
+      last_rsi_14_gt_56 = last_rsi_14 > 56.0
+      last_rsi_14_lt_22 = last_rsi_14 < 22.0
+      last_rsi_3_lt_10 = last_rsi_3 < 10.0
+      last_rsi_3_1h_gt_85 = last_rsi_3_1h > 85.0
+      last_rsi_3_1h_gt_50 = last_rsi_3_1h > 50.0
+      last_rsi_3_1h_gt_90 = last_rsi_3_1h > 90.0
+      last_rsi_3_1h_gt_75 = last_rsi_3_1h > 75.0
+      last_rsi_3_4h_gt_60 = last_rsi_3_4h > 60.0
+      last_rsi_3_4h_gt_75 = last_rsi_3_4h > 75.0
+      last_rsi_14_gt_60 = last_rsi_14 > 60.0
+      last_rsi_3_1h_gt_40 = last_rsi_3_1h > 40.0
+      last_stochrsi_k_4h_lt_60 = last_stochrsi_k_4h < 60.0
+      last_rsi_14_gt_58 = last_rsi_14 > 58.0
+      last_stochrsi_k_4h_lt_80 = last_stochrsi_k_4h < 80.0
+      last_change_pct_1d_gt_5 = last_change_pct_1d > 5.0
+      last_stochrsi_k_4h_lt_10 = last_stochrsi_k_4h < 10.0
+      last_rsi_3_4h_gt_85 = last_rsi_3_4h > 85.0
+      last_stochrsi_k_1h_lt_30 = last_stochrsi_k_1h < 30.0
+      last_stochrsi_k_4h_lt_70 = last_stochrsi_k_4h < 70.0
+      last_rsi_3_1d_gt_75 = last_rsi_3_1d > 75.0
+      last_rsi_3_lt_16 = last_rsi_3 < 16.0
+      last_rsi_3_lt_4 = last_rsi_3 < 4.0
+      last_stochrsi_k_1h_lt_20 = last_stochrsi_k_1h < 20.0
+      last_rsi_14_gt_52 = last_rsi_14 > 52.0
+      last_stochrsi_k_1h_lt_60 = last_stochrsi_k_1h < 60.0
+      last_aroond_14_1h_gt_75 = last_aroond_14_1h > 75.0
+      last_rsi_3_4h_gt_40 = last_rsi_3_4h > 40.0
+      last_stochrsi_k_lt_5 = last_stochrsi_k < 5.0
+      last_roc_9_1h_gt_10 = last_roc_9_1h > 10.0
+      last_change_pct_4h_gt_5 = last_change_pct_4h > 5.0
+      last_aroond_14_4h_gt_25 = last_aroond_14_4h > 25.0
+      last_aroond_14_4h_gt_75 = last_aroond_14_4h > 75.0
+      last_stochrsi_k_1h_lt_70 = last_stochrsi_k_1h < 70.0
+      last_stochrsi_k_4h_lt_75 = last_stochrsi_k_4h < 75.0
+      last_rsi_14_gt_62 = last_rsi_14 > 62.0
+      last_rsi_3_1h_gt_60 = last_rsi_3_1h > 60.0
+      last_rsi_3_1h_gt_55 = last_rsi_3_1h > 55.0
+      last_aroonu_14_4h_lt_50 = last_aroonu_14_4h < 50.0
+      last_aroond_14_4h_gt_50 = last_aroond_14_4h > 50.0
+      last_rsi_3_1h_gt_65 = last_rsi_3_1h > 65.0
+      last_rsi_3_lt_8 = last_rsi_3 < 8.0
+      last_rsi_14_4h_lt_30 = last_rsi_14_4h < 30.0
+      last_rsi_3_1d_gt_70 = last_rsi_3_1d > 70.0
       if (
         (last_willr_14 < -99.0)
-        and (last_rsi_14 < 22.0)
+        and (last_rsi_14_lt_22)
         and (isinstance(last_ema_200_1h, np.float64) and (last_ema_12_1h > last_ema_200_1h))
         and (isinstance(last_ema_200_4h, np.float64) and (last_ema_12_4h > last_ema_200_4h))
         and (last_kst_1h > last_ksts_9_1h)
@@ -51755,7 +51806,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_0_1"
       elif (
         (last_willr_14 <= -99.0)
-        and (last_rsi_14 < 22.0)
+        and (last_rsi_14_lt_22)
         and (last_cmf_20_1h > 0.0)
         and (isinstance(last_ema_200_1h, np.float64) and (last_ema_12_1h > last_ema_200_1h))
         and (isinstance(last_ema_200_4h, np.float64) and (last_ema_12_4h > last_ema_200_4h))
@@ -51766,31 +51817,31 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_stochrsi_k < 1.0)
         and (last_cmf_20_1h > 0.0)
         and (last_cmf_20_4h > 0.0)
-        and ((last_stochrsi_k_4h < 80.0) and (last_stochrsi_k_change_pct_4h > 10.0))
+        and ((last_stochrsi_k_4h_lt_80) and (last_stochrsi_k_change_pct_4h > 10.0))
       ):
         return True, f"exit_{mode_name}_d_0_3"
       elif (
         (last_willr_14 <= -99.0)
-        and (last_rsi_14 < 22.0)
-        and (last_stochrsi_k < 5.0)
+        and (last_rsi_14_lt_22)
+        and (last_stochrsi_k_lt_5)
         and (last_stochrsi_k_4h < 30.0)
         and (isinstance(last_ema_200_1h, np.float64) and (last_ema_12_1h > last_ema_200_1h))
         and (isinstance(last_ema_200_4h, np.float64) and (last_ema_12_4h > last_ema_200_4h))
       ):
         return True, f"exit_{mode_name}_d_0_4"
-      elif (last_willr_14 <= -99.0) and (last_rsi_14 < 22.0) and (last_roc_9_1h > 5.0) and (last_roc_9_4h > 5.0):
+      elif (last_willr_14 <= -99.0) and (last_rsi_14_lt_22) and (last_roc_9_1h > 5.0) and (last_roc_9_4h > 5.0):
         return True, f"exit_{mode_name}_d_0_5"
       elif (
-        (last_rsi_3 < 5.0)
-        and (last_stochrsi_k < 5.0)
-        and (last_rsi_14 > 60.0)
-        and (last_roc_9_1h > 10.0)
+        (last_rsi_3_lt_5)
+        and (last_stochrsi_k_lt_5)
+        and (last_rsi_14_gt_60)
+        and (last_roc_9_1h_gt_10)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -50.0))
       ):
         return True, f"exit_{mode_name}_d_0_6"
       elif (
         (last_rsi_14_gt_50)
-        and (last_stochrsi_k < 5.0)
+        and (last_stochrsi_k_lt_5)
         and (last_stochrsi_k_4h_lt_50)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 40.0))
       ):
@@ -51800,136 +51851,136 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_stochrsi_k < 1.0)
         and (last_cmf_20_1h > 0.1)
         and (last_cmf_20_4h > 0.1)
-        and (last_change_pct_1d > 5.0)
+        and (last_change_pct_1d_gt_5)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -15.0))
       ):
         return True, f"exit_{mode_name}_d_0_8"
       elif (
         (last_willr_14 < -99.0)
-        and (last_rsi_3 < 1.0)
-        and (last_change_pct_4h > 5.0)
+        and (last_rsi_3_lt_1)
+        and (last_change_pct_4h_gt_5)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
       ):
         return True, f"exit_{mode_name}_d_0_9"
       elif (
         (last_willr_14 < -99.0)
         and (last_rsi_14_gt_50)
-        and (last_roc_9_1h > 10.0)
+        and (last_roc_9_1h_gt_10)
         and (last_roc_9_4h > 10.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -10.0))
       ):
         return True, f"exit_{mode_name}_d_0_10"
       elif (
-        (last_rsi_3 < 5.0)
+        (last_rsi_3_lt_5)
         and (last_rsi_14 > 55.0)
         and (last_roc_9_15m > 10.0)
-        and (last_roc_9_1h > 10.0)
+        and (last_roc_9_1h_gt_10)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 20.0))
       ):
         return True, f"exit_{mode_name}_d_0_11"
       elif (
-        (last_rsi_3 < 5.0)
+        (last_rsi_3_lt_5)
         and (last_rsi_14_gt_50)
-        and (last_rsi_3_4h > 90.0)
+        and (last_rsi_3_4h_gt_90)
         and (last_roc_9_1h > 20.0)
         and (last_roc_9_4h > 20.0)
       ):
         return True, f"exit_{mode_name}_d_0_12"
-      elif (last_rsi_3 < 1.0) and (last_rsi_3_4h > 95.0) and (last_roc_9_4h > 25.0):
+      elif (last_rsi_3_lt_1) and (last_rsi_3_4h > 95.0) and (last_roc_9_4h > 25.0):
         return True, f"exit_{mode_name}_d_0_13"
-      elif (last_rsi_3 < 1.0) and (last_willr_14 < -99.0) and (last_rsi_3_4h > 95.0) and (last_aroond_14_4h > 25.0):
+      elif (last_rsi_3_lt_1) and (last_willr_14 < -99.0) and (last_rsi_3_4h > 95.0) and (last_aroond_14_4h_gt_25):
         return True, f"exit_{mode_name}_d_0_14"
-      elif (last_rsi_3 < 1.0) and (last_rsi_14 < 22.0) and (last_roc_9_4h > 30.0):
+      elif (last_rsi_3_lt_1) and (last_rsi_14_lt_22) and (last_roc_9_4h > 30.0):
         return True, f"exit_{mode_name}_d_0_15"
       elif (
-        (last_rsi_3 < 1.0)
-        and (last_aroond_14_4h > 25.0)
+        (last_rsi_3_lt_1)
+        and (last_aroond_14_4h_gt_25)
         and (last_roc_9_4h > 25.0)
         and (last_aroond_14_1d > 50.0)
         and (last_change_pct_1d > 15.0)
       ):
         return True, f"exit_{mode_name}_d_0_16"
       elif (
-        (last_rsi_3 < 1.0)
+        (last_rsi_3_lt_1)
         and (last_willr_14 < -99.0)
-        and (last_rsi_3_1h > 90.0)
-        and (last_stochrsi_k_4h < 10.0)
+        and (last_rsi_3_1h_gt_90)
+        and (last_stochrsi_k_4h_lt_10)
         and (last_roc_9_4h < -30.0)
       ):
         return True, f"exit_{mode_name}_d_0_17"
-      elif (last_rsi_3 < 5.0) and (last_rsi_14 < 25.0) and (last_rsi_3_4h > 80.0) and (last_roc_2_1d > 50.0):
+      elif (last_rsi_3_lt_5) and (last_rsi_14 < 25.0) and (last_rsi_3_4h_gt_80) and (last_roc_2_1d > 50.0):
         return True, f"exit_{mode_name}_d_0_18"
       elif (
-        (last_rsi_3 < 1.0)
-        and (last_rsi_14 < 22.0)
-        and (last_rsi_3_4h > 90.0)
+        (last_rsi_3_lt_1)
+        and (last_rsi_14_lt_22)
+        and (last_rsi_3_4h_gt_90)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 30.0))
       ):
         return True, f"exit_{mode_name}_d_0_19"
-      elif (last_rsi_3 < 10.0) and (last_rsi_14 > 60.0) and (last_rsi_3_1h > 90.0) and (last_aroond_14_1h > 25.0):
+      elif (last_rsi_3_lt_10) and (last_rsi_14_gt_60) and (last_rsi_3_1h_gt_90) and (last_aroond_14_1h > 25.0):
         return True, f"exit_{mode_name}_d_0_20"
-      elif (last_rsi_3 < 5.0) and (last_rsi_14 > 60.0) and (last_rsi_3_1h > 80.0) and (last_stochrsi_k_4h < 10.0):
+      elif (last_rsi_3_lt_5) and (last_rsi_14_gt_60) and (last_rsi_3_1h_gt_80) and (last_stochrsi_k_4h_lt_10):
         return True, f"exit_{mode_name}_d_0_21"
       elif (
-        (last_rsi_3 < 1.0)
+        (last_rsi_3_lt_1)
         and (last_willr_14 < -99.0)
-        and (last_change_pct_4h > 5.0)
+        and (last_change_pct_4h_gt_5)
         and (last_stochrsi_k_4h_lt_50)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
       ):
         return True, f"exit_{mode_name}_d_0_22"
-      elif (last_rsi_3 < 2.0) and (last_willr_14 < -95.0) and (last_rsi_3_1h > 85.0) and (last_rsi_3_1d > 95.0):
+      elif (last_rsi_3_lt_2) and (last_willr_14 < -95.0) and (last_rsi_3_1h_gt_85) and (last_rsi_3_1d > 95.0):
         return True, f"exit_{mode_name}_d_0_23"
       elif (
-        (last_rsi_3 < 1.0)
-        and (last_rsi_14 < 22.0)
+        (last_rsi_3_lt_1)
+        and (last_rsi_14_lt_22)
         and (last_willr_14 < -95.0)
         and (last_rsi_3_4h_gt_70)
-        and (last_aroond_14_4h > 75.0)
+        and (last_aroond_14_4h_gt_75)
       ):
         return True, f"exit_{mode_name}_d_0_24"
       elif (
-        (last_rsi_3 < 5.0)
+        (last_rsi_3_lt_5)
         and (last_willr_14 < -98.0)
-        and (last_rsi_3_4h > 90.0)
+        and (last_rsi_3_4h_gt_90)
         and (last_roc_9_4h > 15.0)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 50.0))
       ):
         return True, f"exit_{mode_name}_d_0_25"
-      elif (last_rsi_3 < 5.0) and (last_willr_14 < -99.0) and (last_rsi_3_4h > 85.0) and (last_roc_9_4h > 20.0):
+      elif (last_rsi_3_lt_5) and (last_willr_14 < -99.0) and (last_rsi_3_4h_gt_85) and (last_roc_9_4h > 20.0):
         return True, f"exit_{mode_name}_d_0_26"
       elif (
-        (last_rsi_3 < 5.0)
+        (last_rsi_3_lt_5)
         and (last_rsi_14_gt_50)
-        and (last_rsi_3_1h > 80.0)
-        and (last_rsi_3_4h > 80.0)
-        and (last_stochrsi_k_4h < 80.0)
+        and (last_rsi_3_1h_gt_80)
+        and (last_rsi_3_4h_gt_80)
+        and (last_stochrsi_k_4h_lt_80)
       ):
         return True, f"exit_{mode_name}_d_0_27"
-      elif (last_rsi_3 < 5.0) and (last_rsi_14_gt_50) and (last_rsi_3_15m > 90.0) and (last_roc_9_4h < -50.0):
+      elif (last_rsi_3_lt_5) and (last_rsi_14_gt_50) and (last_rsi_3_15m > 90.0) and (last_roc_9_4h < -50.0):
         return True, f"exit_{mode_name}_d_0_28"
       elif (
-        (last_rsi_3 < 5.0)
+        (last_rsi_3_lt_5)
         and (last_rsi_14_gt_50)
-        and (last_rsi_3_1h > 80.0)
-        and (last_rsi_3_4h > 80.0)
-        and (last_stochrsi_k_1h < 70.0)
+        and (last_rsi_3_1h_gt_80)
+        and (last_rsi_3_4h_gt_80)
+        and (last_stochrsi_k_1h_lt_70)
       ):
         return True, f"exit_{mode_name}_d_0_29"
-      elif (last_rsi_3 < 1.0) and (last_rsi_3_1h > 75.0) and (last_rsi_3_4h > 90.0) and (last_stochrsi_k_1h < 30.0):
+      elif (last_rsi_3_lt_1) and (last_rsi_3_1h_gt_75) and (last_rsi_3_4h_gt_90) and (last_stochrsi_k_1h_lt_30):
         return True, f"exit_{mode_name}_d_0_30"
       elif (
-        (last_rsi_3 < 5.0)
+        (last_rsi_3_lt_5)
         and (last_rsi_14_gt_50)
-        and (last_rsi_3_1h > 85.0)
-        and (last_rsi_3_4h > 85.0)
+        and (last_rsi_3_1h_gt_85)
+        and (last_rsi_3_4h_gt_85)
         and (last_stochrsi_k_1h < 75.0)
       ):
         return True, f"exit_{mode_name}_d_0_31"
-      elif (last_rsi_3 < 5.0) and (last_rsi_3_1h > 85.0) and (last_roc_2_4h > 30.0) and (last_stochrsi_k_4h < 70.0):
+      elif (last_rsi_3_lt_5) and (last_rsi_3_1h_gt_85) and (last_roc_2_4h > 30.0) and (last_stochrsi_k_4h_lt_70):
         return True, f"exit_{mode_name}_d_0_32"
       elif (
-        (last_rsi_3 < 5.0)
+        (last_rsi_3_lt_5)
         and (last_willr_14 < -99.0)
         and (last_roc_2_1h > 10.0)
         and (last_roc_9_1h < -30.0)
@@ -51938,127 +51989,127 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_0_33"
       elif (last_rsi_3 < 35.0) and (last_rsi_3_15m > 70.0) and (last_rsi_14_1h < 20.0) and (last_roc_9_1h < -40.0):
         return True, f"exit_{mode_name}_d_0_34"
-      elif (last_rsi_3 < 5.0) and (last_willr_14 < -95.0) and (last_rsi_3_1d > 75.0) and (last_stochrsi_k_1h < 25.0):
+      elif (last_rsi_3_lt_5) and (last_willr_14 < -95.0) and (last_rsi_3_1d_gt_75) and (last_stochrsi_k_1h < 25.0):
         return True, f"exit_{mode_name}_d_0_35"
       elif (
-        (last_rsi_3 < 5.0)
+        (last_rsi_3_lt_5)
         and (last_willr_14 < -99.0)
         and (last_roc_9_4h > 25.0)
-        and (last_rsi_3_1d > 75.0)
+        and (last_rsi_3_1d_gt_75)
         and (last_stochrsi_k_1h_lt_50)
       ):
         return True, f"exit_{mode_name}_d_0_36"
       elif (
-        (last_rsi_3 < 16.0)
+        (last_rsi_3_lt_16)
         and (last_rsi_14_gt_50)
         and (last_rsi_3_1h < 80.0)
         and (last_rsi_3_1d < 75.0)
         and (last_stochrsi_k_4h_lt_50)
       ):
         return True, f"exit_{mode_name}_d_0_37"
-      elif (last_rsi_3 < 10.0) and (last_willr_14 < -90.0) and (last_rsi_3_4h > 90.0) and (last_stochrsi_k_4h < 80.0):
+      elif (last_rsi_3_lt_10) and (last_willr_14 < -90.0) and (last_rsi_3_4h_gt_90) and (last_stochrsi_k_4h_lt_80):
         return True, f"exit_{mode_name}_d_0_38"
-      elif (last_rsi_3 < 1.0) and (last_willr_14 < -99.0) and (last_cmf_20_4h > 0.0) and (last_rsi_3_4h > 90.0):
+      elif (last_rsi_3_lt_1) and (last_willr_14 < -99.0) and (last_cmf_20_4h > 0.0) and (last_rsi_3_4h_gt_90):
         return True, f"exit_{mode_name}_d_0_39"
       elif (
-        (last_rsi_3 < 2.0)
+        (last_rsi_3_lt_2)
         and (last_willr_14 < -98.0)
         and (last_rsi_3_1h_gt_70)
-        and (last_stochrsi_k_1h < 70.0)
+        and (last_stochrsi_k_1h_lt_70)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 10.0))
       ):
         return True, f"exit_{mode_name}_d_0_40"
       elif (
-        (last_rsi_3 < 2.0)
+        (last_rsi_3_lt_2)
         and (last_willr_14 < -95.0)
         and (last_rsi_3_1h_gt_70)
-        and (last_stochrsi_k_4h < 75.0)
+        and (last_stochrsi_k_4h_lt_75)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -50.0))
       ):
         return True, f"exit_{mode_name}_d_0_41"
       elif (
-        (last_rsi_3 < 5.0)
+        (last_rsi_3_lt_5)
         and (last_willr_14 < -98.0)
-        and (last_stochrsi_k_4h < 70.0)
+        and (last_stochrsi_k_4h_lt_70)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -40.0))
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 30.0))
       ):
         return True, f"exit_{mode_name}_d_0_42"
       elif (
-        (last_rsi_3 < 5.0)
+        (last_rsi_3_lt_5)
         and (last_rsi_14_gt_50)
-        and (last_rsi_3_1h > 85.0)
-        and (last_rsi_3_4h > 60.0)
+        and (last_rsi_3_1h_gt_85)
+        and (last_rsi_3_4h_gt_60)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 10.0))
       ):
         return True, f"exit_{mode_name}_d_0_43"
       elif (
-        (last_rsi_3 < 10.0)
+        (last_rsi_3_lt_10)
         and (last_willr_14 < -98.0)
         and (last_rsi_3_4h_gt_70)
         and (last_rsi_3_1d > 25.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
       ):
         return True, f"exit_{mode_name}_d_0_44"
-      elif (last_rsi_3 < 4.0) and (last_willr_14 < -96.0) and (last_rsi_3_1h > 90.0):
+      elif (last_rsi_3_lt_4) and (last_willr_14 < -96.0) and (last_rsi_3_1h_gt_90):
         return True, f"exit_{mode_name}_d_0_45"
-      elif (last_rsi_3 < 2.0) and (last_rsi_3_1h > 85.0) and (last_rsi_3_4h > 90.0) and (last_roc_2_1d > 20.0):
+      elif (last_rsi_3_lt_2) and (last_rsi_3_1h_gt_85) and (last_rsi_3_4h_gt_90) and (last_roc_2_1d > 20.0):
         return True, f"exit_{mode_name}_d_0_46"
       elif (
-        (last_rsi_3 < 2.0)
-        and (last_stochrsi_k_1h < 20.0)
-        and (last_stochrsi_k_4h < 60.0)
-        and (last_change_pct_1d > 5.0)
+        (last_rsi_3_lt_2)
+        and (last_stochrsi_k_1h_lt_20)
+        and (last_stochrsi_k_4h_lt_60)
+        and (last_change_pct_1d_gt_5)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 5.0))
       ):
         return True, f"exit_{mode_name}_d_0_47"
       elif (
         (last_rsi_3 < 30.0)
-        and (last_rsi_14 > 58.0)
+        and (last_rsi_14_gt_58)
         and (last_rsi_3_1h_gt_70)
-        and (last_rsi_3_4h > 80.0)
+        and (last_rsi_3_4h_gt_80)
         and (last_stochrsi_k_1h_lt_50)
       ):
         return True, f"exit_{mode_name}_d_0_48"
       elif (
-        (last_rsi_3 < 5.0)
+        (last_rsi_3_lt_5)
         and (last_willr_14 < -98.0)
-        and (last_rsi_3_4h > 80.0)
-        and (last_change_pct_1d > 5.0)
+        and (last_rsi_3_4h_gt_80)
+        and (last_change_pct_1d_gt_5)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 50.0))
       ):
         return True, f"exit_{mode_name}_d_0_49"
       elif (last_rsi_3 < 20.0) and (last_willr_14 < -98.0) and (last_rsi_3_1d > 90.0) and (last_stochrsi_k_1h < 10.0):
         return True, f"exit_{mode_name}_d_0_50"
-      elif (last_rsi_3 < 32.0) and (last_rsi_14 > 56.0) and (last_rsi_3_4h > 80.0) and (last_stochrsi_k_1h_lt_50):
+      elif (last_rsi_3 < 32.0) and (last_rsi_14_gt_56) and (last_rsi_3_4h_gt_80) and (last_stochrsi_k_1h_lt_50):
         return True, f"exit_{mode_name}_d_0_51"
       elif (
-        (last_rsi_3 < 5.0)
+        (last_rsi_3_lt_5)
         and (last_rsi_14 < 38.0)
         and (last_willr_14 < -90.0)
-        and (last_stochrsi_k_1h < 30.0)
+        and (last_stochrsi_k_1h_lt_30)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 15.0))
       ):
         return True, f"exit_{mode_name}_d_0_52"
       elif (
-        (last_rsi_3 < 5.0)
+        (last_rsi_3_lt_5)
         and (last_rsi_14_gt_50)
         and (last_willr_14 < -95.0)
-        and (last_rsi_3_1h > 80.0)
+        and (last_rsi_3_1h_gt_80)
         and (last_stochrsi_k_4h_lt_50)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 50.0))
       ):
         return True, f"exit_{mode_name}_d_0_53"
       elif (
         (last_rsi_3 < 20.0)
-        and (last_rsi_14 > 56.0)
+        and (last_rsi_14_gt_56)
         and (last_stochrsi_k_1h_lt_50)
         and (last_roc_9_4h > 10.0)
         and (last_change_pct_1d > 10.0)
       ):
         return True, f"exit_{mode_name}_d_0_54"
       elif (
-        (last_rsi_3 < 2.0)
+        (last_rsi_3_lt_2)
         and (last_willr_14 < -88.0)
         and (last_roc_9_4h > 5.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -10.0))
@@ -52066,10 +52117,10 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_0_55"
       elif (
-        (last_rsi_3 < 5.0)
+        (last_rsi_3_lt_5)
         and (last_rsi_14_gt_50)
         and (last_rsi_3_1h_gt_70)
-        and (last_rsi_3_4h > 75.0)
+        and (last_rsi_3_4h_gt_75)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
         and (last_stochrsi_k_4h < 90.0)
       ):
@@ -52082,7 +52133,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_0_57"
       elif (
-        (last_rsi_3 < 5.0)
+        (last_rsi_3_lt_5)
         and (last_rsi_3_1h_gt_70)
         and (last_rsi_3_4h_gt_70)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 15.0))
@@ -52090,158 +52141,154 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_0_58"
       elif (
-        (last_rsi_3 < 5.0)
+        (last_rsi_3_lt_5)
         and (last_willr_14 < -90.0)
-        and (last_rsi_3_4h > 75.0)
+        and (last_rsi_3_4h_gt_75)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 15.0))
-        and (last_stochrsi_k_4h < 60.0)
+        and (last_stochrsi_k_4h_lt_60)
       ):
         return True, f"exit_{mode_name}_d_0_59"
       elif (
-        (last_rsi_3 < 5.0)
-        and (last_rsi_14 > 62.0)
+        (last_rsi_3_lt_5)
+        and (last_rsi_14_gt_62)
         and (last_rsi_14_4h < 35.0)
         and (last_stochrsi_k_4h_lt_50)
         and (last_stochrsi_k_1d < 50.0)
       ):
         return True, f"exit_{mode_name}_d_0_60"
-      elif (last_rsi_3 < 2.0) and (last_willr_14 < -75.0) and (last_rsi_3_4h > 90.0) and (last_stochrsi_k_1h < 70.0):
+      elif (last_rsi_3_lt_2) and (last_willr_14 < -75.0) and (last_rsi_3_4h_gt_90) and (last_stochrsi_k_1h_lt_70):
         return True, f"exit_{mode_name}_d_0_61"
       elif (
         (last_rsi_3 < 12.0)
         and (last_willr_14 < -99.0)
         and (last_rsi_3_1h_gt_70)
-        and (last_rsi_3_4h > 80.0)
+        and (last_rsi_3_4h_gt_80)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -20.0))
-        and (last_change_pct_1d > 5.0)
+        and (last_change_pct_1d_gt_5)
       ):
         return True, f"exit_{mode_name}_d_0_62"
-      elif (
-        (last_rsi_3 < 2.0) and (last_rsi_3_1d > 75.0) and (last_stochrsi_k_1h < 20.0) and (last_stochrsi_k_4h < 70.0)
-      ):
+      elif (last_rsi_3_lt_2) and (last_rsi_3_1d_gt_75) and (last_stochrsi_k_1h_lt_20) and (last_stochrsi_k_4h_lt_70):
         return True, f"exit_{mode_name}_d_0_63"
       elif (
-        (last_rsi_3 < 2.0)
+        (last_rsi_3_lt_2)
         and (last_rsi_3_1h_gt_70)
         and (last_rsi_3_4h_gt_70)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
       ):
         return True, f"exit_{mode_name}_d_0_64"
-      elif (last_rsi_3 < 10.0) and (last_rsi_14 > 60.0) and (last_rsi_3_1h > 80.0) and (last_rsi_3_4h > 85.0):
+      elif (last_rsi_3_lt_10) and (last_rsi_14_gt_60) and (last_rsi_3_1h_gt_80) and (last_rsi_3_4h_gt_85):
         return True, f"exit_{mode_name}_d_0_65"
-      elif (last_rsi_3 < 16.0) and (last_rsi_14 > 54.0) and (last_rsi_3_1h > 80.0) and (last_stochrsi_k_1h_lt_50):
+      elif (last_rsi_3_lt_16) and (last_rsi_14_gt_54) and (last_rsi_3_1h_gt_80) and (last_stochrsi_k_1h_lt_50):
         return True, f"exit_{mode_name}_d_0_66"
       elif (
         (last_rsi_3 < 50.0)
-        and (last_rsi_14 > 60.0)
+        and (last_rsi_14_gt_60)
         and (last_stochrsi_k_4h < 20.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 25.0))
       ):
         return True, f"exit_{mode_name}_d_0_67"
       elif (
         (last_rsi_3 < 14.0)
-        and (last_rsi_14 > 54.0)
-        and (last_rsi_3_1h > 75.0)
+        and (last_rsi_14_gt_54)
+        and (last_rsi_3_1h_gt_75)
         and (last_roc_2_4h > 30.0)
-        and (last_stochrsi_k_4h < 75.0)
+        and (last_stochrsi_k_4h_lt_75)
       ):
         return True, f"exit_{mode_name}_d_0_68"
-      elif (
-        (last_rsi_3 < 3.0) and (last_roc_9_4h < -20.0) and (last_stochrsi_k_4h_lt_50) and (last_change_pct_4h > 5.0)
-      ):
+      elif (last_rsi_3 < 3.0) and (last_roc_9_4h < -20.0) and (last_stochrsi_k_4h_lt_50) and (last_change_pct_4h_gt_5):
         return True, f"exit_{mode_name}_d_0_69"
-      elif (last_rsi_3 < 5.0) and (last_rsi_14 > 62.0) and (last_rsi_3_1h > 75.0) and (last_stochrsi_k_4h < 80.0):
+      elif (last_rsi_3_lt_5) and (last_rsi_14_gt_62) and (last_rsi_3_1h_gt_75) and (last_stochrsi_k_4h_lt_80):
         return True, f"exit_{mode_name}_d_0_70"
-      elif (last_rsi_3 < 5.0) and (last_rsi_14 > 58.0) and (last_rsi_3_4h > 75.0) and (last_stochrsi_k_1h < 80.0):
+      elif (last_rsi_3_lt_5) and (last_rsi_14_gt_58) and (last_rsi_3_4h_gt_75) and (last_stochrsi_k_1h < 80.0):
         return True, f"exit_{mode_name}_d_0_71"
-      elif (last_rsi_3 < 5.0) and (last_rsi_14 > 60.0) and (last_rsi_3_1h > 90.0) and (last_aroond_14_4h > 25.0):
+      elif (last_rsi_3_lt_5) and (last_rsi_14_gt_60) and (last_rsi_3_1h_gt_90) and (last_aroond_14_4h_gt_25):
         return True, f"exit_{mode_name}_d_0_72"
       elif (
-        (last_rsi_3 < 5.0)
-        and (last_rsi_3_1h > 75.0)
-        and (last_rsi_3_4h > 85.0)
+        (last_rsi_3_lt_5)
+        and (last_rsi_3_1h_gt_75)
+        and (last_rsi_3_4h_gt_85)
         and (last_roc_9_4h > 20.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 25.0))
       ):
         return True, f"exit_{mode_name}_d_0_73"
       elif (
-        (last_rsi_3 < 1.0)
+        (last_rsi_3_lt_1)
         and (last_willr_14 < -90.0)
-        and (last_rsi_3_4h > 75.0)
-        and (last_rsi_3_1d > 75.0)
+        and (last_rsi_3_4h_gt_75)
+        and (last_rsi_3_1d_gt_75)
         and (last_stochrsi_k_1h > 50.0)
       ):
         return True, f"exit_{mode_name}_d_0_74"
       elif (
-        (last_rsi_3 < 2.0)
+        (last_rsi_3_lt_2)
         and (last_rsi_3_1h_gt_70)
-        and (last_rsi_3_4h > 80.0)
+        and (last_rsi_3_4h_gt_80)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 50.0))
       ):
         return True, f"exit_{mode_name}_d_0_75"
-      elif (last_rsi_3 < 5.0) and (last_rsi_14 > 52.0) and (last_roc_9_1h < -80.0) and (last_stochrsi_k_4h < 20.0):
+      elif (last_rsi_3_lt_5) and (last_rsi_14_gt_52) and (last_roc_9_1h < -80.0) and (last_stochrsi_k_4h < 20.0):
         return True, f"exit_{mode_name}_d_0_76"
       elif (
-        (last_rsi_3 < 5.0)
-        and (last_rsi_14 > 56.0)
+        (last_rsi_3_lt_5)
+        and (last_rsi_14_gt_56)
         and (last_rsi_3_1h_gt_70)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -50.0))
       ):
         return True, f"exit_{mode_name}_d_0_77"
       elif (
-        (last_rsi_3 < 2.0)
+        (last_rsi_3_lt_2)
         and (last_willr_14 < -86.0)
         and (last_rsi_3_1h_gt_70)
-        and (last_rsi_3_4h > 80.0)
+        and (last_rsi_3_4h_gt_80)
         and (last_rsi_3_1d > 80.0)
       ):
         return True, f"exit_{mode_name}_d_0_78"
-      elif (last_rsi_3 < 6.0) and (last_willr_14 < -99.0) and (last_rsi_3_1h_gt_70) and (last_rsi_3_4h > 90.0):
+      elif (last_rsi_3 < 6.0) and (last_willr_14 < -99.0) and (last_rsi_3_1h_gt_70) and (last_rsi_3_4h_gt_90):
         return True, f"exit_{mode_name}_d_0_79"
       elif (
         (last_rsi_3 < 26.0)
-        and (last_rsi_14 > 56.0)
+        and (last_rsi_14_gt_56)
         and (last_rsi_3_1h_gt_70)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -50.0))
-        and (last_stochrsi_k_4h < 75.0)
+        and (last_stochrsi_k_4h_lt_75)
       ):
         return True, f"exit_{mode_name}_d_0_80"
       elif (
-        (last_rsi_3 < 4.0)
+        (last_rsi_3_lt_4)
         and (last_willr_14 < -92.0)
-        and (last_rsi_3_1h > 75.0)
-        and (last_rsi_3_4h > 75.0)
+        and (last_rsi_3_1h_gt_75)
+        and (last_rsi_3_4h_gt_75)
         and (isinstance(last_rsi_14_1d, np.float64) and (last_rsi_14_1d < 50.0))
       ):
         return True, f"exit_{mode_name}_d_0_81"
       elif (
-        (last_rsi_3 < 16.0)
+        (last_rsi_3_lt_16)
         and (last_willr_14 < -92.0)
         and (last_rsi_3_4h_gt_70)
         and (last_rsi_3_1d > 85.0)
-        and (last_stochrsi_k_4h < 60.0)
+        and (last_stochrsi_k_4h_lt_60)
       ):
         return True, f"exit_{mode_name}_d_0_82"
       elif (
-        (last_rsi_3 < 5.0)
-        and (last_rsi_14 > 56.0)
-        and (last_rsi_3_1h > 60.0)
+        (last_rsi_3_lt_5)
+        and (last_rsi_14_gt_56)
+        and (last_rsi_3_1h_gt_60)
         and (last_stochrsi_k_1h_lt_50)
-        and (last_stochrsi_k_4h < 60.0)
+        and (last_stochrsi_k_4h_lt_60)
       ):
         return True, f"exit_{mode_name}_d_0_83"
-      elif (last_rsi_3 < 1.0) and (last_willr_14 < -99.0) and (last_rsi_3_4h_gt_70) and (last_stochrsi_k_1h < 80.0):
+      elif (last_rsi_3_lt_1) and (last_willr_14 < -99.0) and (last_rsi_3_4h_gt_70) and (last_stochrsi_k_1h < 80.0):
         return True, f"exit_{mode_name}_d_0_84"
       elif (
-        (last_rsi_3 < 1.0)
+        (last_rsi_3_lt_1)
         and (last_willr_14 < -94.0)
         and (last_rsi_3_1h_gt_70)
-        and (last_rsi_3_4h > 60.0)
+        and (last_rsi_3_4h_gt_60)
         and (last_stochrsi_k_4h_lt_50)
       ):
         return True, f"exit_{mode_name}_d_0_85"
       elif (
-        (last_rsi_3 < 4.0)
+        (last_rsi_3_lt_4)
         and (last_rsi_14_4h < 20.0)
         and (last_roc_2_1h > 5.0)
         and (last_roc_9_1h < -5.0)
@@ -52249,24 +52296,24 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_0_86"
       elif (
-        (last_rsi_3 < 5.0)
-        and (last_rsi_14 > 58.0)
-        and (last_rsi_3_1h > 55.0)
+        (last_rsi_3_lt_5)
+        and (last_rsi_14_gt_58)
+        and (last_rsi_3_1h_gt_55)
         and (last_rsi_3_4h > 50.0)
         and (last_stochrsi_k_4h_lt_50)
       ):
         return True, f"exit_{mode_name}_d_0_87"
       elif (
-        (last_rsi_3 < 5.0)
+        (last_rsi_3_lt_5)
         and (last_willr_14 < -98.0)
-        and (last_stochrsi_k_1h < 60.0)
+        and (last_stochrsi_k_1h_lt_60)
         and (last_stochrsi_k_4h_lt_50)
         and (last_change_pct_1h > 2.0)
       ):
         return True, f"exit_{mode_name}_d_0_88"
       elif (
-        (last_rsi_3 < 10.0)
-        and (last_rsi_14 > 62.0)
+        (last_rsi_3_lt_10)
+        and (last_rsi_14_gt_62)
         and (last_roc_9_1h > 5.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -25.0))
       ):
@@ -52274,282 +52321,282 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 6.0)
         and (last_willr_14 < -75.0)
-        and (last_rsi_3_1h > 50.0)
+        and (last_rsi_3_1h_gt_50)
         and (last_rsi_3_4h_gt_70)
-        and (last_aroonu_14_4h < 50.0)
+        and (last_aroonu_14_4h_lt_50)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -40.0))
       ):
         return True, f"exit_{mode_name}_d_0_90"
       elif (
-        (last_rsi_3 < 10.0)
-        and (last_rsi_14 > 56.0)
-        and (last_rsi_3_1h > 75.0)
-        and (last_rsi_3_4h > 75.0)
-        and (last_aroonu_14_4h < 50.0)
+        (last_rsi_3_lt_10)
+        and (last_rsi_14_gt_56)
+        and (last_rsi_3_1h_gt_75)
+        and (last_rsi_3_4h_gt_75)
+        and (last_aroonu_14_4h_lt_50)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 50.0))
       ):
         return True, f"exit_{mode_name}_d_0_91"
       elif (
-        (last_rsi_3 < 5.0)
-        and (last_rsi_14 > 54.0)
-        and (last_rsi_3_1h > 60.0)
+        (last_rsi_3_lt_5)
+        and (last_rsi_14_gt_54)
+        and (last_rsi_3_1h_gt_60)
         and (last_stochrsi_k_1h < 75.0)
         and (last_stochrsi_k_4h_lt_50)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 25.0))
       ):
         return True, f"exit_{mode_name}_d_0_92"
       elif (
-        (last_rsi_3 < 10.0)
-        and (last_rsi_14 > 52.0)
+        (last_rsi_3_lt_10)
+        and (last_rsi_14_gt_52)
         and (last_rsi_3_15m > 50.0)
-        and (last_aroond_14_1h > 75.0)
-        and (last_stochrsi_k_1h < 30.0)
-        and (last_aroond_14_4h > 50.0)
+        and (last_aroond_14_1h_gt_75)
+        and (last_stochrsi_k_1h_lt_30)
+        and (last_aroond_14_4h_gt_50)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 10.0))
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
       ):
         return True, f"exit_{mode_name}_d_0_93"
       elif (
-        (last_rsi_3 < 5.0)
-        and (last_rsi_14 > 52.0)
-        and (last_rsi_3_1h > 75.0)
+        (last_rsi_3_lt_5)
+        and (last_rsi_14_gt_52)
+        and (last_rsi_3_1h_gt_75)
         and (last_rsi_3_4h > 55.0)
-        and (last_aroond_14_1h > 75.0)
+        and (last_aroond_14_1h_gt_75)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 10.0))
       ):
         return True, f"exit_{mode_name}_d_0_94"
       elif (
-        (last_rsi_3 < 5.0)
+        (last_rsi_3_lt_5)
         and (last_willr_14 < -90.0)
-        and (last_rsi_3_1h > 55.0)
-        and (last_rsi_3_4h > 60.0)
+        and (last_rsi_3_1h_gt_55)
+        and (last_rsi_3_4h_gt_60)
         and (last_stochrsi_k_4h < 90.0)
         and (isinstance(last_aroond_14_1d, np.float64) and (last_aroond_14_1d > 75.0))
       ):
         return True, f"exit_{mode_name}_d_0_95"
       elif (
-        (last_rsi_3 < 10.0)
-        and (last_rsi_14 > 56.0)
-        and (last_rsi_3_1h > 55.0)
+        (last_rsi_3_lt_10)
+        and (last_rsi_14_gt_56)
+        and (last_rsi_3_1h_gt_55)
         and (last_rsi_3_1d > 55.0)
         and (last_stochrsi_k_1h_lt_50)
       ):
         return True, f"exit_{mode_name}_d_0_96"
       elif (
-        (last_rsi_3 < 16.0)
-        and (last_rsi_14 > 56.0)
-        and (last_rsi_3_1h > 65.0)
-        and (last_aroond_14_4h > 50.0)
-        and (last_stochrsi_k_4h < 70.0)
+        (last_rsi_3_lt_16)
+        and (last_rsi_14_gt_56)
+        and (last_rsi_3_1h_gt_65)
+        and (last_aroond_14_4h_gt_50)
+        and (last_stochrsi_k_4h_lt_70)
       ):
         return True, f"exit_{mode_name}_d_0_97"
       elif (
-        (last_rsi_3 < 8.0)
+        (last_rsi_3_lt_8)
         and (last_rsi_3_15m < 26.0)
-        and (last_rsi_3_1h > 40.0)
-        and (last_rsi_3_4h > 40.0)
+        and (last_rsi_3_1h_gt_40)
+        and (last_rsi_3_4h_gt_40)
         and (last_rsi_3_1d < 20.0)
         and (last_stochrsi_k_4h_lt_50)
       ):
         return True, f"exit_{mode_name}_d_0_98"
       elif (
-        (last_rsi_3 < 5.0)
+        (last_rsi_3_lt_5)
         and (last_rsi_14_gt_50)
         and (last_rsi_3_1h > 35.0)
-        and (last_rsi_3_4h > 40.0)
-        and (last_aroond_14_4h > 50.0)
+        and (last_rsi_3_4h_gt_40)
+        and (last_aroond_14_4h_gt_50)
         and (last_stoch_k_4h < 60.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -80.0))
       ):
         return True, f"exit_{mode_name}_d_0_99"
-      elif (last_rsi_3 < 1.0) and (last_rsi_14 < 22.0) and (last_rsi_3_15m < 30.0) and (last_rsi_3_4h > 20.0):
+      elif (last_rsi_3_lt_1) and (last_rsi_14_lt_22) and (last_rsi_3_15m < 30.0) and (last_rsi_3_4h > 20.0):
         return True, f"exit_{mode_name}_d_0_100"
       elif (
         (last_rsi_3 < 14.0)
         and (last_willr_14 < -86.0)
-        and (last_rsi_3_1h > 50.0)
-        and (last_stochrsi_k_4h < 60.0)
+        and (last_rsi_3_1h_gt_50)
+        and (last_stochrsi_k_4h_lt_60)
         and (isinstance(last_roc_9_4h, np.float64) and (last_roc_9_4h < -40.0))
       ):
         return True, f"exit_{mode_name}_d_0_101"
       elif (
-        (last_rsi_3 < 5.0)
-        and (last_rsi_14 > 54.0)
-        and (last_rsi_3_1h > 40.0)
-        and (last_rsi_3_4h > 60.0)
+        (last_rsi_3_lt_5)
+        and (last_rsi_14_gt_54)
+        and (last_rsi_3_1h_gt_40)
+        and (last_rsi_3_4h_gt_60)
         and (last_stochrsi_k_4h > 70.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -40.0))
       ):
         return True, f"exit_{mode_name}_d_0_102"
       elif (
-        (last_rsi_3 < 5.0)
+        (last_rsi_3_lt_5)
         and (last_rsi_14 > 46.0)
-        and (last_rsi_3_1h > 40.0)
-        and (last_rsi_14_4h < 30.0)
+        and (last_rsi_3_1h_gt_40)
+        and (last_rsi_14_4h_lt_30)
         and (isinstance(last_roc_9_4h, np.float64) and (last_roc_9_4h < -80.0))
       ):
         return True, f"exit_{mode_name}_d_0_103"
       elif (
-        (last_rsi_3 < 5.0)
-        and (last_rsi_14 > 54.0)
-        and (last_rsi_3_1h > 40.0)
-        and (last_stochrsi_k_1h < 60.0)
-        and (last_stochrsi_k_4h < 10.0)
+        (last_rsi_3_lt_5)
+        and (last_rsi_14_gt_54)
+        and (last_rsi_3_1h_gt_40)
+        and (last_stochrsi_k_1h_lt_60)
+        and (last_stochrsi_k_4h_lt_10)
         and (last_roc_9_4h < -40.0)
       ):
         return True, f"exit_{mode_name}_d_0_104"
       elif (
-        (last_rsi_3 < 5.0)
-        and (last_rsi_14 > 54.0)
+        (last_rsi_3_lt_5)
+        and (last_rsi_14_gt_54)
         and (last_rsi_3_15m > 45.0)
-        and (last_stochrsi_k_4h < 10.0)
+        and (last_stochrsi_k_4h_lt_10)
         and (last_roc_9_4h < -25.0)
       ):
         return True, f"exit_{mode_name}_d_0_105"
       elif (
-        (last_rsi_3 < 5.0)
-        and (last_rsi_14 > 54.0)
-        and (last_rsi_3_1h > 50.0)
+        (last_rsi_3_lt_5)
+        and (last_rsi_14_gt_54)
+        and (last_rsi_3_1h_gt_50)
         and (last_stochrsi_k_1h_lt_50)
-        and (last_rsi_14_4h < 30.0)
+        and (last_rsi_14_4h_lt_30)
         and (last_roc_9_4h < -40.0)
       ):
         return True, f"exit_{mode_name}_d_0_106"
       elif (
-        (last_rsi_3 < 5.0)
-        and (last_rsi_14 > 54.0)
-        and (last_rsi_3_1h > 50.0)
-        and (last_stochrsi_k_1h < 30.0)
+        (last_rsi_3_lt_5)
+        and (last_rsi_14_gt_54)
+        and (last_rsi_3_1h_gt_50)
+        and (last_stochrsi_k_1h_lt_30)
         and (last_rsi_14_4h < 50.0)
       ):
         return True, f"exit_{mode_name}_d_0_107"
-      elif (last_rsi_3 < 5.0) and (last_rsi_14 > 54.0) and (last_rsi_3_1h > 40.0) and (last_stochrsi_k_1h < 20.0):
+      elif (last_rsi_3_lt_5) and (last_rsi_14_gt_54) and (last_rsi_3_1h_gt_40) and (last_stochrsi_k_1h_lt_20):
         return True, f"exit_{mode_name}_d_0_108"
       elif (
-        (last_rsi_3 < 5.0)
+        (last_rsi_3_lt_5)
         and (last_willr_14 < -94.0)
-        and (last_rsi_3_1h > 50.0)
-        and (last_rsi_3_4h > 80.0)
+        and (last_rsi_3_1h_gt_50)
+        and (last_rsi_3_4h_gt_80)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -50.0))
       ):
         return True, f"exit_{mode_name}_d_0_109"
-      elif (last_rsi_3 < 5.0) and (last_rsi_3_4h > 35.0) and (last_stochrsi_k_4h_lt_50) and (last_roc_9_4h < -25.0):
+      elif (last_rsi_3_lt_5) and (last_rsi_3_4h > 35.0) and (last_stochrsi_k_4h_lt_50) and (last_roc_9_4h < -25.0):
         return True, f"exit_{mode_name}_d_0_110"
       elif (
-        (last_rsi_3 < 5.0)
-        and (last_rsi_14 > 58.0)
-        and (last_rsi_3_1h > 50.0)
-        and (last_rsi_14_4h < 30.0)
-        and (last_aroond_14_1h > 75.0)
-        and (last_aroond_14_4h > 75.0)
+        (last_rsi_3_lt_5)
+        and (last_rsi_14_gt_58)
+        and (last_rsi_3_1h_gt_50)
+        and (last_rsi_14_4h_lt_30)
+        and (last_aroond_14_1h_gt_75)
+        and (last_aroond_14_4h_gt_75)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -20.0))
       ):
         return True, f"exit_{mode_name}_d_0_111"
       elif (
-        (last_rsi_3 < 5.0)
+        (last_rsi_3_lt_5)
         and (last_willr_14 < -80.0)
         and (last_rsi_14_gt_50)
-        and (last_rsi_3_1h > 65.0)
+        and (last_rsi_3_1h_gt_65)
         and (last_rsi_3_4h > 65.0)
         and (last_rsi_3_1d > 40.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
       ):
         return True, f"exit_{mode_name}_d_0_112"
       elif (
-        (last_rsi_3 < 5.0)
+        (last_rsi_3_lt_5)
         and (last_willr_14 < -99.0)
-        and (last_rsi_3_1d > 70.0)
+        and (last_rsi_3_1d_gt_70)
         and (last_stochrsi_k_4h_lt_50)
         and (isinstance(last_roc_9_4h, np.float64) and (last_roc_9_4h < -10.0))
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 10.0))
       ):
         return True, f"exit_{mode_name}_d_0_113"
       elif (
-        (last_rsi_3 < 5.0)
-        and (last_rsi_14 > 52.0)
-        and (last_rsi_3_1h > 80.0)
+        (last_rsi_3_lt_5)
+        and (last_rsi_14_gt_52)
+        and (last_rsi_3_1h_gt_80)
         and (last_rsi_3_4h_gt_70)
-        and (last_rsi_3_1d > 70.0)
+        and (last_rsi_3_1d_gt_70)
       ):
         return True, f"exit_{mode_name}_d_0_114"
       elif (
-        (last_rsi_3 < 5.0)
-        and (last_rsi_14 > 54.0)
+        (last_rsi_3_lt_5)
+        and (last_rsi_14_gt_54)
         and (last_rsi_3_15m > 70.0)
         and (last_stochrsi_k_1h_lt_50)
         and (last_stochrsi_k_4h_lt_50)
       ):
         return True, f"exit_{mode_name}_d_0_115"
-      elif (last_rsi_3 < 8.0) and (last_rsi_3_1h > 85.0) and (last_rsi_3_4h > 60.0) and (last_aroonu_14_4h < 50.0):
+      elif (last_rsi_3_lt_8) and (last_rsi_3_1h_gt_85) and (last_rsi_3_4h_gt_60) and (last_aroonu_14_4h_lt_50):
         return True, f"exit_{mode_name}_d_0_116"
-      elif (last_rsi_3 < 5.0) and (last_rsi_3_1h > 50.0) and (last_aroonu_14_1h < 20.0) and (last_aroonu_14_4h < 20.0):
+      elif (last_rsi_3_lt_5) and (last_rsi_3_1h_gt_50) and (last_aroonu_14_1h < 20.0) and (last_aroonu_14_4h < 20.0):
         return True, f"exit_{mode_name}_d_0_117"
-      elif (last_rsi_3 < 8.0) and (last_rsi_3_1h > 80.0) and (last_rsi_3_4h > 40.0) and (last_aroond_14_4h > 40.0):
+      elif (last_rsi_3_lt_8) and (last_rsi_3_1h_gt_80) and (last_rsi_3_4h_gt_40) and (last_aroond_14_4h > 40.0):
         return True, f"exit_{mode_name}_d_0_118"
       elif (
-        (last_rsi_3 < 5.0)
+        (last_rsi_3_lt_5)
         and (last_willr_14 < -80.0)
-        and (last_rsi_3_1h > 40.0)
-        and (last_rsi_3_4h > 40.0)
-        and (last_stochrsi_k_1h < 60.0)
+        and (last_rsi_3_1h_gt_40)
+        and (last_rsi_3_4h_gt_40)
+        and (last_stochrsi_k_1h_lt_60)
       ):
         return True, f"exit_{mode_name}_d_0_119"
-      elif (last_rsi_3 < 5.0) and (last_rsi_14 > 54.0) and (last_rsi_3_1h > 60.0) and (last_aroond_14_4h > 75.0):
+      elif (last_rsi_3_lt_5) and (last_rsi_14_gt_54) and (last_rsi_3_1h_gt_60) and (last_aroond_14_4h_gt_75):
         return True, f"exit_{mode_name}_d_0_120"
-      elif (last_rsi_3 < 5.0) and (last_rsi_14 > 56.0) and (last_rsi_3_1h > 50.0) and (last_rsi_14_4h < 15.0):
+      elif (last_rsi_3_lt_5) and (last_rsi_14_gt_56) and (last_rsi_3_1h_gt_50) and (last_rsi_14_4h < 15.0):
         return True, f"exit_{mode_name}_d_0_121"
-      elif (last_rsi_3 < 5.0) and (last_rsi_14 > 58.0) and (last_rsi_3_4h_gt_70) and (last_stochrsi_k_1h_lt_50):
+      elif (last_rsi_3_lt_5) and (last_rsi_14_gt_58) and (last_rsi_3_4h_gt_70) and (last_stochrsi_k_1h_lt_50):
         return True, f"exit_{mode_name}_d_0_122"
-      elif (last_rsi_3 < 5.0) and (last_willr_14 < -98.0) and (last_rsi_3_1h > 90.0) and (last_rsi_3_1d > 70.0):
+      elif (last_rsi_3_lt_5) and (last_willr_14 < -98.0) and (last_rsi_3_1h_gt_90) and (last_rsi_3_1d_gt_70):
         return True, f"exit_{mode_name}_d_0_123"
       elif (
-        (last_rsi_3 < 5.0)
-        and (last_rsi_3_1h > 85.0)
+        (last_rsi_3_lt_5)
+        and (last_rsi_3_1h_gt_85)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 20.0))
       ):
         return True, f"exit_{mode_name}_d_0_124"
       elif (
-        (last_rsi_3 < 5.0)
+        (last_rsi_3_lt_5)
         and (last_willr_14 < -98.0)
-        and (last_rsi_3_1h > 90.0)
-        and (last_rsi_3_4h > 60.0)
+        and (last_rsi_3_1h_gt_90)
+        and (last_rsi_3_4h_gt_60)
         and (last_rsi_3_1d > 60.0)
         and (last_close > (last_low_min_30_1d * 2.0))
       ):
         return True, f"exit_{mode_name}_d_0_125"
-      elif (last_rsi_3 < 5.0) and (last_rsi_3_1h > 85.0) and (last_rsi_3_4h > 60.0) and (last_stochrsi_k_4h_lt_50):
+      elif (last_rsi_3_lt_5) and (last_rsi_3_1h_gt_85) and (last_rsi_3_4h_gt_60) and (last_stochrsi_k_4h_lt_50):
         return True, f"exit_{mode_name}_d_0_126"
-      elif (last_rsi_3 < 5.0) and (last_rsi_3_1h > 90.0) and (last_rsi_3_4h_gt_70) and (last_rsi_3_1d > 60.0):
+      elif (last_rsi_3_lt_5) and (last_rsi_3_1h_gt_90) and (last_rsi_3_4h_gt_70) and (last_rsi_3_1d > 60.0):
         return True, f"exit_{mode_name}_d_0_127"
-      elif (last_rsi_3 < 4.0) and (last_rsi_3_4h_gt_70) and (last_aroond_14_4h > 85.0):
+      elif (last_rsi_3_lt_4) and (last_rsi_3_4h_gt_70) and (last_aroond_14_4h > 85.0):
         return True, f"exit_{mode_name}_d_0_128"
       elif (
-        (last_rsi_3 < 5.0)
-        and (last_rsi_3_4h > 75.0)
+        (last_rsi_3_lt_5)
+        and (last_rsi_3_4h_gt_75)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -80.0))
       ):
         return True, f"exit_{mode_name}_d_0_129"
       elif (
-        (last_rsi_3 < 5.0)
+        (last_rsi_3_lt_5)
         and (last_rsi_14_1h < 35.0)
-        and (last_stochrsi_k_1h < 20.0)
+        and (last_stochrsi_k_1h_lt_20)
         and (last_cci_20_change_pct_1h > 0.0)
       ):
         return True, f"exit_{mode_name}_d_0_130"
-      elif (last_rsi_14 > 64.0) and (last_rsi_3_1h > 80.0) and (last_rsi_3_4h_gt_70) and (last_stochrsi_k_4h_lt_50):
+      elif (last_rsi_14 > 64.0) and (last_rsi_3_1h_gt_80) and (last_rsi_3_4h_gt_70) and (last_stochrsi_k_4h_lt_50):
         return True, f"exit_{mode_name}_d_0_131"
       elif (
-        (last_rsi_3 < 5.0)
-        and (last_rsi_3_1h > 65.0)
+        (last_rsi_3_lt_5)
+        and (last_rsi_3_1h_gt_65)
         and (last_rsi_3_4h > 65.0)
         and (last_aroond_14_1h > 50.0)
-        and (last_stochrsi_k_1h < 60.0)
+        and (last_stochrsi_k_1h_lt_60)
       ):
         return True, f"exit_{mode_name}_d_0_132"
       elif (
-        (last_rsi_3 < 5.0)
+        (last_rsi_3_lt_5)
         and (last_aroond_14_15m > 75.0)
-        and (last_aroond_14_1h > 75.0)
+        and (last_aroond_14_1h_gt_75)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -25.0))
       ):
         return True, f"exit_{mode_name}_d_0_133"


### PR DESCRIPTION
## Summary
- Hoists repeated short `short_exit_dec` threshold checks for the 0.1-1% profit bracket into local boolean aliases.
- Keeps the branch independent on latest upstream `main`.

## Safety
- Only already-read scalar threshold comparisons inside the same current-profit branch are reused.
- Indicator formulas, candle selection, profit arithmetic, thresholds, condition order, return values, order classification, and stake logic are unchanged.
- Touched function: `short_exit_dec`. No v3 grind-entry code is touched.

## Backtest scope
- Full backtesting was not required because this patch only reuses already-read scalar threshold checks inside the same `short_exit_dec` current-profit branch. Trading conditions and output values are unchanged.

## Checks
- `python3 ~/.codex/skills/nfi-upstream-pr/scripts/validate_nfi_pr.py --base origin/main`
- `AST undefined-local scan from validator reported zero findings for introduced `last_*` aliases`
- `git merge-tree conflict simulation against origin/main`
- `targeted git diff origin/main...HEAD -- NostalgiaForInfinityX7.py review`
- `git diff --check`
- `ruff format --check NostalgiaForInfinityX7.py`
- `ruff check NostalgiaForInfinityX7.py`
- `PYTHONDONTWRITEBYTECODE=1 python3 -m py_compile NostalgiaForInfinityX7.py`
