### PR TITLE
Hoist X7 short dec 3-4% thresholds

### DIFF
--- a/NostalgiaForInfinityX7.py
+++ b/NostalgiaForInfinityX7.py
@@ -54178,6 +54178,69 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_2_133"
     elif 0.04 > current_profit >= 0.03:
+      # Reused short exit decision threshold checks for this profit bracket
+      last_rsi_3_lt_20 = last_rsi_3 < 20.0
+      last_rsi_14_gt_48 = last_rsi_14 > 48.0
+      last_rsi_3_lt_30 = last_rsi_3 < 30.0
+      last_rsi_3_4h_gt_80 = last_rsi_3_4h > 80.0
+      last_rsi_3_4h_gt_90 = last_rsi_3_4h > 90.0
+      last_rsi_3_1h_gt_80 = last_rsi_3_1h > 80.0
+      last_rsi_3_1h_gt_85 = last_rsi_3_1h > 85.0
+      last_rsi_3_1h_gt_50 = last_rsi_3_1h > 50.0
+      last_rsi_3_lt_25 = last_rsi_3 < 25.0
+      last_rsi_3_lt_10 = last_rsi_3 < 10.0
+      last_rsi_3_1h_gt_90 = last_rsi_3_1h > 90.0
+      last_rsi_3_1h_gt_75 = last_rsi_3_1h > 75.0
+      last_rsi_3_4h_gt_60 = last_rsi_3_4h > 60.0
+      last_rsi_3_lt_26 = last_rsi_3 < 26.0
+      last_rsi_3_4h_gt_75 = last_rsi_3_4h > 75.0
+      last_rsi_3_lt_16 = last_rsi_3 < 16.0
+      last_rsi_3_lt_18 = last_rsi_3 < 18.0
+      last_rsi_3_lt_24 = last_rsi_3 < 24.0
+      last_rsi_3_lt_32 = last_rsi_3 < 32.0
+      last_rsi_3_lt_14 = last_rsi_3 < 14.0
+      last_rsi_3_1h_gt_40 = last_rsi_3_1h > 40.0
+      last_stochrsi_k_4h_lt_60 = last_stochrsi_k_4h < 60.0
+      last_rsi_14_gt_52 = last_rsi_14 > 52.0
+      last_stochrsi_k_4h_lt_80 = last_stochrsi_k_4h < 80.0
+      last_change_pct_1d_gt_5 = last_change_pct_1d > 5.0
+      last_stochrsi_k_4h_lt_10 = last_stochrsi_k_4h < 10.0
+      last_rsi_3_lt_12 = last_rsi_3 < 12.0
+      last_rsi_14_gt_56 = last_rsi_14 > 56.0
+      last_rsi_3_lt_40 = last_rsi_3 < 40.0
+      last_rsi_3_4h_gt_85 = last_rsi_3_4h > 85.0
+      last_stochrsi_k_1h_lt_30 = last_stochrsi_k_1h < 30.0
+      last_stochrsi_k_4h_lt_70 = last_stochrsi_k_4h < 70.0
+      last_rsi_3_1d_gt_75 = last_rsi_3_1d > 75.0
+      last_stochrsi_k_1h_lt_20 = last_stochrsi_k_1h < 20.0
+      last_rsi_3_lt_36 = last_rsi_3 < 36.0
+      last_rsi_14_gt_46 = last_rsi_14 > 46.0
+      last_stochrsi_k_1h_lt_60 = last_stochrsi_k_1h < 60.0
+      last_aroond_14_1h_gt_75 = last_aroond_14_1h > 75.0
+      last_rsi_3_4h_gt_40 = last_rsi_3_4h > 40.0
+      last_stochrsi_k_lt_5 = last_stochrsi_k < 5.0
+      last_rsi_14_lt_32 = last_rsi_14 < 32.0
+      last_roc_9_1h_gt_10 = last_roc_9_1h > 10.0
+      last_change_pct_4h_gt_5 = last_change_pct_4h > 5.0
+      last_aroond_14_4h_gt_25 = last_aroond_14_4h > 25.0
+      last_rsi_3_lt_6 = last_rsi_3 < 6.0
+      last_rsi_3_lt_15 = last_rsi_3 < 15.0
+      last_aroond_14_4h_gt_75 = last_aroond_14_4h > 75.0
+      last_rsi_3_lt_35 = last_rsi_3 < 35.0
+      last_stochrsi_k_1h_lt_70 = last_stochrsi_k_1h < 70.0
+      last_rsi_3_lt_22 = last_rsi_3 < 22.0
+      last_stochrsi_k_4h_lt_75 = last_stochrsi_k_4h < 75.0
+      last_rsi_3_lt_38 = last_rsi_3 < 38.0
+      last_rsi_3_lt_50 = last_rsi_3 < 50.0
+      last_rsi_14_gt_54 = last_rsi_14 > 54.0
+      last_rsi_3_lt_28 = last_rsi_3 < 28.0
+      last_rsi_3_1h_gt_60 = last_rsi_3_1h > 60.0
+      last_rsi_3_1h_gt_55 = last_rsi_3_1h > 55.0
+      last_aroonu_14_4h_lt_50 = last_aroonu_14_4h < 50.0
+      last_aroond_14_4h_gt_50 = last_aroond_14_4h > 50.0
+      last_rsi_3_1h_gt_65 = last_rsi_3_1h > 65.0
+      last_rsi_14_4h_lt_30 = last_rsi_14_4h < 30.0
+      last_rsi_3_1d_gt_70 = last_rsi_3_1d > 70.0
       if (
         (last_willr_14 < -99.0)
         and (last_rsi_14 < 22.0)
@@ -54197,28 +54260,28 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_3_2"
       elif (
         (last_willr_14 < -80.0)
-        and (last_stochrsi_k < 5.0)
+        and (last_stochrsi_k_lt_5)
         and (last_cmf_20_1h > 0.0)
         and (last_cmf_20_4h > 0.0)
-        and ((last_stochrsi_k_4h < 80.0) and (last_stochrsi_k_change_pct_4h > 10.0))
+        and ((last_stochrsi_k_4h_lt_80) and (last_stochrsi_k_change_pct_4h > 10.0))
       ):
         return True, f"exit_{mode_name}_d_3_3"
       elif (
         (last_willr_14 < -70.0)
         and (last_rsi_14 < 35.0)
-        and (last_stochrsi_k < 5.0)
+        and (last_stochrsi_k_lt_5)
         and (last_stochrsi_k_4h < 30.0)
         and (isinstance(last_ema_200_1h, np.float64) and (last_ema_12_1h > last_ema_200_1h))
         and (isinstance(last_ema_200_4h, np.float64) and (last_ema_12_4h > last_ema_200_4h))
       ):
         return True, f"exit_{mode_name}_d_3_4"
-      elif (last_willr_14 < -94.0) and (last_rsi_14 < 32.0) and (last_roc_9_1h > 5.0) and (last_roc_9_4h > 5.0):
+      elif (last_willr_14 < -94.0) and (last_rsi_14_lt_32) and (last_roc_9_1h > 5.0) and (last_roc_9_4h > 5.0):
         return True, f"exit_{mode_name}_d_3_5"
       elif (
-        (last_rsi_3 < 30.0)
+        (last_rsi_3_lt_30)
         and (last_stochrsi_k < 30.0)
         and (last_rsi_14 > 60.0)
-        and (last_roc_9_1h > 10.0)
+        and (last_roc_9_1h_gt_10)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -50.0))
       ):
         return True, f"exit_{mode_name}_d_3_6"
@@ -54231,198 +54294,198 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_3_7"
       elif (
         (last_willr_14 < -94.0)
-        and (last_stochrsi_k < 5.0)
+        and (last_stochrsi_k_lt_5)
         and (last_cmf_20_1h > 0.1)
         and (last_cmf_20_4h > 0.1)
-        and (last_change_pct_1d > 5.0)
+        and (last_change_pct_1d_gt_5)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -15.0))
       ):
         return True, f"exit_{mode_name}_d_3_8"
       elif (
         (last_willr_14 < -94.0)
         and (last_rsi_3 < 5.0)
-        and (last_change_pct_4h > 5.0)
+        and (last_change_pct_4h_gt_5)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
       ):
         return True, f"exit_{mode_name}_d_3_9"
       elif (
         (last_willr_14 < -80.0)
         and (last_rsi_14_gt_50)
-        and (last_roc_9_1h > 10.0)
+        and (last_roc_9_1h_gt_10)
         and (last_roc_9_4h > 10.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -10.0))
       ):
         return True, f"exit_{mode_name}_d_3_10"
       elif (
-        (last_rsi_3 < 25.0)
+        (last_rsi_3_lt_25)
         and (last_rsi_14 > 55.0)
         and (last_roc_9_15m > 10.0)
-        and (last_roc_9_1h > 10.0)
+        and (last_roc_9_1h_gt_10)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 20.0))
       ):
         return True, f"exit_{mode_name}_d_3_11"
       elif (
-        (last_rsi_3 < 30.0)
+        (last_rsi_3_lt_30)
         and (last_rsi_14_gt_50)
-        and (last_rsi_3_4h > 90.0)
+        and (last_rsi_3_4h_gt_90)
         and (last_roc_9_1h > 20.0)
         and (last_roc_9_4h > 20.0)
       ):
         return True, f"exit_{mode_name}_d_3_12"
-      elif (last_rsi_3 < 20.0) and (last_rsi_3_4h > 95.0) and (last_roc_9_4h > 25.0):
+      elif (last_rsi_3_lt_20) and (last_rsi_3_4h > 95.0) and (last_roc_9_4h > 25.0):
         return True, f"exit_{mode_name}_d_3_13"
-      elif (last_rsi_3 < 10.0) and (last_willr_14 < -92.0) and (last_rsi_3_4h > 95.0) and (last_aroond_14_4h > 25.0):
+      elif (last_rsi_3_lt_10) and (last_willr_14 < -92.0) and (last_rsi_3_4h > 95.0) and (last_aroond_14_4h_gt_25):
         return True, f"exit_{mode_name}_d_3_14"
-      elif (last_rsi_3 < 10.0) and (last_rsi_14 < 35.0) and (last_roc_9_4h > 30.0):
+      elif (last_rsi_3_lt_10) and (last_rsi_14 < 35.0) and (last_roc_9_4h > 30.0):
         return True, f"exit_{mode_name}_d_3_15"
       elif (
-        (last_rsi_3 < 30.0)
-        and (last_aroond_14_4h > 25.0)
+        (last_rsi_3_lt_30)
+        and (last_aroond_14_4h_gt_25)
         and (last_roc_9_4h > 25.0)
         and (last_aroond_14_1d > 50.0)
         and (last_change_pct_1d > 15.0)
       ):
         return True, f"exit_{mode_name}_d_3_16"
       elif (
-        (last_rsi_3 < 20.0)
+        (last_rsi_3_lt_20)
         and (last_willr_14 < -75.0)
-        and (last_rsi_3_1h > 90.0)
-        and (last_stochrsi_k_4h < 10.0)
+        and (last_rsi_3_1h_gt_90)
+        and (last_stochrsi_k_4h_lt_10)
         and (last_roc_9_4h < -30.0)
       ):
         return True, f"exit_{mode_name}_d_3_17"
-      elif (last_rsi_3 < 25.0) and (last_rsi_14 < 40.0) and (last_rsi_3_4h > 80.0) and (last_roc_2_1d > 50.0):
+      elif (last_rsi_3_lt_25) and (last_rsi_14 < 40.0) and (last_rsi_3_4h_gt_80) and (last_roc_2_1d > 50.0):
         return True, f"exit_{mode_name}_d_3_18"
       elif (
-        (last_rsi_3 < 12.0)
-        and (last_rsi_14 < 32.0)
-        and (last_rsi_3_4h > 90.0)
+        (last_rsi_3_lt_12)
+        and (last_rsi_14_lt_32)
+        and (last_rsi_3_4h_gt_90)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 30.0))
       ):
         return True, f"exit_{mode_name}_d_3_19"
-      elif (last_rsi_3 < 54.0) and (last_rsi_14 > 56.0) and (last_rsi_3_1h > 90.0) and (last_aroond_14_1h > 25.0):
+      elif (last_rsi_3 < 54.0) and (last_rsi_14_gt_56) and (last_rsi_3_1h_gt_90) and (last_aroond_14_1h > 25.0):
         return True, f"exit_{mode_name}_d_3_20"
-      elif (last_rsi_3 < 40.0) and (last_rsi_14_gt_50) and (last_rsi_3_1h > 80.0) and (last_stochrsi_k_4h < 10.0):
+      elif (last_rsi_3_lt_40) and (last_rsi_14_gt_50) and (last_rsi_3_1h_gt_80) and (last_stochrsi_k_4h_lt_10):
         return True, f"exit_{mode_name}_d_3_21"
       elif (
-        (last_rsi_3 < 6.0)
+        (last_rsi_3_lt_6)
         and (last_willr_14 < -94.0)
-        and (last_change_pct_4h > 5.0)
+        and (last_change_pct_4h_gt_5)
         and (last_stochrsi_k_4h_lt_50)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
       ):
         return True, f"exit_{mode_name}_d_3_22"
-      elif (last_rsi_3 < 15.0) and (last_willr_14 < -80.0) and (last_rsi_3_1h > 85.0) and (last_rsi_3_1d > 95.0):
+      elif (last_rsi_3_lt_15) and (last_willr_14 < -80.0) and (last_rsi_3_1h_gt_85) and (last_rsi_3_1d > 95.0):
         return True, f"exit_{mode_name}_d_3_23"
       elif (
-        (last_rsi_3 < 12.0)
-        and (last_rsi_14 < 32.0)
+        (last_rsi_3_lt_12)
+        and (last_rsi_14_lt_32)
         and (last_willr_14 < -75.0)
         and (last_rsi_3_4h_gt_70)
-        and (last_aroond_14_4h > 75.0)
+        and (last_aroond_14_4h_gt_75)
       ):
         return True, f"exit_{mode_name}_d_3_24"
       elif (
-        (last_rsi_3 < 20.0)
+        (last_rsi_3_lt_20)
         and (last_willr_14 < -92.0)
-        and (last_rsi_3_4h > 90.0)
+        and (last_rsi_3_4h_gt_90)
         and (last_roc_9_4h > 15.0)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 50.0))
       ):
         return True, f"exit_{mode_name}_d_3_25"
-      elif (last_rsi_3 < 25.0) and (last_willr_14 < -92.0) and (last_rsi_3_4h > 85.0) and (last_roc_9_4h > 20.0):
+      elif (last_rsi_3_lt_25) and (last_willr_14 < -92.0) and (last_rsi_3_4h_gt_85) and (last_roc_9_4h > 20.0):
         return True, f"exit_{mode_name}_d_3_26"
       elif (
-        (last_rsi_3 < 35.0)
+        (last_rsi_3_lt_35)
         and (last_rsi_14_gt_50)
-        and (last_rsi_3_1h > 80.0)
-        and (last_rsi_3_4h > 80.0)
-        and (last_stochrsi_k_4h < 80.0)
+        and (last_rsi_3_1h_gt_80)
+        and (last_rsi_3_4h_gt_80)
+        and (last_stochrsi_k_4h_lt_80)
       ):
         return True, f"exit_{mode_name}_d_3_27"
-      elif (last_rsi_3 < 30.0) and (last_rsi_14_gt_50) and (last_rsi_3_15m > 90.0) and (last_roc_9_4h < -50.0):
+      elif (last_rsi_3_lt_30) and (last_rsi_14_gt_50) and (last_rsi_3_15m > 90.0) and (last_roc_9_4h < -50.0):
         return True, f"exit_{mode_name}_d_3_28"
       elif (
-        (last_rsi_3 < 25.0)
+        (last_rsi_3_lt_25)
         and (last_rsi_14_gt_50)
-        and (last_rsi_3_1h > 80.0)
-        and (last_rsi_3_4h > 80.0)
-        and (last_stochrsi_k_1h < 70.0)
+        and (last_rsi_3_1h_gt_80)
+        and (last_rsi_3_4h_gt_80)
+        and (last_stochrsi_k_1h_lt_70)
       ):
         return True, f"exit_{mode_name}_d_3_29"
-      elif (last_rsi_3 < 20.0) and (last_rsi_3_1h > 75.0) and (last_rsi_3_4h > 90.0) and (last_stochrsi_k_1h < 30.0):
+      elif (last_rsi_3_lt_20) and (last_rsi_3_1h_gt_75) and (last_rsi_3_4h_gt_90) and (last_stochrsi_k_1h_lt_30):
         return True, f"exit_{mode_name}_d_3_30"
       elif (
-        (last_rsi_3 < 30.0)
+        (last_rsi_3_lt_30)
         and (last_rsi_14_gt_50)
-        and (last_rsi_3_1h > 85.0)
-        and (last_rsi_3_4h > 85.0)
+        and (last_rsi_3_1h_gt_85)
+        and (last_rsi_3_4h_gt_85)
         and (last_stochrsi_k_1h < 75.0)
       ):
         return True, f"exit_{mode_name}_d_3_31"
-      elif (last_rsi_3 < 20.0) and (last_rsi_3_1h > 85.0) and (last_roc_2_4h > 30.0) and (last_stochrsi_k_4h < 70.0):
+      elif (last_rsi_3_lt_20) and (last_rsi_3_1h_gt_85) and (last_roc_2_4h > 30.0) and (last_stochrsi_k_4h_lt_70):
         return True, f"exit_{mode_name}_d_3_32"
       elif (
-        (last_rsi_3 < 20.0)
+        (last_rsi_3_lt_20)
         and (last_willr_14 < -94.0)
         and (last_roc_2_1h > 10.0)
         and (last_roc_9_1h < -30.0)
         and (last_stochrsi_k_1h_lt_50)
       ):
         return True, f"exit_{mode_name}_d_3_33"
-      elif (last_rsi_3 < 35.0) and (last_rsi_3_15m > 70.0) and (last_rsi_14_1h < 20.0) and (last_roc_9_1h < -40.0):
+      elif (last_rsi_3_lt_35) and (last_rsi_3_15m > 70.0) and (last_rsi_14_1h < 20.0) and (last_roc_9_1h < -40.0):
         return True, f"exit_{mode_name}_d_3_34"
-      elif (last_rsi_3 < 16.0) and (last_willr_14 < -92.0) and (last_rsi_3_1d > 75.0) and (last_stochrsi_k_1h < 25.0):
+      elif (last_rsi_3_lt_16) and (last_willr_14 < -92.0) and (last_rsi_3_1d_gt_75) and (last_stochrsi_k_1h < 25.0):
         return True, f"exit_{mode_name}_d_3_35"
       elif (
-        (last_rsi_3 < 25.0)
+        (last_rsi_3_lt_25)
         and (last_willr_14 < -75.0)
         and (last_roc_9_4h > 25.0)
-        and (last_rsi_3_1d > 75.0)
+        and (last_rsi_3_1d_gt_75)
         and (last_stochrsi_k_1h_lt_50)
       ):
         return True, f"exit_{mode_name}_d_3_36"
       elif (
-        (last_rsi_3 < 22.0)
+        (last_rsi_3_lt_22)
         and (last_rsi_14_gt_50)
         and (last_rsi_3_1h < 80.0)
         and (last_rsi_3_1d < 75.0)
         and (last_stochrsi_k_4h_lt_50)
       ):
         return True, f"exit_{mode_name}_d_3_37"
-      elif (last_rsi_3 < 25.0) and (last_willr_14 < -75.0) and (last_rsi_3_4h > 90.0) and (last_stochrsi_k_4h < 80.0):
+      elif (last_rsi_3_lt_25) and (last_willr_14 < -75.0) and (last_rsi_3_4h_gt_90) and (last_stochrsi_k_4h_lt_80):
         return True, f"exit_{mode_name}_d_3_38"
-      elif (last_rsi_3 < 7.0) and (last_willr_14 < -93.0) and (last_cmf_20_4h > 0.0) and (last_rsi_3_4h > 90.0):
+      elif (last_rsi_3 < 7.0) and (last_willr_14 < -93.0) and (last_cmf_20_4h > 0.0) and (last_rsi_3_4h_gt_90):
         return True, f"exit_{mode_name}_d_3_39"
       elif (
-        (last_rsi_3 < 25.0)
+        (last_rsi_3_lt_25)
         and (last_willr_14 < -75.0)
         and (last_rsi_3_1h_gt_70)
-        and (last_stochrsi_k_1h < 70.0)
+        and (last_stochrsi_k_1h_lt_70)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 10.0))
       ):
         return True, f"exit_{mode_name}_d_3_40"
       elif (
-        (last_rsi_3 < 15.0)
+        (last_rsi_3_lt_15)
         and (last_willr_14 < -80.0)
         and (last_rsi_3_1h_gt_70)
-        and (last_stochrsi_k_4h < 75.0)
+        and (last_stochrsi_k_4h_lt_75)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -50.0))
       ):
         return True, f"exit_{mode_name}_d_3_41"
       elif (
-        (last_rsi_3 < 20.0)
+        (last_rsi_3_lt_20)
         and (last_willr_14 < -65.0)
-        and (last_stochrsi_k_4h < 70.0)
+        and (last_stochrsi_k_4h_lt_70)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -40.0))
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 30.0))
       ):
         return True, f"exit_{mode_name}_d_3_42"
       elif (
-        (last_rsi_3 < 20.0)
+        (last_rsi_3_lt_20)
         and (last_rsi_14_gt_50)
-        and (last_rsi_3_1h > 85.0)
-        and (last_rsi_3_4h > 60.0)
+        and (last_rsi_3_1h_gt_85)
+        and (last_rsi_3_4h_gt_60)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 10.0))
       ):
         return True, f"exit_{mode_name}_d_3_43"
@@ -54434,57 +54497,57 @@ class NostalgiaForInfinityX7(IStrategy):
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
       ):
         return True, f"exit_{mode_name}_d_3_44"
-      elif (last_rsi_3 < 10.0) and (last_willr_14 < -90.0) and (last_rsi_3_1h > 90.0):
+      elif (last_rsi_3_lt_10) and (last_willr_14 < -90.0) and (last_rsi_3_1h_gt_90):
         return True, f"exit_{mode_name}_d_3_45"
-      elif (last_rsi_3 < 30.0) and (last_rsi_3_1h > 85.0) and (last_rsi_3_4h > 90.0) and (last_roc_2_1d > 20.0):
+      elif (last_rsi_3_lt_30) and (last_rsi_3_1h_gt_85) and (last_rsi_3_4h_gt_90) and (last_roc_2_1d > 20.0):
         return True, f"exit_{mode_name}_d_3_46"
       elif (
-        (last_rsi_3 < 18.0)
-        and (last_stochrsi_k_1h < 20.0)
-        and (last_stochrsi_k_4h < 60.0)
-        and (last_change_pct_1d > 5.0)
+        (last_rsi_3_lt_18)
+        and (last_stochrsi_k_1h_lt_20)
+        and (last_stochrsi_k_4h_lt_60)
+        and (last_change_pct_1d_gt_5)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 5.0))
       ):
         return True, f"exit_{mode_name}_d_3_47"
       elif (
         (last_rsi_3 < 45.0)
-        and (last_rsi_14 > 52.0)
+        and (last_rsi_14_gt_52)
         and (last_rsi_3_1h_gt_70)
-        and (last_rsi_3_4h > 80.0)
+        and (last_rsi_3_4h_gt_80)
         and (last_stochrsi_k_1h_lt_50)
       ):
         return True, f"exit_{mode_name}_d_3_48"
       elif (
-        (last_rsi_3 < 20.0)
+        (last_rsi_3_lt_20)
         and (last_willr_14 < -92.0)
-        and (last_rsi_3_4h > 80.0)
-        and (last_change_pct_1d > 5.0)
+        and (last_rsi_3_4h_gt_80)
+        and (last_change_pct_1d_gt_5)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 50.0))
       ):
         return True, f"exit_{mode_name}_d_3_49"
-      elif (last_rsi_3 < 20.0) and (last_willr_14 < -92.0) and (last_rsi_3_1d > 90.0) and (last_stochrsi_k_1h < 10.0):
+      elif (last_rsi_3_lt_20) and (last_willr_14 < -92.0) and (last_rsi_3_1d > 90.0) and (last_stochrsi_k_1h < 10.0):
         return True, f"exit_{mode_name}_d_3_50"
-      elif (last_rsi_3 < 38.0) and (last_rsi_14_gt_50) and (last_rsi_3_4h > 80.0) and (last_stochrsi_k_1h_lt_50):
+      elif (last_rsi_3_lt_38) and (last_rsi_14_gt_50) and (last_rsi_3_4h_gt_80) and (last_stochrsi_k_1h_lt_50):
         return True, f"exit_{mode_name}_d_3_51"
       elif (
-        (last_rsi_3 < 24.0)
+        (last_rsi_3_lt_24)
         and (last_rsi_14 < 44.0)
         and (last_willr_14 < -90.0)
-        and (last_stochrsi_k_1h < 30.0)
+        and (last_stochrsi_k_1h_lt_30)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 15.0))
       ):
         return True, f"exit_{mode_name}_d_3_52"
       elif (
-        (last_rsi_3 < 30.0)
+        (last_rsi_3_lt_30)
         and (last_rsi_14_gt_50)
         and (last_willr_14 < -75.0)
-        and (last_rsi_3_1h > 80.0)
+        and (last_rsi_3_1h_gt_80)
         and (last_stochrsi_k_4h_lt_50)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 50.0))
       ):
         return True, f"exit_{mode_name}_d_3_53"
       elif (
-        (last_rsi_3 < 26.0)
+        (last_rsi_3_lt_26)
         and (last_rsi_14_gt_50)
         and (last_stochrsi_k_1h_lt_50)
         and (last_roc_9_4h > 10.0)
@@ -54492,7 +54555,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_3_54"
       elif (
-        (last_rsi_3 < 10.0)
+        (last_rsi_3_lt_10)
         and (last_willr_14 < -82.0)
         and (last_roc_9_4h > 5.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -10.0))
@@ -54500,23 +54563,23 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_3_55"
       elif (
-        (last_rsi_3 < 40.0)
+        (last_rsi_3_lt_40)
         and (last_rsi_14_gt_50)
         and (last_rsi_3_1h_gt_70)
-        and (last_rsi_3_4h > 75.0)
+        and (last_rsi_3_4h_gt_75)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
         and (last_stochrsi_k_4h < 90.0)
       ):
         return True, f"exit_{mode_name}_d_3_56"
       elif (
-        (last_rsi_3 < 50.0)
+        (last_rsi_3_lt_50)
         and (last_rsi_14 > 60.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
         and (last_stochrsi_k_4h < 30.0)
       ):
         return True, f"exit_{mode_name}_d_3_57"
       elif (
-        (last_rsi_3 < 30.0)
+        (last_rsi_3_lt_30)
         and (last_rsi_3_1h_gt_70)
         and (last_rsi_3_4h_gt_70)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 15.0))
@@ -54524,76 +54587,72 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_3_58"
       elif (
-        (last_rsi_3 < 15.0)
+        (last_rsi_3_lt_15)
         and (last_willr_14 < -84.0)
-        and (last_rsi_3_4h > 75.0)
+        and (last_rsi_3_4h_gt_75)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 15.0))
-        and (last_stochrsi_k_4h < 60.0)
+        and (last_stochrsi_k_4h_lt_60)
       ):
         return True, f"exit_{mode_name}_d_3_59"
       elif (
-        (last_rsi_3 < 35.0)
-        and (last_rsi_14 > 56.0)
+        (last_rsi_3_lt_35)
+        and (last_rsi_14_gt_56)
         and (last_rsi_14_4h < 35.0)
         and (last_stochrsi_k_4h_lt_50)
         and (last_stochrsi_k_1d < 50.0)
       ):
         return True, f"exit_{mode_name}_d_3_60"
-      elif (last_rsi_3 < 10.0) and (last_willr_14 < -75.0) and (last_rsi_3_4h > 90.0) and (last_stochrsi_k_1h < 70.0):
+      elif (last_rsi_3_lt_10) and (last_willr_14 < -75.0) and (last_rsi_3_4h_gt_90) and (last_stochrsi_k_1h_lt_70):
         return True, f"exit_{mode_name}_d_3_61"
       elif (
-        (last_rsi_3 < 18.0)
+        (last_rsi_3_lt_18)
         and (last_willr_14 < -94.0)
         and (last_rsi_3_1h_gt_70)
-        and (last_rsi_3_4h > 80.0)
+        and (last_rsi_3_4h_gt_80)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -20.0))
-        and (last_change_pct_1d > 5.0)
+        and (last_change_pct_1d_gt_5)
       ):
         return True, f"exit_{mode_name}_d_3_62"
-      elif (
-        (last_rsi_3 < 36.0) and (last_rsi_3_1d > 75.0) and (last_stochrsi_k_1h < 20.0) and (last_stochrsi_k_4h < 70.0)
-      ):
+      elif (last_rsi_3_lt_36) and (last_rsi_3_1d_gt_75) and (last_stochrsi_k_1h_lt_20) and (last_stochrsi_k_4h_lt_70):
         return True, f"exit_{mode_name}_d_3_63"
       elif (
-        (last_rsi_3 < 16.0)
+        (last_rsi_3_lt_16)
         and (last_rsi_3_1h_gt_70)
         and (last_rsi_3_4h_gt_70)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
       ):
         return True, f"exit_{mode_name}_d_3_64"
-      elif (last_rsi_3 < 36.0) and (last_rsi_14 > 54.0) and (last_rsi_3_1h > 80.0) and (last_rsi_3_4h > 85.0):
+      elif (last_rsi_3_lt_36) and (last_rsi_14_gt_54) and (last_rsi_3_1h_gt_80) and (last_rsi_3_4h_gt_85):
         return True, f"exit_{mode_name}_d_3_65"
-      elif (last_rsi_3 < 22.0) and (last_rsi_14 > 48.0) and (last_rsi_3_1h > 80.0) and (last_stochrsi_k_1h_lt_50):
+      elif (last_rsi_3_lt_22) and (last_rsi_14_gt_48) and (last_rsi_3_1h_gt_80) and (last_stochrsi_k_1h_lt_50):
         return True, f"exit_{mode_name}_d_3_66"
       elif (
-        (last_rsi_3 < 50.0)
-        and (last_rsi_14 > 54.0)
+        (last_rsi_3_lt_50)
+        and (last_rsi_14_gt_54)
         and (last_stochrsi_k_4h < 20.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 25.0))
       ):
         return True, f"exit_{mode_name}_d_3_67"
       elif (
-        (last_rsi_3 < 20.0)
-        and (last_rsi_14 > 48.0)
-        and (last_rsi_3_1h > 75.0)
+        (last_rsi_3_lt_20)
+        and (last_rsi_14_gt_48)
+        and (last_rsi_3_1h_gt_75)
         and (last_roc_2_4h > 30.0)
-        and (last_stochrsi_k_4h < 75.0)
+        and (last_stochrsi_k_4h_lt_75)
       ):
         return True, f"exit_{mode_name}_d_3_68"
-      elif (
-        (last_rsi_3 < 6.0) and (last_roc_9_4h < -20.0) and (last_stochrsi_k_4h_lt_50) and (last_change_pct_4h > 5.0)
-      ):
+      elif (last_rsi_3_lt_6) and (last_roc_9_4h < -20.0) and (last_stochrsi_k_4h_lt_50) and (last_change_pct_4h_gt_5):
         return True, f"exit_{mode_name}_d_3_69"
-      elif (last_rsi_3 < 38.0) and (last_rsi_14 > 56.0) and (last_rsi_3_1h > 75.0) and (last_stochrsi_k_4h < 80.0):
+      elif (last_rsi_3_lt_38) and (last_rsi_14_gt_56) and (last_rsi_3_1h_gt_75) and (last_stochrsi_k_4h_lt_80):
         return True, f"exit_{mode_name}_d_3_70"
-      elif (last_rsi_3 < 40.0) and (last_rsi_14 > 52.0) and (last_rsi_3_4h > 75.0) and (last_stochrsi_k_1h < 80.0):
+      elif (last_rsi_3_lt_40) and (last_rsi_14_gt_52) and (last_rsi_3_4h_gt_75) and (last_stochrsi_k_1h < 80.0):
         return True, f"exit_{mode_name}_d_3_71"
-      elif (last_rsi_3 < 26.0) and (last_rsi_14 > 54.0) and (last_rsi_3_1h > 90.0) and (last_aroond_14_4h > 25.0):
+      elif (last_rsi_3_lt_26) and (last_rsi_14_gt_54) and (last_rsi_3_1h_gt_90) and (last_aroond_14_4h_gt_25):
         return True, f"exit_{mode_name}_d_3_72"
       elif (
-        (last_rsi_3 < 26.0)
-        and (last_rsi_3_1h > 75.0)
-        and (last_rsi_3_4h > 85.0)
+        (last_rsi_3_lt_26)
+        and (last_rsi_3_1h_gt_75)
+        and (last_rsi_3_4h_gt_85)
         and (last_roc_9_4h > 20.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 25.0))
       ):
@@ -54601,81 +54660,81 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 4.0)
         and (last_willr_14 < -90.0)
-        and (last_rsi_3_4h > 75.0)
-        and (last_rsi_3_1d > 75.0)
+        and (last_rsi_3_4h_gt_75)
+        and (last_rsi_3_1d_gt_75)
         and (last_stochrsi_k_1h > 50.0)
       ):
         return True, f"exit_{mode_name}_d_3_74"
       elif (
         (last_rsi_3 < 8.0)
         and (last_rsi_3_1h_gt_70)
-        and (last_rsi_3_4h > 80.0)
+        and (last_rsi_3_4h_gt_80)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 50.0))
       ):
         return True, f"exit_{mode_name}_d_3_75"
-      elif (last_rsi_3 < 36.0) and (last_rsi_14 > 46.0) and (last_roc_9_1h < -80.0) and (last_stochrsi_k_4h < 20.0):
+      elif (last_rsi_3_lt_36) and (last_rsi_14_gt_46) and (last_roc_9_1h < -80.0) and (last_stochrsi_k_4h < 20.0):
         return True, f"exit_{mode_name}_d_3_76"
       elif (
-        (last_rsi_3 < 28.0)
+        (last_rsi_3_lt_28)
         and (last_rsi_14_gt_50)
         and (last_rsi_3_1h_gt_70)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -50.0))
       ):
         return True, f"exit_{mode_name}_d_3_77"
       elif (
-        (last_rsi_3 < 18.0)
+        (last_rsi_3_lt_18)
         and (last_willr_14 < -80.0)
         and (last_rsi_3_1h_gt_70)
-        and (last_rsi_3_4h > 80.0)
+        and (last_rsi_3_4h_gt_80)
         and (last_rsi_3_1d > 80.0)
       ):
         return True, f"exit_{mode_name}_d_3_78"
-      elif (last_rsi_3 < 12.0) and (last_willr_14 < -94.0) and (last_rsi_3_1h_gt_70) and (last_rsi_3_4h > 90.0):
+      elif (last_rsi_3_lt_12) and (last_willr_14 < -94.0) and (last_rsi_3_1h_gt_70) and (last_rsi_3_4h_gt_90):
         return True, f"exit_{mode_name}_d_3_79"
       elif (
-        (last_rsi_3 < 32.0)
+        (last_rsi_3_lt_32)
         and (last_rsi_14_gt_50)
         and (last_rsi_3_1h_gt_70)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -50.0))
-        and (last_stochrsi_k_4h < 75.0)
+        and (last_stochrsi_k_4h_lt_75)
       ):
         return True, f"exit_{mode_name}_d_3_80"
       elif (
-        (last_rsi_3 < 20.0)
+        (last_rsi_3_lt_20)
         and (last_willr_14 < -86.0)
-        and (last_rsi_3_1h > 75.0)
-        and (last_rsi_3_4h > 75.0)
+        and (last_rsi_3_1h_gt_75)
+        and (last_rsi_3_4h_gt_75)
         and (isinstance(last_rsi_14_1d, np.float64) and (last_rsi_14_1d < 50.0))
       ):
         return True, f"exit_{mode_name}_d_3_81"
       elif (
-        (last_rsi_3 < 22.0)
+        (last_rsi_3_lt_22)
         and (last_willr_14 < -86.0)
         and (last_rsi_3_4h_gt_70)
         and (last_rsi_3_1d > 85.0)
-        and (last_stochrsi_k_4h < 60.0)
+        and (last_stochrsi_k_4h_lt_60)
       ):
         return True, f"exit_{mode_name}_d_3_82"
       elif (
-        (last_rsi_3 < 32.0)
+        (last_rsi_3_lt_32)
         and (last_rsi_14_gt_50)
-        and (last_rsi_3_1h > 60.0)
+        and (last_rsi_3_1h_gt_60)
         and (last_stochrsi_k_1h_lt_50)
-        and (last_stochrsi_k_4h < 60.0)
+        and (last_stochrsi_k_4h_lt_60)
       ):
         return True, f"exit_{mode_name}_d_3_83"
-      elif (last_rsi_3 < 14.0) and (last_willr_14 < -94.0) and (last_rsi_3_4h_gt_70) and (last_stochrsi_k_1h < 80.0):
+      elif (last_rsi_3_lt_14) and (last_willr_14 < -94.0) and (last_rsi_3_4h_gt_70) and (last_stochrsi_k_1h < 80.0):
         return True, f"exit_{mode_name}_d_3_84"
       elif (
-        (last_rsi_3 < 16.0)
+        (last_rsi_3_lt_16)
         and (last_willr_14 < -88.0)
         and (last_rsi_3_1h_gt_70)
-        and (last_rsi_3_4h > 60.0)
+        and (last_rsi_3_4h_gt_60)
         and (last_stochrsi_k_4h_lt_50)
       ):
         return True, f"exit_{mode_name}_d_3_85"
       elif (
-        (last_rsi_3 < 10.0)
+        (last_rsi_3_lt_10)
         and (last_rsi_14_4h < 20.0)
         and (last_roc_2_1h > 5.0)
         and (last_roc_9_1h < -5.0)
@@ -54683,80 +54742,80 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_3_86"
       elif (
-        (last_rsi_3 < 38.0)
-        and (last_rsi_14 > 52.0)
-        and (last_rsi_3_1h > 55.0)
+        (last_rsi_3_lt_38)
+        and (last_rsi_14_gt_52)
+        and (last_rsi_3_1h_gt_55)
         and (last_rsi_3_4h > 50.0)
         and (last_stochrsi_k_4h_lt_50)
       ):
         return True, f"exit_{mode_name}_d_3_87"
       elif (
-        (last_rsi_3 < 16.0)
+        (last_rsi_3_lt_16)
         and (last_willr_14 < -76.0)
-        and (last_stochrsi_k_1h < 60.0)
+        and (last_stochrsi_k_1h_lt_60)
         and (last_stochrsi_k_4h_lt_50)
         and (last_change_pct_1h > 2.0)
       ):
         return True, f"exit_{mode_name}_d_3_88"
       elif (
-        (last_rsi_3 < 26.0)
-        and (last_rsi_14 > 56.0)
+        (last_rsi_3_lt_26)
+        and (last_rsi_14_gt_56)
         and (last_roc_9_1h > 5.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -25.0))
       ):
         return True, f"exit_{mode_name}_d_3_89"
       elif (
-        (last_rsi_3 < 12.0)
+        (last_rsi_3_lt_12)
         and (last_willr_14 < -75.0)
-        and (last_rsi_3_1h > 50.0)
+        and (last_rsi_3_1h_gt_50)
         and (last_rsi_3_4h_gt_70)
-        and (last_aroonu_14_4h < 50.0)
+        and (last_aroonu_14_4h_lt_50)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -40.0))
       ):
         return True, f"exit_{mode_name}_d_3_90"
       elif (
-        (last_rsi_3 < 32.0)
+        (last_rsi_3_lt_32)
         and (last_rsi_14_gt_50)
-        and (last_rsi_3_1h > 75.0)
-        and (last_rsi_3_4h > 75.0)
-        and (last_aroonu_14_4h < 50.0)
+        and (last_rsi_3_1h_gt_75)
+        and (last_rsi_3_4h_gt_75)
+        and (last_aroonu_14_4h_lt_50)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 50.0))
       ):
         return True, f"exit_{mode_name}_d_3_91"
       elif (
-        (last_rsi_3 < 24.0)
-        and (last_rsi_14 > 48.0)
-        and (last_rsi_3_1h > 60.0)
+        (last_rsi_3_lt_24)
+        and (last_rsi_14_gt_48)
+        and (last_rsi_3_1h_gt_60)
         and (last_stochrsi_k_1h < 75.0)
         and (last_stochrsi_k_4h_lt_50)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 25.0))
       ):
         return True, f"exit_{mode_name}_d_3_92"
       elif (
-        (last_rsi_3 < 32.0)
-        and (last_rsi_14 > 46.0)
+        (last_rsi_3_lt_32)
+        and (last_rsi_14_gt_46)
         and (last_rsi_3_15m > 50.0)
-        and (last_aroond_14_1h > 75.0)
-        and (last_stochrsi_k_1h < 30.0)
-        and (last_aroond_14_4h > 50.0)
+        and (last_aroond_14_1h_gt_75)
+        and (last_stochrsi_k_1h_lt_30)
+        and (last_aroond_14_4h_gt_50)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 10.0))
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
       ):
         return True, f"exit_{mode_name}_d_3_93"
       elif (
-        (last_rsi_3 < 24.0)
-        and (last_rsi_14 > 46.0)
-        and (last_rsi_3_1h > 75.0)
+        (last_rsi_3_lt_24)
+        and (last_rsi_14_gt_46)
+        and (last_rsi_3_1h_gt_75)
         and (last_rsi_3_4h > 55.0)
-        and (last_aroond_14_1h > 75.0)
+        and (last_aroond_14_1h_gt_75)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 10.0))
       ):
         return True, f"exit_{mode_name}_d_3_94"
       elif (
-        (last_rsi_3 < 20.0)
+        (last_rsi_3_lt_20)
         and (last_willr_14 < -84.0)
-        and (last_rsi_3_1h > 55.0)
-        and (last_rsi_3_4h > 60.0)
+        and (last_rsi_3_1h_gt_55)
+        and (last_rsi_3_4h_gt_60)
         and (last_stochrsi_k_4h < 90.0)
         and (isinstance(last_aroond_14_1d, np.float64) and (last_aroond_14_1d > 75.0))
       ):
@@ -54764,24 +54823,24 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 42.0)
         and (last_rsi_14_gt_50)
-        and (last_rsi_3_1h > 55.0)
+        and (last_rsi_3_1h_gt_55)
         and (last_rsi_3_1d > 55.0)
         and (last_stochrsi_k_1h_lt_50)
       ):
         return True, f"exit_{mode_name}_d_3_96"
       elif (
-        (last_rsi_3 < 20.0)
+        (last_rsi_3_lt_20)
         and (last_rsi_14_gt_50)
-        and (last_rsi_3_1h > 65.0)
-        and (last_aroond_14_4h > 50.0)
-        and (last_stochrsi_k_4h < 70.0)
+        and (last_rsi_3_1h_gt_65)
+        and (last_aroond_14_4h_gt_50)
+        and (last_stochrsi_k_4h_lt_70)
       ):
         return True, f"exit_{mode_name}_d_3_97"
       elif (
-        (last_rsi_3 < 14.0)
+        (last_rsi_3_lt_14)
         and (last_rsi_3_15m < 32.0)
-        and (last_rsi_3_1h > 40.0)
-        and (last_rsi_3_4h > 40.0)
+        and (last_rsi_3_1h_gt_40)
+        and (last_rsi_3_4h_gt_40)
         and (last_rsi_3_1d < 20.0)
         and (last_stochrsi_k_4h_lt_50)
       ):
@@ -54790,202 +54849,200 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 44.0)
         and (last_rsi_14 > 44.0)
         and (last_rsi_3_1h > 35.0)
-        and (last_rsi_3_4h > 40.0)
-        and (last_aroond_14_4h > 50.0)
+        and (last_rsi_3_4h_gt_40)
+        and (last_aroond_14_4h_gt_50)
         and (last_stoch_k_4h < 60.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -80.0))
       ):
         return True, f"exit_{mode_name}_d_3_99"
-      elif (last_rsi_3 < 6.0) and (last_rsi_14 < 28.0) and (last_rsi_3_15m < 30.0) and (last_rsi_3_4h > 20.0):
+      elif (last_rsi_3_lt_6) and (last_rsi_14 < 28.0) and (last_rsi_3_15m < 30.0) and (last_rsi_3_4h > 20.0):
         return True, f"exit_{mode_name}_d_3_100"
       elif (
-        (last_rsi_3 < 20.0)
+        (last_rsi_3_lt_20)
         and (last_willr_14 < -80.0)
-        and (last_rsi_3_1h > 50.0)
-        and (last_stochrsi_k_4h < 60.0)
+        and (last_rsi_3_1h_gt_50)
+        and (last_stochrsi_k_4h_lt_60)
         and (isinstance(last_roc_9_4h, np.float64) and (last_roc_9_4h < -40.0))
       ):
         return True, f"exit_{mode_name}_d_3_101"
       elif (
-        (last_rsi_3 < 36.0)
-        and (last_rsi_14 > 48.0)
-        and (last_rsi_3_1h > 40.0)
-        and (last_rsi_3_4h > 60.0)
+        (last_rsi_3_lt_36)
+        and (last_rsi_14_gt_48)
+        and (last_rsi_3_1h_gt_40)
+        and (last_rsi_3_4h_gt_60)
         and (last_stochrsi_k_4h > 70.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -40.0))
       ):
         return True, f"exit_{mode_name}_d_3_102"
       elif (
-        (last_rsi_3 < 26.0)
+        (last_rsi_3_lt_26)
         and (last_rsi_14 > 40.0)
-        and (last_rsi_3_1h > 40.0)
-        and (last_rsi_14_4h < 30.0)
+        and (last_rsi_3_1h_gt_40)
+        and (last_rsi_14_4h_lt_30)
         and (isinstance(last_roc_9_4h, np.float64) and (last_roc_9_4h < -80.0))
       ):
         return True, f"exit_{mode_name}_d_3_103"
       elif (
-        (last_rsi_3 < 40.0)
-        and (last_rsi_14 > 48.0)
-        and (last_rsi_3_1h > 40.0)
-        and (last_stochrsi_k_1h < 60.0)
-        and (last_stochrsi_k_4h < 10.0)
+        (last_rsi_3_lt_40)
+        and (last_rsi_14_gt_48)
+        and (last_rsi_3_1h_gt_40)
+        and (last_stochrsi_k_1h_lt_60)
+        and (last_stochrsi_k_4h_lt_10)
         and (last_roc_9_4h < -40.0)
       ):
         return True, f"exit_{mode_name}_d_3_104"
       elif (
-        (last_rsi_3 < 26.0)
-        and (last_rsi_14 > 48.0)
+        (last_rsi_3_lt_26)
+        and (last_rsi_14_gt_48)
         and (last_rsi_3_15m > 45.0)
-        and (last_stochrsi_k_4h < 10.0)
+        and (last_stochrsi_k_4h_lt_10)
         and (last_roc_9_4h < -25.0)
       ):
         return True, f"exit_{mode_name}_d_3_105"
       elif (
-        (last_rsi_3 < 32.0)
-        and (last_rsi_14 > 48.0)
-        and (last_rsi_3_1h > 50.0)
+        (last_rsi_3_lt_32)
+        and (last_rsi_14_gt_48)
+        and (last_rsi_3_1h_gt_50)
         and (last_stochrsi_k_1h_lt_50)
-        and (last_rsi_14_4h < 30.0)
+        and (last_rsi_14_4h_lt_30)
         and (last_roc_9_4h < -40.0)
       ):
         return True, f"exit_{mode_name}_d_3_106"
       elif (
-        (last_rsi_3 < 30.0)
-        and (last_rsi_14 > 48.0)
-        and (last_rsi_3_1h > 50.0)
-        and (last_stochrsi_k_1h < 30.0)
+        (last_rsi_3_lt_30)
+        and (last_rsi_14_gt_48)
+        and (last_rsi_3_1h_gt_50)
+        and (last_stochrsi_k_1h_lt_30)
         and (last_rsi_14_4h < 50.0)
       ):
         return True, f"exit_{mode_name}_d_3_107"
-      elif (last_rsi_3 < 48.0) and (last_rsi_14 > 48.0) and (last_rsi_3_1h > 40.0) and (last_stochrsi_k_1h < 20.0):
+      elif (last_rsi_3 < 48.0) and (last_rsi_14_gt_48) and (last_rsi_3_1h_gt_40) and (last_stochrsi_k_1h_lt_20):
         return True, f"exit_{mode_name}_d_3_108"
       elif (
-        (last_rsi_3 < 28.0)
+        (last_rsi_3_lt_28)
         and (last_willr_14 < -88.0)
-        and (last_rsi_3_1h > 50.0)
-        and (last_rsi_3_4h > 80.0)
+        and (last_rsi_3_1h_gt_50)
+        and (last_rsi_3_4h_gt_80)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -50.0))
       ):
         return True, f"exit_{mode_name}_d_3_109"
-      elif (last_rsi_3 < 32.0) and (last_rsi_3_4h > 35.0) and (last_stochrsi_k_4h_lt_50) and (last_roc_9_4h < -25.0):
+      elif (last_rsi_3_lt_32) and (last_rsi_3_4h > 35.0) and (last_stochrsi_k_4h_lt_50) and (last_roc_9_4h < -25.0):
         return True, f"exit_{mode_name}_d_3_110"
       elif (
         (last_rsi_3 < 54.0)
-        and (last_rsi_14 > 52.0)
-        and (last_rsi_3_1h > 50.0)
-        and (last_rsi_14_4h < 30.0)
-        and (last_aroond_14_1h > 75.0)
-        and (last_aroond_14_4h > 75.0)
+        and (last_rsi_14_gt_52)
+        and (last_rsi_3_1h_gt_50)
+        and (last_rsi_14_4h_lt_30)
+        and (last_aroond_14_1h_gt_75)
+        and (last_aroond_14_4h_gt_75)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -20.0))
       ):
         return True, f"exit_{mode_name}_d_3_111"
       elif (
-        (last_rsi_3 < 24.0)
+        (last_rsi_3_lt_24)
         and (last_willr_14 < -65.0)
         and (last_rsi_14 > 44.0)
-        and (last_rsi_3_1h > 65.0)
+        and (last_rsi_3_1h_gt_65)
         and (last_rsi_3_4h > 65.0)
         and (last_rsi_3_1d > 40.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
       ):
         return True, f"exit_{mode_name}_d_3_112"
       elif (
-        (last_rsi_3 < 20.0)
+        (last_rsi_3_lt_20)
         and (last_willr_14 < -94.0)
-        and (last_rsi_3_1d > 70.0)
+        and (last_rsi_3_1d_gt_70)
         and (last_stochrsi_k_4h_lt_50)
         and (isinstance(last_roc_9_4h, np.float64) and (last_roc_9_4h < -10.0))
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 10.0))
       ):
         return True, f"exit_{mode_name}_d_3_113"
       elif (
-        (last_rsi_3 < 20.0)
-        and (last_rsi_14 > 46.0)
-        and (last_rsi_3_1h > 80.0)
+        (last_rsi_3_lt_20)
+        and (last_rsi_14_gt_46)
+        and (last_rsi_3_1h_gt_80)
         and (last_rsi_3_4h_gt_70)
-        and (last_rsi_3_1d > 70.0)
+        and (last_rsi_3_1d_gt_70)
       ):
         return True, f"exit_{mode_name}_d_3_114"
       elif (
-        (last_rsi_3 < 26.0)
-        and (last_rsi_14 > 48.0)
+        (last_rsi_3_lt_26)
+        and (last_rsi_14_gt_48)
         and (last_rsi_3_15m > 70.0)
         and (last_stochrsi_k_1h_lt_50)
         and (last_stochrsi_k_4h_lt_50)
       ):
         return True, f"exit_{mode_name}_d_3_115"
-      elif (last_rsi_3 < 14.0) and (last_rsi_3_1h > 85.0) and (last_rsi_3_4h > 60.0) and (last_aroonu_14_4h < 50.0):
+      elif (last_rsi_3_lt_14) and (last_rsi_3_1h_gt_85) and (last_rsi_3_4h_gt_60) and (last_aroonu_14_4h_lt_50):
         return True, f"exit_{mode_name}_d_3_116"
-      elif (
-        (last_rsi_3 < 18.0) and (last_rsi_3_1h > 50.0) and (last_aroonu_14_1h < 20.0) and (last_aroonu_14_4h < 20.0)
-      ):
+      elif (last_rsi_3_lt_18) and (last_rsi_3_1h_gt_50) and (last_aroonu_14_1h < 20.0) and (last_aroonu_14_4h < 20.0):
         return True, f"exit_{mode_name}_d_3_117"
-      elif (last_rsi_3 < 14.0) and (last_rsi_3_1h > 80.0) and (last_rsi_3_4h > 40.0) and (last_aroond_14_4h > 40.0):
+      elif (last_rsi_3_lt_14) and (last_rsi_3_1h_gt_80) and (last_rsi_3_4h_gt_40) and (last_aroond_14_4h > 40.0):
         return True, f"exit_{mode_name}_d_3_118"
       elif (
-        (last_rsi_3 < 18.0)
+        (last_rsi_3_lt_18)
         and (last_willr_14 < -80.0)
-        and (last_rsi_3_1h > 40.0)
-        and (last_rsi_3_4h > 40.0)
-        and (last_stochrsi_k_1h < 60.0)
+        and (last_rsi_3_1h_gt_40)
+        and (last_rsi_3_4h_gt_40)
+        and (last_stochrsi_k_1h_lt_60)
       ):
         return True, f"exit_{mode_name}_d_3_119"
-      elif (last_rsi_3 < 50.0) and (last_rsi_14 > 48.0) and (last_rsi_3_1h > 60.0) and (last_aroond_14_4h > 75.0):
+      elif (last_rsi_3_lt_50) and (last_rsi_14_gt_48) and (last_rsi_3_1h_gt_60) and (last_aroond_14_4h_gt_75):
         return True, f"exit_{mode_name}_d_3_120"
-      elif (last_rsi_3 < 44.0) and (last_rsi_14_gt_50) and (last_rsi_3_1h > 50.0) and (last_rsi_14_4h < 15.0):
+      elif (last_rsi_3 < 44.0) and (last_rsi_14_gt_50) and (last_rsi_3_1h_gt_50) and (last_rsi_14_4h < 15.0):
         return True, f"exit_{mode_name}_d_3_121"
-      elif (last_rsi_3 < 46.0) and (last_rsi_14 > 52.0) and (last_rsi_3_4h_gt_70) and (last_stochrsi_k_1h_lt_50):
+      elif (last_rsi_3 < 46.0) and (last_rsi_14_gt_52) and (last_rsi_3_4h_gt_70) and (last_stochrsi_k_1h_lt_50):
         return True, f"exit_{mode_name}_d_3_122"
-      elif (last_rsi_3 < 16.0) and (last_willr_14 < -92.0) and (last_rsi_3_1h > 90.0) and (last_rsi_3_1d > 70.0):
+      elif (last_rsi_3_lt_16) and (last_willr_14 < -92.0) and (last_rsi_3_1h_gt_90) and (last_rsi_3_1d_gt_70):
         return True, f"exit_{mode_name}_d_3_123"
       elif (
-        (last_rsi_3 < 16.0)
-        and (last_rsi_3_1h > 85.0)
+        (last_rsi_3_lt_16)
+        and (last_rsi_3_1h_gt_85)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 20.0))
       ):
         return True, f"exit_{mode_name}_d_3_124"
       elif (
-        (last_rsi_3 < 28.0)
+        (last_rsi_3_lt_28)
         and (last_willr_14 < -92.0)
-        and (last_rsi_3_1h > 90.0)
-        and (last_rsi_3_4h > 60.0)
+        and (last_rsi_3_1h_gt_90)
+        and (last_rsi_3_4h_gt_60)
         and (last_rsi_3_1d > 60.0)
         and (last_close > (last_low_min_30_1d * 2.0))
       ):
         return True, f"exit_{mode_name}_d_3_125"
-      elif (last_rsi_3 < 14.0) and (last_rsi_3_1h > 85.0) and (last_rsi_3_4h > 60.0) and (last_stochrsi_k_4h_lt_50):
+      elif (last_rsi_3_lt_14) and (last_rsi_3_1h_gt_85) and (last_rsi_3_4h_gt_60) and (last_stochrsi_k_4h_lt_50):
         return True, f"exit_{mode_name}_d_3_126"
-      elif (last_rsi_3 < 14.0) and (last_rsi_3_1h > 90.0) and (last_rsi_3_4h_gt_70) and (last_rsi_3_1d > 60.0):
+      elif (last_rsi_3_lt_14) and (last_rsi_3_1h_gt_90) and (last_rsi_3_4h_gt_70) and (last_rsi_3_1d > 60.0):
         return True, f"exit_{mode_name}_d_3_127"
-      elif (last_rsi_3 < 10.0) and (last_rsi_3_4h_gt_70) and (last_aroond_14_4h > 85.0):
+      elif (last_rsi_3_lt_10) and (last_rsi_3_4h_gt_70) and (last_aroond_14_4h > 85.0):
         return True, f"exit_{mode_name}_d_3_128"
       elif (
-        (last_rsi_3 < 18.0)
-        and (last_rsi_3_4h > 75.0)
+        (last_rsi_3_lt_18)
+        and (last_rsi_3_4h_gt_75)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -80.0))
       ):
         return True, f"exit_{mode_name}_d_3_129"
       elif (
-        (last_rsi_3 < 30.0)
+        (last_rsi_3_lt_30)
         and (last_rsi_14_1h < 35.0)
-        and (last_stochrsi_k_1h < 20.0)
+        and (last_stochrsi_k_1h_lt_20)
         and (last_cci_20_change_pct_1h > 0.0)
       ):
         return True, f"exit_{mode_name}_d_3_130"
-      elif (last_rsi_14 > 58.0) and (last_rsi_3_1h > 80.0) and (last_rsi_3_4h_gt_70) and (last_stochrsi_k_4h_lt_50):
+      elif (last_rsi_14 > 58.0) and (last_rsi_3_1h_gt_80) and (last_rsi_3_4h_gt_70) and (last_stochrsi_k_4h_lt_50):
         return True, f"exit_{mode_name}_d_3_131"
       elif (
-        (last_rsi_3 < 24.0)
-        and (last_rsi_3_1h > 65.0)
+        (last_rsi_3_lt_24)
+        and (last_rsi_3_1h_gt_65)
         and (last_rsi_3_4h > 65.0)
         and (last_aroond_14_1h > 50.0)
-        and (last_stochrsi_k_1h < 60.0)
+        and (last_stochrsi_k_1h_lt_60)
       ):
         return True, f"exit_{mode_name}_d_3_132"
       elif (
-        (last_rsi_3 < 24.0)
+        (last_rsi_3_lt_24)
         and (last_aroond_14_15m > 75.0)
-        and (last_aroond_14_1h > 75.0)
+        and (last_aroond_14_1h_gt_75)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -25.0))
       ):
         return True, f"exit_{mode_name}_d_3_133"


### PR DESCRIPTION
## Summary
- Hoists repeated short `short_exit_dec` threshold checks for the 3-4% profit bracket into local boolean aliases.
- Keeps the branch independent on latest upstream `main`.

## Safety
- Only already-read scalar threshold comparisons inside the same current-profit branch are reused.
- Indicator formulas, candle selection, profit arithmetic, thresholds, condition order, return values, order classification, and stake logic are unchanged.
- Touched function: `short_exit_dec`. No v3 grind-entry code is touched.

## Backtest scope
- Full backtesting was not required because this patch only reuses already-read scalar threshold checks inside the same `short_exit_dec` current-profit branch. Trading conditions and output values are unchanged.

## Checks
- `python3 ~/.codex/skills/nfi-upstream-pr/scripts/validate_nfi_pr.py --base origin/main`
- `AST undefined-local scan from validator reported zero findings for introduced `last_*` aliases`
- `git merge-tree conflict simulation against origin/main`
- `targeted git diff origin/main...HEAD -- NostalgiaForInfinityX7.py review`
- `git diff --check`
- `ruff format --check NostalgiaForInfinityX7.py`
- `ruff check NostalgiaForInfinityX7.py`
- `PYTHONDONTWRITEBYTECODE=1 python3 -m py_compile NostalgiaForInfinityX7.py`
