### PR TITLE
Reduce X7 long dec 5-6% threshold repeats

### DIFF
--- a/NostalgiaForInfinityX7.py
+++ b/NostalgiaForInfinityX7.py
@@ -32650,6 +32650,62 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_4_133"
     elif 0.06 > current_profit >= 0.05:
+      # Reused long exit decision threshold checks for this profit bracket
+      last_rsi_3_gt_70 = last_rsi_3 > 70.0
+      last_rsi_14_lt_56 = last_rsi_14 < 56.0
+      last_rsi_3_gt_80 = last_rsi_3 > 80.0
+      last_rsi_3_4h_lt_20 = last_rsi_3_4h < 20.0
+      last_rsi_3_1h_lt_20 = last_rsi_3_1h < 20.0
+      last_rsi_3_4h_lt_10 = last_rsi_3_4h < 10.0
+      last_rsi_14_lt_54 = last_rsi_14 < 54.0
+      last_rsi_3_1h_lt_15 = last_rsi_3_1h < 15.0
+      last_rsi_3_1h_lt_50 = last_rsi_3_1h < 50.0
+      last_rsi_3_1h_lt_10 = last_rsi_3_1h < 10.0
+      last_rsi_3_gt_65 = last_rsi_3 > 65.0
+      last_rsi_3_gt_60 = last_rsi_3 > 60.0
+      last_rsi_3_1h_lt_25 = last_rsi_3_1h < 25.0
+      last_rsi_3_4h_lt_40 = last_rsi_3_4h < 40.0
+      last_rsi_3_4h_lt_25 = last_rsi_3_4h < 25.0
+      last_rsi_3_gt_76 = last_rsi_3 > 76.0
+      last_rsi_3_1d_lt_25 = last_rsi_3_1d < 25.0
+      last_rsi_3_gt_78 = last_rsi_3 > 78.0
+      last_rsi_3_gt_72 = last_rsi_3 > 72.0
+      last_rsi_3_gt_64 = last_rsi_3 > 64.0
+      last_rsi_3_gt_82 = last_rsi_3 > 82.0
+      last_aroonu_14_4h_gt_50 = last_aroonu_14_4h > 50.0
+      last_rsi_3_1h_lt_60 = last_rsi_3_1h < 60.0
+      last_rsi_3_gt_75 = last_rsi_3 > 75.0
+      last_rsi_3_gt_86 = last_rsi_3 > 86.0
+      last_rsi_3_gt_50 = last_rsi_3 > 50.0
+      last_stochrsi_k_4h_gt_30 = last_stochrsi_k_4h > 30.0
+      last_stochrsi_k_4h_gt_40 = last_stochrsi_k_4h > 40.0
+      last_rsi_14_lt_52 = last_rsi_14 < 52.0
+      last_stochrsi_k_4h_gt_20 = last_stochrsi_k_4h > 20.0
+      last_rsi_3_gt_90 = last_rsi_3 > 90.0
+      last_stochrsi_k_4h_gt_90 = last_stochrsi_k_4h > 90.0
+      last_rsi_3_gt_84 = last_rsi_3 > 84.0
+      last_rsi_14_lt_48 = last_rsi_14 < 48.0
+      last_rsi_3_4h_lt_15 = last_rsi_3_4h < 15.0
+      last_stochrsi_k_1h_gt_70 = last_stochrsi_k_1h > 70.0
+      last_stochrsi_k_1h_gt_80 = last_stochrsi_k_1h > 80.0
+      last_rsi_14_lt_58 = last_rsi_14 < 58.0
+      last_stochrsi_k_1h_gt_40 = last_stochrsi_k_1h > 40.0
+      last_aroonu_14_1h_gt_75 = last_aroonu_14_1h > 75.0
+      last_rsi_3_4h_lt_60 = last_rsi_3_4h < 60.0
+      last_stochrsi_k_gt_95 = last_stochrsi_k > 95.0
+      last_rsi_14_gt_64 = last_rsi_14 > 64.0
+      last_aroonu_14_4h_gt_25 = last_aroonu_14_4h > 25.0
+      last_aroonu_14_4h_gt_75 = last_aroonu_14_4h > 75.0
+      last_stochrsi_k_1h_gt_30 = last_stochrsi_k_1h > 30.0
+      last_rsi_3_gt_74 = last_rsi_3 > 74.0
+      last_stochrsi_k_4h_gt_25 = last_stochrsi_k_4h > 25.0
+      last_rsi_3_gt_58 = last_rsi_3 > 58.0
+      last_rsi_3_gt_68 = last_rsi_3 > 68.0
+      last_rsi_3_1h_lt_40 = last_rsi_3_1h < 40.0
+      last_rsi_3_1h_lt_45 = last_rsi_3_1h < 45.0
+      last_rsi_3_1h_lt_35 = last_rsi_3_1h < 35.0
+      last_rsi_14_4h_gt_70 = last_rsi_14_4h > 70.0
+      last_rsi_3_1d_lt_30 = last_rsi_3_1d < 30.0
       if (
         (last_willr_14 > -1.0)
         and (last_rsi_14 > 78.0)
@@ -32669,25 +32725,25 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_5_2"
       elif (
         (last_willr_14 > -20.0)
-        and (last_stochrsi_k > 95.0)
+        and (last_stochrsi_k_gt_95)
         and (last_cmf_20_1h < -0.0)
         and (last_cmf_20_4h < -0.0)
-        and ((last_stochrsi_k_4h > 20.0) and (last_stochrsi_k_change_pct_4h < -10.0))
+        and ((last_stochrsi_k_4h_gt_20) and (last_stochrsi_k_change_pct_4h < -10.0))
       ):
         return True, f"exit_{mode_name}_d_5_3"
       elif (
         (last_willr_14 > -30.0)
         and (last_rsi_14 > 65.0)
-        and (last_stochrsi_k > 95.0)
+        and (last_stochrsi_k_gt_95)
         and (last_stochrsi_k_4h > 70.0)
         and (isinstance(last_ema_200_1h, np.float64) and (last_ema_12_1h < last_ema_200_1h))
         and (isinstance(last_ema_200_4h, np.float64) and (last_ema_12_4h < last_ema_200_4h))
       ):
         return True, f"exit_{mode_name}_d_5_4"
-      elif (last_willr_14 > -10.0) and (last_rsi_14 > 64.0) and (last_roc_9_1h < -5.0) and (last_roc_9_4h < -5.0):
+      elif (last_willr_14 > -10.0) and (last_rsi_14_gt_64) and (last_roc_9_1h < -5.0) and (last_roc_9_4h < -5.0):
         return True, f"exit_{mode_name}_d_5_5"
       elif (
-        (last_rsi_3 > 70.0)
+        (last_rsi_3_gt_70)
         and (last_stochrsi_k > 70.0)
         and (last_rsi_14 < 40.0)
         and (last_roc_9_1h < -10.0)
@@ -32703,7 +32759,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_5_7"
       elif (
         (last_willr_14 > -10.0)
-        and (last_stochrsi_k > 95.0)
+        and (last_stochrsi_k_gt_95)
         and (last_cmf_20_1h < -0.1)
         and (last_cmf_20_4h < -0.1)
         and (last_change_pct_1d < -5.0)
@@ -32726,7 +32782,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_5_10"
       elif (
-        (last_rsi_3 > 75.0)
+        (last_rsi_3_gt_75)
         and (last_rsi_14 < 45.0)
         and (last_roc_9_15m < -10.0)
         and (last_roc_9_1h < -10.0)
@@ -32734,237 +32790,237 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_5_11"
       elif (
-        (last_rsi_3 > 70.0)
+        (last_rsi_3_gt_70)
         and (last_rsi_14_lt_50)
-        and (last_rsi_3_4h < 10.0)
+        and (last_rsi_3_4h_lt_10)
         and (last_roc_9_1h < -20.0)
         and (last_roc_9_4h < -20.0)
       ):
         return True, f"exit_{mode_name}_d_5_12"
-      elif (last_rsi_3 > 80.0) and (last_rsi_3_4h < 5.0) and (last_roc_9_4h < -25.0):
+      elif (last_rsi_3_gt_80) and (last_rsi_3_4h < 5.0) and (last_roc_9_4h < -25.0):
         return True, f"exit_{mode_name}_d_5_13"
-      elif (last_rsi_3 > 90.0) and (last_willr_14 > -12.0) and (last_rsi_3_4h < 5.0) and (last_aroonu_14_4h > 25.0):
+      elif (last_rsi_3_gt_90) and (last_willr_14 > -12.0) and (last_rsi_3_4h < 5.0) and (last_aroonu_14_4h_gt_25):
         return True, f"exit_{mode_name}_d_5_14"
-      elif (last_rsi_3 > 86.0) and (last_rsi_14 > 58.0) and (last_roc_9_4h < -30.0):
+      elif (last_rsi_3_gt_86) and (last_rsi_14 > 58.0) and (last_roc_9_4h < -30.0):
         return True, f"exit_{mode_name}_d_5_15"
       elif (
-        (last_rsi_3 > 70.0)
-        and (last_aroonu_14_4h > 25.0)
+        (last_rsi_3_gt_70)
+        and (last_aroonu_14_4h_gt_25)
         and (last_roc_9_4h < -25.0)
         and (last_aroonu_14_1d > 50.0)
         and (last_change_pct_1d < -15.0)
       ):
         return True, f"exit_{mode_name}_d_5_16"
       elif (
-        (last_rsi_3 > 80.0)
+        (last_rsi_3_gt_80)
         and (last_willr_14 > -35.0)
-        and (last_rsi_3_1h < 10.0)
-        and (last_stochrsi_k_4h > 90.0)
+        and (last_rsi_3_1h_lt_10)
+        and (last_stochrsi_k_4h_gt_90)
         and (last_roc_9_4h > 30.0)
       ):
         return True, f"exit_{mode_name}_d_5_17"
-      elif (last_rsi_3 > 75.0) and (last_rsi_14 > 60.0) and (last_rsi_3_4h < 20.0) and (last_roc_2_1d < -50.0):
+      elif (last_rsi_3_gt_75) and (last_rsi_14 > 60.0) and (last_rsi_3_4h_lt_20) and (last_roc_2_1d < -50.0):
         return True, f"exit_{mode_name}_d_5_18"
       elif (
-        (last_rsi_3 > 84.0)
-        and (last_rsi_14 > 64.0)
-        and (last_rsi_3_4h < 10.0)
+        (last_rsi_3_gt_84)
+        and (last_rsi_14_gt_64)
+        and (last_rsi_3_4h_lt_10)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d > 70.0))
       ):
         return True, f"exit_{mode_name}_d_5_19"
-      elif (last_rsi_3 > 42.0) and (last_rsi_14 < 48.0) and (last_rsi_3_1h < 10.0) and (last_aroonu_14_1h > 25.0):
+      elif (last_rsi_3 > 42.0) and (last_rsi_14_lt_48) and (last_rsi_3_1h_lt_10) and (last_aroonu_14_1h > 25.0):
         return True, f"exit_{mode_name}_d_5_20"
-      elif (last_rsi_3 > 50.0) and (last_rsi_14_lt_50) and (last_rsi_3_1h < 20.0) and (last_stochrsi_k_4h > 90.0):
+      elif (last_rsi_3_gt_50) and (last_rsi_14_lt_50) and (last_rsi_3_1h_lt_20) and (last_stochrsi_k_4h_gt_90):
         return True, f"exit_{mode_name}_d_5_21"
       elif (
-        (last_rsi_3 > 90.0)
+        (last_rsi_3_gt_90)
         and (last_willr_14 > -10.0)
         and (last_change_pct_4h < -5.0)
         and (last_stochrsi_k_4h_gt_50)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
       ):
         return True, f"exit_{mode_name}_d_5_22"
-      elif (last_rsi_3 > 75.0) and (last_willr_14 > -30.0) and (last_rsi_3_1h < 15.0) and (last_rsi_3_1d < 5.0):
+      elif (last_rsi_3_gt_75) and (last_willr_14 > -30.0) and (last_rsi_3_1h_lt_15) and (last_rsi_3_1d < 5.0):
         return True, f"exit_{mode_name}_d_5_23"
       elif (
-        (last_rsi_3 > 84.0)
-        and (last_rsi_14 > 64.0)
+        (last_rsi_3_gt_84)
+        and (last_rsi_14_gt_64)
         and (last_willr_14 > -35.0)
         and (last_rsi_3_4h_lt_30)
-        and (last_aroonu_14_4h > 75.0)
+        and (last_aroonu_14_4h_gt_75)
       ):
         return True, f"exit_{mode_name}_d_5_24"
       elif (
-        (last_rsi_3 > 70.0)
+        (last_rsi_3_gt_70)
         and (last_willr_14 > -12.0)
-        and (last_rsi_3_4h < 10.0)
+        and (last_rsi_3_4h_lt_10)
         and (last_roc_9_4h < -15.0)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d > 50.0))
       ):
         return True, f"exit_{mode_name}_d_5_25"
-      elif (last_rsi_3 > 65.0) and (last_willr_14 > -12.0) and (last_rsi_3_4h < 15.0) and (last_roc_9_4h < -20.0):
+      elif (last_rsi_3_gt_65) and (last_willr_14 > -12.0) and (last_rsi_3_4h_lt_15) and (last_roc_9_4h < -20.0):
         return True, f"exit_{mode_name}_d_5_26"
       elif (
-        (last_rsi_3 > 65.0)
+        (last_rsi_3_gt_65)
         and (last_rsi_14_lt_50)
-        and (last_rsi_3_1h < 20.0)
-        and (last_rsi_3_4h < 20.0)
-        and (last_stochrsi_k_4h > 20.0)
+        and (last_rsi_3_1h_lt_20)
+        and (last_rsi_3_4h_lt_20)
+        and (last_stochrsi_k_4h_gt_20)
       ):
         return True, f"exit_{mode_name}_d_5_27"
-      elif (last_rsi_3 > 60.0) and (last_rsi_14_lt_50) and (last_rsi_3_15m < 10.0) and (last_roc_9_4h > 50.0):
+      elif (last_rsi_3_gt_60) and (last_rsi_14_lt_50) and (last_rsi_3_15m < 10.0) and (last_roc_9_4h > 50.0):
         return True, f"exit_{mode_name}_d_5_28"
       elif (
-        (last_rsi_3 > 75.0)
+        (last_rsi_3_gt_75)
         and (last_rsi_14_lt_50)
-        and (last_rsi_3_1h < 20.0)
-        and (last_rsi_3_4h < 20.0)
-        and (last_stochrsi_k_1h > 30.0)
+        and (last_rsi_3_1h_lt_20)
+        and (last_rsi_3_4h_lt_20)
+        and (last_stochrsi_k_1h_gt_30)
       ):
         return True, f"exit_{mode_name}_d_5_29"
-      elif (last_rsi_3 > 70.0) and (last_rsi_3_1h < 25.0) and (last_rsi_3_4h < 10.0) and (last_stochrsi_k_1h > 70.0):
+      elif (last_rsi_3_gt_70) and (last_rsi_3_1h_lt_25) and (last_rsi_3_4h_lt_10) and (last_stochrsi_k_1h_gt_70):
         return True, f"exit_{mode_name}_d_5_30"
       elif (
-        (last_rsi_3 > 60.0)
+        (last_rsi_3_gt_60)
         and (last_rsi_14_lt_50)
-        and (last_rsi_3_1h < 15.0)
-        and (last_rsi_3_4h < 15.0)
+        and (last_rsi_3_1h_lt_15)
+        and (last_rsi_3_4h_lt_15)
         and (last_stochrsi_k_1h > 25.0)
       ):
         return True, f"exit_{mode_name}_d_5_31"
-      elif (last_rsi_3 > 70.0) and (last_rsi_3_1h < 15.0) and (last_roc_2_4h < -30.0) and (last_stochrsi_k_4h > 30.0):
+      elif (last_rsi_3_gt_70) and (last_rsi_3_1h_lt_15) and (last_roc_2_4h < -30.0) and (last_stochrsi_k_4h_gt_30):
         return True, f"exit_{mode_name}_d_5_32"
       elif (
-        (last_rsi_3 > 70.0)
+        (last_rsi_3_gt_70)
         and (last_willr_14 > -10.0)
         and (last_roc_2_1h < -10.0)
         and (last_roc_9_1h > 30.0)
         and (last_stochrsi_k_1h_gt_50)
       ):
         return True, f"exit_{mode_name}_d_5_33"
-      elif (last_rsi_3 > 65.0) and (last_rsi_3_15m < 30.0) and (last_rsi_14_1h > 80.0) and (last_roc_9_1h > 40.0):
+      elif (last_rsi_3_gt_65) and (last_rsi_3_15m < 30.0) and (last_rsi_14_1h > 80.0) and (last_roc_9_1h > 40.0):
         return True, f"exit_{mode_name}_d_5_34"
-      elif (last_rsi_3 > 80.0) and (last_willr_14 > -10.0) and (last_rsi_3_1d < 25.0) and (last_stochrsi_k_1h > 75.0):
+      elif (last_rsi_3_gt_80) and (last_willr_14 > -10.0) and (last_rsi_3_1d_lt_25) and (last_stochrsi_k_1h > 75.0):
         return True, f"exit_{mode_name}_d_5_35"
       elif (
-        (last_rsi_3 > 65.0)
+        (last_rsi_3_gt_65)
         and (last_willr_14 > -35.0)
         and (last_roc_9_4h < -25.0)
-        and (last_rsi_3_1d < 25.0)
+        and (last_rsi_3_1d_lt_25)
         and (last_stochrsi_k_1h_gt_50)
       ):
         return True, f"exit_{mode_name}_d_5_36"
       elif (
-        (last_rsi_3 > 74.0)
+        (last_rsi_3_gt_74)
         and (last_rsi_14_lt_50)
-        and (last_rsi_3_1h < 20.0)
-        and (last_rsi_3_1d < 25.0)
+        and (last_rsi_3_1h_lt_20)
+        and (last_rsi_3_1d_lt_25)
         and (last_stochrsi_k_4h_gt_50)
       ):
         return True, f"exit_{mode_name}_d_5_37"
-      elif (last_rsi_3 > 65.0) and (last_willr_14 > -35.0) and (last_rsi_3_4h < 10.0) and (last_stochrsi_k_4h > 20.0):
+      elif (last_rsi_3_gt_65) and (last_willr_14 > -35.0) and (last_rsi_3_4h_lt_10) and (last_stochrsi_k_4h_gt_20):
         return True, f"exit_{mode_name}_d_5_38"
-      elif (last_rsi_3 > 91.0) and (last_willr_14 > -9.0) and (last_cmf_20_4h < -0.0) and (last_rsi_3_4h < 10.0):
+      elif (last_rsi_3 > 91.0) and (last_willr_14 > -9.0) and (last_cmf_20_4h < -0.0) and (last_rsi_3_4h_lt_10):
         return True, f"exit_{mode_name}_d_5_39"
       elif (
-        (last_rsi_3 > 65.0)
+        (last_rsi_3_gt_65)
         and (last_willr_14 > -35.0)
         and (last_rsi_3_1h_lt_30)
-        and (last_stochrsi_k_1h > 30.0)
+        and (last_stochrsi_k_1h_gt_30)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d > 90.0))
       ):
         return True, f"exit_{mode_name}_d_5_40"
       elif (
-        (last_rsi_3 > 75.0)
+        (last_rsi_3_gt_75)
         and (last_willr_14 > -30.0)
         and (last_rsi_3_1h_lt_30)
-        and (last_stochrsi_k_4h > 25.0)
+        and (last_stochrsi_k_4h_gt_25)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 50.0))
       ):
         return True, f"exit_{mode_name}_d_5_41"
       elif (
-        (last_rsi_3 > 70.0)
+        (last_rsi_3_gt_70)
         and (last_willr_14 > -45.0)
-        and (last_stochrsi_k_4h > 30.0)
+        and (last_stochrsi_k_4h_gt_30)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 40.0))
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d > 70.0))
       ):
         return True, f"exit_{mode_name}_d_5_42"
       elif (
-        (last_rsi_3 > 80.0)
+        (last_rsi_3_gt_80)
         and (last_rsi_14_lt_50)
-        and (last_rsi_3_1h < 15.0)
-        and (last_rsi_3_4h < 40.0)
+        and (last_rsi_3_1h_lt_15)
+        and (last_rsi_3_4h_lt_40)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d > 90.0))
       ):
         return True, f"exit_{mode_name}_d_5_43"
       elif (
-        (last_rsi_3 > 50.0)
+        (last_rsi_3_gt_50)
         and (last_willr_14 > -25.0)
         and (last_rsi_3_4h_lt_30)
-        and (last_rsi_3_1d < 25.0)
+        and (last_rsi_3_1d_lt_25)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
       ):
         return True, f"exit_{mode_name}_d_5_44"
-      elif (last_rsi_3 > 86.0) and (last_willr_14 > -14.0) and (last_rsi_3_1h < 10.0):
+      elif (last_rsi_3_gt_86) and (last_willr_14 > -14.0) and (last_rsi_3_1h_lt_10):
         return True, f"exit_{mode_name}_d_5_45"
-      elif (last_rsi_3 > 70.0) and (last_rsi_3_1h < 15.0) and (last_rsi_3_4h < 10.0) and (last_roc_2_1d < -20.0):
+      elif (last_rsi_3_gt_70) and (last_rsi_3_1h_lt_15) and (last_rsi_3_4h_lt_10) and (last_roc_2_1d < -20.0):
         return True, f"exit_{mode_name}_d_5_46"
       elif (
-        (last_rsi_3 > 78.0)
-        and (last_stochrsi_k_1h > 80.0)
-        and (last_stochrsi_k_4h > 40.0)
+        (last_rsi_3_gt_78)
+        and (last_stochrsi_k_1h_gt_80)
+        and (last_stochrsi_k_4h_gt_40)
         and (last_change_pct_1d < -5.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -5.0))
       ):
         return True, f"exit_{mode_name}_d_5_47"
       elif (
         (last_rsi_3 > 45.0)
-        and (last_rsi_14 < 52.0)
+        and (last_rsi_14_lt_52)
         and (last_rsi_3_1h_lt_30)
-        and (last_rsi_3_4h < 20.0)
+        and (last_rsi_3_4h_lt_20)
         and (last_stochrsi_k_1h_gt_50)
       ):
         return True, f"exit_{mode_name}_d_5_48"
       elif (
-        (last_rsi_3 > 70.0)
+        (last_rsi_3_gt_70)
         and (last_willr_14 > -12.0)
-        and (last_rsi_3_4h < 20.0)
+        and (last_rsi_3_4h_lt_20)
         and (last_change_pct_1d < -5.0)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d > 50.0))
       ):
         return True, f"exit_{mode_name}_d_5_49"
-      elif (last_rsi_3 > 80.0) and (last_willr_14 > -12.0) and (last_rsi_3_1d < 10.0) and (last_stochrsi_k_1h > 90.0):
+      elif (last_rsi_3_gt_80) and (last_willr_14 > -12.0) and (last_rsi_3_1d < 10.0) and (last_stochrsi_k_1h > 90.0):
         return True, f"exit_{mode_name}_d_5_50"
-      elif (last_rsi_3 > 58.0) and (last_rsi_14 < 54.0) and (last_rsi_3_4h < 20.0) and (last_stochrsi_k_1h_gt_50):
+      elif (last_rsi_3_gt_58) and (last_rsi_14_lt_54) and (last_rsi_3_4h_lt_20) and (last_stochrsi_k_1h_gt_50):
         return True, f"exit_{mode_name}_d_5_51"
       elif (
-        (last_rsi_3 > 72.0)
+        (last_rsi_3_gt_72)
         and (last_rsi_14 > 52.0)
         and (last_willr_14 > -10.0)
-        and (last_stochrsi_k_1h > 70.0)
+        and (last_stochrsi_k_1h_gt_70)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -15.0))
       ):
         return True, f"exit_{mode_name}_d_5_52"
       elif (
-        (last_rsi_3 > 70.0)
+        (last_rsi_3_gt_70)
         and (last_rsi_14_lt_50)
         and (last_willr_14 > -25.0)
-        and (last_rsi_3_1h < 20.0)
+        and (last_rsi_3_1h_lt_20)
         and (last_stochrsi_k_4h_gt_50)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d > 50.0))
       ):
         return True, f"exit_{mode_name}_d_5_53"
       elif (
-        (last_rsi_3 > 70.0)
-        and (last_rsi_14 < 54.0)
+        (last_rsi_3_gt_70)
+        and (last_rsi_14_lt_54)
         and (last_stochrsi_k_1h_gt_50)
         and (last_roc_9_4h < -10.0)
         and (last_change_pct_1d < -10.0)
       ):
         return True, f"exit_{mode_name}_d_5_54"
       elif (
-        (last_rsi_3 > 86.0)
+        (last_rsi_3_gt_86)
         and (last_willr_14 > -22.0)
         and (last_roc_9_4h < -5.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 10.0))
@@ -32972,23 +33028,23 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_5_55"
       elif (
-        (last_rsi_3 > 60.0)
+        (last_rsi_3_gt_60)
         and (last_rsi_14_lt_50)
         and (last_rsi_3_1h_lt_30)
-        and (last_rsi_3_4h < 25.0)
+        and (last_rsi_3_4h_lt_25)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
         and (last_stochrsi_k_4h > 10.0)
       ):
         return True, f"exit_{mode_name}_d_5_56"
       elif (
-        (last_rsi_3 > 50.0)
+        (last_rsi_3_gt_50)
         and (last_rsi_14 < 44.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
         and (last_stochrsi_k_4h > 70.0)
       ):
         return True, f"exit_{mode_name}_d_5_57"
       elif (
-        (last_rsi_3 > 70.0)
+        (last_rsi_3_gt_70)
         and (last_rsi_3_1h_lt_30)
         and (last_rsi_3_4h_lt_30)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -15.0))
@@ -32998,74 +33054,72 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 85.0)
         and (last_willr_14 > -20.0)
-        and (last_rsi_3_4h < 25.0)
+        and (last_rsi_3_4h_lt_25)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -15.0))
-        and (last_stochrsi_k_4h > 40.0)
+        and (last_stochrsi_k_4h_gt_40)
       ):
         return True, f"exit_{mode_name}_d_5_59"
       elif (
-        (last_rsi_3 > 65.0)
-        and (last_rsi_14 < 48.0)
+        (last_rsi_3_gt_65)
+        and (last_rsi_14_lt_48)
         and (last_rsi_14_4h > 65.0)
         and (last_stochrsi_k_4h_gt_50)
         and (last_stochrsi_k_1d > 50.0)
       ):
         return True, f"exit_{mode_name}_d_5_60"
-      elif (last_rsi_3 > 90.0) and (last_willr_14 > -25.0) and (last_rsi_3_4h < 10.0) and (last_stochrsi_k_1h > 30.0):
+      elif (last_rsi_3_gt_90) and (last_willr_14 > -25.0) and (last_rsi_3_4h_lt_10) and (last_stochrsi_k_1h_gt_30):
         return True, f"exit_{mode_name}_d_5_61"
       elif (
-        (last_rsi_3 > 78.0)
+        (last_rsi_3_gt_78)
         and (last_willr_14 > -10.0)
         and (last_rsi_3_1h_lt_30)
-        and (last_rsi_3_4h < 20.0)
+        and (last_rsi_3_4h_lt_20)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 20.0))
         and (last_change_pct_1d < -5.0)
       ):
         return True, f"exit_{mode_name}_d_5_62"
-      elif (
-        (last_rsi_3 > 60.0) and (last_rsi_3_1d < 25.0) and (last_stochrsi_k_1h > 80.0) and (last_stochrsi_k_4h > 30.0)
-      ):
+      elif (last_rsi_3_gt_60) and (last_rsi_3_1d_lt_25) and (last_stochrsi_k_1h_gt_80) and (last_stochrsi_k_4h_gt_30):
         return True, f"exit_{mode_name}_d_5_63"
       elif (
-        (last_rsi_3 > 80.0)
+        (last_rsi_3_gt_80)
         and (last_rsi_3_1h_lt_30)
         and (last_rsi_3_4h_lt_30)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
       ):
         return True, f"exit_{mode_name}_d_5_64"
-      elif (last_rsi_3 > 60.0) and (last_rsi_14_lt_50) and (last_rsi_3_1h < 20.0) and (last_rsi_3_4h < 15.0):
+      elif (last_rsi_3_gt_60) and (last_rsi_14_lt_50) and (last_rsi_3_1h_lt_20) and (last_rsi_3_4h_lt_15):
         return True, f"exit_{mode_name}_d_5_65"
-      elif (last_rsi_3 > 74.0) and (last_rsi_14 < 56.0) and (last_rsi_3_1h < 20.0) and (last_stochrsi_k_1h_gt_50):
+      elif (last_rsi_3_gt_74) and (last_rsi_14_lt_56) and (last_rsi_3_1h_lt_20) and (last_stochrsi_k_1h_gt_50):
         return True, f"exit_{mode_name}_d_5_66"
       elif (
-        (last_rsi_3 > 50.0)
+        (last_rsi_3_gt_50)
         and (last_rsi_14_lt_50)
         and (last_stochrsi_k_4h > 80.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -25.0))
       ):
         return True, f"exit_{mode_name}_d_5_67"
       elif (
-        (last_rsi_3 > 76.0)
-        and (last_rsi_14 < 56.0)
-        and (last_rsi_3_1h < 25.0)
+        (last_rsi_3_gt_76)
+        and (last_rsi_14_lt_56)
+        and (last_rsi_3_1h_lt_25)
         and (last_roc_2_4h < -30.0)
-        and (last_stochrsi_k_4h > 25.0)
+        and (last_stochrsi_k_4h_gt_25)
       ):
         return True, f"exit_{mode_name}_d_5_68"
       elif (
         (last_rsi_3 > 92.0) and (last_roc_9_4h > 20.0) and (last_stochrsi_k_4h_gt_50) and (last_change_pct_4h < -5.0)
       ):
         return True, f"exit_{mode_name}_d_5_69"
-      elif (last_rsi_3 > 58.0) and (last_rsi_14 < 48.0) and (last_rsi_3_1h < 25.0) and (last_stochrsi_k_4h > 20.0):
+      elif (last_rsi_3_gt_58) and (last_rsi_14_lt_48) and (last_rsi_3_1h_lt_25) and (last_stochrsi_k_4h_gt_20):
         return True, f"exit_{mode_name}_d_5_70"
-      elif (last_rsi_3 > 56.0) and (last_rsi_14 < 52.0) and (last_rsi_3_4h < 25.0) and (last_stochrsi_k_1h > 20.0):
+      elif (last_rsi_3 > 56.0) and (last_rsi_14_lt_52) and (last_rsi_3_4h_lt_25) and (last_stochrsi_k_1h > 20.0):
         return True, f"exit_{mode_name}_d_5_71"
-      elif (last_rsi_3 > 70.0) and (last_rsi_14_lt_50) and (last_rsi_3_1h < 10.0) and (last_aroonu_14_4h > 25.0):
+      elif (last_rsi_3_gt_70) and (last_rsi_14_lt_50) and (last_rsi_3_1h_lt_10) and (last_aroonu_14_4h_gt_25):
         return True, f"exit_{mode_name}_d_5_72"
       elif (
-        (last_rsi_3 > 70.0)
-        and (last_rsi_3_1h < 25.0)
-        and (last_rsi_3_4h < 15.0)
+        (last_rsi_3_gt_70)
+        and (last_rsi_3_1h_lt_25)
+        and (last_rsi_3_4h_lt_15)
         and (last_roc_9_4h < -20.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -25.0))
       ):
@@ -33073,81 +33127,81 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 94.0)
         and (last_willr_14 > -10.0)
-        and (last_rsi_3_4h < 25.0)
-        and (last_rsi_3_1d < 25.0)
+        and (last_rsi_3_4h_lt_25)
+        and (last_rsi_3_1d_lt_25)
         and (last_stochrsi_k_1h_gt_50)
       ):
         return True, f"exit_{mode_name}_d_5_74"
       elif (
         (last_rsi_3 > 88.0)
         and (last_rsi_3_1h_lt_30)
-        and (last_rsi_3_4h < 20.0)
+        and (last_rsi_3_4h_lt_20)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d > 50.0))
       ):
         return True, f"exit_{mode_name}_d_5_75"
-      elif (last_rsi_3 > 60.0) and (last_rsi_14 < 58.0) and (last_roc_9_1h > 80.0) and (last_stochrsi_k_4h > 80.0):
+      elif (last_rsi_3_gt_60) and (last_rsi_14_lt_58) and (last_roc_9_1h > 80.0) and (last_stochrsi_k_4h > 80.0):
         return True, f"exit_{mode_name}_d_5_76"
       elif (
-        (last_rsi_3 > 68.0)
-        and (last_rsi_14 < 54.0)
+        (last_rsi_3_gt_68)
+        and (last_rsi_14_lt_54)
         and (last_rsi_3_1h_lt_30)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 50.0))
       ):
         return True, f"exit_{mode_name}_d_5_77"
       elif (
-        (last_rsi_3 > 78.0)
+        (last_rsi_3_gt_78)
         and (last_willr_14 > -24.0)
         and (last_rsi_3_1h_lt_30)
-        and (last_rsi_3_4h < 20.0)
+        and (last_rsi_3_4h_lt_20)
         and (last_rsi_3_1d < 20.0)
       ):
         return True, f"exit_{mode_name}_d_5_78"
-      elif (last_rsi_3 > 84.0) and (last_willr_14 > -10.0) and (last_rsi_3_1h_lt_30) and (last_rsi_3_4h < 10.0):
+      elif (last_rsi_3_gt_84) and (last_willr_14 > -10.0) and (last_rsi_3_1h_lt_30) and (last_rsi_3_4h_lt_10):
         return True, f"exit_{mode_name}_d_5_79"
       elif (
-        (last_rsi_3 > 64.0)
-        and (last_rsi_14 < 54.0)
+        (last_rsi_3_gt_64)
+        and (last_rsi_14_lt_54)
         and (last_rsi_3_1h_lt_30)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 50.0))
-        and (last_stochrsi_k_4h > 25.0)
+        and (last_stochrsi_k_4h_gt_25)
       ):
         return True, f"exit_{mode_name}_d_5_80"
       elif (
-        (last_rsi_3 > 76.0)
+        (last_rsi_3_gt_76)
         and (last_willr_14 > -18.0)
-        and (last_rsi_3_1h < 25.0)
-        and (last_rsi_3_4h < 25.0)
+        and (last_rsi_3_1h_lt_25)
+        and (last_rsi_3_4h_lt_25)
         and (isinstance(last_rsi_14_1d, np.float64) and (last_rsi_14_1d > 50.0))
       ):
         return True, f"exit_{mode_name}_d_5_81"
       elif (
-        (last_rsi_3 > 74.0)
+        (last_rsi_3_gt_74)
         and (last_willr_14 > -18.0)
         and (last_rsi_3_4h_lt_30)
         and (last_rsi_3_1d < 15.0)
-        and (last_stochrsi_k_4h > 40.0)
+        and (last_stochrsi_k_4h_gt_40)
       ):
         return True, f"exit_{mode_name}_d_5_82"
       elif (
-        (last_rsi_3 > 64.0)
-        and (last_rsi_14 < 54.0)
-        and (last_rsi_3_1h < 40.0)
+        (last_rsi_3_gt_64)
+        and (last_rsi_14_lt_54)
+        and (last_rsi_3_1h_lt_40)
         and (last_stochrsi_k_1h_gt_50)
-        and (last_stochrsi_k_4h > 40.0)
+        and (last_stochrsi_k_4h_gt_40)
       ):
         return True, f"exit_{mode_name}_d_5_83"
-      elif (last_rsi_3 > 82.0) and (last_willr_14 > -10.0) and (last_rsi_3_4h_lt_30) and (last_stochrsi_k_1h > 20.0):
+      elif (last_rsi_3_gt_82) and (last_willr_14 > -10.0) and (last_rsi_3_4h_lt_30) and (last_stochrsi_k_1h > 20.0):
         return True, f"exit_{mode_name}_d_5_84"
       elif (
-        (last_rsi_3 > 80.0)
+        (last_rsi_3_gt_80)
         and (last_willr_14 > -16.0)
         and (last_rsi_3_1h_lt_30)
-        and (last_rsi_3_4h < 40.0)
+        and (last_rsi_3_4h_lt_40)
         and (last_stochrsi_k_4h_gt_50)
       ):
         return True, f"exit_{mode_name}_d_5_85"
       elif (
-        (last_rsi_3 > 86.0)
+        (last_rsi_3_gt_86)
         and (last_rsi_14_4h > 80.0)
         and (last_roc_2_1h < -5.0)
         and (last_roc_9_1h > 5.0)
@@ -33155,105 +33209,105 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_5_86"
       elif (
-        (last_rsi_3 > 58.0)
-        and (last_rsi_14 < 52.0)
-        and (last_rsi_3_1h < 45.0)
+        (last_rsi_3_gt_58)
+        and (last_rsi_14_lt_52)
+        and (last_rsi_3_1h_lt_45)
         and (last_rsi_3_4h < 50.0)
         and (last_stochrsi_k_4h_gt_50)
       ):
         return True, f"exit_{mode_name}_d_5_87"
       elif (
-        (last_rsi_3 > 80.0)
+        (last_rsi_3_gt_80)
         and (last_willr_14 > -28.0)
-        and (last_stochrsi_k_1h > 40.0)
+        and (last_stochrsi_k_1h_gt_40)
         and (last_stochrsi_k_4h_gt_50)
         and (last_change_pct_1h < -2.0)
       ):
         return True, f"exit_{mode_name}_d_5_88"
       elif (
-        (last_rsi_3 > 70.0)
-        and (last_rsi_14 < 48.0)
+        (last_rsi_3_gt_70)
+        and (last_rsi_14_lt_48)
         and (last_roc_9_1h < -5.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 25.0))
       ):
         return True, f"exit_{mode_name}_d_5_89"
       elif (
-        (last_rsi_3 > 84.0)
+        (last_rsi_3_gt_84)
         and (last_willr_14 > -25.0)
-        and (last_rsi_3_1h < 50.0)
+        and (last_rsi_3_1h_lt_50)
         and (last_rsi_3_4h_lt_30)
-        and (last_aroonu_14_4h > 50.0)
+        and (last_aroonu_14_4h_gt_50)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 40.0))
       ):
         return True, f"exit_{mode_name}_d_5_90"
       elif (
-        (last_rsi_3 > 64.0)
-        and (last_rsi_14 < 54.0)
-        and (last_rsi_3_1h < 25.0)
-        and (last_rsi_3_4h < 25.0)
-        and (last_aroonu_14_4h > 50.0)
+        (last_rsi_3_gt_64)
+        and (last_rsi_14_lt_54)
+        and (last_rsi_3_1h_lt_25)
+        and (last_rsi_3_4h_lt_25)
+        and (last_aroonu_14_4h_gt_50)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d > 50.0))
       ):
         return True, f"exit_{mode_name}_d_5_91"
       elif (
-        (last_rsi_3 > 72.0)
-        and (last_rsi_14 < 56.0)
-        and (last_rsi_3_1h < 40.0)
+        (last_rsi_3_gt_72)
+        and (last_rsi_14_lt_56)
+        and (last_rsi_3_1h_lt_40)
         and (last_stochrsi_k_1h > 25.0)
         and (last_stochrsi_k_4h_gt_50)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -25.0))
       ):
         return True, f"exit_{mode_name}_d_5_92"
       elif (
-        (last_rsi_3 > 64.0)
-        and (last_rsi_14 < 58.0)
+        (last_rsi_3_gt_64)
+        and (last_rsi_14_lt_58)
         and (last_rsi_3_15m < 50.0)
-        and (last_aroonu_14_1h > 75.0)
-        and (last_stochrsi_k_1h > 70.0)
-        and (last_aroonu_14_4h > 50.0)
+        and (last_aroonu_14_1h_gt_75)
+        and (last_stochrsi_k_1h_gt_70)
+        and (last_aroonu_14_4h_gt_50)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d > 90.0))
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
       ):
         return True, f"exit_{mode_name}_d_5_93"
       elif (
-        (last_rsi_3 > 72.0)
-        and (last_rsi_14 < 58.0)
-        and (last_rsi_3_1h < 25.0)
+        (last_rsi_3_gt_72)
+        and (last_rsi_14_lt_58)
+        and (last_rsi_3_1h_lt_25)
         and (last_rsi_3_4h < 45.0)
-        and (last_aroonu_14_1h > 75.0)
+        and (last_aroonu_14_1h_gt_75)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d > 90.0))
       ):
         return True, f"exit_{mode_name}_d_5_94"
       elif (
-        (last_rsi_3 > 76.0)
+        (last_rsi_3_gt_76)
         and (last_willr_14 > -20.0)
-        and (last_rsi_3_1h < 45.0)
-        and (last_rsi_3_4h < 40.0)
+        and (last_rsi_3_1h_lt_45)
+        and (last_rsi_3_4h_lt_40)
         and (last_stochrsi_k_4h > 10.0)
         and (isinstance(last_aroonu_14_1d, np.float64) and (last_aroonu_14_1d > 75.0))
       ):
         return True, f"exit_{mode_name}_d_5_95"
       elif (
         (last_rsi_3 > 54.0)
-        and (last_rsi_14 < 54.0)
-        and (last_rsi_3_1h < 45.0)
+        and (last_rsi_14_lt_54)
+        and (last_rsi_3_1h_lt_45)
         and (last_rsi_3_1d < 45.0)
         and (last_stochrsi_k_1h_gt_50)
       ):
         return True, f"exit_{mode_name}_d_5_96"
       elif (
-        (last_rsi_3 > 76.0)
-        and (last_rsi_14 < 54.0)
-        and (last_rsi_3_1h < 35.0)
-        and (last_aroonu_14_4h > 50.0)
-        and (last_stochrsi_k_4h > 30.0)
+        (last_rsi_3_gt_76)
+        and (last_rsi_14_lt_54)
+        and (last_rsi_3_1h_lt_35)
+        and (last_aroonu_14_4h_gt_50)
+        and (last_stochrsi_k_4h_gt_30)
       ):
         return True, f"exit_{mode_name}_d_5_97"
       elif (
-        (last_rsi_3 > 82.0)
+        (last_rsi_3_gt_82)
         and (last_rsi_3_15m > 64.0)
-        and (last_rsi_3_1h < 60.0)
-        and (last_rsi_3_4h < 60.0)
+        and (last_rsi_3_1h_lt_60)
+        and (last_rsi_3_4h_lt_60)
         and (last_rsi_3_1d > 80.0)
         and (last_stochrsi_k_4h_gt_50)
       ):
@@ -33262,202 +33316,200 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 52.0)
         and (last_rsi_14 < 60.0)
         and (last_rsi_3_1h < 65.0)
-        and (last_rsi_3_4h < 60.0)
-        and (last_aroonu_14_4h > 50.0)
+        and (last_rsi_3_4h_lt_60)
+        and (last_aroonu_14_4h_gt_50)
         and (last_stoch_k_4h > 40.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 80.0))
       ):
         return True, f"exit_{mode_name}_d_5_99"
-      elif (last_rsi_3 > 90.0) and (last_rsi_14 > 68.0) and (last_rsi_3_15m > 70.0) and (last_rsi_3_4h < 80.0):
+      elif (last_rsi_3_gt_90) and (last_rsi_14 > 68.0) and (last_rsi_3_15m > 70.0) and (last_rsi_3_4h < 80.0):
         return True, f"exit_{mode_name}_d_5_100"
       elif (
-        (last_rsi_3 > 76.0)
+        (last_rsi_3_gt_76)
         and (last_willr_14 > -24.0)
-        and (last_rsi_3_1h < 50.0)
-        and (last_stochrsi_k_4h > 40.0)
+        and (last_rsi_3_1h_lt_50)
+        and (last_stochrsi_k_4h_gt_40)
         and (isinstance(last_roc_9_4h, np.float64) and (last_roc_9_4h > 40.0))
       ):
         return True, f"exit_{mode_name}_d_5_101"
       elif (
-        (last_rsi_3 > 60.0)
-        and (last_rsi_14 < 56.0)
-        and (last_rsi_3_1h < 60.0)
-        and (last_rsi_3_4h < 40.0)
-        and (last_stochrsi_k_4h > 30.0)
+        (last_rsi_3_gt_60)
+        and (last_rsi_14_lt_56)
+        and (last_rsi_3_1h_lt_60)
+        and (last_rsi_3_4h_lt_40)
+        and (last_stochrsi_k_4h_gt_30)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 40.0))
       ):
         return True, f"exit_{mode_name}_d_5_102"
       elif (
-        (last_rsi_3 > 70.0)
+        (last_rsi_3_gt_70)
         and (last_rsi_14 < 64.0)
-        and (last_rsi_3_1h < 60.0)
-        and (last_rsi_14_4h > 70.0)
+        and (last_rsi_3_1h_lt_60)
+        and (last_rsi_14_4h_gt_70)
         and (isinstance(last_roc_9_4h, np.float64) and (last_roc_9_4h > 80.0))
       ):
         return True, f"exit_{mode_name}_d_5_103"
       elif (
         (last_rsi_3 > 56.0)
-        and (last_rsi_14 < 56.0)
-        and (last_rsi_3_1h < 60.0)
-        and (last_stochrsi_k_1h > 40.0)
-        and (last_stochrsi_k_4h > 90.0)
+        and (last_rsi_14_lt_56)
+        and (last_rsi_3_1h_lt_60)
+        and (last_stochrsi_k_1h_gt_40)
+        and (last_stochrsi_k_4h_gt_90)
         and (last_roc_9_4h > 40.0)
       ):
         return True, f"exit_{mode_name}_d_5_104"
       elif (
-        (last_rsi_3 > 70.0)
-        and (last_rsi_14 < 56.0)
+        (last_rsi_3_gt_70)
+        and (last_rsi_14_lt_56)
         and (last_rsi_3_15m < 55.0)
-        and (last_stochrsi_k_4h > 90.0)
+        and (last_stochrsi_k_4h_gt_90)
         and (last_roc_9_4h > 25.0)
       ):
         return True, f"exit_{mode_name}_d_5_105"
       elif (
-        (last_rsi_3 > 64.0)
-        and (last_rsi_14 < 56.0)
-        and (last_rsi_3_1h < 50.0)
+        (last_rsi_3_gt_64)
+        and (last_rsi_14_lt_56)
+        and (last_rsi_3_1h_lt_50)
         and (last_stochrsi_k_1h_gt_50)
-        and (last_rsi_14_4h > 70.0)
+        and (last_rsi_14_4h_gt_70)
         and (last_roc_9_4h > 40.0)
       ):
         return True, f"exit_{mode_name}_d_5_106"
       elif (
         (last_rsi_3 > 66.0)
-        and (last_rsi_14 < 56.0)
-        and (last_rsi_3_1h < 50.0)
-        and (last_stochrsi_k_1h > 70.0)
+        and (last_rsi_14_lt_56)
+        and (last_rsi_3_1h_lt_50)
+        and (last_stochrsi_k_1h_gt_70)
         and (last_rsi_14_4h > 50.0)
       ):
         return True, f"exit_{mode_name}_d_5_107"
-      elif (last_rsi_3 > 48.0) and (last_rsi_14 < 56.0) and (last_rsi_3_1h < 60.0) and (last_stochrsi_k_1h > 80.0):
+      elif (last_rsi_3 > 48.0) and (last_rsi_14_lt_56) and (last_rsi_3_1h_lt_60) and (last_stochrsi_k_1h_gt_80):
         return True, f"exit_{mode_name}_d_5_108"
       elif (
-        (last_rsi_3 > 68.0)
+        (last_rsi_3_gt_68)
         and (last_willr_14 > -16.0)
-        and (last_rsi_3_1h < 50.0)
-        and (last_rsi_3_4h < 20.0)
+        and (last_rsi_3_1h_lt_50)
+        and (last_rsi_3_4h_lt_20)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 50.0))
       ):
         return True, f"exit_{mode_name}_d_5_109"
-      elif (last_rsi_3 > 64.0) and (last_rsi_3_4h < 65.0) and (last_stochrsi_k_4h_gt_50) and (last_roc_9_4h > 25.0):
+      elif (last_rsi_3_gt_64) and (last_rsi_3_4h < 65.0) and (last_stochrsi_k_4h_gt_50) and (last_roc_9_4h > 25.0):
         return True, f"exit_{mode_name}_d_5_110"
       elif (
         (last_rsi_3 > 42.0)
-        and (last_rsi_14 < 52.0)
-        and (last_rsi_3_1h < 50.0)
-        and (last_rsi_14_4h > 70.0)
-        and (last_aroonu_14_1h > 75.0)
-        and (last_aroonu_14_4h > 75.0)
+        and (last_rsi_14_lt_52)
+        and (last_rsi_3_1h_lt_50)
+        and (last_rsi_14_4h_gt_70)
+        and (last_aroonu_14_1h_gt_75)
+        and (last_aroonu_14_4h_gt_75)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 20.0))
       ):
         return True, f"exit_{mode_name}_d_5_111"
       elif (
-        (last_rsi_3 > 72.0)
+        (last_rsi_3_gt_72)
         and (last_willr_14 > -45.0)
         and (last_rsi_14 < 60.0)
-        and (last_rsi_3_1h < 35.0)
+        and (last_rsi_3_1h_lt_35)
         and (last_rsi_3_4h < 35.0)
         and (last_rsi_3_1d < 60.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
       ):
         return True, f"exit_{mode_name}_d_5_112"
       elif (
-        (last_rsi_3 > 76.0)
+        (last_rsi_3_gt_76)
         and (last_willr_14 > -10.0)
-        and (last_rsi_3_1d < 30.0)
+        and (last_rsi_3_1d_lt_30)
         and (last_stochrsi_k_4h_gt_50)
         and (isinstance(last_roc_9_4h, np.float64) and (last_roc_9_4h > 10.0))
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -10.0))
       ):
         return True, f"exit_{mode_name}_d_5_113"
       elif (
-        (last_rsi_3 > 76.0)
-        and (last_rsi_14 < 58.0)
-        and (last_rsi_3_1h < 20.0)
+        (last_rsi_3_gt_76)
+        and (last_rsi_14_lt_58)
+        and (last_rsi_3_1h_lt_20)
         and (last_rsi_3_4h_lt_30)
-        and (last_rsi_3_1d < 30.0)
+        and (last_rsi_3_1d_lt_30)
       ):
         return True, f"exit_{mode_name}_d_5_114"
       elif (
-        (last_rsi_3 > 70.0)
-        and (last_rsi_14 < 56.0)
+        (last_rsi_3_gt_70)
+        and (last_rsi_14_lt_56)
         and (last_rsi_3_15m < 30.0)
         and (last_stochrsi_k_1h_gt_50)
         and (last_stochrsi_k_4h_gt_50)
       ):
         return True, f"exit_{mode_name}_d_5_115"
-      elif (last_rsi_3 > 82.0) and (last_rsi_3_1h < 15.0) and (last_rsi_3_4h < 40.0) and (last_aroonu_14_4h > 50.0):
+      elif (last_rsi_3_gt_82) and (last_rsi_3_1h_lt_15) and (last_rsi_3_4h_lt_40) and (last_aroonu_14_4h_gt_50):
         return True, f"exit_{mode_name}_d_5_116"
-      elif (
-        (last_rsi_3 > 78.0) and (last_rsi_3_1h < 50.0) and (last_aroonu_14_1h > 80.0) and (last_aroonu_14_4h > 80.0)
-      ):
+      elif (last_rsi_3_gt_78) and (last_rsi_3_1h_lt_50) and (last_aroonu_14_1h > 80.0) and (last_aroonu_14_4h > 80.0):
         return True, f"exit_{mode_name}_d_5_117"
-      elif (last_rsi_3 > 82.0) and (last_rsi_3_1h < 20.0) and (last_rsi_3_4h < 60.0) and (last_aroonu_14_4h > 40.0):
+      elif (last_rsi_3_gt_82) and (last_rsi_3_1h_lt_20) and (last_rsi_3_4h_lt_60) and (last_aroonu_14_4h > 40.0):
         return True, f"exit_{mode_name}_d_5_118"
       elif (
-        (last_rsi_3 > 78.0)
+        (last_rsi_3_gt_78)
         and (last_willr_14 > -20.0)
-        and (last_rsi_3_1h < 60.0)
-        and (last_rsi_3_4h < 60.0)
-        and (last_stochrsi_k_1h > 40.0)
+        and (last_rsi_3_1h_lt_60)
+        and (last_rsi_3_4h_lt_60)
+        and (last_stochrsi_k_1h_gt_40)
       ):
         return True, f"exit_{mode_name}_d_5_119"
-      elif (last_rsi_3 > 46.0) and (last_rsi_14 < 56.0) and (last_rsi_3_1h < 40.0) and (last_aroonu_14_4h > 75.0):
+      elif (last_rsi_3 > 46.0) and (last_rsi_14_lt_56) and (last_rsi_3_1h_lt_40) and (last_aroonu_14_4h_gt_75):
         return True, f"exit_{mode_name}_d_5_120"
-      elif (last_rsi_3 > 52.0) and (last_rsi_14 < 54.0) and (last_rsi_3_1h < 50.0) and (last_rsi_14_4h > 85.0):
+      elif (last_rsi_3 > 52.0) and (last_rsi_14_lt_54) and (last_rsi_3_1h_lt_50) and (last_rsi_14_4h > 85.0):
         return True, f"exit_{mode_name}_d_5_121"
-      elif (last_rsi_3 > 50.0) and (last_rsi_14 < 52.0) and (last_rsi_3_4h_lt_30) and (last_stochrsi_k_1h_gt_50):
+      elif (last_rsi_3_gt_50) and (last_rsi_14_lt_52) and (last_rsi_3_4h_lt_30) and (last_stochrsi_k_1h_gt_50):
         return True, f"exit_{mode_name}_d_5_122"
-      elif (last_rsi_3 > 80.0) and (last_willr_14 > -12.0) and (last_rsi_3_1h < 10.0) and (last_rsi_3_1d < 30.0):
+      elif (last_rsi_3_gt_80) and (last_willr_14 > -12.0) and (last_rsi_3_1h_lt_10) and (last_rsi_3_1d_lt_30):
         return True, f"exit_{mode_name}_d_5_123"
       elif (
-        (last_rsi_3 > 80.0)
-        and (last_rsi_3_1h < 15.0)
+        (last_rsi_3_gt_80)
+        and (last_rsi_3_1h_lt_15)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d > 80.0))
       ):
         return True, f"exit_{mode_name}_d_5_124"
       elif (
-        (last_rsi_3 > 68.0)
+        (last_rsi_3_gt_68)
         and (last_willr_14 > -12.0)
-        and (last_rsi_3_1h < 10.0)
-        and (last_rsi_3_4h < 40.0)
+        and (last_rsi_3_1h_lt_10)
+        and (last_rsi_3_4h_lt_40)
         and (last_rsi_3_1d < 40.0)
         and (last_close < (last_high_max_30_1d * 0.50))
       ):
         return True, f"exit_{mode_name}_d_5_125"
-      elif (last_rsi_3 > 82.0) and (last_rsi_3_1h < 15.0) and (last_rsi_3_4h < 40.0) and (last_stochrsi_k_4h_gt_50):
+      elif (last_rsi_3_gt_82) and (last_rsi_3_1h_lt_15) and (last_rsi_3_4h_lt_40) and (last_stochrsi_k_4h_gt_50):
         return True, f"exit_{mode_name}_d_5_126"
-      elif (last_rsi_3 > 82.0) and (last_rsi_3_1h < 10.0) and (last_rsi_3_4h_lt_30) and (last_rsi_3_1d < 40.0):
+      elif (last_rsi_3_gt_82) and (last_rsi_3_1h_lt_10) and (last_rsi_3_4h_lt_30) and (last_rsi_3_1d < 40.0):
         return True, f"exit_{mode_name}_d_5_127"
-      elif (last_rsi_3 > 86.0) and (last_rsi_3_4h_lt_30) and (last_aroonu_14_4h > 85.0):
+      elif (last_rsi_3_gt_86) and (last_rsi_3_4h_lt_30) and (last_aroonu_14_4h > 85.0):
         return True, f"exit_{mode_name}_d_5_128"
       elif (
-        (last_rsi_3 > 78.0)
-        and (last_rsi_3_4h < 25.0)
+        (last_rsi_3_gt_78)
+        and (last_rsi_3_4h_lt_25)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 80.0))
       ):
         return True, f"exit_{mode_name}_d_5_129"
       elif (
         (last_rsi_3 > 66.0)
         and (last_rsi_14_1h > 65.0)
-        and (last_stochrsi_k_1h > 80.0)
+        and (last_stochrsi_k_1h_gt_80)
         and (last_cci_20_change_pct_1h < -0.0)
       ):
         return True, f"exit_{mode_name}_d_5_130"
-      elif (last_rsi_14 < 46.0) and (last_rsi_3_1h < 20.0) and (last_rsi_3_4h_lt_30) and (last_stochrsi_k_4h_gt_50):
+      elif (last_rsi_14 < 46.0) and (last_rsi_3_1h_lt_20) and (last_rsi_3_4h_lt_30) and (last_stochrsi_k_4h_gt_50):
         return True, f"exit_{mode_name}_d_5_131"
       elif (
-        (last_rsi_3 > 72.0)
-        and (last_rsi_3_1h < 35.0)
+        (last_rsi_3_gt_72)
+        and (last_rsi_3_1h_lt_35)
         and (last_rsi_3_4h < 35.0)
         and (last_aroonu_14_1h > 50.0)
-        and (last_stochrsi_k_1h > 40.0)
+        and (last_stochrsi_k_1h_gt_40)
       ):
         return True, f"exit_{mode_name}_d_5_132"
       elif (
-        (last_rsi_3 > 72.0)
+        (last_rsi_3_gt_72)
         and (last_aroonu_14_15m > 75.0)
-        and (last_aroonu_14_1h > 75.0)
+        and (last_aroonu_14_1h_gt_75)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 25.0))
       ):
         return True, f"exit_{mode_name}_d_5_133"


### PR DESCRIPTION
## Summary
- Reduces repeated long `long_exit_dec` threshold checks for the 5-6% profit bracket through local boolean aliases.
- Keeps the branch independent on latest upstream `main`.

## Safety
- Only already-read scalar threshold comparisons inside the same current-profit branch are reused.
- Indicator formulas, candle selection, profit arithmetic, thresholds, condition order, return values, order classification, and stake logic are unchanged.
- Touched function: `long_exit_dec`. No v3 grind-entry code is touched.

## Backtest scope
- Full backtesting was not required because this patch only reuses already-read scalar threshold checks inside the same `long_exit_dec` current-profit branch. Trading conditions and output values are unchanged.

## Checks
- `python3 ~/.codex/skills/nfi-upstream-pr/scripts/validate_nfi_pr.py --base origin/main`
- `AST undefined-local scan from validator reported zero findings for introduced `last_*` aliases`
- `git merge-tree conflict simulation against origin/main`
- `targeted git diff origin/main...HEAD -- NostalgiaForInfinityX7.py review`
- `git diff --check`
- `ruff format --check NostalgiaForInfinityX7.py`
- `ruff check NostalgiaForInfinityX7.py`
- `PYTHONDONTWRITEBYTECODE=1 python3 -m py_compile NostalgiaForInfinityX7.py`
