### PR TITLE
Hoist X7 long dec 6-7% thresholds

### DIFF
--- a/NostalgiaForInfinityX7.py
+++ b/NostalgiaForInfinityX7.py
@@ -33462,6 +33462,63 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_5_133"
     elif 0.07 > current_profit >= 0.06:
+      # Reused long exit decision threshold checks for this profit bracket
+      last_rsi_3_gt_80 = last_rsi_3 > 80.0
+      last_rsi_14_lt_54 = last_rsi_14 < 54.0
+      last_rsi_3_gt_70 = last_rsi_3 > 70.0
+      last_rsi_3_gt_75 = last_rsi_3 > 75.0
+      last_rsi_3_4h_lt_20 = last_rsi_3_4h < 20.0
+      last_rsi_3_1h_lt_20 = last_rsi_3_1h < 20.0
+      last_rsi_3_4h_lt_10 = last_rsi_3_4h < 10.0
+      last_rsi_14_lt_52 = last_rsi_14 < 52.0
+      last_rsi_3_1h_lt_15 = last_rsi_3_1h < 15.0
+      last_rsi_3_1h_lt_50 = last_rsi_3_1h < 50.0
+      last_rsi_3_1h_lt_10 = last_rsi_3_1h < 10.0
+      last_rsi_3_1h_lt_25 = last_rsi_3_1h < 25.0
+      last_rsi_3_4h_lt_40 = last_rsi_3_4h < 40.0
+      last_rsi_3_gt_72 = last_rsi_3 > 72.0
+      last_rsi_3_4h_lt_25 = last_rsi_3_4h < 25.0
+      last_rsi_3_gt_78 = last_rsi_3 > 78.0
+      last_rsi_3_gt_82 = last_rsi_3 > 82.0
+      last_rsi_3_1d_lt_25 = last_rsi_3_1d < 25.0
+      last_rsi_3_gt_74 = last_rsi_3 > 74.0
+      last_rsi_3_gt_66 = last_rsi_3 > 66.0
+      last_rsi_3_gt_84 = last_rsi_3 > 84.0
+      last_aroonu_14_4h_gt_50 = last_aroonu_14_4h > 50.0
+      last_rsi_3_1h_lt_60 = last_rsi_3_1h < 60.0
+      last_rsi_3_gt_88 = last_rsi_3 > 88.0
+      last_rsi_3_gt_65 = last_rsi_3 > 65.0
+      last_stochrsi_k_4h_gt_30 = last_stochrsi_k_4h > 30.0
+      last_stochrsi_k_4h_gt_40 = last_stochrsi_k_4h > 40.0
+      last_stochrsi_k_4h_gt_20 = last_stochrsi_k_4h > 20.0
+      last_stochrsi_k_4h_gt_90 = last_stochrsi_k_4h > 90.0
+      last_rsi_3_gt_86 = last_rsi_3 > 86.0
+      last_rsi_14_lt_46 = last_rsi_14 < 46.0
+      last_rsi_3_gt_60 = last_rsi_3 > 60.0
+      last_rsi_3_4h_lt_15 = last_rsi_3_4h < 15.0
+      last_stochrsi_k_1h_gt_70 = last_stochrsi_k_1h > 70.0
+      last_stochrsi_k_1h_gt_80 = last_stochrsi_k_1h > 80.0
+      last_rsi_3_gt_50 = last_rsi_3 > 50.0
+      last_rsi_3_gt_62 = last_rsi_3 > 62.0
+      last_rsi_14_lt_56 = last_rsi_14 < 56.0
+      last_stochrsi_k_1h_gt_40 = last_stochrsi_k_1h > 40.0
+      last_aroonu_14_1h_gt_75 = last_aroonu_14_1h > 75.0
+      last_rsi_3_4h_lt_60 = last_rsi_3_4h < 60.0
+      last_rsi_14_gt_66 = last_rsi_14 > 66.0
+      last_rsi_3_gt_85 = last_rsi_3 > 85.0
+      last_rsi_3_gt_90 = last_rsi_3 > 90.0
+      last_aroonu_14_4h_gt_25 = last_aroonu_14_4h > 25.0
+      last_rsi_3_gt_92 = last_rsi_3 > 92.0
+      last_aroonu_14_4h_gt_75 = last_aroonu_14_4h > 75.0
+      last_stochrsi_k_1h_gt_30 = last_stochrsi_k_1h > 30.0
+      last_rsi_3_gt_76 = last_rsi_3 > 76.0
+      last_stochrsi_k_4h_gt_25 = last_stochrsi_k_4h > 25.0
+      last_rsi_14_lt_48 = last_rsi_14 < 48.0
+      last_rsi_3_1h_lt_40 = last_rsi_3_1h < 40.0
+      last_rsi_3_1h_lt_45 = last_rsi_3_1h < 45.0
+      last_rsi_3_1h_lt_35 = last_rsi_3_1h < 35.0
+      last_rsi_14_4h_gt_70 = last_rsi_14_4h > 70.0
+      last_rsi_3_1d_lt_30 = last_rsi_3_1d < 30.0
       if (
         (last_willr_14 > -1.0)
         and (last_rsi_14 > 78.0)
@@ -33484,7 +33541,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_stochrsi_k > 98.0)
         and (last_cmf_20_1h < -0.0)
         and (last_cmf_20_4h < -0.0)
-        and ((last_stochrsi_k_4h > 20.0) and (last_stochrsi_k_change_pct_4h < -10.0))
+        and ((last_stochrsi_k_4h_gt_20) and (last_stochrsi_k_change_pct_4h < -10.0))
       ):
         return True, f"exit_{mode_name}_d_6_3"
       elif (
@@ -33496,10 +33553,10 @@ class NostalgiaForInfinityX7(IStrategy):
         and (isinstance(last_ema_200_4h, np.float64) and (last_ema_12_4h < last_ema_200_4h))
       ):
         return True, f"exit_{mode_name}_d_6_4"
-      elif (last_willr_14 > -8.0) and (last_rsi_14 > 66.0) and (last_roc_9_1h < -5.0) and (last_roc_9_4h < -5.0):
+      elif (last_willr_14 > -8.0) and (last_rsi_14_gt_66) and (last_roc_9_1h < -5.0) and (last_roc_9_4h < -5.0):
         return True, f"exit_{mode_name}_d_6_5"
       elif (
-        (last_rsi_3 > 70.0)
+        (last_rsi_3_gt_70)
         and (last_stochrsi_k > 70.0)
         and (last_rsi_14 < 40.0)
         and (last_roc_9_1h < -10.0)
@@ -33538,7 +33595,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_6_10"
       elif (
-        (last_rsi_3 > 80.0)
+        (last_rsi_3_gt_80)
         and (last_rsi_14 < 45.0)
         and (last_roc_9_15m < -10.0)
         and (last_roc_9_1h < -10.0)
@@ -33546,167 +33603,167 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_6_11"
       elif (
-        (last_rsi_3 > 75.0)
+        (last_rsi_3_gt_75)
         and (last_rsi_14_lt_50)
-        and (last_rsi_3_4h < 10.0)
+        and (last_rsi_3_4h_lt_10)
         and (last_roc_9_1h < -20.0)
         and (last_roc_9_4h < -20.0)
       ):
         return True, f"exit_{mode_name}_d_6_12"
-      elif (last_rsi_3 > 85.0) and (last_rsi_3_4h < 5.0) and (last_roc_9_4h < -25.0):
+      elif (last_rsi_3_gt_85) and (last_rsi_3_4h < 5.0) and (last_roc_9_4h < -25.0):
         return True, f"exit_{mode_name}_d_6_13"
-      elif (last_rsi_3 > 90.0) and (last_willr_14 > -10.0) and (last_rsi_3_4h < 5.0) and (last_aroonu_14_4h > 25.0):
+      elif (last_rsi_3_gt_90) and (last_willr_14 > -10.0) and (last_rsi_3_4h < 5.0) and (last_aroonu_14_4h_gt_25):
         return True, f"exit_{mode_name}_d_6_14"
-      elif (last_rsi_3 > 88.0) and (last_rsi_14 > 60.0) and (last_roc_9_4h < -30.0):
+      elif (last_rsi_3_gt_88) and (last_rsi_14 > 60.0) and (last_roc_9_4h < -30.0):
         return True, f"exit_{mode_name}_d_6_15"
       elif (
-        (last_rsi_3 > 75.0)
-        and (last_aroonu_14_4h > 25.0)
+        (last_rsi_3_gt_75)
+        and (last_aroonu_14_4h_gt_25)
         and (last_roc_9_4h < -25.0)
         and (last_aroonu_14_1d > 50.0)
         and (last_change_pct_1d < -15.0)
       ):
         return True, f"exit_{mode_name}_d_6_16"
       elif (
-        (last_rsi_3 > 85.0)
+        (last_rsi_3_gt_85)
         and (last_willr_14 > -30.0)
-        and (last_rsi_3_1h < 10.0)
-        and (last_stochrsi_k_4h > 90.0)
+        and (last_rsi_3_1h_lt_10)
+        and (last_stochrsi_k_4h_gt_90)
         and (last_roc_9_4h > 30.0)
       ):
         return True, f"exit_{mode_name}_d_6_17"
-      elif (last_rsi_3 > 80.0) and (last_rsi_14 > 65.0) and (last_rsi_3_4h < 20.0) and (last_roc_2_1d < -50.0):
+      elif (last_rsi_3_gt_80) and (last_rsi_14 > 65.0) and (last_rsi_3_4h_lt_20) and (last_roc_2_1d < -50.0):
         return True, f"exit_{mode_name}_d_6_18"
       elif (
-        (last_rsi_3 > 86.0)
-        and (last_rsi_14 > 66.0)
-        and (last_rsi_3_4h < 10.0)
+        (last_rsi_3_gt_86)
+        and (last_rsi_14_gt_66)
+        and (last_rsi_3_4h_lt_10)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d > 70.0))
       ):
         return True, f"exit_{mode_name}_d_6_19"
-      elif (last_rsi_3 > 44.0) and (last_rsi_14 < 46.0) and (last_rsi_3_1h < 10.0) and (last_aroonu_14_1h > 25.0):
+      elif (last_rsi_3 > 44.0) and (last_rsi_14_lt_46) and (last_rsi_3_1h_lt_10) and (last_aroonu_14_1h > 25.0):
         return True, f"exit_{mode_name}_d_6_20"
-      elif (last_rsi_3 > 60.0) and (last_rsi_14_lt_50) and (last_rsi_3_1h < 20.0) and (last_stochrsi_k_4h > 90.0):
+      elif (last_rsi_3_gt_60) and (last_rsi_14_lt_50) and (last_rsi_3_1h_lt_20) and (last_stochrsi_k_4h_gt_90):
         return True, f"exit_{mode_name}_d_6_21"
       elif (
-        (last_rsi_3 > 92.0)
+        (last_rsi_3_gt_92)
         and (last_willr_14 > -8.0)
         and (last_change_pct_4h < -5.0)
         and (last_stochrsi_k_4h_gt_50)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
       ):
         return True, f"exit_{mode_name}_d_6_22"
-      elif (last_rsi_3 > 80.0) and (last_willr_14 > -25.0) and (last_rsi_3_1h < 15.0) and (last_rsi_3_1d < 5.0):
+      elif (last_rsi_3_gt_80) and (last_willr_14 > -25.0) and (last_rsi_3_1h_lt_15) and (last_rsi_3_1d < 5.0):
         return True, f"exit_{mode_name}_d_6_23"
       elif (
-        (last_rsi_3 > 86.0)
-        and (last_rsi_14 > 66.0)
+        (last_rsi_3_gt_86)
+        and (last_rsi_14_gt_66)
         and (last_willr_14 > -30.0)
         and (last_rsi_3_4h_lt_30)
-        and (last_aroonu_14_4h > 75.0)
+        and (last_aroonu_14_4h_gt_75)
       ):
         return True, f"exit_{mode_name}_d_6_24"
       elif (
-        (last_rsi_3 > 75.0)
+        (last_rsi_3_gt_75)
         and (last_willr_14 > -10.0)
-        and (last_rsi_3_4h < 10.0)
+        and (last_rsi_3_4h_lt_10)
         and (last_roc_9_4h < -15.0)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d > 50.0))
       ):
         return True, f"exit_{mode_name}_d_6_25"
-      elif (last_rsi_3 > 70.0) and (last_willr_14 > -10.0) and (last_rsi_3_4h < 15.0) and (last_roc_9_4h < -20.0):
+      elif (last_rsi_3_gt_70) and (last_willr_14 > -10.0) and (last_rsi_3_4h_lt_15) and (last_roc_9_4h < -20.0):
         return True, f"exit_{mode_name}_d_6_26"
       elif (
-        (last_rsi_3 > 70.0)
+        (last_rsi_3_gt_70)
         and (last_rsi_14_lt_50)
-        and (last_rsi_3_1h < 20.0)
-        and (last_rsi_3_4h < 20.0)
-        and (last_stochrsi_k_4h > 20.0)
+        and (last_rsi_3_1h_lt_20)
+        and (last_rsi_3_4h_lt_20)
+        and (last_stochrsi_k_4h_gt_20)
       ):
         return True, f"exit_{mode_name}_d_6_27"
-      elif (last_rsi_3 > 65.0) and (last_rsi_14_lt_50) and (last_rsi_3_15m < 10.0) and (last_roc_9_4h > 50.0):
+      elif (last_rsi_3_gt_65) and (last_rsi_14_lt_50) and (last_rsi_3_15m < 10.0) and (last_roc_9_4h > 50.0):
         return True, f"exit_{mode_name}_d_6_28"
       elif (
-        (last_rsi_3 > 80.0)
+        (last_rsi_3_gt_80)
         and (last_rsi_14_lt_50)
-        and (last_rsi_3_1h < 20.0)
-        and (last_rsi_3_4h < 20.0)
-        and (last_stochrsi_k_1h > 30.0)
+        and (last_rsi_3_1h_lt_20)
+        and (last_rsi_3_4h_lt_20)
+        and (last_stochrsi_k_1h_gt_30)
       ):
         return True, f"exit_{mode_name}_d_6_29"
-      elif (last_rsi_3 > 75.0) and (last_rsi_3_1h < 25.0) and (last_rsi_3_4h < 10.0) and (last_stochrsi_k_1h > 70.0):
+      elif (last_rsi_3_gt_75) and (last_rsi_3_1h_lt_25) and (last_rsi_3_4h_lt_10) and (last_stochrsi_k_1h_gt_70):
         return True, f"exit_{mode_name}_d_6_30"
       elif (
-        (last_rsi_3 > 65.0)
+        (last_rsi_3_gt_65)
         and (last_rsi_14_lt_50)
-        and (last_rsi_3_1h < 15.0)
-        and (last_rsi_3_4h < 15.0)
+        and (last_rsi_3_1h_lt_15)
+        and (last_rsi_3_4h_lt_15)
         and (last_stochrsi_k_1h > 25.0)
       ):
         return True, f"exit_{mode_name}_d_6_31"
-      elif (last_rsi_3 > 75.0) and (last_rsi_3_1h < 15.0) and (last_roc_2_4h < -30.0) and (last_stochrsi_k_4h > 30.0):
+      elif (last_rsi_3_gt_75) and (last_rsi_3_1h_lt_15) and (last_roc_2_4h < -30.0) and (last_stochrsi_k_4h_gt_30):
         return True, f"exit_{mode_name}_d_6_32"
       elif (
-        (last_rsi_3 > 75.0)
+        (last_rsi_3_gt_75)
         and (last_willr_14 > -8.0)
         and (last_roc_2_1h < -10.0)
         and (last_roc_9_1h > 30.0)
         and (last_stochrsi_k_1h_gt_50)
       ):
         return True, f"exit_{mode_name}_d_6_33"
-      elif (last_rsi_3 > 65.0) and (last_rsi_3_15m < 30.0) and (last_rsi_14_1h > 80.0) and (last_roc_9_1h > 40.0):
+      elif (last_rsi_3_gt_65) and (last_rsi_3_15m < 30.0) and (last_rsi_14_1h > 80.0) and (last_roc_9_1h > 40.0):
         return True, f"exit_{mode_name}_d_6_34"
-      elif (last_rsi_3 > 82.0) and (last_willr_14 > -9.0) and (last_rsi_3_1d < 25.0) and (last_stochrsi_k_1h > 75.0):
+      elif (last_rsi_3_gt_82) and (last_willr_14 > -9.0) and (last_rsi_3_1d_lt_25) and (last_stochrsi_k_1h > 75.0):
         return True, f"exit_{mode_name}_d_6_35"
       elif (
-        (last_rsi_3 > 70.0)
+        (last_rsi_3_gt_70)
         and (last_willr_14 > -30.0)
         and (last_roc_9_4h < -25.0)
-        and (last_rsi_3_1d < 25.0)
+        and (last_rsi_3_1d_lt_25)
         and (last_stochrsi_k_1h_gt_50)
       ):
         return True, f"exit_{mode_name}_d_6_36"
       elif (
-        (last_rsi_3 > 76.0)
+        (last_rsi_3_gt_76)
         and (last_rsi_14_lt_50)
-        and (last_rsi_3_1h < 20.0)
-        and (last_rsi_3_1d < 25.0)
+        and (last_rsi_3_1h_lt_20)
+        and (last_rsi_3_1d_lt_25)
         and (last_stochrsi_k_4h_gt_50)
       ):
         return True, f"exit_{mode_name}_d_6_37"
-      elif (last_rsi_3 > 70.0) and (last_willr_14 > -30.0) and (last_rsi_3_4h < 10.0) and (last_stochrsi_k_4h > 20.0):
+      elif (last_rsi_3_gt_70) and (last_willr_14 > -30.0) and (last_rsi_3_4h_lt_10) and (last_stochrsi_k_4h_gt_20):
         return True, f"exit_{mode_name}_d_6_38"
-      elif (last_rsi_3 > 92.0) and (last_willr_14 > -8.0) and (last_cmf_20_4h < -0.0) and (last_rsi_3_4h < 10.0):
+      elif (last_rsi_3_gt_92) and (last_willr_14 > -8.0) and (last_cmf_20_4h < -0.0) and (last_rsi_3_4h_lt_10):
         return True, f"exit_{mode_name}_d_6_39"
       elif (
-        (last_rsi_3 > 70.0)
+        (last_rsi_3_gt_70)
         and (last_willr_14 > -30.0)
         and (last_rsi_3_1h_lt_30)
-        and (last_stochrsi_k_1h > 30.0)
+        and (last_stochrsi_k_1h_gt_30)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d > 90.0))
       ):
         return True, f"exit_{mode_name}_d_6_40"
       elif (
-        (last_rsi_3 > 80.0)
+        (last_rsi_3_gt_80)
         and (last_willr_14 > -25.0)
         and (last_rsi_3_1h_lt_30)
-        and (last_stochrsi_k_4h > 25.0)
+        and (last_stochrsi_k_4h_gt_25)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 50.0))
       ):
         return True, f"exit_{mode_name}_d_6_41"
       elif (
-        (last_rsi_3 > 75.0)
+        (last_rsi_3_gt_75)
         and (last_willr_14 > -40.0)
-        and (last_stochrsi_k_4h > 30.0)
+        and (last_stochrsi_k_4h_gt_30)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 40.0))
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d > 70.0))
       ):
         return True, f"exit_{mode_name}_d_6_42"
       elif (
-        (last_rsi_3 > 80.0)
+        (last_rsi_3_gt_80)
         and (last_rsi_14_lt_50)
-        and (last_rsi_3_1h < 15.0)
-        and (last_rsi_3_4h < 40.0)
+        and (last_rsi_3_1h_lt_15)
+        and (last_rsi_3_4h_lt_40)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d > 90.0))
       ):
         return True, f"exit_{mode_name}_d_6_43"
@@ -33714,69 +33771,69 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 55.0)
         and (last_willr_14 > -20.0)
         and (last_rsi_3_4h_lt_30)
-        and (last_rsi_3_1d < 25.0)
+        and (last_rsi_3_1d_lt_25)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
       ):
         return True, f"exit_{mode_name}_d_6_44"
-      elif (last_rsi_3 > 88.0) and (last_willr_14 > -12.0) and (last_rsi_3_1h < 10.0):
+      elif (last_rsi_3_gt_88) and (last_willr_14 > -12.0) and (last_rsi_3_1h_lt_10):
         return True, f"exit_{mode_name}_d_6_45"
-      elif (last_rsi_3 > 75.0) and (last_rsi_3_1h < 15.0) and (last_rsi_3_4h < 10.0) and (last_roc_2_1d < -20.0):
+      elif (last_rsi_3_gt_75) and (last_rsi_3_1h_lt_15) and (last_rsi_3_4h_lt_10) and (last_roc_2_1d < -20.0):
         return True, f"exit_{mode_name}_d_6_46"
       elif (
-        (last_rsi_3 > 80.0)
-        and (last_stochrsi_k_1h > 80.0)
-        and (last_stochrsi_k_4h > 40.0)
+        (last_rsi_3_gt_80)
+        and (last_stochrsi_k_1h_gt_80)
+        and (last_stochrsi_k_4h_gt_40)
         and (last_change_pct_1d < -5.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -5.0))
       ):
         return True, f"exit_{mode_name}_d_6_47"
       elif (
-        (last_rsi_3 > 50.0)
+        (last_rsi_3_gt_50)
         and (last_rsi_14_lt_50)
         and (last_rsi_3_1h_lt_30)
-        and (last_rsi_3_4h < 20.0)
+        and (last_rsi_3_4h_lt_20)
         and (last_stochrsi_k_1h_gt_50)
       ):
         return True, f"exit_{mode_name}_d_6_48"
       elif (
-        (last_rsi_3 > 75.0)
+        (last_rsi_3_gt_75)
         and (last_willr_14 > -10.0)
-        and (last_rsi_3_4h < 20.0)
+        and (last_rsi_3_4h_lt_20)
         and (last_change_pct_1d < -5.0)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d > 50.0))
       ):
         return True, f"exit_{mode_name}_d_6_49"
-      elif (last_rsi_3 > 80.0) and (last_willr_14 > -10.0) and (last_rsi_3_1d < 10.0) and (last_stochrsi_k_1h > 90.0):
+      elif (last_rsi_3_gt_80) and (last_willr_14 > -10.0) and (last_rsi_3_1d < 10.0) and (last_stochrsi_k_1h > 90.0):
         return True, f"exit_{mode_name}_d_6_50"
-      elif (last_rsi_3 > 60.0) and (last_rsi_14 < 52.0) and (last_rsi_3_4h < 20.0) and (last_stochrsi_k_1h_gt_50):
+      elif (last_rsi_3_gt_60) and (last_rsi_14_lt_52) and (last_rsi_3_4h_lt_20) and (last_stochrsi_k_1h_gt_50):
         return True, f"exit_{mode_name}_d_6_51"
       elif (
-        (last_rsi_3 > 74.0)
+        (last_rsi_3_gt_74)
         and (last_rsi_14 > 54.0)
         and (last_willr_14 > -10.0)
-        and (last_stochrsi_k_1h > 70.0)
+        and (last_stochrsi_k_1h_gt_70)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -15.0))
       ):
         return True, f"exit_{mode_name}_d_6_52"
       elif (
-        (last_rsi_3 > 70.0)
+        (last_rsi_3_gt_70)
         and (last_rsi_14_lt_50)
         and (last_willr_14 > -25.0)
-        and (last_rsi_3_1h < 20.0)
+        and (last_rsi_3_1h_lt_20)
         and (last_stochrsi_k_4h_gt_50)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d > 50.0))
       ):
         return True, f"exit_{mode_name}_d_6_53"
       elif (
-        (last_rsi_3 > 72.0)
-        and (last_rsi_14 < 52.0)
+        (last_rsi_3_gt_72)
+        and (last_rsi_14_lt_52)
         and (last_stochrsi_k_1h_gt_50)
         and (last_roc_9_4h < -10.0)
         and (last_change_pct_1d < -10.0)
       ):
         return True, f"exit_{mode_name}_d_6_54"
       elif (
-        (last_rsi_3 > 88.0)
+        (last_rsi_3_gt_88)
         and (last_willr_14 > -20.0)
         and (last_roc_9_4h < -5.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 10.0))
@@ -33784,23 +33841,23 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_6_55"
       elif (
-        (last_rsi_3 > 65.0)
+        (last_rsi_3_gt_65)
         and (last_rsi_14_lt_50)
         and (last_rsi_3_1h_lt_30)
-        and (last_rsi_3_4h < 25.0)
+        and (last_rsi_3_4h_lt_25)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
         and (last_stochrsi_k_4h > 10.0)
       ):
         return True, f"exit_{mode_name}_d_6_56"
       elif (
-        (last_rsi_3 > 50.0)
+        (last_rsi_3_gt_50)
         and (last_rsi_14 < 42.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
         and (last_stochrsi_k_4h > 70.0)
       ):
         return True, f"exit_{mode_name}_d_6_57"
       elif (
-        (last_rsi_3 > 75.0)
+        (last_rsi_3_gt_75)
         and (last_rsi_3_1h_lt_30)
         and (last_rsi_3_4h_lt_30)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -15.0))
@@ -33808,76 +33865,74 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_6_58"
       elif (
-        (last_rsi_3 > 85.0)
+        (last_rsi_3_gt_85)
         and (last_willr_14 > -18.0)
-        and (last_rsi_3_4h < 25.0)
+        and (last_rsi_3_4h_lt_25)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -15.0))
-        and (last_stochrsi_k_4h > 40.0)
+        and (last_stochrsi_k_4h_gt_40)
       ):
         return True, f"exit_{mode_name}_d_6_59"
       elif (
-        (last_rsi_3 > 65.0)
-        and (last_rsi_14 < 46.0)
+        (last_rsi_3_gt_65)
+        and (last_rsi_14_lt_46)
         and (last_rsi_14_4h > 65.0)
         and (last_stochrsi_k_4h_gt_50)
         and (last_stochrsi_k_1d > 50.0)
       ):
         return True, f"exit_{mode_name}_d_6_60"
-      elif (last_rsi_3 > 90.0) and (last_willr_14 > -25.0) and (last_rsi_3_4h < 10.0) and (last_stochrsi_k_1h > 30.0):
+      elif (last_rsi_3_gt_90) and (last_willr_14 > -25.0) and (last_rsi_3_4h_lt_10) and (last_stochrsi_k_1h_gt_30):
         return True, f"exit_{mode_name}_d_6_61"
       elif (
-        (last_rsi_3 > 80.0)
+        (last_rsi_3_gt_80)
         and (last_willr_14 > -8.0)
         and (last_rsi_3_1h_lt_30)
-        and (last_rsi_3_4h < 20.0)
+        and (last_rsi_3_4h_lt_20)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 20.0))
         and (last_change_pct_1d < -5.0)
       ):
         return True, f"exit_{mode_name}_d_6_62"
-      elif (
-        (last_rsi_3 > 62.0) and (last_rsi_3_1d < 25.0) and (last_stochrsi_k_1h > 80.0) and (last_stochrsi_k_4h > 30.0)
-      ):
+      elif (last_rsi_3_gt_62) and (last_rsi_3_1d_lt_25) and (last_stochrsi_k_1h_gt_80) and (last_stochrsi_k_4h_gt_30):
         return True, f"exit_{mode_name}_d_6_63"
       elif (
-        (last_rsi_3 > 82.0)
+        (last_rsi_3_gt_82)
         and (last_rsi_3_1h_lt_30)
         and (last_rsi_3_4h_lt_30)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
       ):
         return True, f"exit_{mode_name}_d_6_64"
-      elif (last_rsi_3 > 62.0) and (last_rsi_14 < 48.0) and (last_rsi_3_1h < 20.0) and (last_rsi_3_4h < 15.0):
+      elif (last_rsi_3_gt_62) and (last_rsi_14_lt_48) and (last_rsi_3_1h_lt_20) and (last_rsi_3_4h_lt_15):
         return True, f"exit_{mode_name}_d_6_65"
-      elif (last_rsi_3 > 76.0) and (last_rsi_14 < 54.0) and (last_rsi_3_1h < 20.0) and (last_stochrsi_k_1h_gt_50):
+      elif (last_rsi_3_gt_76) and (last_rsi_14_lt_54) and (last_rsi_3_1h_lt_20) and (last_stochrsi_k_1h_gt_50):
         return True, f"exit_{mode_name}_d_6_66"
       elif (
-        (last_rsi_3 > 50.0)
-        and (last_rsi_14 < 48.0)
+        (last_rsi_3_gt_50)
+        and (last_rsi_14_lt_48)
         and (last_stochrsi_k_4h > 80.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -25.0))
       ):
         return True, f"exit_{mode_name}_d_6_67"
       elif (
-        (last_rsi_3 > 78.0)
-        and (last_rsi_14 < 54.0)
-        and (last_rsi_3_1h < 25.0)
+        (last_rsi_3_gt_78)
+        and (last_rsi_14_lt_54)
+        and (last_rsi_3_1h_lt_25)
         and (last_roc_2_4h < -30.0)
-        and (last_stochrsi_k_4h > 25.0)
+        and (last_stochrsi_k_4h_gt_25)
       ):
         return True, f"exit_{mode_name}_d_6_68"
       elif (
         (last_rsi_3 > 93.0) and (last_roc_9_4h > 20.0) and (last_stochrsi_k_4h_gt_50) and (last_change_pct_4h < -5.0)
       ):
         return True, f"exit_{mode_name}_d_6_69"
-      elif (last_rsi_3 > 60.0) and (last_rsi_14 < 46.0) and (last_rsi_3_1h < 25.0) and (last_stochrsi_k_4h > 20.0):
+      elif (last_rsi_3_gt_60) and (last_rsi_14_lt_46) and (last_rsi_3_1h_lt_25) and (last_stochrsi_k_4h_gt_20):
         return True, f"exit_{mode_name}_d_6_70"
-      elif (last_rsi_3 > 58.0) and (last_rsi_14_lt_50) and (last_rsi_3_4h < 25.0) and (last_stochrsi_k_1h > 20.0):
+      elif (last_rsi_3 > 58.0) and (last_rsi_14_lt_50) and (last_rsi_3_4h_lt_25) and (last_stochrsi_k_1h > 20.0):
         return True, f"exit_{mode_name}_d_6_71"
-      elif (last_rsi_3 > 72.0) and (last_rsi_14 < 48.0) and (last_rsi_3_1h < 10.0) and (last_aroonu_14_4h > 25.0):
+      elif (last_rsi_3_gt_72) and (last_rsi_14_lt_48) and (last_rsi_3_1h_lt_10) and (last_aroonu_14_4h_gt_25):
         return True, f"exit_{mode_name}_d_6_72"
       elif (
-        (last_rsi_3 > 72.0)
-        and (last_rsi_3_1h < 25.0)
-        and (last_rsi_3_4h < 15.0)
+        (last_rsi_3_gt_72)
+        and (last_rsi_3_1h_lt_25)
+        and (last_rsi_3_4h_lt_15)
         and (last_roc_9_4h < -20.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -25.0))
       ):
@@ -33885,81 +33940,81 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 95.0)
         and (last_willr_14 > -10.0)
-        and (last_rsi_3_4h < 25.0)
-        and (last_rsi_3_1d < 25.0)
+        and (last_rsi_3_4h_lt_25)
+        and (last_rsi_3_1d_lt_25)
         and (last_stochrsi_k_1h_gt_50)
       ):
         return True, f"exit_{mode_name}_d_6_74"
       elif (
-        (last_rsi_3 > 90.0)
+        (last_rsi_3_gt_90)
         and (last_rsi_3_1h_lt_30)
-        and (last_rsi_3_4h < 20.0)
+        and (last_rsi_3_4h_lt_20)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d > 50.0))
       ):
         return True, f"exit_{mode_name}_d_6_75"
-      elif (last_rsi_3 > 62.0) and (last_rsi_14 < 56.0) and (last_roc_9_1h > 80.0) and (last_stochrsi_k_4h > 80.0):
+      elif (last_rsi_3_gt_62) and (last_rsi_14_lt_56) and (last_roc_9_1h > 80.0) and (last_stochrsi_k_4h > 80.0):
         return True, f"exit_{mode_name}_d_6_76"
       elif (
-        (last_rsi_3 > 70.0)
-        and (last_rsi_14 < 52.0)
+        (last_rsi_3_gt_70)
+        and (last_rsi_14_lt_52)
         and (last_rsi_3_1h_lt_30)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 50.0))
       ):
         return True, f"exit_{mode_name}_d_6_77"
       elif (
-        (last_rsi_3 > 80.0)
+        (last_rsi_3_gt_80)
         and (last_willr_14 > -22.0)
         and (last_rsi_3_1h_lt_30)
-        and (last_rsi_3_4h < 20.0)
+        and (last_rsi_3_4h_lt_20)
         and (last_rsi_3_1d < 20.0)
       ):
         return True, f"exit_{mode_name}_d_6_78"
-      elif (last_rsi_3 > 86.0) and (last_willr_14 > -8.0) and (last_rsi_3_1h_lt_30) and (last_rsi_3_4h < 10.0):
+      elif (last_rsi_3_gt_86) and (last_willr_14 > -8.0) and (last_rsi_3_1h_lt_30) and (last_rsi_3_4h_lt_10):
         return True, f"exit_{mode_name}_d_6_79"
       elif (
-        (last_rsi_3 > 66.0)
-        and (last_rsi_14 < 52.0)
+        (last_rsi_3_gt_66)
+        and (last_rsi_14_lt_52)
         and (last_rsi_3_1h_lt_30)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 50.0))
-        and (last_stochrsi_k_4h > 25.0)
+        and (last_stochrsi_k_4h_gt_25)
       ):
         return True, f"exit_{mode_name}_d_6_80"
       elif (
-        (last_rsi_3 > 78.0)
+        (last_rsi_3_gt_78)
         and (last_willr_14 > -16.0)
-        and (last_rsi_3_1h < 25.0)
-        and (last_rsi_3_4h < 25.0)
+        and (last_rsi_3_1h_lt_25)
+        and (last_rsi_3_4h_lt_25)
         and (isinstance(last_rsi_14_1d, np.float64) and (last_rsi_14_1d > 50.0))
       ):
         return True, f"exit_{mode_name}_d_6_81"
       elif (
-        (last_rsi_3 > 76.0)
+        (last_rsi_3_gt_76)
         and (last_willr_14 > -16.0)
         and (last_rsi_3_4h_lt_30)
         and (last_rsi_3_1d < 15.0)
-        and (last_stochrsi_k_4h > 40.0)
+        and (last_stochrsi_k_4h_gt_40)
       ):
         return True, f"exit_{mode_name}_d_6_82"
       elif (
-        (last_rsi_3 > 66.0)
-        and (last_rsi_14 < 52.0)
-        and (last_rsi_3_1h < 40.0)
+        (last_rsi_3_gt_66)
+        and (last_rsi_14_lt_52)
+        and (last_rsi_3_1h_lt_40)
         and (last_stochrsi_k_1h_gt_50)
-        and (last_stochrsi_k_4h > 40.0)
+        and (last_stochrsi_k_4h_gt_40)
       ):
         return True, f"exit_{mode_name}_d_6_83"
-      elif (last_rsi_3 > 84.0) and (last_willr_14 > -8.0) and (last_rsi_3_4h_lt_30) and (last_stochrsi_k_1h > 20.0):
+      elif (last_rsi_3_gt_84) and (last_willr_14 > -8.0) and (last_rsi_3_4h_lt_30) and (last_stochrsi_k_1h > 20.0):
         return True, f"exit_{mode_name}_d_6_84"
       elif (
-        (last_rsi_3 > 82.0)
+        (last_rsi_3_gt_82)
         and (last_willr_14 > -14.0)
         and (last_rsi_3_1h_lt_30)
-        and (last_rsi_3_4h < 40.0)
+        and (last_rsi_3_4h_lt_40)
         and (last_stochrsi_k_4h_gt_50)
       ):
         return True, f"exit_{mode_name}_d_6_85"
       elif (
-        (last_rsi_3 > 88.0)
+        (last_rsi_3_gt_88)
         and (last_rsi_14_4h > 80.0)
         and (last_roc_2_1h < -5.0)
         and (last_roc_9_1h > 5.0)
@@ -33967,105 +34022,105 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_6_86"
       elif (
-        (last_rsi_3 > 60.0)
+        (last_rsi_3_gt_60)
         and (last_rsi_14_lt_50)
-        and (last_rsi_3_1h < 45.0)
+        and (last_rsi_3_1h_lt_45)
         and (last_rsi_3_4h < 50.0)
         and (last_stochrsi_k_4h_gt_50)
       ):
         return True, f"exit_{mode_name}_d_6_87"
       elif (
-        (last_rsi_3 > 82.0)
+        (last_rsi_3_gt_82)
         and (last_willr_14 > -26.0)
-        and (last_stochrsi_k_1h > 40.0)
+        and (last_stochrsi_k_1h_gt_40)
         and (last_stochrsi_k_4h_gt_50)
         and (last_change_pct_1h < -2.0)
       ):
         return True, f"exit_{mode_name}_d_6_88"
       elif (
-        (last_rsi_3 > 72.0)
-        and (last_rsi_14 < 46.0)
+        (last_rsi_3_gt_72)
+        and (last_rsi_14_lt_46)
         and (last_roc_9_1h < -5.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 25.0))
       ):
         return True, f"exit_{mode_name}_d_6_89"
       elif (
-        (last_rsi_3 > 86.0)
+        (last_rsi_3_gt_86)
         and (last_willr_14 > -25.0)
-        and (last_rsi_3_1h < 50.0)
+        and (last_rsi_3_1h_lt_50)
         and (last_rsi_3_4h_lt_30)
-        and (last_aroonu_14_4h > 50.0)
+        and (last_aroonu_14_4h_gt_50)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 40.0))
       ):
         return True, f"exit_{mode_name}_d_6_90"
       elif (
-        (last_rsi_3 > 66.0)
-        and (last_rsi_14 < 52.0)
-        and (last_rsi_3_1h < 25.0)
-        and (last_rsi_3_4h < 25.0)
-        and (last_aroonu_14_4h > 50.0)
+        (last_rsi_3_gt_66)
+        and (last_rsi_14_lt_52)
+        and (last_rsi_3_1h_lt_25)
+        and (last_rsi_3_4h_lt_25)
+        and (last_aroonu_14_4h_gt_50)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d > 50.0))
       ):
         return True, f"exit_{mode_name}_d_6_91"
       elif (
-        (last_rsi_3 > 74.0)
-        and (last_rsi_14 < 54.0)
-        and (last_rsi_3_1h < 40.0)
+        (last_rsi_3_gt_74)
+        and (last_rsi_14_lt_54)
+        and (last_rsi_3_1h_lt_40)
         and (last_stochrsi_k_1h > 25.0)
         and (last_stochrsi_k_4h_gt_50)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -25.0))
       ):
         return True, f"exit_{mode_name}_d_6_92"
       elif (
-        (last_rsi_3 > 66.0)
-        and (last_rsi_14 < 56.0)
+        (last_rsi_3_gt_66)
+        and (last_rsi_14_lt_56)
         and (last_rsi_3_15m < 50.0)
-        and (last_aroonu_14_1h > 75.0)
-        and (last_stochrsi_k_1h > 70.0)
-        and (last_aroonu_14_4h > 50.0)
+        and (last_aroonu_14_1h_gt_75)
+        and (last_stochrsi_k_1h_gt_70)
+        and (last_aroonu_14_4h_gt_50)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d > 90.0))
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
       ):
         return True, f"exit_{mode_name}_d_6_93"
       elif (
-        (last_rsi_3 > 74.0)
-        and (last_rsi_14 < 56.0)
-        and (last_rsi_3_1h < 25.0)
+        (last_rsi_3_gt_74)
+        and (last_rsi_14_lt_56)
+        and (last_rsi_3_1h_lt_25)
         and (last_rsi_3_4h < 45.0)
-        and (last_aroonu_14_1h > 75.0)
+        and (last_aroonu_14_1h_gt_75)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d > 90.0))
       ):
         return True, f"exit_{mode_name}_d_6_94"
       elif (
-        (last_rsi_3 > 78.0)
+        (last_rsi_3_gt_78)
         and (last_willr_14 > -18.0)
-        and (last_rsi_3_1h < 45.0)
-        and (last_rsi_3_4h < 40.0)
+        and (last_rsi_3_1h_lt_45)
+        and (last_rsi_3_4h_lt_40)
         and (last_stochrsi_k_4h > 10.0)
         and (isinstance(last_aroonu_14_1d, np.float64) and (last_aroonu_14_1d > 75.0))
       ):
         return True, f"exit_{mode_name}_d_6_95"
       elif (
         (last_rsi_3 > 56.0)
-        and (last_rsi_14 < 52.0)
-        and (last_rsi_3_1h < 45.0)
+        and (last_rsi_14_lt_52)
+        and (last_rsi_3_1h_lt_45)
         and (last_rsi_3_1d < 45.0)
         and (last_stochrsi_k_1h_gt_50)
       ):
         return True, f"exit_{mode_name}_d_6_96"
       elif (
-        (last_rsi_3 > 78.0)
-        and (last_rsi_14 < 52.0)
-        and (last_rsi_3_1h < 35.0)
-        and (last_aroonu_14_4h > 50.0)
-        and (last_stochrsi_k_4h > 30.0)
+        (last_rsi_3_gt_78)
+        and (last_rsi_14_lt_52)
+        and (last_rsi_3_1h_lt_35)
+        and (last_aroonu_14_4h_gt_50)
+        and (last_stochrsi_k_4h_gt_30)
       ):
         return True, f"exit_{mode_name}_d_6_97"
       elif (
-        (last_rsi_3 > 84.0)
+        (last_rsi_3_gt_84)
         and (last_rsi_3_15m > 66.0)
-        and (last_rsi_3_1h < 60.0)
-        and (last_rsi_3_4h < 60.0)
+        and (last_rsi_3_1h_lt_60)
+        and (last_rsi_3_4h_lt_60)
         and (last_rsi_3_1d > 80.0)
         and (last_stochrsi_k_4h_gt_50)
       ):
@@ -34074,202 +34129,200 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 54.0)
         and (last_rsi_14 < 58.0)
         and (last_rsi_3_1h < 65.0)
-        and (last_rsi_3_4h < 60.0)
-        and (last_aroonu_14_4h > 50.0)
+        and (last_rsi_3_4h_lt_60)
+        and (last_aroonu_14_4h_gt_50)
         and (last_stoch_k_4h > 40.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 80.0))
       ):
         return True, f"exit_{mode_name}_d_6_99"
-      elif (last_rsi_3 > 92.0) and (last_rsi_14 > 70.0) and (last_rsi_3_15m > 70.0) and (last_rsi_3_4h < 80.0):
+      elif (last_rsi_3_gt_92) and (last_rsi_14 > 70.0) and (last_rsi_3_15m > 70.0) and (last_rsi_3_4h < 80.0):
         return True, f"exit_{mode_name}_d_6_100"
       elif (
-        (last_rsi_3 > 78.0)
+        (last_rsi_3_gt_78)
         and (last_willr_14 > -22.0)
-        and (last_rsi_3_1h < 50.0)
-        and (last_stochrsi_k_4h > 40.0)
+        and (last_rsi_3_1h_lt_50)
+        and (last_stochrsi_k_4h_gt_40)
         and (isinstance(last_roc_9_4h, np.float64) and (last_roc_9_4h > 40.0))
       ):
         return True, f"exit_{mode_name}_d_6_101"
       elif (
-        (last_rsi_3 > 62.0)
-        and (last_rsi_14 < 54.0)
-        and (last_rsi_3_1h < 60.0)
-        and (last_rsi_3_4h < 40.0)
-        and (last_stochrsi_k_4h > 30.0)
+        (last_rsi_3_gt_62)
+        and (last_rsi_14_lt_54)
+        and (last_rsi_3_1h_lt_60)
+        and (last_rsi_3_4h_lt_40)
+        and (last_stochrsi_k_4h_gt_30)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 40.0))
       ):
         return True, f"exit_{mode_name}_d_6_102"
       elif (
-        (last_rsi_3 > 72.0)
+        (last_rsi_3_gt_72)
         and (last_rsi_14 < 62.0)
-        and (last_rsi_3_1h < 60.0)
-        and (last_rsi_14_4h > 70.0)
+        and (last_rsi_3_1h_lt_60)
+        and (last_rsi_14_4h_gt_70)
         and (isinstance(last_roc_9_4h, np.float64) and (last_roc_9_4h > 80.0))
       ):
         return True, f"exit_{mode_name}_d_6_103"
       elif (
         (last_rsi_3 > 58.0)
-        and (last_rsi_14 < 54.0)
-        and (last_rsi_3_1h < 60.0)
-        and (last_stochrsi_k_1h > 40.0)
-        and (last_stochrsi_k_4h > 90.0)
+        and (last_rsi_14_lt_54)
+        and (last_rsi_3_1h_lt_60)
+        and (last_stochrsi_k_1h_gt_40)
+        and (last_stochrsi_k_4h_gt_90)
         and (last_roc_9_4h > 40.0)
       ):
         return True, f"exit_{mode_name}_d_6_104"
       elif (
-        (last_rsi_3 > 72.0)
-        and (last_rsi_14 < 54.0)
+        (last_rsi_3_gt_72)
+        and (last_rsi_14_lt_54)
         and (last_rsi_3_15m < 55.0)
-        and (last_stochrsi_k_4h > 90.0)
+        and (last_stochrsi_k_4h_gt_90)
         and (last_roc_9_4h > 25.0)
       ):
         return True, f"exit_{mode_name}_d_6_105"
       elif (
-        (last_rsi_3 > 66.0)
-        and (last_rsi_14 < 54.0)
-        and (last_rsi_3_1h < 50.0)
+        (last_rsi_3_gt_66)
+        and (last_rsi_14_lt_54)
+        and (last_rsi_3_1h_lt_50)
         and (last_stochrsi_k_1h_gt_50)
-        and (last_rsi_14_4h > 70.0)
+        and (last_rsi_14_4h_gt_70)
         and (last_roc_9_4h > 40.0)
       ):
         return True, f"exit_{mode_name}_d_6_106"
       elif (
         (last_rsi_3 > 68.0)
-        and (last_rsi_14 < 54.0)
-        and (last_rsi_3_1h < 50.0)
-        and (last_stochrsi_k_1h > 70.0)
+        and (last_rsi_14_lt_54)
+        and (last_rsi_3_1h_lt_50)
+        and (last_stochrsi_k_1h_gt_70)
         and (last_rsi_14_4h > 50.0)
       ):
         return True, f"exit_{mode_name}_d_6_107"
-      elif (last_rsi_3 > 50.0) and (last_rsi_14 < 54.0) and (last_rsi_3_1h < 60.0) and (last_stochrsi_k_1h > 80.0):
+      elif (last_rsi_3_gt_50) and (last_rsi_14_lt_54) and (last_rsi_3_1h_lt_60) and (last_stochrsi_k_1h_gt_80):
         return True, f"exit_{mode_name}_d_6_108"
       elif (
-        (last_rsi_3 > 70.0)
+        (last_rsi_3_gt_70)
         and (last_willr_14 > -14.0)
-        and (last_rsi_3_1h < 50.0)
-        and (last_rsi_3_4h < 20.0)
+        and (last_rsi_3_1h_lt_50)
+        and (last_rsi_3_4h_lt_20)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 50.0))
       ):
         return True, f"exit_{mode_name}_d_6_109"
-      elif (last_rsi_3 > 66.0) and (last_rsi_3_4h < 65.0) and (last_stochrsi_k_4h_gt_50) and (last_roc_9_4h > 25.0):
+      elif (last_rsi_3_gt_66) and (last_rsi_3_4h < 65.0) and (last_stochrsi_k_4h_gt_50) and (last_roc_9_4h > 25.0):
         return True, f"exit_{mode_name}_d_6_110"
       elif (
         (last_rsi_3 > 44.0)
         and (last_rsi_14_lt_50)
-        and (last_rsi_3_1h < 50.0)
-        and (last_rsi_14_4h > 70.0)
-        and (last_aroonu_14_1h > 75.0)
-        and (last_aroonu_14_4h > 75.0)
+        and (last_rsi_3_1h_lt_50)
+        and (last_rsi_14_4h_gt_70)
+        and (last_aroonu_14_1h_gt_75)
+        and (last_aroonu_14_4h_gt_75)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 20.0))
       ):
         return True, f"exit_{mode_name}_d_6_111"
       elif (
-        (last_rsi_3 > 74.0)
+        (last_rsi_3_gt_74)
         and (last_willr_14 > -40.0)
         and (last_rsi_14 < 58.0)
-        and (last_rsi_3_1h < 35.0)
+        and (last_rsi_3_1h_lt_35)
         and (last_rsi_3_4h < 35.0)
         and (last_rsi_3_1d < 60.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
       ):
         return True, f"exit_{mode_name}_d_6_112"
       elif (
-        (last_rsi_3 > 78.0)
+        (last_rsi_3_gt_78)
         and (last_willr_14 > -8.0)
-        and (last_rsi_3_1d < 30.0)
+        and (last_rsi_3_1d_lt_30)
         and (last_stochrsi_k_4h_gt_50)
         and (isinstance(last_roc_9_4h, np.float64) and (last_roc_9_4h > 10.0))
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -10.0))
       ):
         return True, f"exit_{mode_name}_d_6_113"
       elif (
-        (last_rsi_3 > 78.0)
-        and (last_rsi_14 < 56.0)
-        and (last_rsi_3_1h < 20.0)
+        (last_rsi_3_gt_78)
+        and (last_rsi_14_lt_56)
+        and (last_rsi_3_1h_lt_20)
         and (last_rsi_3_4h_lt_30)
-        and (last_rsi_3_1d < 30.0)
+        and (last_rsi_3_1d_lt_30)
       ):
         return True, f"exit_{mode_name}_d_6_114"
       elif (
-        (last_rsi_3 > 72.0)
-        and (last_rsi_14 < 54.0)
+        (last_rsi_3_gt_72)
+        and (last_rsi_14_lt_54)
         and (last_rsi_3_15m < 30.0)
         and (last_stochrsi_k_1h_gt_50)
         and (last_stochrsi_k_4h_gt_50)
       ):
         return True, f"exit_{mode_name}_d_6_115"
-      elif (last_rsi_3 > 84.0) and (last_rsi_3_1h < 15.0) and (last_rsi_3_4h < 40.0) and (last_aroonu_14_4h > 50.0):
+      elif (last_rsi_3_gt_84) and (last_rsi_3_1h_lt_15) and (last_rsi_3_4h_lt_40) and (last_aroonu_14_4h_gt_50):
         return True, f"exit_{mode_name}_d_6_116"
-      elif (
-        (last_rsi_3 > 80.0) and (last_rsi_3_1h < 50.0) and (last_aroonu_14_1h > 80.0) and (last_aroonu_14_4h > 80.0)
-      ):
+      elif (last_rsi_3_gt_80) and (last_rsi_3_1h_lt_50) and (last_aroonu_14_1h > 80.0) and (last_aroonu_14_4h > 80.0):
         return True, f"exit_{mode_name}_d_6_117"
-      elif (last_rsi_3 > 84.0) and (last_rsi_3_1h < 20.0) and (last_rsi_3_4h < 60.0) and (last_aroonu_14_4h > 40.0):
+      elif (last_rsi_3_gt_84) and (last_rsi_3_1h_lt_20) and (last_rsi_3_4h_lt_60) and (last_aroonu_14_4h > 40.0):
         return True, f"exit_{mode_name}_d_6_118"
       elif (
-        (last_rsi_3 > 80.0)
+        (last_rsi_3_gt_80)
         and (last_willr_14 > -20.0)
-        and (last_rsi_3_1h < 60.0)
-        and (last_rsi_3_4h < 60.0)
-        and (last_stochrsi_k_1h > 40.0)
+        and (last_rsi_3_1h_lt_60)
+        and (last_rsi_3_4h_lt_60)
+        and (last_stochrsi_k_1h_gt_40)
       ):
         return True, f"exit_{mode_name}_d_6_119"
-      elif (last_rsi_3 > 48.0) and (last_rsi_14 < 54.0) and (last_rsi_3_1h < 40.0) and (last_aroonu_14_4h > 75.0):
+      elif (last_rsi_3 > 48.0) and (last_rsi_14_lt_54) and (last_rsi_3_1h_lt_40) and (last_aroonu_14_4h_gt_75):
         return True, f"exit_{mode_name}_d_6_120"
-      elif (last_rsi_3 > 54.0) and (last_rsi_14 < 52.0) and (last_rsi_3_1h < 50.0) and (last_rsi_14_4h > 85.0):
+      elif (last_rsi_3 > 54.0) and (last_rsi_14_lt_52) and (last_rsi_3_1h_lt_50) and (last_rsi_14_4h > 85.0):
         return True, f"exit_{mode_name}_d_6_121"
       elif (last_rsi_3 > 52.0) and (last_rsi_14_lt_50) and (last_rsi_3_4h_lt_30) and (last_stochrsi_k_1h_gt_50):
         return True, f"exit_{mode_name}_d_6_122"
-      elif (last_rsi_3 > 82.0) and (last_willr_14 > -10.0) and (last_rsi_3_1h < 10.0) and (last_rsi_3_1d < 30.0):
+      elif (last_rsi_3_gt_82) and (last_willr_14 > -10.0) and (last_rsi_3_1h_lt_10) and (last_rsi_3_1d_lt_30):
         return True, f"exit_{mode_name}_d_6_123"
       elif (
-        (last_rsi_3 > 82.0)
-        and (last_rsi_3_1h < 15.0)
+        (last_rsi_3_gt_82)
+        and (last_rsi_3_1h_lt_15)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d > 80.0))
       ):
         return True, f"exit_{mode_name}_d_6_124"
       elif (
-        (last_rsi_3 > 70.0)
+        (last_rsi_3_gt_70)
         and (last_willr_14 > -10.0)
-        and (last_rsi_3_1h < 10.0)
-        and (last_rsi_3_4h < 40.0)
+        and (last_rsi_3_1h_lt_10)
+        and (last_rsi_3_4h_lt_40)
         and (last_rsi_3_1d < 40.0)
         and (last_close < (last_high_max_30_1d * 0.50))
       ):
         return True, f"exit_{mode_name}_d_6_125"
-      elif (last_rsi_3 > 84.0) and (last_rsi_3_1h < 15.0) and (last_rsi_3_4h < 40.0) and (last_stochrsi_k_4h_gt_50):
+      elif (last_rsi_3_gt_84) and (last_rsi_3_1h_lt_15) and (last_rsi_3_4h_lt_40) and (last_stochrsi_k_4h_gt_50):
         return True, f"exit_{mode_name}_d_6_126"
-      elif (last_rsi_3 > 84.0) and (last_rsi_3_1h < 10.0) and (last_rsi_3_4h_lt_30) and (last_rsi_3_1d < 40.0):
+      elif (last_rsi_3_gt_84) and (last_rsi_3_1h_lt_10) and (last_rsi_3_4h_lt_30) and (last_rsi_3_1d < 40.0):
         return True, f"exit_{mode_name}_d_6_127"
-      elif (last_rsi_3 > 88.0) and (last_rsi_3_4h_lt_30) and (last_aroonu_14_4h > 85.0):
+      elif (last_rsi_3_gt_88) and (last_rsi_3_4h_lt_30) and (last_aroonu_14_4h > 85.0):
         return True, f"exit_{mode_name}_d_6_128"
       elif (
-        (last_rsi_3 > 80.0)
-        and (last_rsi_3_4h < 25.0)
+        (last_rsi_3_gt_80)
+        and (last_rsi_3_4h_lt_25)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 80.0))
       ):
         return True, f"exit_{mode_name}_d_6_129"
       elif (
         (last_rsi_3 > 68.0)
         and (last_rsi_14_1h > 65.0)
-        and (last_stochrsi_k_1h > 80.0)
+        and (last_stochrsi_k_1h_gt_80)
         and (last_cci_20_change_pct_1h < -0.0)
       ):
         return True, f"exit_{mode_name}_d_6_130"
-      elif (last_rsi_14 < 44.0) and (last_rsi_3_1h < 20.0) and (last_rsi_3_4h_lt_30) and (last_stochrsi_k_4h_gt_50):
+      elif (last_rsi_14 < 44.0) and (last_rsi_3_1h_lt_20) and (last_rsi_3_4h_lt_30) and (last_stochrsi_k_4h_gt_50):
         return True, f"exit_{mode_name}_d_6_131"
       elif (
-        (last_rsi_3 > 74.0)
-        and (last_rsi_3_1h < 35.0)
+        (last_rsi_3_gt_74)
+        and (last_rsi_3_1h_lt_35)
         and (last_rsi_3_4h < 35.0)
         and (last_aroonu_14_1h > 50.0)
-        and (last_stochrsi_k_1h > 40.0)
+        and (last_stochrsi_k_1h_gt_40)
       ):
         return True, f"exit_{mode_name}_d_6_132"
       elif (
-        (last_rsi_3 > 74.0)
+        (last_rsi_3_gt_74)
         and (last_aroonu_14_15m > 75.0)
-        and (last_aroonu_14_1h > 75.0)
+        and (last_aroonu_14_1h_gt_75)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 25.0))
       ):
         return True, f"exit_{mode_name}_d_6_133"


### PR DESCRIPTION
## Summary
- Hoists repeated long `long_exit_dec` threshold checks for the 6-7% profit bracket into local boolean aliases.
- Keeps the branch independent on latest upstream `main`.

## Safety
- Only already-read scalar threshold comparisons inside the same current-profit branch are reused.
- Indicator formulas, candle selection, profit arithmetic, thresholds, condition order, return values, order classification, and stake logic are unchanged.
- Touched function: `long_exit_dec`. No v3 grind-entry code is touched.

## Backtest scope
- Full backtesting was not required because this patch only reuses already-read scalar threshold checks inside the same `long_exit_dec` current-profit branch. Trading conditions and output values are unchanged.

## Checks
- `python3 ~/.codex/skills/nfi-upstream-pr/scripts/validate_nfi_pr.py --base origin/main`
- `AST undefined-local scan from validator reported zero findings for introduced `last_*` aliases`
- `git merge-tree conflict simulation against origin/main`
- `targeted git diff origin/main...HEAD -- NostalgiaForInfinityX7.py review`
- `git diff --check`
- `ruff format --check NostalgiaForInfinityX7.py`
- `ruff check NostalgiaForInfinityX7.py`
- `PYTHONDONTWRITEBYTECODE=1 python3 -m py_compile NostalgiaForInfinityX7.py`
