### PR TITLE
Reduce X7 long Williams exit gates

### DIFF
--- a/NostalgiaForInfinityX7.py
+++ b/NostalgiaForInfinityX7.py
@@ -27248,14 +27248,52 @@ class NostalgiaForInfinityX7(IStrategy):
     last_rsi_14_4h_gt_60 = last_rsi_14_4h > 60.0
     last_roc_9_1h_lt_neg_5 = last_roc_9_1h < -5.0
 
+    # Reused long Williams-R exit thresholds
+    last_top_wick_pct_1d_gt_20 = last_top_wick_pct_1d > 20.0
+    last_roc_9_4h_gt_20 = last_roc_9_4h > 20.0
+    last_roc_9_4h_gt_10 = last_roc_9_4h > 10.0
+    last_roc_9_1h_lt_0 = last_roc_9_1h < -0.0
+    last_cmf_20_4h_lt_0 = last_cmf_20_4h < -0.0
+    last_cmf_20_1h_lt_0 = last_cmf_20_1h < -0.0
+    last_cci_20_change_pct_4h_lt_0 = last_cci_20_change_pct_4h < -0.0
+    last_rsi_3_gt_80 = last_rsi_3 > 80.0
+    last_willr_14_gt_neg_12 = last_willr_14 > -12.0
+    last_rsi_14_gt_70 = last_rsi_14 > 70.0
+    last_willr_14_gte_neg_15 = last_willr_14 >= -15.0
+    last_rsi_14_gt_75 = last_rsi_14 > 75.0
+    last_rsi_14_lt_52 = last_rsi_14 < 52.0
+    last_rsi_14_lt_50 = last_rsi_14 < 50.0
+    last_rsi_14_lt_48 = last_rsi_14 < 48.0
+    last_willr_14_gte_neg_5 = last_willr_14 >= -5.0
+    last_willr_14_gt_neg_14 = last_willr_14 > -14.0
+    last_rsi_14_gt_80 = last_rsi_14 > 80.0
+    last_rsi_14_gt_78 = last_rsi_14 > 78.0
+    last_rsi_14_lt_54 = last_rsi_14 < 54.0
+    last_rsi_14_lt_46 = last_rsi_14 < 46.0
+    last_willr_14_gt_neg_24 = last_willr_14 > -24.0
+    last_willr_14_gt_neg_22 = last_willr_14 > -22.0
+    last_willr_14_gt_neg_18 = last_willr_14 > -18.0
+    last_willr_14_gt_neg_16 = last_willr_14 > -16.0
+    last_rsi_3_gt_95 = last_rsi_3 > 95.0
+    last_rsi_3_gt_78 = last_rsi_3 > 78.0
+    last_rsi_3_gt_50 = last_rsi_3 > 50.0
+    last_rsi_3_gt_48 = last_rsi_3 > 48.0
+    last_rsi_3_gt_46 = last_rsi_3 > 46.0
+    last_rsi_3_gt_44 = last_rsi_3 > 44.0
+    last_rsi_14_gt_77 = last_rsi_14 > 77.0
+    last_rsi_14_gt_76 = last_rsi_14 > 76.0
+    last_rsi_14_lt_56 = last_rsi_14 < 56.0
+    last_rsi_14_lt_44 = last_rsi_14 < 44.0
+    last_rsi_14_lt_40 = last_rsi_14 < 40.0
+
     if 0.01 > current_profit >= 0.001:
-      if (last_willr_480 > -0.1) and (last_willr_14_gte_neg_1) and (last_rsi_14 > 75.0):
+      if (last_willr_480 > -0.1) and (last_willr_14_gte_neg_1) and (last_rsi_14_gt_75):
         return True, f"exit_{mode_name}_w_0_1"
       elif (last_willr_14_gte_neg_1) and (last_rsi_14 > 84.0):
         return True, f"exit_{mode_name}_w_0_2"
-      elif (last_willr_14_gte_neg_1) and (last_rsi_14 < 40.0):
+      elif (last_willr_14_gte_neg_1) and (last_rsi_14_lt_40):
         return True, f"exit_{mode_name}_w_0_3"
-      elif (last_willr_14_gte_neg_1) and (last_rsi_14 > 80.0) and (last_roc_9_1h < -0.0) and (last_roc_9_4h > 20.0):
+      elif (last_willr_14_gte_neg_1) and (last_rsi_14_gt_80) and (last_roc_9_1h_lt_0) and (last_roc_9_4h_gt_20):
         return True, f"exit_{mode_name}_w_0_4"
       elif (
         (last_rsi_3_gt_99)
@@ -27275,8 +27313,8 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3_gt_90)
         and (last_willr_14_gt_neg_2)
         and (last_rsi_14_4h_gt_60)
-        and (last_cmf_20_1h < -0.0)
-        and (last_cmf_20_4h < -0.0)
+        and (last_cmf_20_1h_lt_0)
+        and (last_cmf_20_4h_lt_0)
       ):
         return True, f"exit_{mode_name}_w_0_7"
       elif (last_rsi_3_gt_90) and (last_willr_14_gt_neg_2) and (last_rsi_3_1h_lt_25) and (last_stochrsi_k_1h_gt_20):
@@ -27285,15 +27323,15 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3_gt_88)
         and (last_willr_14_gt_neg_1)
         and (last_roc_9_1h_lt_neg_5)
-        and (last_roc_9_4h > 10.0)
+        and (last_roc_9_4h_gt_10)
         and (last_stochrsi_k_4h_gt_40)
       ):
         return True, f"exit_{mode_name}_w_0_9"
       elif (
         (last_rsi_3_gt_96)
-        and (last_willr_14 > -16.0)
+        and (last_willr_14_gt_neg_16)
         and (last_aroonu_14_4h_gt_50)
-        and (last_cci_20_change_pct_4h < -0.0)
+        and (last_cci_20_change_pct_4h_lt_0)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d > 90.0))
       ):
         return True, f"exit_{mode_name}_w_0_10"
@@ -27311,16 +27349,16 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_w_0_13"
       elif (
-        (last_rsi_3 > 95.0)
+        (last_rsi_3_gt_95)
         and (last_willr_14_gt_neg_2)
         and (last_rsi_3_1h_lt_60)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 80.0))
       ):
         return True, f"exit_{mode_name}_w_0_14"
       elif (
-        (last_rsi_3 > 95.0)
+        (last_rsi_3_gt_95)
         and (last_willr_480_gt_neg_25)
-        and (last_rsi_14 < 48.0)
+        and (last_rsi_14_lt_48)
         and (last_rsi_14_4h_gt_70)
         and (last_stochrsi_k_4h_gt_80)
         and (isinstance(last_roc_9_4h, np.float64) and (last_roc_9_4h > 100.0))
@@ -27341,20 +27379,17 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_w_0_17"
       elif (
-        (last_rsi_3_gt_90)
-        and (last_willr_14_gt_neg_20)
-        and (last_aroonu_14_4h_gt_50)
-        and (last_top_wick_pct_1d > 20.0)
+        (last_rsi_3_gt_90) and (last_willr_14_gt_neg_20) and (last_aroonu_14_4h_gt_50) and (last_top_wick_pct_1d_gt_20)
       ):
         return True, f"exit_{mode_name}_w_0_18"
     elif 0.02 > current_profit >= 0.01:
       if last_willr_480 > -0.2:
         return True, f"exit_{mode_name}_w_1_1"
-      elif (last_willr_14_gte_neg_1) and (last_rsi_14 > 78.0):
+      elif (last_willr_14_gte_neg_1) and (last_rsi_14_gt_78):
         return True, f"exit_{mode_name}_w_1_2"
-      elif (last_willr_14_gte_neg_2) and (last_rsi_14 < 46.0):
+      elif (last_willr_14_gte_neg_2) and (last_rsi_14_lt_46):
         return True, f"exit_{mode_name}_w_1_3"
-      elif (last_willr_14_gte_neg_2) and (last_rsi_14 > 78.0) and (last_roc_9_1h < -0.0) and (last_roc_9_4h > 20.0):
+      elif (last_willr_14_gte_neg_2) and (last_rsi_14_gt_78) and (last_roc_9_1h_lt_0) and (last_roc_9_4h_gt_20):
         return True, f"exit_{mode_name}_w_1_4"
       elif (
         (last_rsi_3_gt_98)
@@ -27374,8 +27409,8 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3_gt_88)
         and (last_willr_14_gt_neg_4)
         and (last_rsi_14_4h_gt_60)
-        and (last_cmf_20_1h < -0.0)
-        and (last_cmf_20_4h < -0.0)
+        and (last_cmf_20_1h_lt_0)
+        and (last_cmf_20_4h_lt_0)
       ):
         return True, f"exit_{mode_name}_w_1_7"
       elif (last_rsi_3_gt_88) and (last_willr_14_gt_neg_2) and (last_rsi_3_1h_lt_25) and (last_stochrsi_k_1h_gt_20):
@@ -27384,15 +27419,15 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3_gt_86)
         and (last_willr_14_gt_neg_2)
         and (last_roc_9_1h_lt_neg_5)
-        and (last_roc_9_4h > 10.0)
+        and (last_roc_9_4h_gt_10)
         and (last_stochrsi_k_4h_gt_40)
       ):
         return True, f"exit_{mode_name}_w_1_9"
       elif (
         (last_rsi_3_gt_94)
-        and (last_willr_14 > -18.0)
+        and (last_willr_14_gt_neg_18)
         and (last_aroonu_14_4h_gt_50)
-        and (last_cci_20_change_pct_4h < -0.0)
+        and (last_cci_20_change_pct_4h_lt_0)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d > 90.0))
       ):
         return True, f"exit_{mode_name}_w_1_10"
@@ -27417,9 +27452,9 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_w_1_14"
       elif (
-        (last_rsi_3 > 50.0)
+        (last_rsi_3_gt_50)
         and (last_willr_480_gt_neg_25)
-        and (last_rsi_14 < 50.0)
+        and (last_rsi_14_lt_50)
         and (last_rsi_14_4h_gt_70)
         and (last_stochrsi_k_4h_gt_80)
         and (isinstance(last_roc_9_4h, np.float64) and (last_roc_9_4h > 100.0))
@@ -27440,20 +27475,17 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_w_1_17"
       elif (
-        (last_rsi_3_gt_88)
-        and (last_willr_14_gt_neg_20)
-        and (last_aroonu_14_4h_gt_50)
-        and (last_top_wick_pct_1d > 20.0)
+        (last_rsi_3_gt_88) and (last_willr_14_gt_neg_20) and (last_aroonu_14_4h_gt_50) and (last_top_wick_pct_1d_gt_20)
       ):
         return True, f"exit_{mode_name}_d_1_18"
     elif 0.03 > current_profit >= 0.02:
       if last_willr_480 > -0.3:
         return True, f"exit_{mode_name}_w_2_1"
-      elif (last_willr_14_gte_neg_1) and (last_rsi_14 > 77.0):
+      elif (last_willr_14_gte_neg_1) and (last_rsi_14_gt_77):
         return True, f"exit_{mode_name}_w_2_2"
-      elif (last_willr_14_gte_neg_2) and (last_rsi_14 < 48.0):
+      elif (last_willr_14_gte_neg_2) and (last_rsi_14_lt_48):
         return True, f"exit_{mode_name}_w_2_3"
-      elif (last_willr_14 >= -5.0) and (last_rsi_14 > 75.0) and (last_roc_9_1h < -0.0) and (last_roc_9_4h > 20.0):
+      elif (last_willr_14_gte_neg_5) and (last_rsi_14_gt_75) and (last_roc_9_1h_lt_0) and (last_roc_9_4h_gt_20):
         return True, f"exit_{mode_name}_w_2_4"
       elif (
         (last_rsi_3_gt_98)
@@ -27473,8 +27505,8 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3_gt_86)
         and (last_willr_14_gt_neg_6)
         and (last_rsi_14_4h_gt_60)
-        and (last_cmf_20_1h < -0.0)
-        and (last_cmf_20_4h < -0.0)
+        and (last_cmf_20_1h_lt_0)
+        and (last_cmf_20_4h_lt_0)
       ):
         return True, f"exit_{mode_name}_w_2_7"
       elif (last_rsi_3_gt_86) and (last_willr_14_gt_neg_2) and (last_rsi_3_1h_lt_25) and (last_stochrsi_k_1h_gt_20):
@@ -27483,7 +27515,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3_gt_84)
         and (last_willr_14_gt_neg_4)
         and (last_roc_9_1h_lt_neg_5)
-        and (last_roc_9_4h > 10.0)
+        and (last_roc_9_4h_gt_10)
         and (last_stochrsi_k_4h_gt_40)
       ):
         return True, f"exit_{mode_name}_w_2_9"
@@ -27491,7 +27523,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3_gt_92)
         and (last_willr_14_gt_neg_20)
         and (last_aroonu_14_4h_gt_50)
-        and (last_cci_20_change_pct_4h < -0.0)
+        and (last_cci_20_change_pct_4h_lt_0)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d > 90.0))
       ):
         return True, f"exit_{mode_name}_w_2_10"
@@ -27516,9 +27548,9 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_w_2_14"
       elif (
-        (last_rsi_3 > 48.0)
+        (last_rsi_3_gt_48)
         and (last_willr_480_gt_neg_25)
-        and (last_rsi_14 < 52.0)
+        and (last_rsi_14_lt_52)
         and (last_rsi_14_4h_gt_70)
         and (last_stochrsi_k_4h_gt_80)
         and (isinstance(last_roc_9_4h, np.float64) and (last_roc_9_4h > 100.0))
@@ -27539,20 +27571,17 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_w_2_17"
       elif (
-        (last_rsi_3_gt_86)
-        and (last_willr_14_gt_neg_20)
-        and (last_aroonu_14_4h_gt_50)
-        and (last_top_wick_pct_1d > 20.0)
+        (last_rsi_3_gt_86) and (last_willr_14_gt_neg_20) and (last_aroonu_14_4h_gt_50) and (last_top_wick_pct_1d_gt_20)
       ):
         return True, f"exit_{mode_name}_w_2_18"
     elif 0.04 > current_profit >= 0.03:
       if last_willr_480 > -0.4:
         return True, f"exit_{mode_name}_w_3_1"
-      elif (last_willr_14_gte_neg_1) and (last_rsi_14 > 76.0):
+      elif (last_willr_14_gte_neg_1) and (last_rsi_14_gt_76):
         return True, f"exit_{mode_name}_w_3_2"
-      elif (last_willr_14_gte_neg_2) and (last_rsi_14 < 50.0):
+      elif (last_willr_14_gte_neg_2) and (last_rsi_14_lt_50):
         return True, f"exit_{mode_name}_w_3_3"
-      elif (last_willr_14 >= -5.0) and (last_rsi_14 > 75.0) and (last_roc_9_1h < -0.0) and (last_roc_9_4h > 20.0):
+      elif (last_willr_14_gte_neg_5) and (last_rsi_14_gt_75) and (last_roc_9_1h_lt_0) and (last_roc_9_4h_gt_20):
         return True, f"exit_{mode_name}_w_3_4"
       elif (
         (last_rsi_3_gt_96)
@@ -27572,8 +27601,8 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3_gt_84)
         and (last_willr_14_gt_neg_8)
         and (last_rsi_14_4h_gt_60)
-        and (last_cmf_20_1h < -0.0)
-        and (last_cmf_20_4h < -0.0)
+        and (last_cmf_20_1h_lt_0)
+        and (last_cmf_20_4h_lt_0)
       ):
         return True, f"exit_{mode_name}_w_3_7"
       elif (last_rsi_3_gt_84) and (last_willr_14_gt_neg_2) and (last_rsi_3_1h_lt_25) and (last_stochrsi_k_1h_gt_20):
@@ -27582,15 +27611,15 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3_gt_82)
         and (last_willr_14_gt_neg_6)
         and (last_roc_9_1h_lt_neg_5)
-        and (last_roc_9_4h > 10.0)
+        and (last_roc_9_4h_gt_10)
         and (last_stochrsi_k_4h_gt_40)
       ):
         return True, f"exit_{mode_name}_w_3_9"
       elif (
         (last_rsi_3_gt_90)
-        and (last_willr_14 > -22.0)
+        and (last_willr_14_gt_neg_22)
         and (last_aroonu_14_4h_gt_50)
-        and (last_cci_20_change_pct_4h < -0.0)
+        and (last_cci_20_change_pct_4h_lt_0)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d > 90.0))
       ):
         return True, f"exit_{mode_name}_w_3_10"
@@ -27615,9 +27644,9 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_w_3_14"
       elif (
-        (last_rsi_3 > 46.0)
+        (last_rsi_3_gt_46)
         and (last_willr_480_gt_neg_25)
-        and (last_rsi_14 < 54.0)
+        and (last_rsi_14_lt_54)
         and (last_rsi_14_4h_gt_70)
         and (last_stochrsi_k_4h_gt_80)
         and (isinstance(last_roc_9_4h, np.float64) and (last_roc_9_4h > 100.0))
@@ -27638,24 +27667,21 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_w_3_17"
       elif (
-        (last_rsi_3_gt_84)
-        and (last_willr_14_gt_neg_20)
-        and (last_aroonu_14_4h_gt_50)
-        and (last_top_wick_pct_1d > 20.0)
+        (last_rsi_3_gt_84) and (last_willr_14_gt_neg_20) and (last_aroonu_14_4h_gt_50) and (last_top_wick_pct_1d_gt_20)
       ):
         return True, f"exit_{mode_name}_w_3_18"
     elif 0.05 > current_profit >= 0.04:
       if last_willr_480 > -0.5:
         return True, f"exit_{mode_name}_w_4_1"
-      elif (last_willr_14_gte_neg_1) and (last_rsi_14 > 75.0):
+      elif (last_willr_14_gte_neg_1) and (last_rsi_14_gt_75):
         return True, f"exit_{mode_name}_w_4_2"
-      elif (last_willr_14_gte_neg_2) and (last_rsi_14 < 52.0):
+      elif (last_willr_14_gte_neg_2) and (last_rsi_14_lt_52):
         return True, f"exit_{mode_name}_w_4_3"
-      elif (last_willr_14 >= -5.0) and (last_rsi_14 > 75.0) and (last_roc_9_1h < -0.0) and (last_roc_9_4h > 20.0):
+      elif (last_willr_14_gte_neg_5) and (last_rsi_14_gt_75) and (last_roc_9_1h_lt_0) and (last_roc_9_4h_gt_20):
         return True, f"exit_{mode_name}_w_4_4"
       elif (
         (last_rsi_3_gt_94)
-        and (last_willr_14 > -12.0)
+        and (last_willr_14_gt_neg_12)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 50.0))
         and (last_stochrsi_k_4h_gt_70)
       ):
@@ -27671,25 +27697,25 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3_gt_82)
         and (last_willr_14_gt_neg_10)
         and (last_rsi_14_4h_gt_60)
-        and (last_cmf_20_1h < -0.0)
-        and (last_cmf_20_4h < -0.0)
+        and (last_cmf_20_1h_lt_0)
+        and (last_cmf_20_4h_lt_0)
       ):
         return True, f"exit_{mode_name}_w_4_7"
       elif (last_rsi_3_gt_82) and (last_willr_14_gt_neg_2) and (last_rsi_3_1h_lt_25) and (last_stochrsi_k_1h_gt_20):
         return True, f"exit_{mode_name}_w_4_8"
       elif (
-        (last_rsi_3 > 80.0)
+        (last_rsi_3_gt_80)
         and (last_willr_14_gt_neg_8)
         and (last_roc_9_1h_lt_neg_5)
-        and (last_roc_9_4h > 10.0)
+        and (last_roc_9_4h_gt_10)
         and (last_stochrsi_k_4h_gt_40)
       ):
         return True, f"exit_{mode_name}_w_4_9"
       elif (
         (last_rsi_3_gt_88)
-        and (last_willr_14 > -24.0)
+        and (last_willr_14_gt_neg_24)
         and (last_aroonu_14_4h_gt_50)
-        and (last_cci_20_change_pct_4h < -0.0)
+        and (last_cci_20_change_pct_4h_lt_0)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d > 90.0))
       ):
         return True, f"exit_{mode_name}_w_4_10"
@@ -27714,9 +27740,9 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_w_4_14"
       elif (
-        (last_rsi_3 > 44.0)
+        (last_rsi_3_gt_44)
         and (last_willr_480_gt_neg_25)
-        and (last_rsi_14 < 56.0)
+        and (last_rsi_14_lt_56)
         and (last_rsi_14_4h_gt_70)
         and (last_stochrsi_k_4h_gt_80)
         and (isinstance(last_roc_9_4h, np.float64) and (last_roc_9_4h > 100.0))
@@ -27724,7 +27750,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_w_4_15"
       elif (
-        (last_rsi_3 > 80.0)
+        (last_rsi_3_gt_80)
         and (last_willr_14_gt_neg_8)
         and (last_rsi_3_1h_lt_40)
         and (last_aroonu_14_4h_gt_75)
@@ -27732,13 +27758,12 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_stochrsi_k_4h_gt_30)
       ):
         return True, f"exit_{mode_name}_w_4_16"
-      elif (last_rsi_3_gt_90) and (last_willr_14 > -12.0) and (last_aroonu_14_4h_gt_75) and (last_stochrsi_k_4h_gt_70):
+      elif (
+        (last_rsi_3_gt_90) and (last_willr_14_gt_neg_12) and (last_aroonu_14_4h_gt_75) and (last_stochrsi_k_4h_gt_70)
+      ):
         return True, f"exit_{mode_name}_w_4_17"
       elif (
-        (last_rsi_3_gt_82)
-        and (last_willr_14_gt_neg_20)
-        and (last_aroonu_14_4h_gt_50)
-        and (last_top_wick_pct_1d > 20.0)
+        (last_rsi_3_gt_82) and (last_willr_14_gt_neg_20) and (last_aroonu_14_4h_gt_50) and (last_top_wick_pct_1d_gt_20)
       ):
         return True, f"exit_{mode_name}_w_4_18"
     elif 0.06 > current_profit >= 0.05:
@@ -27746,13 +27771,13 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_w_5_1"
       elif (last_willr_14_gte_neg_1) and (last_rsi_14 > 74.0):
         return True, f"exit_{mode_name}_w_5_2"
-      elif (last_willr_14_gte_neg_2) and (last_rsi_14 < 54.0):
+      elif (last_willr_14_gte_neg_2) and (last_rsi_14_lt_54):
         return True, f"exit_{mode_name}_w_5_3"
-      elif (last_willr_14 >= -10.0) and (last_rsi_14 > 70.0) and (last_roc_9_1h < -0.0) and (last_roc_9_4h > 20.0):
+      elif (last_willr_14 >= -10.0) and (last_rsi_14_gt_70) and (last_roc_9_1h_lt_0) and (last_roc_9_4h_gt_20):
         return True, f"exit_{mode_name}_w_5_4"
       elif (
         (last_rsi_3_gt_92)
-        and (last_willr_14 > -14.0)
+        and (last_willr_14_gt_neg_14)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 50.0))
         and (last_stochrsi_k_4h_gt_70)
       ):
@@ -27765,20 +27790,20 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_w_5_6"
       elif (
-        (last_rsi_3 > 80.0)
-        and (last_willr_14 > -12.0)
+        (last_rsi_3_gt_80)
+        and (last_willr_14_gt_neg_12)
         and (last_rsi_14_4h_gt_60)
-        and (last_cmf_20_1h < -0.0)
-        and (last_cmf_20_4h < -0.0)
+        and (last_cmf_20_1h_lt_0)
+        and (last_cmf_20_4h_lt_0)
       ):
         return True, f"exit_{mode_name}_w_5_7"
-      elif (last_rsi_3 > 80.0) and (last_willr_14_gt_neg_2) and (last_rsi_3_1h_lt_25) and (last_stochrsi_k_1h_gt_20):
+      elif (last_rsi_3_gt_80) and (last_willr_14_gt_neg_2) and (last_rsi_3_1h_lt_25) and (last_stochrsi_k_1h_gt_20):
         return True, f"exit_{mode_name}_w_5_8"
       elif (
-        (last_rsi_3 > 78.0)
+        (last_rsi_3_gt_78)
         and (last_willr_14_gt_neg_10)
         and (last_roc_9_1h_lt_neg_5)
-        and (last_roc_9_4h > 10.0)
+        and (last_roc_9_4h_gt_10)
         and (last_stochrsi_k_4h_gt_40)
       ):
         return True, f"exit_{mode_name}_w_5_9"
@@ -27786,11 +27811,11 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3_gt_86)
         and (last_willr_14 > -26.0)
         and (last_aroonu_14_4h_gt_50)
-        and (last_cci_20_change_pct_4h < -0.0)
+        and (last_cci_20_change_pct_4h_lt_0)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d > 90.0))
       ):
         return True, f"exit_{mode_name}_w_5_10"
-      elif (last_rsi_3 > 80.0) and (last_willr_14_gt_neg_10) and (last_rsi_3_1h_lt_30) and (last_rsi_3_4h_lt_25):
+      elif (last_rsi_3_gt_80) and (last_willr_14_gt_neg_10) and (last_rsi_3_1h_lt_30) and (last_rsi_3_4h_lt_25):
         return True, f"exit_{mode_name}_w_5_11"
       elif (last_rsi_3_gt_90) and (last_willr_14_gt_neg_10) and (last_rsi_3_4h_lt_40) and (last_aroonu_14_4h_gt_50):
         return True, f"exit_{mode_name}_w_5_12"
@@ -27805,7 +27830,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_w_5_13"
       elif (
         (last_rsi_3_gt_82)
-        and (last_willr_14 > -12.0)
+        and (last_willr_14_gt_neg_12)
         and (last_rsi_3_1h_lt_60)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 80.0))
       ):
@@ -27821,7 +27846,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_w_5_15"
       elif (
-        (last_rsi_3 > 78.0)
+        (last_rsi_3_gt_78)
         and (last_willr_14_gt_neg_10)
         and (last_rsi_3_1h_lt_40)
         and (last_aroonu_14_4h_gt_75)
@@ -27829,27 +27854,26 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_stochrsi_k_4h_gt_30)
       ):
         return True, f"exit_{mode_name}_w_5_16"
-      elif (last_rsi_3_gt_88) and (last_willr_14 > -14.0) and (last_aroonu_14_4h_gt_75) and (last_stochrsi_k_4h_gt_70):
+      elif (
+        (last_rsi_3_gt_88) and (last_willr_14_gt_neg_14) and (last_aroonu_14_4h_gt_75) and (last_stochrsi_k_4h_gt_70)
+      ):
         return True, f"exit_{mode_name}_w_5_17"
       elif (
-        (last_rsi_3 > 80.0)
-        and (last_willr_14_gt_neg_20)
-        and (last_aroonu_14_4h_gt_50)
-        and (last_top_wick_pct_1d > 20.0)
+        (last_rsi_3_gt_80) and (last_willr_14_gt_neg_20) and (last_aroonu_14_4h_gt_50) and (last_top_wick_pct_1d_gt_20)
       ):
         return True, f"exit_{mode_name}_w_5_18"
     elif 0.07 > current_profit >= 0.06:
       if last_willr_480 > -0.7:
         return True, f"exit_{mode_name}_w_6_1"
-      elif (last_willr_14_gte_neg_1) and (last_rsi_14 > 75.0):
+      elif (last_willr_14_gte_neg_1) and (last_rsi_14_gt_75):
         return True, f"exit_{mode_name}_w_6_2"
-      elif (last_willr_14_gte_neg_2) and (last_rsi_14 < 52.0):
+      elif (last_willr_14_gte_neg_2) and (last_rsi_14_lt_52):
         return True, f"exit_{mode_name}_w_6_3"
-      elif (last_willr_14 >= -15.0) and (last_rsi_14 > 70.0) and (last_roc_9_1h < -0.0) and (last_roc_9_4h > 20.0):
+      elif (last_willr_14_gte_neg_15) and (last_rsi_14_gt_70) and (last_roc_9_1h_lt_0) and (last_roc_9_4h_gt_20):
         return True, f"exit_{mode_name}_w_6_4"
       elif (
         (last_rsi_3_gt_94)
-        and (last_willr_14 > -12.0)
+        and (last_willr_14_gt_neg_12)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 50.0))
         and (last_stochrsi_k_4h_gt_70)
       ):
@@ -27865,25 +27889,25 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3_gt_82)
         and (last_willr_14_gt_neg_10)
         and (last_rsi_14_4h_gt_60)
-        and (last_cmf_20_1h < -0.0)
-        and (last_cmf_20_4h < -0.0)
+        and (last_cmf_20_1h_lt_0)
+        and (last_cmf_20_4h_lt_0)
       ):
         return True, f"exit_{mode_name}_w_6_7"
       elif (last_rsi_3_gt_82) and (last_willr_14_gt_neg_2) and (last_rsi_3_1h_lt_25) and (last_stochrsi_k_1h_gt_20):
         return True, f"exit_{mode_name}_w_6_8"
       elif (
-        (last_rsi_3 > 80.0)
+        (last_rsi_3_gt_80)
         and (last_willr_14_gt_neg_8)
         and (last_roc_9_1h_lt_neg_5)
-        and (last_roc_9_4h > 10.0)
+        and (last_roc_9_4h_gt_10)
         and (last_stochrsi_k_4h_gt_40)
       ):
         return True, f"exit_{mode_name}_w_6_9"
       elif (
         (last_rsi_3_gt_88)
-        and (last_willr_14 > -24.0)
+        and (last_willr_14_gt_neg_24)
         and (last_aroonu_14_4h_gt_50)
-        and (last_cci_20_change_pct_4h < -0.0)
+        and (last_cci_20_change_pct_4h_lt_0)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d > 90.0))
       ):
         return True, f"exit_{mode_name}_w_6_10"
@@ -27908,9 +27932,9 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_w_6_14"
       elif (
-        (last_rsi_3 > 44.0)
+        (last_rsi_3_gt_44)
         and (last_willr_480_gt_neg_25)
-        and (last_rsi_14 < 56.0)
+        and (last_rsi_14_lt_56)
         and (last_rsi_14_4h_gt_70)
         and (last_stochrsi_k_4h_gt_80)
         and (isinstance(last_roc_9_4h, np.float64) and (last_roc_9_4h > 100.0))
@@ -27918,7 +27942,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_w_6_15"
       elif (
-        (last_rsi_3 > 80.0)
+        (last_rsi_3_gt_80)
         and (last_willr_14_gt_neg_8)
         and (last_rsi_3_1h_lt_40)
         and (last_aroonu_14_4h_gt_75)
@@ -27926,23 +27950,22 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_stochrsi_k_4h_gt_30)
       ):
         return True, f"exit_{mode_name}_w_6_16"
-      elif (last_rsi_3_gt_90) and (last_willr_14 > -12.0) and (last_aroonu_14_4h_gt_75) and (last_stochrsi_k_4h_gt_70):
+      elif (
+        (last_rsi_3_gt_90) and (last_willr_14_gt_neg_12) and (last_aroonu_14_4h_gt_75) and (last_stochrsi_k_4h_gt_70)
+      ):
         return True, f"exit_{mode_name}_w_6_17"
       elif (
-        (last_rsi_3_gt_82)
-        and (last_willr_14_gt_neg_20)
-        and (last_aroonu_14_4h_gt_50)
-        and (last_top_wick_pct_1d > 20.0)
+        (last_rsi_3_gt_82) and (last_willr_14_gt_neg_20) and (last_aroonu_14_4h_gt_50) and (last_top_wick_pct_1d_gt_20)
       ):
         return True, f"exit_{mode_name}_w_6_18"
     elif 0.08 > current_profit >= 0.07:
       if last_willr_480 > -0.8:
         return True, f"exit_{mode_name}_w_7_1"
-      elif (last_willr_14_gte_neg_1) and (last_rsi_14 > 76.0):
+      elif (last_willr_14_gte_neg_1) and (last_rsi_14_gt_76):
         return True, f"exit_{mode_name}_w_7_2"
-      elif (last_willr_14_gte_neg_2) and (last_rsi_14 < 50.0):
+      elif (last_willr_14_gte_neg_2) and (last_rsi_14_lt_50):
         return True, f"exit_{mode_name}_w_7_3"
-      elif (last_willr_14 >= -15.0) and (last_rsi_14 > 70.0) and (last_roc_9_1h < -0.0) and (last_roc_9_4h > 20.0):
+      elif (last_willr_14_gte_neg_15) and (last_rsi_14_gt_70) and (last_roc_9_1h_lt_0) and (last_roc_9_4h_gt_20):
         return True, f"exit_{mode_name}_w_7_4"
       elif (
         (last_rsi_3_gt_96)
@@ -27962,8 +27985,8 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3_gt_84)
         and (last_willr_14_gt_neg_8)
         and (last_rsi_14_4h_gt_60)
-        and (last_cmf_20_1h < -0.0)
-        and (last_cmf_20_4h < -0.0)
+        and (last_cmf_20_1h_lt_0)
+        and (last_cmf_20_4h_lt_0)
       ):
         return True, f"exit_{mode_name}_w_7_7"
       elif (last_rsi_3_gt_84) and (last_willr_14_gt_neg_2) and (last_rsi_3_1h_lt_25) and (last_stochrsi_k_1h_gt_20):
@@ -27972,15 +27995,15 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3_gt_82)
         and (last_willr_14_gt_neg_6)
         and (last_roc_9_1h_lt_neg_5)
-        and (last_roc_9_4h > 10.0)
+        and (last_roc_9_4h_gt_10)
         and (last_stochrsi_k_4h_gt_40)
       ):
         return True, f"exit_{mode_name}_w_7_9"
       elif (
         (last_rsi_3_gt_90)
-        and (last_willr_14 > -22.0)
+        and (last_willr_14_gt_neg_22)
         and (last_aroonu_14_4h_gt_50)
-        and (last_cci_20_change_pct_4h < -0.0)
+        and (last_cci_20_change_pct_4h_lt_0)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d > 90.0))
       ):
         return True, f"exit_{mode_name}_w_7_10"
@@ -28005,9 +28028,9 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_w_7_14"
       elif (
-        (last_rsi_3 > 46.0)
+        (last_rsi_3_gt_46)
         and (last_willr_480_gt_neg_25)
-        and (last_rsi_14 < 54.0)
+        and (last_rsi_14_lt_54)
         and (last_rsi_14_4h_gt_70)
         and (last_stochrsi_k_4h_gt_80)
         and (isinstance(last_roc_9_4h, np.float64) and (last_roc_9_4h > 100.0))
@@ -28028,20 +28051,17 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_w_7_17"
       elif (
-        (last_rsi_3_gt_84)
-        and (last_willr_14_gt_neg_20)
-        and (last_aroonu_14_4h_gt_50)
-        and (last_top_wick_pct_1d > 20.0)
+        (last_rsi_3_gt_84) and (last_willr_14_gt_neg_20) and (last_aroonu_14_4h_gt_50) and (last_top_wick_pct_1d_gt_20)
       ):
         return True, f"exit_{mode_name}_w_7_18"
     elif 0.09 > current_profit >= 0.08:
       if last_willr_480 > -0.9:
         return True, f"exit_{mode_name}_w_8_1"
-      elif (last_willr_14_gte_neg_1) and (last_rsi_14 > 77.0):
+      elif (last_willr_14_gte_neg_1) and (last_rsi_14_gt_77):
         return True, f"exit_{mode_name}_w_8_2"
-      elif (last_willr_14_gte_neg_2) and (last_rsi_14 < 48.0):
+      elif (last_willr_14_gte_neg_2) and (last_rsi_14_lt_48):
         return True, f"exit_{mode_name}_w_8_3"
-      elif (last_willr_14 >= -15.0) and (last_rsi_14 > 70.0) and (last_roc_9_1h < -0.0) and (last_roc_9_4h > 20.0):
+      elif (last_willr_14_gte_neg_15) and (last_rsi_14_gt_70) and (last_roc_9_1h_lt_0) and (last_roc_9_4h_gt_20):
         return True, f"exit_{mode_name}_w_8_4"
       elif (
         (last_rsi_3_gt_98)
@@ -28061,8 +28081,8 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3_gt_86)
         and (last_willr_14_gt_neg_6)
         and (last_rsi_14_4h_gt_60)
-        and (last_cmf_20_1h < -0.0)
-        and (last_cmf_20_4h < -0.0)
+        and (last_cmf_20_1h_lt_0)
+        and (last_cmf_20_4h_lt_0)
       ):
         return True, f"exit_{mode_name}_w_8_7"
       elif (last_rsi_3_gt_86) and (last_willr_14_gt_neg_2) and (last_rsi_3_1h_lt_25) and (last_stochrsi_k_1h_gt_20):
@@ -28071,7 +28091,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3_gt_84)
         and (last_willr_14_gt_neg_4)
         and (last_roc_9_1h_lt_neg_5)
-        and (last_roc_9_4h > 10.0)
+        and (last_roc_9_4h_gt_10)
         and (last_stochrsi_k_4h_gt_40)
       ):
         return True, f"exit_{mode_name}_w_8_9"
@@ -28079,7 +28099,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3_gt_92)
         and (last_willr_14_gt_neg_20)
         and (last_aroonu_14_4h_gt_50)
-        and (last_cci_20_change_pct_4h < -0.0)
+        and (last_cci_20_change_pct_4h_lt_0)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d > 90.0))
       ):
         return True, f"exit_{mode_name}_w_8_10"
@@ -28104,9 +28124,9 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_w_8_14"
       elif (
-        (last_rsi_3 > 48.0)
+        (last_rsi_3_gt_48)
         and (last_willr_480_gt_neg_25)
-        and (last_rsi_14 < 52.0)
+        and (last_rsi_14_lt_52)
         and (last_rsi_14_4h_gt_70)
         and (last_stochrsi_k_4h_gt_80)
         and (isinstance(last_roc_9_4h, np.float64) and (last_roc_9_4h > 100.0))
@@ -28127,20 +28147,17 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_w_8_17"
       elif (
-        (last_rsi_3_gt_86)
-        and (last_willr_14_gt_neg_20)
-        and (last_aroonu_14_4h_gt_50)
-        and (last_top_wick_pct_1d > 20.0)
+        (last_rsi_3_gt_86) and (last_willr_14_gt_neg_20) and (last_aroonu_14_4h_gt_50) and (last_top_wick_pct_1d_gt_20)
       ):
         return True, f"exit_{mode_name}_w_8_18"
     elif 0.1 > current_profit >= 0.09:
       if last_willr_480 > -1.0:
         return True, f"exit_{mode_name}_w_9_1"
-      elif (last_willr_14_gte_neg_1) and (last_rsi_14 > 78.0):
+      elif (last_willr_14_gte_neg_1) and (last_rsi_14_gt_78):
         return True, f"exit_{mode_name}_w_9_2"
-      elif (last_willr_14_gte_neg_2) and (last_rsi_14 < 46.0):
+      elif (last_willr_14_gte_neg_2) and (last_rsi_14_lt_46):
         return True, f"exit_{mode_name}_w_9_3"
-      elif (last_willr_14 >= -15.0) and (last_rsi_14 > 70.0) and (last_roc_9_1h < -0.0) and (last_roc_9_4h > 20.0):
+      elif (last_willr_14_gte_neg_15) and (last_rsi_14_gt_70) and (last_roc_9_1h_lt_0) and (last_roc_9_4h_gt_20):
         return True, f"exit_{mode_name}_w_9_4"
       elif (
         (last_rsi_3_gt_98)
@@ -28160,8 +28177,8 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3_gt_88)
         and (last_willr_14_gt_neg_4)
         and (last_rsi_14_4h_gt_60)
-        and (last_cmf_20_1h < -0.0)
-        and (last_cmf_20_4h < -0.0)
+        and (last_cmf_20_1h_lt_0)
+        and (last_cmf_20_4h_lt_0)
       ):
         return True, f"exit_{mode_name}_w_9_7"
       elif (last_rsi_3_gt_88) and (last_willr_14_gt_neg_2) and (last_rsi_3_1h_lt_25) and (last_stochrsi_k_1h_gt_20):
@@ -28170,15 +28187,15 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3_gt_86)
         and (last_willr_14_gt_neg_2)
         and (last_roc_9_1h_lt_neg_5)
-        and (last_roc_9_4h > 10.0)
+        and (last_roc_9_4h_gt_10)
         and (last_stochrsi_k_4h_gt_40)
       ):
         return True, f"exit_{mode_name}_w_9_9"
       elif (
         (last_rsi_3_gt_94)
-        and (last_willr_14 > -18.0)
+        and (last_willr_14_gt_neg_18)
         and (last_aroonu_14_4h_gt_50)
-        and (last_cci_20_change_pct_4h < -0.0)
+        and (last_cci_20_change_pct_4h_lt_0)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d > 90.0))
       ):
         return True, f"exit_{mode_name}_w_9_10"
@@ -28203,9 +28220,9 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_w_9_14"
       elif (
-        (last_rsi_3 > 50.0)
+        (last_rsi_3_gt_50)
         and (last_willr_480_gt_neg_25)
-        and (last_rsi_14 < 50.0)
+        and (last_rsi_14_lt_50)
         and (last_rsi_14_4h_gt_70)
         and (last_stochrsi_k_4h_gt_80)
         and (isinstance(last_roc_9_4h, np.float64) and (last_roc_9_4h > 100.0))
@@ -28226,10 +28243,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_w_9_17"
       elif (
-        (last_rsi_3_gt_88)
-        and (last_willr_14_gt_neg_20)
-        and (last_aroonu_14_4h_gt_50)
-        and (last_top_wick_pct_1d > 20.0)
+        (last_rsi_3_gt_88) and (last_willr_14_gt_neg_20) and (last_aroonu_14_4h_gt_50) and (last_top_wick_pct_1d_gt_20)
       ):
         return True, f"exit_{mode_name}_w_9_18"
     elif 0.12 > current_profit >= 0.1:
@@ -28237,9 +28251,9 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_w_10_1"
       elif (last_willr_14_gte_neg_1) and (last_rsi_14 > 79.0):
         return True, f"exit_{mode_name}_w_10_2"
-      elif (last_willr_14_gte_neg_2) and (last_rsi_14 < 44.0):
+      elif (last_willr_14_gte_neg_2) and (last_rsi_14_lt_44):
         return True, f"exit_{mode_name}_w_10_3"
-      elif (last_willr_14 >= -15.0) and (last_rsi_14 > 70.0) and (last_roc_9_1h < -0.0) and (last_roc_9_4h > 20.0):
+      elif (last_willr_14_gte_neg_15) and (last_rsi_14_gt_70) and (last_roc_9_1h_lt_0) and (last_roc_9_4h_gt_20):
         return True, f"exit_{mode_name}_w_10_4"
       elif (
         (last_rsi_3_gt_98)
@@ -28259,8 +28273,8 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3_gt_90)
         and (last_willr_14_gt_neg_2)
         and (last_rsi_14_4h_gt_60)
-        and (last_cmf_20_1h < -0.0)
-        and (last_cmf_20_4h < -0.0)
+        and (last_cmf_20_1h_lt_0)
+        and (last_cmf_20_4h_lt_0)
       ):
         return True, f"exit_{mode_name}_w_10_7"
       elif (last_rsi_3_gt_90) and (last_willr_14_gt_neg_2) and (last_rsi_3_1h_lt_25) and (last_stochrsi_k_1h_gt_20):
@@ -28269,15 +28283,15 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3_gt_88)
         and (last_willr_14_gt_neg_1)
         and (last_roc_9_1h_lt_neg_5)
-        and (last_roc_9_4h > 10.0)
+        and (last_roc_9_4h_gt_10)
         and (last_stochrsi_k_4h_gt_40)
       ):
         return True, f"exit_{mode_name}_w_10_9"
       elif (
         (last_rsi_3_gt_96)
-        and (last_willr_14 > -16.0)
+        and (last_willr_14_gt_neg_16)
         and (last_aroonu_14_4h_gt_50)
-        and (last_cci_20_change_pct_4h < -0.0)
+        and (last_cci_20_change_pct_4h_lt_0)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d > 90.0))
       ):
         return True, f"exit_{mode_name}_w_10_10"
@@ -28304,7 +28318,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 52.0)
         and (last_willr_480_gt_neg_25)
-        and (last_rsi_14 < 48.0)
+        and (last_rsi_14_lt_48)
         and (last_rsi_14_4h_gt_70)
         and (last_stochrsi_k_4h_gt_80)
         and (isinstance(last_roc_9_4h, np.float64) and (last_roc_9_4h > 100.0))
@@ -28325,20 +28339,17 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_w_10_17"
       elif (
-        (last_rsi_3_gt_90)
-        and (last_willr_14_gt_neg_20)
-        and (last_aroonu_14_4h_gt_50)
-        and (last_top_wick_pct_1d > 20.0)
+        (last_rsi_3_gt_90) and (last_willr_14_gt_neg_20) and (last_aroonu_14_4h_gt_50) and (last_top_wick_pct_1d_gt_20)
       ):
         return True, f"exit_{mode_name}_w_10_18"
     elif 0.2 > current_profit >= 0.12:
       if last_willr_480 > -0.4:
         return True, f"exit_{mode_name}_w_11_1"
-      elif (last_willr_14_gte_neg_1) and (last_rsi_14 > 80.0):
+      elif (last_willr_14_gte_neg_1) and (last_rsi_14_gt_80):
         return True, f"exit_{mode_name}_w_11_2"
       elif (last_willr_14_gte_neg_2) and (last_rsi_14 < 42.0):
         return True, f"exit_{mode_name}_w_11_3"
-      elif (last_willr_14 >= -15.0) and (last_rsi_14 > 70.0) and (last_roc_9_1h < -0.0) and (last_roc_9_4h > 20.0):
+      elif (last_willr_14_gte_neg_15) and (last_rsi_14_gt_70) and (last_roc_9_1h_lt_0) and (last_roc_9_4h_gt_20):
         return True, f"exit_{mode_name}_w_11_4"
       elif (
         (last_rsi_3_gt_98)
@@ -28358,8 +28369,8 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3_gt_92)
         and (last_willr_14_gt_neg_1)
         and (last_rsi_14_4h_gt_60)
-        and (last_cmf_20_1h < -0.0)
-        and (last_cmf_20_4h < -0.0)
+        and (last_cmf_20_1h_lt_0)
+        and (last_cmf_20_4h_lt_0)
       ):
         return True, f"exit_{mode_name}_w_11_7"
       elif (last_rsi_3_gt_92) and (last_willr_14_gt_neg_2) and (last_rsi_3_1h_lt_25) and (last_stochrsi_k_1h_gt_20):
@@ -28368,15 +28379,15 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3_gt_90)
         and (last_willr_14_gt_neg_1)
         and (last_roc_9_1h_lt_neg_5)
-        and (last_roc_9_4h > 10.0)
+        and (last_roc_9_4h_gt_10)
         and (last_stochrsi_k_4h_gt_40)
       ):
         return True, f"exit_{mode_name}_w_11_9"
       elif (
         (last_rsi_3_gt_98)
-        and (last_willr_14 > -14.0)
+        and (last_willr_14_gt_neg_14)
         and (last_aroonu_14_4h_gt_50)
-        and (last_cci_20_change_pct_4h < -0.0)
+        and (last_cci_20_change_pct_4h_lt_0)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d > 90.0))
       ):
         return True, f"exit_{mode_name}_w_11_10"
@@ -28403,7 +28414,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 54.0)
         and (last_willr_480_gt_neg_25)
-        and (last_rsi_14 < 46.0)
+        and (last_rsi_14_lt_46)
         and (last_rsi_14_4h_gt_70)
         and (last_stochrsi_k_4h_gt_80)
         and (isinstance(last_roc_9_4h, np.float64) and (last_roc_9_4h > 100.0))
@@ -28424,10 +28435,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_w_11_17"
       elif (
-        (last_rsi_3_gt_92)
-        and (last_willr_14_gt_neg_20)
-        and (last_aroonu_14_4h_gt_50)
-        and (last_top_wick_pct_1d > 20.0)
+        (last_rsi_3_gt_92) and (last_willr_14_gt_neg_20) and (last_aroonu_14_4h_gt_50) and (last_top_wick_pct_1d_gt_20)
       ):
         return True, f"exit_{mode_name}_w_11_18"
     elif current_profit >= 0.2:
@@ -28435,9 +28443,9 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_w_12_1"
       elif (last_willr_14_gte_neg_1) and (last_rsi_14 > 81.0):
         return True, f"exit_{mode_name}_w_12_2"
-      elif (last_willr_14_gte_neg_2) and (last_rsi_14 < 40.0):
+      elif (last_willr_14_gte_neg_2) and (last_rsi_14_lt_40):
         return True, f"exit_{mode_name}_w_12_3"
-      elif (last_willr_14_gte_neg_1) and (last_rsi_14 > 80.0) and (last_roc_9_1h < -0.0) and (last_roc_9_4h > 20.0):
+      elif (last_willr_14_gte_neg_1) and (last_rsi_14_gt_80) and (last_roc_9_1h_lt_0) and (last_roc_9_4h_gt_20):
         return True, f"exit_{mode_name}_w_12_4"
       elif (
         (last_rsi_3_gt_99)
@@ -28457,8 +28465,8 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3_gt_94)
         and (last_willr_14_gt_neg_1)
         and (last_rsi_14_4h_gt_60)
-        and (last_cmf_20_1h < -0.0)
-        and (last_cmf_20_4h < -0.0)
+        and (last_cmf_20_1h_lt_0)
+        and (last_cmf_20_4h_lt_0)
       ):
         return True, f"exit_{mode_name}_w_12_7"
       elif (last_rsi_3_gt_94) and (last_willr_14_gt_neg_2) and (last_rsi_3_1h_lt_25) and (last_stochrsi_k_1h_gt_20):
@@ -28467,15 +28475,15 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3_gt_92)
         and (last_willr_14_gt_neg_1)
         and (last_roc_9_1h_lt_neg_5)
-        and (last_roc_9_4h > 10.0)
+        and (last_roc_9_4h_gt_10)
         and (last_stochrsi_k_4h_gt_40)
       ):
         return True, f"exit_{mode_name}_w_12_9"
       elif (
         (last_rsi_3_gt_99)
-        and (last_willr_14 > -12.0)
+        and (last_willr_14_gt_neg_12)
         and (last_aroonu_14_4h_gt_50)
-        and (last_cci_20_change_pct_4h < -0.0)
+        and (last_cci_20_change_pct_4h_lt_0)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d > 90.0))
       ):
         return True, f"exit_{mode_name}_w_12_10"
@@ -28502,7 +28510,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 56.0)
         and (last_willr_480_gt_neg_25)
-        and (last_rsi_14 < 44.0)
+        and (last_rsi_14_lt_44)
         and (last_rsi_14_4h_gt_70)
         and (last_stochrsi_k_4h_gt_80)
         and (isinstance(last_roc_9_4h, np.float64) and (last_roc_9_4h > 100.0))
@@ -28523,10 +28531,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_w_12_17"
       elif (
-        (last_rsi_3_gt_94)
-        and (last_willr_14_gt_neg_20)
-        and (last_aroonu_14_4h_gt_50)
-        and (last_top_wick_pct_1d > 20.0)
+        (last_rsi_3_gt_94) and (last_willr_14_gt_neg_20) and (last_aroonu_14_4h_gt_50) and (last_top_wick_pct_1d_gt_20)
       ):
         return True, f"exit_{mode_name}_w_12_18"
 


### PR DESCRIPTION
## Summary
- Reuses repeated long Williams-R exit threshold checks after all candle fields are already read.
- This branch is independent on latest upstream `main`.

## Safety
- Only already-read values are reused inside the same call.
- Indicator formulas, candle selection, order classification, profit arithmetic, thresholds, condition order, and return values are unchanged.
- No v3 grind-entry code is touched.
- Touched function(s): `long_exit_williams_r`.

## Backtest scope
- Full backtesting was not required because this patch only reuses already-read local values inside the same call. Indicators, candle selection, order classification, profit arithmetic, thresholds, and trading conditions are unchanged.

## Checks
- `python3 ~/.codex/skills/nfi-upstream-pr/scripts/validate_nfi_pr.py --base origin/main`
- `git merge-tree` conflict simulation against `origin/main` (via validator)
- AST undefined-local scan for introduced `last_*` / `previous_*` / `current_*` locals (via validator)
- `git diff --check` (via validator)
- `ruff format --check NostalgiaForInfinityX7.py` (via validator)
- `ruff check NostalgiaForInfinityX7.py` (via validator)
- `PYTHONDONTWRITEBYTECODE=1 python3 -m py_compile NostalgiaForInfinityX7.py` (via validator)
