### PR TITLE
Hoist X7 long DEC exit gates

### DIFF
--- a/NostalgiaForInfinityX7.py
+++ b/NostalgiaForInfinityX7.py
@@ -28602,6 +28602,53 @@ class NostalgiaForInfinityX7(IStrategy):
     last_rsi_3_1h_lt_30 = last_rsi_3_1h < 30.0
     last_rsi_3_4h_lt_30 = last_rsi_3_4h < 30.0
 
+    # Reused long DEC exit thresholds
+    last_willr_14_gt_neg_10 = last_willr_14 > -10.0
+    last_willr_14_gt_neg_1 = last_willr_14 > -1.0
+    last_willr_14_gt_neg_2 = last_willr_14 > -2.0
+    last_willr_14_gt_neg_25 = last_willr_14 > -25.0
+    last_willr_14_gt_neg_8 = last_willr_14 > -8.0
+    last_willr_14_gt_neg_20 = last_willr_14 > -20.0
+    last_change_pct_1d_lt_neg_5 = last_change_pct_1d < -5.0
+    last_willr_14_gt_neg_6 = last_willr_14 > -6.0
+    last_willr_14_gt_neg_4 = last_willr_14 > -4.0
+    last_roc_9_4h_lt_neg_25 = last_roc_9_4h < -25.0
+    last_roc_9_4h_lt_neg_20 = last_roc_9_4h < -20.0
+    last_roc_9_1h_lt_neg_10 = last_roc_9_1h < -10.0
+    last_change_pct_4h_lt_neg_5 = last_change_pct_4h < -5.0
+    last_stochrsi_k_4h_gt_80 = last_stochrsi_k_4h > 80.0
+    last_stochrsi_k_4h_gt_70 = last_stochrsi_k_4h > 70.0
+    last_stochrsi_k_4h_gt_10 = last_stochrsi_k_4h > 10.0
+    last_stochrsi_k_1h_gt_25 = last_stochrsi_k_1h > 25.0
+    last_stochrsi_k_1h_gt_20 = last_stochrsi_k_1h > 20.0
+    last_rsi_3_4h_lt_5 = last_rsi_3_4h < 5.0
+    last_rsi_3_4h_lt_35 = last_rsi_3_4h < 35.0
+    last_rsi_3_1d_lt_40 = last_rsi_3_1d < 40.0
+    last_rsi_3_15m_lt_30 = last_rsi_3_15m < 30.0
+    last_roc_9_4h_gt_40 = last_roc_9_4h > 40.0
+    last_roc_9_4h_gt_25 = last_roc_9_4h > 25.0
+    last_roc_9_4h_lt_neg_5 = last_roc_9_4h < -5.0
+    last_roc_9_4h_lt_neg_10 = last_roc_9_4h < -10.0
+    last_roc_9_1h_lt_neg_5 = last_roc_9_1h < -5.0
+    last_roc_2_4h_lt_neg_30 = last_roc_2_4h < -30.0
+    last_cmf_20_4h_lt_0 = last_cmf_20_4h < -0.0
+    last_cmf_20_1h_lt_0 = last_cmf_20_1h < -0.0
+    last_willr_14_gt_neg_12 = last_willr_14 > -12.0
+    last_stochrsi_k_gt_70 = last_stochrsi_k > 70.0
+    last_willr_14_gt_neg_30 = last_willr_14 > -30.0
+    last_willr_14_gt_neg_15 = last_willr_14 > -15.0
+    last_willr_14_gt_neg_14 = last_willr_14 > -14.0
+    last_willr_14_gt_neg_5 = last_willr_14 > -5.0
+    last_willr_14_gt_neg_16 = last_willr_14 > -16.0
+    last_rsi_3_15m_gt_70 = last_rsi_3_15m > 70.0
+    last_rsi_3_gt_56 = last_rsi_3 > 56.0
+    last_willr_14_gt_neg_18 = last_willr_14 > -18.0
+    last_stochrsi_k_change_pct_4h_lt_neg_10 = last_stochrsi_k_change_pct_4h < -10.0
+    last_stochrsi_k_1h_gt_90 = last_stochrsi_k_1h > 90.0
+    last_stochrsi_k_1h_gt_75 = last_stochrsi_k_1h > 75.0
+    last_stochrsi_k_1d_gt_50 = last_stochrsi_k_1d > 50.0
+    last_stoch_k_4h_gt_40 = last_stoch_k_4h > 40.0
+
     if 0.01 > current_profit >= 0.001:
       # Reused long exit decision threshold checks for this profit bracket
       last_rsi_3_gt_95 = last_rsi_3 > 95.0
@@ -28651,7 +28698,7 @@ class NostalgiaForInfinityX7(IStrategy):
       last_rsi_14_4h_gt_70 = last_rsi_14_4h > 70.0
       last_rsi_3_1d_lt_30 = last_rsi_3_1d < 30.0
       if (
-        (last_willr_14 > -1.0)
+        (last_willr_14_gt_neg_1)
         and (last_rsi_14_gt_78)
         and (isinstance(last_ema_200_1h, np.float64) and (last_ema_12_1h < last_ema_200_1h))
         and (isinstance(last_ema_200_4h, np.float64) and (last_ema_12_4h < last_ema_200_4h))
@@ -28660,37 +28707,37 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_0_1"
       elif (
-        (last_willr_14 > -1.0)
+        (last_willr_14_gt_neg_1)
         and (last_rsi_14_gt_78)
-        and (last_cmf_20_1h < -0.0)
+        and (last_cmf_20_1h_lt_0)
         and (isinstance(last_ema_200_1h, np.float64) and (last_ema_12_1h < last_ema_200_1h))
         and (isinstance(last_ema_200_4h, np.float64) and (last_ema_12_4h < last_ema_200_4h))
       ):
         return True, f"exit_{mode_name}_d_0_2"
       elif (
-        (last_willr_14 > -1.0)
+        (last_willr_14_gt_neg_1)
         and (last_stochrsi_k > 99.0)
-        and (last_cmf_20_1h < -0.0)
-        and (last_cmf_20_4h < -0.0)
-        and ((last_stochrsi_k_4h_gt_20) and (last_stochrsi_k_change_pct_4h < -10.0))
+        and (last_cmf_20_1h_lt_0)
+        and (last_cmf_20_4h_lt_0)
+        and ((last_stochrsi_k_4h_gt_20) and (last_stochrsi_k_change_pct_4h_lt_neg_10))
       ):
         return True, f"exit_{mode_name}_d_0_3"
       elif (
-        (last_willr_14 > -1.0)
+        (last_willr_14_gt_neg_1)
         and (last_rsi_14_gt_78)
         and (last_stochrsi_k_gt_95)
-        and (last_stochrsi_k_4h > 70.0)
+        and (last_stochrsi_k_4h_gt_70)
         and (isinstance(last_ema_200_1h, np.float64) and (last_ema_12_1h < last_ema_200_1h))
         and (isinstance(last_ema_200_4h, np.float64) and (last_ema_12_4h < last_ema_200_4h))
       ):
         return True, f"exit_{mode_name}_d_0_4"
-      elif (last_willr_14 > -1.0) and (last_rsi_14_gt_78) and (last_roc_9_1h < -5.0) and (last_roc_9_4h < -5.0):
+      elif (last_willr_14_gt_neg_1) and (last_rsi_14_gt_78) and (last_roc_9_1h_lt_neg_5) and (last_roc_9_4h_lt_neg_5):
         return True, f"exit_{mode_name}_d_0_5"
       elif (
         (last_rsi_3_gt_95)
         and (last_stochrsi_k_gt_95)
         and (last_rsi_14_lt_40)
-        and (last_roc_9_1h < -10.0)
+        and (last_roc_9_1h_lt_neg_10)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 50.0))
       ):
         return True, f"exit_{mode_name}_d_0_6"
@@ -28702,26 +28749,26 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_0_7"
       elif (
-        (last_willr_14 > -1.0)
+        (last_willr_14_gt_neg_1)
         and (last_stochrsi_k > 99.0)
         and (last_cmf_20_1h < -0.1)
         and (last_cmf_20_4h < -0.1)
-        and (last_change_pct_1d < -5.0)
+        and (last_change_pct_1d_lt_neg_5)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 15.0))
       ):
         return True, f"exit_{mode_name}_d_0_8"
       elif (
-        (last_willr_14 > -1.0)
+        (last_willr_14_gt_neg_1)
         and (last_rsi_3_gt_99)
-        and (last_change_pct_4h < -5.0)
+        and (last_change_pct_4h_lt_neg_5)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
       ):
         return True, f"exit_{mode_name}_d_0_9"
       elif (
-        (last_willr_14 > -1.0)
+        (last_willr_14_gt_neg_1)
         and (last_rsi_14_lt_50)
-        and (last_roc_9_1h < -10.0)
-        and (last_roc_9_4h < -10.0)
+        and (last_roc_9_1h_lt_neg_10)
+        and (last_roc_9_4h_lt_neg_10)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 10.0))
       ):
         return True, f"exit_{mode_name}_d_0_10"
@@ -28729,7 +28776,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3_gt_95)
         and (last_rsi_14 < 45.0)
         and (last_roc_9_15m < -10.0)
-        and (last_roc_9_1h < -10.0)
+        and (last_roc_9_1h_lt_neg_10)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -20.0))
       ):
         return True, f"exit_{mode_name}_d_0_11"
@@ -28738,26 +28785,26 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14_lt_50)
         and (last_rsi_3_4h_lt_10)
         and (last_roc_9_1h < -20.0)
-        and (last_roc_9_4h < -20.0)
+        and (last_roc_9_4h_lt_neg_20)
       ):
         return True, f"exit_{mode_name}_d_0_12"
-      elif (last_rsi_3_gt_99) and (last_rsi_3_4h < 5.0) and (last_roc_9_4h < -25.0):
+      elif (last_rsi_3_gt_99) and (last_rsi_3_4h_lt_5) and (last_roc_9_4h_lt_neg_25):
         return True, f"exit_{mode_name}_d_0_13"
-      elif (last_rsi_3_gt_99) and (last_willr_14 > -1.0) and (last_rsi_3_4h < 5.0) and (last_aroonu_14_4h_gt_25):
+      elif (last_rsi_3_gt_99) and (last_willr_14_gt_neg_1) and (last_rsi_3_4h_lt_5) and (last_aroonu_14_4h_gt_25):
         return True, f"exit_{mode_name}_d_0_14"
       elif (last_rsi_3_gt_99) and (last_rsi_14_gt_78) and (last_roc_9_4h < -30.0):
         return True, f"exit_{mode_name}_d_0_15"
       elif (
         (last_rsi_3_gt_99)
         and (last_aroonu_14_4h_gt_25)
-        and (last_roc_9_4h < -25.0)
+        and (last_roc_9_4h_lt_neg_25)
         and (last_aroonu_14_1d > 50.0)
         and (last_change_pct_1d < -15.0)
       ):
         return True, f"exit_{mode_name}_d_0_16"
       elif (
         (last_rsi_3_gt_99)
-        and (last_willr_14 > -1.0)
+        and (last_willr_14_gt_neg_1)
         and (last_rsi_3_1h_lt_10)
         and (last_stochrsi_k_4h_gt_90)
         and (last_roc_9_4h > 30.0)
@@ -28778,31 +28825,31 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_0_21"
       elif (
         (last_rsi_3_gt_99)
-        and (last_willr_14 > -1.0)
-        and (last_change_pct_4h < -5.0)
+        and (last_willr_14_gt_neg_1)
+        and (last_change_pct_4h_lt_neg_5)
         and (last_stochrsi_k_4h_gt_50)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
       ):
         return True, f"exit_{mode_name}_d_0_22"
-      elif (last_rsi_3_gt_98) and (last_willr_14 > -5.0) and (last_rsi_3_1h_lt_15) and (last_rsi_3_1d < 5.0):
+      elif (last_rsi_3_gt_98) and (last_willr_14_gt_neg_5) and (last_rsi_3_1h_lt_15) and (last_rsi_3_1d < 5.0):
         return True, f"exit_{mode_name}_d_0_23"
       elif (
         (last_rsi_3_gt_99)
         and (last_rsi_14_gt_78)
-        and (last_willr_14 > -5.0)
+        and (last_willr_14_gt_neg_5)
         and (last_rsi_3_4h_lt_30)
         and (last_aroonu_14_4h_gt_75)
       ):
         return True, f"exit_{mode_name}_d_0_24"
       elif (
         (last_rsi_3_gt_95)
-        and (last_willr_14 > -2.0)
+        and (last_willr_14_gt_neg_2)
         and (last_rsi_3_4h_lt_10)
         and (last_roc_9_4h < -15.0)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d > 50.0))
       ):
         return True, f"exit_{mode_name}_d_0_25"
-      elif (last_rsi_3_gt_95) and (last_willr_14 > -1.0) and (last_rsi_3_4h_lt_15) and (last_roc_9_4h < -20.0):
+      elif (last_rsi_3_gt_95) and (last_willr_14_gt_neg_1) and (last_rsi_3_4h_lt_15) and (last_roc_9_4h_lt_neg_20):
         return True, f"exit_{mode_name}_d_0_26"
       elif (
         (last_rsi_3_gt_95)
@@ -28829,27 +28876,27 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14_lt_50)
         and (last_rsi_3_1h_lt_15)
         and (last_rsi_3_4h_lt_15)
-        and (last_stochrsi_k_1h > 25.0)
+        and (last_stochrsi_k_1h_gt_25)
       ):
         return True, f"exit_{mode_name}_d_0_31"
-      elif (last_rsi_3_gt_95) and (last_rsi_3_1h_lt_15) and (last_roc_2_4h < -30.0) and (last_stochrsi_k_4h_gt_30):
+      elif (last_rsi_3_gt_95) and (last_rsi_3_1h_lt_15) and (last_roc_2_4h_lt_neg_30) and (last_stochrsi_k_4h_gt_30):
         return True, f"exit_{mode_name}_d_0_32"
       elif (
         (last_rsi_3_gt_95)
-        and (last_willr_14 > -1.0)
+        and (last_willr_14_gt_neg_1)
         and (last_roc_2_1h < -10.0)
         and (last_roc_9_1h > 30.0)
         and (last_stochrsi_k_1h_gt_50)
       ):
         return True, f"exit_{mode_name}_d_0_33"
-      elif (last_rsi_3 > 65.0) and (last_rsi_3_15m < 30.0) and (last_rsi_14_1h > 80.0) and (last_roc_9_1h > 40.0):
+      elif (last_rsi_3 > 65.0) and (last_rsi_3_15m_lt_30) and (last_rsi_14_1h > 80.0) and (last_roc_9_1h > 40.0):
         return True, f"exit_{mode_name}_d_0_34"
-      elif (last_rsi_3_gt_95) and (last_willr_14 > -5.0) and (last_rsi_3_1d_lt_25) and (last_stochrsi_k_1h > 75.0):
+      elif (last_rsi_3_gt_95) and (last_willr_14_gt_neg_5) and (last_rsi_3_1d_lt_25) and (last_stochrsi_k_1h_gt_75):
         return True, f"exit_{mode_name}_d_0_35"
       elif (
         (last_rsi_3_gt_95)
-        and (last_willr_14 > -1.0)
-        and (last_roc_9_4h < -25.0)
+        and (last_willr_14_gt_neg_1)
+        and (last_roc_9_4h_lt_neg_25)
         and (last_rsi_3_1d_lt_25)
         and (last_stochrsi_k_1h_gt_50)
       ):
@@ -28862,13 +28909,13 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_stochrsi_k_4h_gt_50)
       ):
         return True, f"exit_{mode_name}_d_0_37"
-      elif (last_rsi_3_gt_90) and (last_willr_14 > -10.0) and (last_rsi_3_4h_lt_10) and (last_stochrsi_k_4h_gt_20):
+      elif (last_rsi_3_gt_90) and (last_willr_14_gt_neg_10) and (last_rsi_3_4h_lt_10) and (last_stochrsi_k_4h_gt_20):
         return True, f"exit_{mode_name}_d_0_38"
-      elif (last_rsi_3_gt_99) and (last_willr_14 > -1.0) and (last_cmf_20_4h < -0.0) and (last_rsi_3_4h_lt_10):
+      elif (last_rsi_3_gt_99) and (last_willr_14_gt_neg_1) and (last_cmf_20_4h_lt_0) and (last_rsi_3_4h_lt_10):
         return True, f"exit_{mode_name}_d_0_39"
       elif (
         (last_rsi_3_gt_98)
-        and (last_willr_14 > -2.0)
+        and (last_willr_14_gt_neg_2)
         and (last_rsi_3_1h_lt_30)
         and (last_stochrsi_k_1h_gt_30)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d > 90.0))
@@ -28876,7 +28923,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_0_40"
       elif (
         (last_rsi_3_gt_98)
-        and (last_willr_14 > -5.0)
+        and (last_willr_14_gt_neg_5)
         and (last_rsi_3_1h_lt_30)
         and (last_stochrsi_k_4h_gt_25)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 50.0))
@@ -28884,7 +28931,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_0_41"
       elif (
         (last_rsi_3_gt_95)
-        and (last_willr_14 > -2.0)
+        and (last_willr_14_gt_neg_2)
         and (last_stochrsi_k_4h_gt_30)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 40.0))
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d > 70.0))
@@ -28900,13 +28947,13 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_0_43"
       elif (
         (last_rsi_3_gt_90)
-        and (last_willr_14 > -2.0)
+        and (last_willr_14_gt_neg_2)
         and (last_rsi_3_4h_lt_30)
         and (last_rsi_3_1d_lt_25)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
       ):
         return True, f"exit_{mode_name}_d_0_44"
-      elif (last_rsi_3_gt_96) and (last_willr_14 > -4.0) and (last_rsi_3_1h_lt_10):
+      elif (last_rsi_3_gt_96) and (last_willr_14_gt_neg_4) and (last_rsi_3_1h_lt_10):
         return True, f"exit_{mode_name}_d_0_45"
       elif (last_rsi_3_gt_98) and (last_rsi_3_1h_lt_15) and (last_rsi_3_4h_lt_10) and (last_roc_2_1d < -20.0):
         return True, f"exit_{mode_name}_d_0_46"
@@ -28914,7 +28961,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3_gt_98)
         and (last_stochrsi_k_1h_gt_80)
         and (last_stochrsi_k_4h_gt_40)
-        and (last_change_pct_1d < -5.0)
+        and (last_change_pct_1d_lt_neg_5)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -5.0))
       ):
         return True, f"exit_{mode_name}_d_0_47"
@@ -28928,20 +28975,20 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_0_48"
       elif (
         (last_rsi_3_gt_95)
-        and (last_willr_14 > -2.0)
+        and (last_willr_14_gt_neg_2)
         and (last_rsi_3_4h_lt_20)
-        and (last_change_pct_1d < -5.0)
+        and (last_change_pct_1d_lt_neg_5)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d > 50.0))
       ):
         return True, f"exit_{mode_name}_d_0_49"
-      elif (last_rsi_3 > 80.0) and (last_willr_14 > -2.0) and (last_rsi_3_1d < 10.0) and (last_stochrsi_k_1h > 90.0):
+      elif (last_rsi_3 > 80.0) and (last_willr_14_gt_neg_2) and (last_rsi_3_1d < 10.0) and (last_stochrsi_k_1h_gt_90):
         return True, f"exit_{mode_name}_d_0_50"
       elif (last_rsi_3 > 68.0) and (last_rsi_14_lt_44) and (last_rsi_3_4h_lt_20) and (last_stochrsi_k_1h_gt_50):
         return True, f"exit_{mode_name}_d_0_51"
       elif (
         (last_rsi_3_gt_95)
         and (last_rsi_14 > 62.0)
-        and (last_willr_14 > -10.0)
+        and (last_willr_14_gt_neg_10)
         and (last_stochrsi_k_1h_gt_70)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -15.0))
       ):
@@ -28949,7 +28996,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3_gt_95)
         and (last_rsi_14_lt_50)
-        and (last_willr_14 > -5.0)
+        and (last_willr_14_gt_neg_5)
         and (last_rsi_3_1h_lt_20)
         and (last_stochrsi_k_4h_gt_50)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d > 50.0))
@@ -28959,14 +29006,14 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 80.0)
         and (last_rsi_14_lt_44)
         and (last_stochrsi_k_1h_gt_50)
-        and (last_roc_9_4h < -10.0)
+        and (last_roc_9_4h_lt_neg_10)
         and (last_change_pct_1d < -10.0)
       ):
         return True, f"exit_{mode_name}_d_0_54"
       elif (
         (last_rsi_3_gt_98)
-        and (last_willr_14 > -12.0)
-        and (last_roc_9_4h < -5.0)
+        and (last_willr_14_gt_neg_12)
+        and (last_roc_9_4h_lt_neg_5)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 10.0))
         and (last_stochrsi_k_1h_gt_50)
       ):
@@ -28977,14 +29024,14 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_3_1h_lt_30)
         and (last_rsi_3_4h_lt_25)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
-        and (last_stochrsi_k_4h > 10.0)
+        and (last_stochrsi_k_4h_gt_10)
       ):
         return True, f"exit_{mode_name}_d_0_56"
       elif (
         (last_rsi_3 > 50.0)
         and (last_rsi_14 < 34.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
-        and (last_stochrsi_k_4h > 70.0)
+        and (last_stochrsi_k_4h_gt_70)
       ):
         return True, f"exit_{mode_name}_d_0_57"
       elif (
@@ -28997,7 +29044,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_0_58"
       elif (
         (last_rsi_3_gt_95)
-        and (last_willr_14 > -10.0)
+        and (last_willr_14_gt_neg_10)
         and (last_rsi_3_4h_lt_25)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -15.0))
         and (last_stochrsi_k_4h_gt_40)
@@ -29008,18 +29055,18 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14_lt_38)
         and (last_rsi_14_4h > 65.0)
         and (last_stochrsi_k_4h_gt_50)
-        and (last_stochrsi_k_1d > 50.0)
+        and (last_stochrsi_k_1d_gt_50)
       ):
         return True, f"exit_{mode_name}_d_0_60"
-      elif (last_rsi_3_gt_98) and (last_willr_14 > -25.0) and (last_rsi_3_4h_lt_10) and (last_stochrsi_k_1h_gt_30):
+      elif (last_rsi_3_gt_98) and (last_willr_14_gt_neg_25) and (last_rsi_3_4h_lt_10) and (last_stochrsi_k_1h_gt_30):
         return True, f"exit_{mode_name}_d_0_61"
       elif (
         (last_rsi_3 > 88.0)
-        and (last_willr_14 > -1.0)
+        and (last_willr_14_gt_neg_1)
         and (last_rsi_3_1h_lt_30)
         and (last_rsi_3_4h_lt_20)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 20.0))
-        and (last_change_pct_1d < -5.0)
+        and (last_change_pct_1d_lt_neg_5)
       ):
         return True, f"exit_{mode_name}_d_0_62"
       elif (last_rsi_3_gt_98) and (last_rsi_3_1d_lt_25) and (last_stochrsi_k_1h_gt_80) and (last_stochrsi_k_4h_gt_30):
@@ -29038,7 +29085,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 50.0)
         and (last_rsi_14_lt_40)
-        and (last_stochrsi_k_4h > 80.0)
+        and (last_stochrsi_k_4h_gt_80)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -25.0))
       ):
         return True, f"exit_{mode_name}_d_0_67"
@@ -29046,17 +29093,17 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 86.0)
         and (last_rsi_14_lt_46)
         and (last_rsi_3_1h_lt_25)
-        and (last_roc_2_4h < -30.0)
+        and (last_roc_2_4h_lt_neg_30)
         and (last_stochrsi_k_4h_gt_25)
       ):
         return True, f"exit_{mode_name}_d_0_68"
       elif (
-        (last_rsi_3 > 97.0) and (last_roc_9_4h > 20.0) and (last_stochrsi_k_4h_gt_50) and (last_change_pct_4h < -5.0)
+        (last_rsi_3 > 97.0) and (last_roc_9_4h > 20.0) and (last_stochrsi_k_4h_gt_50) and (last_change_pct_4h_lt_neg_5)
       ):
         return True, f"exit_{mode_name}_d_0_69"
       elif (last_rsi_3_gt_95) and (last_rsi_14_lt_38) and (last_rsi_3_1h_lt_25) and (last_stochrsi_k_4h_gt_20):
         return True, f"exit_{mode_name}_d_0_70"
-      elif (last_rsi_3_gt_95) and (last_rsi_14_lt_42) and (last_rsi_3_4h_lt_25) and (last_stochrsi_k_1h > 20.0):
+      elif (last_rsi_3_gt_95) and (last_rsi_14_lt_42) and (last_rsi_3_4h_lt_25) and (last_stochrsi_k_1h_gt_20):
         return True, f"exit_{mode_name}_d_0_71"
       elif (last_rsi_3_gt_95) and (last_rsi_14_lt_40) and (last_rsi_3_1h_lt_10) and (last_aroonu_14_4h_gt_25):
         return True, f"exit_{mode_name}_d_0_72"
@@ -29064,13 +29111,13 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3_gt_95)
         and (last_rsi_3_1h_lt_25)
         and (last_rsi_3_4h_lt_15)
-        and (last_roc_9_4h < -20.0)
+        and (last_roc_9_4h_lt_neg_20)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -25.0))
       ):
         return True, f"exit_{mode_name}_d_0_73"
       elif (
         (last_rsi_3_gt_99)
-        and (last_willr_14 > -10.0)
+        and (last_willr_14_gt_neg_10)
         and (last_rsi_3_4h_lt_25)
         and (last_rsi_3_1d_lt_25)
         and (last_stochrsi_k_1h_gt_50)
@@ -29083,7 +29130,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d > 50.0))
       ):
         return True, f"exit_{mode_name}_d_0_75"
-      elif (last_rsi_3_gt_95) and (last_rsi_14_lt_48) and (last_roc_9_1h > 80.0) and (last_stochrsi_k_4h > 80.0):
+      elif (last_rsi_3_gt_95) and (last_rsi_14_lt_48) and (last_roc_9_1h > 80.0) and (last_stochrsi_k_4h_gt_80):
         return True, f"exit_{mode_name}_d_0_76"
       elif (
         (last_rsi_3_gt_95)
@@ -29094,13 +29141,13 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_0_77"
       elif (
         (last_rsi_3_gt_98)
-        and (last_willr_14 > -14.0)
+        and (last_willr_14_gt_neg_14)
         and (last_rsi_3_1h_lt_30)
         and (last_rsi_3_4h_lt_20)
         and (last_rsi_3_1d < 20.0)
       ):
         return True, f"exit_{mode_name}_d_0_78"
-      elif (last_rsi_3 > 94.0) and (last_willr_14 > -1.0) and (last_rsi_3_1h_lt_30) and (last_rsi_3_4h_lt_10):
+      elif (last_rsi_3 > 94.0) and (last_willr_14_gt_neg_1) and (last_rsi_3_1h_lt_30) and (last_rsi_3_4h_lt_10):
         return True, f"exit_{mode_name}_d_0_79"
       elif (
         (last_rsi_3 > 74.0)
@@ -29112,7 +29159,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_0_80"
       elif (
         (last_rsi_3_gt_96)
-        and (last_willr_14 > -8.0)
+        and (last_willr_14_gt_neg_8)
         and (last_rsi_3_1h_lt_25)
         and (last_rsi_3_4h_lt_25)
         and (isinstance(last_rsi_14_1d, np.float64) and (last_rsi_14_1d > 50.0))
@@ -29120,7 +29167,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_0_81"
       elif (
         (last_rsi_3_gt_84)
-        and (last_willr_14 > -8.0)
+        and (last_willr_14_gt_neg_8)
         and (last_rsi_3_4h_lt_30)
         and (last_rsi_3_1d < 15.0)
         and (last_stochrsi_k_4h_gt_40)
@@ -29134,11 +29181,11 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_stochrsi_k_4h_gt_40)
       ):
         return True, f"exit_{mode_name}_d_0_83"
-      elif (last_rsi_3_gt_99) and (last_willr_14 > -1.0) and (last_rsi_3_4h_lt_30) and (last_stochrsi_k_1h > 20.0):
+      elif (last_rsi_3_gt_99) and (last_willr_14_gt_neg_1) and (last_rsi_3_4h_lt_30) and (last_stochrsi_k_1h_gt_20):
         return True, f"exit_{mode_name}_d_0_84"
       elif (
         (last_rsi_3_gt_99)
-        and (last_willr_14 > -6.0)
+        and (last_willr_14_gt_neg_6)
         and (last_rsi_3_1h_lt_30)
         and (last_rsi_3_4h_lt_40)
         and (last_stochrsi_k_4h_gt_50)
@@ -29162,7 +29209,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_0_87"
       elif (
         (last_rsi_3_gt_95)
-        and (last_willr_14 > -2.0)
+        and (last_willr_14_gt_neg_2)
         and (last_stochrsi_k_1h_gt_40)
         and (last_stochrsi_k_4h_gt_50)
         and (last_change_pct_1h < -2.0)
@@ -29171,13 +29218,13 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3_gt_90)
         and (last_rsi_14_lt_38)
-        and (last_roc_9_1h < -5.0)
+        and (last_roc_9_1h_lt_neg_5)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 25.0))
       ):
         return True, f"exit_{mode_name}_d_0_89"
       elif (
         (last_rsi_3 > 94.0)
-        and (last_willr_14 > -25.0)
+        and (last_willr_14_gt_neg_25)
         and (last_rsi_3_1h_lt_50)
         and (last_rsi_3_4h_lt_30)
         and (last_aroonu_14_4h_gt_50)
@@ -29197,7 +29244,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3_gt_95)
         and (last_rsi_14_lt_46)
         and (last_rsi_3_1h_lt_40)
-        and (last_stochrsi_k_1h > 25.0)
+        and (last_stochrsi_k_1h_gt_25)
         and (last_stochrsi_k_4h_gt_50)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -25.0))
       ):
@@ -29224,10 +29271,10 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_0_94"
       elif (
         (last_rsi_3_gt_95)
-        and (last_willr_14 > -10.0)
+        and (last_willr_14_gt_neg_10)
         and (last_rsi_3_1h_lt_45)
         and (last_rsi_3_4h_lt_40)
-        and (last_stochrsi_k_4h > 10.0)
+        and (last_stochrsi_k_4h_gt_10)
         and (isinstance(last_aroonu_14_1d, np.float64) and (last_aroonu_14_1d > 75.0))
       ):
         return True, f"exit_{mode_name}_d_0_95"
@@ -29262,15 +29309,15 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_3_1h < 65.0)
         and (last_rsi_3_4h_lt_60)
         and (last_aroonu_14_4h_gt_50)
-        and (last_stoch_k_4h > 40.0)
+        and (last_stoch_k_4h_gt_40)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 80.0))
       ):
         return True, f"exit_{mode_name}_d_0_99"
-      elif (last_rsi_3_gt_99) and (last_rsi_14_gt_78) and (last_rsi_3_15m > 70.0) and (last_rsi_3_4h < 80.0):
+      elif (last_rsi_3_gt_99) and (last_rsi_14_gt_78) and (last_rsi_3_15m_gt_70) and (last_rsi_3_4h < 80.0):
         return True, f"exit_{mode_name}_d_0_100"
       elif (
         (last_rsi_3 > 86.0)
-        and (last_willr_14 > -14.0)
+        and (last_willr_14_gt_neg_14)
         and (last_rsi_3_1h_lt_50)
         and (last_stochrsi_k_4h_gt_40)
         and (isinstance(last_roc_9_4h, np.float64) and (last_roc_9_4h > 40.0))
@@ -29299,7 +29346,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_3_1h_lt_60)
         and (last_stochrsi_k_1h_gt_40)
         and (last_stochrsi_k_4h_gt_90)
-        and (last_roc_9_4h > 40.0)
+        and (last_roc_9_4h_gt_40)
       ):
         return True, f"exit_{mode_name}_d_0_104"
       elif (
@@ -29307,7 +29354,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14_lt_46)
         and (last_rsi_3_15m < 55.0)
         and (last_stochrsi_k_4h_gt_90)
-        and (last_roc_9_4h > 25.0)
+        and (last_roc_9_4h_gt_25)
       ):
         return True, f"exit_{mode_name}_d_0_105"
       elif (
@@ -29316,7 +29363,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_3_1h_lt_50)
         and (last_stochrsi_k_1h_gt_50)
         and (last_rsi_14_4h_gt_70)
-        and (last_roc_9_4h > 40.0)
+        and (last_roc_9_4h_gt_40)
       ):
         return True, f"exit_{mode_name}_d_0_106"
       elif (
@@ -29331,13 +29378,13 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_0_108"
       elif (
         (last_rsi_3_gt_95)
-        and (last_willr_14 > -6.0)
+        and (last_willr_14_gt_neg_6)
         and (last_rsi_3_1h_lt_50)
         and (last_rsi_3_4h_lt_20)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 50.0))
       ):
         return True, f"exit_{mode_name}_d_0_109"
-      elif (last_rsi_3_gt_95) and (last_rsi_3_4h < 65.0) and (last_stochrsi_k_4h_gt_50) and (last_roc_9_4h > 25.0):
+      elif (last_rsi_3_gt_95) and (last_rsi_3_4h < 65.0) and (last_stochrsi_k_4h_gt_50) and (last_roc_9_4h_gt_25):
         return True, f"exit_{mode_name}_d_0_110"
       elif (
         (last_rsi_3_gt_95)
@@ -29351,17 +29398,17 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_0_111"
       elif (
         (last_rsi_3_gt_95)
-        and (last_willr_14 > -20.0)
+        and (last_willr_14_gt_neg_20)
         and (last_rsi_14_lt_50)
         and (last_rsi_3_1h_lt_35)
-        and (last_rsi_3_4h < 35.0)
+        and (last_rsi_3_4h_lt_35)
         and (last_rsi_3_1d < 60.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
       ):
         return True, f"exit_{mode_name}_d_0_112"
       elif (
         (last_rsi_3_gt_95)
-        and (last_willr_14 > -1.0)
+        and (last_willr_14_gt_neg_1)
         and (last_rsi_3_1d_lt_30)
         and (last_stochrsi_k_4h_gt_50)
         and (isinstance(last_roc_9_4h, np.float64) and (last_roc_9_4h > 10.0))
@@ -29379,7 +29426,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3_gt_95)
         and (last_rsi_14_lt_46)
-        and (last_rsi_3_15m < 30.0)
+        and (last_rsi_3_15m_lt_30)
         and (last_stochrsi_k_1h_gt_50)
         and (last_stochrsi_k_4h_gt_50)
       ):
@@ -29392,7 +29439,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_0_118"
       elif (
         (last_rsi_3_gt_95)
-        and (last_willr_14 > -20.0)
+        and (last_willr_14_gt_neg_20)
         and (last_rsi_3_1h_lt_60)
         and (last_rsi_3_4h_lt_60)
         and (last_stochrsi_k_1h_gt_40)
@@ -29404,7 +29451,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_0_121"
       elif (last_rsi_3_gt_95) and (last_rsi_14_lt_42) and (last_rsi_3_4h_lt_30) and (last_stochrsi_k_1h_gt_50):
         return True, f"exit_{mode_name}_d_0_122"
-      elif (last_rsi_3_gt_95) and (last_willr_14 > -2.0) and (last_rsi_3_1h_lt_10) and (last_rsi_3_1d_lt_30):
+      elif (last_rsi_3_gt_95) and (last_willr_14_gt_neg_2) and (last_rsi_3_1h_lt_10) and (last_rsi_3_1d_lt_30):
         return True, f"exit_{mode_name}_d_0_123"
       elif (
         (last_rsi_3_gt_95)
@@ -29414,16 +29461,16 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_0_124"
       elif (
         (last_rsi_3_gt_95)
-        and (last_willr_14 > -2.0)
+        and (last_willr_14_gt_neg_2)
         and (last_rsi_3_1h_lt_10)
         and (last_rsi_3_4h_lt_40)
-        and (last_rsi_3_1d < 40.0)
+        and (last_rsi_3_1d_lt_40)
         and (last_close < (last_high_max_30_1d * 0.50))
       ):
         return True, f"exit_{mode_name}_d_0_125"
       elif (last_rsi_3_gt_95) and (last_rsi_3_1h_lt_15) and (last_rsi_3_4h_lt_40) and (last_stochrsi_k_4h_gt_50):
         return True, f"exit_{mode_name}_d_0_126"
-      elif (last_rsi_3_gt_95) and (last_rsi_3_1h_lt_10) and (last_rsi_3_4h_lt_30) and (last_rsi_3_1d < 40.0):
+      elif (last_rsi_3_gt_95) and (last_rsi_3_1h_lt_10) and (last_rsi_3_4h_lt_30) and (last_rsi_3_1d_lt_40):
         return True, f"exit_{mode_name}_d_0_127"
       elif (last_rsi_3_gt_96) and (last_rsi_3_4h_lt_30) and (last_aroonu_14_4h > 85.0):
         return True, f"exit_{mode_name}_d_0_128"
@@ -29445,7 +29492,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3_gt_95)
         and (last_rsi_3_1h_lt_35)
-        and (last_rsi_3_4h < 35.0)
+        and (last_rsi_3_4h_lt_35)
         and (last_aroonu_14_1h > 50.0)
         and (last_stochrsi_k_1h_gt_40)
       ):
@@ -29515,7 +29562,7 @@ class NostalgiaForInfinityX7(IStrategy):
       last_rsi_14_4h_gt_70 = last_rsi_14_4h > 70.0
       last_rsi_3_1d_lt_30 = last_rsi_3_1d < 30.0
       if (
-        (last_willr_14 > -1.0)
+        (last_willr_14_gt_neg_1)
         and (last_rsi_14 > 78.0)
         and (isinstance(last_ema_200_1h, np.float64) and (last_ema_12_1h < last_ema_200_1h))
         and (isinstance(last_ema_200_4h, np.float64) and (last_ema_12_4h < last_ema_200_4h))
@@ -29524,68 +29571,68 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_1_1"
       elif (
-        (last_willr_14 > -1.0)
+        (last_willr_14_gt_neg_1)
         and (last_rsi_14 > 68.0)
-        and (last_cmf_20_1h < -0.0)
+        and (last_cmf_20_1h_lt_0)
         and (isinstance(last_ema_200_1h, np.float64) and (last_ema_12_1h < last_ema_200_1h))
         and (isinstance(last_ema_200_4h, np.float64) and (last_ema_12_4h < last_ema_200_4h))
       ):
         return True, f"exit_{mode_name}_d_1_2"
       elif (
-        (last_willr_14 > -8.0)
+        (last_willr_14_gt_neg_8)
         and (last_stochrsi_k > 99.0)
-        and (last_cmf_20_1h < -0.0)
-        and (last_cmf_20_4h < -0.0)
-        and ((last_stochrsi_k_4h_gt_20) and (last_stochrsi_k_change_pct_4h < -10.0))
+        and (last_cmf_20_1h_lt_0)
+        and (last_cmf_20_4h_lt_0)
+        and ((last_stochrsi_k_4h_gt_20) and (last_stochrsi_k_change_pct_4h_lt_neg_10))
       ):
         return True, f"exit_{mode_name}_d_1_3"
       elif (
-        (last_willr_14 > -30.0)
+        (last_willr_14_gt_neg_30)
         and (last_rsi_14 > 65.0)
         and (last_stochrsi_k > 95.0)
-        and (last_stochrsi_k_4h > 70.0)
+        and (last_stochrsi_k_4h_gt_70)
         and (isinstance(last_ema_200_1h, np.float64) and (last_ema_12_1h < last_ema_200_1h))
         and (isinstance(last_ema_200_4h, np.float64) and (last_ema_12_4h < last_ema_200_4h))
       ):
         return True, f"exit_{mode_name}_d_1_4"
-      elif (last_willr_14 > -2.0) and (last_rsi_14 > 72.0) and (last_roc_9_1h < -5.0) and (last_roc_9_4h < -5.0):
+      elif (last_willr_14_gt_neg_2) and (last_rsi_14 > 72.0) and (last_roc_9_1h_lt_neg_5) and (last_roc_9_4h_lt_neg_5):
         return True, f"exit_{mode_name}_d_1_5"
       elif (
         (last_rsi_3_gt_70)
-        and (last_stochrsi_k > 70.0)
+        and (last_stochrsi_k_gt_70)
         and (last_rsi_14_lt_40)
-        and (last_roc_9_1h < -10.0)
+        and (last_roc_9_1h_lt_neg_10)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 50.0))
       ):
         return True, f"exit_{mode_name}_d_1_6"
       elif (
         (last_rsi_14_lt_50)
-        and (last_stochrsi_k > 70.0)
+        and (last_stochrsi_k_gt_70)
         and (last_stochrsi_k_4h_gt_50)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -40.0))
       ):
         return True, f"exit_{mode_name}_d_1_7"
       elif (
-        (last_willr_14 > -2.0)
+        (last_willr_14_gt_neg_2)
         and (last_stochrsi_k > 95.0)
         and (last_cmf_20_1h < -0.1)
         and (last_cmf_20_4h < -0.1)
-        and (last_change_pct_1d < -5.0)
+        and (last_change_pct_1d_lt_neg_5)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 15.0))
       ):
         return True, f"exit_{mode_name}_d_1_8"
       elif (
-        (last_willr_14 > -2.0)
+        (last_willr_14_gt_neg_2)
         and (last_rsi_3_gt_95)
-        and (last_change_pct_4h < -5.0)
+        and (last_change_pct_4h_lt_neg_5)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
       ):
         return True, f"exit_{mode_name}_d_1_9"
       elif (
-        (last_willr_14 > -20.0)
+        (last_willr_14_gt_neg_20)
         and (last_rsi_14_lt_50)
-        and (last_roc_9_1h < -10.0)
-        and (last_roc_9_4h < -10.0)
+        and (last_roc_9_1h_lt_neg_10)
+        and (last_roc_9_4h_lt_neg_10)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 10.0))
       ):
         return True, f"exit_{mode_name}_d_1_10"
@@ -29593,7 +29640,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 75.0)
         and (last_rsi_14 < 45.0)
         and (last_roc_9_15m < -10.0)
-        and (last_roc_9_1h < -10.0)
+        and (last_roc_9_1h_lt_neg_10)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -20.0))
       ):
         return True, f"exit_{mode_name}_d_1_11"
@@ -29602,26 +29649,26 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14_lt_50)
         and (last_rsi_3_4h_lt_10)
         and (last_roc_9_1h < -20.0)
-        and (last_roc_9_4h < -20.0)
+        and (last_roc_9_4h_lt_neg_20)
       ):
         return True, f"exit_{mode_name}_d_1_12"
-      elif (last_rsi_3_gt_80) and (last_rsi_3_4h < 5.0) and (last_roc_9_4h < -25.0):
+      elif (last_rsi_3_gt_80) and (last_rsi_3_4h_lt_5) and (last_roc_9_4h_lt_neg_25):
         return True, f"exit_{mode_name}_d_1_13"
-      elif (last_rsi_3_gt_90) and (last_willr_14 > -4.0) and (last_rsi_3_4h < 5.0) and (last_aroonu_14_4h_gt_25):
+      elif (last_rsi_3_gt_90) and (last_willr_14_gt_neg_4) and (last_rsi_3_4h_lt_5) and (last_aroonu_14_4h_gt_25):
         return True, f"exit_{mode_name}_d_1_14"
       elif (last_rsi_3_gt_95) and (last_rsi_14 > 75.0) and (last_roc_9_4h < -30.0):
         return True, f"exit_{mode_name}_d_1_15"
       elif (
         (last_rsi_3_gt_95)
         and (last_aroonu_14_4h_gt_25)
-        and (last_roc_9_4h < -25.0)
+        and (last_roc_9_4h_lt_neg_25)
         and (last_aroonu_14_1d > 50.0)
         and (last_change_pct_1d < -15.0)
       ):
         return True, f"exit_{mode_name}_d_1_16"
       elif (
         (last_rsi_3_gt_90)
-        and (last_willr_14 > -10.0)
+        and (last_willr_14_gt_neg_10)
         and (last_rsi_3_1h_lt_10)
         and (last_stochrsi_k_4h_gt_90)
         and (last_roc_9_4h > 30.0)
@@ -29642,31 +29689,31 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_1_21"
       elif (
         (last_rsi_3_gt_98)
-        and (last_willr_14 > -2.0)
-        and (last_change_pct_4h < -5.0)
+        and (last_willr_14_gt_neg_2)
+        and (last_change_pct_4h_lt_neg_5)
         and (last_stochrsi_k_4h_gt_50)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
       ):
         return True, f"exit_{mode_name}_d_1_22"
-      elif (last_rsi_3_gt_95) and (last_willr_14 > -10.0) and (last_rsi_3_1h_lt_15) and (last_rsi_3_1d < 5.0):
+      elif (last_rsi_3_gt_95) and (last_willr_14_gt_neg_10) and (last_rsi_3_1h_lt_15) and (last_rsi_3_1d < 5.0):
         return True, f"exit_{mode_name}_d_1_23"
       elif (
         (last_rsi_3_gt_95)
         and (last_rsi_14 > 75.0)
-        and (last_willr_14 > -10.0)
+        and (last_willr_14_gt_neg_10)
         and (last_rsi_3_4h_lt_30)
         and (last_aroonu_14_4h_gt_75)
       ):
         return True, f"exit_{mode_name}_d_1_24"
       elif (
         (last_rsi_3_gt_90)
-        and (last_willr_14 > -4.0)
+        and (last_willr_14_gt_neg_4)
         and (last_rsi_3_4h_lt_10)
         and (last_roc_9_4h < -15.0)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d > 50.0))
       ):
         return True, f"exit_{mode_name}_d_1_25"
-      elif (last_rsi_3_gt_85) and (last_willr_14 > -4.0) and (last_rsi_3_4h_lt_15) and (last_roc_9_4h < -20.0):
+      elif (last_rsi_3_gt_85) and (last_willr_14_gt_neg_4) and (last_rsi_3_4h_lt_15) and (last_roc_9_4h_lt_neg_20):
         return True, f"exit_{mode_name}_d_1_26"
       elif (
         (last_rsi_3_gt_65)
@@ -29693,27 +29740,27 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14_lt_50)
         and (last_rsi_3_1h_lt_15)
         and (last_rsi_3_4h_lt_15)
-        and (last_stochrsi_k_1h > 25.0)
+        and (last_stochrsi_k_1h_gt_25)
       ):
         return True, f"exit_{mode_name}_d_1_31"
-      elif (last_rsi_3_gt_90) and (last_rsi_3_1h_lt_15) and (last_roc_2_4h < -30.0) and (last_stochrsi_k_4h_gt_30):
+      elif (last_rsi_3_gt_90) and (last_rsi_3_1h_lt_15) and (last_roc_2_4h_lt_neg_30) and (last_stochrsi_k_4h_gt_30):
         return True, f"exit_{mode_name}_d_1_32"
       elif (
         (last_rsi_3_gt_90)
-        and (last_willr_14 > -2.0)
+        and (last_willr_14_gt_neg_2)
         and (last_roc_2_1h < -10.0)
         and (last_roc_9_1h > 30.0)
         and (last_stochrsi_k_1h_gt_50)
       ):
         return True, f"exit_{mode_name}_d_1_33"
-      elif (last_rsi_3_gt_65) and (last_rsi_3_15m < 30.0) and (last_rsi_14_1h > 80.0) and (last_roc_9_1h > 40.0):
+      elif (last_rsi_3_gt_65) and (last_rsi_3_15m_lt_30) and (last_rsi_14_1h > 80.0) and (last_roc_9_1h > 40.0):
         return True, f"exit_{mode_name}_d_1_34"
-      elif (last_rsi_3_gt_88) and (last_willr_14 > -6.0) and (last_rsi_3_1d_lt_25) and (last_stochrsi_k_1h > 75.0):
+      elif (last_rsi_3_gt_88) and (last_willr_14_gt_neg_6) and (last_rsi_3_1d_lt_25) and (last_stochrsi_k_1h_gt_75):
         return True, f"exit_{mode_name}_d_1_35"
       elif (
         (last_rsi_3_gt_85)
-        and (last_willr_14 > -15.0)
-        and (last_roc_9_4h < -25.0)
+        and (last_willr_14_gt_neg_15)
+        and (last_roc_9_4h_lt_neg_25)
         and (last_rsi_3_1d_lt_25)
         and (last_stochrsi_k_1h_gt_50)
       ):
@@ -29726,13 +29773,13 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_stochrsi_k_4h_gt_50)
       ):
         return True, f"exit_{mode_name}_d_1_37"
-      elif (last_rsi_3_gt_85) and (last_willr_14 > -15.0) and (last_rsi_3_4h_lt_10) and (last_stochrsi_k_4h_gt_20):
+      elif (last_rsi_3_gt_85) and (last_willr_14_gt_neg_15) and (last_rsi_3_4h_lt_10) and (last_stochrsi_k_4h_gt_20):
         return True, f"exit_{mode_name}_d_1_38"
-      elif (last_rsi_3_gt_95) and (last_willr_14 > -5.0) and (last_cmf_20_4h < -0.0) and (last_rsi_3_4h_lt_10):
+      elif (last_rsi_3_gt_95) and (last_willr_14_gt_neg_5) and (last_cmf_20_4h_lt_0) and (last_rsi_3_4h_lt_10):
         return True, f"exit_{mode_name}_d_1_39"
       elif (
         (last_rsi_3_gt_85)
-        and (last_willr_14 > -15.0)
+        and (last_willr_14_gt_neg_15)
         and (last_rsi_3_1h_lt_30)
         and (last_stochrsi_k_1h_gt_30)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d > 90.0))
@@ -29740,7 +29787,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_1_40"
       elif (
         (last_rsi_3_gt_95)
-        and (last_willr_14 > -10.0)
+        and (last_willr_14_gt_neg_10)
         and (last_rsi_3_1h_lt_30)
         and (last_stochrsi_k_4h_gt_25)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 50.0))
@@ -29748,7 +29795,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_1_41"
       elif (
         (last_rsi_3_gt_90)
-        and (last_willr_14 > -25.0)
+        and (last_willr_14_gt_neg_25)
         and (last_stochrsi_k_4h_gt_30)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 40.0))
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d > 70.0))
@@ -29764,13 +29811,13 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_1_43"
       elif (
         (last_rsi_3_gt_65)
-        and (last_willr_14 > -5.0)
+        and (last_willr_14_gt_neg_5)
         and (last_rsi_3_4h_lt_30)
         and (last_rsi_3_1d_lt_25)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
       ):
         return True, f"exit_{mode_name}_d_1_44"
-      elif (last_rsi_3_gt_94) and (last_willr_14 > -6.0) and (last_rsi_3_1h_lt_10):
+      elif (last_rsi_3_gt_94) and (last_willr_14_gt_neg_6) and (last_rsi_3_1h_lt_10):
         return True, f"exit_{mode_name}_d_1_45"
       elif (last_rsi_3_gt_70) and (last_rsi_3_1h_lt_15) and (last_rsi_3_4h_lt_10) and (last_roc_2_1d < -20.0):
         return True, f"exit_{mode_name}_d_1_46"
@@ -29778,7 +29825,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3_gt_86)
         and (last_stochrsi_k_1h_gt_80)
         and (last_stochrsi_k_4h_gt_40)
-        and (last_change_pct_1d < -5.0)
+        and (last_change_pct_1d_lt_neg_5)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -5.0))
       ):
         return True, f"exit_{mode_name}_d_1_47"
@@ -29792,20 +29839,20 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_1_48"
       elif (
         (last_rsi_3_gt_90)
-        and (last_willr_14 > -4.0)
+        and (last_willr_14_gt_neg_4)
         and (last_rsi_3_4h_lt_20)
-        and (last_change_pct_1d < -5.0)
+        and (last_change_pct_1d_lt_neg_5)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d > 50.0))
       ):
         return True, f"exit_{mode_name}_d_1_49"
-      elif (last_rsi_3_gt_80) and (last_willr_14 > -4.0) and (last_rsi_3_1d < 10.0) and (last_stochrsi_k_1h > 90.0):
+      elif (last_rsi_3_gt_80) and (last_willr_14_gt_neg_4) and (last_rsi_3_1d < 10.0) and (last_stochrsi_k_1h_gt_90):
         return True, f"exit_{mode_name}_d_1_50"
       elif (last_rsi_3_gt_66) and (last_rsi_14_lt_46) and (last_rsi_3_4h_lt_20) and (last_stochrsi_k_1h_gt_50):
         return True, f"exit_{mode_name}_d_1_51"
       elif (
         (last_rsi_3_gt_80)
         and (last_rsi_14 > 60.0)
-        and (last_willr_14 > -10.0)
+        and (last_willr_14_gt_neg_10)
         and (last_stochrsi_k_1h_gt_70)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -15.0))
       ):
@@ -29813,7 +29860,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3_gt_70)
         and (last_rsi_14_lt_50)
-        and (last_willr_14 > -25.0)
+        and (last_willr_14_gt_neg_25)
         and (last_rsi_3_1h_lt_20)
         and (last_stochrsi_k_4h_gt_50)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d > 50.0))
@@ -29823,14 +29870,14 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3_gt_78)
         and (last_rsi_14_lt_46)
         and (last_stochrsi_k_1h_gt_50)
-        and (last_roc_9_4h < -10.0)
+        and (last_roc_9_4h_lt_neg_10)
         and (last_change_pct_1d < -10.0)
       ):
         return True, f"exit_{mode_name}_d_1_54"
       elif (
         (last_rsi_3_gt_94)
-        and (last_willr_14 > -14.0)
-        and (last_roc_9_4h < -5.0)
+        and (last_willr_14_gt_neg_14)
+        and (last_roc_9_4h_lt_neg_5)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 10.0))
         and (last_stochrsi_k_1h_gt_50)
       ):
@@ -29841,14 +29888,14 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_3_1h_lt_30)
         and (last_rsi_3_4h_lt_25)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
-        and (last_stochrsi_k_4h > 10.0)
+        and (last_stochrsi_k_4h_gt_10)
       ):
         return True, f"exit_{mode_name}_d_1_56"
       elif (
         (last_rsi_3_gt_50)
         and (last_rsi_14 < 36.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
-        and (last_stochrsi_k_4h > 70.0)
+        and (last_stochrsi_k_4h_gt_70)
       ):
         return True, f"exit_{mode_name}_d_1_57"
       elif (
@@ -29861,7 +29908,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_1_58"
       elif (
         (last_rsi_3_gt_85)
-        and (last_willr_14 > -12.0)
+        and (last_willr_14_gt_neg_12)
         and (last_rsi_3_4h_lt_25)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -15.0))
         and (last_stochrsi_k_4h_gt_40)
@@ -29872,18 +29919,18 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14_lt_40)
         and (last_rsi_14_4h > 65.0)
         and (last_stochrsi_k_4h_gt_50)
-        and (last_stochrsi_k_1d > 50.0)
+        and (last_stochrsi_k_1d_gt_50)
       ):
         return True, f"exit_{mode_name}_d_1_60"
-      elif (last_rsi_3_gt_90) and (last_willr_14 > -25.0) and (last_rsi_3_4h_lt_10) and (last_stochrsi_k_1h_gt_30):
+      elif (last_rsi_3_gt_90) and (last_willr_14_gt_neg_25) and (last_rsi_3_4h_lt_10) and (last_stochrsi_k_1h_gt_30):
         return True, f"exit_{mode_name}_d_1_61"
       elif (
         (last_rsi_3_gt_86)
-        and (last_willr_14 > -2.0)
+        and (last_willr_14_gt_neg_2)
         and (last_rsi_3_1h_lt_30)
         and (last_rsi_3_4h_lt_20)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 20.0))
-        and (last_change_pct_1d < -5.0)
+        and (last_change_pct_1d_lt_neg_5)
       ):
         return True, f"exit_{mode_name}_d_1_62"
       elif (last_rsi_3_gt_68) and (last_rsi_3_1d_lt_25) and (last_stochrsi_k_1h_gt_80) and (last_stochrsi_k_4h_gt_30):
@@ -29902,7 +29949,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3_gt_50)
         and (last_rsi_14_lt_42)
-        and (last_stochrsi_k_4h > 80.0)
+        and (last_stochrsi_k_4h_gt_80)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -25.0))
       ):
         return True, f"exit_{mode_name}_d_1_67"
@@ -29910,17 +29957,17 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3_gt_84)
         and (last_rsi_14_lt_48)
         and (last_rsi_3_1h_lt_25)
-        and (last_roc_2_4h < -30.0)
+        and (last_roc_2_4h_lt_neg_30)
         and (last_stochrsi_k_4h_gt_25)
       ):
         return True, f"exit_{mode_name}_d_1_68"
       elif (
-        (last_rsi_3 > 96.0) and (last_roc_9_4h > 20.0) and (last_stochrsi_k_4h_gt_50) and (last_change_pct_4h < -5.0)
+        (last_rsi_3 > 96.0) and (last_roc_9_4h > 20.0) and (last_stochrsi_k_4h_gt_50) and (last_change_pct_4h_lt_neg_5)
       ):
         return True, f"exit_{mode_name}_d_1_69"
       elif (last_rsi_3_gt_66) and (last_rsi_14_lt_40) and (last_rsi_3_1h_lt_25) and (last_stochrsi_k_4h_gt_20):
         return True, f"exit_{mode_name}_d_1_70"
-      elif (last_rsi_3 > 64.0) and (last_rsi_14_lt_44) and (last_rsi_3_4h_lt_25) and (last_stochrsi_k_1h > 20.0):
+      elif (last_rsi_3 > 64.0) and (last_rsi_14_lt_44) and (last_rsi_3_4h_lt_25) and (last_stochrsi_k_1h_gt_20):
         return True, f"exit_{mode_name}_d_1_71"
       elif (last_rsi_3_gt_78) and (last_rsi_14_lt_42) and (last_rsi_3_1h_lt_10) and (last_aroonu_14_4h_gt_25):
         return True, f"exit_{mode_name}_d_1_72"
@@ -29928,13 +29975,13 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3_gt_78)
         and (last_rsi_3_1h_lt_25)
         and (last_rsi_3_4h_lt_15)
-        and (last_roc_9_4h < -20.0)
+        and (last_roc_9_4h_lt_neg_20)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -25.0))
       ):
         return True, f"exit_{mode_name}_d_1_73"
       elif (
         (last_rsi_3_gt_98)
-        and (last_willr_14 > -10.0)
+        and (last_willr_14_gt_neg_10)
         and (last_rsi_3_4h_lt_25)
         and (last_rsi_3_1d_lt_25)
         and (last_stochrsi_k_1h_gt_50)
@@ -29947,7 +29994,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d > 50.0))
       ):
         return True, f"exit_{mode_name}_d_1_75"
-      elif (last_rsi_3_gt_68) and (last_rsi_14_lt_50) and (last_roc_9_1h > 80.0) and (last_stochrsi_k_4h > 80.0):
+      elif (last_rsi_3_gt_68) and (last_rsi_14_lt_50) and (last_roc_9_1h > 80.0) and (last_stochrsi_k_4h_gt_80):
         return True, f"exit_{mode_name}_d_1_76"
       elif (
         (last_rsi_3_gt_76)
@@ -29958,13 +30005,13 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_1_77"
       elif (
         (last_rsi_3_gt_86)
-        and (last_willr_14 > -16.0)
+        and (last_willr_14_gt_neg_16)
         and (last_rsi_3_1h_lt_30)
         and (last_rsi_3_4h_lt_20)
         and (last_rsi_3_1d < 20.0)
       ):
         return True, f"exit_{mode_name}_d_1_78"
-      elif (last_rsi_3 > 92.0) and (last_willr_14 > -2.0) and (last_rsi_3_1h_lt_30) and (last_rsi_3_4h_lt_10):
+      elif (last_rsi_3 > 92.0) and (last_willr_14_gt_neg_2) and (last_rsi_3_1h_lt_30) and (last_rsi_3_4h_lt_10):
         return True, f"exit_{mode_name}_d_1_79"
       elif (
         (last_rsi_3_gt_72)
@@ -29976,7 +30023,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_1_80"
       elif (
         (last_rsi_3_gt_84)
-        and (last_willr_14 > -10.0)
+        and (last_willr_14_gt_neg_10)
         and (last_rsi_3_1h_lt_25)
         and (last_rsi_3_4h_lt_25)
         and (isinstance(last_rsi_14_1d, np.float64) and (last_rsi_14_1d > 50.0))
@@ -29984,7 +30031,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_1_81"
       elif (
         (last_rsi_3_gt_82)
-        and (last_willr_14 > -10.0)
+        and (last_willr_14_gt_neg_10)
         and (last_rsi_3_4h_lt_30)
         and (last_rsi_3_1d < 15.0)
         and (last_stochrsi_k_4h_gt_40)
@@ -29998,11 +30045,11 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_stochrsi_k_4h_gt_40)
       ):
         return True, f"exit_{mode_name}_d_1_83"
-      elif (last_rsi_3_gt_90) and (last_willr_14 > -2.0) and (last_rsi_3_4h_lt_30) and (last_stochrsi_k_1h > 20.0):
+      elif (last_rsi_3_gt_90) and (last_willr_14_gt_neg_2) and (last_rsi_3_4h_lt_30) and (last_stochrsi_k_1h_gt_20):
         return True, f"exit_{mode_name}_d_1_84"
       elif (
         (last_rsi_3_gt_88)
-        and (last_willr_14 > -8.0)
+        and (last_willr_14_gt_neg_8)
         and (last_rsi_3_1h_lt_30)
         and (last_rsi_3_4h_lt_40)
         and (last_stochrsi_k_4h_gt_50)
@@ -30026,7 +30073,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_1_87"
       elif (
         (last_rsi_3_gt_88)
-        and (last_willr_14 > -20.0)
+        and (last_willr_14_gt_neg_20)
         and (last_stochrsi_k_1h_gt_40)
         and (last_stochrsi_k_4h_gt_50)
         and (last_change_pct_1h < -2.0)
@@ -30035,13 +30082,13 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3_gt_78)
         and (last_rsi_14_lt_40)
-        and (last_roc_9_1h < -5.0)
+        and (last_roc_9_1h_lt_neg_5)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 25.0))
       ):
         return True, f"exit_{mode_name}_d_1_89"
       elif (
         (last_rsi_3 > 92.0)
-        and (last_willr_14 > -25.0)
+        and (last_willr_14_gt_neg_25)
         and (last_rsi_3_1h_lt_50)
         and (last_rsi_3_4h_lt_30)
         and (last_aroonu_14_4h_gt_50)
@@ -30061,7 +30108,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3_gt_80)
         and (last_rsi_14_lt_48)
         and (last_rsi_3_1h_lt_40)
-        and (last_stochrsi_k_1h > 25.0)
+        and (last_stochrsi_k_1h_gt_25)
         and (last_stochrsi_k_4h_gt_50)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -25.0))
       ):
@@ -30088,10 +30135,10 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_1_94"
       elif (
         (last_rsi_3_gt_84)
-        and (last_willr_14 > -12.0)
+        and (last_willr_14_gt_neg_12)
         and (last_rsi_3_1h_lt_45)
         and (last_rsi_3_4h_lt_40)
-        and (last_stochrsi_k_4h > 10.0)
+        and (last_stochrsi_k_4h_gt_10)
         and (isinstance(last_aroonu_14_1d, np.float64) and (last_aroonu_14_1d > 75.0))
       ):
         return True, f"exit_{mode_name}_d_1_95"
@@ -30126,15 +30173,15 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_3_1h < 65.0)
         and (last_rsi_3_4h_lt_60)
         and (last_aroonu_14_4h_gt_50)
-        and (last_stoch_k_4h > 40.0)
+        and (last_stoch_k_4h_gt_40)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 80.0))
       ):
         return True, f"exit_{mode_name}_d_1_99"
-      elif (last_rsi_3_gt_98) and (last_rsi_14 > 76.0) and (last_rsi_3_15m > 70.0) and (last_rsi_3_4h < 80.0):
+      elif (last_rsi_3_gt_98) and (last_rsi_14 > 76.0) and (last_rsi_3_15m_gt_70) and (last_rsi_3_4h < 80.0):
         return True, f"exit_{mode_name}_d_1_100"
       elif (
         (last_rsi_3_gt_84)
-        and (last_willr_14 > -16.0)
+        and (last_willr_14_gt_neg_16)
         and (last_rsi_3_1h_lt_50)
         and (last_stochrsi_k_4h_gt_40)
         and (isinstance(last_roc_9_4h, np.float64) and (last_roc_9_4h > 40.0))
@@ -30163,7 +30210,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_3_1h_lt_60)
         and (last_stochrsi_k_1h_gt_40)
         and (last_stochrsi_k_4h_gt_90)
-        and (last_roc_9_4h > 40.0)
+        and (last_roc_9_4h_gt_40)
       ):
         return True, f"exit_{mode_name}_d_1_104"
       elif (
@@ -30171,7 +30218,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14_lt_48)
         and (last_rsi_3_15m < 55.0)
         and (last_stochrsi_k_4h_gt_90)
-        and (last_roc_9_4h > 25.0)
+        and (last_roc_9_4h_gt_25)
       ):
         return True, f"exit_{mode_name}_d_1_105"
       elif (
@@ -30180,7 +30227,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_3_1h_lt_50)
         and (last_stochrsi_k_1h_gt_50)
         and (last_rsi_14_4h_gt_70)
-        and (last_roc_9_4h > 40.0)
+        and (last_roc_9_4h_gt_40)
       ):
         return True, f"exit_{mode_name}_d_1_106"
       elif (
@@ -30191,17 +30238,17 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14_4h > 50.0)
       ):
         return True, f"exit_{mode_name}_d_1_107"
-      elif (last_rsi_3 > 56.0) and (last_rsi_14_lt_48) and (last_rsi_3_1h_lt_60) and (last_stochrsi_k_1h_gt_80):
+      elif (last_rsi_3_gt_56) and (last_rsi_14_lt_48) and (last_rsi_3_1h_lt_60) and (last_stochrsi_k_1h_gt_80):
         return True, f"exit_{mode_name}_d_1_108"
       elif (
         (last_rsi_3_gt_76)
-        and (last_willr_14 > -8.0)
+        and (last_willr_14_gt_neg_8)
         and (last_rsi_3_1h_lt_50)
         and (last_rsi_3_4h_lt_20)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 50.0))
       ):
         return True, f"exit_{mode_name}_d_1_109"
-      elif (last_rsi_3_gt_72) and (last_rsi_3_4h < 65.0) and (last_stochrsi_k_4h_gt_50) and (last_roc_9_4h > 25.0):
+      elif (last_rsi_3_gt_72) and (last_rsi_3_4h < 65.0) and (last_stochrsi_k_4h_gt_50) and (last_roc_9_4h_gt_25):
         return True, f"exit_{mode_name}_d_1_110"
       elif (
         (last_rsi_3_gt_50)
@@ -30215,17 +30262,17 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_1_111"
       elif (
         (last_rsi_3_gt_80)
-        and (last_willr_14 > -25.0)
+        and (last_willr_14_gt_neg_25)
         and (last_rsi_14 < 52.0)
         and (last_rsi_3_1h_lt_35)
-        and (last_rsi_3_4h < 35.0)
+        and (last_rsi_3_4h_lt_35)
         and (last_rsi_3_1d < 60.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
       ):
         return True, f"exit_{mode_name}_d_1_112"
       elif (
         (last_rsi_3_gt_84)
-        and (last_willr_14 > -2.0)
+        and (last_willr_14_gt_neg_2)
         and (last_rsi_3_1d_lt_30)
         and (last_stochrsi_k_4h_gt_50)
         and (isinstance(last_roc_9_4h, np.float64) and (last_roc_9_4h > 10.0))
@@ -30243,7 +30290,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3_gt_78)
         and (last_rsi_14_lt_48)
-        and (last_rsi_3_15m < 30.0)
+        and (last_rsi_3_15m_lt_30)
         and (last_stochrsi_k_1h_gt_50)
         and (last_stochrsi_k_4h_gt_50)
       ):
@@ -30256,7 +30303,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_1_118"
       elif (
         (last_rsi_3_gt_86)
-        and (last_willr_14 > -20.0)
+        and (last_willr_14_gt_neg_20)
         and (last_rsi_3_1h_lt_60)
         and (last_rsi_3_4h_lt_60)
         and (last_stochrsi_k_1h_gt_40)
@@ -30268,7 +30315,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_1_121"
       elif (last_rsi_3 > 58.0) and (last_rsi_14_lt_44) and (last_rsi_3_4h_lt_30) and (last_stochrsi_k_1h_gt_50):
         return True, f"exit_{mode_name}_d_1_122"
-      elif (last_rsi_3_gt_88) and (last_willr_14 > -4.0) and (last_rsi_3_1h_lt_10) and (last_rsi_3_1d_lt_30):
+      elif (last_rsi_3_gt_88) and (last_willr_14_gt_neg_4) and (last_rsi_3_1h_lt_10) and (last_rsi_3_1d_lt_30):
         return True, f"exit_{mode_name}_d_1_123"
       elif (
         (last_rsi_3_gt_88)
@@ -30278,16 +30325,16 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_1_124"
       elif (
         (last_rsi_3_gt_76)
-        and (last_willr_14 > -4.0)
+        and (last_willr_14_gt_neg_4)
         and (last_rsi_3_1h_lt_10)
         and (last_rsi_3_4h_lt_40)
-        and (last_rsi_3_1d < 40.0)
+        and (last_rsi_3_1d_lt_40)
         and (last_close < (last_high_max_30_1d * 0.50))
       ):
         return True, f"exit_{mode_name}_d_1_125"
       elif (last_rsi_3_gt_90) and (last_rsi_3_1h_lt_15) and (last_rsi_3_4h_lt_40) and (last_stochrsi_k_4h_gt_50):
         return True, f"exit_{mode_name}_d_1_126"
-      elif (last_rsi_3_gt_90) and (last_rsi_3_1h_lt_10) and (last_rsi_3_4h_lt_30) and (last_rsi_3_1d < 40.0):
+      elif (last_rsi_3_gt_90) and (last_rsi_3_1h_lt_10) and (last_rsi_3_4h_lt_30) and (last_rsi_3_1d_lt_40):
         return True, f"exit_{mode_name}_d_1_127"
       elif (last_rsi_3_gt_94) and (last_rsi_3_4h_lt_30) and (last_aroonu_14_4h > 85.0):
         return True, f"exit_{mode_name}_d_1_128"
@@ -30309,7 +30356,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3_gt_80)
         and (last_rsi_3_1h_lt_35)
-        and (last_rsi_3_4h < 35.0)
+        and (last_rsi_3_4h_lt_35)
         and (last_aroonu_14_1h > 50.0)
         and (last_stochrsi_k_1h_gt_40)
       ):
@@ -30378,7 +30425,7 @@ class NostalgiaForInfinityX7(IStrategy):
       last_rsi_14_4h_gt_70 = last_rsi_14_4h > 70.0
       last_rsi_3_1d_lt_30 = last_rsi_3_1d < 30.0
       if (
-        (last_willr_14 > -1.0)
+        (last_willr_14_gt_neg_1)
         and (last_rsi_14 > 78.0)
         and (isinstance(last_ema_200_1h, np.float64) and (last_ema_12_1h < last_ema_200_1h))
         and (isinstance(last_ema_200_4h, np.float64) and (last_ema_12_4h < last_ema_200_4h))
@@ -30387,68 +30434,68 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_2_1"
       elif (
-        (last_willr_14 > -1.0)
+        (last_willr_14_gt_neg_1)
         and (last_rsi_14 > 66.0)
-        and (last_cmf_20_1h < -0.0)
+        and (last_cmf_20_1h_lt_0)
         and (isinstance(last_ema_200_1h, np.float64) and (last_ema_12_1h < last_ema_200_1h))
         and (isinstance(last_ema_200_4h, np.float64) and (last_ema_12_4h < last_ema_200_4h))
       ):
         return True, f"exit_{mode_name}_d_2_2"
       elif (
-        (last_willr_14 > -10.0)
+        (last_willr_14_gt_neg_10)
         and (last_stochrsi_k > 99.0)
-        and (last_cmf_20_1h < -0.0)
-        and (last_cmf_20_4h < -0.0)
-        and ((last_stochrsi_k_4h_gt_20) and (last_stochrsi_k_change_pct_4h < -10.0))
+        and (last_cmf_20_1h_lt_0)
+        and (last_cmf_20_4h_lt_0)
+        and ((last_stochrsi_k_4h_gt_20) and (last_stochrsi_k_change_pct_4h_lt_neg_10))
       ):
         return True, f"exit_{mode_name}_d_2_3"
       elif (
-        (last_willr_14 > -30.0)
+        (last_willr_14_gt_neg_30)
         and (last_rsi_14 > 65.0)
         and (last_stochrsi_k > 95.0)
-        and (last_stochrsi_k_4h > 70.0)
+        and (last_stochrsi_k_4h_gt_70)
         and (isinstance(last_ema_200_1h, np.float64) and (last_ema_12_1h < last_ema_200_1h))
         and (isinstance(last_ema_200_4h, np.float64) and (last_ema_12_4h < last_ema_200_4h))
       ):
         return True, f"exit_{mode_name}_d_2_4"
-      elif (last_willr_14 > -4.0) and (last_rsi_14_gt_70) and (last_roc_9_1h < -5.0) and (last_roc_9_4h < -5.0):
+      elif (last_willr_14_gt_neg_4) and (last_rsi_14_gt_70) and (last_roc_9_1h_lt_neg_5) and (last_roc_9_4h_lt_neg_5):
         return True, f"exit_{mode_name}_d_2_5"
       elif (
         (last_rsi_3_gt_70)
-        and (last_stochrsi_k > 70.0)
+        and (last_stochrsi_k_gt_70)
         and (last_rsi_14 < 40.0)
-        and (last_roc_9_1h < -10.0)
+        and (last_roc_9_1h_lt_neg_10)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 50.0))
       ):
         return True, f"exit_{mode_name}_d_2_6"
       elif (
         (last_rsi_14_lt_50)
-        and (last_stochrsi_k > 70.0)
+        and (last_stochrsi_k_gt_70)
         and (last_stochrsi_k_4h_gt_50)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -40.0))
       ):
         return True, f"exit_{mode_name}_d_2_7"
       elif (
-        (last_willr_14 > -4.0)
+        (last_willr_14_gt_neg_4)
         and (last_stochrsi_k > 95.0)
         and (last_cmf_20_1h < -0.1)
         and (last_cmf_20_4h < -0.1)
-        and (last_change_pct_1d < -5.0)
+        and (last_change_pct_1d_lt_neg_5)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 15.0))
       ):
         return True, f"exit_{mode_name}_d_2_8"
       elif (
-        (last_willr_14 > -4.0)
+        (last_willr_14_gt_neg_4)
         and (last_rsi_3 > 95.0)
-        and (last_change_pct_4h < -5.0)
+        and (last_change_pct_4h_lt_neg_5)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
       ):
         return True, f"exit_{mode_name}_d_2_9"
       elif (
-        (last_willr_14 > -20.0)
+        (last_willr_14_gt_neg_20)
         and (last_rsi_14_lt_50)
-        and (last_roc_9_1h < -10.0)
-        and (last_roc_9_4h < -10.0)
+        and (last_roc_9_1h_lt_neg_10)
+        and (last_roc_9_4h_lt_neg_10)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 10.0))
       ):
         return True, f"exit_{mode_name}_d_2_10"
@@ -30456,7 +30503,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3_gt_75)
         and (last_rsi_14 < 45.0)
         and (last_roc_9_15m < -10.0)
-        and (last_roc_9_1h < -10.0)
+        and (last_roc_9_1h_lt_neg_10)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -20.0))
       ):
         return True, f"exit_{mode_name}_d_2_11"
@@ -30465,26 +30512,26 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14_lt_50)
         and (last_rsi_3_4h_lt_10)
         and (last_roc_9_1h < -20.0)
-        and (last_roc_9_4h < -20.0)
+        and (last_roc_9_4h_lt_neg_20)
       ):
         return True, f"exit_{mode_name}_d_2_12"
-      elif (last_rsi_3_gt_80) and (last_rsi_3_4h < 5.0) and (last_roc_9_4h < -25.0):
+      elif (last_rsi_3_gt_80) and (last_rsi_3_4h_lt_5) and (last_roc_9_4h_lt_neg_25):
         return True, f"exit_{mode_name}_d_2_13"
-      elif (last_rsi_3_gt_90) and (last_willr_14 > -6.0) and (last_rsi_3_4h < 5.0) and (last_aroonu_14_4h_gt_25):
+      elif (last_rsi_3_gt_90) and (last_willr_14_gt_neg_6) and (last_rsi_3_4h_lt_5) and (last_aroonu_14_4h_gt_25):
         return True, f"exit_{mode_name}_d_2_14"
       elif (last_rsi_3_gt_92) and (last_rsi_14_gt_70) and (last_roc_9_4h < -30.0):
         return True, f"exit_{mode_name}_d_2_15"
       elif (
         (last_rsi_3_gt_70)
         and (last_aroonu_14_4h_gt_25)
-        and (last_roc_9_4h < -25.0)
+        and (last_roc_9_4h_lt_neg_25)
         and (last_aroonu_14_1d > 50.0)
         and (last_change_pct_1d < -15.0)
       ):
         return True, f"exit_{mode_name}_d_2_16"
       elif (
         (last_rsi_3_gt_80)
-        and (last_willr_14 > -20.0)
+        and (last_willr_14_gt_neg_20)
         and (last_rsi_3_1h_lt_10)
         and (last_stochrsi_k_4h_gt_90)
         and (last_roc_9_4h > 30.0)
@@ -30505,31 +30552,31 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_2_21"
       elif (
         (last_rsi_3 > 96.0)
-        and (last_willr_14 > -4.0)
-        and (last_change_pct_4h < -5.0)
+        and (last_willr_14_gt_neg_4)
+        and (last_change_pct_4h_lt_neg_5)
         and (last_stochrsi_k_4h_gt_50)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
       ):
         return True, f"exit_{mode_name}_d_2_22"
-      elif (last_rsi_3_gt_90) and (last_willr_14 > -15.0) and (last_rsi_3_1h_lt_15) and (last_rsi_3_1d < 5.0):
+      elif (last_rsi_3_gt_90) and (last_willr_14_gt_neg_15) and (last_rsi_3_1h_lt_15) and (last_rsi_3_1d < 5.0):
         return True, f"exit_{mode_name}_d_2_23"
       elif (
         (last_rsi_3_gt_90)
         and (last_rsi_14_gt_70)
-        and (last_willr_14 > -20.0)
+        and (last_willr_14_gt_neg_20)
         and (last_rsi_3_4h_lt_30)
         and (last_aroonu_14_4h_gt_75)
       ):
         return True, f"exit_{mode_name}_d_2_24"
       elif (
         (last_rsi_3_gt_85)
-        and (last_willr_14 > -6.0)
+        and (last_willr_14_gt_neg_6)
         and (last_rsi_3_4h_lt_10)
         and (last_roc_9_4h < -15.0)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d > 50.0))
       ):
         return True, f"exit_{mode_name}_d_2_25"
-      elif (last_rsi_3_gt_80) and (last_willr_14 > -6.0) and (last_rsi_3_4h_lt_15) and (last_roc_9_4h < -20.0):
+      elif (last_rsi_3_gt_80) and (last_willr_14_gt_neg_6) and (last_rsi_3_4h_lt_15) and (last_roc_9_4h_lt_neg_20):
         return True, f"exit_{mode_name}_d_2_26"
       elif (
         (last_rsi_3_gt_65)
@@ -30556,27 +30603,27 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14_lt_50)
         and (last_rsi_3_1h_lt_15)
         and (last_rsi_3_4h_lt_15)
-        and (last_stochrsi_k_1h > 25.0)
+        and (last_stochrsi_k_1h_gt_25)
       ):
         return True, f"exit_{mode_name}_d_2_31"
-      elif (last_rsi_3_gt_85) and (last_rsi_3_1h_lt_15) and (last_roc_2_4h < -30.0) and (last_stochrsi_k_4h_gt_30):
+      elif (last_rsi_3_gt_85) and (last_rsi_3_1h_lt_15) and (last_roc_2_4h_lt_neg_30) and (last_stochrsi_k_4h_gt_30):
         return True, f"exit_{mode_name}_d_2_32"
       elif (
         (last_rsi_3_gt_85)
-        and (last_willr_14 > -4.0)
+        and (last_willr_14_gt_neg_4)
         and (last_roc_2_1h < -10.0)
         and (last_roc_9_1h > 30.0)
         and (last_stochrsi_k_1h_gt_50)
       ):
         return True, f"exit_{mode_name}_d_2_33"
-      elif (last_rsi_3_gt_65) and (last_rsi_3_15m < 30.0) and (last_rsi_14_1h > 80.0) and (last_roc_9_1h > 40.0):
+      elif (last_rsi_3_gt_65) and (last_rsi_3_15m_lt_30) and (last_rsi_14_1h > 80.0) and (last_roc_9_1h > 40.0):
         return True, f"exit_{mode_name}_d_2_34"
-      elif (last_rsi_3_gt_86) and (last_willr_14 > -7.0) and (last_rsi_3_1d_lt_25) and (last_stochrsi_k_1h > 75.0):
+      elif (last_rsi_3_gt_86) and (last_willr_14 > -7.0) and (last_rsi_3_1d_lt_25) and (last_stochrsi_k_1h_gt_75):
         return True, f"exit_{mode_name}_d_2_35"
       elif (
         (last_rsi_3_gt_80)
-        and (last_willr_14 > -20.0)
-        and (last_roc_9_4h < -25.0)
+        and (last_willr_14_gt_neg_20)
+        and (last_roc_9_4h_lt_neg_25)
         and (last_rsi_3_1d_lt_25)
         and (last_stochrsi_k_1h_gt_50)
       ):
@@ -30589,13 +30636,13 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_stochrsi_k_4h_gt_50)
       ):
         return True, f"exit_{mode_name}_d_2_37"
-      elif (last_rsi_3_gt_80) and (last_willr_14 > -20.0) and (last_rsi_3_4h_lt_10) and (last_stochrsi_k_4h_gt_20):
+      elif (last_rsi_3_gt_80) and (last_willr_14_gt_neg_20) and (last_rsi_3_4h_lt_10) and (last_stochrsi_k_4h_gt_20):
         return True, f"exit_{mode_name}_d_2_38"
-      elif (last_rsi_3 > 94.0) and (last_willr_14 > -6.0) and (last_cmf_20_4h < -0.0) and (last_rsi_3_4h_lt_10):
+      elif (last_rsi_3 > 94.0) and (last_willr_14_gt_neg_6) and (last_cmf_20_4h_lt_0) and (last_rsi_3_4h_lt_10):
         return True, f"exit_{mode_name}_d_2_39"
       elif (
         (last_rsi_3_gt_80)
-        and (last_willr_14 > -20.0)
+        and (last_willr_14_gt_neg_20)
         and (last_rsi_3_1h_lt_30)
         and (last_stochrsi_k_1h_gt_30)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d > 90.0))
@@ -30603,7 +30650,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_2_40"
       elif (
         (last_rsi_3_gt_90)
-        and (last_willr_14 > -15.0)
+        and (last_willr_14_gt_neg_15)
         and (last_rsi_3_1h_lt_30)
         and (last_stochrsi_k_4h_gt_25)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 50.0))
@@ -30611,7 +30658,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_2_41"
       elif (
         (last_rsi_3_gt_85)
-        and (last_willr_14 > -30.0)
+        and (last_willr_14_gt_neg_30)
         and (last_stochrsi_k_4h_gt_30)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 40.0))
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d > 70.0))
@@ -30627,13 +30674,13 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_2_43"
       elif (
         (last_rsi_3_gt_60)
-        and (last_willr_14 > -10.0)
+        and (last_willr_14_gt_neg_10)
         and (last_rsi_3_4h_lt_30)
         and (last_rsi_3_1d_lt_25)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
       ):
         return True, f"exit_{mode_name}_d_2_44"
-      elif (last_rsi_3_gt_92) and (last_willr_14 > -8.0) and (last_rsi_3_1h_lt_10):
+      elif (last_rsi_3_gt_92) and (last_willr_14_gt_neg_8) and (last_rsi_3_1h_lt_10):
         return True, f"exit_{mode_name}_d_2_45"
       elif (last_rsi_3_gt_70) and (last_rsi_3_1h_lt_15) and (last_rsi_3_4h_lt_10) and (last_roc_2_1d < -20.0):
         return True, f"exit_{mode_name}_d_2_46"
@@ -30641,7 +30688,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3_gt_84)
         and (last_stochrsi_k_1h_gt_80)
         and (last_stochrsi_k_4h_gt_40)
-        and (last_change_pct_1d < -5.0)
+        and (last_change_pct_1d_lt_neg_5)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -5.0))
       ):
         return True, f"exit_{mode_name}_d_2_47"
@@ -30655,20 +30702,20 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_2_48"
       elif (
         (last_rsi_3_gt_85)
-        and (last_willr_14 > -6.0)
+        and (last_willr_14_gt_neg_6)
         and (last_rsi_3_4h_lt_20)
-        and (last_change_pct_1d < -5.0)
+        and (last_change_pct_1d_lt_neg_5)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d > 50.0))
       ):
         return True, f"exit_{mode_name}_d_2_49"
-      elif (last_rsi_3_gt_80) and (last_willr_14 > -6.0) and (last_rsi_3_1d < 10.0) and (last_stochrsi_k_1h > 90.0):
+      elif (last_rsi_3_gt_80) and (last_willr_14_gt_neg_6) and (last_rsi_3_1d < 10.0) and (last_stochrsi_k_1h_gt_90):
         return True, f"exit_{mode_name}_d_2_50"
       elif (last_rsi_3_gt_64) and (last_rsi_14_lt_48) and (last_rsi_3_4h_lt_20) and (last_stochrsi_k_1h_gt_50):
         return True, f"exit_{mode_name}_d_2_51"
       elif (
         (last_rsi_3_gt_78)
         and (last_rsi_14 > 58.0)
-        and (last_willr_14 > -10.0)
+        and (last_willr_14_gt_neg_10)
         and (last_stochrsi_k_1h_gt_70)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -15.0))
       ):
@@ -30676,7 +30723,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3_gt_70)
         and (last_rsi_14_lt_50)
-        and (last_willr_14 > -25.0)
+        and (last_willr_14_gt_neg_25)
         and (last_rsi_3_1h_lt_20)
         and (last_stochrsi_k_4h_gt_50)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d > 50.0))
@@ -30686,14 +30733,14 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3_gt_76)
         and (last_rsi_14_lt_48)
         and (last_stochrsi_k_1h_gt_50)
-        and (last_roc_9_4h < -10.0)
+        and (last_roc_9_4h_lt_neg_10)
         and (last_change_pct_1d < -10.0)
       ):
         return True, f"exit_{mode_name}_d_2_54"
       elif (
         (last_rsi_3_gt_92)
-        and (last_willr_14 > -16.0)
-        and (last_roc_9_4h < -5.0)
+        and (last_willr_14_gt_neg_16)
+        and (last_roc_9_4h_lt_neg_5)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 10.0))
         and (last_stochrsi_k_1h_gt_50)
       ):
@@ -30704,14 +30751,14 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_3_1h_lt_30)
         and (last_rsi_3_4h_lt_25)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
-        and (last_stochrsi_k_4h > 10.0)
+        and (last_stochrsi_k_4h_gt_10)
       ):
         return True, f"exit_{mode_name}_d_2_56"
       elif (
         (last_rsi_3 > 50.0)
         and (last_rsi_14 < 38.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
-        and (last_stochrsi_k_4h > 70.0)
+        and (last_stochrsi_k_4h_gt_70)
       ):
         return True, f"exit_{mode_name}_d_2_57"
       elif (
@@ -30724,7 +30771,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_2_58"
       elif (
         (last_rsi_3_gt_85)
-        and (last_willr_14 > -14.0)
+        and (last_willr_14_gt_neg_14)
         and (last_rsi_3_4h_lt_25)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -15.0))
         and (last_stochrsi_k_4h_gt_40)
@@ -30735,18 +30782,18 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14_lt_42)
         and (last_rsi_14_4h > 65.0)
         and (last_stochrsi_k_4h_gt_50)
-        and (last_stochrsi_k_1d > 50.0)
+        and (last_stochrsi_k_1d_gt_50)
       ):
         return True, f"exit_{mode_name}_d_2_60"
-      elif (last_rsi_3_gt_90) and (last_willr_14 > -25.0) and (last_rsi_3_4h_lt_10) and (last_stochrsi_k_1h_gt_30):
+      elif (last_rsi_3_gt_90) and (last_willr_14_gt_neg_25) and (last_rsi_3_4h_lt_10) and (last_stochrsi_k_1h_gt_30):
         return True, f"exit_{mode_name}_d_2_61"
       elif (
         (last_rsi_3_gt_84)
-        and (last_willr_14 > -4.0)
+        and (last_willr_14_gt_neg_4)
         and (last_rsi_3_1h_lt_30)
         and (last_rsi_3_4h_lt_20)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 20.0))
-        and (last_change_pct_1d < -5.0)
+        and (last_change_pct_1d_lt_neg_5)
       ):
         return True, f"exit_{mode_name}_d_2_62"
       elif (last_rsi_3_gt_66) and (last_rsi_3_1d_lt_25) and (last_stochrsi_k_1h_gt_80) and (last_stochrsi_k_4h_gt_30):
@@ -30765,7 +30812,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 50.0)
         and (last_rsi_14_lt_44)
-        and (last_stochrsi_k_4h > 80.0)
+        and (last_stochrsi_k_4h_gt_80)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -25.0))
       ):
         return True, f"exit_{mode_name}_d_2_67"
@@ -30773,17 +30820,17 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3_gt_82)
         and (last_rsi_14_lt_50)
         and (last_rsi_3_1h_lt_25)
-        and (last_roc_2_4h < -30.0)
+        and (last_roc_2_4h_lt_neg_30)
         and (last_stochrsi_k_4h_gt_25)
       ):
         return True, f"exit_{mode_name}_d_2_68"
       elif (
-        (last_rsi_3 > 95.0) and (last_roc_9_4h > 20.0) and (last_stochrsi_k_4h_gt_50) and (last_change_pct_4h < -5.0)
+        (last_rsi_3 > 95.0) and (last_roc_9_4h > 20.0) and (last_stochrsi_k_4h_gt_50) and (last_change_pct_4h_lt_neg_5)
       ):
         return True, f"exit_{mode_name}_d_2_69"
       elif (last_rsi_3_gt_64) and (last_rsi_14_lt_42) and (last_rsi_3_1h_lt_25) and (last_stochrsi_k_4h_gt_20):
         return True, f"exit_{mode_name}_d_2_70"
-      elif (last_rsi_3 > 62.0) and (last_rsi_14_lt_46) and (last_rsi_3_4h_lt_25) and (last_stochrsi_k_1h > 20.0):
+      elif (last_rsi_3 > 62.0) and (last_rsi_14_lt_46) and (last_rsi_3_4h_lt_25) and (last_stochrsi_k_1h_gt_20):
         return True, f"exit_{mode_name}_d_2_71"
       elif (last_rsi_3_gt_76) and (last_rsi_14_lt_44) and (last_rsi_3_1h_lt_10) and (last_aroonu_14_4h_gt_25):
         return True, f"exit_{mode_name}_d_2_72"
@@ -30791,13 +30838,13 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3_gt_76)
         and (last_rsi_3_1h_lt_25)
         and (last_rsi_3_4h_lt_15)
-        and (last_roc_9_4h < -20.0)
+        and (last_roc_9_4h_lt_neg_20)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -25.0))
       ):
         return True, f"exit_{mode_name}_d_2_73"
       elif (
         (last_rsi_3 > 97.0)
-        and (last_willr_14 > -10.0)
+        and (last_willr_14_gt_neg_10)
         and (last_rsi_3_4h_lt_25)
         and (last_rsi_3_1d_lt_25)
         and (last_stochrsi_k_1h_gt_50)
@@ -30810,7 +30857,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d > 50.0))
       ):
         return True, f"exit_{mode_name}_d_2_75"
-      elif (last_rsi_3_gt_66) and (last_rsi_14_lt_52) and (last_roc_9_1h > 80.0) and (last_stochrsi_k_4h > 80.0):
+      elif (last_rsi_3_gt_66) and (last_rsi_14_lt_52) and (last_roc_9_1h > 80.0) and (last_stochrsi_k_4h_gt_80):
         return True, f"exit_{mode_name}_d_2_76"
       elif (
         (last_rsi_3_gt_74)
@@ -30821,13 +30868,13 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_2_77"
       elif (
         (last_rsi_3_gt_84)
-        and (last_willr_14 > -18.0)
+        and (last_willr_14_gt_neg_18)
         and (last_rsi_3_1h_lt_30)
         and (last_rsi_3_4h_lt_20)
         and (last_rsi_3_1d < 20.0)
       ):
         return True, f"exit_{mode_name}_d_2_78"
-      elif (last_rsi_3_gt_90) and (last_willr_14 > -4.0) and (last_rsi_3_1h_lt_30) and (last_rsi_3_4h_lt_10):
+      elif (last_rsi_3_gt_90) and (last_willr_14_gt_neg_4) and (last_rsi_3_1h_lt_30) and (last_rsi_3_4h_lt_10):
         return True, f"exit_{mode_name}_d_2_79"
       elif (
         (last_rsi_3_gt_70)
@@ -30839,7 +30886,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_2_80"
       elif (
         (last_rsi_3_gt_82)
-        and (last_willr_14 > -12.0)
+        and (last_willr_14_gt_neg_12)
         and (last_rsi_3_1h_lt_25)
         and (last_rsi_3_4h_lt_25)
         and (isinstance(last_rsi_14_1d, np.float64) and (last_rsi_14_1d > 50.0))
@@ -30847,7 +30894,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_2_81"
       elif (
         (last_rsi_3_gt_80)
-        and (last_willr_14 > -12.0)
+        and (last_willr_14_gt_neg_12)
         and (last_rsi_3_4h_lt_30)
         and (last_rsi_3_1d < 15.0)
         and (last_stochrsi_k_4h_gt_40)
@@ -30861,11 +30908,11 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_stochrsi_k_4h_gt_40)
       ):
         return True, f"exit_{mode_name}_d_2_83"
-      elif (last_rsi_3_gt_88) and (last_willr_14 > -4.0) and (last_rsi_3_4h_lt_30) and (last_stochrsi_k_1h > 20.0):
+      elif (last_rsi_3_gt_88) and (last_willr_14_gt_neg_4) and (last_rsi_3_4h_lt_30) and (last_stochrsi_k_1h_gt_20):
         return True, f"exit_{mode_name}_d_2_84"
       elif (
         (last_rsi_3_gt_86)
-        and (last_willr_14 > -10.0)
+        and (last_willr_14_gt_neg_10)
         and (last_rsi_3_1h_lt_30)
         and (last_rsi_3_4h_lt_40)
         and (last_stochrsi_k_4h_gt_50)
@@ -30898,13 +30945,13 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3_gt_76)
         and (last_rsi_14_lt_42)
-        and (last_roc_9_1h < -5.0)
+        and (last_roc_9_1h_lt_neg_5)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 25.0))
       ):
         return True, f"exit_{mode_name}_d_2_89"
       elif (
         (last_rsi_3_gt_90)
-        and (last_willr_14 > -25.0)
+        and (last_willr_14_gt_neg_25)
         and (last_rsi_3_1h_lt_50)
         and (last_rsi_3_4h_lt_30)
         and (last_aroonu_14_4h_gt_50)
@@ -30924,7 +30971,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3_gt_78)
         and (last_rsi_14_lt_50)
         and (last_rsi_3_1h_lt_40)
-        and (last_stochrsi_k_1h > 25.0)
+        and (last_stochrsi_k_1h_gt_25)
         and (last_stochrsi_k_4h_gt_50)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -25.0))
       ):
@@ -30951,10 +30998,10 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_2_94"
       elif (
         (last_rsi_3_gt_82)
-        and (last_willr_14 > -14.0)
+        and (last_willr_14_gt_neg_14)
         and (last_rsi_3_1h_lt_45)
         and (last_rsi_3_4h_lt_40)
-        and (last_stochrsi_k_4h > 10.0)
+        and (last_stochrsi_k_4h_gt_10)
         and (isinstance(last_aroonu_14_1d, np.float64) and (last_aroonu_14_1d > 75.0))
       ):
         return True, f"exit_{mode_name}_d_2_95"
@@ -30976,7 +31023,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_2_97"
       elif (
         (last_rsi_3_gt_88)
-        and (last_rsi_3_15m > 70.0)
+        and (last_rsi_3_15m_gt_70)
         and (last_rsi_3_1h_lt_60)
         and (last_rsi_3_4h_lt_60)
         and (last_rsi_3_1d > 80.0)
@@ -30989,15 +31036,15 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_3_1h < 65.0)
         and (last_rsi_3_4h_lt_60)
         and (last_aroonu_14_4h_gt_50)
-        and (last_stoch_k_4h > 40.0)
+        and (last_stoch_k_4h_gt_40)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 80.0))
       ):
         return True, f"exit_{mode_name}_d_2_99"
-      elif (last_rsi_3 > 96.0) and (last_rsi_14 > 74.0) and (last_rsi_3_15m > 70.0) and (last_rsi_3_4h < 80.0):
+      elif (last_rsi_3 > 96.0) and (last_rsi_14 > 74.0) and (last_rsi_3_15m_gt_70) and (last_rsi_3_4h < 80.0):
         return True, f"exit_{mode_name}_d_2_100"
       elif (
         (last_rsi_3_gt_82)
-        and (last_willr_14 > -18.0)
+        and (last_willr_14_gt_neg_18)
         and (last_rsi_3_1h_lt_50)
         and (last_stochrsi_k_4h_gt_40)
         and (isinstance(last_roc_9_4h, np.float64) and (last_roc_9_4h > 40.0))
@@ -31026,7 +31073,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_3_1h_lt_60)
         and (last_stochrsi_k_1h_gt_40)
         and (last_stochrsi_k_4h_gt_90)
-        and (last_roc_9_4h > 40.0)
+        and (last_roc_9_4h_gt_40)
       ):
         return True, f"exit_{mode_name}_d_2_104"
       elif (
@@ -31034,7 +31081,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14_lt_50)
         and (last_rsi_3_15m < 55.0)
         and (last_stochrsi_k_4h_gt_90)
-        and (last_roc_9_4h > 25.0)
+        and (last_roc_9_4h_gt_25)
       ):
         return True, f"exit_{mode_name}_d_2_105"
       elif (
@@ -31043,7 +31090,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_3_1h_lt_50)
         and (last_stochrsi_k_1h_gt_50)
         and (last_rsi_14_4h_gt_70)
-        and (last_roc_9_4h > 40.0)
+        and (last_roc_9_4h_gt_40)
       ):
         return True, f"exit_{mode_name}_d_2_106"
       elif (
@@ -31058,13 +31105,13 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_2_108"
       elif (
         (last_rsi_3_gt_74)
-        and (last_willr_14 > -10.0)
+        and (last_willr_14_gt_neg_10)
         and (last_rsi_3_1h_lt_50)
         and (last_rsi_3_4h_lt_20)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 50.0))
       ):
         return True, f"exit_{mode_name}_d_2_109"
-      elif (last_rsi_3_gt_70) and (last_rsi_3_4h < 65.0) and (last_stochrsi_k_4h_gt_50) and (last_roc_9_4h > 25.0):
+      elif (last_rsi_3_gt_70) and (last_rsi_3_4h < 65.0) and (last_stochrsi_k_4h_gt_50) and (last_roc_9_4h_gt_25):
         return True, f"exit_{mode_name}_d_2_110"
       elif (
         (last_rsi_3 > 48.0)
@@ -31078,17 +31125,17 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_2_111"
       elif (
         (last_rsi_3_gt_78)
-        and (last_willr_14 > -30.0)
+        and (last_willr_14_gt_neg_30)
         and (last_rsi_14 < 54.0)
         and (last_rsi_3_1h_lt_35)
-        and (last_rsi_3_4h < 35.0)
+        and (last_rsi_3_4h_lt_35)
         and (last_rsi_3_1d < 60.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
       ):
         return True, f"exit_{mode_name}_d_2_112"
       elif (
         (last_rsi_3_gt_82)
-        and (last_willr_14 > -4.0)
+        and (last_willr_14_gt_neg_4)
         and (last_rsi_3_1d_lt_30)
         and (last_stochrsi_k_4h_gt_50)
         and (isinstance(last_roc_9_4h, np.float64) and (last_roc_9_4h > 10.0))
@@ -31106,7 +31153,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3_gt_76)
         and (last_rsi_14_lt_50)
-        and (last_rsi_3_15m < 30.0)
+        and (last_rsi_3_15m_lt_30)
         and (last_stochrsi_k_1h_gt_50)
         and (last_stochrsi_k_4h_gt_50)
       ):
@@ -31119,7 +31166,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_2_118"
       elif (
         (last_rsi_3_gt_84)
-        and (last_willr_14 > -20.0)
+        and (last_willr_14_gt_neg_20)
         and (last_rsi_3_1h_lt_60)
         and (last_rsi_3_4h_lt_60)
         and (last_stochrsi_k_1h_gt_40)
@@ -31129,9 +31176,9 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_2_120"
       elif (last_rsi_3 > 58.0) and (last_rsi_14_lt_48) and (last_rsi_3_1h_lt_50) and (last_rsi_14_4h > 85.0):
         return True, f"exit_{mode_name}_d_2_121"
-      elif (last_rsi_3 > 56.0) and (last_rsi_14_lt_46) and (last_rsi_3_4h_lt_30) and (last_stochrsi_k_1h_gt_50):
+      elif (last_rsi_3_gt_56) and (last_rsi_14_lt_46) and (last_rsi_3_4h_lt_30) and (last_stochrsi_k_1h_gt_50):
         return True, f"exit_{mode_name}_d_2_122"
-      elif (last_rsi_3_gt_86) and (last_willr_14 > -6.0) and (last_rsi_3_1h_lt_10) and (last_rsi_3_1d_lt_30):
+      elif (last_rsi_3_gt_86) and (last_willr_14_gt_neg_6) and (last_rsi_3_1h_lt_10) and (last_rsi_3_1d_lt_30):
         return True, f"exit_{mode_name}_d_2_123"
       elif (
         (last_rsi_3_gt_86)
@@ -31141,16 +31188,16 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_2_124"
       elif (
         (last_rsi_3_gt_74)
-        and (last_willr_14 > -6.0)
+        and (last_willr_14_gt_neg_6)
         and (last_rsi_3_1h_lt_10)
         and (last_rsi_3_4h_lt_40)
-        and (last_rsi_3_1d < 40.0)
+        and (last_rsi_3_1d_lt_40)
         and (last_close < (last_high_max_30_1d * 0.50))
       ):
         return True, f"exit_{mode_name}_d_2_125"
       elif (last_rsi_3_gt_88) and (last_rsi_3_1h_lt_15) and (last_rsi_3_4h_lt_40) and (last_stochrsi_k_4h_gt_50):
         return True, f"exit_{mode_name}_d_2_126"
-      elif (last_rsi_3_gt_88) and (last_rsi_3_1h_lt_10) and (last_rsi_3_4h_lt_30) and (last_rsi_3_1d < 40.0):
+      elif (last_rsi_3_gt_88) and (last_rsi_3_1h_lt_10) and (last_rsi_3_4h_lt_30) and (last_rsi_3_1d_lt_40):
         return True, f"exit_{mode_name}_d_2_127"
       elif (last_rsi_3_gt_92) and (last_rsi_3_4h_lt_30) and (last_aroonu_14_4h > 85.0):
         return True, f"exit_{mode_name}_d_2_128"
@@ -31172,7 +31219,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3_gt_78)
         and (last_rsi_3_1h_lt_35)
-        and (last_rsi_3_4h < 35.0)
+        and (last_rsi_3_4h_lt_35)
         and (last_aroonu_14_1h > 50.0)
         and (last_stochrsi_k_1h_gt_40)
       ):
@@ -31245,7 +31292,7 @@ class NostalgiaForInfinityX7(IStrategy):
       last_rsi_14_4h_gt_70 = last_rsi_14_4h > 70.0
       last_rsi_3_1d_lt_30 = last_rsi_3_1d < 30.0
       if (
-        (last_willr_14 > -1.0)
+        (last_willr_14_gt_neg_1)
         and (last_rsi_14 > 78.0)
         and (isinstance(last_ema_200_1h, np.float64) and (last_ema_12_1h < last_ema_200_1h))
         and (isinstance(last_ema_200_4h, np.float64) and (last_ema_12_4h < last_ema_200_4h))
@@ -31254,68 +31301,68 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_3_1"
       elif (
-        (last_willr_14 > -1.0)
+        (last_willr_14_gt_neg_1)
         and (last_rsi_14 > 64.0)
-        and (last_cmf_20_1h < -0.0)
+        and (last_cmf_20_1h_lt_0)
         and (isinstance(last_ema_200_1h, np.float64) and (last_ema_12_1h < last_ema_200_1h))
         and (isinstance(last_ema_200_4h, np.float64) and (last_ema_12_4h < last_ema_200_4h))
       ):
         return True, f"exit_{mode_name}_d_3_2"
       elif (
-        (last_willr_14 > -20.0)
+        (last_willr_14_gt_neg_20)
         and (last_stochrsi_k_gt_95)
-        and (last_cmf_20_1h < -0.0)
-        and (last_cmf_20_4h < -0.0)
-        and ((last_stochrsi_k_4h_gt_20) and (last_stochrsi_k_change_pct_4h < -10.0))
+        and (last_cmf_20_1h_lt_0)
+        and (last_cmf_20_4h_lt_0)
+        and ((last_stochrsi_k_4h_gt_20) and (last_stochrsi_k_change_pct_4h_lt_neg_10))
       ):
         return True, f"exit_{mode_name}_d_3_3"
       elif (
-        (last_willr_14 > -30.0)
+        (last_willr_14_gt_neg_30)
         and (last_rsi_14 > 65.0)
         and (last_stochrsi_k_gt_95)
-        and (last_stochrsi_k_4h > 70.0)
+        and (last_stochrsi_k_4h_gt_70)
         and (isinstance(last_ema_200_1h, np.float64) and (last_ema_12_1h < last_ema_200_1h))
         and (isinstance(last_ema_200_4h, np.float64) and (last_ema_12_4h < last_ema_200_4h))
       ):
         return True, f"exit_{mode_name}_d_3_4"
-      elif (last_willr_14 > -6.0) and (last_rsi_14_gt_68) and (last_roc_9_1h < -5.0) and (last_roc_9_4h < -5.0):
+      elif (last_willr_14_gt_neg_6) and (last_rsi_14_gt_68) and (last_roc_9_1h_lt_neg_5) and (last_roc_9_4h_lt_neg_5):
         return True, f"exit_{mode_name}_d_3_5"
       elif (
         (last_rsi_3_gt_70)
-        and (last_stochrsi_k > 70.0)
+        and (last_stochrsi_k_gt_70)
         and (last_rsi_14 < 40.0)
-        and (last_roc_9_1h < -10.0)
+        and (last_roc_9_1h_lt_neg_10)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 50.0))
       ):
         return True, f"exit_{mode_name}_d_3_6"
       elif (
         (last_rsi_14_lt_50)
-        and (last_stochrsi_k > 70.0)
+        and (last_stochrsi_k_gt_70)
         and (last_stochrsi_k_4h_gt_50)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -40.0))
       ):
         return True, f"exit_{mode_name}_d_3_7"
       elif (
-        (last_willr_14 > -6.0)
+        (last_willr_14_gt_neg_6)
         and (last_stochrsi_k_gt_95)
         and (last_cmf_20_1h < -0.1)
         and (last_cmf_20_4h < -0.1)
-        and (last_change_pct_1d < -5.0)
+        and (last_change_pct_1d_lt_neg_5)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 15.0))
       ):
         return True, f"exit_{mode_name}_d_3_8"
       elif (
-        (last_willr_14 > -6.0)
+        (last_willr_14_gt_neg_6)
         and (last_rsi_3 > 95.0)
-        and (last_change_pct_4h < -5.0)
+        and (last_change_pct_4h_lt_neg_5)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
       ):
         return True, f"exit_{mode_name}_d_3_9"
       elif (
-        (last_willr_14 > -20.0)
+        (last_willr_14_gt_neg_20)
         and (last_rsi_14_lt_50)
-        and (last_roc_9_1h < -10.0)
-        and (last_roc_9_4h < -10.0)
+        and (last_roc_9_1h_lt_neg_10)
+        and (last_roc_9_4h_lt_neg_10)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 10.0))
       ):
         return True, f"exit_{mode_name}_d_3_10"
@@ -31323,7 +31370,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3_gt_75)
         and (last_rsi_14 < 45.0)
         and (last_roc_9_15m < -10.0)
-        and (last_roc_9_1h < -10.0)
+        and (last_roc_9_1h_lt_neg_10)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -20.0))
       ):
         return True, f"exit_{mode_name}_d_3_11"
@@ -31332,26 +31379,26 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14_lt_50)
         and (last_rsi_3_4h_lt_10)
         and (last_roc_9_1h < -20.0)
-        and (last_roc_9_4h < -20.0)
+        and (last_roc_9_4h_lt_neg_20)
       ):
         return True, f"exit_{mode_name}_d_3_12"
-      elif (last_rsi_3_gt_80) and (last_rsi_3_4h < 5.0) and (last_roc_9_4h < -25.0):
+      elif (last_rsi_3_gt_80) and (last_rsi_3_4h_lt_5) and (last_roc_9_4h_lt_neg_25):
         return True, f"exit_{mode_name}_d_3_13"
-      elif (last_rsi_3_gt_90) and (last_willr_14 > -8.0) and (last_rsi_3_4h < 5.0) and (last_aroonu_14_4h_gt_25):
+      elif (last_rsi_3_gt_90) and (last_willr_14_gt_neg_8) and (last_rsi_3_4h_lt_5) and (last_aroonu_14_4h_gt_25):
         return True, f"exit_{mode_name}_d_3_14"
       elif (last_rsi_3_gt_90) and (last_rsi_14 > 65.0) and (last_roc_9_4h < -30.0):
         return True, f"exit_{mode_name}_d_3_15"
       elif (
         (last_rsi_3_gt_70)
         and (last_aroonu_14_4h_gt_25)
-        and (last_roc_9_4h < -25.0)
+        and (last_roc_9_4h_lt_neg_25)
         and (last_aroonu_14_1d > 50.0)
         and (last_change_pct_1d < -15.0)
       ):
         return True, f"exit_{mode_name}_d_3_16"
       elif (
         (last_rsi_3_gt_80)
-        and (last_willr_14 > -25.0)
+        and (last_willr_14_gt_neg_25)
         and (last_rsi_3_1h_lt_10)
         and (last_stochrsi_k_4h_gt_90)
         and (last_roc_9_4h > 30.0)
@@ -31372,31 +31419,31 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_3_21"
       elif (
         (last_rsi_3_gt_94)
-        and (last_willr_14 > -6.0)
-        and (last_change_pct_4h < -5.0)
+        and (last_willr_14_gt_neg_6)
+        and (last_change_pct_4h_lt_neg_5)
         and (last_stochrsi_k_4h_gt_50)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
       ):
         return True, f"exit_{mode_name}_d_3_22"
-      elif (last_rsi_3_gt_85) and (last_willr_14 > -20.0) and (last_rsi_3_1h_lt_15) and (last_rsi_3_1d < 5.0):
+      elif (last_rsi_3_gt_85) and (last_willr_14_gt_neg_20) and (last_rsi_3_1h_lt_15) and (last_rsi_3_1d < 5.0):
         return True, f"exit_{mode_name}_d_3_23"
       elif (
         (last_rsi_3_gt_88)
         and (last_rsi_14_gt_68)
-        and (last_willr_14 > -25.0)
+        and (last_willr_14_gt_neg_25)
         and (last_rsi_3_4h_lt_30)
         and (last_aroonu_14_4h_gt_75)
       ):
         return True, f"exit_{mode_name}_d_3_24"
       elif (
         (last_rsi_3_gt_80)
-        and (last_willr_14 > -8.0)
+        and (last_willr_14_gt_neg_8)
         and (last_rsi_3_4h_lt_10)
         and (last_roc_9_4h < -15.0)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d > 50.0))
       ):
         return True, f"exit_{mode_name}_d_3_25"
-      elif (last_rsi_3_gt_75) and (last_willr_14 > -8.0) and (last_rsi_3_4h_lt_15) and (last_roc_9_4h < -20.0):
+      elif (last_rsi_3_gt_75) and (last_willr_14_gt_neg_8) and (last_rsi_3_4h_lt_15) and (last_roc_9_4h_lt_neg_20):
         return True, f"exit_{mode_name}_d_3_26"
       elif (
         (last_rsi_3_gt_65)
@@ -31423,27 +31470,27 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14_lt_50)
         and (last_rsi_3_1h_lt_15)
         and (last_rsi_3_4h_lt_15)
-        and (last_stochrsi_k_1h > 25.0)
+        and (last_stochrsi_k_1h_gt_25)
       ):
         return True, f"exit_{mode_name}_d_3_31"
-      elif (last_rsi_3_gt_80) and (last_rsi_3_1h_lt_15) and (last_roc_2_4h < -30.0) and (last_stochrsi_k_4h_gt_30):
+      elif (last_rsi_3_gt_80) and (last_rsi_3_1h_lt_15) and (last_roc_2_4h_lt_neg_30) and (last_stochrsi_k_4h_gt_30):
         return True, f"exit_{mode_name}_d_3_32"
       elif (
         (last_rsi_3_gt_80)
-        and (last_willr_14 > -6.0)
+        and (last_willr_14_gt_neg_6)
         and (last_roc_2_1h < -10.0)
         and (last_roc_9_1h > 30.0)
         and (last_stochrsi_k_1h_gt_50)
       ):
         return True, f"exit_{mode_name}_d_3_33"
-      elif (last_rsi_3_gt_65) and (last_rsi_3_15m < 30.0) and (last_rsi_14_1h > 80.0) and (last_roc_9_1h > 40.0):
+      elif (last_rsi_3_gt_65) and (last_rsi_3_15m_lt_30) and (last_rsi_14_1h > 80.0) and (last_roc_9_1h > 40.0):
         return True, f"exit_{mode_name}_d_3_34"
-      elif (last_rsi_3_gt_84) and (last_willr_14 > -8.0) and (last_rsi_3_1d_lt_25) and (last_stochrsi_k_1h > 75.0):
+      elif (last_rsi_3_gt_84) and (last_willr_14_gt_neg_8) and (last_rsi_3_1d_lt_25) and (last_stochrsi_k_1h_gt_75):
         return True, f"exit_{mode_name}_d_3_35"
       elif (
         (last_rsi_3_gt_75)
-        and (last_willr_14 > -25.0)
-        and (last_roc_9_4h < -25.0)
+        and (last_willr_14_gt_neg_25)
+        and (last_roc_9_4h_lt_neg_25)
         and (last_rsi_3_1d_lt_25)
         and (last_stochrsi_k_1h_gt_50)
       ):
@@ -31456,13 +31503,13 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_stochrsi_k_4h_gt_50)
       ):
         return True, f"exit_{mode_name}_d_3_37"
-      elif (last_rsi_3_gt_75) and (last_willr_14 > -25.0) and (last_rsi_3_4h_lt_10) and (last_stochrsi_k_4h_gt_20):
+      elif (last_rsi_3_gt_75) and (last_willr_14_gt_neg_25) and (last_rsi_3_4h_lt_10) and (last_stochrsi_k_4h_gt_20):
         return True, f"exit_{mode_name}_d_3_38"
-      elif (last_rsi_3 > 93.0) and (last_willr_14 > -7.0) and (last_cmf_20_4h < -0.0) and (last_rsi_3_4h_lt_10):
+      elif (last_rsi_3 > 93.0) and (last_willr_14 > -7.0) and (last_cmf_20_4h_lt_0) and (last_rsi_3_4h_lt_10):
         return True, f"exit_{mode_name}_d_3_39"
       elif (
         (last_rsi_3_gt_75)
-        and (last_willr_14 > -25.0)
+        and (last_willr_14_gt_neg_25)
         and (last_rsi_3_1h_lt_30)
         and (last_stochrsi_k_1h_gt_30)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d > 90.0))
@@ -31470,7 +31517,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_3_40"
       elif (
         (last_rsi_3_gt_85)
-        and (last_willr_14 > -20.0)
+        and (last_willr_14_gt_neg_20)
         and (last_rsi_3_1h_lt_30)
         and (last_stochrsi_k_4h_gt_25)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 50.0))
@@ -31494,13 +31541,13 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_3_43"
       elif (
         (last_rsi_3 > 55.0)
-        and (last_willr_14 > -15.0)
+        and (last_willr_14_gt_neg_15)
         and (last_rsi_3_4h_lt_30)
         and (last_rsi_3_1d_lt_25)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
       ):
         return True, f"exit_{mode_name}_d_3_44"
-      elif (last_rsi_3_gt_90) and (last_willr_14 > -10.0) and (last_rsi_3_1h_lt_10):
+      elif (last_rsi_3_gt_90) and (last_willr_14_gt_neg_10) and (last_rsi_3_1h_lt_10):
         return True, f"exit_{mode_name}_d_3_45"
       elif (last_rsi_3_gt_70) and (last_rsi_3_1h_lt_15) and (last_rsi_3_4h_lt_10) and (last_roc_2_1d < -20.0):
         return True, f"exit_{mode_name}_d_3_46"
@@ -31508,7 +31555,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3_gt_82)
         and (last_stochrsi_k_1h_gt_80)
         and (last_stochrsi_k_4h_gt_40)
-        and (last_change_pct_1d < -5.0)
+        and (last_change_pct_1d_lt_neg_5)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -5.0))
       ):
         return True, f"exit_{mode_name}_d_3_47"
@@ -31522,20 +31569,20 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_3_48"
       elif (
         (last_rsi_3_gt_80)
-        and (last_willr_14 > -8.0)
+        and (last_willr_14_gt_neg_8)
         and (last_rsi_3_4h_lt_20)
-        and (last_change_pct_1d < -5.0)
+        and (last_change_pct_1d_lt_neg_5)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d > 50.0))
       ):
         return True, f"exit_{mode_name}_d_3_49"
-      elif (last_rsi_3_gt_80) and (last_willr_14 > -8.0) and (last_rsi_3_1d < 10.0) and (last_stochrsi_k_1h > 90.0):
+      elif (last_rsi_3_gt_80) and (last_willr_14_gt_neg_8) and (last_rsi_3_1d < 10.0) and (last_stochrsi_k_1h_gt_90):
         return True, f"exit_{mode_name}_d_3_50"
       elif (last_rsi_3_gt_62) and (last_rsi_14_lt_50) and (last_rsi_3_4h_lt_20) and (last_stochrsi_k_1h_gt_50):
         return True, f"exit_{mode_name}_d_3_51"
       elif (
         (last_rsi_3_gt_76)
         and (last_rsi_14 > 56.0)
-        and (last_willr_14 > -10.0)
+        and (last_willr_14_gt_neg_10)
         and (last_stochrsi_k_1h_gt_70)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -15.0))
       ):
@@ -31543,7 +31590,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3_gt_70)
         and (last_rsi_14_lt_50)
-        and (last_willr_14 > -25.0)
+        and (last_willr_14_gt_neg_25)
         and (last_rsi_3_1h_lt_20)
         and (last_stochrsi_k_4h_gt_50)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d > 50.0))
@@ -31553,14 +31600,14 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3_gt_74)
         and (last_rsi_14_lt_50)
         and (last_stochrsi_k_1h_gt_50)
-        and (last_roc_9_4h < -10.0)
+        and (last_roc_9_4h_lt_neg_10)
         and (last_change_pct_1d < -10.0)
       ):
         return True, f"exit_{mode_name}_d_3_54"
       elif (
         (last_rsi_3_gt_90)
-        and (last_willr_14 > -18.0)
-        and (last_roc_9_4h < -5.0)
+        and (last_willr_14_gt_neg_18)
+        and (last_roc_9_4h_lt_neg_5)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 10.0))
         and (last_stochrsi_k_1h_gt_50)
       ):
@@ -31571,14 +31618,14 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_3_1h_lt_30)
         and (last_rsi_3_4h_lt_25)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
-        and (last_stochrsi_k_4h > 10.0)
+        and (last_stochrsi_k_4h_gt_10)
       ):
         return True, f"exit_{mode_name}_d_3_56"
       elif (
         (last_rsi_3_gt_50)
         and (last_rsi_14 < 40.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
-        and (last_stochrsi_k_4h > 70.0)
+        and (last_stochrsi_k_4h_gt_70)
       ):
         return True, f"exit_{mode_name}_d_3_57"
       elif (
@@ -31591,7 +31638,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_3_58"
       elif (
         (last_rsi_3_gt_85)
-        and (last_willr_14 > -16.0)
+        and (last_willr_14_gt_neg_16)
         and (last_rsi_3_4h_lt_25)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -15.0))
         and (last_stochrsi_k_4h_gt_40)
@@ -31602,18 +31649,18 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14_lt_44)
         and (last_rsi_14_4h > 65.0)
         and (last_stochrsi_k_4h_gt_50)
-        and (last_stochrsi_k_1d > 50.0)
+        and (last_stochrsi_k_1d_gt_50)
       ):
         return True, f"exit_{mode_name}_d_3_60"
-      elif (last_rsi_3_gt_90) and (last_willr_14 > -25.0) and (last_rsi_3_4h_lt_10) and (last_stochrsi_k_1h_gt_30):
+      elif (last_rsi_3_gt_90) and (last_willr_14_gt_neg_25) and (last_rsi_3_4h_lt_10) and (last_stochrsi_k_1h_gt_30):
         return True, f"exit_{mode_name}_d_3_61"
       elif (
         (last_rsi_3_gt_82)
-        and (last_willr_14 > -6.0)
+        and (last_willr_14_gt_neg_6)
         and (last_rsi_3_1h_lt_30)
         and (last_rsi_3_4h_lt_20)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 20.0))
-        and (last_change_pct_1d < -5.0)
+        and (last_change_pct_1d_lt_neg_5)
       ):
         return True, f"exit_{mode_name}_d_3_62"
       elif (last_rsi_3_gt_64) and (last_rsi_3_1d_lt_25) and (last_stochrsi_k_1h_gt_80) and (last_stochrsi_k_4h_gt_30):
@@ -31632,7 +31679,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3_gt_50)
         and (last_rsi_14_lt_46)
-        and (last_stochrsi_k_4h > 80.0)
+        and (last_stochrsi_k_4h_gt_80)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -25.0))
       ):
         return True, f"exit_{mode_name}_d_3_67"
@@ -31640,17 +31687,17 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3_gt_80)
         and (last_rsi_14_lt_52)
         and (last_rsi_3_1h_lt_25)
-        and (last_roc_2_4h < -30.0)
+        and (last_roc_2_4h_lt_neg_30)
         and (last_stochrsi_k_4h_gt_25)
       ):
         return True, f"exit_{mode_name}_d_3_68"
       elif (
-        (last_rsi_3_gt_94) and (last_roc_9_4h > 20.0) and (last_stochrsi_k_4h_gt_50) and (last_change_pct_4h < -5.0)
+        (last_rsi_3_gt_94) and (last_roc_9_4h > 20.0) and (last_stochrsi_k_4h_gt_50) and (last_change_pct_4h_lt_neg_5)
       ):
         return True, f"exit_{mode_name}_d_3_69"
       elif (last_rsi_3_gt_62) and (last_rsi_14_lt_44) and (last_rsi_3_1h_lt_25) and (last_stochrsi_k_4h_gt_20):
         return True, f"exit_{mode_name}_d_3_70"
-      elif (last_rsi_3_gt_60) and (last_rsi_14_lt_48) and (last_rsi_3_4h_lt_25) and (last_stochrsi_k_1h > 20.0):
+      elif (last_rsi_3_gt_60) and (last_rsi_14_lt_48) and (last_rsi_3_4h_lt_25) and (last_stochrsi_k_1h_gt_20):
         return True, f"exit_{mode_name}_d_3_71"
       elif (last_rsi_3_gt_74) and (last_rsi_14_lt_46) and (last_rsi_3_1h_lt_10) and (last_aroonu_14_4h_gt_25):
         return True, f"exit_{mode_name}_d_3_72"
@@ -31658,13 +31705,13 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3_gt_74)
         and (last_rsi_3_1h_lt_25)
         and (last_rsi_3_4h_lt_15)
-        and (last_roc_9_4h < -20.0)
+        and (last_roc_9_4h_lt_neg_20)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -25.0))
       ):
         return True, f"exit_{mode_name}_d_3_73"
       elif (
         (last_rsi_3 > 96.0)
-        and (last_willr_14 > -10.0)
+        and (last_willr_14_gt_neg_10)
         and (last_rsi_3_4h_lt_25)
         and (last_rsi_3_1d_lt_25)
         and (last_stochrsi_k_1h_gt_50)
@@ -31677,7 +31724,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d > 50.0))
       ):
         return True, f"exit_{mode_name}_d_3_75"
-      elif (last_rsi_3_gt_64) and (last_rsi_14_lt_54) and (last_roc_9_1h > 80.0) and (last_stochrsi_k_4h > 80.0):
+      elif (last_rsi_3_gt_64) and (last_rsi_14_lt_54) and (last_roc_9_1h > 80.0) and (last_stochrsi_k_4h_gt_80):
         return True, f"exit_{mode_name}_d_3_76"
       elif (
         (last_rsi_3_gt_72)
@@ -31688,13 +31735,13 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_3_77"
       elif (
         (last_rsi_3_gt_82)
-        and (last_willr_14 > -20.0)
+        and (last_willr_14_gt_neg_20)
         and (last_rsi_3_1h_lt_30)
         and (last_rsi_3_4h_lt_20)
         and (last_rsi_3_1d < 20.0)
       ):
         return True, f"exit_{mode_name}_d_3_78"
-      elif (last_rsi_3_gt_88) and (last_willr_14 > -6.0) and (last_rsi_3_1h_lt_30) and (last_rsi_3_4h_lt_10):
+      elif (last_rsi_3_gt_88) and (last_willr_14_gt_neg_6) and (last_rsi_3_1h_lt_30) and (last_rsi_3_4h_lt_10):
         return True, f"exit_{mode_name}_d_3_79"
       elif (
         (last_rsi_3_gt_68)
@@ -31706,7 +31753,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_3_80"
       elif (
         (last_rsi_3_gt_80)
-        and (last_willr_14 > -14.0)
+        and (last_willr_14_gt_neg_14)
         and (last_rsi_3_1h_lt_25)
         and (last_rsi_3_4h_lt_25)
         and (isinstance(last_rsi_14_1d, np.float64) and (last_rsi_14_1d > 50.0))
@@ -31714,7 +31761,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_3_81"
       elif (
         (last_rsi_3_gt_78)
-        and (last_willr_14 > -14.0)
+        and (last_willr_14_gt_neg_14)
         and (last_rsi_3_4h_lt_30)
         and (last_rsi_3_1d < 15.0)
         and (last_stochrsi_k_4h_gt_40)
@@ -31728,11 +31775,11 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_stochrsi_k_4h_gt_40)
       ):
         return True, f"exit_{mode_name}_d_3_83"
-      elif (last_rsi_3_gt_86) and (last_willr_14 > -6.0) and (last_rsi_3_4h_lt_30) and (last_stochrsi_k_1h > 20.0):
+      elif (last_rsi_3_gt_86) and (last_willr_14_gt_neg_6) and (last_rsi_3_4h_lt_30) and (last_stochrsi_k_1h_gt_20):
         return True, f"exit_{mode_name}_d_3_84"
       elif (
         (last_rsi_3_gt_84)
-        and (last_willr_14 > -12.0)
+        and (last_willr_14_gt_neg_12)
         and (last_rsi_3_1h_lt_30)
         and (last_rsi_3_4h_lt_40)
         and (last_stochrsi_k_4h_gt_50)
@@ -31765,13 +31812,13 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3_gt_74)
         and (last_rsi_14_lt_44)
-        and (last_roc_9_1h < -5.0)
+        and (last_roc_9_1h_lt_neg_5)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 25.0))
       ):
         return True, f"exit_{mode_name}_d_3_89"
       elif (
         (last_rsi_3_gt_88)
-        and (last_willr_14 > -25.0)
+        and (last_willr_14_gt_neg_25)
         and (last_rsi_3_1h_lt_50)
         and (last_rsi_3_4h_lt_30)
         and (last_aroonu_14_4h_gt_50)
@@ -31791,7 +31838,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3_gt_76)
         and (last_rsi_14_lt_52)
         and (last_rsi_3_1h_lt_40)
-        and (last_stochrsi_k_1h > 25.0)
+        and (last_stochrsi_k_1h_gt_25)
         and (last_stochrsi_k_4h_gt_50)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -25.0))
       ):
@@ -31818,10 +31865,10 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_3_94"
       elif (
         (last_rsi_3_gt_80)
-        and (last_willr_14 > -16.0)
+        and (last_willr_14_gt_neg_16)
         and (last_rsi_3_1h_lt_45)
         and (last_rsi_3_4h_lt_40)
-        and (last_stochrsi_k_4h > 10.0)
+        and (last_stochrsi_k_4h_gt_10)
         and (isinstance(last_aroonu_14_1d, np.float64) and (last_aroonu_14_1d > 75.0))
       ):
         return True, f"exit_{mode_name}_d_3_95"
@@ -31851,20 +31898,20 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_3_98"
       elif (
-        (last_rsi_3 > 56.0)
+        (last_rsi_3_gt_56)
         and (last_rsi_14 < 56.0)
         and (last_rsi_3_1h < 65.0)
         and (last_rsi_3_4h_lt_60)
         and (last_aroonu_14_4h_gt_50)
-        and (last_stoch_k_4h > 40.0)
+        and (last_stoch_k_4h_gt_40)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 80.0))
       ):
         return True, f"exit_{mode_name}_d_3_99"
-      elif (last_rsi_3_gt_94) and (last_rsi_14 > 72.0) and (last_rsi_3_15m > 70.0) and (last_rsi_3_4h < 80.0):
+      elif (last_rsi_3_gt_94) and (last_rsi_14 > 72.0) and (last_rsi_3_15m_gt_70) and (last_rsi_3_4h < 80.0):
         return True, f"exit_{mode_name}_d_3_100"
       elif (
         (last_rsi_3_gt_80)
-        and (last_willr_14 > -20.0)
+        and (last_willr_14_gt_neg_20)
         and (last_rsi_3_1h_lt_50)
         and (last_stochrsi_k_4h_gt_40)
         and (isinstance(last_roc_9_4h, np.float64) and (last_roc_9_4h > 40.0))
@@ -31893,7 +31940,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_3_1h_lt_60)
         and (last_stochrsi_k_1h_gt_40)
         and (last_stochrsi_k_4h_gt_90)
-        and (last_roc_9_4h > 40.0)
+        and (last_roc_9_4h_gt_40)
       ):
         return True, f"exit_{mode_name}_d_3_104"
       elif (
@@ -31901,7 +31948,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14_lt_52)
         and (last_rsi_3_15m < 55.0)
         and (last_stochrsi_k_4h_gt_90)
-        and (last_roc_9_4h > 25.0)
+        and (last_roc_9_4h_gt_25)
       ):
         return True, f"exit_{mode_name}_d_3_105"
       elif (
@@ -31910,7 +31957,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_3_1h_lt_50)
         and (last_stochrsi_k_1h_gt_50)
         and (last_rsi_14_4h_gt_70)
-        and (last_roc_9_4h > 40.0)
+        and (last_roc_9_4h_gt_40)
       ):
         return True, f"exit_{mode_name}_d_3_106"
       elif (
@@ -31925,13 +31972,13 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_3_108"
       elif (
         (last_rsi_3_gt_72)
-        and (last_willr_14 > -12.0)
+        and (last_willr_14_gt_neg_12)
         and (last_rsi_3_1h_lt_50)
         and (last_rsi_3_4h_lt_20)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 50.0))
       ):
         return True, f"exit_{mode_name}_d_3_109"
-      elif (last_rsi_3_gt_68) and (last_rsi_3_4h < 65.0) and (last_stochrsi_k_4h_gt_50) and (last_roc_9_4h > 25.0):
+      elif (last_rsi_3_gt_68) and (last_rsi_3_4h < 65.0) and (last_stochrsi_k_4h_gt_50) and (last_roc_9_4h_gt_25):
         return True, f"exit_{mode_name}_d_3_110"
       elif (
         (last_rsi_3 > 46.0)
@@ -31948,14 +31995,14 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_willr_14 > -35.0)
         and (last_rsi_14 < 56.0)
         and (last_rsi_3_1h_lt_35)
-        and (last_rsi_3_4h < 35.0)
+        and (last_rsi_3_4h_lt_35)
         and (last_rsi_3_1d < 60.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
       ):
         return True, f"exit_{mode_name}_d_3_112"
       elif (
         (last_rsi_3_gt_80)
-        and (last_willr_14 > -6.0)
+        and (last_willr_14_gt_neg_6)
         and (last_rsi_3_1d_lt_30)
         and (last_stochrsi_k_4h_gt_50)
         and (isinstance(last_roc_9_4h, np.float64) and (last_roc_9_4h > 10.0))
@@ -31973,7 +32020,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3_gt_74)
         and (last_rsi_14_lt_52)
-        and (last_rsi_3_15m < 30.0)
+        and (last_rsi_3_15m_lt_30)
         and (last_stochrsi_k_1h_gt_50)
         and (last_stochrsi_k_4h_gt_50)
       ):
@@ -31986,7 +32033,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_3_118"
       elif (
         (last_rsi_3_gt_82)
-        and (last_willr_14 > -20.0)
+        and (last_willr_14_gt_neg_20)
         and (last_rsi_3_1h_lt_60)
         and (last_rsi_3_4h_lt_60)
         and (last_stochrsi_k_1h_gt_40)
@@ -31994,11 +32041,11 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_3_119"
       elif (last_rsi_3_gt_50) and (last_rsi_14_lt_52) and (last_rsi_3_1h_lt_40) and (last_aroonu_14_4h_gt_75):
         return True, f"exit_{mode_name}_d_3_120"
-      elif (last_rsi_3 > 56.0) and (last_rsi_14_lt_50) and (last_rsi_3_1h_lt_50) and (last_rsi_14_4h > 85.0):
+      elif (last_rsi_3_gt_56) and (last_rsi_14_lt_50) and (last_rsi_3_1h_lt_50) and (last_rsi_14_4h > 85.0):
         return True, f"exit_{mode_name}_d_3_121"
       elif (last_rsi_3 > 54.0) and (last_rsi_14_lt_48) and (last_rsi_3_4h_lt_30) and (last_stochrsi_k_1h_gt_50):
         return True, f"exit_{mode_name}_d_3_122"
-      elif (last_rsi_3_gt_84) and (last_willr_14 > -8.0) and (last_rsi_3_1h_lt_10) and (last_rsi_3_1d_lt_30):
+      elif (last_rsi_3_gt_84) and (last_willr_14_gt_neg_8) and (last_rsi_3_1h_lt_10) and (last_rsi_3_1d_lt_30):
         return True, f"exit_{mode_name}_d_3_123"
       elif (
         (last_rsi_3_gt_84)
@@ -32008,16 +32055,16 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_3_124"
       elif (
         (last_rsi_3_gt_72)
-        and (last_willr_14 > -8.0)
+        and (last_willr_14_gt_neg_8)
         and (last_rsi_3_1h_lt_10)
         and (last_rsi_3_4h_lt_40)
-        and (last_rsi_3_1d < 40.0)
+        and (last_rsi_3_1d_lt_40)
         and (last_close < (last_high_max_30_1d * 0.50))
       ):
         return True, f"exit_{mode_name}_d_3_125"
       elif (last_rsi_3_gt_86) and (last_rsi_3_1h_lt_15) and (last_rsi_3_4h_lt_40) and (last_stochrsi_k_4h_gt_50):
         return True, f"exit_{mode_name}_d_3_126"
-      elif (last_rsi_3_gt_86) and (last_rsi_3_1h_lt_10) and (last_rsi_3_4h_lt_30) and (last_rsi_3_1d < 40.0):
+      elif (last_rsi_3_gt_86) and (last_rsi_3_1h_lt_10) and (last_rsi_3_4h_lt_30) and (last_rsi_3_1d_lt_40):
         return True, f"exit_{mode_name}_d_3_127"
       elif (last_rsi_3_gt_90) and (last_rsi_3_4h_lt_30) and (last_aroonu_14_4h > 85.0):
         return True, f"exit_{mode_name}_d_3_128"
@@ -32039,7 +32086,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3_gt_76)
         and (last_rsi_3_1h_lt_35)
-        and (last_rsi_3_4h < 35.0)
+        and (last_rsi_3_4h_lt_35)
         and (last_aroonu_14_1h > 50.0)
         and (last_stochrsi_k_1h_gt_40)
       ):
@@ -32110,7 +32157,7 @@ class NostalgiaForInfinityX7(IStrategy):
       last_rsi_14_4h_gt_70 = last_rsi_14_4h > 70.0
       last_rsi_3_1d_lt_30 = last_rsi_3_1d < 30.0
       if (
-        (last_willr_14 > -1.0)
+        (last_willr_14_gt_neg_1)
         and (last_rsi_14 > 78.0)
         and (isinstance(last_ema_200_1h, np.float64) and (last_ema_12_1h < last_ema_200_1h))
         and (isinstance(last_ema_200_4h, np.float64) and (last_ema_12_4h < last_ema_200_4h))
@@ -32119,68 +32166,68 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_4_1"
       elif (
-        (last_willr_14 > -1.0)
+        (last_willr_14_gt_neg_1)
         and (last_rsi_14 > 62.0)
-        and (last_cmf_20_1h < -0.0)
+        and (last_cmf_20_1h_lt_0)
         and (isinstance(last_ema_200_1h, np.float64) and (last_ema_12_1h < last_ema_200_1h))
         and (isinstance(last_ema_200_4h, np.float64) and (last_ema_12_4h < last_ema_200_4h))
       ):
         return True, f"exit_{mode_name}_d_4_2"
       elif (
-        (last_willr_14 > -20.0)
+        (last_willr_14_gt_neg_20)
         and (last_stochrsi_k_gt_95)
-        and (last_cmf_20_1h < -0.0)
-        and (last_cmf_20_4h < -0.0)
-        and ((last_stochrsi_k_4h_gt_20) and (last_stochrsi_k_change_pct_4h < -10.0))
+        and (last_cmf_20_1h_lt_0)
+        and (last_cmf_20_4h_lt_0)
+        and ((last_stochrsi_k_4h_gt_20) and (last_stochrsi_k_change_pct_4h_lt_neg_10))
       ):
         return True, f"exit_{mode_name}_d_4_3"
       elif (
-        (last_willr_14 > -30.0)
+        (last_willr_14_gt_neg_30)
         and (last_rsi_14 > 65.0)
         and (last_stochrsi_k_gt_95)
-        and (last_stochrsi_k_4h > 70.0)
+        and (last_stochrsi_k_4h_gt_70)
         and (isinstance(last_ema_200_1h, np.float64) and (last_ema_12_1h < last_ema_200_1h))
         and (isinstance(last_ema_200_4h, np.float64) and (last_ema_12_4h < last_ema_200_4h))
       ):
         return True, f"exit_{mode_name}_d_4_4"
-      elif (last_willr_14 > -8.0) and (last_rsi_14_gt_66) and (last_roc_9_1h < -5.0) and (last_roc_9_4h < -5.0):
+      elif (last_willr_14_gt_neg_8) and (last_rsi_14_gt_66) and (last_roc_9_1h_lt_neg_5) and (last_roc_9_4h_lt_neg_5):
         return True, f"exit_{mode_name}_d_4_5"
       elif (
         (last_rsi_3_gt_70)
-        and (last_stochrsi_k > 70.0)
+        and (last_stochrsi_k_gt_70)
         and (last_rsi_14 < 40.0)
-        and (last_roc_9_1h < -10.0)
+        and (last_roc_9_1h_lt_neg_10)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 50.0))
       ):
         return True, f"exit_{mode_name}_d_4_6"
       elif (
         (last_rsi_14_lt_50)
-        and (last_stochrsi_k > 70.0)
+        and (last_stochrsi_k_gt_70)
         and (last_stochrsi_k_4h_gt_50)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -40.0))
       ):
         return True, f"exit_{mode_name}_d_4_7"
       elif (
-        (last_willr_14 > -8.0)
+        (last_willr_14_gt_neg_8)
         and (last_stochrsi_k_gt_95)
         and (last_cmf_20_1h < -0.1)
         and (last_cmf_20_4h < -0.1)
-        and (last_change_pct_1d < -5.0)
+        and (last_change_pct_1d_lt_neg_5)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 15.0))
       ):
         return True, f"exit_{mode_name}_d_4_8"
       elif (
         (last_willr_14 > -7.0)
         and (last_rsi_3 > 95.0)
-        and (last_change_pct_4h < -5.0)
+        and (last_change_pct_4h_lt_neg_5)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
       ):
         return True, f"exit_{mode_name}_d_4_9"
       elif (
-        (last_willr_14 > -20.0)
+        (last_willr_14_gt_neg_20)
         and (last_rsi_14_lt_50)
-        and (last_roc_9_1h < -10.0)
-        and (last_roc_9_4h < -10.0)
+        and (last_roc_9_1h_lt_neg_10)
+        and (last_roc_9_4h_lt_neg_10)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 10.0))
       ):
         return True, f"exit_{mode_name}_d_4_10"
@@ -32188,7 +32235,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3_gt_75)
         and (last_rsi_14 < 45.0)
         and (last_roc_9_15m < -10.0)
-        and (last_roc_9_1h < -10.0)
+        and (last_roc_9_1h_lt_neg_10)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -20.0))
       ):
         return True, f"exit_{mode_name}_d_4_11"
@@ -32197,26 +32244,26 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14_lt_50)
         and (last_rsi_3_4h_lt_10)
         and (last_roc_9_1h < -20.0)
-        and (last_roc_9_4h < -20.0)
+        and (last_roc_9_4h_lt_neg_20)
       ):
         return True, f"exit_{mode_name}_d_4_12"
-      elif (last_rsi_3_gt_80) and (last_rsi_3_4h < 5.0) and (last_roc_9_4h < -25.0):
+      elif (last_rsi_3_gt_80) and (last_rsi_3_4h_lt_5) and (last_roc_9_4h_lt_neg_25):
         return True, f"exit_{mode_name}_d_4_13"
-      elif (last_rsi_3_gt_90) and (last_willr_14 > -10.0) and (last_rsi_3_4h < 5.0) and (last_aroonu_14_4h_gt_25):
+      elif (last_rsi_3_gt_90) and (last_willr_14_gt_neg_10) and (last_rsi_3_4h_lt_5) and (last_aroonu_14_4h_gt_25):
         return True, f"exit_{mode_name}_d_4_14"
       elif (last_rsi_3_gt_88) and (last_rsi_14 > 60.0) and (last_roc_9_4h < -30.0):
         return True, f"exit_{mode_name}_d_4_15"
       elif (
         (last_rsi_3_gt_70)
         and (last_aroonu_14_4h_gt_25)
-        and (last_roc_9_4h < -25.0)
+        and (last_roc_9_4h_lt_neg_25)
         and (last_aroonu_14_1d > 50.0)
         and (last_change_pct_1d < -15.0)
       ):
         return True, f"exit_{mode_name}_d_4_16"
       elif (
         (last_rsi_3_gt_80)
-        and (last_willr_14 > -30.0)
+        and (last_willr_14_gt_neg_30)
         and (last_rsi_3_1h_lt_10)
         and (last_stochrsi_k_4h_gt_90)
         and (last_roc_9_4h > 30.0)
@@ -32237,31 +32284,31 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_4_21"
       elif (
         (last_rsi_3_gt_92)
-        and (last_willr_14 > -8.0)
-        and (last_change_pct_4h < -5.0)
+        and (last_willr_14_gt_neg_8)
+        and (last_change_pct_4h_lt_neg_5)
         and (last_stochrsi_k_4h_gt_50)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
       ):
         return True, f"exit_{mode_name}_d_4_22"
-      elif (last_rsi_3_gt_80) and (last_willr_14 > -25.0) and (last_rsi_3_1h_lt_15) and (last_rsi_3_1d < 5.0):
+      elif (last_rsi_3_gt_80) and (last_willr_14_gt_neg_25) and (last_rsi_3_1h_lt_15) and (last_rsi_3_1d < 5.0):
         return True, f"exit_{mode_name}_d_4_23"
       elif (
         (last_rsi_3_gt_86)
         and (last_rsi_14_gt_66)
-        and (last_willr_14 > -30.0)
+        and (last_willr_14_gt_neg_30)
         and (last_rsi_3_4h_lt_30)
         and (last_aroonu_14_4h_gt_75)
       ):
         return True, f"exit_{mode_name}_d_4_24"
       elif (
         (last_rsi_3_gt_75)
-        and (last_willr_14 > -10.0)
+        and (last_willr_14_gt_neg_10)
         and (last_rsi_3_4h_lt_10)
         and (last_roc_9_4h < -15.0)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d > 50.0))
       ):
         return True, f"exit_{mode_name}_d_4_25"
-      elif (last_rsi_3_gt_70) and (last_willr_14 > -10.0) and (last_rsi_3_4h_lt_15) and (last_roc_9_4h < -20.0):
+      elif (last_rsi_3_gt_70) and (last_willr_14_gt_neg_10) and (last_rsi_3_4h_lt_15) and (last_roc_9_4h_lt_neg_20):
         return True, f"exit_{mode_name}_d_4_26"
       elif (
         (last_rsi_3_gt_65)
@@ -32288,27 +32335,27 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14_lt_50)
         and (last_rsi_3_1h_lt_15)
         and (last_rsi_3_4h_lt_15)
-        and (last_stochrsi_k_1h > 25.0)
+        and (last_stochrsi_k_1h_gt_25)
       ):
         return True, f"exit_{mode_name}_d_4_31"
-      elif (last_rsi_3_gt_75) and (last_rsi_3_1h_lt_15) and (last_roc_2_4h < -30.0) and (last_stochrsi_k_4h_gt_30):
+      elif (last_rsi_3_gt_75) and (last_rsi_3_1h_lt_15) and (last_roc_2_4h_lt_neg_30) and (last_stochrsi_k_4h_gt_30):
         return True, f"exit_{mode_name}_d_4_32"
       elif (
         (last_rsi_3_gt_75)
-        and (last_willr_14 > -8.0)
+        and (last_willr_14_gt_neg_8)
         and (last_roc_2_1h < -10.0)
         and (last_roc_9_1h > 30.0)
         and (last_stochrsi_k_1h_gt_50)
       ):
         return True, f"exit_{mode_name}_d_4_33"
-      elif (last_rsi_3_gt_65) and (last_rsi_3_15m < 30.0) and (last_rsi_14_1h > 80.0) and (last_roc_9_1h > 40.0):
+      elif (last_rsi_3_gt_65) and (last_rsi_3_15m_lt_30) and (last_rsi_14_1h > 80.0) and (last_roc_9_1h > 40.0):
         return True, f"exit_{mode_name}_d_4_34"
-      elif (last_rsi_3_gt_82) and (last_willr_14 > -9.0) and (last_rsi_3_1d_lt_25) and (last_stochrsi_k_1h > 75.0):
+      elif (last_rsi_3_gt_82) and (last_willr_14 > -9.0) and (last_rsi_3_1d_lt_25) and (last_stochrsi_k_1h_gt_75):
         return True, f"exit_{mode_name}_d_4_35"
       elif (
         (last_rsi_3_gt_70)
-        and (last_willr_14 > -30.0)
-        and (last_roc_9_4h < -25.0)
+        and (last_willr_14_gt_neg_30)
+        and (last_roc_9_4h_lt_neg_25)
         and (last_rsi_3_1d_lt_25)
         and (last_stochrsi_k_1h_gt_50)
       ):
@@ -32321,13 +32368,13 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_stochrsi_k_4h_gt_50)
       ):
         return True, f"exit_{mode_name}_d_4_37"
-      elif (last_rsi_3_gt_70) and (last_willr_14 > -30.0) and (last_rsi_3_4h_lt_10) and (last_stochrsi_k_4h_gt_20):
+      elif (last_rsi_3_gt_70) and (last_willr_14_gt_neg_30) and (last_rsi_3_4h_lt_10) and (last_stochrsi_k_4h_gt_20):
         return True, f"exit_{mode_name}_d_4_38"
-      elif (last_rsi_3_gt_92) and (last_willr_14 > -8.0) and (last_cmf_20_4h < -0.0) and (last_rsi_3_4h_lt_10):
+      elif (last_rsi_3_gt_92) and (last_willr_14_gt_neg_8) and (last_cmf_20_4h_lt_0) and (last_rsi_3_4h_lt_10):
         return True, f"exit_{mode_name}_d_4_39"
       elif (
         (last_rsi_3_gt_70)
-        and (last_willr_14 > -30.0)
+        and (last_willr_14_gt_neg_30)
         and (last_rsi_3_1h_lt_30)
         and (last_stochrsi_k_1h_gt_30)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d > 90.0))
@@ -32335,7 +32382,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_4_40"
       elif (
         (last_rsi_3_gt_80)
-        and (last_willr_14 > -25.0)
+        and (last_willr_14_gt_neg_25)
         and (last_rsi_3_1h_lt_30)
         and (last_stochrsi_k_4h_gt_25)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 50.0))
@@ -32359,13 +32406,13 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_4_43"
       elif (
         (last_rsi_3_gt_50)
-        and (last_willr_14 > -20.0)
+        and (last_willr_14_gt_neg_20)
         and (last_rsi_3_4h_lt_30)
         and (last_rsi_3_1d_lt_25)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
       ):
         return True, f"exit_{mode_name}_d_4_44"
-      elif (last_rsi_3_gt_88) and (last_willr_14 > -12.0) and (last_rsi_3_1h_lt_10):
+      elif (last_rsi_3_gt_88) and (last_willr_14_gt_neg_12) and (last_rsi_3_1h_lt_10):
         return True, f"exit_{mode_name}_d_4_45"
       elif (last_rsi_3_gt_70) and (last_rsi_3_1h_lt_15) and (last_rsi_3_4h_lt_10) and (last_roc_2_1d < -20.0):
         return True, f"exit_{mode_name}_d_4_46"
@@ -32373,7 +32420,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3_gt_80)
         and (last_stochrsi_k_1h_gt_80)
         and (last_stochrsi_k_4h_gt_40)
-        and (last_change_pct_1d < -5.0)
+        and (last_change_pct_1d_lt_neg_5)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -5.0))
       ):
         return True, f"exit_{mode_name}_d_4_47"
@@ -32387,20 +32434,20 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_4_48"
       elif (
         (last_rsi_3_gt_75)
-        and (last_willr_14 > -10.0)
+        and (last_willr_14_gt_neg_10)
         and (last_rsi_3_4h_lt_20)
-        and (last_change_pct_1d < -5.0)
+        and (last_change_pct_1d_lt_neg_5)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d > 50.0))
       ):
         return True, f"exit_{mode_name}_d_4_49"
-      elif (last_rsi_3_gt_80) and (last_willr_14 > -10.0) and (last_rsi_3_1d < 10.0) and (last_stochrsi_k_1h > 90.0):
+      elif (last_rsi_3_gt_80) and (last_willr_14_gt_neg_10) and (last_rsi_3_1d < 10.0) and (last_stochrsi_k_1h_gt_90):
         return True, f"exit_{mode_name}_d_4_50"
       elif (last_rsi_3_gt_60) and (last_rsi_14_lt_52) and (last_rsi_3_4h_lt_20) and (last_stochrsi_k_1h_gt_50):
         return True, f"exit_{mode_name}_d_4_51"
       elif (
         (last_rsi_3_gt_74)
         and (last_rsi_14 > 54.0)
-        and (last_willr_14 > -10.0)
+        and (last_willr_14_gt_neg_10)
         and (last_stochrsi_k_1h_gt_70)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -15.0))
       ):
@@ -32408,7 +32455,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3_gt_70)
         and (last_rsi_14_lt_50)
-        and (last_willr_14 > -25.0)
+        and (last_willr_14_gt_neg_25)
         and (last_rsi_3_1h_lt_20)
         and (last_stochrsi_k_4h_gt_50)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d > 50.0))
@@ -32418,14 +32465,14 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3_gt_72)
         and (last_rsi_14_lt_52)
         and (last_stochrsi_k_1h_gt_50)
-        and (last_roc_9_4h < -10.0)
+        and (last_roc_9_4h_lt_neg_10)
         and (last_change_pct_1d < -10.0)
       ):
         return True, f"exit_{mode_name}_d_4_54"
       elif (
         (last_rsi_3_gt_88)
-        and (last_willr_14 > -20.0)
-        and (last_roc_9_4h < -5.0)
+        and (last_willr_14_gt_neg_20)
+        and (last_roc_9_4h_lt_neg_5)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 10.0))
         and (last_stochrsi_k_1h_gt_50)
       ):
@@ -32436,14 +32483,14 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_3_1h_lt_30)
         and (last_rsi_3_4h_lt_25)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
-        and (last_stochrsi_k_4h > 10.0)
+        and (last_stochrsi_k_4h_gt_10)
       ):
         return True, f"exit_{mode_name}_d_4_56"
       elif (
         (last_rsi_3_gt_50)
         and (last_rsi_14 < 42.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
-        and (last_stochrsi_k_4h > 70.0)
+        and (last_stochrsi_k_4h_gt_70)
       ):
         return True, f"exit_{mode_name}_d_4_57"
       elif (
@@ -32456,7 +32503,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_4_58"
       elif (
         (last_rsi_3 > 85.0)
-        and (last_willr_14 > -18.0)
+        and (last_willr_14_gt_neg_18)
         and (last_rsi_3_4h_lt_25)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -15.0))
         and (last_stochrsi_k_4h_gt_40)
@@ -32467,18 +32514,18 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14_lt_46)
         and (last_rsi_14_4h > 65.0)
         and (last_stochrsi_k_4h_gt_50)
-        and (last_stochrsi_k_1d > 50.0)
+        and (last_stochrsi_k_1d_gt_50)
       ):
         return True, f"exit_{mode_name}_d_4_60"
-      elif (last_rsi_3_gt_90) and (last_willr_14 > -25.0) and (last_rsi_3_4h_lt_10) and (last_stochrsi_k_1h_gt_30):
+      elif (last_rsi_3_gt_90) and (last_willr_14_gt_neg_25) and (last_rsi_3_4h_lt_10) and (last_stochrsi_k_1h_gt_30):
         return True, f"exit_{mode_name}_d_4_61"
       elif (
         (last_rsi_3_gt_80)
-        and (last_willr_14 > -8.0)
+        and (last_willr_14_gt_neg_8)
         and (last_rsi_3_1h_lt_30)
         and (last_rsi_3_4h_lt_20)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 20.0))
-        and (last_change_pct_1d < -5.0)
+        and (last_change_pct_1d_lt_neg_5)
       ):
         return True, f"exit_{mode_name}_d_4_62"
       elif (last_rsi_3_gt_62) and (last_rsi_3_1d_lt_25) and (last_stochrsi_k_1h_gt_80) and (last_stochrsi_k_4h_gt_30):
@@ -32497,7 +32544,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3_gt_50)
         and (last_rsi_14_lt_48)
-        and (last_stochrsi_k_4h > 80.0)
+        and (last_stochrsi_k_4h_gt_80)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -25.0))
       ):
         return True, f"exit_{mode_name}_d_4_67"
@@ -32505,17 +32552,17 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3_gt_78)
         and (last_rsi_14_lt_54)
         and (last_rsi_3_1h_lt_25)
-        and (last_roc_2_4h < -30.0)
+        and (last_roc_2_4h_lt_neg_30)
         and (last_stochrsi_k_4h_gt_25)
       ):
         return True, f"exit_{mode_name}_d_4_68"
       elif (
-        (last_rsi_3 > 93.0) and (last_roc_9_4h > 20.0) and (last_stochrsi_k_4h_gt_50) and (last_change_pct_4h < -5.0)
+        (last_rsi_3 > 93.0) and (last_roc_9_4h > 20.0) and (last_stochrsi_k_4h_gt_50) and (last_change_pct_4h_lt_neg_5)
       ):
         return True, f"exit_{mode_name}_d_4_69"
       elif (last_rsi_3_gt_60) and (last_rsi_14_lt_46) and (last_rsi_3_1h_lt_25) and (last_stochrsi_k_4h_gt_20):
         return True, f"exit_{mode_name}_d_4_70"
-      elif (last_rsi_3 > 58.0) and (last_rsi_14_lt_50) and (last_rsi_3_4h_lt_25) and (last_stochrsi_k_1h > 20.0):
+      elif (last_rsi_3 > 58.0) and (last_rsi_14_lt_50) and (last_rsi_3_4h_lt_25) and (last_stochrsi_k_1h_gt_20):
         return True, f"exit_{mode_name}_d_4_71"
       elif (last_rsi_3_gt_72) and (last_rsi_14_lt_48) and (last_rsi_3_1h_lt_10) and (last_aroonu_14_4h_gt_25):
         return True, f"exit_{mode_name}_d_4_72"
@@ -32523,13 +32570,13 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3_gt_72)
         and (last_rsi_3_1h_lt_25)
         and (last_rsi_3_4h_lt_15)
-        and (last_roc_9_4h < -20.0)
+        and (last_roc_9_4h_lt_neg_20)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -25.0))
       ):
         return True, f"exit_{mode_name}_d_4_73"
       elif (
         (last_rsi_3 > 95.0)
-        and (last_willr_14 > -10.0)
+        and (last_willr_14_gt_neg_10)
         and (last_rsi_3_4h_lt_25)
         and (last_rsi_3_1d_lt_25)
         and (last_stochrsi_k_1h_gt_50)
@@ -32542,7 +32589,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d > 50.0))
       ):
         return True, f"exit_{mode_name}_d_4_75"
-      elif (last_rsi_3_gt_62) and (last_rsi_14_lt_56) and (last_roc_9_1h > 80.0) and (last_stochrsi_k_4h > 80.0):
+      elif (last_rsi_3_gt_62) and (last_rsi_14_lt_56) and (last_roc_9_1h > 80.0) and (last_stochrsi_k_4h_gt_80):
         return True, f"exit_{mode_name}_d_4_76"
       elif (
         (last_rsi_3_gt_70)
@@ -32559,7 +32606,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_3_1d < 20.0)
       ):
         return True, f"exit_{mode_name}_d_4_78"
-      elif (last_rsi_3_gt_86) and (last_willr_14 > -8.0) and (last_rsi_3_1h_lt_30) and (last_rsi_3_4h_lt_10):
+      elif (last_rsi_3_gt_86) and (last_willr_14_gt_neg_8) and (last_rsi_3_1h_lt_30) and (last_rsi_3_4h_lt_10):
         return True, f"exit_{mode_name}_d_4_79"
       elif (
         (last_rsi_3_gt_66)
@@ -32571,7 +32618,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_4_80"
       elif (
         (last_rsi_3_gt_78)
-        and (last_willr_14 > -16.0)
+        and (last_willr_14_gt_neg_16)
         and (last_rsi_3_1h_lt_25)
         and (last_rsi_3_4h_lt_25)
         and (isinstance(last_rsi_14_1d, np.float64) and (last_rsi_14_1d > 50.0))
@@ -32579,7 +32626,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_4_81"
       elif (
         (last_rsi_3_gt_76)
-        and (last_willr_14 > -16.0)
+        and (last_willr_14_gt_neg_16)
         and (last_rsi_3_4h_lt_30)
         and (last_rsi_3_1d < 15.0)
         and (last_stochrsi_k_4h_gt_40)
@@ -32593,11 +32640,11 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_stochrsi_k_4h_gt_40)
       ):
         return True, f"exit_{mode_name}_d_4_83"
-      elif (last_rsi_3_gt_84) and (last_willr_14 > -8.0) and (last_rsi_3_4h_lt_30) and (last_stochrsi_k_1h > 20.0):
+      elif (last_rsi_3_gt_84) and (last_willr_14_gt_neg_8) and (last_rsi_3_4h_lt_30) and (last_stochrsi_k_1h_gt_20):
         return True, f"exit_{mode_name}_d_4_84"
       elif (
         (last_rsi_3_gt_82)
-        and (last_willr_14 > -14.0)
+        and (last_willr_14_gt_neg_14)
         and (last_rsi_3_1h_lt_30)
         and (last_rsi_3_4h_lt_40)
         and (last_stochrsi_k_4h_gt_50)
@@ -32630,13 +32677,13 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3_gt_72)
         and (last_rsi_14_lt_46)
-        and (last_roc_9_1h < -5.0)
+        and (last_roc_9_1h_lt_neg_5)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 25.0))
       ):
         return True, f"exit_{mode_name}_d_4_89"
       elif (
         (last_rsi_3_gt_86)
-        and (last_willr_14 > -25.0)
+        and (last_willr_14_gt_neg_25)
         and (last_rsi_3_1h_lt_50)
         and (last_rsi_3_4h_lt_30)
         and (last_aroonu_14_4h_gt_50)
@@ -32656,7 +32703,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3_gt_74)
         and (last_rsi_14_lt_54)
         and (last_rsi_3_1h_lt_40)
-        and (last_stochrsi_k_1h > 25.0)
+        and (last_stochrsi_k_1h_gt_25)
         and (last_stochrsi_k_4h_gt_50)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -25.0))
       ):
@@ -32683,15 +32730,15 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_4_94"
       elif (
         (last_rsi_3_gt_78)
-        and (last_willr_14 > -18.0)
+        and (last_willr_14_gt_neg_18)
         and (last_rsi_3_1h_lt_45)
         and (last_rsi_3_4h_lt_40)
-        and (last_stochrsi_k_4h > 10.0)
+        and (last_stochrsi_k_4h_gt_10)
         and (isinstance(last_aroonu_14_1d, np.float64) and (last_aroonu_14_1d > 75.0))
       ):
         return True, f"exit_{mode_name}_d_4_95"
       elif (
-        (last_rsi_3 > 56.0)
+        (last_rsi_3_gt_56)
         and (last_rsi_14_lt_52)
         and (last_rsi_3_1h_lt_45)
         and (last_rsi_3_1d < 45.0)
@@ -32721,11 +32768,11 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_3_1h < 65.0)
         and (last_rsi_3_4h_lt_60)
         and (last_aroonu_14_4h_gt_50)
-        and (last_stoch_k_4h > 40.0)
+        and (last_stoch_k_4h_gt_40)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 80.0))
       ):
         return True, f"exit_{mode_name}_d_4_99"
-      elif (last_rsi_3_gt_92) and (last_rsi_14 > 70.0) and (last_rsi_3_15m > 70.0) and (last_rsi_3_4h < 80.0):
+      elif (last_rsi_3_gt_92) and (last_rsi_14 > 70.0) and (last_rsi_3_15m_gt_70) and (last_rsi_3_4h < 80.0):
         return True, f"exit_{mode_name}_d_4_100"
       elif (
         (last_rsi_3_gt_78)
@@ -32758,7 +32805,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_3_1h_lt_60)
         and (last_stochrsi_k_1h_gt_40)
         and (last_stochrsi_k_4h_gt_90)
-        and (last_roc_9_4h > 40.0)
+        and (last_roc_9_4h_gt_40)
       ):
         return True, f"exit_{mode_name}_d_4_104"
       elif (
@@ -32766,7 +32813,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14_lt_54)
         and (last_rsi_3_15m < 55.0)
         and (last_stochrsi_k_4h_gt_90)
-        and (last_roc_9_4h > 25.0)
+        and (last_roc_9_4h_gt_25)
       ):
         return True, f"exit_{mode_name}_d_4_105"
       elif (
@@ -32775,7 +32822,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_3_1h_lt_50)
         and (last_stochrsi_k_1h_gt_50)
         and (last_rsi_14_4h_gt_70)
-        and (last_roc_9_4h > 40.0)
+        and (last_roc_9_4h_gt_40)
       ):
         return True, f"exit_{mode_name}_d_4_106"
       elif (
@@ -32790,13 +32837,13 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_4_108"
       elif (
         (last_rsi_3_gt_70)
-        and (last_willr_14 > -14.0)
+        and (last_willr_14_gt_neg_14)
         and (last_rsi_3_1h_lt_50)
         and (last_rsi_3_4h_lt_20)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 50.0))
       ):
         return True, f"exit_{mode_name}_d_4_109"
-      elif (last_rsi_3_gt_66) and (last_rsi_3_4h < 65.0) and (last_stochrsi_k_4h_gt_50) and (last_roc_9_4h > 25.0):
+      elif (last_rsi_3_gt_66) and (last_rsi_3_4h < 65.0) and (last_stochrsi_k_4h_gt_50) and (last_roc_9_4h_gt_25):
         return True, f"exit_{mode_name}_d_4_110"
       elif (
         (last_rsi_3 > 44.0)
@@ -32813,14 +32860,14 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_willr_14 > -40.0)
         and (last_rsi_14 < 58.0)
         and (last_rsi_3_1h_lt_35)
-        and (last_rsi_3_4h < 35.0)
+        and (last_rsi_3_4h_lt_35)
         and (last_rsi_3_1d < 60.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
       ):
         return True, f"exit_{mode_name}_d_4_112"
       elif (
         (last_rsi_3_gt_78)
-        and (last_willr_14 > -8.0)
+        and (last_willr_14_gt_neg_8)
         and (last_rsi_3_1d_lt_30)
         and (last_stochrsi_k_4h_gt_50)
         and (isinstance(last_roc_9_4h, np.float64) and (last_roc_9_4h > 10.0))
@@ -32838,7 +32885,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3_gt_72)
         and (last_rsi_14_lt_54)
-        and (last_rsi_3_15m < 30.0)
+        and (last_rsi_3_15m_lt_30)
         and (last_stochrsi_k_1h_gt_50)
         and (last_stochrsi_k_4h_gt_50)
       ):
@@ -32851,7 +32898,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_4_118"
       elif (
         (last_rsi_3_gt_80)
-        and (last_willr_14 > -20.0)
+        and (last_willr_14_gt_neg_20)
         and (last_rsi_3_1h_lt_60)
         and (last_rsi_3_4h_lt_60)
         and (last_stochrsi_k_1h_gt_40)
@@ -32863,7 +32910,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_4_121"
       elif (last_rsi_3 > 52.0) and (last_rsi_14_lt_50) and (last_rsi_3_4h_lt_30) and (last_stochrsi_k_1h_gt_50):
         return True, f"exit_{mode_name}_d_4_122"
-      elif (last_rsi_3_gt_82) and (last_willr_14 > -10.0) and (last_rsi_3_1h_lt_10) and (last_rsi_3_1d_lt_30):
+      elif (last_rsi_3_gt_82) and (last_willr_14_gt_neg_10) and (last_rsi_3_1h_lt_10) and (last_rsi_3_1d_lt_30):
         return True, f"exit_{mode_name}_d_4_123"
       elif (
         (last_rsi_3_gt_82)
@@ -32873,16 +32920,16 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_4_124"
       elif (
         (last_rsi_3_gt_70)
-        and (last_willr_14 > -10.0)
+        and (last_willr_14_gt_neg_10)
         and (last_rsi_3_1h_lt_10)
         and (last_rsi_3_4h_lt_40)
-        and (last_rsi_3_1d < 40.0)
+        and (last_rsi_3_1d_lt_40)
         and (last_close < (last_high_max_30_1d * 0.50))
       ):
         return True, f"exit_{mode_name}_d_4_125"
       elif (last_rsi_3_gt_84) and (last_rsi_3_1h_lt_15) and (last_rsi_3_4h_lt_40) and (last_stochrsi_k_4h_gt_50):
         return True, f"exit_{mode_name}_d_4_126"
-      elif (last_rsi_3_gt_84) and (last_rsi_3_1h_lt_10) and (last_rsi_3_4h_lt_30) and (last_rsi_3_1d < 40.0):
+      elif (last_rsi_3_gt_84) and (last_rsi_3_1h_lt_10) and (last_rsi_3_4h_lt_30) and (last_rsi_3_1d_lt_40):
         return True, f"exit_{mode_name}_d_4_127"
       elif (last_rsi_3_gt_88) and (last_rsi_3_4h_lt_30) and (last_aroonu_14_4h > 85.0):
         return True, f"exit_{mode_name}_d_4_128"
@@ -32904,7 +32951,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3_gt_74)
         and (last_rsi_3_1h_lt_35)
-        and (last_rsi_3_4h < 35.0)
+        and (last_rsi_3_4h_lt_35)
         and (last_aroonu_14_1h > 50.0)
         and (last_stochrsi_k_1h_gt_40)
       ):
@@ -32974,7 +33021,7 @@ class NostalgiaForInfinityX7(IStrategy):
       last_rsi_14_4h_gt_70 = last_rsi_14_4h > 70.0
       last_rsi_3_1d_lt_30 = last_rsi_3_1d < 30.0
       if (
-        (last_willr_14 > -1.0)
+        (last_willr_14_gt_neg_1)
         and (last_rsi_14 > 78.0)
         and (isinstance(last_ema_200_1h, np.float64) and (last_ema_12_1h < last_ema_200_1h))
         and (isinstance(last_ema_200_4h, np.float64) and (last_ema_12_4h < last_ema_200_4h))
@@ -32983,68 +33030,68 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_5_1"
       elif (
-        (last_willr_14 > -1.0)
+        (last_willr_14_gt_neg_1)
         and (last_rsi_14 > 60.0)
-        and (last_cmf_20_1h < -0.0)
+        and (last_cmf_20_1h_lt_0)
         and (isinstance(last_ema_200_1h, np.float64) and (last_ema_12_1h < last_ema_200_1h))
         and (isinstance(last_ema_200_4h, np.float64) and (last_ema_12_4h < last_ema_200_4h))
       ):
         return True, f"exit_{mode_name}_d_5_2"
       elif (
-        (last_willr_14 > -20.0)
+        (last_willr_14_gt_neg_20)
         and (last_stochrsi_k_gt_95)
-        and (last_cmf_20_1h < -0.0)
-        and (last_cmf_20_4h < -0.0)
-        and ((last_stochrsi_k_4h_gt_20) and (last_stochrsi_k_change_pct_4h < -10.0))
+        and (last_cmf_20_1h_lt_0)
+        and (last_cmf_20_4h_lt_0)
+        and ((last_stochrsi_k_4h_gt_20) and (last_stochrsi_k_change_pct_4h_lt_neg_10))
       ):
         return True, f"exit_{mode_name}_d_5_3"
       elif (
-        (last_willr_14 > -30.0)
+        (last_willr_14_gt_neg_30)
         and (last_rsi_14 > 65.0)
         and (last_stochrsi_k_gt_95)
-        and (last_stochrsi_k_4h > 70.0)
+        and (last_stochrsi_k_4h_gt_70)
         and (isinstance(last_ema_200_1h, np.float64) and (last_ema_12_1h < last_ema_200_1h))
         and (isinstance(last_ema_200_4h, np.float64) and (last_ema_12_4h < last_ema_200_4h))
       ):
         return True, f"exit_{mode_name}_d_5_4"
-      elif (last_willr_14 > -10.0) and (last_rsi_14_gt_64) and (last_roc_9_1h < -5.0) and (last_roc_9_4h < -5.0):
+      elif (last_willr_14_gt_neg_10) and (last_rsi_14_gt_64) and (last_roc_9_1h_lt_neg_5) and (last_roc_9_4h_lt_neg_5):
         return True, f"exit_{mode_name}_d_5_5"
       elif (
         (last_rsi_3_gt_70)
-        and (last_stochrsi_k > 70.0)
+        and (last_stochrsi_k_gt_70)
         and (last_rsi_14 < 40.0)
-        and (last_roc_9_1h < -10.0)
+        and (last_roc_9_1h_lt_neg_10)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 50.0))
       ):
         return True, f"exit_{mode_name}_d_5_6"
       elif (
         (last_rsi_14_lt_50)
-        and (last_stochrsi_k > 70.0)
+        and (last_stochrsi_k_gt_70)
         and (last_stochrsi_k_4h_gt_50)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -40.0))
       ):
         return True, f"exit_{mode_name}_d_5_7"
       elif (
-        (last_willr_14 > -10.0)
+        (last_willr_14_gt_neg_10)
         and (last_stochrsi_k_gt_95)
         and (last_cmf_20_1h < -0.1)
         and (last_cmf_20_4h < -0.1)
-        and (last_change_pct_1d < -5.0)
+        and (last_change_pct_1d_lt_neg_5)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 15.0))
       ):
         return True, f"exit_{mode_name}_d_5_8"
       elif (
-        (last_willr_14 > -8.0)
+        (last_willr_14_gt_neg_8)
         and (last_rsi_3 > 95.0)
-        and (last_change_pct_4h < -5.0)
+        and (last_change_pct_4h_lt_neg_5)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
       ):
         return True, f"exit_{mode_name}_d_5_9"
       elif (
-        (last_willr_14 > -20.0)
+        (last_willr_14_gt_neg_20)
         and (last_rsi_14_lt_50)
-        and (last_roc_9_1h < -10.0)
-        and (last_roc_9_4h < -10.0)
+        and (last_roc_9_1h_lt_neg_10)
+        and (last_roc_9_4h_lt_neg_10)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 10.0))
       ):
         return True, f"exit_{mode_name}_d_5_10"
@@ -33052,7 +33099,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3_gt_75)
         and (last_rsi_14 < 45.0)
         and (last_roc_9_15m < -10.0)
-        and (last_roc_9_1h < -10.0)
+        and (last_roc_9_1h_lt_neg_10)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -20.0))
       ):
         return True, f"exit_{mode_name}_d_5_11"
@@ -33061,19 +33108,19 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14_lt_50)
         and (last_rsi_3_4h_lt_10)
         and (last_roc_9_1h < -20.0)
-        and (last_roc_9_4h < -20.0)
+        and (last_roc_9_4h_lt_neg_20)
       ):
         return True, f"exit_{mode_name}_d_5_12"
-      elif (last_rsi_3_gt_80) and (last_rsi_3_4h < 5.0) and (last_roc_9_4h < -25.0):
+      elif (last_rsi_3_gt_80) and (last_rsi_3_4h_lt_5) and (last_roc_9_4h_lt_neg_25):
         return True, f"exit_{mode_name}_d_5_13"
-      elif (last_rsi_3_gt_90) and (last_willr_14 > -12.0) and (last_rsi_3_4h < 5.0) and (last_aroonu_14_4h_gt_25):
+      elif (last_rsi_3_gt_90) and (last_willr_14_gt_neg_12) and (last_rsi_3_4h_lt_5) and (last_aroonu_14_4h_gt_25):
         return True, f"exit_{mode_name}_d_5_14"
       elif (last_rsi_3_gt_86) and (last_rsi_14 > 58.0) and (last_roc_9_4h < -30.0):
         return True, f"exit_{mode_name}_d_5_15"
       elif (
         (last_rsi_3_gt_70)
         and (last_aroonu_14_4h_gt_25)
-        and (last_roc_9_4h < -25.0)
+        and (last_roc_9_4h_lt_neg_25)
         and (last_aroonu_14_1d > 50.0)
         and (last_change_pct_1d < -15.0)
       ):
@@ -33101,13 +33148,13 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_5_21"
       elif (
         (last_rsi_3_gt_90)
-        and (last_willr_14 > -10.0)
-        and (last_change_pct_4h < -5.0)
+        and (last_willr_14_gt_neg_10)
+        and (last_change_pct_4h_lt_neg_5)
         and (last_stochrsi_k_4h_gt_50)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
       ):
         return True, f"exit_{mode_name}_d_5_22"
-      elif (last_rsi_3_gt_75) and (last_willr_14 > -30.0) and (last_rsi_3_1h_lt_15) and (last_rsi_3_1d < 5.0):
+      elif (last_rsi_3_gt_75) and (last_willr_14_gt_neg_30) and (last_rsi_3_1h_lt_15) and (last_rsi_3_1d < 5.0):
         return True, f"exit_{mode_name}_d_5_23"
       elif (
         (last_rsi_3_gt_84)
@@ -33119,13 +33166,13 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_5_24"
       elif (
         (last_rsi_3_gt_70)
-        and (last_willr_14 > -12.0)
+        and (last_willr_14_gt_neg_12)
         and (last_rsi_3_4h_lt_10)
         and (last_roc_9_4h < -15.0)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d > 50.0))
       ):
         return True, f"exit_{mode_name}_d_5_25"
-      elif (last_rsi_3_gt_65) and (last_willr_14 > -12.0) and (last_rsi_3_4h_lt_15) and (last_roc_9_4h < -20.0):
+      elif (last_rsi_3_gt_65) and (last_willr_14_gt_neg_12) and (last_rsi_3_4h_lt_15) and (last_roc_9_4h_lt_neg_20):
         return True, f"exit_{mode_name}_d_5_26"
       elif (
         (last_rsi_3_gt_65)
@@ -33152,27 +33199,27 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14_lt_50)
         and (last_rsi_3_1h_lt_15)
         and (last_rsi_3_4h_lt_15)
-        and (last_stochrsi_k_1h > 25.0)
+        and (last_stochrsi_k_1h_gt_25)
       ):
         return True, f"exit_{mode_name}_d_5_31"
-      elif (last_rsi_3_gt_70) and (last_rsi_3_1h_lt_15) and (last_roc_2_4h < -30.0) and (last_stochrsi_k_4h_gt_30):
+      elif (last_rsi_3_gt_70) and (last_rsi_3_1h_lt_15) and (last_roc_2_4h_lt_neg_30) and (last_stochrsi_k_4h_gt_30):
         return True, f"exit_{mode_name}_d_5_32"
       elif (
         (last_rsi_3_gt_70)
-        and (last_willr_14 > -10.0)
+        and (last_willr_14_gt_neg_10)
         and (last_roc_2_1h < -10.0)
         and (last_roc_9_1h > 30.0)
         and (last_stochrsi_k_1h_gt_50)
       ):
         return True, f"exit_{mode_name}_d_5_33"
-      elif (last_rsi_3_gt_65) and (last_rsi_3_15m < 30.0) and (last_rsi_14_1h > 80.0) and (last_roc_9_1h > 40.0):
+      elif (last_rsi_3_gt_65) and (last_rsi_3_15m_lt_30) and (last_rsi_14_1h > 80.0) and (last_roc_9_1h > 40.0):
         return True, f"exit_{mode_name}_d_5_34"
-      elif (last_rsi_3_gt_80) and (last_willr_14 > -10.0) and (last_rsi_3_1d_lt_25) and (last_stochrsi_k_1h > 75.0):
+      elif (last_rsi_3_gt_80) and (last_willr_14_gt_neg_10) and (last_rsi_3_1d_lt_25) and (last_stochrsi_k_1h_gt_75):
         return True, f"exit_{mode_name}_d_5_35"
       elif (
         (last_rsi_3_gt_65)
         and (last_willr_14 > -35.0)
-        and (last_roc_9_4h < -25.0)
+        and (last_roc_9_4h_lt_neg_25)
         and (last_rsi_3_1d_lt_25)
         and (last_stochrsi_k_1h_gt_50)
       ):
@@ -33187,7 +33234,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_5_37"
       elif (last_rsi_3_gt_65) and (last_willr_14 > -35.0) and (last_rsi_3_4h_lt_10) and (last_stochrsi_k_4h_gt_20):
         return True, f"exit_{mode_name}_d_5_38"
-      elif (last_rsi_3 > 91.0) and (last_willr_14 > -9.0) and (last_cmf_20_4h < -0.0) and (last_rsi_3_4h_lt_10):
+      elif (last_rsi_3 > 91.0) and (last_willr_14 > -9.0) and (last_cmf_20_4h_lt_0) and (last_rsi_3_4h_lt_10):
         return True, f"exit_{mode_name}_d_5_39"
       elif (
         (last_rsi_3_gt_65)
@@ -33199,7 +33246,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_5_40"
       elif (
         (last_rsi_3_gt_75)
-        and (last_willr_14 > -30.0)
+        and (last_willr_14_gt_neg_30)
         and (last_rsi_3_1h_lt_30)
         and (last_stochrsi_k_4h_gt_25)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 50.0))
@@ -33223,13 +33270,13 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_5_43"
       elif (
         (last_rsi_3_gt_50)
-        and (last_willr_14 > -25.0)
+        and (last_willr_14_gt_neg_25)
         and (last_rsi_3_4h_lt_30)
         and (last_rsi_3_1d_lt_25)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
       ):
         return True, f"exit_{mode_name}_d_5_44"
-      elif (last_rsi_3_gt_86) and (last_willr_14 > -14.0) and (last_rsi_3_1h_lt_10):
+      elif (last_rsi_3_gt_86) and (last_willr_14_gt_neg_14) and (last_rsi_3_1h_lt_10):
         return True, f"exit_{mode_name}_d_5_45"
       elif (last_rsi_3_gt_70) and (last_rsi_3_1h_lt_15) and (last_rsi_3_4h_lt_10) and (last_roc_2_1d < -20.0):
         return True, f"exit_{mode_name}_d_5_46"
@@ -33237,7 +33284,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3_gt_78)
         and (last_stochrsi_k_1h_gt_80)
         and (last_stochrsi_k_4h_gt_40)
-        and (last_change_pct_1d < -5.0)
+        and (last_change_pct_1d_lt_neg_5)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -5.0))
       ):
         return True, f"exit_{mode_name}_d_5_47"
@@ -33251,20 +33298,20 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_5_48"
       elif (
         (last_rsi_3_gt_70)
-        and (last_willr_14 > -12.0)
+        and (last_willr_14_gt_neg_12)
         and (last_rsi_3_4h_lt_20)
-        and (last_change_pct_1d < -5.0)
+        and (last_change_pct_1d_lt_neg_5)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d > 50.0))
       ):
         return True, f"exit_{mode_name}_d_5_49"
-      elif (last_rsi_3_gt_80) and (last_willr_14 > -12.0) and (last_rsi_3_1d < 10.0) and (last_stochrsi_k_1h > 90.0):
+      elif (last_rsi_3_gt_80) and (last_willr_14_gt_neg_12) and (last_rsi_3_1d < 10.0) and (last_stochrsi_k_1h_gt_90):
         return True, f"exit_{mode_name}_d_5_50"
       elif (last_rsi_3_gt_58) and (last_rsi_14_lt_54) and (last_rsi_3_4h_lt_20) and (last_stochrsi_k_1h_gt_50):
         return True, f"exit_{mode_name}_d_5_51"
       elif (
         (last_rsi_3_gt_72)
         and (last_rsi_14 > 52.0)
-        and (last_willr_14 > -10.0)
+        and (last_willr_14_gt_neg_10)
         and (last_stochrsi_k_1h_gt_70)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -15.0))
       ):
@@ -33272,7 +33319,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3_gt_70)
         and (last_rsi_14_lt_50)
-        and (last_willr_14 > -25.0)
+        and (last_willr_14_gt_neg_25)
         and (last_rsi_3_1h_lt_20)
         and (last_stochrsi_k_4h_gt_50)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d > 50.0))
@@ -33282,14 +33329,14 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3_gt_70)
         and (last_rsi_14_lt_54)
         and (last_stochrsi_k_1h_gt_50)
-        and (last_roc_9_4h < -10.0)
+        and (last_roc_9_4h_lt_neg_10)
         and (last_change_pct_1d < -10.0)
       ):
         return True, f"exit_{mode_name}_d_5_54"
       elif (
         (last_rsi_3_gt_86)
         and (last_willr_14 > -22.0)
-        and (last_roc_9_4h < -5.0)
+        and (last_roc_9_4h_lt_neg_5)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 10.0))
         and (last_stochrsi_k_1h_gt_50)
       ):
@@ -33300,14 +33347,14 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_3_1h_lt_30)
         and (last_rsi_3_4h_lt_25)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
-        and (last_stochrsi_k_4h > 10.0)
+        and (last_stochrsi_k_4h_gt_10)
       ):
         return True, f"exit_{mode_name}_d_5_56"
       elif (
         (last_rsi_3_gt_50)
         and (last_rsi_14 < 44.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
-        and (last_stochrsi_k_4h > 70.0)
+        and (last_stochrsi_k_4h_gt_70)
       ):
         return True, f"exit_{mode_name}_d_5_57"
       elif (
@@ -33320,7 +33367,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_5_58"
       elif (
         (last_rsi_3 > 85.0)
-        and (last_willr_14 > -20.0)
+        and (last_willr_14_gt_neg_20)
         and (last_rsi_3_4h_lt_25)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -15.0))
         and (last_stochrsi_k_4h_gt_40)
@@ -33331,18 +33378,18 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14_lt_48)
         and (last_rsi_14_4h > 65.0)
         and (last_stochrsi_k_4h_gt_50)
-        and (last_stochrsi_k_1d > 50.0)
+        and (last_stochrsi_k_1d_gt_50)
       ):
         return True, f"exit_{mode_name}_d_5_60"
-      elif (last_rsi_3_gt_90) and (last_willr_14 > -25.0) and (last_rsi_3_4h_lt_10) and (last_stochrsi_k_1h_gt_30):
+      elif (last_rsi_3_gt_90) and (last_willr_14_gt_neg_25) and (last_rsi_3_4h_lt_10) and (last_stochrsi_k_1h_gt_30):
         return True, f"exit_{mode_name}_d_5_61"
       elif (
         (last_rsi_3_gt_78)
-        and (last_willr_14 > -10.0)
+        and (last_willr_14_gt_neg_10)
         and (last_rsi_3_1h_lt_30)
         and (last_rsi_3_4h_lt_20)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 20.0))
-        and (last_change_pct_1d < -5.0)
+        and (last_change_pct_1d_lt_neg_5)
       ):
         return True, f"exit_{mode_name}_d_5_62"
       elif (last_rsi_3_gt_60) and (last_rsi_3_1d_lt_25) and (last_stochrsi_k_1h_gt_80) and (last_stochrsi_k_4h_gt_30):
@@ -33361,7 +33408,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3_gt_50)
         and (last_rsi_14_lt_50)
-        and (last_stochrsi_k_4h > 80.0)
+        and (last_stochrsi_k_4h_gt_80)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -25.0))
       ):
         return True, f"exit_{mode_name}_d_5_67"
@@ -33369,17 +33416,17 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3_gt_76)
         and (last_rsi_14_lt_56)
         and (last_rsi_3_1h_lt_25)
-        and (last_roc_2_4h < -30.0)
+        and (last_roc_2_4h_lt_neg_30)
         and (last_stochrsi_k_4h_gt_25)
       ):
         return True, f"exit_{mode_name}_d_5_68"
       elif (
-        (last_rsi_3 > 92.0) and (last_roc_9_4h > 20.0) and (last_stochrsi_k_4h_gt_50) and (last_change_pct_4h < -5.0)
+        (last_rsi_3 > 92.0) and (last_roc_9_4h > 20.0) and (last_stochrsi_k_4h_gt_50) and (last_change_pct_4h_lt_neg_5)
       ):
         return True, f"exit_{mode_name}_d_5_69"
       elif (last_rsi_3_gt_58) and (last_rsi_14_lt_48) and (last_rsi_3_1h_lt_25) and (last_stochrsi_k_4h_gt_20):
         return True, f"exit_{mode_name}_d_5_70"
-      elif (last_rsi_3 > 56.0) and (last_rsi_14_lt_52) and (last_rsi_3_4h_lt_25) and (last_stochrsi_k_1h > 20.0):
+      elif (last_rsi_3_gt_56) and (last_rsi_14_lt_52) and (last_rsi_3_4h_lt_25) and (last_stochrsi_k_1h_gt_20):
         return True, f"exit_{mode_name}_d_5_71"
       elif (last_rsi_3_gt_70) and (last_rsi_14_lt_50) and (last_rsi_3_1h_lt_10) and (last_aroonu_14_4h_gt_25):
         return True, f"exit_{mode_name}_d_5_72"
@@ -33387,13 +33434,13 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3_gt_70)
         and (last_rsi_3_1h_lt_25)
         and (last_rsi_3_4h_lt_15)
-        and (last_roc_9_4h < -20.0)
+        and (last_roc_9_4h_lt_neg_20)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -25.0))
       ):
         return True, f"exit_{mode_name}_d_5_73"
       elif (
         (last_rsi_3 > 94.0)
-        and (last_willr_14 > -10.0)
+        and (last_willr_14_gt_neg_10)
         and (last_rsi_3_4h_lt_25)
         and (last_rsi_3_1d_lt_25)
         and (last_stochrsi_k_1h_gt_50)
@@ -33406,7 +33453,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d > 50.0))
       ):
         return True, f"exit_{mode_name}_d_5_75"
-      elif (last_rsi_3_gt_60) and (last_rsi_14_lt_58) and (last_roc_9_1h > 80.0) and (last_stochrsi_k_4h > 80.0):
+      elif (last_rsi_3_gt_60) and (last_rsi_14_lt_58) and (last_roc_9_1h > 80.0) and (last_stochrsi_k_4h_gt_80):
         return True, f"exit_{mode_name}_d_5_76"
       elif (
         (last_rsi_3_gt_68)
@@ -33423,7 +33470,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_3_1d < 20.0)
       ):
         return True, f"exit_{mode_name}_d_5_78"
-      elif (last_rsi_3_gt_84) and (last_willr_14 > -10.0) and (last_rsi_3_1h_lt_30) and (last_rsi_3_4h_lt_10):
+      elif (last_rsi_3_gt_84) and (last_willr_14_gt_neg_10) and (last_rsi_3_1h_lt_30) and (last_rsi_3_4h_lt_10):
         return True, f"exit_{mode_name}_d_5_79"
       elif (
         (last_rsi_3_gt_64)
@@ -33435,7 +33482,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_5_80"
       elif (
         (last_rsi_3_gt_76)
-        and (last_willr_14 > -18.0)
+        and (last_willr_14_gt_neg_18)
         and (last_rsi_3_1h_lt_25)
         and (last_rsi_3_4h_lt_25)
         and (isinstance(last_rsi_14_1d, np.float64) and (last_rsi_14_1d > 50.0))
@@ -33443,7 +33490,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_5_81"
       elif (
         (last_rsi_3_gt_74)
-        and (last_willr_14 > -18.0)
+        and (last_willr_14_gt_neg_18)
         and (last_rsi_3_4h_lt_30)
         and (last_rsi_3_1d < 15.0)
         and (last_stochrsi_k_4h_gt_40)
@@ -33457,11 +33504,11 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_stochrsi_k_4h_gt_40)
       ):
         return True, f"exit_{mode_name}_d_5_83"
-      elif (last_rsi_3_gt_82) and (last_willr_14 > -10.0) and (last_rsi_3_4h_lt_30) and (last_stochrsi_k_1h > 20.0):
+      elif (last_rsi_3_gt_82) and (last_willr_14_gt_neg_10) and (last_rsi_3_4h_lt_30) and (last_stochrsi_k_1h_gt_20):
         return True, f"exit_{mode_name}_d_5_84"
       elif (
         (last_rsi_3_gt_80)
-        and (last_willr_14 > -16.0)
+        and (last_willr_14_gt_neg_16)
         and (last_rsi_3_1h_lt_30)
         and (last_rsi_3_4h_lt_40)
         and (last_stochrsi_k_4h_gt_50)
@@ -33494,13 +33541,13 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3_gt_70)
         and (last_rsi_14_lt_48)
-        and (last_roc_9_1h < -5.0)
+        and (last_roc_9_1h_lt_neg_5)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 25.0))
       ):
         return True, f"exit_{mode_name}_d_5_89"
       elif (
         (last_rsi_3_gt_84)
-        and (last_willr_14 > -25.0)
+        and (last_willr_14_gt_neg_25)
         and (last_rsi_3_1h_lt_50)
         and (last_rsi_3_4h_lt_30)
         and (last_aroonu_14_4h_gt_50)
@@ -33520,7 +33567,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3_gt_72)
         and (last_rsi_14_lt_56)
         and (last_rsi_3_1h_lt_40)
-        and (last_stochrsi_k_1h > 25.0)
+        and (last_stochrsi_k_1h_gt_25)
         and (last_stochrsi_k_4h_gt_50)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -25.0))
       ):
@@ -33547,10 +33594,10 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_5_94"
       elif (
         (last_rsi_3_gt_76)
-        and (last_willr_14 > -20.0)
+        and (last_willr_14_gt_neg_20)
         and (last_rsi_3_1h_lt_45)
         and (last_rsi_3_4h_lt_40)
-        and (last_stochrsi_k_4h > 10.0)
+        and (last_stochrsi_k_4h_gt_10)
         and (isinstance(last_aroonu_14_1d, np.float64) and (last_aroonu_14_1d > 75.0))
       ):
         return True, f"exit_{mode_name}_d_5_95"
@@ -33585,11 +33632,11 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_3_1h < 65.0)
         and (last_rsi_3_4h_lt_60)
         and (last_aroonu_14_4h_gt_50)
-        and (last_stoch_k_4h > 40.0)
+        and (last_stoch_k_4h_gt_40)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 80.0))
       ):
         return True, f"exit_{mode_name}_d_5_99"
-      elif (last_rsi_3_gt_90) and (last_rsi_14 > 68.0) and (last_rsi_3_15m > 70.0) and (last_rsi_3_4h < 80.0):
+      elif (last_rsi_3_gt_90) and (last_rsi_14 > 68.0) and (last_rsi_3_15m_gt_70) and (last_rsi_3_4h < 80.0):
         return True, f"exit_{mode_name}_d_5_100"
       elif (
         (last_rsi_3_gt_76)
@@ -33617,12 +33664,12 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_5_103"
       elif (
-        (last_rsi_3 > 56.0)
+        (last_rsi_3_gt_56)
         and (last_rsi_14_lt_56)
         and (last_rsi_3_1h_lt_60)
         and (last_stochrsi_k_1h_gt_40)
         and (last_stochrsi_k_4h_gt_90)
-        and (last_roc_9_4h > 40.0)
+        and (last_roc_9_4h_gt_40)
       ):
         return True, f"exit_{mode_name}_d_5_104"
       elif (
@@ -33630,7 +33677,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14_lt_56)
         and (last_rsi_3_15m < 55.0)
         and (last_stochrsi_k_4h_gt_90)
-        and (last_roc_9_4h > 25.0)
+        and (last_roc_9_4h_gt_25)
       ):
         return True, f"exit_{mode_name}_d_5_105"
       elif (
@@ -33639,7 +33686,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_3_1h_lt_50)
         and (last_stochrsi_k_1h_gt_50)
         and (last_rsi_14_4h_gt_70)
-        and (last_roc_9_4h > 40.0)
+        and (last_roc_9_4h_gt_40)
       ):
         return True, f"exit_{mode_name}_d_5_106"
       elif (
@@ -33654,13 +33701,13 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_5_108"
       elif (
         (last_rsi_3_gt_68)
-        and (last_willr_14 > -16.0)
+        and (last_willr_14_gt_neg_16)
         and (last_rsi_3_1h_lt_50)
         and (last_rsi_3_4h_lt_20)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 50.0))
       ):
         return True, f"exit_{mode_name}_d_5_109"
-      elif (last_rsi_3_gt_64) and (last_rsi_3_4h < 65.0) and (last_stochrsi_k_4h_gt_50) and (last_roc_9_4h > 25.0):
+      elif (last_rsi_3_gt_64) and (last_rsi_3_4h < 65.0) and (last_stochrsi_k_4h_gt_50) and (last_roc_9_4h_gt_25):
         return True, f"exit_{mode_name}_d_5_110"
       elif (
         (last_rsi_3 > 42.0)
@@ -33677,14 +33724,14 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_willr_14 > -45.0)
         and (last_rsi_14 < 60.0)
         and (last_rsi_3_1h_lt_35)
-        and (last_rsi_3_4h < 35.0)
+        and (last_rsi_3_4h_lt_35)
         and (last_rsi_3_1d < 60.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
       ):
         return True, f"exit_{mode_name}_d_5_112"
       elif (
         (last_rsi_3_gt_76)
-        and (last_willr_14 > -10.0)
+        and (last_willr_14_gt_neg_10)
         and (last_rsi_3_1d_lt_30)
         and (last_stochrsi_k_4h_gt_50)
         and (isinstance(last_roc_9_4h, np.float64) and (last_roc_9_4h > 10.0))
@@ -33702,7 +33749,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3_gt_70)
         and (last_rsi_14_lt_56)
-        and (last_rsi_3_15m < 30.0)
+        and (last_rsi_3_15m_lt_30)
         and (last_stochrsi_k_1h_gt_50)
         and (last_stochrsi_k_4h_gt_50)
       ):
@@ -33715,7 +33762,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_5_118"
       elif (
         (last_rsi_3_gt_78)
-        and (last_willr_14 > -20.0)
+        and (last_willr_14_gt_neg_20)
         and (last_rsi_3_1h_lt_60)
         and (last_rsi_3_4h_lt_60)
         and (last_stochrsi_k_1h_gt_40)
@@ -33727,7 +33774,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_5_121"
       elif (last_rsi_3_gt_50) and (last_rsi_14_lt_52) and (last_rsi_3_4h_lt_30) and (last_stochrsi_k_1h_gt_50):
         return True, f"exit_{mode_name}_d_5_122"
-      elif (last_rsi_3_gt_80) and (last_willr_14 > -12.0) and (last_rsi_3_1h_lt_10) and (last_rsi_3_1d_lt_30):
+      elif (last_rsi_3_gt_80) and (last_willr_14_gt_neg_12) and (last_rsi_3_1h_lt_10) and (last_rsi_3_1d_lt_30):
         return True, f"exit_{mode_name}_d_5_123"
       elif (
         (last_rsi_3_gt_80)
@@ -33737,16 +33784,16 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_5_124"
       elif (
         (last_rsi_3_gt_68)
-        and (last_willr_14 > -12.0)
+        and (last_willr_14_gt_neg_12)
         and (last_rsi_3_1h_lt_10)
         and (last_rsi_3_4h_lt_40)
-        and (last_rsi_3_1d < 40.0)
+        and (last_rsi_3_1d_lt_40)
         and (last_close < (last_high_max_30_1d * 0.50))
       ):
         return True, f"exit_{mode_name}_d_5_125"
       elif (last_rsi_3_gt_82) and (last_rsi_3_1h_lt_15) and (last_rsi_3_4h_lt_40) and (last_stochrsi_k_4h_gt_50):
         return True, f"exit_{mode_name}_d_5_126"
-      elif (last_rsi_3_gt_82) and (last_rsi_3_1h_lt_10) and (last_rsi_3_4h_lt_30) and (last_rsi_3_1d < 40.0):
+      elif (last_rsi_3_gt_82) and (last_rsi_3_1h_lt_10) and (last_rsi_3_4h_lt_30) and (last_rsi_3_1d_lt_40):
         return True, f"exit_{mode_name}_d_5_127"
       elif (last_rsi_3_gt_86) and (last_rsi_3_4h_lt_30) and (last_aroonu_14_4h > 85.0):
         return True, f"exit_{mode_name}_d_5_128"
@@ -33768,7 +33815,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3_gt_72)
         and (last_rsi_3_1h_lt_35)
-        and (last_rsi_3_4h < 35.0)
+        and (last_rsi_3_4h_lt_35)
         and (last_aroonu_14_1h > 50.0)
         and (last_stochrsi_k_1h_gt_40)
       ):
@@ -33839,7 +33886,7 @@ class NostalgiaForInfinityX7(IStrategy):
       last_rsi_14_4h_gt_70 = last_rsi_14_4h > 70.0
       last_rsi_3_1d_lt_30 = last_rsi_3_1d < 30.0
       if (
-        (last_willr_14 > -1.0)
+        (last_willr_14_gt_neg_1)
         and (last_rsi_14 > 78.0)
         and (isinstance(last_ema_200_1h, np.float64) and (last_ema_12_1h < last_ema_200_1h))
         and (isinstance(last_ema_200_4h, np.float64) and (last_ema_12_4h < last_ema_200_4h))
@@ -33848,68 +33895,68 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_6_1"
       elif (
-        (last_willr_14 > -1.0)
+        (last_willr_14_gt_neg_1)
         and (last_rsi_14 > 62.0)
-        and (last_cmf_20_1h < -0.0)
+        and (last_cmf_20_1h_lt_0)
         and (isinstance(last_ema_200_1h, np.float64) and (last_ema_12_1h < last_ema_200_1h))
         and (isinstance(last_ema_200_4h, np.float64) and (last_ema_12_4h < last_ema_200_4h))
       ):
         return True, f"exit_{mode_name}_d_6_2"
       elif (
-        (last_willr_14 > -15.0)
+        (last_willr_14_gt_neg_15)
         and (last_stochrsi_k > 98.0)
-        and (last_cmf_20_1h < -0.0)
-        and (last_cmf_20_4h < -0.0)
-        and ((last_stochrsi_k_4h_gt_20) and (last_stochrsi_k_change_pct_4h < -10.0))
+        and (last_cmf_20_1h_lt_0)
+        and (last_cmf_20_4h_lt_0)
+        and ((last_stochrsi_k_4h_gt_20) and (last_stochrsi_k_change_pct_4h_lt_neg_10))
       ):
         return True, f"exit_{mode_name}_d_6_3"
       elif (
-        (last_willr_14 > -25.0)
+        (last_willr_14_gt_neg_25)
         and (last_rsi_14 > 68.0)
         and (last_stochrsi_k > 95.0)
-        and (last_stochrsi_k_4h > 70.0)
+        and (last_stochrsi_k_4h_gt_70)
         and (isinstance(last_ema_200_1h, np.float64) and (last_ema_12_1h < last_ema_200_1h))
         and (isinstance(last_ema_200_4h, np.float64) and (last_ema_12_4h < last_ema_200_4h))
       ):
         return True, f"exit_{mode_name}_d_6_4"
-      elif (last_willr_14 > -8.0) and (last_rsi_14_gt_66) and (last_roc_9_1h < -5.0) and (last_roc_9_4h < -5.0):
+      elif (last_willr_14_gt_neg_8) and (last_rsi_14_gt_66) and (last_roc_9_1h_lt_neg_5) and (last_roc_9_4h_lt_neg_5):
         return True, f"exit_{mode_name}_d_6_5"
       elif (
         (last_rsi_3_gt_70)
-        and (last_stochrsi_k > 70.0)
+        and (last_stochrsi_k_gt_70)
         and (last_rsi_14 < 40.0)
-        and (last_roc_9_1h < -10.0)
+        and (last_roc_9_1h_lt_neg_10)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 50.0))
       ):
         return True, f"exit_{mode_name}_d_6_6"
       elif (
         (last_rsi_14_lt_50)
-        and (last_stochrsi_k > 70.0)
+        and (last_stochrsi_k_gt_70)
         and (last_stochrsi_k_4h_gt_50)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -40.0))
       ):
         return True, f"exit_{mode_name}_d_6_7"
       elif (
-        (last_willr_14 > -8.0)
+        (last_willr_14_gt_neg_8)
         and (last_stochrsi_k > 95.0)
         and (last_cmf_20_1h < -0.1)
         and (last_cmf_20_4h < -0.1)
-        and (last_change_pct_1d < -5.0)
+        and (last_change_pct_1d_lt_neg_5)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 15.0))
       ):
         return True, f"exit_{mode_name}_d_6_8"
       elif (
         (last_willr_14 > -7.0)
         and (last_rsi_3 > 95.0)
-        and (last_change_pct_4h < -5.0)
+        and (last_change_pct_4h_lt_neg_5)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
       ):
         return True, f"exit_{mode_name}_d_6_9"
       elif (
-        (last_willr_14 > -15.0)
+        (last_willr_14_gt_neg_15)
         and (last_rsi_14_lt_50)
-        and (last_roc_9_1h < -10.0)
-        and (last_roc_9_4h < -10.0)
+        and (last_roc_9_1h_lt_neg_10)
+        and (last_roc_9_4h_lt_neg_10)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 10.0))
       ):
         return True, f"exit_{mode_name}_d_6_10"
@@ -33917,7 +33964,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3_gt_80)
         and (last_rsi_14 < 45.0)
         and (last_roc_9_15m < -10.0)
-        and (last_roc_9_1h < -10.0)
+        and (last_roc_9_1h_lt_neg_10)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -20.0))
       ):
         return True, f"exit_{mode_name}_d_6_11"
@@ -33926,26 +33973,26 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14_lt_50)
         and (last_rsi_3_4h_lt_10)
         and (last_roc_9_1h < -20.0)
-        and (last_roc_9_4h < -20.0)
+        and (last_roc_9_4h_lt_neg_20)
       ):
         return True, f"exit_{mode_name}_d_6_12"
-      elif (last_rsi_3_gt_85) and (last_rsi_3_4h < 5.0) and (last_roc_9_4h < -25.0):
+      elif (last_rsi_3_gt_85) and (last_rsi_3_4h_lt_5) and (last_roc_9_4h_lt_neg_25):
         return True, f"exit_{mode_name}_d_6_13"
-      elif (last_rsi_3_gt_90) and (last_willr_14 > -10.0) and (last_rsi_3_4h < 5.0) and (last_aroonu_14_4h_gt_25):
+      elif (last_rsi_3_gt_90) and (last_willr_14_gt_neg_10) and (last_rsi_3_4h_lt_5) and (last_aroonu_14_4h_gt_25):
         return True, f"exit_{mode_name}_d_6_14"
       elif (last_rsi_3_gt_88) and (last_rsi_14 > 60.0) and (last_roc_9_4h < -30.0):
         return True, f"exit_{mode_name}_d_6_15"
       elif (
         (last_rsi_3_gt_75)
         and (last_aroonu_14_4h_gt_25)
-        and (last_roc_9_4h < -25.0)
+        and (last_roc_9_4h_lt_neg_25)
         and (last_aroonu_14_1d > 50.0)
         and (last_change_pct_1d < -15.0)
       ):
         return True, f"exit_{mode_name}_d_6_16"
       elif (
         (last_rsi_3_gt_85)
-        and (last_willr_14 > -30.0)
+        and (last_willr_14_gt_neg_30)
         and (last_rsi_3_1h_lt_10)
         and (last_stochrsi_k_4h_gt_90)
         and (last_roc_9_4h > 30.0)
@@ -33966,31 +34013,31 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_6_21"
       elif (
         (last_rsi_3_gt_92)
-        and (last_willr_14 > -8.0)
-        and (last_change_pct_4h < -5.0)
+        and (last_willr_14_gt_neg_8)
+        and (last_change_pct_4h_lt_neg_5)
         and (last_stochrsi_k_4h_gt_50)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
       ):
         return True, f"exit_{mode_name}_d_6_22"
-      elif (last_rsi_3_gt_80) and (last_willr_14 > -25.0) and (last_rsi_3_1h_lt_15) and (last_rsi_3_1d < 5.0):
+      elif (last_rsi_3_gt_80) and (last_willr_14_gt_neg_25) and (last_rsi_3_1h_lt_15) and (last_rsi_3_1d < 5.0):
         return True, f"exit_{mode_name}_d_6_23"
       elif (
         (last_rsi_3_gt_86)
         and (last_rsi_14_gt_66)
-        and (last_willr_14 > -30.0)
+        and (last_willr_14_gt_neg_30)
         and (last_rsi_3_4h_lt_30)
         and (last_aroonu_14_4h_gt_75)
       ):
         return True, f"exit_{mode_name}_d_6_24"
       elif (
         (last_rsi_3_gt_75)
-        and (last_willr_14 > -10.0)
+        and (last_willr_14_gt_neg_10)
         and (last_rsi_3_4h_lt_10)
         and (last_roc_9_4h < -15.0)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d > 50.0))
       ):
         return True, f"exit_{mode_name}_d_6_25"
-      elif (last_rsi_3_gt_70) and (last_willr_14 > -10.0) and (last_rsi_3_4h_lt_15) and (last_roc_9_4h < -20.0):
+      elif (last_rsi_3_gt_70) and (last_willr_14_gt_neg_10) and (last_rsi_3_4h_lt_15) and (last_roc_9_4h_lt_neg_20):
         return True, f"exit_{mode_name}_d_6_26"
       elif (
         (last_rsi_3_gt_70)
@@ -34017,27 +34064,27 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14_lt_50)
         and (last_rsi_3_1h_lt_15)
         and (last_rsi_3_4h_lt_15)
-        and (last_stochrsi_k_1h > 25.0)
+        and (last_stochrsi_k_1h_gt_25)
       ):
         return True, f"exit_{mode_name}_d_6_31"
-      elif (last_rsi_3_gt_75) and (last_rsi_3_1h_lt_15) and (last_roc_2_4h < -30.0) and (last_stochrsi_k_4h_gt_30):
+      elif (last_rsi_3_gt_75) and (last_rsi_3_1h_lt_15) and (last_roc_2_4h_lt_neg_30) and (last_stochrsi_k_4h_gt_30):
         return True, f"exit_{mode_name}_d_6_32"
       elif (
         (last_rsi_3_gt_75)
-        and (last_willr_14 > -8.0)
+        and (last_willr_14_gt_neg_8)
         and (last_roc_2_1h < -10.0)
         and (last_roc_9_1h > 30.0)
         and (last_stochrsi_k_1h_gt_50)
       ):
         return True, f"exit_{mode_name}_d_6_33"
-      elif (last_rsi_3_gt_65) and (last_rsi_3_15m < 30.0) and (last_rsi_14_1h > 80.0) and (last_roc_9_1h > 40.0):
+      elif (last_rsi_3_gt_65) and (last_rsi_3_15m_lt_30) and (last_rsi_14_1h > 80.0) and (last_roc_9_1h > 40.0):
         return True, f"exit_{mode_name}_d_6_34"
-      elif (last_rsi_3_gt_82) and (last_willr_14 > -9.0) and (last_rsi_3_1d_lt_25) and (last_stochrsi_k_1h > 75.0):
+      elif (last_rsi_3_gt_82) and (last_willr_14 > -9.0) and (last_rsi_3_1d_lt_25) and (last_stochrsi_k_1h_gt_75):
         return True, f"exit_{mode_name}_d_6_35"
       elif (
         (last_rsi_3_gt_70)
-        and (last_willr_14 > -30.0)
-        and (last_roc_9_4h < -25.0)
+        and (last_willr_14_gt_neg_30)
+        and (last_roc_9_4h_lt_neg_25)
         and (last_rsi_3_1d_lt_25)
         and (last_stochrsi_k_1h_gt_50)
       ):
@@ -34050,13 +34097,13 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_stochrsi_k_4h_gt_50)
       ):
         return True, f"exit_{mode_name}_d_6_37"
-      elif (last_rsi_3_gt_70) and (last_willr_14 > -30.0) and (last_rsi_3_4h_lt_10) and (last_stochrsi_k_4h_gt_20):
+      elif (last_rsi_3_gt_70) and (last_willr_14_gt_neg_30) and (last_rsi_3_4h_lt_10) and (last_stochrsi_k_4h_gt_20):
         return True, f"exit_{mode_name}_d_6_38"
-      elif (last_rsi_3_gt_92) and (last_willr_14 > -8.0) and (last_cmf_20_4h < -0.0) and (last_rsi_3_4h_lt_10):
+      elif (last_rsi_3_gt_92) and (last_willr_14_gt_neg_8) and (last_cmf_20_4h_lt_0) and (last_rsi_3_4h_lt_10):
         return True, f"exit_{mode_name}_d_6_39"
       elif (
         (last_rsi_3_gt_70)
-        and (last_willr_14 > -30.0)
+        and (last_willr_14_gt_neg_30)
         and (last_rsi_3_1h_lt_30)
         and (last_stochrsi_k_1h_gt_30)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d > 90.0))
@@ -34064,7 +34111,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_6_40"
       elif (
         (last_rsi_3_gt_80)
-        and (last_willr_14 > -25.0)
+        and (last_willr_14_gt_neg_25)
         and (last_rsi_3_1h_lt_30)
         and (last_stochrsi_k_4h_gt_25)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 50.0))
@@ -34088,13 +34135,13 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_6_43"
       elif (
         (last_rsi_3 > 55.0)
-        and (last_willr_14 > -20.0)
+        and (last_willr_14_gt_neg_20)
         and (last_rsi_3_4h_lt_30)
         and (last_rsi_3_1d_lt_25)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
       ):
         return True, f"exit_{mode_name}_d_6_44"
-      elif (last_rsi_3_gt_88) and (last_willr_14 > -12.0) and (last_rsi_3_1h_lt_10):
+      elif (last_rsi_3_gt_88) and (last_willr_14_gt_neg_12) and (last_rsi_3_1h_lt_10):
         return True, f"exit_{mode_name}_d_6_45"
       elif (last_rsi_3_gt_75) and (last_rsi_3_1h_lt_15) and (last_rsi_3_4h_lt_10) and (last_roc_2_1d < -20.0):
         return True, f"exit_{mode_name}_d_6_46"
@@ -34102,7 +34149,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3_gt_80)
         and (last_stochrsi_k_1h_gt_80)
         and (last_stochrsi_k_4h_gt_40)
-        and (last_change_pct_1d < -5.0)
+        and (last_change_pct_1d_lt_neg_5)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -5.0))
       ):
         return True, f"exit_{mode_name}_d_6_47"
@@ -34116,20 +34163,20 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_6_48"
       elif (
         (last_rsi_3_gt_75)
-        and (last_willr_14 > -10.0)
+        and (last_willr_14_gt_neg_10)
         and (last_rsi_3_4h_lt_20)
-        and (last_change_pct_1d < -5.0)
+        and (last_change_pct_1d_lt_neg_5)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d > 50.0))
       ):
         return True, f"exit_{mode_name}_d_6_49"
-      elif (last_rsi_3_gt_80) and (last_willr_14 > -10.0) and (last_rsi_3_1d < 10.0) and (last_stochrsi_k_1h > 90.0):
+      elif (last_rsi_3_gt_80) and (last_willr_14_gt_neg_10) and (last_rsi_3_1d < 10.0) and (last_stochrsi_k_1h_gt_90):
         return True, f"exit_{mode_name}_d_6_50"
       elif (last_rsi_3_gt_60) and (last_rsi_14_lt_52) and (last_rsi_3_4h_lt_20) and (last_stochrsi_k_1h_gt_50):
         return True, f"exit_{mode_name}_d_6_51"
       elif (
         (last_rsi_3_gt_74)
         and (last_rsi_14 > 54.0)
-        and (last_willr_14 > -10.0)
+        and (last_willr_14_gt_neg_10)
         and (last_stochrsi_k_1h_gt_70)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -15.0))
       ):
@@ -34137,7 +34184,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3_gt_70)
         and (last_rsi_14_lt_50)
-        and (last_willr_14 > -25.0)
+        and (last_willr_14_gt_neg_25)
         and (last_rsi_3_1h_lt_20)
         and (last_stochrsi_k_4h_gt_50)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d > 50.0))
@@ -34147,14 +34194,14 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3_gt_72)
         and (last_rsi_14_lt_52)
         and (last_stochrsi_k_1h_gt_50)
-        and (last_roc_9_4h < -10.0)
+        and (last_roc_9_4h_lt_neg_10)
         and (last_change_pct_1d < -10.0)
       ):
         return True, f"exit_{mode_name}_d_6_54"
       elif (
         (last_rsi_3_gt_88)
-        and (last_willr_14 > -20.0)
-        and (last_roc_9_4h < -5.0)
+        and (last_willr_14_gt_neg_20)
+        and (last_roc_9_4h_lt_neg_5)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 10.0))
         and (last_stochrsi_k_1h_gt_50)
       ):
@@ -34165,14 +34212,14 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_3_1h_lt_30)
         and (last_rsi_3_4h_lt_25)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
-        and (last_stochrsi_k_4h > 10.0)
+        and (last_stochrsi_k_4h_gt_10)
       ):
         return True, f"exit_{mode_name}_d_6_56"
       elif (
         (last_rsi_3_gt_50)
         and (last_rsi_14 < 42.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
-        and (last_stochrsi_k_4h > 70.0)
+        and (last_stochrsi_k_4h_gt_70)
       ):
         return True, f"exit_{mode_name}_d_6_57"
       elif (
@@ -34185,7 +34232,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_6_58"
       elif (
         (last_rsi_3_gt_85)
-        and (last_willr_14 > -18.0)
+        and (last_willr_14_gt_neg_18)
         and (last_rsi_3_4h_lt_25)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -15.0))
         and (last_stochrsi_k_4h_gt_40)
@@ -34196,18 +34243,18 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14_lt_46)
         and (last_rsi_14_4h > 65.0)
         and (last_stochrsi_k_4h_gt_50)
-        and (last_stochrsi_k_1d > 50.0)
+        and (last_stochrsi_k_1d_gt_50)
       ):
         return True, f"exit_{mode_name}_d_6_60"
-      elif (last_rsi_3_gt_90) and (last_willr_14 > -25.0) and (last_rsi_3_4h_lt_10) and (last_stochrsi_k_1h_gt_30):
+      elif (last_rsi_3_gt_90) and (last_willr_14_gt_neg_25) and (last_rsi_3_4h_lt_10) and (last_stochrsi_k_1h_gt_30):
         return True, f"exit_{mode_name}_d_6_61"
       elif (
         (last_rsi_3_gt_80)
-        and (last_willr_14 > -8.0)
+        and (last_willr_14_gt_neg_8)
         and (last_rsi_3_1h_lt_30)
         and (last_rsi_3_4h_lt_20)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 20.0))
-        and (last_change_pct_1d < -5.0)
+        and (last_change_pct_1d_lt_neg_5)
       ):
         return True, f"exit_{mode_name}_d_6_62"
       elif (last_rsi_3_gt_62) and (last_rsi_3_1d_lt_25) and (last_stochrsi_k_1h_gt_80) and (last_stochrsi_k_4h_gt_30):
@@ -34226,7 +34273,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3_gt_50)
         and (last_rsi_14_lt_48)
-        and (last_stochrsi_k_4h > 80.0)
+        and (last_stochrsi_k_4h_gt_80)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -25.0))
       ):
         return True, f"exit_{mode_name}_d_6_67"
@@ -34234,17 +34281,17 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3_gt_78)
         and (last_rsi_14_lt_54)
         and (last_rsi_3_1h_lt_25)
-        and (last_roc_2_4h < -30.0)
+        and (last_roc_2_4h_lt_neg_30)
         and (last_stochrsi_k_4h_gt_25)
       ):
         return True, f"exit_{mode_name}_d_6_68"
       elif (
-        (last_rsi_3 > 93.0) and (last_roc_9_4h > 20.0) and (last_stochrsi_k_4h_gt_50) and (last_change_pct_4h < -5.0)
+        (last_rsi_3 > 93.0) and (last_roc_9_4h > 20.0) and (last_stochrsi_k_4h_gt_50) and (last_change_pct_4h_lt_neg_5)
       ):
         return True, f"exit_{mode_name}_d_6_69"
       elif (last_rsi_3_gt_60) and (last_rsi_14_lt_46) and (last_rsi_3_1h_lt_25) and (last_stochrsi_k_4h_gt_20):
         return True, f"exit_{mode_name}_d_6_70"
-      elif (last_rsi_3 > 58.0) and (last_rsi_14_lt_50) and (last_rsi_3_4h_lt_25) and (last_stochrsi_k_1h > 20.0):
+      elif (last_rsi_3 > 58.0) and (last_rsi_14_lt_50) and (last_rsi_3_4h_lt_25) and (last_stochrsi_k_1h_gt_20):
         return True, f"exit_{mode_name}_d_6_71"
       elif (last_rsi_3_gt_72) and (last_rsi_14_lt_48) and (last_rsi_3_1h_lt_10) and (last_aroonu_14_4h_gt_25):
         return True, f"exit_{mode_name}_d_6_72"
@@ -34252,13 +34299,13 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3_gt_72)
         and (last_rsi_3_1h_lt_25)
         and (last_rsi_3_4h_lt_15)
-        and (last_roc_9_4h < -20.0)
+        and (last_roc_9_4h_lt_neg_20)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -25.0))
       ):
         return True, f"exit_{mode_name}_d_6_73"
       elif (
         (last_rsi_3 > 95.0)
-        and (last_willr_14 > -10.0)
+        and (last_willr_14_gt_neg_10)
         and (last_rsi_3_4h_lt_25)
         and (last_rsi_3_1d_lt_25)
         and (last_stochrsi_k_1h_gt_50)
@@ -34271,7 +34318,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d > 50.0))
       ):
         return True, f"exit_{mode_name}_d_6_75"
-      elif (last_rsi_3_gt_62) and (last_rsi_14_lt_56) and (last_roc_9_1h > 80.0) and (last_stochrsi_k_4h > 80.0):
+      elif (last_rsi_3_gt_62) and (last_rsi_14_lt_56) and (last_roc_9_1h > 80.0) and (last_stochrsi_k_4h_gt_80):
         return True, f"exit_{mode_name}_d_6_76"
       elif (
         (last_rsi_3_gt_70)
@@ -34288,7 +34335,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_3_1d < 20.0)
       ):
         return True, f"exit_{mode_name}_d_6_78"
-      elif (last_rsi_3_gt_86) and (last_willr_14 > -8.0) and (last_rsi_3_1h_lt_30) and (last_rsi_3_4h_lt_10):
+      elif (last_rsi_3_gt_86) and (last_willr_14_gt_neg_8) and (last_rsi_3_1h_lt_30) and (last_rsi_3_4h_lt_10):
         return True, f"exit_{mode_name}_d_6_79"
       elif (
         (last_rsi_3_gt_66)
@@ -34300,7 +34347,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_6_80"
       elif (
         (last_rsi_3_gt_78)
-        and (last_willr_14 > -16.0)
+        and (last_willr_14_gt_neg_16)
         and (last_rsi_3_1h_lt_25)
         and (last_rsi_3_4h_lt_25)
         and (isinstance(last_rsi_14_1d, np.float64) and (last_rsi_14_1d > 50.0))
@@ -34308,7 +34355,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_6_81"
       elif (
         (last_rsi_3_gt_76)
-        and (last_willr_14 > -16.0)
+        and (last_willr_14_gt_neg_16)
         and (last_rsi_3_4h_lt_30)
         and (last_rsi_3_1d < 15.0)
         and (last_stochrsi_k_4h_gt_40)
@@ -34322,11 +34369,11 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_stochrsi_k_4h_gt_40)
       ):
         return True, f"exit_{mode_name}_d_6_83"
-      elif (last_rsi_3_gt_84) and (last_willr_14 > -8.0) and (last_rsi_3_4h_lt_30) and (last_stochrsi_k_1h > 20.0):
+      elif (last_rsi_3_gt_84) and (last_willr_14_gt_neg_8) and (last_rsi_3_4h_lt_30) and (last_stochrsi_k_1h_gt_20):
         return True, f"exit_{mode_name}_d_6_84"
       elif (
         (last_rsi_3_gt_82)
-        and (last_willr_14 > -14.0)
+        and (last_willr_14_gt_neg_14)
         and (last_rsi_3_1h_lt_30)
         and (last_rsi_3_4h_lt_40)
         and (last_stochrsi_k_4h_gt_50)
@@ -34359,13 +34406,13 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3_gt_72)
         and (last_rsi_14_lt_46)
-        and (last_roc_9_1h < -5.0)
+        and (last_roc_9_1h_lt_neg_5)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 25.0))
       ):
         return True, f"exit_{mode_name}_d_6_89"
       elif (
         (last_rsi_3_gt_86)
-        and (last_willr_14 > -25.0)
+        and (last_willr_14_gt_neg_25)
         and (last_rsi_3_1h_lt_50)
         and (last_rsi_3_4h_lt_30)
         and (last_aroonu_14_4h_gt_50)
@@ -34385,7 +34432,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3_gt_74)
         and (last_rsi_14_lt_54)
         and (last_rsi_3_1h_lt_40)
-        and (last_stochrsi_k_1h > 25.0)
+        and (last_stochrsi_k_1h_gt_25)
         and (last_stochrsi_k_4h_gt_50)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -25.0))
       ):
@@ -34412,15 +34459,15 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_6_94"
       elif (
         (last_rsi_3_gt_78)
-        and (last_willr_14 > -18.0)
+        and (last_willr_14_gt_neg_18)
         and (last_rsi_3_1h_lt_45)
         and (last_rsi_3_4h_lt_40)
-        and (last_stochrsi_k_4h > 10.0)
+        and (last_stochrsi_k_4h_gt_10)
         and (isinstance(last_aroonu_14_1d, np.float64) and (last_aroonu_14_1d > 75.0))
       ):
         return True, f"exit_{mode_name}_d_6_95"
       elif (
-        (last_rsi_3 > 56.0)
+        (last_rsi_3_gt_56)
         and (last_rsi_14_lt_52)
         and (last_rsi_3_1h_lt_45)
         and (last_rsi_3_1d < 45.0)
@@ -34450,11 +34497,11 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_3_1h < 65.0)
         and (last_rsi_3_4h_lt_60)
         and (last_aroonu_14_4h_gt_50)
-        and (last_stoch_k_4h > 40.0)
+        and (last_stoch_k_4h_gt_40)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 80.0))
       ):
         return True, f"exit_{mode_name}_d_6_99"
-      elif (last_rsi_3_gt_92) and (last_rsi_14 > 70.0) and (last_rsi_3_15m > 70.0) and (last_rsi_3_4h < 80.0):
+      elif (last_rsi_3_gt_92) and (last_rsi_14 > 70.0) and (last_rsi_3_15m_gt_70) and (last_rsi_3_4h < 80.0):
         return True, f"exit_{mode_name}_d_6_100"
       elif (
         (last_rsi_3_gt_78)
@@ -34487,7 +34534,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_3_1h_lt_60)
         and (last_stochrsi_k_1h_gt_40)
         and (last_stochrsi_k_4h_gt_90)
-        and (last_roc_9_4h > 40.0)
+        and (last_roc_9_4h_gt_40)
       ):
         return True, f"exit_{mode_name}_d_6_104"
       elif (
@@ -34495,7 +34542,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14_lt_54)
         and (last_rsi_3_15m < 55.0)
         and (last_stochrsi_k_4h_gt_90)
-        and (last_roc_9_4h > 25.0)
+        and (last_roc_9_4h_gt_25)
       ):
         return True, f"exit_{mode_name}_d_6_105"
       elif (
@@ -34504,7 +34551,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_3_1h_lt_50)
         and (last_stochrsi_k_1h_gt_50)
         and (last_rsi_14_4h_gt_70)
-        and (last_roc_9_4h > 40.0)
+        and (last_roc_9_4h_gt_40)
       ):
         return True, f"exit_{mode_name}_d_6_106"
       elif (
@@ -34519,13 +34566,13 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_6_108"
       elif (
         (last_rsi_3_gt_70)
-        and (last_willr_14 > -14.0)
+        and (last_willr_14_gt_neg_14)
         and (last_rsi_3_1h_lt_50)
         and (last_rsi_3_4h_lt_20)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 50.0))
       ):
         return True, f"exit_{mode_name}_d_6_109"
-      elif (last_rsi_3_gt_66) and (last_rsi_3_4h < 65.0) and (last_stochrsi_k_4h_gt_50) and (last_roc_9_4h > 25.0):
+      elif (last_rsi_3_gt_66) and (last_rsi_3_4h < 65.0) and (last_stochrsi_k_4h_gt_50) and (last_roc_9_4h_gt_25):
         return True, f"exit_{mode_name}_d_6_110"
       elif (
         (last_rsi_3 > 44.0)
@@ -34542,14 +34589,14 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_willr_14 > -40.0)
         and (last_rsi_14 < 58.0)
         and (last_rsi_3_1h_lt_35)
-        and (last_rsi_3_4h < 35.0)
+        and (last_rsi_3_4h_lt_35)
         and (last_rsi_3_1d < 60.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
       ):
         return True, f"exit_{mode_name}_d_6_112"
       elif (
         (last_rsi_3_gt_78)
-        and (last_willr_14 > -8.0)
+        and (last_willr_14_gt_neg_8)
         and (last_rsi_3_1d_lt_30)
         and (last_stochrsi_k_4h_gt_50)
         and (isinstance(last_roc_9_4h, np.float64) and (last_roc_9_4h > 10.0))
@@ -34567,7 +34614,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3_gt_72)
         and (last_rsi_14_lt_54)
-        and (last_rsi_3_15m < 30.0)
+        and (last_rsi_3_15m_lt_30)
         and (last_stochrsi_k_1h_gt_50)
         and (last_stochrsi_k_4h_gt_50)
       ):
@@ -34580,7 +34627,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_6_118"
       elif (
         (last_rsi_3_gt_80)
-        and (last_willr_14 > -20.0)
+        and (last_willr_14_gt_neg_20)
         and (last_rsi_3_1h_lt_60)
         and (last_rsi_3_4h_lt_60)
         and (last_stochrsi_k_1h_gt_40)
@@ -34592,7 +34639,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_6_121"
       elif (last_rsi_3 > 52.0) and (last_rsi_14_lt_50) and (last_rsi_3_4h_lt_30) and (last_stochrsi_k_1h_gt_50):
         return True, f"exit_{mode_name}_d_6_122"
-      elif (last_rsi_3_gt_82) and (last_willr_14 > -10.0) and (last_rsi_3_1h_lt_10) and (last_rsi_3_1d_lt_30):
+      elif (last_rsi_3_gt_82) and (last_willr_14_gt_neg_10) and (last_rsi_3_1h_lt_10) and (last_rsi_3_1d_lt_30):
         return True, f"exit_{mode_name}_d_6_123"
       elif (
         (last_rsi_3_gt_82)
@@ -34602,16 +34649,16 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_6_124"
       elif (
         (last_rsi_3_gt_70)
-        and (last_willr_14 > -10.0)
+        and (last_willr_14_gt_neg_10)
         and (last_rsi_3_1h_lt_10)
         and (last_rsi_3_4h_lt_40)
-        and (last_rsi_3_1d < 40.0)
+        and (last_rsi_3_1d_lt_40)
         and (last_close < (last_high_max_30_1d * 0.50))
       ):
         return True, f"exit_{mode_name}_d_6_125"
       elif (last_rsi_3_gt_84) and (last_rsi_3_1h_lt_15) and (last_rsi_3_4h_lt_40) and (last_stochrsi_k_4h_gt_50):
         return True, f"exit_{mode_name}_d_6_126"
-      elif (last_rsi_3_gt_84) and (last_rsi_3_1h_lt_10) and (last_rsi_3_4h_lt_30) and (last_rsi_3_1d < 40.0):
+      elif (last_rsi_3_gt_84) and (last_rsi_3_1h_lt_10) and (last_rsi_3_4h_lt_30) and (last_rsi_3_1d_lt_40):
         return True, f"exit_{mode_name}_d_6_127"
       elif (last_rsi_3_gt_88) and (last_rsi_3_4h_lt_30) and (last_aroonu_14_4h > 85.0):
         return True, f"exit_{mode_name}_d_6_128"
@@ -34633,7 +34680,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3_gt_74)
         and (last_rsi_3_1h_lt_35)
-        and (last_rsi_3_4h < 35.0)
+        and (last_rsi_3_4h_lt_35)
         and (last_aroonu_14_1h > 50.0)
         and (last_stochrsi_k_1h_gt_40)
       ):
@@ -34704,7 +34751,7 @@ class NostalgiaForInfinityX7(IStrategy):
       last_rsi_14_4h_gt_70 = last_rsi_14_4h > 70.0
       last_rsi_3_1d_lt_30 = last_rsi_3_1d < 30.0
       if (
-        (last_willr_14 > -1.0)
+        (last_willr_14_gt_neg_1)
         and (last_rsi_14 > 78.0)
         and (isinstance(last_ema_200_1h, np.float64) and (last_ema_12_1h < last_ema_200_1h))
         and (isinstance(last_ema_200_4h, np.float64) and (last_ema_12_4h < last_ema_200_4h))
@@ -34713,68 +34760,68 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_7_1"
       elif (
-        (last_willr_14 > -1.0)
+        (last_willr_14_gt_neg_1)
         and (last_rsi_14 > 64.0)
-        and (last_cmf_20_1h < -0.0)
+        and (last_cmf_20_1h_lt_0)
         and (isinstance(last_ema_200_1h, np.float64) and (last_ema_12_1h < last_ema_200_1h))
         and (isinstance(last_ema_200_4h, np.float64) and (last_ema_12_4h < last_ema_200_4h))
       ):
         return True, f"exit_{mode_name}_d_7_2"
       elif (
-        (last_willr_14 > -10.0)
+        (last_willr_14_gt_neg_10)
         and (last_stochrsi_k > 98.0)
-        and (last_cmf_20_1h < -0.0)
-        and (last_cmf_20_4h < -0.0)
-        and ((last_stochrsi_k_4h_gt_20) and (last_stochrsi_k_change_pct_4h < -10.0))
+        and (last_cmf_20_1h_lt_0)
+        and (last_cmf_20_4h_lt_0)
+        and ((last_stochrsi_k_4h_gt_20) and (last_stochrsi_k_change_pct_4h_lt_neg_10))
       ):
         return True, f"exit_{mode_name}_d_7_3"
       elif (
-        (last_willr_14 > -20.0)
+        (last_willr_14_gt_neg_20)
         and (last_rsi_14 > 70.0)
         and (last_stochrsi_k > 95.0)
-        and (last_stochrsi_k_4h > 70.0)
+        and (last_stochrsi_k_4h_gt_70)
         and (isinstance(last_ema_200_1h, np.float64) and (last_ema_12_1h < last_ema_200_1h))
         and (isinstance(last_ema_200_4h, np.float64) and (last_ema_12_4h < last_ema_200_4h))
       ):
         return True, f"exit_{mode_name}_d_7_4"
-      elif (last_willr_14 > -6.0) and (last_rsi_14_gt_68) and (last_roc_9_1h < -5.0) and (last_roc_9_4h < -5.0):
+      elif (last_willr_14_gt_neg_6) and (last_rsi_14_gt_68) and (last_roc_9_1h_lt_neg_5) and (last_roc_9_4h_lt_neg_5):
         return True, f"exit_{mode_name}_d_7_5"
       elif (
         (last_rsi_3_gt_70)
-        and (last_stochrsi_k > 70.0)
+        and (last_stochrsi_k_gt_70)
         and (last_rsi_14 < 40.0)
-        and (last_roc_9_1h < -10.0)
+        and (last_roc_9_1h_lt_neg_10)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 50.0))
       ):
         return True, f"exit_{mode_name}_d_7_6"
       elif (
         (last_rsi_14_lt_50)
-        and (last_stochrsi_k > 70.0)
+        and (last_stochrsi_k_gt_70)
         and (last_stochrsi_k_4h_gt_50)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -40.0))
       ):
         return True, f"exit_{mode_name}_d_7_7"
       elif (
-        (last_willr_14 > -6.0)
+        (last_willr_14_gt_neg_6)
         and (last_stochrsi_k > 95.0)
         and (last_cmf_20_1h < -0.1)
         and (last_cmf_20_4h < -0.1)
-        and (last_change_pct_1d < -5.0)
+        and (last_change_pct_1d_lt_neg_5)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 15.0))
       ):
         return True, f"exit_{mode_name}_d_7_8"
       elif (
-        (last_willr_14 > -6.0)
+        (last_willr_14_gt_neg_6)
         and (last_rsi_3 > 95.0)
-        and (last_change_pct_4h < -5.0)
+        and (last_change_pct_4h_lt_neg_5)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
       ):
         return True, f"exit_{mode_name}_d_7_9"
       elif (
-        (last_willr_14 > -10.0)
+        (last_willr_14_gt_neg_10)
         and (last_rsi_14_lt_50)
-        and (last_roc_9_1h < -10.0)
-        and (last_roc_9_4h < -10.0)
+        and (last_roc_9_1h_lt_neg_10)
+        and (last_roc_9_4h_lt_neg_10)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 10.0))
       ):
         return True, f"exit_{mode_name}_d_7_10"
@@ -34782,7 +34829,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3_gt_85)
         and (last_rsi_14 < 45.0)
         and (last_roc_9_15m < -10.0)
-        and (last_roc_9_1h < -10.0)
+        and (last_roc_9_1h_lt_neg_10)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -20.0))
       ):
         return True, f"exit_{mode_name}_d_7_11"
@@ -34791,26 +34838,26 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14_lt_50)
         and (last_rsi_3_4h_lt_10)
         and (last_roc_9_1h < -20.0)
-        and (last_roc_9_4h < -20.0)
+        and (last_roc_9_4h_lt_neg_20)
       ):
         return True, f"exit_{mode_name}_d_7_12"
-      elif (last_rsi_3_gt_90) and (last_rsi_3_4h < 5.0) and (last_roc_9_4h < -25.0):
+      elif (last_rsi_3_gt_90) and (last_rsi_3_4h_lt_5) and (last_roc_9_4h_lt_neg_25):
         return True, f"exit_{mode_name}_d_7_13"
-      elif (last_rsi_3_gt_90) and (last_willr_14 > -8.0) and (last_rsi_3_4h < 5.0) and (last_aroonu_14_4h_gt_25):
+      elif (last_rsi_3_gt_90) and (last_willr_14_gt_neg_8) and (last_rsi_3_4h_lt_5) and (last_aroonu_14_4h_gt_25):
         return True, f"exit_{mode_name}_d_7_14"
       elif (last_rsi_3_gt_90) and (last_rsi_14 > 62.0) and (last_roc_9_4h < -30.0):
         return True, f"exit_{mode_name}_d_7_15"
       elif (
         (last_rsi_3_gt_80)
         and (last_aroonu_14_4h_gt_25)
-        and (last_roc_9_4h < -25.0)
+        and (last_roc_9_4h_lt_neg_25)
         and (last_aroonu_14_1d > 50.0)
         and (last_change_pct_1d < -15.0)
       ):
         return True, f"exit_{mode_name}_d_7_16"
       elif (
         (last_rsi_3_gt_90)
-        and (last_willr_14 > -25.0)
+        and (last_willr_14_gt_neg_25)
         and (last_rsi_3_1h_lt_10)
         and (last_stochrsi_k_4h_gt_90)
         and (last_roc_9_4h > 30.0)
@@ -34831,31 +34878,31 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_7_21"
       elif (
         (last_rsi_3_gt_94)
-        and (last_willr_14 > -6.0)
-        and (last_change_pct_4h < -5.0)
+        and (last_willr_14_gt_neg_6)
+        and (last_change_pct_4h_lt_neg_5)
         and (last_stochrsi_k_4h_gt_50)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
       ):
         return True, f"exit_{mode_name}_d_7_22"
-      elif (last_rsi_3_gt_85) and (last_willr_14 > -20.0) and (last_rsi_3_1h_lt_15) and (last_rsi_3_1d < 5.0):
+      elif (last_rsi_3_gt_85) and (last_willr_14_gt_neg_20) and (last_rsi_3_1h_lt_15) and (last_rsi_3_1d < 5.0):
         return True, f"exit_{mode_name}_d_7_23"
       elif (
         (last_rsi_3_gt_88)
         and (last_rsi_14_gt_68)
-        and (last_willr_14 > -25.0)
+        and (last_willr_14_gt_neg_25)
         and (last_rsi_3_4h_lt_30)
         and (last_aroonu_14_4h_gt_75)
       ):
         return True, f"exit_{mode_name}_d_7_24"
       elif (
         (last_rsi_3_gt_80)
-        and (last_willr_14 > -8.0)
+        and (last_willr_14_gt_neg_8)
         and (last_rsi_3_4h_lt_10)
         and (last_roc_9_4h < -15.0)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d > 50.0))
       ):
         return True, f"exit_{mode_name}_d_7_25"
-      elif (last_rsi_3_gt_75) and (last_willr_14 > -8.0) and (last_rsi_3_4h_lt_15) and (last_roc_9_4h < -20.0):
+      elif (last_rsi_3_gt_75) and (last_willr_14_gt_neg_8) and (last_rsi_3_4h_lt_15) and (last_roc_9_4h_lt_neg_20):
         return True, f"exit_{mode_name}_d_7_26"
       elif (
         (last_rsi_3_gt_75)
@@ -34882,27 +34929,27 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14_lt_50)
         and (last_rsi_3_1h_lt_15)
         and (last_rsi_3_4h_lt_15)
-        and (last_stochrsi_k_1h > 25.0)
+        and (last_stochrsi_k_1h_gt_25)
       ):
         return True, f"exit_{mode_name}_d_7_31"
-      elif (last_rsi_3_gt_80) and (last_rsi_3_1h_lt_15) and (last_roc_2_4h < -30.0) and (last_stochrsi_k_4h_gt_30):
+      elif (last_rsi_3_gt_80) and (last_rsi_3_1h_lt_15) and (last_roc_2_4h_lt_neg_30) and (last_stochrsi_k_4h_gt_30):
         return True, f"exit_{mode_name}_d_7_32"
       elif (
         (last_rsi_3_gt_80)
-        and (last_willr_14 > -6.0)
+        and (last_willr_14_gt_neg_6)
         and (last_roc_2_1h < -10.0)
         and (last_roc_9_1h > 30.0)
         and (last_stochrsi_k_1h_gt_50)
       ):
         return True, f"exit_{mode_name}_d_7_33"
-      elif (last_rsi_3 > 65.0) and (last_rsi_3_15m < 30.0) and (last_rsi_14_1h > 80.0) and (last_roc_9_1h > 40.0):
+      elif (last_rsi_3 > 65.0) and (last_rsi_3_15m_lt_30) and (last_rsi_14_1h > 80.0) and (last_roc_9_1h > 40.0):
         return True, f"exit_{mode_name}_d_7_34"
-      elif (last_rsi_3_gt_84) and (last_willr_14 > -8.0) and (last_rsi_3_1d_lt_25) and (last_stochrsi_k_1h > 75.0):
+      elif (last_rsi_3_gt_84) and (last_willr_14_gt_neg_8) and (last_rsi_3_1d_lt_25) and (last_stochrsi_k_1h_gt_75):
         return True, f"exit_{mode_name}_d_7_35"
       elif (
         (last_rsi_3_gt_75)
-        and (last_willr_14 > -25.0)
-        and (last_roc_9_4h < -25.0)
+        and (last_willr_14_gt_neg_25)
+        and (last_roc_9_4h_lt_neg_25)
         and (last_rsi_3_1d_lt_25)
         and (last_stochrsi_k_1h_gt_50)
       ):
@@ -34915,13 +34962,13 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_stochrsi_k_4h_gt_50)
       ):
         return True, f"exit_{mode_name}_d_7_37"
-      elif (last_rsi_3_gt_75) and (last_willr_14 > -25.0) and (last_rsi_3_4h_lt_10) and (last_stochrsi_k_4h_gt_20):
+      elif (last_rsi_3_gt_75) and (last_willr_14_gt_neg_25) and (last_rsi_3_4h_lt_10) and (last_stochrsi_k_4h_gt_20):
         return True, f"exit_{mode_name}_d_7_38"
-      elif (last_rsi_3 > 93.0) and (last_willr_14 > -7.0) and (last_cmf_20_4h < -0.0) and (last_rsi_3_4h_lt_10):
+      elif (last_rsi_3 > 93.0) and (last_willr_14 > -7.0) and (last_cmf_20_4h_lt_0) and (last_rsi_3_4h_lt_10):
         return True, f"exit_{mode_name}_d_7_39"
       elif (
         (last_rsi_3_gt_75)
-        and (last_willr_14 > -25.0)
+        and (last_willr_14_gt_neg_25)
         and (last_rsi_3_1h_lt_30)
         and (last_stochrsi_k_1h_gt_30)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d > 90.0))
@@ -34929,7 +34976,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_7_40"
       elif (
         (last_rsi_3_gt_85)
-        and (last_willr_14 > -20.0)
+        and (last_willr_14_gt_neg_20)
         and (last_rsi_3_1h_lt_30)
         and (last_stochrsi_k_4h_gt_25)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 50.0))
@@ -34953,13 +35000,13 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_7_43"
       elif (
         (last_rsi_3_gt_60)
-        and (last_willr_14 > -15.0)
+        and (last_willr_14_gt_neg_15)
         and (last_rsi_3_4h_lt_30)
         and (last_rsi_3_1d_lt_25)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
       ):
         return True, f"exit_{mode_name}_d_7_44"
-      elif (last_rsi_3_gt_90) and (last_willr_14 > -10.0) and (last_rsi_3_1h_lt_10):
+      elif (last_rsi_3_gt_90) and (last_willr_14_gt_neg_10) and (last_rsi_3_1h_lt_10):
         return True, f"exit_{mode_name}_d_7_45"
       elif (last_rsi_3_gt_80) and (last_rsi_3_1h_lt_15) and (last_rsi_3_4h_lt_10) and (last_roc_2_1d < -20.0):
         return True, f"exit_{mode_name}_d_7_46"
@@ -34967,7 +35014,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3_gt_82)
         and (last_stochrsi_k_1h_gt_80)
         and (last_stochrsi_k_4h_gt_40)
-        and (last_change_pct_1d < -5.0)
+        and (last_change_pct_1d_lt_neg_5)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -5.0))
       ):
         return True, f"exit_{mode_name}_d_7_47"
@@ -34981,20 +35028,20 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_7_48"
       elif (
         (last_rsi_3_gt_80)
-        and (last_willr_14 > -8.0)
+        and (last_willr_14_gt_neg_8)
         and (last_rsi_3_4h_lt_20)
-        and (last_change_pct_1d < -5.0)
+        and (last_change_pct_1d_lt_neg_5)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d > 50.0))
       ):
         return True, f"exit_{mode_name}_d_7_49"
-      elif (last_rsi_3_gt_80) and (last_willr_14 > -8.0) and (last_rsi_3_1d < 10.0) and (last_stochrsi_k_1h > 90.0):
+      elif (last_rsi_3_gt_80) and (last_willr_14_gt_neg_8) and (last_rsi_3_1d < 10.0) and (last_stochrsi_k_1h_gt_90):
         return True, f"exit_{mode_name}_d_7_50"
       elif (last_rsi_3_gt_62) and (last_rsi_14_lt_50) and (last_rsi_3_4h_lt_20) and (last_stochrsi_k_1h_gt_50):
         return True, f"exit_{mode_name}_d_7_51"
       elif (
         (last_rsi_3_gt_76)
         and (last_rsi_14 > 56.0)
-        and (last_willr_14 > -10.0)
+        and (last_willr_14_gt_neg_10)
         and (last_stochrsi_k_1h_gt_70)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -15.0))
       ):
@@ -35002,7 +35049,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3_gt_70)
         and (last_rsi_14_lt_50)
-        and (last_willr_14 > -25.0)
+        and (last_willr_14_gt_neg_25)
         and (last_rsi_3_1h_lt_20)
         and (last_stochrsi_k_4h_gt_50)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d > 50.0))
@@ -35012,14 +35059,14 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3_gt_74)
         and (last_rsi_14_lt_50)
         and (last_stochrsi_k_1h_gt_50)
-        and (last_roc_9_4h < -10.0)
+        and (last_roc_9_4h_lt_neg_10)
         and (last_change_pct_1d < -10.0)
       ):
         return True, f"exit_{mode_name}_d_7_54"
       elif (
         (last_rsi_3_gt_90)
-        and (last_willr_14 > -18.0)
-        and (last_roc_9_4h < -5.0)
+        and (last_willr_14_gt_neg_18)
+        and (last_roc_9_4h_lt_neg_5)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 10.0))
         and (last_stochrsi_k_1h_gt_50)
       ):
@@ -35030,14 +35077,14 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_3_1h_lt_30)
         and (last_rsi_3_4h_lt_25)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
-        and (last_stochrsi_k_4h > 10.0)
+        and (last_stochrsi_k_4h_gt_10)
       ):
         return True, f"exit_{mode_name}_d_7_56"
       elif (
         (last_rsi_3_gt_50)
         and (last_rsi_14 < 40.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
-        and (last_stochrsi_k_4h > 70.0)
+        and (last_stochrsi_k_4h_gt_70)
       ):
         return True, f"exit_{mode_name}_d_7_57"
       elif (
@@ -35050,7 +35097,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_7_58"
       elif (
         (last_rsi_3_gt_85)
-        and (last_willr_14 > -16.0)
+        and (last_willr_14_gt_neg_16)
         and (last_rsi_3_4h_lt_25)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -15.0))
         and (last_stochrsi_k_4h_gt_40)
@@ -35061,18 +35108,18 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14_lt_44)
         and (last_rsi_14_4h > 65.0)
         and (last_stochrsi_k_4h_gt_50)
-        and (last_stochrsi_k_1d > 50.0)
+        and (last_stochrsi_k_1d_gt_50)
       ):
         return True, f"exit_{mode_name}_d_7_60"
-      elif (last_rsi_3_gt_90) and (last_willr_14 > -25.0) and (last_rsi_3_4h_lt_10) and (last_stochrsi_k_1h_gt_30):
+      elif (last_rsi_3_gt_90) and (last_willr_14_gt_neg_25) and (last_rsi_3_4h_lt_10) and (last_stochrsi_k_1h_gt_30):
         return True, f"exit_{mode_name}_d_7_61"
       elif (
         (last_rsi_3_gt_82)
-        and (last_willr_14 > -6.0)
+        and (last_willr_14_gt_neg_6)
         and (last_rsi_3_1h_lt_30)
         and (last_rsi_3_4h_lt_20)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 20.0))
-        and (last_change_pct_1d < -5.0)
+        and (last_change_pct_1d_lt_neg_5)
       ):
         return True, f"exit_{mode_name}_d_7_62"
       elif (last_rsi_3_gt_64) and (last_rsi_3_1d_lt_25) and (last_stochrsi_k_1h_gt_80) and (last_stochrsi_k_4h_gt_30):
@@ -35091,7 +35138,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3_gt_50)
         and (last_rsi_14_lt_46)
-        and (last_stochrsi_k_4h > 80.0)
+        and (last_stochrsi_k_4h_gt_80)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -25.0))
       ):
         return True, f"exit_{mode_name}_d_7_67"
@@ -35099,17 +35146,17 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3_gt_80)
         and (last_rsi_14_lt_52)
         and (last_rsi_3_1h_lt_25)
-        and (last_roc_2_4h < -30.0)
+        and (last_roc_2_4h_lt_neg_30)
         and (last_stochrsi_k_4h_gt_25)
       ):
         return True, f"exit_{mode_name}_d_7_68"
       elif (
-        (last_rsi_3_gt_94) and (last_roc_9_4h > 20.0) and (last_stochrsi_k_4h_gt_50) and (last_change_pct_4h < -5.0)
+        (last_rsi_3_gt_94) and (last_roc_9_4h > 20.0) and (last_stochrsi_k_4h_gt_50) and (last_change_pct_4h_lt_neg_5)
       ):
         return True, f"exit_{mode_name}_d_7_69"
       elif (last_rsi_3_gt_62) and (last_rsi_14_lt_44) and (last_rsi_3_1h_lt_25) and (last_stochrsi_k_4h_gt_20):
         return True, f"exit_{mode_name}_d_7_70"
-      elif (last_rsi_3_gt_60) and (last_rsi_14_lt_48) and (last_rsi_3_4h_lt_25) and (last_stochrsi_k_1h > 20.0):
+      elif (last_rsi_3_gt_60) and (last_rsi_14_lt_48) and (last_rsi_3_4h_lt_25) and (last_stochrsi_k_1h_gt_20):
         return True, f"exit_{mode_name}_d_7_71"
       elif (last_rsi_3_gt_74) and (last_rsi_14_lt_46) and (last_rsi_3_1h_lt_10) and (last_aroonu_14_4h_gt_25):
         return True, f"exit_{mode_name}_d_7_72"
@@ -35117,13 +35164,13 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3_gt_74)
         and (last_rsi_3_1h_lt_25)
         and (last_rsi_3_4h_lt_15)
-        and (last_roc_9_4h < -20.0)
+        and (last_roc_9_4h_lt_neg_20)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -25.0))
       ):
         return True, f"exit_{mode_name}_d_7_73"
       elif (
         (last_rsi_3 > 96.0)
-        and (last_willr_14 > -10.0)
+        and (last_willr_14_gt_neg_10)
         and (last_rsi_3_4h_lt_25)
         and (last_rsi_3_1d_lt_25)
         and (last_stochrsi_k_1h_gt_50)
@@ -35136,7 +35183,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d > 50.0))
       ):
         return True, f"exit_{mode_name}_d_7_75"
-      elif (last_rsi_3_gt_64) and (last_rsi_14_lt_54) and (last_roc_9_1h > 80.0) and (last_stochrsi_k_4h > 80.0):
+      elif (last_rsi_3_gt_64) and (last_rsi_14_lt_54) and (last_roc_9_1h > 80.0) and (last_stochrsi_k_4h_gt_80):
         return True, f"exit_{mode_name}_d_7_76"
       elif (
         (last_rsi_3_gt_72)
@@ -35147,13 +35194,13 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_7_77"
       elif (
         (last_rsi_3_gt_82)
-        and (last_willr_14 > -20.0)
+        and (last_willr_14_gt_neg_20)
         and (last_rsi_3_1h_lt_30)
         and (last_rsi_3_4h_lt_20)
         and (last_rsi_3_1d < 20.0)
       ):
         return True, f"exit_{mode_name}_d_7_78"
-      elif (last_rsi_3_gt_88) and (last_willr_14 > -6.0) and (last_rsi_3_1h_lt_30) and (last_rsi_3_4h_lt_10):
+      elif (last_rsi_3_gt_88) and (last_willr_14_gt_neg_6) and (last_rsi_3_1h_lt_30) and (last_rsi_3_4h_lt_10):
         return True, f"exit_{mode_name}_d_7_79"
       elif (
         (last_rsi_3_gt_68)
@@ -35165,7 +35212,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_7_80"
       elif (
         (last_rsi_3_gt_80)
-        and (last_willr_14 > -14.0)
+        and (last_willr_14_gt_neg_14)
         and (last_rsi_3_1h_lt_25)
         and (last_rsi_3_4h_lt_25)
         and (isinstance(last_rsi_14_1d, np.float64) and (last_rsi_14_1d > 50.0))
@@ -35173,7 +35220,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_7_81"
       elif (
         (last_rsi_3_gt_78)
-        and (last_willr_14 > -14.0)
+        and (last_willr_14_gt_neg_14)
         and (last_rsi_3_4h_lt_30)
         and (last_rsi_3_1d < 15.0)
         and (last_stochrsi_k_4h_gt_40)
@@ -35187,11 +35234,11 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_stochrsi_k_4h_gt_40)
       ):
         return True, f"exit_{mode_name}_d_7_83"
-      elif (last_rsi_3_gt_86) and (last_willr_14 > -6.0) and (last_rsi_3_4h_lt_30) and (last_stochrsi_k_1h > 20.0):
+      elif (last_rsi_3_gt_86) and (last_willr_14_gt_neg_6) and (last_rsi_3_4h_lt_30) and (last_stochrsi_k_1h_gt_20):
         return True, f"exit_{mode_name}_d_7_84"
       elif (
         (last_rsi_3_gt_84)
-        and (last_willr_14 > -12.0)
+        and (last_willr_14_gt_neg_12)
         and (last_rsi_3_1h_lt_30)
         and (last_rsi_3_4h_lt_40)
         and (last_stochrsi_k_4h_gt_50)
@@ -35224,13 +35271,13 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3_gt_74)
         and (last_rsi_14_lt_44)
-        and (last_roc_9_1h < -5.0)
+        and (last_roc_9_1h_lt_neg_5)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 25.0))
       ):
         return True, f"exit_{mode_name}_d_7_89"
       elif (
         (last_rsi_3_gt_88)
-        and (last_willr_14 > -25.0)
+        and (last_willr_14_gt_neg_25)
         and (last_rsi_3_1h_lt_50)
         and (last_rsi_3_4h_lt_30)
         and (last_aroonu_14_4h_gt_50)
@@ -35250,7 +35297,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3_gt_76)
         and (last_rsi_14_lt_52)
         and (last_rsi_3_1h_lt_40)
-        and (last_stochrsi_k_1h > 25.0)
+        and (last_stochrsi_k_1h_gt_25)
         and (last_stochrsi_k_4h_gt_50)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -25.0))
       ):
@@ -35277,10 +35324,10 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_7_94"
       elif (
         (last_rsi_3_gt_80)
-        and (last_willr_14 > -16.0)
+        and (last_willr_14_gt_neg_16)
         and (last_rsi_3_1h_lt_45)
         and (last_rsi_3_4h_lt_40)
-        and (last_stochrsi_k_4h > 10.0)
+        and (last_stochrsi_k_4h_gt_10)
         and (isinstance(last_aroonu_14_1d, np.float64) and (last_aroonu_14_1d > 75.0))
       ):
         return True, f"exit_{mode_name}_d_7_95"
@@ -35310,20 +35357,20 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_7_98"
       elif (
-        (last_rsi_3 > 56.0)
+        (last_rsi_3_gt_56)
         and (last_rsi_14 < 56.0)
         and (last_rsi_3_1h < 65.0)
         and (last_rsi_3_4h_lt_60)
         and (last_aroonu_14_4h_gt_50)
-        and (last_stoch_k_4h > 40.0)
+        and (last_stoch_k_4h_gt_40)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 80.0))
       ):
         return True, f"exit_{mode_name}_d_7_99"
-      elif (last_rsi_3_gt_94) and (last_rsi_14 > 72.0) and (last_rsi_3_15m > 70.0) and (last_rsi_3_4h < 80.0):
+      elif (last_rsi_3_gt_94) and (last_rsi_14 > 72.0) and (last_rsi_3_15m_gt_70) and (last_rsi_3_4h < 80.0):
         return True, f"exit_{mode_name}_d_7_100"
       elif (
         (last_rsi_3_gt_80)
-        and (last_willr_14 > -20.0)
+        and (last_willr_14_gt_neg_20)
         and (last_rsi_3_1h_lt_50)
         and (last_stochrsi_k_4h_gt_40)
         and (isinstance(last_roc_9_4h, np.float64) and (last_roc_9_4h > 40.0))
@@ -35352,7 +35399,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_3_1h_lt_60)
         and (last_stochrsi_k_1h_gt_40)
         and (last_stochrsi_k_4h_gt_90)
-        and (last_roc_9_4h > 40.0)
+        and (last_roc_9_4h_gt_40)
       ):
         return True, f"exit_{mode_name}_d_7_104"
       elif (
@@ -35360,7 +35407,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14_lt_52)
         and (last_rsi_3_15m < 55.0)
         and (last_stochrsi_k_4h_gt_90)
-        and (last_roc_9_4h > 25.0)
+        and (last_roc_9_4h_gt_25)
       ):
         return True, f"exit_{mode_name}_d_7_105"
       elif (
@@ -35369,7 +35416,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_3_1h_lt_50)
         and (last_stochrsi_k_1h_gt_50)
         and (last_rsi_14_4h_gt_70)
-        and (last_roc_9_4h > 40.0)
+        and (last_roc_9_4h_gt_40)
       ):
         return True, f"exit_{mode_name}_d_7_106"
       elif (
@@ -35384,13 +35431,13 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_7_108"
       elif (
         (last_rsi_3_gt_72)
-        and (last_willr_14 > -12.0)
+        and (last_willr_14_gt_neg_12)
         and (last_rsi_3_1h_lt_50)
         and (last_rsi_3_4h_lt_20)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 50.0))
       ):
         return True, f"exit_{mode_name}_d_7_109"
-      elif (last_rsi_3_gt_68) and (last_rsi_3_4h < 65.0) and (last_stochrsi_k_4h_gt_50) and (last_roc_9_4h > 25.0):
+      elif (last_rsi_3_gt_68) and (last_rsi_3_4h < 65.0) and (last_stochrsi_k_4h_gt_50) and (last_roc_9_4h_gt_25):
         return True, f"exit_{mode_name}_d_7_110"
       elif (
         (last_rsi_3 > 46.0)
@@ -35407,14 +35454,14 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_willr_14 > -35.0)
         and (last_rsi_14 < 56.0)
         and (last_rsi_3_1h_lt_35)
-        and (last_rsi_3_4h < 35.0)
+        and (last_rsi_3_4h_lt_35)
         and (last_rsi_3_1d < 60.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
       ):
         return True, f"exit_{mode_name}_d_7_112"
       elif (
         (last_rsi_3_gt_80)
-        and (last_willr_14 > -4.0)
+        and (last_willr_14_gt_neg_4)
         and (last_rsi_3_1d_lt_30)
         and (last_stochrsi_k_4h_gt_50)
         and (isinstance(last_roc_9_4h, np.float64) and (last_roc_9_4h > 10.0))
@@ -35432,7 +35479,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3_gt_74)
         and (last_rsi_14_lt_52)
-        and (last_rsi_3_15m < 30.0)
+        and (last_rsi_3_15m_lt_30)
         and (last_stochrsi_k_1h_gt_50)
         and (last_stochrsi_k_4h_gt_50)
       ):
@@ -35445,7 +35492,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_7_118"
       elif (
         (last_rsi_3_gt_82)
-        and (last_willr_14 > -20.0)
+        and (last_willr_14_gt_neg_20)
         and (last_rsi_3_1h_lt_60)
         and (last_rsi_3_4h_lt_60)
         and (last_stochrsi_k_1h_gt_40)
@@ -35453,11 +35500,11 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_7_119"
       elif (last_rsi_3_gt_50) and (last_rsi_14_lt_52) and (last_rsi_3_1h_lt_40) and (last_aroonu_14_4h_gt_75):
         return True, f"exit_{mode_name}_d_7_120"
-      elif (last_rsi_3 > 56.0) and (last_rsi_14_lt_50) and (last_rsi_3_1h_lt_50) and (last_rsi_14_4h > 85.0):
+      elif (last_rsi_3_gt_56) and (last_rsi_14_lt_50) and (last_rsi_3_1h_lt_50) and (last_rsi_14_4h > 85.0):
         return True, f"exit_{mode_name}_d_7_121"
       elif (last_rsi_3 > 54.0) and (last_rsi_14_lt_48) and (last_rsi_3_4h_lt_30) and (last_stochrsi_k_1h_gt_50):
         return True, f"exit_{mode_name}_d_7_122"
-      elif (last_rsi_3_gt_84) and (last_willr_14 > -8.0) and (last_rsi_3_1h_lt_10) and (last_rsi_3_1d_lt_30):
+      elif (last_rsi_3_gt_84) and (last_willr_14_gt_neg_8) and (last_rsi_3_1h_lt_10) and (last_rsi_3_1d_lt_30):
         return True, f"exit_{mode_name}_d_7_123"
       elif (
         (last_rsi_3_gt_84)
@@ -35467,16 +35514,16 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_7_124"
       elif (
         (last_rsi_3_gt_72)
-        and (last_willr_14 > -8.0)
+        and (last_willr_14_gt_neg_8)
         and (last_rsi_3_1h_lt_10)
         and (last_rsi_3_4h_lt_40)
-        and (last_rsi_3_1d < 40.0)
+        and (last_rsi_3_1d_lt_40)
         and (last_close < (last_high_max_30_1d * 0.50))
       ):
         return True, f"exit_{mode_name}_d_7_125"
       elif (last_rsi_3_gt_86) and (last_rsi_3_1h_lt_15) and (last_rsi_3_4h_lt_40) and (last_stochrsi_k_4h_gt_50):
         return True, f"exit_{mode_name}_d_7_126"
-      elif (last_rsi_3_gt_86) and (last_rsi_3_1h_lt_10) and (last_rsi_3_4h_lt_30) and (last_rsi_3_1d < 40.0):
+      elif (last_rsi_3_gt_86) and (last_rsi_3_1h_lt_10) and (last_rsi_3_4h_lt_30) and (last_rsi_3_1d_lt_40):
         return True, f"exit_{mode_name}_d_7_127"
       elif (last_rsi_3_gt_90) and (last_rsi_3_4h_lt_30) and (last_aroonu_14_4h > 85.0):
         return True, f"exit_{mode_name}_d_7_128"
@@ -35498,7 +35545,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3_gt_76)
         and (last_rsi_3_1h_lt_35)
-        and (last_rsi_3_4h < 35.0)
+        and (last_rsi_3_4h_lt_35)
         and (last_aroonu_14_1h > 50.0)
         and (last_stochrsi_k_1h_gt_40)
       ):
@@ -35566,7 +35613,7 @@ class NostalgiaForInfinityX7(IStrategy):
       last_rsi_14_4h_gt_70 = last_rsi_14_4h > 70.0
       last_rsi_3_1d_lt_30 = last_rsi_3_1d < 30.0
       if (
-        (last_willr_14 > -1.0)
+        (last_willr_14_gt_neg_1)
         and (last_rsi_14 > 78.0)
         and (isinstance(last_ema_200_1h, np.float64) and (last_ema_12_1h < last_ema_200_1h))
         and (isinstance(last_ema_200_4h, np.float64) and (last_ema_12_4h < last_ema_200_4h))
@@ -35575,68 +35622,68 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_8_1"
       elif (
-        (last_willr_14 > -1.0)
+        (last_willr_14_gt_neg_1)
         and (last_rsi_14 > 66.0)
-        and (last_cmf_20_1h < -0.0)
+        and (last_cmf_20_1h_lt_0)
         and (isinstance(last_ema_200_1h, np.float64) and (last_ema_12_1h < last_ema_200_1h))
         and (isinstance(last_ema_200_4h, np.float64) and (last_ema_12_4h < last_ema_200_4h))
       ):
         return True, f"exit_{mode_name}_d_8_2"
       elif (
-        (last_willr_14 > -8.0)
+        (last_willr_14_gt_neg_8)
         and (last_stochrsi_k > 98.0)
-        and (last_cmf_20_1h < -0.0)
-        and (last_cmf_20_4h < -0.0)
-        and ((last_stochrsi_k_4h_gt_20) and (last_stochrsi_k_change_pct_4h < -10.0))
+        and (last_cmf_20_1h_lt_0)
+        and (last_cmf_20_4h_lt_0)
+        and ((last_stochrsi_k_4h_gt_20) and (last_stochrsi_k_change_pct_4h_lt_neg_10))
       ):
         return True, f"exit_{mode_name}_d_8_3"
       elif (
-        (last_willr_14 > -15.0)
+        (last_willr_14_gt_neg_15)
         and (last_rsi_14 > 72.0)
         and (last_stochrsi_k > 95.0)
-        and (last_stochrsi_k_4h > 70.0)
+        and (last_stochrsi_k_4h_gt_70)
         and (isinstance(last_ema_200_1h, np.float64) and (last_ema_12_1h < last_ema_200_1h))
         and (isinstance(last_ema_200_4h, np.float64) and (last_ema_12_4h < last_ema_200_4h))
       ):
         return True, f"exit_{mode_name}_d_8_4"
-      elif (last_willr_14 > -4.0) and (last_rsi_14_gt_70) and (last_roc_9_1h < -5.0) and (last_roc_9_4h < -5.0):
+      elif (last_willr_14_gt_neg_4) and (last_rsi_14_gt_70) and (last_roc_9_1h_lt_neg_5) and (last_roc_9_4h_lt_neg_5):
         return True, f"exit_{mode_name}_d_8_5"
       elif (
         (last_rsi_3_gt_70)
-        and (last_stochrsi_k > 70.0)
+        and (last_stochrsi_k_gt_70)
         and (last_rsi_14 < 40.0)
-        and (last_roc_9_1h < -10.0)
+        and (last_roc_9_1h_lt_neg_10)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 50.0))
       ):
         return True, f"exit_{mode_name}_d_8_6"
       elif (
         (last_rsi_14_lt_50)
-        and (last_stochrsi_k > 70.0)
+        and (last_stochrsi_k_gt_70)
         and (last_stochrsi_k_4h_gt_50)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -40.0))
       ):
         return True, f"exit_{mode_name}_d_8_7"
       elif (
-        (last_willr_14 > -4.0)
+        (last_willr_14_gt_neg_4)
         and (last_stochrsi_k > 95.0)
         and (last_cmf_20_1h < -0.1)
         and (last_cmf_20_4h < -0.1)
-        and (last_change_pct_1d < -5.0)
+        and (last_change_pct_1d_lt_neg_5)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 15.0))
       ):
         return True, f"exit_{mode_name}_d_8_8"
       elif (
-        (last_willr_14 > -5.0)
+        (last_willr_14_gt_neg_5)
         and (last_rsi_3_gt_95)
-        and (last_change_pct_4h < -5.0)
+        and (last_change_pct_4h_lt_neg_5)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
       ):
         return True, f"exit_{mode_name}_d_8_9"
       elif (
-        (last_willr_14 > -8.0)
+        (last_willr_14_gt_neg_8)
         and (last_rsi_14_lt_50)
-        and (last_roc_9_1h < -10.0)
-        and (last_roc_9_4h < -10.0)
+        and (last_roc_9_1h_lt_neg_10)
+        and (last_roc_9_4h_lt_neg_10)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 10.0))
       ):
         return True, f"exit_{mode_name}_d_8_10"
@@ -35644,7 +35691,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3_gt_90)
         and (last_rsi_14 < 45.0)
         and (last_roc_9_15m < -10.0)
-        and (last_roc_9_1h < -10.0)
+        and (last_roc_9_1h_lt_neg_10)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -20.0))
       ):
         return True, f"exit_{mode_name}_d_8_11"
@@ -35653,26 +35700,26 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14_lt_50)
         and (last_rsi_3_4h_lt_10)
         and (last_roc_9_1h < -20.0)
-        and (last_roc_9_4h < -20.0)
+        and (last_roc_9_4h_lt_neg_20)
       ):
         return True, f"exit_{mode_name}_d_8_12"
-      elif (last_rsi_3_gt_95) and (last_rsi_3_4h < 5.0) and (last_roc_9_4h < -25.0):
+      elif (last_rsi_3_gt_95) and (last_rsi_3_4h_lt_5) and (last_roc_9_4h_lt_neg_25):
         return True, f"exit_{mode_name}_d_8_13"
-      elif (last_rsi_3_gt_90) and (last_willr_14 > -6.0) and (last_rsi_3_4h < 5.0) and (last_aroonu_14_4h_gt_25):
+      elif (last_rsi_3_gt_90) and (last_willr_14_gt_neg_6) and (last_rsi_3_4h_lt_5) and (last_aroonu_14_4h_gt_25):
         return True, f"exit_{mode_name}_d_8_14"
       elif (last_rsi_3_gt_92) and (last_rsi_14 > 64.0) and (last_roc_9_4h < -30.0):
         return True, f"exit_{mode_name}_d_8_15"
       elif (
         (last_rsi_3_gt_85)
         and (last_aroonu_14_4h_gt_25)
-        and (last_roc_9_4h < -25.0)
+        and (last_roc_9_4h_lt_neg_25)
         and (last_aroonu_14_1d > 50.0)
         and (last_change_pct_1d < -15.0)
       ):
         return True, f"exit_{mode_name}_d_8_16"
       elif (
         (last_rsi_3_gt_95)
-        and (last_willr_14 > -20.0)
+        and (last_willr_14_gt_neg_20)
         and (last_rsi_3_1h_lt_10)
         and (last_stochrsi_k_4h_gt_90)
         and (last_roc_9_4h > 30.0)
@@ -35693,31 +35740,31 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_8_21"
       elif (
         (last_rsi_3 > 96.0)
-        and (last_willr_14 > -4.0)
-        and (last_change_pct_4h < -5.0)
+        and (last_willr_14_gt_neg_4)
+        and (last_change_pct_4h_lt_neg_5)
         and (last_stochrsi_k_4h_gt_50)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
       ):
         return True, f"exit_{mode_name}_d_8_22"
-      elif (last_rsi_3_gt_90) and (last_willr_14 > -15.0) and (last_rsi_3_1h_lt_15) and (last_rsi_3_1d < 5.0):
+      elif (last_rsi_3_gt_90) and (last_willr_14_gt_neg_15) and (last_rsi_3_1h_lt_15) and (last_rsi_3_1d < 5.0):
         return True, f"exit_{mode_name}_d_8_23"
       elif (
         (last_rsi_3_gt_90)
         and (last_rsi_14_gt_70)
-        and (last_willr_14 > -20.0)
+        and (last_willr_14_gt_neg_20)
         and (last_rsi_3_4h_lt_30)
         and (last_aroonu_14_4h_gt_75)
       ):
         return True, f"exit_{mode_name}_d_8_24"
       elif (
         (last_rsi_3_gt_85)
-        and (last_willr_14 > -6.0)
+        and (last_willr_14_gt_neg_6)
         and (last_rsi_3_4h_lt_10)
         and (last_roc_9_4h < -15.0)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d > 50.0))
       ):
         return True, f"exit_{mode_name}_d_8_25"
-      elif (last_rsi_3_gt_80) and (last_willr_14 > -6.0) and (last_rsi_3_4h_lt_15) and (last_roc_9_4h < -20.0):
+      elif (last_rsi_3_gt_80) and (last_willr_14_gt_neg_6) and (last_rsi_3_4h_lt_15) and (last_roc_9_4h_lt_neg_20):
         return True, f"exit_{mode_name}_d_8_26"
       elif (
         (last_rsi_3_gt_80)
@@ -35744,27 +35791,27 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14_lt_50)
         and (last_rsi_3_1h_lt_15)
         and (last_rsi_3_4h_lt_15)
-        and (last_stochrsi_k_1h > 25.0)
+        and (last_stochrsi_k_1h_gt_25)
       ):
         return True, f"exit_{mode_name}_d_8_31"
-      elif (last_rsi_3_gt_85) and (last_rsi_3_1h_lt_15) and (last_roc_2_4h < -30.0) and (last_stochrsi_k_4h_gt_30):
+      elif (last_rsi_3_gt_85) and (last_rsi_3_1h_lt_15) and (last_roc_2_4h_lt_neg_30) and (last_stochrsi_k_4h_gt_30):
         return True, f"exit_{mode_name}_d_8_32"
       elif (
         (last_rsi_3_gt_85)
-        and (last_willr_14 > -4.0)
+        and (last_willr_14_gt_neg_4)
         and (last_roc_2_1h < -10.0)
         and (last_roc_9_1h > 30.0)
         and (last_stochrsi_k_1h_gt_50)
       ):
         return True, f"exit_{mode_name}_d_8_33"
-      elif (last_rsi_3 > 65.0) and (last_rsi_3_15m < 30.0) and (last_rsi_14_1h > 80.0) and (last_roc_9_1h > 40.0):
+      elif (last_rsi_3 > 65.0) and (last_rsi_3_15m_lt_30) and (last_rsi_14_1h > 80.0) and (last_roc_9_1h > 40.0):
         return True, f"exit_{mode_name}_d_8_34"
-      elif (last_rsi_3_gt_86) and (last_willr_14 > -7.0) and (last_rsi_3_1d_lt_25) and (last_stochrsi_k_1h > 75.0):
+      elif (last_rsi_3_gt_86) and (last_willr_14 > -7.0) and (last_rsi_3_1d_lt_25) and (last_stochrsi_k_1h_gt_75):
         return True, f"exit_{mode_name}_d_8_35"
       elif (
         (last_rsi_3_gt_80)
-        and (last_willr_14 > -20.0)
-        and (last_roc_9_4h < -25.0)
+        and (last_willr_14_gt_neg_20)
+        and (last_roc_9_4h_lt_neg_25)
         and (last_rsi_3_1d_lt_25)
         and (last_stochrsi_k_1h_gt_50)
       ):
@@ -35777,13 +35824,13 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_stochrsi_k_4h_gt_50)
       ):
         return True, f"exit_{mode_name}_d_8_37"
-      elif (last_rsi_3_gt_80) and (last_willr_14 > -20.0) and (last_rsi_3_4h_lt_10) and (last_stochrsi_k_4h_gt_20):
+      elif (last_rsi_3_gt_80) and (last_willr_14_gt_neg_20) and (last_rsi_3_4h_lt_10) and (last_stochrsi_k_4h_gt_20):
         return True, f"exit_{mode_name}_d_8_38"
-      elif (last_rsi_3 > 94.0) and (last_willr_14 > -6.0) and (last_cmf_20_4h < -0.0) and (last_rsi_3_4h_lt_10):
+      elif (last_rsi_3 > 94.0) and (last_willr_14_gt_neg_6) and (last_cmf_20_4h_lt_0) and (last_rsi_3_4h_lt_10):
         return True, f"exit_{mode_name}_d_8_39"
       elif (
         (last_rsi_3_gt_80)
-        and (last_willr_14 > -20.0)
+        and (last_willr_14_gt_neg_20)
         and (last_rsi_3_1h_lt_30)
         and (last_stochrsi_k_1h_gt_30)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d > 90.0))
@@ -35791,7 +35838,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_8_40"
       elif (
         (last_rsi_3_gt_90)
-        and (last_willr_14 > -15.0)
+        and (last_willr_14_gt_neg_15)
         and (last_rsi_3_1h_lt_30)
         and (last_stochrsi_k_4h_gt_25)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 50.0))
@@ -35799,7 +35846,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_8_41"
       elif (
         (last_rsi_3_gt_85)
-        and (last_willr_14 > -30.0)
+        and (last_willr_14_gt_neg_30)
         and (last_stochrsi_k_4h_gt_30)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 40.0))
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d > 70.0))
@@ -35815,13 +35862,13 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_8_43"
       elif (
         (last_rsi_3 > 65.0)
-        and (last_willr_14 > -10.0)
+        and (last_willr_14_gt_neg_10)
         and (last_rsi_3_4h_lt_30)
         and (last_rsi_3_1d_lt_25)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
       ):
         return True, f"exit_{mode_name}_d_8_44"
-      elif (last_rsi_3_gt_92) and (last_willr_14 > -8.0) and (last_rsi_3_1h_lt_10):
+      elif (last_rsi_3_gt_92) and (last_willr_14_gt_neg_8) and (last_rsi_3_1h_lt_10):
         return True, f"exit_{mode_name}_d_8_45"
       elif (last_rsi_3_gt_85) and (last_rsi_3_1h_lt_15) and (last_rsi_3_4h_lt_10) and (last_roc_2_1d < -20.0):
         return True, f"exit_{mode_name}_d_8_46"
@@ -35829,7 +35876,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3_gt_84)
         and (last_stochrsi_k_1h_gt_80)
         and (last_stochrsi_k_4h_gt_40)
-        and (last_change_pct_1d < -5.0)
+        and (last_change_pct_1d_lt_neg_5)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -5.0))
       ):
         return True, f"exit_{mode_name}_d_8_47"
@@ -35843,20 +35890,20 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_8_48"
       elif (
         (last_rsi_3_gt_85)
-        and (last_willr_14 > -6.0)
+        and (last_willr_14_gt_neg_6)
         and (last_rsi_3_4h_lt_20)
-        and (last_change_pct_1d < -5.0)
+        and (last_change_pct_1d_lt_neg_5)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d > 50.0))
       ):
         return True, f"exit_{mode_name}_d_8_49"
-      elif (last_rsi_3_gt_80) and (last_willr_14 > -6.0) and (last_rsi_3_1d < 10.0) and (last_stochrsi_k_1h > 90.0):
+      elif (last_rsi_3_gt_80) and (last_willr_14_gt_neg_6) and (last_rsi_3_1d < 10.0) and (last_stochrsi_k_1h_gt_90):
         return True, f"exit_{mode_name}_d_8_50"
       elif (last_rsi_3_gt_64) and (last_rsi_14_lt_48) and (last_rsi_3_4h_lt_20) and (last_stochrsi_k_1h_gt_50):
         return True, f"exit_{mode_name}_d_8_51"
       elif (
         (last_rsi_3_gt_78)
         and (last_rsi_14 > 58.0)
-        and (last_willr_14 > -10.0)
+        and (last_willr_14_gt_neg_10)
         and (last_stochrsi_k_1h_gt_70)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -15.0))
       ):
@@ -35864,7 +35911,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3_gt_70)
         and (last_rsi_14_lt_50)
-        and (last_willr_14 > -25.0)
+        and (last_willr_14_gt_neg_25)
         and (last_rsi_3_1h_lt_20)
         and (last_stochrsi_k_4h_gt_50)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d > 50.0))
@@ -35874,14 +35921,14 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3_gt_76)
         and (last_rsi_14_lt_48)
         and (last_stochrsi_k_1h_gt_50)
-        and (last_roc_9_4h < -10.0)
+        and (last_roc_9_4h_lt_neg_10)
         and (last_change_pct_1d < -10.0)
       ):
         return True, f"exit_{mode_name}_d_8_54"
       elif (
         (last_rsi_3_gt_92)
-        and (last_willr_14 > -16.0)
-        and (last_roc_9_4h < -5.0)
+        and (last_willr_14_gt_neg_16)
+        and (last_roc_9_4h_lt_neg_5)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 10.0))
         and (last_stochrsi_k_1h_gt_50)
       ):
@@ -35892,14 +35939,14 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_3_1h_lt_30)
         and (last_rsi_3_4h_lt_25)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
-        and (last_stochrsi_k_4h > 10.0)
+        and (last_stochrsi_k_4h_gt_10)
       ):
         return True, f"exit_{mode_name}_d_8_56"
       elif (
         (last_rsi_3 > 50.0)
         and (last_rsi_14 < 38.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
-        and (last_stochrsi_k_4h > 70.0)
+        and (last_stochrsi_k_4h_gt_70)
       ):
         return True, f"exit_{mode_name}_d_8_57"
       elif (
@@ -35912,7 +35959,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_8_58"
       elif (
         (last_rsi_3_gt_85)
-        and (last_willr_14 > -14.0)
+        and (last_willr_14_gt_neg_14)
         and (last_rsi_3_4h_lt_25)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -15.0))
         and (last_stochrsi_k_4h_gt_40)
@@ -35923,18 +35970,18 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14_lt_42)
         and (last_rsi_14_4h > 65.0)
         and (last_stochrsi_k_4h_gt_50)
-        and (last_stochrsi_k_1d > 50.0)
+        and (last_stochrsi_k_1d_gt_50)
       ):
         return True, f"exit_{mode_name}_d_8_60"
-      elif (last_rsi_3_gt_90) and (last_willr_14 > -25.0) and (last_rsi_3_4h_lt_10) and (last_stochrsi_k_1h_gt_30):
+      elif (last_rsi_3_gt_90) and (last_willr_14_gt_neg_25) and (last_rsi_3_4h_lt_10) and (last_stochrsi_k_1h_gt_30):
         return True, f"exit_{mode_name}_d_8_61"
       elif (
         (last_rsi_3_gt_84)
-        and (last_willr_14 > -4.0)
+        and (last_willr_14_gt_neg_4)
         and (last_rsi_3_1h_lt_30)
         and (last_rsi_3_4h_lt_20)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 20.0))
-        and (last_change_pct_1d < -5.0)
+        and (last_change_pct_1d_lt_neg_5)
       ):
         return True, f"exit_{mode_name}_d_8_62"
       elif (last_rsi_3_gt_66) and (last_rsi_3_1d_lt_25) and (last_stochrsi_k_1h_gt_80) and (last_stochrsi_k_4h_gt_30):
@@ -35953,7 +36000,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 50.0)
         and (last_rsi_14_lt_44)
-        and (last_stochrsi_k_4h > 80.0)
+        and (last_stochrsi_k_4h_gt_80)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -25.0))
       ):
         return True, f"exit_{mode_name}_d_8_67"
@@ -35961,17 +36008,17 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3_gt_82)
         and (last_rsi_14_lt_50)
         and (last_rsi_3_1h_lt_25)
-        and (last_roc_2_4h < -30.0)
+        and (last_roc_2_4h_lt_neg_30)
         and (last_stochrsi_k_4h_gt_25)
       ):
         return True, f"exit_{mode_name}_d_8_68"
       elif (
-        (last_rsi_3_gt_95) and (last_roc_9_4h > 20.0) and (last_stochrsi_k_4h_gt_50) and (last_change_pct_4h < -5.0)
+        (last_rsi_3_gt_95) and (last_roc_9_4h > 20.0) and (last_stochrsi_k_4h_gt_50) and (last_change_pct_4h_lt_neg_5)
       ):
         return True, f"exit_{mode_name}_d_8_69"
       elif (last_rsi_3_gt_64) and (last_rsi_14_lt_42) and (last_rsi_3_1h_lt_25) and (last_stochrsi_k_4h_gt_20):
         return True, f"exit_{mode_name}_d_8_70"
-      elif (last_rsi_3 > 62.0) and (last_rsi_14_lt_46) and (last_rsi_3_4h_lt_25) and (last_stochrsi_k_1h > 20.0):
+      elif (last_rsi_3 > 62.0) and (last_rsi_14_lt_46) and (last_rsi_3_4h_lt_25) and (last_stochrsi_k_1h_gt_20):
         return True, f"exit_{mode_name}_d_8_71"
       elif (last_rsi_3_gt_76) and (last_rsi_14_lt_44) and (last_rsi_3_1h_lt_10) and (last_aroonu_14_4h_gt_25):
         return True, f"exit_{mode_name}_d_8_72"
@@ -35979,13 +36026,13 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3_gt_76)
         and (last_rsi_3_1h_lt_25)
         and (last_rsi_3_4h_lt_15)
-        and (last_roc_9_4h < -20.0)
+        and (last_roc_9_4h_lt_neg_20)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -25.0))
       ):
         return True, f"exit_{mode_name}_d_8_73"
       elif (
         (last_rsi_3 > 97.0)
-        and (last_willr_14 > -10.0)
+        and (last_willr_14_gt_neg_10)
         and (last_rsi_3_4h_lt_25)
         and (last_rsi_3_1d_lt_25)
         and (last_stochrsi_k_1h_gt_50)
@@ -35998,7 +36045,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d > 50.0))
       ):
         return True, f"exit_{mode_name}_d_8_75"
-      elif (last_rsi_3_gt_66) and (last_rsi_14_lt_52) and (last_roc_9_1h > 80.0) and (last_stochrsi_k_4h > 80.0):
+      elif (last_rsi_3_gt_66) and (last_rsi_14_lt_52) and (last_roc_9_1h > 80.0) and (last_stochrsi_k_4h_gt_80):
         return True, f"exit_{mode_name}_d_8_76"
       elif (
         (last_rsi_3_gt_74)
@@ -36009,13 +36056,13 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_8_77"
       elif (
         (last_rsi_3_gt_84)
-        and (last_willr_14 > -18.0)
+        and (last_willr_14_gt_neg_18)
         and (last_rsi_3_1h_lt_30)
         and (last_rsi_3_4h_lt_20)
         and (last_rsi_3_1d < 20.0)
       ):
         return True, f"exit_{mode_name}_d_8_78"
-      elif (last_rsi_3_gt_90) and (last_willr_14 > -4.0) and (last_rsi_3_1h_lt_30) and (last_rsi_3_4h_lt_10):
+      elif (last_rsi_3_gt_90) and (last_willr_14_gt_neg_4) and (last_rsi_3_1h_lt_30) and (last_rsi_3_4h_lt_10):
         return True, f"exit_{mode_name}_d_8_79"
       elif (
         (last_rsi_3_gt_70)
@@ -36027,7 +36074,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_8_80"
       elif (
         (last_rsi_3_gt_82)
-        and (last_willr_14 > -12.0)
+        and (last_willr_14_gt_neg_12)
         and (last_rsi_3_1h_lt_25)
         and (last_rsi_3_4h_lt_25)
         and (isinstance(last_rsi_14_1d, np.float64) and (last_rsi_14_1d > 50.0))
@@ -36035,7 +36082,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_8_81"
       elif (
         (last_rsi_3_gt_80)
-        and (last_willr_14 > -12.0)
+        and (last_willr_14_gt_neg_12)
         and (last_rsi_3_4h_lt_30)
         and (last_rsi_3_1d < 15.0)
         and (last_stochrsi_k_4h_gt_40)
@@ -36049,11 +36096,11 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_stochrsi_k_4h_gt_40)
       ):
         return True, f"exit_{mode_name}_d_8_83"
-      elif (last_rsi_3_gt_88) and (last_willr_14 > -4.0) and (last_rsi_3_4h_lt_30) and (last_stochrsi_k_1h > 20.0):
+      elif (last_rsi_3_gt_88) and (last_willr_14_gt_neg_4) and (last_rsi_3_4h_lt_30) and (last_stochrsi_k_1h_gt_20):
         return True, f"exit_{mode_name}_d_8_84"
       elif (
         (last_rsi_3_gt_86)
-        and (last_willr_14 > -10.0)
+        and (last_willr_14_gt_neg_10)
         and (last_rsi_3_1h_lt_30)
         and (last_rsi_3_4h_lt_40)
         and (last_stochrsi_k_4h_gt_50)
@@ -36086,13 +36133,13 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3_gt_76)
         and (last_rsi_14_lt_42)
-        and (last_roc_9_1h < -5.0)
+        and (last_roc_9_1h_lt_neg_5)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 25.0))
       ):
         return True, f"exit_{mode_name}_d_8_89"
       elif (
         (last_rsi_3_gt_90)
-        and (last_willr_14 > -25.0)
+        and (last_willr_14_gt_neg_25)
         and (last_rsi_3_1h_lt_50)
         and (last_rsi_3_4h_lt_30)
         and (last_aroonu_14_4h_gt_50)
@@ -36112,7 +36159,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3_gt_78)
         and (last_rsi_14_lt_50)
         and (last_rsi_3_1h_lt_40)
-        and (last_stochrsi_k_1h > 25.0)
+        and (last_stochrsi_k_1h_gt_25)
         and (last_stochrsi_k_4h_gt_50)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -25.0))
       ):
@@ -36139,10 +36186,10 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_8_94"
       elif (
         (last_rsi_3_gt_82)
-        and (last_willr_14 > -14.0)
+        and (last_willr_14_gt_neg_14)
         and (last_rsi_3_1h_lt_45)
         and (last_rsi_3_4h_lt_40)
-        and (last_stochrsi_k_4h > 10.0)
+        and (last_stochrsi_k_4h_gt_10)
         and (isinstance(last_aroonu_14_1d, np.float64) and (last_aroonu_14_1d > 75.0))
       ):
         return True, f"exit_{mode_name}_d_8_95"
@@ -36164,7 +36211,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_8_97"
       elif (
         (last_rsi_3_gt_88)
-        and (last_rsi_3_15m > 70.0)
+        and (last_rsi_3_15m_gt_70)
         and (last_rsi_3_1h_lt_60)
         and (last_rsi_3_4h_lt_60)
         and (last_rsi_3_1d > 80.0)
@@ -36177,15 +36224,15 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_3_1h < 65.0)
         and (last_rsi_3_4h_lt_60)
         and (last_aroonu_14_4h_gt_50)
-        and (last_stoch_k_4h > 40.0)
+        and (last_stoch_k_4h_gt_40)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 80.0))
       ):
         return True, f"exit_{mode_name}_d_8_99"
-      elif (last_rsi_3 > 96.0) and (last_rsi_14 > 74.0) and (last_rsi_3_15m > 70.0) and (last_rsi_3_4h < 80.0):
+      elif (last_rsi_3 > 96.0) and (last_rsi_14 > 74.0) and (last_rsi_3_15m_gt_70) and (last_rsi_3_4h < 80.0):
         return True, f"exit_{mode_name}_d_8_100"
       elif (
         (last_rsi_3_gt_82)
-        and (last_willr_14 > -18.0)
+        and (last_willr_14_gt_neg_18)
         and (last_rsi_3_1h_lt_50)
         and (last_stochrsi_k_4h_gt_40)
         and (isinstance(last_roc_9_4h, np.float64) and (last_roc_9_4h > 40.0))
@@ -36214,7 +36261,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_3_1h_lt_60)
         and (last_stochrsi_k_1h_gt_40)
         and (last_stochrsi_k_4h_gt_90)
-        and (last_roc_9_4h > 40.0)
+        and (last_roc_9_4h_gt_40)
       ):
         return True, f"exit_{mode_name}_d_8_104"
       elif (
@@ -36222,7 +36269,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14_lt_50)
         and (last_rsi_3_15m < 55.0)
         and (last_stochrsi_k_4h_gt_90)
-        and (last_roc_9_4h > 25.0)
+        and (last_roc_9_4h_gt_25)
       ):
         return True, f"exit_{mode_name}_d_8_105"
       elif (
@@ -36231,7 +36278,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_3_1h_lt_50)
         and (last_stochrsi_k_1h_gt_50)
         and (last_rsi_14_4h_gt_70)
-        and (last_roc_9_4h > 40.0)
+        and (last_roc_9_4h_gt_40)
       ):
         return True, f"exit_{mode_name}_d_8_106"
       elif (
@@ -36246,13 +36293,13 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_8_108"
       elif (
         (last_rsi_3_gt_74)
-        and (last_willr_14 > -10.0)
+        and (last_willr_14_gt_neg_10)
         and (last_rsi_3_1h_lt_50)
         and (last_rsi_3_4h_lt_20)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 50.0))
       ):
         return True, f"exit_{mode_name}_d_8_109"
-      elif (last_rsi_3_gt_70) and (last_rsi_3_4h < 65.0) and (last_stochrsi_k_4h_gt_50) and (last_roc_9_4h > 25.0):
+      elif (last_rsi_3_gt_70) and (last_rsi_3_4h < 65.0) and (last_stochrsi_k_4h_gt_50) and (last_roc_9_4h_gt_25):
         return True, f"exit_{mode_name}_d_8_110"
       elif (
         (last_rsi_3 > 48.0)
@@ -36266,17 +36313,17 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_8_111"
       elif (
         (last_rsi_3_gt_78)
-        and (last_willr_14 > -30.0)
+        and (last_willr_14_gt_neg_30)
         and (last_rsi_14 < 54.0)
         and (last_rsi_3_1h_lt_35)
-        and (last_rsi_3_4h < 35.0)
+        and (last_rsi_3_4h_lt_35)
         and (last_rsi_3_1d < 60.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
       ):
         return True, f"exit_{mode_name}_d_8_112"
       elif (
         (last_rsi_3_gt_82)
-        and (last_willr_14 > -2.0)
+        and (last_willr_14_gt_neg_2)
         and (last_rsi_3_1d_lt_30)
         and (last_stochrsi_k_4h_gt_50)
         and (isinstance(last_roc_9_4h, np.float64) and (last_roc_9_4h > 10.0))
@@ -36294,7 +36341,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3_gt_76)
         and (last_rsi_14_lt_50)
-        and (last_rsi_3_15m < 30.0)
+        and (last_rsi_3_15m_lt_30)
         and (last_stochrsi_k_1h_gt_50)
         and (last_stochrsi_k_4h_gt_50)
       ):
@@ -36307,7 +36354,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_8_118"
       elif (
         (last_rsi_3_gt_84)
-        and (last_willr_14 > -20.0)
+        and (last_willr_14_gt_neg_20)
         and (last_rsi_3_1h_lt_60)
         and (last_rsi_3_4h_lt_60)
         and (last_stochrsi_k_1h_gt_40)
@@ -36317,9 +36364,9 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_8_120"
       elif (last_rsi_3 > 58.0) and (last_rsi_14_lt_48) and (last_rsi_3_1h_lt_50) and (last_rsi_14_4h > 85.0):
         return True, f"exit_{mode_name}_d_8_121"
-      elif (last_rsi_3 > 56.0) and (last_rsi_14_lt_46) and (last_rsi_3_4h_lt_30) and (last_stochrsi_k_1h_gt_50):
+      elif (last_rsi_3_gt_56) and (last_rsi_14_lt_46) and (last_rsi_3_4h_lt_30) and (last_stochrsi_k_1h_gt_50):
         return True, f"exit_{mode_name}_d_8_122"
-      elif (last_rsi_3_gt_86) and (last_willr_14 > -6.0) and (last_rsi_3_1h_lt_10) and (last_rsi_3_1d_lt_30):
+      elif (last_rsi_3_gt_86) and (last_willr_14_gt_neg_6) and (last_rsi_3_1h_lt_10) and (last_rsi_3_1d_lt_30):
         return True, f"exit_{mode_name}_d_8_123"
       elif (
         (last_rsi_3_gt_86)
@@ -36329,16 +36376,16 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_8_124"
       elif (
         (last_rsi_3_gt_74)
-        and (last_willr_14 > -6.0)
+        and (last_willr_14_gt_neg_6)
         and (last_rsi_3_1h_lt_10)
         and (last_rsi_3_4h_lt_40)
-        and (last_rsi_3_1d < 40.0)
+        and (last_rsi_3_1d_lt_40)
         and (last_close < (last_high_max_30_1d * 0.50))
       ):
         return True, f"exit_{mode_name}_d_8_125"
       elif (last_rsi_3_gt_88) and (last_rsi_3_1h_lt_15) and (last_rsi_3_4h_lt_40) and (last_stochrsi_k_4h_gt_50):
         return True, f"exit_{mode_name}_d_8_126"
-      elif (last_rsi_3_gt_88) and (last_rsi_3_1h_lt_10) and (last_rsi_3_4h_lt_30) and (last_rsi_3_1d < 40.0):
+      elif (last_rsi_3_gt_88) and (last_rsi_3_1h_lt_10) and (last_rsi_3_4h_lt_30) and (last_rsi_3_1d_lt_40):
         return True, f"exit_{mode_name}_d_8_127"
       elif (last_rsi_3_gt_92) and (last_rsi_3_4h_lt_30) and (last_aroonu_14_4h > 85.0):
         return True, f"exit_{mode_name}_d_8_128"
@@ -36360,7 +36407,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3_gt_78)
         and (last_rsi_3_1h_lt_35)
-        and (last_rsi_3_4h < 35.0)
+        and (last_rsi_3_4h_lt_35)
         and (last_aroonu_14_1h > 50.0)
         and (last_stochrsi_k_1h_gt_40)
       ):
@@ -36431,7 +36478,7 @@ class NostalgiaForInfinityX7(IStrategy):
       last_rsi_14_4h_gt_70 = last_rsi_14_4h > 70.0
       last_rsi_3_1d_lt_30 = last_rsi_3_1d < 30.0
       if (
-        (last_willr_14 > -1.0)
+        (last_willr_14_gt_neg_1)
         and (last_rsi_14 > 78.0)
         and (isinstance(last_ema_200_1h, np.float64) and (last_ema_12_1h < last_ema_200_1h))
         and (isinstance(last_ema_200_4h, np.float64) and (last_ema_12_4h < last_ema_200_4h))
@@ -36440,68 +36487,68 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_9_1"
       elif (
-        (last_willr_14 > -1.0)
+        (last_willr_14_gt_neg_1)
         and (last_rsi_14 > 68.0)
-        and (last_cmf_20_1h < -0.0)
+        and (last_cmf_20_1h_lt_0)
         and (isinstance(last_ema_200_1h, np.float64) and (last_ema_12_1h < last_ema_200_1h))
         and (isinstance(last_ema_200_4h, np.float64) and (last_ema_12_4h < last_ema_200_4h))
       ):
         return True, f"exit_{mode_name}_d_9_2"
       elif (
-        (last_willr_14 > -6.0)
+        (last_willr_14_gt_neg_6)
         and (last_stochrsi_k > 98.0)
-        and (last_cmf_20_1h < -0.0)
-        and (last_cmf_20_4h < -0.0)
-        and ((last_stochrsi_k_4h_gt_20) and (last_stochrsi_k_change_pct_4h < -10.0))
+        and (last_cmf_20_1h_lt_0)
+        and (last_cmf_20_4h_lt_0)
+        and ((last_stochrsi_k_4h_gt_20) and (last_stochrsi_k_change_pct_4h_lt_neg_10))
       ):
         return True, f"exit_{mode_name}_d_9_3"
       elif (
-        (last_willr_14 > -10.0)
+        (last_willr_14_gt_neg_10)
         and (last_rsi_14 > 74.0)
         and (last_stochrsi_k > 95.0)
-        and (last_stochrsi_k_4h > 70.0)
+        and (last_stochrsi_k_4h_gt_70)
         and (isinstance(last_ema_200_1h, np.float64) and (last_ema_12_1h < last_ema_200_1h))
         and (isinstance(last_ema_200_4h, np.float64) and (last_ema_12_4h < last_ema_200_4h))
       ):
         return True, f"exit_{mode_name}_d_9_4"
-      elif (last_willr_14 > -2.0) and (last_rsi_14_gt_72) and (last_roc_9_1h < -5.0) and (last_roc_9_4h < -5.0):
+      elif (last_willr_14_gt_neg_2) and (last_rsi_14_gt_72) and (last_roc_9_1h_lt_neg_5) and (last_roc_9_4h_lt_neg_5):
         return True, f"exit_{mode_name}_d_9_5"
       elif (
         (last_rsi_3_gt_70)
-        and (last_stochrsi_k > 70.0)
+        and (last_stochrsi_k_gt_70)
         and (last_rsi_14_lt_40)
-        and (last_roc_9_1h < -10.0)
+        and (last_roc_9_1h_lt_neg_10)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 50.0))
       ):
         return True, f"exit_{mode_name}_d_9_6"
       elif (
         (last_rsi_14_lt_50)
-        and (last_stochrsi_k > 70.0)
+        and (last_stochrsi_k_gt_70)
         and (last_stochrsi_k_4h_gt_50)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -40.0))
       ):
         return True, f"exit_{mode_name}_d_9_7"
       elif (
-        (last_willr_14 > -2.0)
+        (last_willr_14_gt_neg_2)
         and (last_stochrsi_k > 95.0)
         and (last_cmf_20_1h < -0.1)
         and (last_cmf_20_4h < -0.1)
-        and (last_change_pct_1d < -5.0)
+        and (last_change_pct_1d_lt_neg_5)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 15.0))
       ):
         return True, f"exit_{mode_name}_d_9_8"
       elif (
-        (last_willr_14 > -4.0)
+        (last_willr_14_gt_neg_4)
         and (last_rsi_3_gt_95)
-        and (last_change_pct_4h < -5.0)
+        and (last_change_pct_4h_lt_neg_5)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
       ):
         return True, f"exit_{mode_name}_d_9_9"
       elif (
-        (last_willr_14 > -6.0)
+        (last_willr_14_gt_neg_6)
         and (last_rsi_14_lt_50)
-        and (last_roc_9_1h < -10.0)
-        and (last_roc_9_4h < -10.0)
+        and (last_roc_9_1h_lt_neg_10)
+        and (last_roc_9_4h_lt_neg_10)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 10.0))
       ):
         return True, f"exit_{mode_name}_d_9_10"
@@ -36509,7 +36556,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3_gt_92)
         and (last_rsi_14 < 45.0)
         and (last_roc_9_15m < -10.0)
-        and (last_roc_9_1h < -10.0)
+        and (last_roc_9_1h_lt_neg_10)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -20.0))
       ):
         return True, f"exit_{mode_name}_d_9_11"
@@ -36518,26 +36565,26 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14_lt_50)
         and (last_rsi_3_4h_lt_10)
         and (last_roc_9_1h < -20.0)
-        and (last_roc_9_4h < -20.0)
+        and (last_roc_9_4h_lt_neg_20)
       ):
         return True, f"exit_{mode_name}_d_9_12"
-      elif (last_rsi_3_gt_96) and (last_rsi_3_4h < 5.0) and (last_roc_9_4h < -25.0):
+      elif (last_rsi_3_gt_96) and (last_rsi_3_4h_lt_5) and (last_roc_9_4h_lt_neg_25):
         return True, f"exit_{mode_name}_d_9_13"
-      elif (last_rsi_3_gt_90) and (last_willr_14 > -4.0) and (last_rsi_3_4h < 5.0) and (last_aroonu_14_4h_gt_25):
+      elif (last_rsi_3_gt_90) and (last_willr_14_gt_neg_4) and (last_rsi_3_4h_lt_5) and (last_aroonu_14_4h_gt_25):
         return True, f"exit_{mode_name}_d_9_14"
       elif (last_rsi_3_gt_94) and (last_rsi_14 > 66.0) and (last_roc_9_4h < -30.0):
         return True, f"exit_{mode_name}_d_9_15"
       elif (
         (last_rsi_3_gt_90)
         and (last_aroonu_14_4h_gt_25)
-        and (last_roc_9_4h < -25.0)
+        and (last_roc_9_4h_lt_neg_25)
         and (last_aroonu_14_1d > 50.0)
         and (last_change_pct_1d < -15.0)
       ):
         return True, f"exit_{mode_name}_d_9_16"
       elif (
         (last_rsi_3_gt_96)
-        and (last_willr_14 > -15.0)
+        and (last_willr_14_gt_neg_15)
         and (last_rsi_3_1h_lt_10)
         and (last_stochrsi_k_4h_gt_90)
         and (last_roc_9_4h > 30.0)
@@ -36558,31 +36605,31 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_9_21"
       elif (
         (last_rsi_3_gt_98)
-        and (last_willr_14 > -2.0)
-        and (last_change_pct_4h < -5.0)
+        and (last_willr_14_gt_neg_2)
+        and (last_change_pct_4h_lt_neg_5)
         and (last_stochrsi_k_4h_gt_50)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
       ):
         return True, f"exit_{mode_name}_d_9_22"
-      elif (last_rsi_3_gt_92) and (last_willr_14 > -10.0) and (last_rsi_3_1h_lt_15) and (last_rsi_3_1d < 5.0):
+      elif (last_rsi_3_gt_92) and (last_willr_14_gt_neg_10) and (last_rsi_3_1h_lt_15) and (last_rsi_3_1d < 5.0):
         return True, f"exit_{mode_name}_d_9_23"
       elif (
         (last_rsi_3_gt_92)
         and (last_rsi_14_gt_72)
-        and (last_willr_14 > -15.0)
+        and (last_willr_14_gt_neg_15)
         and (last_rsi_3_4h_lt_30)
         and (last_aroonu_14_4h_gt_75)
       ):
         return True, f"exit_{mode_name}_d_9_24"
       elif (
         (last_rsi_3_gt_90)
-        and (last_willr_14 > -4.0)
+        and (last_willr_14_gt_neg_4)
         and (last_rsi_3_4h_lt_10)
         and (last_roc_9_4h < -15.0)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d > 50.0))
       ):
         return True, f"exit_{mode_name}_d_9_25"
-      elif (last_rsi_3_gt_85) and (last_willr_14 > -4.0) and (last_rsi_3_4h_lt_15) and (last_roc_9_4h < -20.0):
+      elif (last_rsi_3_gt_85) and (last_willr_14_gt_neg_4) and (last_rsi_3_4h_lt_15) and (last_roc_9_4h_lt_neg_20):
         return True, f"exit_{mode_name}_d_9_26"
       elif (
         (last_rsi_3_gt_85)
@@ -36609,27 +36656,27 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14_lt_50)
         and (last_rsi_3_1h_lt_15)
         and (last_rsi_3_4h_lt_15)
-        and (last_stochrsi_k_1h > 25.0)
+        and (last_stochrsi_k_1h_gt_25)
       ):
         return True, f"exit_{mode_name}_d_9_31"
-      elif (last_rsi_3_gt_90) and (last_rsi_3_1h_lt_15) and (last_roc_2_4h < -30.0) and (last_stochrsi_k_4h_gt_30):
+      elif (last_rsi_3_gt_90) and (last_rsi_3_1h_lt_15) and (last_roc_2_4h_lt_neg_30) and (last_stochrsi_k_4h_gt_30):
         return True, f"exit_{mode_name}_d_9_32"
       elif (
         (last_rsi_3_gt_90)
-        and (last_willr_14 > -2.0)
+        and (last_willr_14_gt_neg_2)
         and (last_roc_2_1h < -10.0)
         and (last_roc_9_1h > 30.0)
         and (last_stochrsi_k_1h_gt_50)
       ):
         return True, f"exit_{mode_name}_d_9_33"
-      elif (last_rsi_3 > 65.0) and (last_rsi_3_15m < 30.0) and (last_rsi_14_1h > 80.0) and (last_roc_9_1h > 40.0):
+      elif (last_rsi_3 > 65.0) and (last_rsi_3_15m_lt_30) and (last_rsi_14_1h > 80.0) and (last_roc_9_1h > 40.0):
         return True, f"exit_{mode_name}_d_9_34"
-      elif (last_rsi_3_gt_88) and (last_willr_14 > -6.0) and (last_rsi_3_1d_lt_25) and (last_stochrsi_k_1h > 75.0):
+      elif (last_rsi_3_gt_88) and (last_willr_14_gt_neg_6) and (last_rsi_3_1d_lt_25) and (last_stochrsi_k_1h_gt_75):
         return True, f"exit_{mode_name}_d_9_35"
       elif (
         (last_rsi_3_gt_85)
-        and (last_willr_14 > -15.0)
-        and (last_roc_9_4h < -25.0)
+        and (last_willr_14_gt_neg_15)
+        and (last_roc_9_4h_lt_neg_25)
         and (last_rsi_3_1d_lt_25)
         and (last_stochrsi_k_1h_gt_50)
       ):
@@ -36642,13 +36689,13 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_stochrsi_k_4h_gt_50)
       ):
         return True, f"exit_{mode_name}_d_9_37"
-      elif (last_rsi_3_gt_85) and (last_willr_14 > -15.0) and (last_rsi_3_4h_lt_10) and (last_stochrsi_k_4h_gt_20):
+      elif (last_rsi_3_gt_85) and (last_willr_14_gt_neg_15) and (last_rsi_3_4h_lt_10) and (last_stochrsi_k_4h_gt_20):
         return True, f"exit_{mode_name}_d_9_38"
-      elif (last_rsi_3_gt_95) and (last_willr_14 > -5.0) and (last_cmf_20_4h < -0.0) and (last_rsi_3_4h_lt_10):
+      elif (last_rsi_3_gt_95) and (last_willr_14_gt_neg_5) and (last_cmf_20_4h_lt_0) and (last_rsi_3_4h_lt_10):
         return True, f"exit_{mode_name}_d_9_39"
       elif (
         (last_rsi_3_gt_85)
-        and (last_willr_14 > -15.0)
+        and (last_willr_14_gt_neg_15)
         and (last_rsi_3_1h_lt_30)
         and (last_stochrsi_k_1h_gt_30)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d > 90.0))
@@ -36656,7 +36703,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_9_40"
       elif (
         (last_rsi_3_gt_95)
-        and (last_willr_14 > -10.0)
+        and (last_willr_14_gt_neg_10)
         and (last_rsi_3_1h_lt_30)
         and (last_stochrsi_k_4h_gt_25)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 50.0))
@@ -36664,7 +36711,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_9_41"
       elif (
         (last_rsi_3_gt_90)
-        and (last_willr_14 > -25.0)
+        and (last_willr_14_gt_neg_25)
         and (last_stochrsi_k_4h_gt_30)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 40.0))
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d > 70.0))
@@ -36680,13 +36727,13 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_9_43"
       elif (
         (last_rsi_3_gt_70)
-        and (last_willr_14 > -5.0)
+        and (last_willr_14_gt_neg_5)
         and (last_rsi_3_4h_lt_30)
         and (last_rsi_3_1d_lt_25)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
       ):
         return True, f"exit_{mode_name}_d_9_44"
-      elif (last_rsi_3_gt_94) and (last_willr_14 > -6.0) and (last_rsi_3_1h_lt_10):
+      elif (last_rsi_3_gt_94) and (last_willr_14_gt_neg_6) and (last_rsi_3_1h_lt_10):
         return True, f"exit_{mode_name}_d_9_45"
       elif (last_rsi_3_gt_90) and (last_rsi_3_1h_lt_15) and (last_rsi_3_4h_lt_10) and (last_roc_2_1d < -20.0):
         return True, f"exit_{mode_name}_d_9_46"
@@ -36694,7 +36741,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3_gt_86)
         and (last_stochrsi_k_1h_gt_80)
         and (last_stochrsi_k_4h_gt_40)
-        and (last_change_pct_1d < -5.0)
+        and (last_change_pct_1d_lt_neg_5)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -5.0))
       ):
         return True, f"exit_{mode_name}_d_9_47"
@@ -36708,20 +36755,20 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_9_48"
       elif (
         (last_rsi_3_gt_90)
-        and (last_willr_14 > -4.0)
+        and (last_willr_14_gt_neg_4)
         and (last_rsi_3_4h_lt_20)
-        and (last_change_pct_1d < -5.0)
+        and (last_change_pct_1d_lt_neg_5)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d > 50.0))
       ):
         return True, f"exit_{mode_name}_d_9_49"
-      elif (last_rsi_3_gt_80) and (last_willr_14 > -4.0) and (last_rsi_3_1d < 10.0) and (last_stochrsi_k_1h > 90.0):
+      elif (last_rsi_3_gt_80) and (last_willr_14_gt_neg_4) and (last_rsi_3_1d < 10.0) and (last_stochrsi_k_1h_gt_90):
         return True, f"exit_{mode_name}_d_9_50"
       elif (last_rsi_3_gt_66) and (last_rsi_14_lt_46) and (last_rsi_3_4h_lt_20) and (last_stochrsi_k_1h_gt_50):
         return True, f"exit_{mode_name}_d_9_51"
       elif (
         (last_rsi_3_gt_80)
         and (last_rsi_14 > 60.0)
-        and (last_willr_14 > -10.0)
+        and (last_willr_14_gt_neg_10)
         and (last_stochrsi_k_1h_gt_70)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -15.0))
       ):
@@ -36729,7 +36776,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3_gt_70)
         and (last_rsi_14_lt_50)
-        and (last_willr_14 > -25.0)
+        and (last_willr_14_gt_neg_25)
         and (last_rsi_3_1h_lt_20)
         and (last_stochrsi_k_4h_gt_50)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d > 50.0))
@@ -36739,14 +36786,14 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3_gt_78)
         and (last_rsi_14_lt_46)
         and (last_stochrsi_k_1h_gt_50)
-        and (last_roc_9_4h < -10.0)
+        and (last_roc_9_4h_lt_neg_10)
         and (last_change_pct_1d < -10.0)
       ):
         return True, f"exit_{mode_name}_d_9_54"
       elif (
         (last_rsi_3_gt_94)
-        and (last_willr_14 > -14.0)
-        and (last_roc_9_4h < -5.0)
+        and (last_willr_14_gt_neg_14)
+        and (last_roc_9_4h_lt_neg_5)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 10.0))
         and (last_stochrsi_k_1h_gt_50)
       ):
@@ -36757,14 +36804,14 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_3_1h_lt_30)
         and (last_rsi_3_4h_lt_25)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
-        and (last_stochrsi_k_4h > 10.0)
+        and (last_stochrsi_k_4h_gt_10)
       ):
         return True, f"exit_{mode_name}_d_9_56"
       elif (
         (last_rsi_3_gt_50)
         and (last_rsi_14 < 36.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
-        and (last_stochrsi_k_4h > 70.0)
+        and (last_stochrsi_k_4h_gt_70)
       ):
         return True, f"exit_{mode_name}_d_9_57"
       elif (
@@ -36777,7 +36824,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_9_58"
       elif (
         (last_rsi_3_gt_85)
-        and (last_willr_14 > -12.0)
+        and (last_willr_14_gt_neg_12)
         and (last_rsi_3_4h_lt_25)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -15.0))
         and (last_stochrsi_k_4h_gt_40)
@@ -36788,18 +36835,18 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14_lt_40)
         and (last_rsi_14_4h > 65.0)
         and (last_stochrsi_k_4h_gt_50)
-        and (last_stochrsi_k_1d > 50.0)
+        and (last_stochrsi_k_1d_gt_50)
       ):
         return True, f"exit_{mode_name}_d_9_60"
-      elif (last_rsi_3_gt_92) and (last_willr_14 > -20.0) and (last_rsi_3_4h_lt_10) and (last_stochrsi_k_1h_gt_30):
+      elif (last_rsi_3_gt_92) and (last_willr_14_gt_neg_20) and (last_rsi_3_4h_lt_10) and (last_stochrsi_k_1h_gt_30):
         return True, f"exit_{mode_name}_d_9_61"
       elif (
         (last_rsi_3_gt_86)
-        and (last_willr_14 > -2.0)
+        and (last_willr_14_gt_neg_2)
         and (last_rsi_3_1h_lt_30)
         and (last_rsi_3_4h_lt_20)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 20.0))
-        and (last_change_pct_1d < -5.0)
+        and (last_change_pct_1d_lt_neg_5)
       ):
         return True, f"exit_{mode_name}_d_9_62"
       elif (last_rsi_3_gt_68) and (last_rsi_3_1d_lt_25) and (last_stochrsi_k_1h_gt_80) and (last_stochrsi_k_4h_gt_30):
@@ -36818,7 +36865,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3_gt_50)
         and (last_rsi_14_lt_42)
-        and (last_stochrsi_k_4h > 80.0)
+        and (last_stochrsi_k_4h_gt_80)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -25.0))
       ):
         return True, f"exit_{mode_name}_d_9_67"
@@ -36826,17 +36873,17 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3_gt_84)
         and (last_rsi_14_lt_48)
         and (last_rsi_3_1h_lt_25)
-        and (last_roc_2_4h < -30.0)
+        and (last_roc_2_4h_lt_neg_30)
         and (last_stochrsi_k_4h_gt_25)
       ):
         return True, f"exit_{mode_name}_d_9_68"
       elif (
-        (last_rsi_3_gt_96) and (last_roc_9_4h > 20.0) and (last_stochrsi_k_4h_gt_50) and (last_change_pct_4h < -5.0)
+        (last_rsi_3_gt_96) and (last_roc_9_4h > 20.0) and (last_stochrsi_k_4h_gt_50) and (last_change_pct_4h_lt_neg_5)
       ):
         return True, f"exit_{mode_name}_d_9_69"
       elif (last_rsi_3_gt_66) and (last_rsi_14_lt_40) and (last_rsi_3_1h_lt_25) and (last_stochrsi_k_4h_gt_20):
         return True, f"exit_{mode_name}_d_9_70"
-      elif (last_rsi_3 > 64.0) and (last_rsi_14_lt_44) and (last_rsi_3_4h_lt_25) and (last_stochrsi_k_1h > 20.0):
+      elif (last_rsi_3 > 64.0) and (last_rsi_14_lt_44) and (last_rsi_3_4h_lt_25) and (last_stochrsi_k_1h_gt_20):
         return True, f"exit_{mode_name}_d_9_71"
       elif (last_rsi_3_gt_78) and (last_rsi_14_lt_42) and (last_rsi_3_1h_lt_10) and (last_aroonu_14_4h_gt_25):
         return True, f"exit_{mode_name}_d_9_72"
@@ -36844,13 +36891,13 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3_gt_78)
         and (last_rsi_3_1h_lt_25)
         and (last_rsi_3_4h_lt_15)
-        and (last_roc_9_4h < -20.0)
+        and (last_roc_9_4h_lt_neg_20)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -25.0))
       ):
         return True, f"exit_{mode_name}_d_9_73"
       elif (
         (last_rsi_3_gt_98)
-        and (last_willr_14 > -10.0)
+        and (last_willr_14_gt_neg_10)
         and (last_rsi_3_4h_lt_25)
         and (last_rsi_3_1d_lt_25)
         and (last_stochrsi_k_1h_gt_50)
@@ -36863,7 +36910,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d > 50.0))
       ):
         return True, f"exit_{mode_name}_d_9_75"
-      elif (last_rsi_3_gt_68) and (last_rsi_14_lt_50) and (last_roc_9_1h > 80.0) and (last_stochrsi_k_4h > 80.0):
+      elif (last_rsi_3_gt_68) and (last_rsi_14_lt_50) and (last_roc_9_1h > 80.0) and (last_stochrsi_k_4h_gt_80):
         return True, f"exit_{mode_name}_d_9_76"
       elif (
         (last_rsi_3_gt_76)
@@ -36874,13 +36921,13 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_9_77"
       elif (
         (last_rsi_3_gt_86)
-        and (last_willr_14 > -16.0)
+        and (last_willr_14_gt_neg_16)
         and (last_rsi_3_1h_lt_30)
         and (last_rsi_3_4h_lt_20)
         and (last_rsi_3_1d < 20.0)
       ):
         return True, f"exit_{mode_name}_d_9_78"
-      elif (last_rsi_3_gt_92) and (last_willr_14 > -2.0) and (last_rsi_3_1h_lt_30) and (last_rsi_3_4h_lt_10):
+      elif (last_rsi_3_gt_92) and (last_willr_14_gt_neg_2) and (last_rsi_3_1h_lt_30) and (last_rsi_3_4h_lt_10):
         return True, f"exit_{mode_name}_d_9_79"
       elif (
         (last_rsi_3_gt_72)
@@ -36892,7 +36939,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_9_80"
       elif (
         (last_rsi_3_gt_84)
-        and (last_willr_14 > -10.0)
+        and (last_willr_14_gt_neg_10)
         and (last_rsi_3_1h_lt_25)
         and (last_rsi_3_4h_lt_25)
         and (isinstance(last_rsi_14_1d, np.float64) and (last_rsi_14_1d > 50.0))
@@ -36900,7 +36947,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_9_81"
       elif (
         (last_rsi_3_gt_82)
-        and (last_willr_14 > -10.0)
+        and (last_willr_14_gt_neg_10)
         and (last_rsi_3_4h_lt_30)
         and (last_rsi_3_1d < 15.0)
         and (last_stochrsi_k_4h_gt_40)
@@ -36914,11 +36961,11 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_stochrsi_k_4h_gt_40)
       ):
         return True, f"exit_{mode_name}_d_9_83"
-      elif (last_rsi_3_gt_90) and (last_willr_14 > -2.0) and (last_rsi_3_4h_lt_30) and (last_stochrsi_k_1h > 20.0):
+      elif (last_rsi_3_gt_90) and (last_willr_14_gt_neg_2) and (last_rsi_3_4h_lt_30) and (last_stochrsi_k_1h_gt_20):
         return True, f"exit_{mode_name}_d_9_84"
       elif (
         (last_rsi_3_gt_88)
-        and (last_willr_14 > -8.0)
+        and (last_willr_14_gt_neg_8)
         and (last_rsi_3_1h_lt_30)
         and (last_rsi_3_4h_lt_40)
         and (last_stochrsi_k_4h_gt_50)
@@ -36942,7 +36989,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_9_87"
       elif (
         (last_rsi_3_gt_88)
-        and (last_willr_14 > -20.0)
+        and (last_willr_14_gt_neg_20)
         and (last_stochrsi_k_1h_gt_40)
         and (last_stochrsi_k_4h_gt_50)
         and (last_change_pct_1h < -2.0)
@@ -36951,13 +36998,13 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3_gt_78)
         and (last_rsi_14_lt_40)
-        and (last_roc_9_1h < -5.0)
+        and (last_roc_9_1h_lt_neg_5)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 25.0))
       ):
         return True, f"exit_{mode_name}_d_9_89"
       elif (
         (last_rsi_3_gt_92)
-        and (last_willr_14 > -25.0)
+        and (last_willr_14_gt_neg_25)
         and (last_rsi_3_1h_lt_50)
         and (last_rsi_3_4h_lt_30)
         and (last_aroonu_14_4h_gt_50)
@@ -36977,7 +37024,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3_gt_80)
         and (last_rsi_14_lt_48)
         and (last_rsi_3_1h_lt_40)
-        and (last_stochrsi_k_1h > 25.0)
+        and (last_stochrsi_k_1h_gt_25)
         and (last_stochrsi_k_4h_gt_50)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -25.0))
       ):
@@ -37004,10 +37051,10 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_9_94"
       elif (
         (last_rsi_3_gt_84)
-        and (last_willr_14 > -12.0)
+        and (last_willr_14_gt_neg_12)
         and (last_rsi_3_1h_lt_45)
         and (last_rsi_3_4h_lt_40)
-        and (last_stochrsi_k_4h > 10.0)
+        and (last_stochrsi_k_4h_gt_10)
         and (isinstance(last_aroonu_14_1d, np.float64) and (last_aroonu_14_1d > 75.0))
       ):
         return True, f"exit_{mode_name}_d_9_95"
@@ -37042,15 +37089,15 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_3_1h < 65.0)
         and (last_rsi_3_4h_lt_60)
         and (last_aroonu_14_4h_gt_50)
-        and (last_stoch_k_4h > 40.0)
+        and (last_stoch_k_4h_gt_40)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 80.0))
       ):
         return True, f"exit_{mode_name}_d_9_99"
-      elif (last_rsi_3_gt_98) and (last_rsi_14 > 76.0) and (last_rsi_3_15m > 70.0) and (last_rsi_3_4h < 80.0):
+      elif (last_rsi_3_gt_98) and (last_rsi_14 > 76.0) and (last_rsi_3_15m_gt_70) and (last_rsi_3_4h < 80.0):
         return True, f"exit_{mode_name}_d_9_100"
       elif (
         (last_rsi_3_gt_84)
-        and (last_willr_14 > -16.0)
+        and (last_willr_14_gt_neg_16)
         and (last_rsi_3_1h_lt_50)
         and (last_stochrsi_k_4h_gt_40)
         and (isinstance(last_roc_9_4h, np.float64) and (last_roc_9_4h > 40.0))
@@ -37079,7 +37126,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_3_1h_lt_60)
         and (last_stochrsi_k_1h_gt_40)
         and (last_stochrsi_k_4h_gt_90)
-        and (last_roc_9_4h > 40.0)
+        and (last_roc_9_4h_gt_40)
       ):
         return True, f"exit_{mode_name}_d_9_104"
       elif (
@@ -37087,7 +37134,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14_lt_48)
         and (last_rsi_3_15m < 55.0)
         and (last_stochrsi_k_4h_gt_90)
-        and (last_roc_9_4h > 25.0)
+        and (last_roc_9_4h_gt_25)
       ):
         return True, f"exit_{mode_name}_d_9_105"
       elif (
@@ -37096,7 +37143,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_3_1h_lt_50)
         and (last_stochrsi_k_1h_gt_50)
         and (last_rsi_14_4h_gt_70)
-        and (last_roc_9_4h > 40.0)
+        and (last_roc_9_4h_gt_40)
       ):
         return True, f"exit_{mode_name}_d_9_106"
       elif (
@@ -37107,17 +37154,17 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14_4h > 50.0)
       ):
         return True, f"exit_{mode_name}_d_9_107"
-      elif (last_rsi_3 > 56.0) and (last_rsi_14_lt_48) and (last_rsi_3_1h_lt_60) and (last_stochrsi_k_1h_gt_80):
+      elif (last_rsi_3_gt_56) and (last_rsi_14_lt_48) and (last_rsi_3_1h_lt_60) and (last_stochrsi_k_1h_gt_80):
         return True, f"exit_{mode_name}_d_9_108"
       elif (
         (last_rsi_3_gt_76)
-        and (last_willr_14 > -8.0)
+        and (last_willr_14_gt_neg_8)
         and (last_rsi_3_1h_lt_50)
         and (last_rsi_3_4h_lt_20)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 50.0))
       ):
         return True, f"exit_{mode_name}_d_9_109"
-      elif (last_rsi_3_gt_72) and (last_rsi_3_4h < 65.0) and (last_stochrsi_k_4h_gt_50) and (last_roc_9_4h > 25.0):
+      elif (last_rsi_3_gt_72) and (last_rsi_3_4h < 65.0) and (last_stochrsi_k_4h_gt_50) and (last_roc_9_4h_gt_25):
         return True, f"exit_{mode_name}_d_9_110"
       elif (
         (last_rsi_3_gt_50)
@@ -37131,17 +37178,17 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_9_111"
       elif (
         (last_rsi_3_gt_80)
-        and (last_willr_14 > -25.0)
+        and (last_willr_14_gt_neg_25)
         and (last_rsi_14 < 52.0)
         and (last_rsi_3_1h_lt_35)
-        and (last_rsi_3_4h < 35.0)
+        and (last_rsi_3_4h_lt_35)
         and (last_rsi_3_1d < 60.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
       ):
         return True, f"exit_{mode_name}_d_9_112"
       elif (
         (last_rsi_3_gt_84)
-        and (last_willr_14 > -1.0)
+        and (last_willr_14_gt_neg_1)
         and (last_rsi_3_1d_lt_30)
         and (last_stochrsi_k_4h_gt_50)
         and (isinstance(last_roc_9_4h, np.float64) and (last_roc_9_4h > 10.0))
@@ -37159,7 +37206,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3_gt_78)
         and (last_rsi_14_lt_48)
-        and (last_rsi_3_15m < 30.0)
+        and (last_rsi_3_15m_lt_30)
         and (last_stochrsi_k_1h_gt_50)
         and (last_stochrsi_k_4h_gt_50)
       ):
@@ -37172,7 +37219,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_9_118"
       elif (
         (last_rsi_3_gt_86)
-        and (last_willr_14 > -20.0)
+        and (last_willr_14_gt_neg_20)
         and (last_rsi_3_1h_lt_60)
         and (last_rsi_3_4h_lt_60)
         and (last_stochrsi_k_1h_gt_40)
@@ -37184,7 +37231,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_9_121"
       elif (last_rsi_3 > 58.0) and (last_rsi_14_lt_44) and (last_rsi_3_4h_lt_30) and (last_stochrsi_k_1h_gt_50):
         return True, f"exit_{mode_name}_d_9_122"
-      elif (last_rsi_3_gt_88) and (last_willr_14 > -4.0) and (last_rsi_3_1h_lt_10) and (last_rsi_3_1d_lt_30):
+      elif (last_rsi_3_gt_88) and (last_willr_14_gt_neg_4) and (last_rsi_3_1h_lt_10) and (last_rsi_3_1d_lt_30):
         return True, f"exit_{mode_name}_d_9_123"
       elif (
         (last_rsi_3_gt_88)
@@ -37194,16 +37241,16 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_9_124"
       elif (
         (last_rsi_3_gt_76)
-        and (last_willr_14 > -4.0)
+        and (last_willr_14_gt_neg_4)
         and (last_rsi_3_1h_lt_10)
         and (last_rsi_3_4h_lt_40)
-        and (last_rsi_3_1d < 40.0)
+        and (last_rsi_3_1d_lt_40)
         and (last_close < (last_high_max_30_1d * 0.50))
       ):
         return True, f"exit_{mode_name}_d_9_125"
       elif (last_rsi_3_gt_90) and (last_rsi_3_1h_lt_15) and (last_rsi_3_4h_lt_40) and (last_stochrsi_k_4h_gt_50):
         return True, f"exit_{mode_name}_d_9_126"
-      elif (last_rsi_3_gt_90) and (last_rsi_3_1h_lt_10) and (last_rsi_3_4h_lt_30) and (last_rsi_3_1d < 40.0):
+      elif (last_rsi_3_gt_90) and (last_rsi_3_1h_lt_10) and (last_rsi_3_4h_lt_30) and (last_rsi_3_1d_lt_40):
         return True, f"exit_{mode_name}_d_9_127"
       elif (last_rsi_3_gt_94) and (last_rsi_3_4h_lt_30) and (last_aroonu_14_4h > 85.0):
         return True, f"exit_{mode_name}_d_9_128"
@@ -37225,7 +37272,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3_gt_80)
         and (last_rsi_3_1h_lt_35)
-        and (last_rsi_3_4h < 35.0)
+        and (last_rsi_3_4h_lt_35)
         and (last_aroonu_14_1h > 50.0)
         and (last_stochrsi_k_1h_gt_40)
       ):
@@ -37294,7 +37341,7 @@ class NostalgiaForInfinityX7(IStrategy):
       last_rsi_14_4h_gt_70 = last_rsi_14_4h > 70.0
       last_rsi_3_1d_lt_30 = last_rsi_3_1d < 30.0
       if (
-        (last_willr_14 > -1.0)
+        (last_willr_14_gt_neg_1)
         and (last_rsi_14 > 78.0)
         and (isinstance(last_ema_200_1h, np.float64) and (last_ema_12_1h < last_ema_200_1h))
         and (isinstance(last_ema_200_4h, np.float64) and (last_ema_12_4h < last_ema_200_4h))
@@ -37303,68 +37350,68 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_10_1"
       elif (
-        (last_willr_14 > -1.0)
+        (last_willr_14_gt_neg_1)
         and (last_rsi_14 > 70.0)
-        and (last_cmf_20_1h < -0.0)
+        and (last_cmf_20_1h_lt_0)
         and (isinstance(last_ema_200_1h, np.float64) and (last_ema_12_1h < last_ema_200_1h))
         and (isinstance(last_ema_200_4h, np.float64) and (last_ema_12_4h < last_ema_200_4h))
       ):
         return True, f"exit_{mode_name}_d_10_2"
       elif (
-        (last_willr_14 > -4.0)
+        (last_willr_14_gt_neg_4)
         and (last_stochrsi_k > 98.0)
-        and (last_cmf_20_1h < -0.0)
-        and (last_cmf_20_4h < -0.0)
-        and ((last_stochrsi_k_4h_gt_20) and (last_stochrsi_k_change_pct_4h < -10.0))
+        and (last_cmf_20_1h_lt_0)
+        and (last_cmf_20_4h_lt_0)
+        and ((last_stochrsi_k_4h_gt_20) and (last_stochrsi_k_change_pct_4h_lt_neg_10))
       ):
         return True, f"exit_{mode_name}_d_10_3"
       elif (
-        (last_willr_14 > -5.0)
+        (last_willr_14_gt_neg_5)
         and (last_rsi_14 > 76.0)
         and (last_stochrsi_k > 95.0)
-        and (last_stochrsi_k_4h > 70.0)
+        and (last_stochrsi_k_4h_gt_70)
         and (isinstance(last_ema_200_1h, np.float64) and (last_ema_12_1h < last_ema_200_1h))
         and (isinstance(last_ema_200_4h, np.float64) and (last_ema_12_4h < last_ema_200_4h))
       ):
         return True, f"exit_{mode_name}_d_10_4"
-      elif (last_willr_14 > -1.0) and (last_rsi_14_gt_74) and (last_roc_9_1h < -5.0) and (last_roc_9_4h < -5.0):
+      elif (last_willr_14_gt_neg_1) and (last_rsi_14_gt_74) and (last_roc_9_1h_lt_neg_5) and (last_roc_9_4h_lt_neg_5):
         return True, f"exit_{mode_name}_d_10_5"
       elif (
         (last_rsi_3_gt_70)
-        and (last_stochrsi_k > 70.0)
+        and (last_stochrsi_k_gt_70)
         and (last_rsi_14_lt_40)
-        and (last_roc_9_1h < -10.0)
+        and (last_roc_9_1h_lt_neg_10)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 50.0))
       ):
         return True, f"exit_{mode_name}_d_10_6"
       elif (
         (last_rsi_14_lt_50)
-        and (last_stochrsi_k > 70.0)
+        and (last_stochrsi_k_gt_70)
         and (last_stochrsi_k_4h_gt_50)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -40.0))
       ):
         return True, f"exit_{mode_name}_d_10_7"
       elif (
-        (last_willr_14 > -1.0)
+        (last_willr_14_gt_neg_1)
         and (last_stochrsi_k > 95.0)
         and (last_cmf_20_1h < -0.1)
         and (last_cmf_20_4h < -0.1)
-        and (last_change_pct_1d < -5.0)
+        and (last_change_pct_1d_lt_neg_5)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 15.0))
       ):
         return True, f"exit_{mode_name}_d_10_8"
       elif (
         (last_willr_14 > -3.0)
         and (last_rsi_3_gt_95)
-        and (last_change_pct_4h < -5.0)
+        and (last_change_pct_4h_lt_neg_5)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
       ):
         return True, f"exit_{mode_name}_d_10_9"
       elif (
-        (last_willr_14 > -4.0)
+        (last_willr_14_gt_neg_4)
         and (last_rsi_14_lt_50)
-        and (last_roc_9_1h < -10.0)
-        and (last_roc_9_4h < -10.0)
+        and (last_roc_9_1h_lt_neg_10)
+        and (last_roc_9_4h_lt_neg_10)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 10.0))
       ):
         return True, f"exit_{mode_name}_d_10_10"
@@ -37372,7 +37419,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3_gt_94)
         and (last_rsi_14 < 45.0)
         and (last_roc_9_15m < -10.0)
-        and (last_roc_9_1h < -10.0)
+        and (last_roc_9_1h_lt_neg_10)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -20.0))
       ):
         return True, f"exit_{mode_name}_d_10_11"
@@ -37381,26 +37428,26 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14_lt_50)
         and (last_rsi_3_4h_lt_10)
         and (last_roc_9_1h < -20.0)
-        and (last_roc_9_4h < -20.0)
+        and (last_roc_9_4h_lt_neg_20)
       ):
         return True, f"exit_{mode_name}_d_10_12"
-      elif (last_rsi_3_gt_96) and (last_rsi_3_4h < 5.0) and (last_roc_9_4h < -25.0):
+      elif (last_rsi_3_gt_96) and (last_rsi_3_4h_lt_5) and (last_roc_9_4h_lt_neg_25):
         return True, f"exit_{mode_name}_d_10_13"
-      elif (last_rsi_3_gt_90) and (last_willr_14 > -2.0) and (last_rsi_3_4h < 5.0) and (last_aroonu_14_4h_gt_25):
+      elif (last_rsi_3_gt_90) and (last_willr_14_gt_neg_2) and (last_rsi_3_4h_lt_5) and (last_aroonu_14_4h_gt_25):
         return True, f"exit_{mode_name}_d_10_14"
       elif (last_rsi_3_gt_96) and (last_rsi_14 > 68.0) and (last_roc_9_4h < -30.0):
         return True, f"exit_{mode_name}_d_10_15"
       elif (
         (last_rsi_3_gt_95)
         and (last_aroonu_14_4h_gt_25)
-        and (last_roc_9_4h < -25.0)
+        and (last_roc_9_4h_lt_neg_25)
         and (last_aroonu_14_1d > 50.0)
         and (last_change_pct_1d < -15.0)
       ):
         return True, f"exit_{mode_name}_d_10_16"
       elif (
         (last_rsi_3 > 97.0)
-        and (last_willr_14 > -10.0)
+        and (last_willr_14_gt_neg_10)
         and (last_rsi_3_1h_lt_10)
         and (last_stochrsi_k_4h_gt_90)
         and (last_roc_9_4h > 30.0)
@@ -37421,31 +37468,31 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_10_21"
       elif (
         (last_rsi_3_gt_99)
-        and (last_willr_14 > -1.0)
-        and (last_change_pct_4h < -5.0)
+        and (last_willr_14_gt_neg_1)
+        and (last_change_pct_4h_lt_neg_5)
         and (last_stochrsi_k_4h_gt_50)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
       ):
         return True, f"exit_{mode_name}_d_10_22"
-      elif (last_rsi_3_gt_95) and (last_willr_14 > -5.0) and (last_rsi_3_1h_lt_15) and (last_rsi_3_1d < 5.0):
+      elif (last_rsi_3_gt_95) and (last_willr_14_gt_neg_5) and (last_rsi_3_1h_lt_15) and (last_rsi_3_1d < 5.0):
         return True, f"exit_{mode_name}_d_10_23"
       elif (
         (last_rsi_3_gt_94)
         and (last_rsi_14_gt_74)
-        and (last_willr_14 > -10.0)
+        and (last_willr_14_gt_neg_10)
         and (last_rsi_3_4h_lt_30)
         and (last_aroonu_14_4h_gt_75)
       ):
         return True, f"exit_{mode_name}_d_10_24"
       elif (
         (last_rsi_3_gt_95)
-        and (last_willr_14 > -2.0)
+        and (last_willr_14_gt_neg_2)
         and (last_rsi_3_4h_lt_10)
         and (last_roc_9_4h < -15.0)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d > 50.0))
       ):
         return True, f"exit_{mode_name}_d_10_25"
-      elif (last_rsi_3_gt_90) and (last_willr_14 > -2.0) and (last_rsi_3_4h_lt_15) and (last_roc_9_4h < -20.0):
+      elif (last_rsi_3_gt_90) and (last_willr_14_gt_neg_2) and (last_rsi_3_4h_lt_15) and (last_roc_9_4h_lt_neg_20):
         return True, f"exit_{mode_name}_d_10_26"
       elif (
         (last_rsi_3_gt_90)
@@ -37472,27 +37519,27 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14_lt_50)
         and (last_rsi_3_1h_lt_15)
         and (last_rsi_3_4h_lt_15)
-        and (last_stochrsi_k_1h > 25.0)
+        and (last_stochrsi_k_1h_gt_25)
       ):
         return True, f"exit_{mode_name}_d_10_31"
-      elif (last_rsi_3_gt_95) and (last_rsi_3_1h_lt_15) and (last_roc_2_4h < -30.0) and (last_stochrsi_k_4h_gt_30):
+      elif (last_rsi_3_gt_95) and (last_rsi_3_1h_lt_15) and (last_roc_2_4h_lt_neg_30) and (last_stochrsi_k_4h_gt_30):
         return True, f"exit_{mode_name}_d_10_32"
       elif (
         (last_rsi_3_gt_95)
-        and (last_willr_14 > -1.0)
+        and (last_willr_14_gt_neg_1)
         and (last_roc_2_1h < -10.0)
         and (last_roc_9_1h > 30.0)
         and (last_stochrsi_k_1h_gt_50)
       ):
         return True, f"exit_{mode_name}_d_10_33"
-      elif (last_rsi_3 > 65.0) and (last_rsi_3_15m < 30.0) and (last_rsi_14_1h > 80.0) and (last_roc_9_1h > 40.0):
+      elif (last_rsi_3 > 65.0) and (last_rsi_3_15m_lt_30) and (last_rsi_14_1h > 80.0) and (last_roc_9_1h > 40.0):
         return True, f"exit_{mode_name}_d_10_34"
-      elif (last_rsi_3_gt_90) and (last_willr_14 > -5.0) and (last_rsi_3_1d_lt_25) and (last_stochrsi_k_1h > 75.0):
+      elif (last_rsi_3_gt_90) and (last_willr_14_gt_neg_5) and (last_rsi_3_1d_lt_25) and (last_stochrsi_k_1h_gt_75):
         return True, f"exit_{mode_name}_d_10_35"
       elif (
         (last_rsi_3_gt_90)
-        and (last_willr_14 > -10.0)
-        and (last_roc_9_4h < -25.0)
+        and (last_willr_14_gt_neg_10)
+        and (last_roc_9_4h_lt_neg_25)
         and (last_rsi_3_1d_lt_25)
         and (last_stochrsi_k_1h_gt_50)
       ):
@@ -37505,13 +37552,13 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_stochrsi_k_4h_gt_50)
       ):
         return True, f"exit_{mode_name}_d_10_37"
-      elif (last_rsi_3_gt_90) and (last_willr_14 > -10.0) and (last_rsi_3_4h_lt_10) and (last_stochrsi_k_4h_gt_20):
+      elif (last_rsi_3_gt_90) and (last_willr_14_gt_neg_10) and (last_rsi_3_4h_lt_10) and (last_stochrsi_k_4h_gt_20):
         return True, f"exit_{mode_name}_d_10_38"
-      elif (last_rsi_3_gt_96) and (last_willr_14 > -4.0) and (last_cmf_20_4h < -0.0) and (last_rsi_3_4h_lt_10):
+      elif (last_rsi_3_gt_96) and (last_willr_14_gt_neg_4) and (last_cmf_20_4h_lt_0) and (last_rsi_3_4h_lt_10):
         return True, f"exit_{mode_name}_d_10_39"
       elif (
         (last_rsi_3_gt_90)
-        and (last_willr_14 > -10.0)
+        and (last_willr_14_gt_neg_10)
         and (last_rsi_3_1h_lt_30)
         and (last_stochrsi_k_1h_gt_30)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d > 90.0))
@@ -37519,7 +37566,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_10_40"
       elif (
         (last_rsi_3_gt_96)
-        and (last_willr_14 > -8.0)
+        and (last_willr_14_gt_neg_8)
         and (last_rsi_3_1h_lt_30)
         and (last_stochrsi_k_4h_gt_25)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 50.0))
@@ -37527,7 +37574,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_10_41"
       elif (
         (last_rsi_3_gt_95)
-        and (last_willr_14 > -20.0)
+        and (last_willr_14_gt_neg_20)
         and (last_stochrsi_k_4h_gt_30)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 40.0))
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d > 70.0))
@@ -37543,13 +37590,13 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_10_43"
       elif (
         (last_rsi_3 > 75.0)
-        and (last_willr_14 > -2.0)
+        and (last_willr_14_gt_neg_2)
         and (last_rsi_3_4h_lt_30)
         and (last_rsi_3_1d_lt_25)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
       ):
         return True, f"exit_{mode_name}_d_10_44"
-      elif (last_rsi_3_gt_96) and (last_willr_14 > -4.0) and (last_rsi_3_1h_lt_10):
+      elif (last_rsi_3_gt_96) and (last_willr_14_gt_neg_4) and (last_rsi_3_1h_lt_10):
         return True, f"exit_{mode_name}_d_10_45"
       elif (last_rsi_3_gt_92) and (last_rsi_3_1h_lt_15) and (last_rsi_3_4h_lt_10) and (last_roc_2_1d < -20.0):
         return True, f"exit_{mode_name}_d_10_46"
@@ -37557,7 +37604,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3_gt_88)
         and (last_stochrsi_k_1h_gt_80)
         and (last_stochrsi_k_4h_gt_40)
-        and (last_change_pct_1d < -5.0)
+        and (last_change_pct_1d_lt_neg_5)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -5.0))
       ):
         return True, f"exit_{mode_name}_d_10_47"
@@ -37571,20 +37618,20 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_10_48"
       elif (
         (last_rsi_3_gt_95)
-        and (last_willr_14 > -2.0)
+        and (last_willr_14_gt_neg_2)
         and (last_rsi_3_4h_lt_20)
-        and (last_change_pct_1d < -5.0)
+        and (last_change_pct_1d_lt_neg_5)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d > 50.0))
       ):
         return True, f"exit_{mode_name}_d_10_49"
-      elif (last_rsi_3_gt_80) and (last_willr_14 > -2.0) and (last_rsi_3_1d < 10.0) and (last_stochrsi_k_1h > 90.0):
+      elif (last_rsi_3_gt_80) and (last_willr_14_gt_neg_2) and (last_rsi_3_1d < 10.0) and (last_stochrsi_k_1h_gt_90):
         return True, f"exit_{mode_name}_d_10_50"
       elif (last_rsi_3_gt_68) and (last_rsi_14_lt_44) and (last_rsi_3_4h_lt_20) and (last_stochrsi_k_1h_gt_50):
         return True, f"exit_{mode_name}_d_10_51"
       elif (
         (last_rsi_3_gt_82)
         and (last_rsi_14 > 62.0)
-        and (last_willr_14 > -10.0)
+        and (last_willr_14_gt_neg_10)
         and (last_stochrsi_k_1h_gt_70)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -15.0))
       ):
@@ -37592,7 +37639,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3_gt_70)
         and (last_rsi_14_lt_50)
-        and (last_willr_14 > -25.0)
+        and (last_willr_14_gt_neg_25)
         and (last_rsi_3_1h_lt_20)
         and (last_stochrsi_k_4h_gt_50)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d > 50.0))
@@ -37602,14 +37649,14 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3_gt_80)
         and (last_rsi_14_lt_44)
         and (last_stochrsi_k_1h_gt_50)
-        and (last_roc_9_4h < -10.0)
+        and (last_roc_9_4h_lt_neg_10)
         and (last_change_pct_1d < -10.0)
       ):
         return True, f"exit_{mode_name}_d_10_54"
       elif (
         (last_rsi_3_gt_96)
-        and (last_willr_14 > -12.0)
-        and (last_roc_9_4h < -5.0)
+        and (last_willr_14_gt_neg_12)
+        and (last_roc_9_4h_lt_neg_5)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 10.0))
         and (last_stochrsi_k_1h_gt_50)
       ):
@@ -37620,14 +37667,14 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_3_1h_lt_30)
         and (last_rsi_3_4h_lt_25)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
-        and (last_stochrsi_k_4h > 10.0)
+        and (last_stochrsi_k_4h_gt_10)
       ):
         return True, f"exit_{mode_name}_d_10_56"
       elif (
         (last_rsi_3 > 50.0)
         and (last_rsi_14 < 34.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
-        and (last_stochrsi_k_4h > 70.0)
+        and (last_stochrsi_k_4h_gt_70)
       ):
         return True, f"exit_{mode_name}_d_10_57"
       elif (
@@ -37640,7 +37687,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_10_58"
       elif (
         (last_rsi_3_gt_85)
-        and (last_willr_14 > -10.0)
+        and (last_willr_14_gt_neg_10)
         and (last_rsi_3_4h_lt_25)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -15.0))
         and (last_stochrsi_k_4h_gt_40)
@@ -37651,18 +37698,18 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14_lt_38)
         and (last_rsi_14_4h > 65.0)
         and (last_stochrsi_k_4h_gt_50)
-        and (last_stochrsi_k_1d > 50.0)
+        and (last_stochrsi_k_1d_gt_50)
       ):
         return True, f"exit_{mode_name}_d_10_60"
-      elif (last_rsi_3_gt_94) and (last_willr_14 > -15.0) and (last_rsi_3_4h_lt_10) and (last_stochrsi_k_1h_gt_30):
+      elif (last_rsi_3_gt_94) and (last_willr_14_gt_neg_15) and (last_rsi_3_4h_lt_10) and (last_stochrsi_k_1h_gt_30):
         return True, f"exit_{mode_name}_d_10_61"
       elif (
         (last_rsi_3_gt_88)
-        and (last_willr_14 > -2.0)
+        and (last_willr_14_gt_neg_2)
         and (last_rsi_3_1h_lt_30)
         and (last_rsi_3_4h_lt_20)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 20.0))
-        and (last_change_pct_1d < -5.0)
+        and (last_change_pct_1d_lt_neg_5)
       ):
         return True, f"exit_{mode_name}_d_10_62"
       elif (last_rsi_3_gt_70) and (last_rsi_3_1d_lt_25) and (last_stochrsi_k_1h_gt_80) and (last_stochrsi_k_4h_gt_30):
@@ -37681,7 +37728,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 50.0)
         and (last_rsi_14_lt_40)
-        and (last_stochrsi_k_4h > 80.0)
+        and (last_stochrsi_k_4h_gt_80)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -25.0))
       ):
         return True, f"exit_{mode_name}_d_10_67"
@@ -37689,17 +37736,17 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3_gt_86)
         and (last_rsi_14_lt_46)
         and (last_rsi_3_1h_lt_25)
-        and (last_roc_2_4h < -30.0)
+        and (last_roc_2_4h_lt_neg_30)
         and (last_stochrsi_k_4h_gt_25)
       ):
         return True, f"exit_{mode_name}_d_10_68"
       elif (
-        (last_rsi_3 > 97.0) and (last_roc_9_4h > 20.0) and (last_stochrsi_k_4h_gt_50) and (last_change_pct_4h < -5.0)
+        (last_rsi_3 > 97.0) and (last_roc_9_4h > 20.0) and (last_stochrsi_k_4h_gt_50) and (last_change_pct_4h_lt_neg_5)
       ):
         return True, f"exit_{mode_name}_d_10_69"
       elif (last_rsi_3_gt_68) and (last_rsi_14_lt_38) and (last_rsi_3_1h_lt_25) and (last_stochrsi_k_4h_gt_20):
         return True, f"exit_{mode_name}_d_10_70"
-      elif (last_rsi_3 > 66.0) and (last_rsi_14_lt_42) and (last_rsi_3_4h_lt_25) and (last_stochrsi_k_1h > 20.0):
+      elif (last_rsi_3 > 66.0) and (last_rsi_14_lt_42) and (last_rsi_3_4h_lt_25) and (last_stochrsi_k_1h_gt_20):
         return True, f"exit_{mode_name}_d_10_71"
       elif (last_rsi_3_gt_80) and (last_rsi_14_lt_40) and (last_rsi_3_1h_lt_10) and (last_aroonu_14_4h_gt_25):
         return True, f"exit_{mode_name}_d_10_72"
@@ -37707,13 +37754,13 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3_gt_80)
         and (last_rsi_3_1h_lt_25)
         and (last_rsi_3_4h_lt_15)
-        and (last_roc_9_4h < -20.0)
+        and (last_roc_9_4h_lt_neg_20)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -25.0))
       ):
         return True, f"exit_{mode_name}_d_10_73"
       elif (
         (last_rsi_3_gt_99)
-        and (last_willr_14 > -10.0)
+        and (last_willr_14_gt_neg_10)
         and (last_rsi_3_4h_lt_25)
         and (last_rsi_3_1d_lt_25)
         and (last_stochrsi_k_1h_gt_50)
@@ -37726,7 +37773,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d > 50.0))
       ):
         return True, f"exit_{mode_name}_d_10_75"
-      elif (last_rsi_3_gt_70) and (last_rsi_14_lt_48) and (last_roc_9_1h > 80.0) and (last_stochrsi_k_4h > 80.0):
+      elif (last_rsi_3_gt_70) and (last_rsi_14_lt_48) and (last_roc_9_1h > 80.0) and (last_stochrsi_k_4h_gt_80):
         return True, f"exit_{mode_name}_d_10_76"
       elif (
         (last_rsi_3_gt_78)
@@ -37737,13 +37784,13 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_10_77"
       elif (
         (last_rsi_3_gt_88)
-        and (last_willr_14 > -14.0)
+        and (last_willr_14_gt_neg_14)
         and (last_rsi_3_1h_lt_30)
         and (last_rsi_3_4h_lt_20)
         and (last_rsi_3_1d < 20.0)
       ):
         return True, f"exit_{mode_name}_d_10_78"
-      elif (last_rsi_3_gt_94) and (last_willr_14 > -1.0) and (last_rsi_3_1h_lt_30) and (last_rsi_3_4h_lt_10):
+      elif (last_rsi_3_gt_94) and (last_willr_14_gt_neg_1) and (last_rsi_3_1h_lt_30) and (last_rsi_3_4h_lt_10):
         return True, f"exit_{mode_name}_d_10_79"
       elif (
         (last_rsi_3_gt_74)
@@ -37755,7 +37802,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_10_80"
       elif (
         (last_rsi_3_gt_86)
-        and (last_willr_14 > -8.0)
+        and (last_willr_14_gt_neg_8)
         and (last_rsi_3_1h_lt_25)
         and (last_rsi_3_4h_lt_25)
         and (isinstance(last_rsi_14_1d, np.float64) and (last_rsi_14_1d > 50.0))
@@ -37763,7 +37810,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_10_81"
       elif (
         (last_rsi_3_gt_84)
-        and (last_willr_14 > -8.0)
+        and (last_willr_14_gt_neg_8)
         and (last_rsi_3_4h_lt_30)
         and (last_rsi_3_1d < 15.0)
         and (last_stochrsi_k_4h_gt_40)
@@ -37777,11 +37824,11 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_stochrsi_k_4h_gt_40)
       ):
         return True, f"exit_{mode_name}_d_10_83"
-      elif (last_rsi_3_gt_92) and (last_willr_14 > -1.0) and (last_rsi_3_4h_lt_30) and (last_stochrsi_k_1h > 20.0):
+      elif (last_rsi_3_gt_92) and (last_willr_14_gt_neg_1) and (last_rsi_3_4h_lt_30) and (last_stochrsi_k_1h_gt_20):
         return True, f"exit_{mode_name}_d_10_84"
       elif (
         (last_rsi_3_gt_90)
-        and (last_willr_14 > -6.0)
+        and (last_willr_14_gt_neg_6)
         and (last_rsi_3_1h_lt_30)
         and (last_rsi_3_4h_lt_40)
         and (last_stochrsi_k_4h_gt_50)
@@ -37805,7 +37852,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_10_87"
       elif (
         (last_rsi_3_gt_90)
-        and (last_willr_14 > -18.0)
+        and (last_willr_14_gt_neg_18)
         and (last_stochrsi_k_1h_gt_40)
         and (last_stochrsi_k_4h_gt_50)
         and (last_change_pct_1h < -2.0)
@@ -37814,13 +37861,13 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3_gt_80)
         and (last_rsi_14_lt_38)
-        and (last_roc_9_1h < -5.0)
+        and (last_roc_9_1h_lt_neg_5)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 25.0))
       ):
         return True, f"exit_{mode_name}_d_10_89"
       elif (
         (last_rsi_3_gt_94)
-        and (last_willr_14 > -25.0)
+        and (last_willr_14_gt_neg_25)
         and (last_rsi_3_1h_lt_50)
         and (last_rsi_3_4h_lt_30)
         and (last_aroonu_14_4h_gt_50)
@@ -37840,7 +37887,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3_gt_82)
         and (last_rsi_14_lt_46)
         and (last_rsi_3_1h_lt_40)
-        and (last_stochrsi_k_1h > 25.0)
+        and (last_stochrsi_k_1h_gt_25)
         and (last_stochrsi_k_4h_gt_50)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -25.0))
       ):
@@ -37867,10 +37914,10 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_10_94"
       elif (
         (last_rsi_3_gt_86)
-        and (last_willr_14 > -10.0)
+        and (last_willr_14_gt_neg_10)
         and (last_rsi_3_1h_lt_45)
         and (last_rsi_3_4h_lt_40)
-        and (last_stochrsi_k_4h > 10.0)
+        and (last_stochrsi_k_4h_gt_10)
         and (isinstance(last_aroonu_14_1d, np.float64) and (last_aroonu_14_1d > 75.0))
       ):
         return True, f"exit_{mode_name}_d_10_95"
@@ -37905,15 +37952,15 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_3_1h < 65.0)
         and (last_rsi_3_4h_lt_60)
         and (last_aroonu_14_4h_gt_50)
-        and (last_stoch_k_4h > 40.0)
+        and (last_stoch_k_4h_gt_40)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 80.0))
       ):
         return True, f"exit_{mode_name}_d_10_99"
-      elif (last_rsi_3_gt_99) and (last_rsi_14 > 78.0) and (last_rsi_3_15m > 70.0) and (last_rsi_3_4h < 80.0):
+      elif (last_rsi_3_gt_99) and (last_rsi_14 > 78.0) and (last_rsi_3_15m_gt_70) and (last_rsi_3_4h < 80.0):
         return True, f"exit_{mode_name}_d_10_100"
       elif (
         (last_rsi_3_gt_86)
-        and (last_willr_14 > -14.0)
+        and (last_willr_14_gt_neg_14)
         and (last_rsi_3_1h_lt_50)
         and (last_stochrsi_k_4h_gt_40)
         and (isinstance(last_roc_9_4h, np.float64) and (last_roc_9_4h > 40.0))
@@ -37942,7 +37989,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_3_1h_lt_60)
         and (last_stochrsi_k_1h_gt_40)
         and (last_stochrsi_k_4h_gt_90)
-        and (last_roc_9_4h > 40.0)
+        and (last_roc_9_4h_gt_40)
       ):
         return True, f"exit_{mode_name}_d_10_104"
       elif (
@@ -37950,7 +37997,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14_lt_46)
         and (last_rsi_3_15m < 55.0)
         and (last_stochrsi_k_4h_gt_90)
-        and (last_roc_9_4h > 25.0)
+        and (last_roc_9_4h_gt_25)
       ):
         return True, f"exit_{mode_name}_d_10_105"
       elif (
@@ -37959,7 +38006,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_3_1h_lt_50)
         and (last_stochrsi_k_1h_gt_50)
         and (last_rsi_14_4h_gt_70)
-        and (last_roc_9_4h > 40.0)
+        and (last_roc_9_4h_gt_40)
       ):
         return True, f"exit_{mode_name}_d_10_106"
       elif (
@@ -37974,13 +38021,13 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_10_108"
       elif (
         (last_rsi_3_gt_78)
-        and (last_willr_14 > -6.0)
+        and (last_willr_14_gt_neg_6)
         and (last_rsi_3_1h_lt_50)
         and (last_rsi_3_4h_lt_20)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 50.0))
       ):
         return True, f"exit_{mode_name}_d_10_109"
-      elif (last_rsi_3_gt_74) and (last_rsi_3_4h < 65.0) and (last_stochrsi_k_4h_gt_50) and (last_roc_9_4h > 25.0):
+      elif (last_rsi_3_gt_74) and (last_rsi_3_4h < 65.0) and (last_stochrsi_k_4h_gt_50) and (last_roc_9_4h_gt_25):
         return True, f"exit_{mode_name}_d_10_110"
       elif (
         (last_rsi_3 > 52.0)
@@ -37994,17 +38041,17 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_10_111"
       elif (
         (last_rsi_3_gt_82)
-        and (last_willr_14 > -20.0)
+        and (last_willr_14_gt_neg_20)
         and (last_rsi_14_lt_50)
         and (last_rsi_3_1h_lt_35)
-        and (last_rsi_3_4h < 35.0)
+        and (last_rsi_3_4h_lt_35)
         and (last_rsi_3_1d < 60.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
       ):
         return True, f"exit_{mode_name}_d_10_112"
       elif (
         (last_rsi_3_gt_86)
-        and (last_willr_14 > -1.0)
+        and (last_willr_14_gt_neg_1)
         and (last_rsi_3_1d_lt_30)
         and (last_stochrsi_k_4h_gt_50)
         and (isinstance(last_roc_9_4h, np.float64) and (last_roc_9_4h > 10.0))
@@ -38022,7 +38069,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3_gt_80)
         and (last_rsi_14_lt_46)
-        and (last_rsi_3_15m < 30.0)
+        and (last_rsi_3_15m_lt_30)
         and (last_stochrsi_k_1h_gt_50)
         and (last_stochrsi_k_4h_gt_50)
       ):
@@ -38035,19 +38082,19 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_10_118"
       elif (
         (last_rsi_3_gt_88)
-        and (last_willr_14 > -20.0)
+        and (last_willr_14_gt_neg_20)
         and (last_rsi_3_1h_lt_60)
         and (last_rsi_3_4h_lt_60)
         and (last_stochrsi_k_1h_gt_40)
       ):
         return True, f"exit_{mode_name}_d_10_119"
-      elif (last_rsi_3 > 56.0) and (last_rsi_14_lt_46) and (last_rsi_3_1h_lt_40) and (last_aroonu_14_4h_gt_75):
+      elif (last_rsi_3_gt_56) and (last_rsi_14_lt_46) and (last_rsi_3_1h_lt_40) and (last_aroonu_14_4h_gt_75):
         return True, f"exit_{mode_name}_d_10_120"
       elif (last_rsi_3 > 62.0) and (last_rsi_14_lt_44) and (last_rsi_3_1h_lt_50) and (last_rsi_14_4h > 85.0):
         return True, f"exit_{mode_name}_d_10_121"
       elif (last_rsi_3 > 60.0) and (last_rsi_14_lt_42) and (last_rsi_3_4h_lt_30) and (last_stochrsi_k_1h_gt_50):
         return True, f"exit_{mode_name}_d_10_122"
-      elif (last_rsi_3_gt_90) and (last_willr_14 > -2.0) and (last_rsi_3_1h_lt_10) and (last_rsi_3_1d_lt_30):
+      elif (last_rsi_3_gt_90) and (last_willr_14_gt_neg_2) and (last_rsi_3_1h_lt_10) and (last_rsi_3_1d_lt_30):
         return True, f"exit_{mode_name}_d_10_123"
       elif (
         (last_rsi_3_gt_90)
@@ -38057,16 +38104,16 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_10_124"
       elif (
         (last_rsi_3_gt_78)
-        and (last_willr_14 > -2.0)
+        and (last_willr_14_gt_neg_2)
         and (last_rsi_3_1h_lt_10)
         and (last_rsi_3_4h_lt_40)
-        and (last_rsi_3_1d < 40.0)
+        and (last_rsi_3_1d_lt_40)
         and (last_close < (last_high_max_30_1d * 0.50))
       ):
         return True, f"exit_{mode_name}_d_10_125"
       elif (last_rsi_3_gt_92) and (last_rsi_3_1h_lt_15) and (last_rsi_3_4h_lt_40) and (last_stochrsi_k_4h_gt_50):
         return True, f"exit_{mode_name}_d_10_126"
-      elif (last_rsi_3_gt_92) and (last_rsi_3_1h_lt_10) and (last_rsi_3_4h_lt_30) and (last_rsi_3_1d < 40.0):
+      elif (last_rsi_3_gt_92) and (last_rsi_3_1h_lt_10) and (last_rsi_3_4h_lt_30) and (last_rsi_3_1d_lt_40):
         return True, f"exit_{mode_name}_d_10_127"
       elif (last_rsi_3_gt_96) and (last_rsi_3_4h_lt_30) and (last_aroonu_14_4h > 85.0):
         return True, f"exit_{mode_name}_d_10_128"
@@ -38088,7 +38135,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3_gt_82)
         and (last_rsi_3_1h_lt_35)
-        and (last_rsi_3_4h < 35.0)
+        and (last_rsi_3_4h_lt_35)
         and (last_aroonu_14_1h > 50.0)
         and (last_stochrsi_k_1h_gt_40)
       ):
@@ -38102,7 +38149,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_10_133"
     elif 0.2 > current_profit >= 0.12:
       if (
-        (last_willr_14 > -1.0)
+        (last_willr_14_gt_neg_1)
         and (last_rsi_14 > 78.0)
         and (isinstance(last_ema_200_1h, np.float64) and (last_ema_12_1h < last_ema_200_1h))
         and (isinstance(last_ema_200_4h, np.float64) and (last_ema_12_4h < last_ema_200_4h))
@@ -38111,68 +38158,68 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_11_1"
       elif (
-        (last_willr_14 > -1.0)
+        (last_willr_14_gt_neg_1)
         and (last_rsi_14 > 74.0)
-        and (last_cmf_20_1h < -0.0)
+        and (last_cmf_20_1h_lt_0)
         and (isinstance(last_ema_200_1h, np.float64) and (last_ema_12_1h < last_ema_200_1h))
         and (isinstance(last_ema_200_4h, np.float64) and (last_ema_12_4h < last_ema_200_4h))
       ):
         return True, f"exit_{mode_name}_d_11_2"
       elif (
-        (last_willr_14 > -2.0)
+        (last_willr_14_gt_neg_2)
         and (last_stochrsi_k > 99.0)
-        and (last_cmf_20_1h < -0.0)
-        and (last_cmf_20_4h < -0.0)
-        and ((last_stochrsi_k_4h > 20.0) and (last_stochrsi_k_change_pct_4h < -10.0))
+        and (last_cmf_20_1h_lt_0)
+        and (last_cmf_20_4h_lt_0)
+        and ((last_stochrsi_k_4h > 20.0) and (last_stochrsi_k_change_pct_4h_lt_neg_10))
       ):
         return True, f"exit_{mode_name}_d_11_3"
       elif (
-        (last_willr_14 > -2.0)
+        (last_willr_14_gt_neg_2)
         and (last_rsi_14 > 78.0)
         and (last_stochrsi_k > 95.0)
-        and (last_stochrsi_k_4h > 70.0)
+        and (last_stochrsi_k_4h_gt_70)
         and (isinstance(last_ema_200_1h, np.float64) and (last_ema_12_1h < last_ema_200_1h))
         and (isinstance(last_ema_200_4h, np.float64) and (last_ema_12_4h < last_ema_200_4h))
       ):
         return True, f"exit_{mode_name}_d_11_4"
-      elif (last_willr_14 > -1.0) and (last_rsi_14 > 76.0) and (last_roc_9_1h < -5.0) and (last_roc_9_4h < -5.0):
+      elif (last_willr_14_gt_neg_1) and (last_rsi_14 > 76.0) and (last_roc_9_1h_lt_neg_5) and (last_roc_9_4h_lt_neg_5):
         return True, f"exit_{mode_name}_d_11_5"
       elif (
         (last_rsi_3 > 70.0)
-        and (last_stochrsi_k > 70.0)
+        and (last_stochrsi_k_gt_70)
         and (last_rsi_14 < 40.0)
-        and (last_roc_9_1h < -10.0)
+        and (last_roc_9_1h_lt_neg_10)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 50.0))
       ):
         return True, f"exit_{mode_name}_d_11_6"
       elif (
         (last_rsi_14_lt_50)
-        and (last_stochrsi_k > 70.0)
+        and (last_stochrsi_k_gt_70)
         and (last_stochrsi_k_4h_gt_50)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -40.0))
       ):
         return True, f"exit_{mode_name}_d_11_7"
       elif (
-        (last_willr_14 > -1.0)
+        (last_willr_14_gt_neg_1)
         and (last_stochrsi_k > 98.0)
         and (last_cmf_20_1h < -0.1)
         and (last_cmf_20_4h < -0.1)
-        and (last_change_pct_1d < -5.0)
+        and (last_change_pct_1d_lt_neg_5)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 15.0))
       ):
         return True, f"exit_{mode_name}_d_11_8"
       elif (
-        (last_willr_14 > -2.0)
+        (last_willr_14_gt_neg_2)
         and (last_rsi_3 > 95.0)
-        and (last_change_pct_4h < -5.0)
+        and (last_change_pct_4h_lt_neg_5)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
       ):
         return True, f"exit_{mode_name}_d_11_9"
       elif (
-        (last_willr_14 > -2.0)
+        (last_willr_14_gt_neg_2)
         and (last_rsi_14_lt_50)
-        and (last_roc_9_1h < -10.0)
-        and (last_roc_9_4h < -10.0)
+        and (last_roc_9_1h_lt_neg_10)
+        and (last_roc_9_4h_lt_neg_10)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 10.0))
       ):
         return True, f"exit_{mode_name}_d_11_10"
@@ -38180,7 +38227,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 96.0)
         and (last_rsi_14 < 45.0)
         and (last_roc_9_15m < -10.0)
-        and (last_roc_9_1h < -10.0)
+        and (last_roc_9_1h_lt_neg_10)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -20.0))
       ):
         return True, f"exit_{mode_name}_d_11_11"
@@ -38189,26 +38236,26 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14_lt_50)
         and (last_rsi_3_4h < 10.0)
         and (last_roc_9_1h < -20.0)
-        and (last_roc_9_4h < -20.0)
+        and (last_roc_9_4h_lt_neg_20)
       ):
         return True, f"exit_{mode_name}_d_11_12"
-      elif (last_rsi_3 > 98.0) and (last_rsi_3_4h < 5.0) and (last_roc_9_4h < -25.0):
+      elif (last_rsi_3 > 98.0) and (last_rsi_3_4h_lt_5) and (last_roc_9_4h_lt_neg_25):
         return True, f"exit_{mode_name}_d_11_13"
-      elif (last_rsi_3 > 95.0) and (last_willr_14 > -1.0) and (last_rsi_3_4h < 5.0) and (last_aroonu_14_4h > 25.0):
+      elif (last_rsi_3 > 95.0) and (last_willr_14_gt_neg_1) and (last_rsi_3_4h_lt_5) and (last_aroonu_14_4h > 25.0):
         return True, f"exit_{mode_name}_d_11_14"
       elif (last_rsi_3 > 98.0) and (last_rsi_14 > 70.0) and (last_roc_9_4h < -30.0):
         return True, f"exit_{mode_name}_d_11_15"
       elif (
         (last_rsi_3 > 98.0)
         and (last_aroonu_14_4h > 25.0)
-        and (last_roc_9_4h < -25.0)
+        and (last_roc_9_4h_lt_neg_25)
         and (last_aroonu_14_1d > 50.0)
         and (last_change_pct_1d < -15.0)
       ):
         return True, f"exit_{mode_name}_d_11_16"
       elif (
         (last_rsi_3 > 98.0)
-        and (last_willr_14 > -5.0)
+        and (last_willr_14_gt_neg_5)
         and (last_rsi_3_1h < 10.0)
         and (last_stochrsi_k_4h > 90.0)
         and (last_roc_9_4h > 30.0)
@@ -38229,31 +38276,31 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_11_21"
       elif (
         (last_rsi_3 > 99.0)
-        and (last_willr_14 > -1.0)
-        and (last_change_pct_4h < -5.0)
+        and (last_willr_14_gt_neg_1)
+        and (last_change_pct_4h_lt_neg_5)
         and (last_stochrsi_k_4h_gt_50)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
       ):
         return True, f"exit_{mode_name}_d_11_22"
-      elif (last_rsi_3 > 98.0) and (last_willr_14 > -2.0) and (last_rsi_3_1h < 15.0) and (last_rsi_3_1d < 5.0):
+      elif (last_rsi_3 > 98.0) and (last_willr_14_gt_neg_2) and (last_rsi_3_1h < 15.0) and (last_rsi_3_1d < 5.0):
         return True, f"exit_{mode_name}_d_11_23"
       elif (
         (last_rsi_3 > 96.0)
         and (last_rsi_14 > 76.0)
-        and (last_willr_14 > -5.0)
+        and (last_willr_14_gt_neg_5)
         and (last_rsi_3_4h_lt_30)
         and (last_aroonu_14_4h > 75.0)
       ):
         return True, f"exit_{mode_name}_d_11_24"
       elif (
         (last_rsi_3 > 97.0)
-        and (last_willr_14 > -1.0)
+        and (last_willr_14_gt_neg_1)
         and (last_rsi_3_4h < 10.0)
         and (last_roc_9_4h < -15.0)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d > 50.0))
       ):
         return True, f"exit_{mode_name}_d_11_25"
-      elif (last_rsi_3 > 95.0) and (last_willr_14 > -1.0) and (last_rsi_3_4h < 15.0) and (last_roc_9_4h < -20.0):
+      elif (last_rsi_3 > 95.0) and (last_willr_14_gt_neg_1) and (last_rsi_3_4h < 15.0) and (last_roc_9_4h_lt_neg_20):
         return True, f"exit_{mode_name}_d_11_26"
       elif (
         (last_rsi_3 > 95.0)
@@ -38280,27 +38327,29 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14_lt_50)
         and (last_rsi_3_1h < 15.0)
         and (last_rsi_3_4h < 15.0)
-        and (last_stochrsi_k_1h > 25.0)
+        and (last_stochrsi_k_1h_gt_25)
       ):
         return True, f"exit_{mode_name}_d_11_31"
-      elif (last_rsi_3 > 98.0) and (last_rsi_3_1h < 15.0) and (last_roc_2_4h < -30.0) and (last_stochrsi_k_4h > 30.0):
+      elif (
+        (last_rsi_3 > 98.0) and (last_rsi_3_1h < 15.0) and (last_roc_2_4h_lt_neg_30) and (last_stochrsi_k_4h > 30.0)
+      ):
         return True, f"exit_{mode_name}_d_11_32"
       elif (
         (last_rsi_3 > 98.0)
-        and (last_willr_14 > -1.0)
+        and (last_willr_14_gt_neg_1)
         and (last_roc_2_1h < -10.0)
         and (last_roc_9_1h > 30.0)
         and (last_stochrsi_k_1h_gt_50)
       ):
         return True, f"exit_{mode_name}_d_11_33"
-      elif (last_rsi_3 > 65.0) and (last_rsi_3_15m < 30.0) and (last_rsi_14_1h > 80.0) and (last_roc_9_1h > 40.0):
+      elif (last_rsi_3 > 65.0) and (last_rsi_3_15m_lt_30) and (last_rsi_14_1h > 80.0) and (last_roc_9_1h > 40.0):
         return True, f"exit_{mode_name}_d_11_34"
-      elif (last_rsi_3 > 92.0) and (last_willr_14 > -4.0) and (last_rsi_3_1d < 25.0) and (last_stochrsi_k_1h > 75.0):
+      elif (last_rsi_3 > 92.0) and (last_willr_14_gt_neg_4) and (last_rsi_3_1d < 25.0) and (last_stochrsi_k_1h_gt_75):
         return True, f"exit_{mode_name}_d_11_35"
       elif (
         (last_rsi_3 > 95.0)
-        and (last_willr_14 > -5.0)
-        and (last_roc_9_4h < -25.0)
+        and (last_willr_14_gt_neg_5)
+        and (last_roc_9_4h_lt_neg_25)
         and (last_rsi_3_1d < 25.0)
         and (last_stochrsi_k_1h_gt_50)
       ):
@@ -38313,13 +38362,13 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_stochrsi_k_4h_gt_50)
       ):
         return True, f"exit_{mode_name}_d_11_37"
-      elif (last_rsi_3 > 95.0) and (last_willr_14 > -5.0) and (last_rsi_3_4h < 10.0) and (last_stochrsi_k_4h > 20.0):
+      elif (last_rsi_3 > 95.0) and (last_willr_14_gt_neg_5) and (last_rsi_3_4h < 10.0) and (last_stochrsi_k_4h > 20.0):
         return True, f"exit_{mode_name}_d_11_38"
-      elif (last_rsi_3 > 97.0) and (last_willr_14 > -3.0) and (last_cmf_20_4h < -0.0) and (last_rsi_3_4h < 10.0):
+      elif (last_rsi_3 > 97.0) and (last_willr_14 > -3.0) and (last_cmf_20_4h_lt_0) and (last_rsi_3_4h < 10.0):
         return True, f"exit_{mode_name}_d_11_39"
       elif (
         (last_rsi_3 > 95.0)
-        and (last_willr_14 > -5.0)
+        and (last_willr_14_gt_neg_5)
         and (last_rsi_3_1h_lt_30)
         and (last_stochrsi_k_1h > 30.0)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d > 90.0))
@@ -38327,7 +38376,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_11_40"
       elif (
         (last_rsi_3 > 97.0)
-        and (last_willr_14 > -4.0)
+        and (last_willr_14_gt_neg_4)
         and (last_rsi_3_1h_lt_30)
         and (last_stochrsi_k_4h > 25.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 50.0))
@@ -38335,7 +38384,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_11_41"
       elif (
         (last_rsi_3 > 96.0)
-        and (last_willr_14 > -15.0)
+        and (last_willr_14_gt_neg_15)
         and (last_stochrsi_k_4h > 30.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 40.0))
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d > 70.0))
@@ -38351,13 +38400,13 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_11_43"
       elif (
         (last_rsi_3 > 80.0)
-        and (last_willr_14 > -2.0)
+        and (last_willr_14_gt_neg_2)
         and (last_rsi_3_4h_lt_30)
         and (last_rsi_3_1d < 25.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
       ):
         return True, f"exit_{mode_name}_d_11_44"
-      elif (last_rsi_3 > 98.0) and (last_willr_14 > -2.0) and (last_rsi_3_1h < 10.0):
+      elif (last_rsi_3 > 98.0) and (last_willr_14_gt_neg_2) and (last_rsi_3_1h < 10.0):
         return True, f"exit_{mode_name}_d_11_45"
       elif (last_rsi_3 > 94.0) and (last_rsi_3_1h < 15.0) and (last_rsi_3_4h < 10.0) and (last_roc_2_1d < -20.0):
         return True, f"exit_{mode_name}_d_11_46"
@@ -38365,7 +38414,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 90.0)
         and (last_stochrsi_k_1h > 80.0)
         and (last_stochrsi_k_4h > 40.0)
-        and (last_change_pct_1d < -5.0)
+        and (last_change_pct_1d_lt_neg_5)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -5.0))
       ):
         return True, f"exit_{mode_name}_d_11_47"
@@ -38379,20 +38428,20 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_11_48"
       elif (
         (last_rsi_3 > 96.0)
-        and (last_willr_14 > -2.0)
+        and (last_willr_14_gt_neg_2)
         and (last_rsi_3_4h < 20.0)
-        and (last_change_pct_1d < -5.0)
+        and (last_change_pct_1d_lt_neg_5)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d > 50.0))
       ):
         return True, f"exit_{mode_name}_d_11_49"
-      elif (last_rsi_3 > 85.0) and (last_willr_14 > -2.0) and (last_rsi_3_1d < 10.0) and (last_stochrsi_k_1h > 90.0):
+      elif (last_rsi_3 > 85.0) and (last_willr_14_gt_neg_2) and (last_rsi_3_1d < 10.0) and (last_stochrsi_k_1h_gt_90):
         return True, f"exit_{mode_name}_d_11_50"
       elif (last_rsi_3 > 70.0) and (last_rsi_14 < 42.0) and (last_rsi_3_4h < 20.0) and (last_stochrsi_k_1h_gt_50):
         return True, f"exit_{mode_name}_d_11_51"
       elif (
         (last_rsi_3 > 84.0)
         and (last_rsi_14 > 64.0)
-        and (last_willr_14 > -10.0)
+        and (last_willr_14_gt_neg_10)
         and (last_stochrsi_k_1h > 70.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -15.0))
       ):
@@ -38400,7 +38449,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 70.0)
         and (last_rsi_14_lt_50)
-        and (last_willr_14 > -25.0)
+        and (last_willr_14_gt_neg_25)
         and (last_rsi_3_1h < 20.0)
         and (last_stochrsi_k_4h_gt_50)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d > 50.0))
@@ -38410,14 +38459,14 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 82.0)
         and (last_rsi_14 < 42.0)
         and (last_stochrsi_k_1h_gt_50)
-        and (last_roc_9_4h < -10.0)
+        and (last_roc_9_4h_lt_neg_10)
         and (last_change_pct_1d < -10.0)
       ):
         return True, f"exit_{mode_name}_d_11_54"
       elif (
         (last_rsi_3 > 98.0)
-        and (last_willr_14 > -10.0)
-        and (last_roc_9_4h < -5.0)
+        and (last_willr_14_gt_neg_10)
+        and (last_roc_9_4h_lt_neg_5)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 10.0))
         and (last_stochrsi_k_1h_gt_50)
       ):
@@ -38428,14 +38477,14 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_3_1h_lt_30)
         and (last_rsi_3_4h < 25.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
-        and (last_stochrsi_k_4h > 10.0)
+        and (last_stochrsi_k_4h_gt_10)
       ):
         return True, f"exit_{mode_name}_d_11_56"
       elif (
         (last_rsi_3 > 50.0)
         and (last_rsi_14 < 32.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
-        and (last_stochrsi_k_4h > 70.0)
+        and (last_stochrsi_k_4h_gt_70)
       ):
         return True, f"exit_{mode_name}_d_11_57"
       elif (
@@ -38448,7 +38497,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_11_58"
       elif (
         (last_rsi_3 > 90.0)
-        and (last_willr_14 > -8.0)
+        and (last_willr_14_gt_neg_8)
         and (last_rsi_3_4h < 25.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -15.0))
         and (last_stochrsi_k_4h > 40.0)
@@ -38459,18 +38508,20 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 < 36.0)
         and (last_rsi_14_4h > 65.0)
         and (last_stochrsi_k_4h_gt_50)
-        and (last_stochrsi_k_1d > 50.0)
+        and (last_stochrsi_k_1d_gt_50)
       ):
         return True, f"exit_{mode_name}_d_11_60"
-      elif (last_rsi_3 > 96.0) and (last_willr_14 > -10.0) and (last_rsi_3_4h < 10.0) and (last_stochrsi_k_1h > 30.0):
+      elif (
+        (last_rsi_3 > 96.0) and (last_willr_14_gt_neg_10) and (last_rsi_3_4h < 10.0) and (last_stochrsi_k_1h > 30.0)
+      ):
         return True, f"exit_{mode_name}_d_11_61"
       elif (
         (last_rsi_3 > 90.0)
-        and (last_willr_14 > -2.0)
+        and (last_willr_14_gt_neg_2)
         and (last_rsi_3_1h_lt_30)
         and (last_rsi_3_4h < 20.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 20.0))
-        and (last_change_pct_1d < -5.0)
+        and (last_change_pct_1d_lt_neg_5)
       ):
         return True, f"exit_{mode_name}_d_11_62"
       elif (
@@ -38491,7 +38542,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 50.0)
         and (last_rsi_14 < 38.0)
-        and (last_stochrsi_k_4h > 80.0)
+        and (last_stochrsi_k_4h_gt_80)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -25.0))
       ):
         return True, f"exit_{mode_name}_d_11_67"
@@ -38499,17 +38550,17 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 88.0)
         and (last_rsi_14 < 44.0)
         and (last_rsi_3_1h < 25.0)
-        and (last_roc_2_4h < -30.0)
+        and (last_roc_2_4h_lt_neg_30)
         and (last_stochrsi_k_4h > 25.0)
       ):
         return True, f"exit_{mode_name}_d_11_68"
       elif (
-        (last_rsi_3 > 98.0) and (last_roc_9_4h > 20.0) and (last_stochrsi_k_4h_gt_50) and (last_change_pct_4h < -5.0)
+        (last_rsi_3 > 98.0) and (last_roc_9_4h > 20.0) and (last_stochrsi_k_4h_gt_50) and (last_change_pct_4h_lt_neg_5)
       ):
         return True, f"exit_{mode_name}_d_11_69"
       elif (last_rsi_3 > 70.0) and (last_rsi_14 < 36.0) and (last_rsi_3_1h < 25.0) and (last_stochrsi_k_4h > 20.0):
         return True, f"exit_{mode_name}_d_11_70"
-      elif (last_rsi_3 > 68.0) and (last_rsi_14 < 40.0) and (last_rsi_3_4h < 25.0) and (last_stochrsi_k_1h > 20.0):
+      elif (last_rsi_3 > 68.0) and (last_rsi_14 < 40.0) and (last_rsi_3_4h < 25.0) and (last_stochrsi_k_1h_gt_20):
         return True, f"exit_{mode_name}_d_11_71"
       elif (last_rsi_3 > 82.0) and (last_rsi_14 < 38.0) and (last_rsi_3_1h < 10.0) and (last_aroonu_14_4h > 25.0):
         return True, f"exit_{mode_name}_d_11_72"
@@ -38517,13 +38568,13 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 82.0)
         and (last_rsi_3_1h < 25.0)
         and (last_rsi_3_4h < 15.0)
-        and (last_roc_9_4h < -20.0)
+        and (last_roc_9_4h_lt_neg_20)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -25.0))
       ):
         return True, f"exit_{mode_name}_d_11_73"
       elif (
         (last_rsi_3 > 99.0)
-        and (last_willr_14 > -10.0)
+        and (last_willr_14_gt_neg_10)
         and (last_rsi_3_4h < 25.0)
         and (last_rsi_3_1d < 25.0)
         and (last_stochrsi_k_1h_gt_50)
@@ -38536,7 +38587,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d > 50.0))
       ):
         return True, f"exit_{mode_name}_d_11_75"
-      elif (last_rsi_3 > 72.0) and (last_rsi_14 < 46.0) and (last_roc_9_1h > 80.0) and (last_stochrsi_k_4h > 80.0):
+      elif (last_rsi_3 > 72.0) and (last_rsi_14 < 46.0) and (last_roc_9_1h > 80.0) and (last_stochrsi_k_4h_gt_80):
         return True, f"exit_{mode_name}_d_11_76"
       elif (
         (last_rsi_3 > 80.0)
@@ -38547,13 +38598,13 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_11_77"
       elif (
         (last_rsi_3 > 90.0)
-        and (last_willr_14 > -12.0)
+        and (last_willr_14_gt_neg_12)
         and (last_rsi_3_1h_lt_30)
         and (last_rsi_3_4h < 20.0)
         and (last_rsi_3_1d < 20.0)
       ):
         return True, f"exit_{mode_name}_d_11_78"
-      elif (last_rsi_3 > 96.0) and (last_willr_14 > -1.0) and (last_rsi_3_1h_lt_30) and (last_rsi_3_4h < 10.0):
+      elif (last_rsi_3 > 96.0) and (last_willr_14_gt_neg_1) and (last_rsi_3_1h_lt_30) and (last_rsi_3_4h < 10.0):
         return True, f"exit_{mode_name}_d_11_79"
       elif (
         (last_rsi_3 > 76.0)
@@ -38565,7 +38616,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_11_80"
       elif (
         (last_rsi_3 > 88.0)
-        and (last_willr_14 > -6.0)
+        and (last_willr_14_gt_neg_6)
         and (last_rsi_3_1h < 25.0)
         and (last_rsi_3_4h < 25.0)
         and (isinstance(last_rsi_14_1d, np.float64) and (last_rsi_14_1d > 50.0))
@@ -38573,7 +38624,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_11_81"
       elif (
         (last_rsi_3 > 86.0)
-        and (last_willr_14 > -6.0)
+        and (last_willr_14_gt_neg_6)
         and (last_rsi_3_4h_lt_30)
         and (last_rsi_3_1d < 15.0)
         and (last_stochrsi_k_4h > 40.0)
@@ -38587,11 +38638,11 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_stochrsi_k_4h > 40.0)
       ):
         return True, f"exit_{mode_name}_d_11_83"
-      elif (last_rsi_3 > 94.0) and (last_willr_14 > -1.0) and (last_rsi_3_4h_lt_30) and (last_stochrsi_k_1h > 20.0):
+      elif (last_rsi_3 > 94.0) and (last_willr_14_gt_neg_1) and (last_rsi_3_4h_lt_30) and (last_stochrsi_k_1h_gt_20):
         return True, f"exit_{mode_name}_d_11_84"
       elif (
         (last_rsi_3 > 92.0)
-        and (last_willr_14 > -4.0)
+        and (last_willr_14_gt_neg_4)
         and (last_rsi_3_1h_lt_30)
         and (last_rsi_3_4h < 40.0)
         and (last_stochrsi_k_4h_gt_50)
@@ -38615,7 +38666,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_11_87"
       elif (
         (last_rsi_3 > 92.0)
-        and (last_willr_14 > -16.0)
+        and (last_willr_14_gt_neg_16)
         and (last_stochrsi_k_1h > 40.0)
         and (last_stochrsi_k_4h_gt_50)
         and (last_change_pct_1h < -2.0)
@@ -38624,13 +38675,13 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 82.0)
         and (last_rsi_14 < 36.0)
-        and (last_roc_9_1h < -5.0)
+        and (last_roc_9_1h_lt_neg_5)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 25.0))
       ):
         return True, f"exit_{mode_name}_d_11_89"
       elif (
         (last_rsi_3 > 96.0)
-        and (last_willr_14 > -25.0)
+        and (last_willr_14_gt_neg_25)
         and (last_rsi_3_1h < 50.0)
         and (last_rsi_3_4h_lt_30)
         and (last_aroonu_14_4h > 50.0)
@@ -38650,7 +38701,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 84.0)
         and (last_rsi_14 < 44.0)
         and (last_rsi_3_1h < 40.0)
-        and (last_stochrsi_k_1h > 25.0)
+        and (last_stochrsi_k_1h_gt_25)
         and (last_stochrsi_k_4h_gt_50)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -25.0))
       ):
@@ -38677,10 +38728,10 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_11_94"
       elif (
         (last_rsi_3 > 88.0)
-        and (last_willr_14 > -8.0)
+        and (last_willr_14_gt_neg_8)
         and (last_rsi_3_1h < 45.0)
         and (last_rsi_3_4h < 40.0)
-        and (last_stochrsi_k_4h > 10.0)
+        and (last_stochrsi_k_4h_gt_10)
         and (isinstance(last_aroonu_14_1d, np.float64) and (last_aroonu_14_1d > 75.0))
       ):
         return True, f"exit_{mode_name}_d_11_95"
@@ -38715,15 +38766,15 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_3_1h < 65.0)
         and (last_rsi_3_4h < 60.0)
         and (last_aroonu_14_4h > 50.0)
-        and (last_stoch_k_4h > 40.0)
+        and (last_stoch_k_4h_gt_40)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 80.0))
       ):
         return True, f"exit_{mode_name}_d_11_99"
-      elif (last_rsi_3 > 99.0) and (last_rsi_14 > 80.0) and (last_rsi_3_15m > 70.0) and (last_rsi_3_4h < 80.0):
+      elif (last_rsi_3 > 99.0) and (last_rsi_14 > 80.0) and (last_rsi_3_15m_gt_70) and (last_rsi_3_4h < 80.0):
         return True, f"exit_{mode_name}_d_11_100"
       elif (
         (last_rsi_3 > 88.0)
-        and (last_willr_14 > -12.0)
+        and (last_willr_14_gt_neg_12)
         and (last_rsi_3_1h < 50.0)
         and (last_stochrsi_k_4h > 40.0)
         and (isinstance(last_roc_9_4h, np.float64) and (last_roc_9_4h > 40.0))
@@ -38752,7 +38803,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_3_1h < 60.0)
         and (last_stochrsi_k_1h > 40.0)
         and (last_stochrsi_k_4h > 90.0)
-        and (last_roc_9_4h > 40.0)
+        and (last_roc_9_4h_gt_40)
       ):
         return True, f"exit_{mode_name}_d_11_104"
       elif (
@@ -38760,7 +38811,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 < 44.0)
         and (last_rsi_3_15m < 55.0)
         and (last_stochrsi_k_4h > 90.0)
-        and (last_roc_9_4h > 25.0)
+        and (last_roc_9_4h_gt_25)
       ):
         return True, f"exit_{mode_name}_d_11_105"
       elif (
@@ -38769,7 +38820,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_3_1h < 50.0)
         and (last_stochrsi_k_1h_gt_50)
         and (last_rsi_14_4h > 70.0)
-        and (last_roc_9_4h > 40.0)
+        and (last_roc_9_4h_gt_40)
       ):
         return True, f"exit_{mode_name}_d_11_106"
       elif (
@@ -38784,13 +38835,13 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_11_108"
       elif (
         (last_rsi_3 > 80.0)
-        and (last_willr_14 > -4.0)
+        and (last_willr_14_gt_neg_4)
         and (last_rsi_3_1h < 50.0)
         and (last_rsi_3_4h < 20.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 50.0))
       ):
         return True, f"exit_{mode_name}_d_11_109"
-      elif (last_rsi_3 > 76.0) and (last_rsi_3_4h < 65.0) and (last_stochrsi_k_4h_gt_50) and (last_roc_9_4h > 25.0):
+      elif (last_rsi_3 > 76.0) and (last_rsi_3_4h < 65.0) and (last_stochrsi_k_4h_gt_50) and (last_roc_9_4h_gt_25):
         return True, f"exit_{mode_name}_d_11_110"
       elif (
         (last_rsi_3 > 54.0)
@@ -38804,17 +38855,17 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_11_111"
       elif (
         (last_rsi_3 > 84.0)
-        and (last_willr_14 > -15.0)
+        and (last_willr_14_gt_neg_15)
         and (last_rsi_14 < 48.0)
         and (last_rsi_3_1h < 35.0)
-        and (last_rsi_3_4h < 35.0)
+        and (last_rsi_3_4h_lt_35)
         and (last_rsi_3_1d < 60.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
       ):
         return True, f"exit_{mode_name}_d_11_112"
       elif (
         (last_rsi_3 > 88.0)
-        and (last_willr_14 > -1.0)
+        and (last_willr_14_gt_neg_1)
         and (last_rsi_3_1d < 30.0)
         and (last_stochrsi_k_4h_gt_50)
         and (isinstance(last_roc_9_4h, np.float64) and (last_roc_9_4h > 10.0))
@@ -38832,7 +38883,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 82.0)
         and (last_rsi_14 < 44.0)
-        and (last_rsi_3_15m < 30.0)
+        and (last_rsi_3_15m_lt_30)
         and (last_stochrsi_k_1h_gt_50)
         and (last_stochrsi_k_4h_gt_50)
       ):
@@ -38847,7 +38898,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_11_118"
       elif (
         (last_rsi_3 > 90.0)
-        and (last_willr_14 > -20.0)
+        and (last_willr_14_gt_neg_20)
         and (last_rsi_3_1h < 60.0)
         and (last_rsi_3_4h < 60.0)
         and (last_stochrsi_k_1h > 40.0)
@@ -38859,7 +38910,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_11_121"
       elif (last_rsi_3 > 62.0) and (last_rsi_14 < 40.0) and (last_rsi_3_4h_lt_30) and (last_stochrsi_k_1h_gt_50):
         return True, f"exit_{mode_name}_d_11_122"
-      elif (last_rsi_3 > 92.0) and (last_willr_14 > -1.0) and (last_rsi_3_1h < 10.0) and (last_rsi_3_1d < 30.0):
+      elif (last_rsi_3 > 92.0) and (last_willr_14_gt_neg_1) and (last_rsi_3_1h < 10.0) and (last_rsi_3_1d < 30.0):
         return True, f"exit_{mode_name}_d_11_123"
       elif (
         (last_rsi_3 > 92.0)
@@ -38869,16 +38920,16 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_11_124"
       elif (
         (last_rsi_3 > 80.0)
-        and (last_willr_14 > -1.0)
+        and (last_willr_14_gt_neg_1)
         and (last_rsi_3_1h < 10.0)
         and (last_rsi_3_4h < 40.0)
-        and (last_rsi_3_1d < 40.0)
+        and (last_rsi_3_1d_lt_40)
         and (last_close < (last_high_max_30_1d * 0.50))
       ):
         return True, f"exit_{mode_name}_d_11_125"
       elif (last_rsi_3 > 94.0) and (last_rsi_3_1h < 15.0) and (last_rsi_3_4h < 40.0) and (last_stochrsi_k_4h_gt_50):
         return True, f"exit_{mode_name}_d_11_126"
-      elif (last_rsi_3 > 94.0) and (last_rsi_3_1h < 10.0) and (last_rsi_3_4h_lt_30) and (last_rsi_3_1d < 40.0):
+      elif (last_rsi_3 > 94.0) and (last_rsi_3_1h < 10.0) and (last_rsi_3_4h_lt_30) and (last_rsi_3_1d_lt_40):
         return True, f"exit_{mode_name}_d_11_127"
       elif (last_rsi_3 > 98.0) and (last_rsi_3_4h_lt_30) and (last_aroonu_14_4h > 85.0):
         return True, f"exit_{mode_name}_d_11_128"
@@ -38900,7 +38951,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 84.0)
         and (last_rsi_3_1h < 35.0)
-        and (last_rsi_3_4h < 35.0)
+        and (last_rsi_3_4h_lt_35)
         and (last_aroonu_14_1h > 50.0)
         and (last_stochrsi_k_1h > 40.0)
       ):
@@ -38914,7 +38965,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_11_133"
     elif current_profit >= 0.2:
       if (
-        (last_willr_14 > -1.0)
+        (last_willr_14_gt_neg_1)
         and (last_rsi_14 > 78.0)
         and (isinstance(last_ema_200_1h, np.float64) and (last_ema_12_1h < last_ema_200_1h))
         and (isinstance(last_ema_200_4h, np.float64) and (last_ema_12_4h < last_ema_200_4h))
@@ -38923,37 +38974,37 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_12_1"
       elif (
-        (last_willr_14 > -1.0)
+        (last_willr_14_gt_neg_1)
         and (last_rsi_14 > 78.0)
-        and (last_cmf_20_1h < -0.0)
+        and (last_cmf_20_1h_lt_0)
         and (isinstance(last_ema_200_1h, np.float64) and (last_ema_12_1h < last_ema_200_1h))
         and (isinstance(last_ema_200_4h, np.float64) and (last_ema_12_4h < last_ema_200_4h))
       ):
         return True, f"exit_{mode_name}_d_12_2"
       elif (
-        (last_willr_14 > -1.0)
+        (last_willr_14_gt_neg_1)
         and (last_stochrsi_k > 99.0)
-        and (last_cmf_20_1h < -0.0)
-        and (last_cmf_20_4h < -0.0)
-        and ((last_stochrsi_k_4h > 20.0) and (last_stochrsi_k_change_pct_4h < -10.0))
+        and (last_cmf_20_1h_lt_0)
+        and (last_cmf_20_4h_lt_0)
+        and ((last_stochrsi_k_4h > 20.0) and (last_stochrsi_k_change_pct_4h_lt_neg_10))
       ):
         return True, f"exit_{mode_name}_d_12_3"
       elif (
-        (last_willr_14 > -1.0)
+        (last_willr_14_gt_neg_1)
         and (last_rsi_14 > 80.0)
         and (last_stochrsi_k > 95.0)
-        and (last_stochrsi_k_4h > 70.0)
+        and (last_stochrsi_k_4h_gt_70)
         and (isinstance(last_ema_200_1h, np.float64) and (last_ema_12_1h < last_ema_200_1h))
         and (isinstance(last_ema_200_4h, np.float64) and (last_ema_12_4h < last_ema_200_4h))
       ):
         return True, f"exit_{mode_name}_d_12_4"
-      elif (last_willr_14 > -1.0) and (last_rsi_14 > 78.0) and (last_roc_9_1h < -5.0) and (last_roc_9_4h < -5.0):
+      elif (last_willr_14_gt_neg_1) and (last_rsi_14 > 78.0) and (last_roc_9_1h_lt_neg_5) and (last_roc_9_4h_lt_neg_5):
         return True, f"exit_{mode_name}_d_12_5"
       elif (
         (last_rsi_3 > 70.0)
-        and (last_stochrsi_k > 70.0)
+        and (last_stochrsi_k_gt_70)
         and (last_rsi_14 < 40.0)
-        and (last_roc_9_1h < -10.0)
+        and (last_roc_9_1h_lt_neg_10)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 50.0))
       ):
         return True, f"exit_{mode_name}_d_12_6"
@@ -38965,26 +39016,26 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_12_7"
       elif (
-        (last_willr_14 > -1.0)
+        (last_willr_14_gt_neg_1)
         and (last_stochrsi_k > 99.0)
         and (last_cmf_20_1h < -0.1)
         and (last_cmf_20_4h < -0.1)
-        and (last_change_pct_1d < -5.0)
+        and (last_change_pct_1d_lt_neg_5)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 15.0))
       ):
         return True, f"exit_{mode_name}_d_12_8"
       elif (
-        (last_willr_14 > -1.0)
+        (last_willr_14_gt_neg_1)
         and (last_rsi_3 > 99.0)
-        and (last_change_pct_4h < -5.0)
+        and (last_change_pct_4h_lt_neg_5)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
       ):
         return True, f"exit_{mode_name}_d_12_9"
       elif (
-        (last_willr_14 > -1.0)
+        (last_willr_14_gt_neg_1)
         and (last_rsi_14_lt_50)
-        and (last_roc_9_1h < -10.0)
-        and (last_roc_9_4h < -10.0)
+        and (last_roc_9_1h_lt_neg_10)
+        and (last_roc_9_4h_lt_neg_10)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 10.0))
       ):
         return True, f"exit_{mode_name}_d_12_10"
@@ -38992,7 +39043,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 99.0)
         and (last_rsi_14 < 45.0)
         and (last_roc_9_15m < -10.0)
-        and (last_roc_9_1h < -10.0)
+        and (last_roc_9_1h_lt_neg_10)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -20.0))
       ):
         return True, f"exit_{mode_name}_d_12_11"
@@ -39001,26 +39052,26 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14_lt_50)
         and (last_rsi_3_4h < 10.0)
         and (last_roc_9_1h < -20.0)
-        and (last_roc_9_4h < -20.0)
+        and (last_roc_9_4h_lt_neg_20)
       ):
         return True, f"exit_{mode_name}_d_12_12"
-      elif (last_rsi_3 > 99.0) and (last_rsi_3_4h < 5.0) and (last_roc_9_4h < -25.0):
+      elif (last_rsi_3 > 99.0) and (last_rsi_3_4h_lt_5) and (last_roc_9_4h_lt_neg_25):
         return True, f"exit_{mode_name}_d_12_13"
-      elif (last_rsi_3 > 99.0) and (last_willr_14 > -1.0) and (last_rsi_3_4h < 5.0) and (last_aroonu_14_4h > 25.0):
+      elif (last_rsi_3 > 99.0) and (last_willr_14_gt_neg_1) and (last_rsi_3_4h_lt_5) and (last_aroonu_14_4h > 25.0):
         return True, f"exit_{mode_name}_d_12_14"
       elif (last_rsi_3 > 99.0) and (last_rsi_14 > 75.0) and (last_roc_9_4h < -30.0):
         return True, f"exit_{mode_name}_d_12_15"
       elif (
         (last_rsi_3 > 99.0)
         and (last_aroonu_14_4h > 25.0)
-        and (last_roc_9_4h < -25.0)
+        and (last_roc_9_4h_lt_neg_25)
         and (last_aroonu_14_1d > 50.0)
         and (last_change_pct_1d < -15.0)
       ):
         return True, f"exit_{mode_name}_d_12_16"
       elif (
         (last_rsi_3 > 99.0)
-        and (last_willr_14 > -1.0)
+        and (last_willr_14_gt_neg_1)
         and (last_rsi_3_1h < 10.0)
         and (last_stochrsi_k_4h > 90.0)
         and (last_roc_9_4h > 30.0)
@@ -39041,31 +39092,31 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_12_21"
       elif (
         (last_rsi_3 > 99.0)
-        and (last_willr_14 > -1.0)
-        and (last_change_pct_4h < -5.0)
+        and (last_willr_14_gt_neg_1)
+        and (last_change_pct_4h_lt_neg_5)
         and (last_stochrsi_k_4h_gt_50)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
       ):
         return True, f"exit_{mode_name}_d_12_22"
-      elif (last_rsi_3 > 99.0) and (last_willr_14 > -1.0) and (last_rsi_3_1h < 15.0) and (last_rsi_3_1d < 5.0):
+      elif (last_rsi_3 > 99.0) and (last_willr_14_gt_neg_1) and (last_rsi_3_1h < 15.0) and (last_rsi_3_1d < 5.0):
         return True, f"exit_{mode_name}_d_12_23"
       elif (
         (last_rsi_3 > 98.0)
         and (last_rsi_14 > 78.0)
-        and (last_willr_14 > -1.0)
+        and (last_willr_14_gt_neg_1)
         and (last_rsi_3_4h_lt_30)
         and (last_aroonu_14_4h > 75.0)
       ):
         return True, f"exit_{mode_name}_d_12_24"
       elif (
         (last_rsi_3 > 99.0)
-        and (last_willr_14 > -1.0)
+        and (last_willr_14_gt_neg_1)
         and (last_rsi_3_4h < 10.0)
         and (last_roc_9_4h < -15.0)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d > 50.0))
       ):
         return True, f"exit_{mode_name}_d_12_25"
-      elif (last_rsi_3 > 99.0) and (last_willr_14 > -1.0) and (last_rsi_3_4h < 15.0) and (last_roc_9_4h < -20.0):
+      elif (last_rsi_3 > 99.0) and (last_willr_14_gt_neg_1) and (last_rsi_3_4h < 15.0) and (last_roc_9_4h_lt_neg_20):
         return True, f"exit_{mode_name}_d_12_26"
       elif (
         (last_rsi_3 > 99.0)
@@ -39092,27 +39143,29 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14_lt_50)
         and (last_rsi_3_1h < 15.0)
         and (last_rsi_3_4h < 15.0)
-        and (last_stochrsi_k_1h > 25.0)
+        and (last_stochrsi_k_1h_gt_25)
       ):
         return True, f"exit_{mode_name}_d_12_31"
-      elif (last_rsi_3 > 99.0) and (last_rsi_3_1h < 15.0) and (last_roc_2_4h < -30.0) and (last_stochrsi_k_4h > 30.0):
+      elif (
+        (last_rsi_3 > 99.0) and (last_rsi_3_1h < 15.0) and (last_roc_2_4h_lt_neg_30) and (last_stochrsi_k_4h > 30.0)
+      ):
         return True, f"exit_{mode_name}_d_12_32"
       elif (
         (last_rsi_3 > 99.0)
-        and (last_willr_14 > -1.0)
+        and (last_willr_14_gt_neg_1)
         and (last_roc_2_1h < -10.0)
         and (last_roc_9_1h > 30.0)
         and (last_stochrsi_k_1h_gt_50)
       ):
         return True, f"exit_{mode_name}_d_12_33"
-      elif (last_rsi_3 > 65.0) and (last_rsi_3_15m < 30.0) and (last_rsi_14_1h > 80.0) and (last_roc_9_1h > 40.0):
+      elif (last_rsi_3 > 65.0) and (last_rsi_3_15m_lt_30) and (last_rsi_14_1h > 80.0) and (last_roc_9_1h > 40.0):
         return True, f"exit_{mode_name}_d_12_34"
-      elif (last_rsi_3 > 94.0) and (last_willr_14 > -2.0) and (last_rsi_3_1d < 25.0) and (last_stochrsi_k_1h > 75.0):
+      elif (last_rsi_3 > 94.0) and (last_willr_14_gt_neg_2) and (last_rsi_3_1d < 25.0) and (last_stochrsi_k_1h_gt_75):
         return True, f"exit_{mode_name}_d_12_35"
       elif (
         (last_rsi_3 > 99.0)
-        and (last_willr_14 > -1.0)
-        and (last_roc_9_4h < -25.0)
+        and (last_willr_14_gt_neg_1)
+        and (last_roc_9_4h_lt_neg_25)
         and (last_rsi_3_1d < 25.0)
         and (last_stochrsi_k_1h_gt_50)
       ):
@@ -39125,13 +39178,13 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_stochrsi_k_4h_gt_50)
       ):
         return True, f"exit_{mode_name}_d_12_37"
-      elif (last_rsi_3 > 99.0) and (last_willr_14 > -1.0) and (last_rsi_3_4h < 10.0) and (last_stochrsi_k_4h > 20.0):
+      elif (last_rsi_3 > 99.0) and (last_willr_14_gt_neg_1) and (last_rsi_3_4h < 10.0) and (last_stochrsi_k_4h > 20.0):
         return True, f"exit_{mode_name}_d_12_38"
-      elif (last_rsi_3 > 98.0) and (last_willr_14 > -2.0) and (last_cmf_20_4h < -0.0) and (last_rsi_3_4h < 10.0):
+      elif (last_rsi_3 > 98.0) and (last_willr_14_gt_neg_2) and (last_cmf_20_4h_lt_0) and (last_rsi_3_4h < 10.0):
         return True, f"exit_{mode_name}_d_12_39"
       elif (
         (last_rsi_3 > 98.0)
-        and (last_willr_14 > -2.0)
+        and (last_willr_14_gt_neg_2)
         and (last_rsi_3_1h_lt_30)
         and (last_stochrsi_k_1h > 30.0)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d > 90.0))
@@ -39139,7 +39192,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_12_40"
       elif (
         (last_rsi_3 > 98.0)
-        and (last_willr_14 > -2.0)
+        and (last_willr_14_gt_neg_2)
         and (last_rsi_3_1h_lt_30)
         and (last_stochrsi_k_4h > 25.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 50.0))
@@ -39147,7 +39200,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_12_41"
       elif (
         (last_rsi_3 > 98.0)
-        and (last_willr_14 > -10.0)
+        and (last_willr_14_gt_neg_10)
         and (last_stochrsi_k_4h > 30.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 40.0))
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d > 70.0))
@@ -39163,13 +39216,13 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_12_43"
       elif (
         (last_rsi_3 > 85.0)
-        and (last_willr_14 > -2.0)
+        and (last_willr_14_gt_neg_2)
         and (last_rsi_3_4h_lt_30)
         and (last_rsi_3_1d < 25.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
       ):
         return True, f"exit_{mode_name}_d_12_44"
-      elif (last_rsi_3 > 99.0) and (last_willr_14 > -1.0) and (last_rsi_3_1h < 10.0):
+      elif (last_rsi_3 > 99.0) and (last_willr_14_gt_neg_1) and (last_rsi_3_1h < 10.0):
         return True, f"exit_{mode_name}_d_12_45"
       elif (last_rsi_3 > 96.0) and (last_rsi_3_1h < 15.0) and (last_rsi_3_4h < 10.0) and (last_roc_2_1d < -20.0):
         return True, f"exit_{mode_name}_d_12_46"
@@ -39177,7 +39230,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 98.0)
         and (last_stochrsi_k_1h > 80.0)
         and (last_stochrsi_k_4h > 40.0)
-        and (last_change_pct_1d < -5.0)
+        and (last_change_pct_1d_lt_neg_5)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -5.0))
       ):
         return True, f"exit_{mode_name}_d_12_47"
@@ -39191,20 +39244,20 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_12_48"
       elif (
         (last_rsi_3 > 98.0)
-        and (last_willr_14 > -2.0)
+        and (last_willr_14_gt_neg_2)
         and (last_rsi_3_4h < 20.0)
-        and (last_change_pct_1d < -5.0)
+        and (last_change_pct_1d_lt_neg_5)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d > 50.0))
       ):
         return True, f"exit_{mode_name}_d_12_49"
-      elif (last_rsi_3 > 90.0) and (last_willr_14 > -2.0) and (last_rsi_3_1d < 10.0) and (last_stochrsi_k_1h > 90.0):
+      elif (last_rsi_3 > 90.0) and (last_willr_14_gt_neg_2) and (last_rsi_3_1d < 10.0) and (last_stochrsi_k_1h_gt_90):
         return True, f"exit_{mode_name}_d_12_50"
       elif (last_rsi_3 > 72.0) and (last_rsi_14 < 40.0) and (last_rsi_3_4h < 20.0) and (last_stochrsi_k_1h_gt_50):
         return True, f"exit_{mode_name}_d_12_51"
       elif (
         (last_rsi_3 > 86.0)
         and (last_rsi_14 > 66.0)
-        and (last_willr_14 > -10.0)
+        and (last_willr_14_gt_neg_10)
         and (last_stochrsi_k_1h > 70.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -15.0))
       ):
@@ -39212,7 +39265,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 70.0)
         and (last_rsi_14_lt_50)
-        and (last_willr_14 > -25.0)
+        and (last_willr_14_gt_neg_25)
         and (last_rsi_3_1h < 20.0)
         and (last_stochrsi_k_4h_gt_50)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d > 50.0))
@@ -39222,14 +39275,14 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 84.0)
         and (last_rsi_14 < 40.0)
         and (last_stochrsi_k_1h_gt_50)
-        and (last_roc_9_4h < -10.0)
+        and (last_roc_9_4h_lt_neg_10)
         and (last_change_pct_1d < -10.0)
       ):
         return True, f"exit_{mode_name}_d_12_54"
       elif (
         (last_rsi_3 > 99.0)
-        and (last_willr_14 > -8.0)
-        and (last_roc_9_4h < -5.0)
+        and (last_willr_14_gt_neg_8)
+        and (last_roc_9_4h_lt_neg_5)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 10.0))
         and (last_stochrsi_k_1h_gt_50)
       ):
@@ -39240,14 +39293,14 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_3_1h_lt_30)
         and (last_rsi_3_4h < 25.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
-        and (last_stochrsi_k_4h > 10.0)
+        and (last_stochrsi_k_4h_gt_10)
       ):
         return True, f"exit_{mode_name}_d_12_56"
       elif (
         (last_rsi_3 > 50.0)
         and (last_rsi_14 < 30.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
-        and (last_stochrsi_k_4h > 70.0)
+        and (last_stochrsi_k_4h_gt_70)
       ):
         return True, f"exit_{mode_name}_d_12_57"
       elif (
@@ -39260,7 +39313,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_12_58"
       elif (
         (last_rsi_3 > 95.0)
-        and (last_willr_14 > -6.0)
+        and (last_willr_14_gt_neg_6)
         and (last_rsi_3_4h < 25.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -15.0))
         and (last_stochrsi_k_4h > 40.0)
@@ -39271,18 +39324,18 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 < 34.0)
         and (last_rsi_14_4h > 65.0)
         and (last_stochrsi_k_4h_gt_50)
-        and (last_stochrsi_k_1d > 50.0)
+        and (last_stochrsi_k_1d_gt_50)
       ):
         return True, f"exit_{mode_name}_d_12_60"
-      elif (last_rsi_3 > 98.0) and (last_willr_14 > -5.0) and (last_rsi_3_4h < 10.0) and (last_stochrsi_k_1h > 30.0):
+      elif (last_rsi_3 > 98.0) and (last_willr_14_gt_neg_5) and (last_rsi_3_4h < 10.0) and (last_stochrsi_k_1h > 30.0):
         return True, f"exit_{mode_name}_d_12_61"
       elif (
         (last_rsi_3 > 92.0)
-        and (last_willr_14 > -2.0)
+        and (last_willr_14_gt_neg_2)
         and (last_rsi_3_1h_lt_30)
         and (last_rsi_3_4h < 20.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 20.0))
-        and (last_change_pct_1d < -5.0)
+        and (last_change_pct_1d_lt_neg_5)
       ):
         return True, f"exit_{mode_name}_d_12_62"
       elif (
@@ -39303,7 +39356,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 50.0)
         and (last_rsi_14 < 36.0)
-        and (last_stochrsi_k_4h > 80.0)
+        and (last_stochrsi_k_4h_gt_80)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -25.0))
       ):
         return True, f"exit_{mode_name}_d_12_67"
@@ -39311,17 +39364,17 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 90.0)
         and (last_rsi_14 < 42.0)
         and (last_rsi_3_1h < 25.0)
-        and (last_roc_2_4h < -30.0)
+        and (last_roc_2_4h_lt_neg_30)
         and (last_stochrsi_k_4h > 25.0)
       ):
         return True, f"exit_{mode_name}_d_12_68"
       elif (
-        (last_rsi_3 > 99.0) and (last_roc_9_4h > 20.0) and (last_stochrsi_k_4h_gt_50) and (last_change_pct_4h < -5.0)
+        (last_rsi_3 > 99.0) and (last_roc_9_4h > 20.0) and (last_stochrsi_k_4h_gt_50) and (last_change_pct_4h_lt_neg_5)
       ):
         return True, f"exit_{mode_name}_d_12_69"
       elif (last_rsi_3 > 72.0) and (last_rsi_14 < 34.0) and (last_rsi_3_1h < 25.0) and (last_stochrsi_k_4h > 20.0):
         return True, f"exit_{mode_name}_d_12_70"
-      elif (last_rsi_3 > 70.0) and (last_rsi_14 < 38.0) and (last_rsi_3_4h < 25.0) and (last_stochrsi_k_1h > 20.0):
+      elif (last_rsi_3 > 70.0) and (last_rsi_14 < 38.0) and (last_rsi_3_4h < 25.0) and (last_stochrsi_k_1h_gt_20):
         return True, f"exit_{mode_name}_d_12_71"
       elif (last_rsi_3 > 84.0) and (last_rsi_14 < 36.0) and (last_rsi_3_1h < 10.0) and (last_aroonu_14_4h > 25.0):
         return True, f"exit_{mode_name}_d_12_72"
@@ -39329,13 +39382,13 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 84.0)
         and (last_rsi_3_1h < 25.0)
         and (last_rsi_3_4h < 15.0)
-        and (last_roc_9_4h < -20.0)
+        and (last_roc_9_4h_lt_neg_20)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -25.0))
       ):
         return True, f"exit_{mode_name}_d_12_73"
       elif (
         (last_rsi_3 > 99.0)
-        and (last_willr_14 > -10.0)
+        and (last_willr_14_gt_neg_10)
         and (last_rsi_3_4h < 25.0)
         and (last_rsi_3_1d < 25.0)
         and (last_stochrsi_k_1h_gt_50)
@@ -39348,7 +39401,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d > 50.0))
       ):
         return True, f"exit_{mode_name}_d_12_75"
-      elif (last_rsi_3 > 74.0) and (last_rsi_14 < 44.0) and (last_roc_9_1h > 80.0) and (last_stochrsi_k_4h > 80.0):
+      elif (last_rsi_3 > 74.0) and (last_rsi_14 < 44.0) and (last_roc_9_1h > 80.0) and (last_stochrsi_k_4h_gt_80):
         return True, f"exit_{mode_name}_d_12_76"
       elif (
         (last_rsi_3 > 82.0)
@@ -39359,13 +39412,13 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_12_77"
       elif (
         (last_rsi_3 > 92.0)
-        and (last_willr_14 > -10.0)
+        and (last_willr_14_gt_neg_10)
         and (last_rsi_3_1h_lt_30)
         and (last_rsi_3_4h < 20.0)
         and (last_rsi_3_1d < 20.0)
       ):
         return True, f"exit_{mode_name}_d_12_78"
-      elif (last_rsi_3 > 98.0) and (last_willr_14 > -1.0) and (last_rsi_3_1h_lt_30) and (last_rsi_3_4h < 10.0):
+      elif (last_rsi_3 > 98.0) and (last_willr_14_gt_neg_1) and (last_rsi_3_1h_lt_30) and (last_rsi_3_4h < 10.0):
         return True, f"exit_{mode_name}_d_12_79"
       elif (
         (last_rsi_3 > 78.0)
@@ -39377,7 +39430,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_12_80"
       elif (
         (last_rsi_3 > 90.0)
-        and (last_willr_14 > -4.0)
+        and (last_willr_14_gt_neg_4)
         and (last_rsi_3_1h < 25.0)
         and (last_rsi_3_4h < 25.0)
         and (isinstance(last_rsi_14_1d, np.float64) and (last_rsi_14_1d > 50.0))
@@ -39385,7 +39438,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_12_81"
       elif (
         (last_rsi_3 > 88.0)
-        and (last_willr_14 > -4.0)
+        and (last_willr_14_gt_neg_4)
         and (last_rsi_3_4h_lt_30)
         and (last_rsi_3_1d < 15.0)
         and (last_stochrsi_k_4h > 40.0)
@@ -39399,11 +39452,11 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_stochrsi_k_4h > 40.0)
       ):
         return True, f"exit_{mode_name}_d_12_83"
-      elif (last_rsi_3 > 96.0) and (last_willr_14 > -1.0) and (last_rsi_3_4h_lt_30) and (last_stochrsi_k_1h > 20.0):
+      elif (last_rsi_3 > 96.0) and (last_willr_14_gt_neg_1) and (last_rsi_3_4h_lt_30) and (last_stochrsi_k_1h_gt_20):
         return True, f"exit_{mode_name}_d_12_84"
       elif (
         (last_rsi_3 > 94.0)
-        and (last_willr_14 > -2.0)
+        and (last_willr_14_gt_neg_2)
         and (last_rsi_3_1h_lt_30)
         and (last_rsi_3_4h < 40.0)
         and (last_stochrsi_k_4h_gt_50)
@@ -39427,7 +39480,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_12_87"
       elif (
         (last_rsi_3 > 94.0)
-        and (last_willr_14 > -14.0)
+        and (last_willr_14_gt_neg_14)
         and (last_stochrsi_k_1h > 40.0)
         and (last_stochrsi_k_4h_gt_50)
         and (last_change_pct_1h < -2.0)
@@ -39436,13 +39489,13 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 84.0)
         and (last_rsi_14 < 34.0)
-        and (last_roc_9_1h < -5.0)
+        and (last_roc_9_1h_lt_neg_5)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 25.0))
       ):
         return True, f"exit_{mode_name}_d_12_89"
       elif (
         (last_rsi_3 > 98.0)
-        and (last_willr_14 > -25.0)
+        and (last_willr_14_gt_neg_25)
         and (last_rsi_3_1h < 50.0)
         and (last_rsi_3_4h_lt_30)
         and (last_aroonu_14_4h > 50.0)
@@ -39462,7 +39515,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 > 86.0)
         and (last_rsi_14 < 42.0)
         and (last_rsi_3_1h < 40.0)
-        and (last_stochrsi_k_1h > 25.0)
+        and (last_stochrsi_k_1h_gt_25)
         and (last_stochrsi_k_4h_gt_50)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -25.0))
       ):
@@ -39489,10 +39542,10 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_12_94"
       elif (
         (last_rsi_3 > 90.0)
-        and (last_willr_14 > -6.0)
+        and (last_willr_14_gt_neg_6)
         and (last_rsi_3_1h < 45.0)
         and (last_rsi_3_4h < 40.0)
-        and (last_stochrsi_k_4h > 10.0)
+        and (last_stochrsi_k_4h_gt_10)
         and (isinstance(last_aroonu_14_1d, np.float64) and (last_aroonu_14_1d > 75.0))
       ):
         return True, f"exit_{mode_name}_d_12_95"
@@ -39527,15 +39580,15 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_3_1h < 65.0)
         and (last_rsi_3_4h < 60.0)
         and (last_aroonu_14_4h > 50.0)
-        and (last_stoch_k_4h > 40.0)
+        and (last_stoch_k_4h_gt_40)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 80.0))
       ):
         return True, f"exit_{mode_name}_d_12_99"
-      elif (last_rsi_3 > 99.0) and (last_rsi_14 > 82.0) and (last_rsi_3_15m > 70.0) and (last_rsi_3_4h < 80.0):
+      elif (last_rsi_3 > 99.0) and (last_rsi_14 > 82.0) and (last_rsi_3_15m_gt_70) and (last_rsi_3_4h < 80.0):
         return True, f"exit_{mode_name}_d_12_100"
       elif (
         (last_rsi_3 > 90.0)
-        and (last_willr_14 > -10.0)
+        and (last_willr_14_gt_neg_10)
         and (last_rsi_3_1h < 50.0)
         and (last_stochrsi_k_4h > 40.0)
         and (isinstance(last_roc_9_4h, np.float64) and (last_roc_9_4h > 40.0))
@@ -39564,7 +39617,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_3_1h < 60.0)
         and (last_stochrsi_k_1h > 40.0)
         and (last_stochrsi_k_4h > 90.0)
-        and (last_roc_9_4h > 40.0)
+        and (last_roc_9_4h_gt_40)
       ):
         return True, f"exit_{mode_name}_d_12_104"
       elif (
@@ -39572,7 +39625,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 < 42.0)
         and (last_rsi_3_15m < 55.0)
         and (last_stochrsi_k_4h > 90.0)
-        and (last_roc_9_4h > 25.0)
+        and (last_roc_9_4h_gt_25)
       ):
         return True, f"exit_{mode_name}_d_12_105"
       elif (
@@ -39581,7 +39634,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_3_1h < 50.0)
         and (last_stochrsi_k_1h_gt_50)
         and (last_rsi_14_4h > 70.0)
-        and (last_roc_9_4h > 40.0)
+        and (last_roc_9_4h_gt_40)
       ):
         return True, f"exit_{mode_name}_d_12_106"
       elif (
@@ -39596,16 +39649,16 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_12_108"
       elif (
         (last_rsi_3 > 82.0)
-        and (last_willr_14 > -2.0)
+        and (last_willr_14_gt_neg_2)
         and (last_rsi_3_1h < 50.0)
         and (last_rsi_3_4h < 20.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 50.0))
       ):
         return True, f"exit_{mode_name}_d_12_109"
-      elif (last_rsi_3 > 78.0) and (last_rsi_3_4h < 65.0) and (last_stochrsi_k_4h_gt_50) and (last_roc_9_4h > 25.0):
+      elif (last_rsi_3 > 78.0) and (last_rsi_3_4h < 65.0) and (last_stochrsi_k_4h_gt_50) and (last_roc_9_4h_gt_25):
         return True, f"exit_{mode_name}_d_12_110"
       elif (
-        (last_rsi_3 > 56.0)
+        (last_rsi_3_gt_56)
         and (last_rsi_14 < 38.0)
         and (last_rsi_3_1h < 50.0)
         and (last_rsi_14_4h > 70.0)
@@ -39616,17 +39669,17 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_12_111"
       elif (
         (last_rsi_3 > 86.0)
-        and (last_willr_14 > -10.0)
+        and (last_willr_14_gt_neg_10)
         and (last_rsi_14 < 46.0)
         and (last_rsi_3_1h < 35.0)
-        and (last_rsi_3_4h < 35.0)
+        and (last_rsi_3_4h_lt_35)
         and (last_rsi_3_1d < 60.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
       ):
         return True, f"exit_{mode_name}_d_12_112"
       elif (
         (last_rsi_3 > 90.0)
-        and (last_willr_14 > -1.0)
+        and (last_willr_14_gt_neg_1)
         and (last_rsi_3_1d < 30.0)
         and (last_stochrsi_k_4h_gt_50)
         and (isinstance(last_roc_9_4h, np.float64) and (last_roc_9_4h > 10.0))
@@ -39644,7 +39697,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 84.0)
         and (last_rsi_14 < 42.0)
-        and (last_rsi_3_15m < 30.0)
+        and (last_rsi_3_15m_lt_30)
         and (last_stochrsi_k_1h_gt_50)
         and (last_stochrsi_k_4h_gt_50)
       ):
@@ -39659,7 +39712,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_12_118"
       elif (
         (last_rsi_3 > 92.0)
-        and (last_willr_14 > -20.0)
+        and (last_willr_14_gt_neg_20)
         and (last_rsi_3_1h < 60.0)
         and (last_rsi_3_4h < 60.0)
         and (last_stochrsi_k_1h > 40.0)
@@ -39671,7 +39724,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_12_121"
       elif (last_rsi_3 > 64.0) and (last_rsi_14 < 38.0) and (last_rsi_3_4h_lt_30) and (last_stochrsi_k_1h_gt_50):
         return True, f"exit_{mode_name}_d_12_122"
-      elif (last_rsi_3 > 94.0) and (last_willr_14 > -1.0) and (last_rsi_3_1h < 10.0) and (last_rsi_3_1d < 30.0):
+      elif (last_rsi_3 > 94.0) and (last_willr_14_gt_neg_1) and (last_rsi_3_1h < 10.0) and (last_rsi_3_1d < 30.0):
         return True, f"exit_{mode_name}_d_12_123"
       elif (
         (last_rsi_3 > 94.0)
@@ -39681,16 +39734,16 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_12_124"
       elif (
         (last_rsi_3 > 82.0)
-        and (last_willr_14 > -1.0)
+        and (last_willr_14_gt_neg_1)
         and (last_rsi_3_1h < 10.0)
         and (last_rsi_3_4h < 40.0)
-        and (last_rsi_3_1d < 40.0)
+        and (last_rsi_3_1d_lt_40)
         and (last_close < (last_high_max_30_1d * 0.50))
       ):
         return True, f"exit_{mode_name}_d_12_125"
       elif (last_rsi_3 > 96.0) and (last_rsi_3_1h < 15.0) and (last_rsi_3_4h < 40.0) and (last_stochrsi_k_4h_gt_50):
         return True, f"exit_{mode_name}_d_12_126"
-      elif (last_rsi_3 > 96.0) and (last_rsi_3_1h < 10.0) and (last_rsi_3_4h_lt_30) and (last_rsi_3_1d < 40.0):
+      elif (last_rsi_3 > 96.0) and (last_rsi_3_1h < 10.0) and (last_rsi_3_4h_lt_30) and (last_rsi_3_1d_lt_40):
         return True, f"exit_{mode_name}_d_12_127"
       elif (last_rsi_3 > 99.0) and (last_rsi_3_4h_lt_30) and (last_aroonu_14_4h > 85.0):
         return True, f"exit_{mode_name}_d_12_128"
@@ -39712,7 +39765,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 > 86.0)
         and (last_rsi_3_1h < 35.0)
-        and (last_rsi_3_4h < 35.0)
+        and (last_rsi_3_4h_lt_35)
         and (last_aroonu_14_1h > 50.0)
         and (last_stochrsi_k_1h > 40.0)
       ):


### PR DESCRIPTION
## Summary
- Hoists repeated long DEC exit threshold checks into local booleans.
- This branch is independent on latest upstream `main`.

## Safety
- Only already-read values are reused inside the same call.
- Indicator formulas, candle selection, order classification, profit arithmetic, thresholds, condition order, and return values are unchanged.
- No v3 grind-entry code is touched.
- Touched function(s): `long_exit_dec`.

## Backtest scope
- Full backtesting was not required because this patch only reuses already-read local values inside the same call. Indicators, candle selection, order classification, profit arithmetic, thresholds, and trading conditions are unchanged.

## Checks
- `python3 ~/.codex/skills/nfi-upstream-pr/scripts/validate_nfi_pr.py --base origin/main`
- `git merge-tree` conflict simulation against `origin/main` (via validator)
- AST undefined-local scan for introduced `last_*` / `previous_*` / `current_*` locals (via validator)
- `git diff --check` (via validator)
- `ruff format --check NostalgiaForInfinityX7.py` (via validator)
- `ruff check NostalgiaForInfinityX7.py` (via validator)
- `PYTHONDONTWRITEBYTECODE=1 python3 -m py_compile NostalgiaForInfinityX7.py` (via validator)
