### PR TITLE
Hoist X7 short DEC exit gates

### DIFF
--- a/NostalgiaForInfinityX7.py
+++ b/NostalgiaForInfinityX7.py
@@ -52323,6 +52323,53 @@ class NostalgiaForInfinityX7(IStrategy):
     last_stochrsi_k_1h_lt_50 = last_stochrsi_k_1h < 50.0
     last_rsi_3_4h_gt_70 = last_rsi_3_4h > 70.0
 
+    # Reused short DEC exit thresholds
+    last_willr_14_lt_neg_90 = last_willr_14 < -90.0
+    last_willr_14_lt_neg_99 = last_willr_14 < -99.0
+    last_willr_14_lt_neg_98 = last_willr_14 < -98.0
+    last_willr_14_lt_neg_75 = last_willr_14 < -75.0
+    last_willr_14_lt_neg_92 = last_willr_14 < -92.0
+    last_willr_14_lt_neg_80 = last_willr_14 < -80.0
+    last_willr_14_lt_neg_94 = last_willr_14 < -94.0
+    last_willr_14_lt_neg_96 = last_willr_14 < -96.0
+    last_roc_9_4h_gt_25 = last_roc_9_4h > 25.0
+    last_roc_9_4h_gt_20 = last_roc_9_4h > 20.0
+    last_stochrsi_k_4h_lt_90 = last_stochrsi_k_4h < 90.0
+    last_stochrsi_k_4h_lt_30 = last_stochrsi_k_4h < 30.0
+    last_stochrsi_k_4h_lt_20 = last_stochrsi_k_4h < 20.0
+    last_stochrsi_k_1h_lt_80 = last_stochrsi_k_1h < 80.0
+    last_stochrsi_k_1h_lt_75 = last_stochrsi_k_1h < 75.0
+    last_rsi_3_4h_gt_95 = last_rsi_3_4h > 95.0
+    last_rsi_3_4h_gt_65 = last_rsi_3_4h > 65.0
+    last_rsi_3_1d_gt_60 = last_rsi_3_1d > 60.0
+    last_rsi_3_15m_gt_70 = last_rsi_3_15m > 70.0
+    last_roc_9_4h_gt_5 = last_roc_9_4h > 5.0
+    last_roc_9_4h_gt_10 = last_roc_9_4h > 10.0
+    last_roc_9_4h_lt_neg_40 = last_roc_9_4h < -40.0
+    last_roc_9_4h_lt_neg_25 = last_roc_9_4h < -25.0
+    last_roc_9_1h_gt_5 = last_roc_9_1h > 5.0
+    last_roc_2_4h_gt_30 = last_roc_2_4h > 30.0
+    last_cmf_20_4h_gt_0 = last_cmf_20_4h > 0.0
+    last_cmf_20_1h_gt_0 = last_cmf_20_1h > 0.0
+    last_willr_14_lt_neg_88 = last_willr_14 < -88.0
+    last_stochrsi_k_lt_30 = last_stochrsi_k < 30.0
+    last_willr_14_lt_neg_70 = last_willr_14 < -70.0
+    last_willr_14_lt_neg_86 = last_willr_14 < -86.0
+    last_willr_14_lt_neg_85 = last_willr_14 < -85.0
+    last_willr_14_lt_neg_95 = last_willr_14 < -95.0
+    last_willr_14_lt_neg_84 = last_willr_14 < -84.0
+    last_rsi_3_lt_42 = last_rsi_3 < 42.0
+    last_rsi_3_15m_lt_30 = last_rsi_3_15m < 30.0
+    last_rsi_3_lt_44 = last_rsi_3 < 44.0
+    last_willr_14_lt_neg_82 = last_willr_14 < -82.0
+    last_stochrsi_k_change_pct_4h_gt_10 = last_stochrsi_k_change_pct_4h > 10.0
+    last_stochrsi_k_4h_gt_70 = last_stochrsi_k_4h > 70.0
+    last_stochrsi_k_1h_gt_50 = last_stochrsi_k_1h > 50.0
+    last_stochrsi_k_1h_lt_25 = last_stochrsi_k_1h < 25.0
+    last_stochrsi_k_1h_lt_10 = last_stochrsi_k_1h < 10.0
+    last_stochrsi_k_1d_lt_50 = last_stochrsi_k_1d < 50.0
+    last_stoch_k_4h_lt_60 = last_stoch_k_4h < 60.0
+
     if 0.01 > current_profit >= 0.001:
       # Reused short exit decision threshold checks for this profit bracket
       last_rsi_3_lt_5 = last_rsi_3 < 5.0
@@ -52376,7 +52423,7 @@ class NostalgiaForInfinityX7(IStrategy):
       last_rsi_14_4h_lt_30 = last_rsi_14_4h < 30.0
       last_rsi_3_1d_gt_70 = last_rsi_3_1d > 70.0
       if (
-        (last_willr_14 < -99.0)
+        (last_willr_14_lt_neg_99)
         and (last_rsi_14_lt_22)
         and (isinstance(last_ema_200_1h, np.float64) and (last_ema_12_1h > last_ema_200_1h))
         and (isinstance(last_ema_200_4h, np.float64) and (last_ema_12_4h > last_ema_200_4h))
@@ -52387,7 +52434,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_willr_14 <= -99.0)
         and (last_rsi_14_lt_22)
-        and (last_cmf_20_1h > 0.0)
+        and (last_cmf_20_1h_gt_0)
         and (isinstance(last_ema_200_1h, np.float64) and (last_ema_12_1h > last_ema_200_1h))
         and (isinstance(last_ema_200_4h, np.float64) and (last_ema_12_4h > last_ema_200_4h))
       ):
@@ -52395,21 +52442,21 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_willr_14 <= -99.0)
         and (last_stochrsi_k < 1.0)
-        and (last_cmf_20_1h > 0.0)
-        and (last_cmf_20_4h > 0.0)
-        and ((last_stochrsi_k_4h_lt_80) and (last_stochrsi_k_change_pct_4h > 10.0))
+        and (last_cmf_20_1h_gt_0)
+        and (last_cmf_20_4h_gt_0)
+        and ((last_stochrsi_k_4h_lt_80) and (last_stochrsi_k_change_pct_4h_gt_10))
       ):
         return True, f"exit_{mode_name}_d_0_3"
       elif (
         (last_willr_14 <= -99.0)
         and (last_rsi_14_lt_22)
         and (last_stochrsi_k_lt_5)
-        and (last_stochrsi_k_4h < 30.0)
+        and (last_stochrsi_k_4h_lt_30)
         and (isinstance(last_ema_200_1h, np.float64) and (last_ema_12_1h > last_ema_200_1h))
         and (isinstance(last_ema_200_4h, np.float64) and (last_ema_12_4h > last_ema_200_4h))
       ):
         return True, f"exit_{mode_name}_d_0_4"
-      elif (last_willr_14 <= -99.0) and (last_rsi_14_lt_22) and (last_roc_9_1h > 5.0) and (last_roc_9_4h > 5.0):
+      elif (last_willr_14 <= -99.0) and (last_rsi_14_lt_22) and (last_roc_9_1h_gt_5) and (last_roc_9_4h_gt_5):
         return True, f"exit_{mode_name}_d_0_5"
       elif (
         (last_rsi_3_lt_5)
@@ -52427,7 +52474,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_0_7"
       elif (
-        (last_willr_14 < -99.0)
+        (last_willr_14_lt_neg_99)
         and (last_stochrsi_k < 1.0)
         and (last_cmf_20_1h > 0.1)
         and (last_cmf_20_4h > 0.1)
@@ -52436,17 +52483,17 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_0_8"
       elif (
-        (last_willr_14 < -99.0)
+        (last_willr_14_lt_neg_99)
         and (last_rsi_3_lt_1)
         and (last_change_pct_4h_gt_5)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
       ):
         return True, f"exit_{mode_name}_d_0_9"
       elif (
-        (last_willr_14 < -99.0)
+        (last_willr_14_lt_neg_99)
         and (last_rsi_14_gt_50)
         and (last_roc_9_1h_gt_10)
-        and (last_roc_9_4h > 10.0)
+        and (last_roc_9_4h_gt_10)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -10.0))
       ):
         return True, f"exit_{mode_name}_d_0_10"
@@ -52463,26 +52510,26 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14_gt_50)
         and (last_rsi_3_4h_gt_90)
         and (last_roc_9_1h > 20.0)
-        and (last_roc_9_4h > 20.0)
+        and (last_roc_9_4h_gt_20)
       ):
         return True, f"exit_{mode_name}_d_0_12"
-      elif (last_rsi_3_lt_1) and (last_rsi_3_4h > 95.0) and (last_roc_9_4h > 25.0):
+      elif (last_rsi_3_lt_1) and (last_rsi_3_4h_gt_95) and (last_roc_9_4h_gt_25):
         return True, f"exit_{mode_name}_d_0_13"
-      elif (last_rsi_3_lt_1) and (last_willr_14 < -99.0) and (last_rsi_3_4h > 95.0) and (last_aroond_14_4h_gt_25):
+      elif (last_rsi_3_lt_1) and (last_willr_14_lt_neg_99) and (last_rsi_3_4h_gt_95) and (last_aroond_14_4h_gt_25):
         return True, f"exit_{mode_name}_d_0_14"
       elif (last_rsi_3_lt_1) and (last_rsi_14_lt_22) and (last_roc_9_4h > 30.0):
         return True, f"exit_{mode_name}_d_0_15"
       elif (
         (last_rsi_3_lt_1)
         and (last_aroond_14_4h_gt_25)
-        and (last_roc_9_4h > 25.0)
+        and (last_roc_9_4h_gt_25)
         and (last_aroond_14_1d > 50.0)
         and (last_change_pct_1d > 15.0)
       ):
         return True, f"exit_{mode_name}_d_0_16"
       elif (
         (last_rsi_3_lt_1)
-        and (last_willr_14 < -99.0)
+        and (last_willr_14_lt_neg_99)
         and (last_rsi_3_1h_gt_90)
         and (last_stochrsi_k_4h_lt_10)
         and (last_roc_9_4h < -30.0)
@@ -52503,31 +52550,31 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_0_21"
       elif (
         (last_rsi_3_lt_1)
-        and (last_willr_14 < -99.0)
+        and (last_willr_14_lt_neg_99)
         and (last_change_pct_4h_gt_5)
         and (last_stochrsi_k_4h_lt_50)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
       ):
         return True, f"exit_{mode_name}_d_0_22"
-      elif (last_rsi_3_lt_2) and (last_willr_14 < -95.0) and (last_rsi_3_1h_gt_85) and (last_rsi_3_1d > 95.0):
+      elif (last_rsi_3_lt_2) and (last_willr_14_lt_neg_95) and (last_rsi_3_1h_gt_85) and (last_rsi_3_1d > 95.0):
         return True, f"exit_{mode_name}_d_0_23"
       elif (
         (last_rsi_3_lt_1)
         and (last_rsi_14_lt_22)
-        and (last_willr_14 < -95.0)
+        and (last_willr_14_lt_neg_95)
         and (last_rsi_3_4h_gt_70)
         and (last_aroond_14_4h_gt_75)
       ):
         return True, f"exit_{mode_name}_d_0_24"
       elif (
         (last_rsi_3_lt_5)
-        and (last_willr_14 < -98.0)
+        and (last_willr_14_lt_neg_98)
         and (last_rsi_3_4h_gt_90)
         and (last_roc_9_4h > 15.0)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 50.0))
       ):
         return True, f"exit_{mode_name}_d_0_25"
-      elif (last_rsi_3_lt_5) and (last_willr_14 < -99.0) and (last_rsi_3_4h_gt_85) and (last_roc_9_4h > 20.0):
+      elif (last_rsi_3_lt_5) and (last_willr_14_lt_neg_99) and (last_rsi_3_4h_gt_85) and (last_roc_9_4h_gt_20):
         return True, f"exit_{mode_name}_d_0_26"
       elif (
         (last_rsi_3_lt_5)
@@ -52554,27 +52601,27 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14_gt_50)
         and (last_rsi_3_1h_gt_85)
         and (last_rsi_3_4h_gt_85)
-        and (last_stochrsi_k_1h < 75.0)
+        and (last_stochrsi_k_1h_lt_75)
       ):
         return True, f"exit_{mode_name}_d_0_31"
-      elif (last_rsi_3_lt_5) and (last_rsi_3_1h_gt_85) and (last_roc_2_4h > 30.0) and (last_stochrsi_k_4h_lt_70):
+      elif (last_rsi_3_lt_5) and (last_rsi_3_1h_gt_85) and (last_roc_2_4h_gt_30) and (last_stochrsi_k_4h_lt_70):
         return True, f"exit_{mode_name}_d_0_32"
       elif (
         (last_rsi_3_lt_5)
-        and (last_willr_14 < -99.0)
+        and (last_willr_14_lt_neg_99)
         and (last_roc_2_1h > 10.0)
         and (last_roc_9_1h < -30.0)
         and (last_stochrsi_k_1h_lt_50)
       ):
         return True, f"exit_{mode_name}_d_0_33"
-      elif (last_rsi_3 < 35.0) and (last_rsi_3_15m > 70.0) and (last_rsi_14_1h < 20.0) and (last_roc_9_1h < -40.0):
+      elif (last_rsi_3 < 35.0) and (last_rsi_3_15m_gt_70) and (last_rsi_14_1h < 20.0) and (last_roc_9_1h < -40.0):
         return True, f"exit_{mode_name}_d_0_34"
-      elif (last_rsi_3_lt_5) and (last_willr_14 < -95.0) and (last_rsi_3_1d_gt_75) and (last_stochrsi_k_1h < 25.0):
+      elif (last_rsi_3_lt_5) and (last_willr_14_lt_neg_95) and (last_rsi_3_1d_gt_75) and (last_stochrsi_k_1h_lt_25):
         return True, f"exit_{mode_name}_d_0_35"
       elif (
         (last_rsi_3_lt_5)
-        and (last_willr_14 < -99.0)
-        and (last_roc_9_4h > 25.0)
+        and (last_willr_14_lt_neg_99)
+        and (last_roc_9_4h_gt_25)
         and (last_rsi_3_1d_gt_75)
         and (last_stochrsi_k_1h_lt_50)
       ):
@@ -52587,13 +52634,13 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_stochrsi_k_4h_lt_50)
       ):
         return True, f"exit_{mode_name}_d_0_37"
-      elif (last_rsi_3_lt_10) and (last_willr_14 < -90.0) and (last_rsi_3_4h_gt_90) and (last_stochrsi_k_4h_lt_80):
+      elif (last_rsi_3_lt_10) and (last_willr_14_lt_neg_90) and (last_rsi_3_4h_gt_90) and (last_stochrsi_k_4h_lt_80):
         return True, f"exit_{mode_name}_d_0_38"
-      elif (last_rsi_3_lt_1) and (last_willr_14 < -99.0) and (last_cmf_20_4h > 0.0) and (last_rsi_3_4h_gt_90):
+      elif (last_rsi_3_lt_1) and (last_willr_14_lt_neg_99) and (last_cmf_20_4h_gt_0) and (last_rsi_3_4h_gt_90):
         return True, f"exit_{mode_name}_d_0_39"
       elif (
         (last_rsi_3_lt_2)
-        and (last_willr_14 < -98.0)
+        and (last_willr_14_lt_neg_98)
         and (last_rsi_3_1h_gt_70)
         and (last_stochrsi_k_1h_lt_70)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 10.0))
@@ -52601,7 +52648,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_0_40"
       elif (
         (last_rsi_3_lt_2)
-        and (last_willr_14 < -95.0)
+        and (last_willr_14_lt_neg_95)
         and (last_rsi_3_1h_gt_70)
         and (last_stochrsi_k_4h_lt_75)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -50.0))
@@ -52609,7 +52656,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_0_41"
       elif (
         (last_rsi_3_lt_5)
-        and (last_willr_14 < -98.0)
+        and (last_willr_14_lt_neg_98)
         and (last_stochrsi_k_4h_lt_70)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -40.0))
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 30.0))
@@ -52625,13 +52672,13 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_0_43"
       elif (
         (last_rsi_3_lt_10)
-        and (last_willr_14 < -98.0)
+        and (last_willr_14_lt_neg_98)
         and (last_rsi_3_4h_gt_70)
         and (last_rsi_3_1d > 25.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
       ):
         return True, f"exit_{mode_name}_d_0_44"
-      elif (last_rsi_3_lt_4) and (last_willr_14 < -96.0) and (last_rsi_3_1h_gt_90):
+      elif (last_rsi_3_lt_4) and (last_willr_14_lt_neg_96) and (last_rsi_3_1h_gt_90):
         return True, f"exit_{mode_name}_d_0_45"
       elif (last_rsi_3_lt_2) and (last_rsi_3_1h_gt_85) and (last_rsi_3_4h_gt_90) and (last_roc_2_1d > 20.0):
         return True, f"exit_{mode_name}_d_0_46"
@@ -52653,20 +52700,20 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_0_48"
       elif (
         (last_rsi_3_lt_5)
-        and (last_willr_14 < -98.0)
+        and (last_willr_14_lt_neg_98)
         and (last_rsi_3_4h_gt_80)
         and (last_change_pct_1d_gt_5)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 50.0))
       ):
         return True, f"exit_{mode_name}_d_0_49"
-      elif (last_rsi_3 < 20.0) and (last_willr_14 < -98.0) and (last_rsi_3_1d > 90.0) and (last_stochrsi_k_1h < 10.0):
+      elif (last_rsi_3 < 20.0) and (last_willr_14_lt_neg_98) and (last_rsi_3_1d > 90.0) and (last_stochrsi_k_1h_lt_10):
         return True, f"exit_{mode_name}_d_0_50"
       elif (last_rsi_3 < 32.0) and (last_rsi_14_gt_56) and (last_rsi_3_4h_gt_80) and (last_stochrsi_k_1h_lt_50):
         return True, f"exit_{mode_name}_d_0_51"
       elif (
         (last_rsi_3_lt_5)
         and (last_rsi_14 < 38.0)
-        and (last_willr_14 < -90.0)
+        and (last_willr_14_lt_neg_90)
         and (last_stochrsi_k_1h_lt_30)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 15.0))
       ):
@@ -52674,7 +52721,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3_lt_5)
         and (last_rsi_14_gt_50)
-        and (last_willr_14 < -95.0)
+        and (last_willr_14_lt_neg_95)
         and (last_rsi_3_1h_gt_80)
         and (last_stochrsi_k_4h_lt_50)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 50.0))
@@ -52684,14 +52731,14 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 20.0)
         and (last_rsi_14_gt_56)
         and (last_stochrsi_k_1h_lt_50)
-        and (last_roc_9_4h > 10.0)
+        and (last_roc_9_4h_gt_10)
         and (last_change_pct_1d > 10.0)
       ):
         return True, f"exit_{mode_name}_d_0_54"
       elif (
         (last_rsi_3_lt_2)
-        and (last_willr_14 < -88.0)
-        and (last_roc_9_4h > 5.0)
+        and (last_willr_14_lt_neg_88)
+        and (last_roc_9_4h_gt_5)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -10.0))
         and (last_stochrsi_k_1h_lt_50)
       ):
@@ -52702,14 +52749,14 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_3_1h_gt_70)
         and (last_rsi_3_4h_gt_75)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
-        and (last_stochrsi_k_4h < 90.0)
+        and (last_stochrsi_k_4h_lt_90)
       ):
         return True, f"exit_{mode_name}_d_0_56"
       elif (
         (last_rsi_3 < 50.0)
         and (last_rsi_14 > 66.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
-        and (last_stochrsi_k_4h < 30.0)
+        and (last_stochrsi_k_4h_lt_30)
       ):
         return True, f"exit_{mode_name}_d_0_57"
       elif (
@@ -52722,7 +52769,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_0_58"
       elif (
         (last_rsi_3_lt_5)
-        and (last_willr_14 < -90.0)
+        and (last_willr_14_lt_neg_90)
         and (last_rsi_3_4h_gt_75)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 15.0))
         and (last_stochrsi_k_4h_lt_60)
@@ -52733,14 +52780,14 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14_gt_62)
         and (last_rsi_14_4h < 35.0)
         and (last_stochrsi_k_4h_lt_50)
-        and (last_stochrsi_k_1d < 50.0)
+        and (last_stochrsi_k_1d_lt_50)
       ):
         return True, f"exit_{mode_name}_d_0_60"
-      elif (last_rsi_3_lt_2) and (last_willr_14 < -75.0) and (last_rsi_3_4h_gt_90) and (last_stochrsi_k_1h_lt_70):
+      elif (last_rsi_3_lt_2) and (last_willr_14_lt_neg_75) and (last_rsi_3_4h_gt_90) and (last_stochrsi_k_1h_lt_70):
         return True, f"exit_{mode_name}_d_0_61"
       elif (
         (last_rsi_3 < 12.0)
-        and (last_willr_14 < -99.0)
+        and (last_willr_14_lt_neg_99)
         and (last_rsi_3_1h_gt_70)
         and (last_rsi_3_4h_gt_80)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -20.0))
@@ -52763,7 +52810,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 50.0)
         and (last_rsi_14_gt_60)
-        and (last_stochrsi_k_4h < 20.0)
+        and (last_stochrsi_k_4h_lt_20)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 25.0))
       ):
         return True, f"exit_{mode_name}_d_0_67"
@@ -52771,7 +52818,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 14.0)
         and (last_rsi_14_gt_54)
         and (last_rsi_3_1h_gt_75)
-        and (last_roc_2_4h > 30.0)
+        and (last_roc_2_4h_gt_30)
         and (last_stochrsi_k_4h_lt_75)
       ):
         return True, f"exit_{mode_name}_d_0_68"
@@ -52779,7 +52826,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_0_69"
       elif (last_rsi_3_lt_5) and (last_rsi_14_gt_62) and (last_rsi_3_1h_gt_75) and (last_stochrsi_k_4h_lt_80):
         return True, f"exit_{mode_name}_d_0_70"
-      elif (last_rsi_3_lt_5) and (last_rsi_14_gt_58) and (last_rsi_3_4h_gt_75) and (last_stochrsi_k_1h < 80.0):
+      elif (last_rsi_3_lt_5) and (last_rsi_14_gt_58) and (last_rsi_3_4h_gt_75) and (last_stochrsi_k_1h_lt_80):
         return True, f"exit_{mode_name}_d_0_71"
       elif (last_rsi_3_lt_5) and (last_rsi_14_gt_60) and (last_rsi_3_1h_gt_90) and (last_aroond_14_4h_gt_25):
         return True, f"exit_{mode_name}_d_0_72"
@@ -52787,16 +52834,16 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3_lt_5)
         and (last_rsi_3_1h_gt_75)
         and (last_rsi_3_4h_gt_85)
-        and (last_roc_9_4h > 20.0)
+        and (last_roc_9_4h_gt_20)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 25.0))
       ):
         return True, f"exit_{mode_name}_d_0_73"
       elif (
         (last_rsi_3_lt_1)
-        and (last_willr_14 < -90.0)
+        and (last_willr_14_lt_neg_90)
         and (last_rsi_3_4h_gt_75)
         and (last_rsi_3_1d_gt_75)
-        and (last_stochrsi_k_1h > 50.0)
+        and (last_stochrsi_k_1h_gt_50)
       ):
         return True, f"exit_{mode_name}_d_0_74"
       elif (
@@ -52806,7 +52853,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 50.0))
       ):
         return True, f"exit_{mode_name}_d_0_75"
-      elif (last_rsi_3_lt_5) and (last_rsi_14_gt_52) and (last_roc_9_1h < -80.0) and (last_stochrsi_k_4h < 20.0):
+      elif (last_rsi_3_lt_5) and (last_rsi_14_gt_52) and (last_roc_9_1h < -80.0) and (last_stochrsi_k_4h_lt_20):
         return True, f"exit_{mode_name}_d_0_76"
       elif (
         (last_rsi_3_lt_5)
@@ -52817,13 +52864,13 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_0_77"
       elif (
         (last_rsi_3_lt_2)
-        and (last_willr_14 < -86.0)
+        and (last_willr_14_lt_neg_86)
         and (last_rsi_3_1h_gt_70)
         and (last_rsi_3_4h_gt_80)
         and (last_rsi_3_1d > 80.0)
       ):
         return True, f"exit_{mode_name}_d_0_78"
-      elif (last_rsi_3 < 6.0) and (last_willr_14 < -99.0) and (last_rsi_3_1h_gt_70) and (last_rsi_3_4h_gt_90):
+      elif (last_rsi_3 < 6.0) and (last_willr_14_lt_neg_99) and (last_rsi_3_1h_gt_70) and (last_rsi_3_4h_gt_90):
         return True, f"exit_{mode_name}_d_0_79"
       elif (
         (last_rsi_3 < 26.0)
@@ -52835,7 +52882,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_0_80"
       elif (
         (last_rsi_3_lt_4)
-        and (last_willr_14 < -92.0)
+        and (last_willr_14_lt_neg_92)
         and (last_rsi_3_1h_gt_75)
         and (last_rsi_3_4h_gt_75)
         and (isinstance(last_rsi_14_1d, np.float64) and (last_rsi_14_1d < 50.0))
@@ -52843,7 +52890,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_0_81"
       elif (
         (last_rsi_3_lt_16)
-        and (last_willr_14 < -92.0)
+        and (last_willr_14_lt_neg_92)
         and (last_rsi_3_4h_gt_70)
         and (last_rsi_3_1d > 85.0)
         and (last_stochrsi_k_4h_lt_60)
@@ -52857,11 +52904,11 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_stochrsi_k_4h_lt_60)
       ):
         return True, f"exit_{mode_name}_d_0_83"
-      elif (last_rsi_3_lt_1) and (last_willr_14 < -99.0) and (last_rsi_3_4h_gt_70) and (last_stochrsi_k_1h < 80.0):
+      elif (last_rsi_3_lt_1) and (last_willr_14_lt_neg_99) and (last_rsi_3_4h_gt_70) and (last_stochrsi_k_1h_lt_80):
         return True, f"exit_{mode_name}_d_0_84"
       elif (
         (last_rsi_3_lt_1)
-        and (last_willr_14 < -94.0)
+        and (last_willr_14_lt_neg_94)
         and (last_rsi_3_1h_gt_70)
         and (last_rsi_3_4h_gt_60)
         and (last_stochrsi_k_4h_lt_50)
@@ -52885,7 +52932,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_0_87"
       elif (
         (last_rsi_3_lt_5)
-        and (last_willr_14 < -98.0)
+        and (last_willr_14_lt_neg_98)
         and (last_stochrsi_k_1h_lt_60)
         and (last_stochrsi_k_4h_lt_50)
         and (last_change_pct_1h > 2.0)
@@ -52894,13 +52941,13 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3_lt_10)
         and (last_rsi_14_gt_62)
-        and (last_roc_9_1h > 5.0)
+        and (last_roc_9_1h_gt_5)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -25.0))
       ):
         return True, f"exit_{mode_name}_d_0_89"
       elif (
         (last_rsi_3 < 6.0)
-        and (last_willr_14 < -75.0)
+        and (last_willr_14_lt_neg_75)
         and (last_rsi_3_1h_gt_50)
         and (last_rsi_3_4h_gt_70)
         and (last_aroonu_14_4h_lt_50)
@@ -52920,7 +52967,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3_lt_5)
         and (last_rsi_14_gt_54)
         and (last_rsi_3_1h_gt_60)
-        and (last_stochrsi_k_1h < 75.0)
+        and (last_stochrsi_k_1h_lt_75)
         and (last_stochrsi_k_4h_lt_50)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 25.0))
       ):
@@ -52947,10 +52994,10 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_0_94"
       elif (
         (last_rsi_3_lt_5)
-        and (last_willr_14 < -90.0)
+        and (last_willr_14_lt_neg_90)
         and (last_rsi_3_1h_gt_55)
         and (last_rsi_3_4h_gt_60)
-        and (last_stochrsi_k_4h < 90.0)
+        and (last_stochrsi_k_4h_lt_90)
         and (isinstance(last_aroond_14_1d, np.float64) and (last_aroond_14_1d > 75.0))
       ):
         return True, f"exit_{mode_name}_d_0_95"
@@ -52985,15 +53032,15 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_3_1h > 35.0)
         and (last_rsi_3_4h_gt_40)
         and (last_aroond_14_4h_gt_50)
-        and (last_stoch_k_4h < 60.0)
+        and (last_stoch_k_4h_lt_60)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -80.0))
       ):
         return True, f"exit_{mode_name}_d_0_99"
-      elif (last_rsi_3_lt_1) and (last_rsi_14_lt_22) and (last_rsi_3_15m < 30.0) and (last_rsi_3_4h > 20.0):
+      elif (last_rsi_3_lt_1) and (last_rsi_14_lt_22) and (last_rsi_3_15m_lt_30) and (last_rsi_3_4h > 20.0):
         return True, f"exit_{mode_name}_d_0_100"
       elif (
         (last_rsi_3 < 14.0)
-        and (last_willr_14 < -86.0)
+        and (last_willr_14_lt_neg_86)
         and (last_rsi_3_1h_gt_50)
         and (last_stochrsi_k_4h_lt_60)
         and (isinstance(last_roc_9_4h, np.float64) and (last_roc_9_4h < -40.0))
@@ -53004,7 +53051,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14_gt_54)
         and (last_rsi_3_1h_gt_40)
         and (last_rsi_3_4h_gt_60)
-        and (last_stochrsi_k_4h > 70.0)
+        and (last_stochrsi_k_4h_gt_70)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -40.0))
       ):
         return True, f"exit_{mode_name}_d_0_102"
@@ -53022,7 +53069,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_3_1h_gt_40)
         and (last_stochrsi_k_1h_lt_60)
         and (last_stochrsi_k_4h_lt_10)
-        and (last_roc_9_4h < -40.0)
+        and (last_roc_9_4h_lt_neg_40)
       ):
         return True, f"exit_{mode_name}_d_0_104"
       elif (
@@ -53030,7 +53077,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14_gt_54)
         and (last_rsi_3_15m > 45.0)
         and (last_stochrsi_k_4h_lt_10)
-        and (last_roc_9_4h < -25.0)
+        and (last_roc_9_4h_lt_neg_25)
       ):
         return True, f"exit_{mode_name}_d_0_105"
       elif (
@@ -53039,7 +53086,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_3_1h_gt_50)
         and (last_stochrsi_k_1h_lt_50)
         and (last_rsi_14_4h_lt_30)
-        and (last_roc_9_4h < -40.0)
+        and (last_roc_9_4h_lt_neg_40)
       ):
         return True, f"exit_{mode_name}_d_0_106"
       elif (
@@ -53054,13 +53101,13 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_0_108"
       elif (
         (last_rsi_3_lt_5)
-        and (last_willr_14 < -94.0)
+        and (last_willr_14_lt_neg_94)
         and (last_rsi_3_1h_gt_50)
         and (last_rsi_3_4h_gt_80)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -50.0))
       ):
         return True, f"exit_{mode_name}_d_0_109"
-      elif (last_rsi_3_lt_5) and (last_rsi_3_4h > 35.0) and (last_stochrsi_k_4h_lt_50) and (last_roc_9_4h < -25.0):
+      elif (last_rsi_3_lt_5) and (last_rsi_3_4h > 35.0) and (last_stochrsi_k_4h_lt_50) and (last_roc_9_4h_lt_neg_25):
         return True, f"exit_{mode_name}_d_0_110"
       elif (
         (last_rsi_3_lt_5)
@@ -53074,17 +53121,17 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_0_111"
       elif (
         (last_rsi_3_lt_5)
-        and (last_willr_14 < -80.0)
+        and (last_willr_14_lt_neg_80)
         and (last_rsi_14_gt_50)
         and (last_rsi_3_1h_gt_65)
-        and (last_rsi_3_4h > 65.0)
+        and (last_rsi_3_4h_gt_65)
         and (last_rsi_3_1d > 40.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
       ):
         return True, f"exit_{mode_name}_d_0_112"
       elif (
         (last_rsi_3_lt_5)
-        and (last_willr_14 < -99.0)
+        and (last_willr_14_lt_neg_99)
         and (last_rsi_3_1d_gt_70)
         and (last_stochrsi_k_4h_lt_50)
         and (isinstance(last_roc_9_4h, np.float64) and (last_roc_9_4h < -10.0))
@@ -53102,7 +53149,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3_lt_5)
         and (last_rsi_14_gt_54)
-        and (last_rsi_3_15m > 70.0)
+        and (last_rsi_3_15m_gt_70)
         and (last_stochrsi_k_1h_lt_50)
         and (last_stochrsi_k_4h_lt_50)
       ):
@@ -53115,7 +53162,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_0_118"
       elif (
         (last_rsi_3_lt_5)
-        and (last_willr_14 < -80.0)
+        and (last_willr_14_lt_neg_80)
         and (last_rsi_3_1h_gt_40)
         and (last_rsi_3_4h_gt_40)
         and (last_stochrsi_k_1h_lt_60)
@@ -53127,7 +53174,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_0_121"
       elif (last_rsi_3_lt_5) and (last_rsi_14_gt_58) and (last_rsi_3_4h_gt_70) and (last_stochrsi_k_1h_lt_50):
         return True, f"exit_{mode_name}_d_0_122"
-      elif (last_rsi_3_lt_5) and (last_willr_14 < -98.0) and (last_rsi_3_1h_gt_90) and (last_rsi_3_1d_gt_70):
+      elif (last_rsi_3_lt_5) and (last_willr_14_lt_neg_98) and (last_rsi_3_1h_gt_90) and (last_rsi_3_1d_gt_70):
         return True, f"exit_{mode_name}_d_0_123"
       elif (
         (last_rsi_3_lt_5)
@@ -53137,16 +53184,16 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_0_124"
       elif (
         (last_rsi_3_lt_5)
-        and (last_willr_14 < -98.0)
+        and (last_willr_14_lt_neg_98)
         and (last_rsi_3_1h_gt_90)
         and (last_rsi_3_4h_gt_60)
-        and (last_rsi_3_1d > 60.0)
+        and (last_rsi_3_1d_gt_60)
         and (last_close > (last_low_min_30_1d * 2.0))
       ):
         return True, f"exit_{mode_name}_d_0_125"
       elif (last_rsi_3_lt_5) and (last_rsi_3_1h_gt_85) and (last_rsi_3_4h_gt_60) and (last_stochrsi_k_4h_lt_50):
         return True, f"exit_{mode_name}_d_0_126"
-      elif (last_rsi_3_lt_5) and (last_rsi_3_1h_gt_90) and (last_rsi_3_4h_gt_70) and (last_rsi_3_1d > 60.0):
+      elif (last_rsi_3_lt_5) and (last_rsi_3_1h_gt_90) and (last_rsi_3_4h_gt_70) and (last_rsi_3_1d_gt_60):
         return True, f"exit_{mode_name}_d_0_127"
       elif (last_rsi_3_lt_4) and (last_rsi_3_4h_gt_70) and (last_aroond_14_4h > 85.0):
         return True, f"exit_{mode_name}_d_0_128"
@@ -53168,7 +53215,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3_lt_5)
         and (last_rsi_3_1h_gt_65)
-        and (last_rsi_3_4h > 65.0)
+        and (last_rsi_3_4h_gt_65)
         and (last_aroond_14_1h > 50.0)
         and (last_stochrsi_k_1h_lt_60)
       ):
@@ -53242,7 +53289,7 @@ class NostalgiaForInfinityX7(IStrategy):
       last_rsi_14_4h_lt_30 = last_rsi_14_4h < 30.0
       last_rsi_3_1d_gt_70 = last_rsi_3_1d > 70.0
       if (
-        (last_willr_14 < -99.0)
+        (last_willr_14_lt_neg_99)
         and (last_rsi_14 < 22.0)
         and (isinstance(last_ema_200_1h, np.float64) and (last_ema_12_1h > last_ema_200_1h))
         and (isinstance(last_ema_200_4h, np.float64) and (last_ema_12_4h > last_ema_200_4h))
@@ -53251,35 +53298,35 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_1_1"
       elif (
-        (last_willr_14 < -99.0)
+        (last_willr_14_lt_neg_99)
         and (last_rsi_14 < 32.0)
-        and (last_cmf_20_1h > 0.0)
+        and (last_cmf_20_1h_gt_0)
         and (isinstance(last_ema_200_1h, np.float64) and (last_ema_12_1h > last_ema_200_1h))
         and (isinstance(last_ema_200_4h, np.float64) and (last_ema_12_4h > last_ema_200_4h))
       ):
         return True, f"exit_{mode_name}_d_1_2"
       elif (
-        (last_willr_14 < -92.0)
+        (last_willr_14_lt_neg_92)
         and (last_stochrsi_k < 1.0)
-        and (last_cmf_20_1h > 0.0)
-        and (last_cmf_20_4h > 0.0)
-        and ((last_stochrsi_k_4h_lt_80) and (last_stochrsi_k_change_pct_4h > 10.0))
+        and (last_cmf_20_1h_gt_0)
+        and (last_cmf_20_4h_gt_0)
+        and ((last_stochrsi_k_4h_lt_80) and (last_stochrsi_k_change_pct_4h_gt_10))
       ):
         return True, f"exit_{mode_name}_d_1_3"
       elif (
-        (last_willr_14 < -70.0)
+        (last_willr_14_lt_neg_70)
         and (last_rsi_14 < 35.0)
         and (last_stochrsi_k < 5.0)
-        and (last_stochrsi_k_4h < 30.0)
+        and (last_stochrsi_k_4h_lt_30)
         and (isinstance(last_ema_200_1h, np.float64) and (last_ema_12_1h > last_ema_200_1h))
         and (isinstance(last_ema_200_4h, np.float64) and (last_ema_12_4h > last_ema_200_4h))
       ):
         return True, f"exit_{mode_name}_d_1_4"
-      elif (last_willr_14 < -98.0) and (last_rsi_14 < 28.0) and (last_roc_9_1h > 5.0) and (last_roc_9_4h > 5.0):
+      elif (last_willr_14_lt_neg_98) and (last_rsi_14 < 28.0) and (last_roc_9_1h_gt_5) and (last_roc_9_4h_gt_5):
         return True, f"exit_{mode_name}_d_1_5"
       elif (
         (last_rsi_3_lt_30)
-        and (last_stochrsi_k < 30.0)
+        and (last_stochrsi_k_lt_30)
         and (last_rsi_14_gt_60)
         and (last_roc_9_1h_gt_10)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -50.0))
@@ -53287,13 +53334,13 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_1_6"
       elif (
         (last_rsi_14_gt_50)
-        and (last_stochrsi_k < 30.0)
+        and (last_stochrsi_k_lt_30)
         and (last_stochrsi_k_4h_lt_50)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 40.0))
       ):
         return True, f"exit_{mode_name}_d_1_7"
       elif (
-        (last_willr_14 < -98.0)
+        (last_willr_14_lt_neg_98)
         and (last_stochrsi_k < 5.0)
         and (last_cmf_20_1h > 0.1)
         and (last_cmf_20_4h > 0.1)
@@ -53302,17 +53349,17 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_1_8"
       elif (
-        (last_willr_14 < -98.0)
+        (last_willr_14_lt_neg_98)
         and (last_rsi_3_lt_5)
         and (last_change_pct_4h_gt_5)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
       ):
         return True, f"exit_{mode_name}_d_1_9"
       elif (
-        (last_willr_14 < -80.0)
+        (last_willr_14_lt_neg_80)
         and (last_rsi_14_gt_50)
         and (last_roc_9_1h_gt_10)
-        and (last_roc_9_4h > 10.0)
+        and (last_roc_9_4h_gt_10)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -10.0))
       ):
         return True, f"exit_{mode_name}_d_1_10"
@@ -53329,26 +53376,26 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14_gt_50)
         and (last_rsi_3_4h_gt_90)
         and (last_roc_9_1h > 20.0)
-        and (last_roc_9_4h > 20.0)
+        and (last_roc_9_4h_gt_20)
       ):
         return True, f"exit_{mode_name}_d_1_12"
-      elif (last_rsi_3_lt_20) and (last_rsi_3_4h > 95.0) and (last_roc_9_4h > 25.0):
+      elif (last_rsi_3_lt_20) and (last_rsi_3_4h_gt_95) and (last_roc_9_4h_gt_25):
         return True, f"exit_{mode_name}_d_1_13"
-      elif (last_rsi_3_lt_10) and (last_willr_14 < -96.0) and (last_rsi_3_4h > 95.0) and (last_aroond_14_4h_gt_25):
+      elif (last_rsi_3_lt_10) and (last_willr_14_lt_neg_96) and (last_rsi_3_4h_gt_95) and (last_aroond_14_4h_gt_25):
         return True, f"exit_{mode_name}_d_1_14"
       elif (last_rsi_3_lt_5) and (last_rsi_14 < 25.0) and (last_roc_9_4h > 30.0):
         return True, f"exit_{mode_name}_d_1_15"
       elif (
         (last_rsi_3_lt_5)
         and (last_aroond_14_4h_gt_25)
-        and (last_roc_9_4h > 25.0)
+        and (last_roc_9_4h_gt_25)
         and (last_aroond_14_1d > 50.0)
         and (last_change_pct_1d > 15.0)
       ):
         return True, f"exit_{mode_name}_d_1_16"
       elif (
         (last_rsi_3_lt_10)
-        and (last_willr_14 < -90.0)
+        and (last_willr_14_lt_neg_90)
         and (last_rsi_3_1h_gt_90)
         and (last_stochrsi_k_4h_lt_10)
         and (last_roc_9_4h < -30.0)
@@ -53369,31 +53416,31 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_1_21"
       elif (
         (last_rsi_3_lt_2)
-        and (last_willr_14 < -98.0)
+        and (last_willr_14_lt_neg_98)
         and (last_change_pct_4h_gt_5)
         and (last_stochrsi_k_4h_lt_50)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
       ):
         return True, f"exit_{mode_name}_d_1_22"
-      elif (last_rsi_3_lt_5) and (last_willr_14 < -90.0) and (last_rsi_3_1h_gt_85) and (last_rsi_3_1d > 95.0):
+      elif (last_rsi_3_lt_5) and (last_willr_14_lt_neg_90) and (last_rsi_3_1h_gt_85) and (last_rsi_3_1d > 95.0):
         return True, f"exit_{mode_name}_d_1_23"
       elif (
         (last_rsi_3_lt_5)
         and (last_rsi_14 < 25.0)
-        and (last_willr_14 < -90.0)
+        and (last_willr_14_lt_neg_90)
         and (last_rsi_3_4h_gt_70)
         and (last_aroond_14_4h_gt_75)
       ):
         return True, f"exit_{mode_name}_d_1_24"
       elif (
         (last_rsi_3_lt_10)
-        and (last_willr_14 < -96.0)
+        and (last_willr_14_lt_neg_96)
         and (last_rsi_3_4h_gt_90)
         and (last_roc_9_4h > 15.0)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 50.0))
       ):
         return True, f"exit_{mode_name}_d_1_25"
-      elif (last_rsi_3_lt_15) and (last_willr_14 < -96.0) and (last_rsi_3_4h_gt_85) and (last_roc_9_4h > 20.0):
+      elif (last_rsi_3_lt_15) and (last_willr_14_lt_neg_96) and (last_rsi_3_4h_gt_85) and (last_roc_9_4h_gt_20):
         return True, f"exit_{mode_name}_d_1_26"
       elif (
         (last_rsi_3_lt_35)
@@ -53420,27 +53467,27 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14_gt_50)
         and (last_rsi_3_1h_gt_85)
         and (last_rsi_3_4h_gt_85)
-        and (last_stochrsi_k_1h < 75.0)
+        and (last_stochrsi_k_1h_lt_75)
       ):
         return True, f"exit_{mode_name}_d_1_31"
-      elif (last_rsi_3_lt_10) and (last_rsi_3_1h_gt_85) and (last_roc_2_4h > 30.0) and (last_stochrsi_k_4h_lt_70):
+      elif (last_rsi_3_lt_10) and (last_rsi_3_1h_gt_85) and (last_roc_2_4h_gt_30) and (last_stochrsi_k_4h_lt_70):
         return True, f"exit_{mode_name}_d_1_32"
       elif (
         (last_rsi_3_lt_10)
-        and (last_willr_14 < -98.0)
+        and (last_willr_14_lt_neg_98)
         and (last_roc_2_1h > 10.0)
         and (last_roc_9_1h < -30.0)
         and (last_stochrsi_k_1h_lt_50)
       ):
         return True, f"exit_{mode_name}_d_1_33"
-      elif (last_rsi_3_lt_35) and (last_rsi_3_15m > 70.0) and (last_rsi_14_1h < 20.0) and (last_roc_9_1h < -40.0):
+      elif (last_rsi_3_lt_35) and (last_rsi_3_15m_gt_70) and (last_rsi_14_1h < 20.0) and (last_roc_9_1h < -40.0):
         return True, f"exit_{mode_name}_d_1_34"
-      elif (last_rsi_3_lt_12) and (last_willr_14 < -94.0) and (last_rsi_3_1d_gt_75) and (last_stochrsi_k_1h < 25.0):
+      elif (last_rsi_3_lt_12) and (last_willr_14_lt_neg_94) and (last_rsi_3_1d_gt_75) and (last_stochrsi_k_1h_lt_25):
         return True, f"exit_{mode_name}_d_1_35"
       elif (
         (last_rsi_3_lt_15)
-        and (last_willr_14 < -85.0)
-        and (last_roc_9_4h > 25.0)
+        and (last_willr_14_lt_neg_85)
+        and (last_roc_9_4h_gt_25)
         and (last_rsi_3_1d_gt_75)
         and (last_stochrsi_k_1h_lt_50)
       ):
@@ -53453,13 +53500,13 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_stochrsi_k_4h_lt_50)
       ):
         return True, f"exit_{mode_name}_d_1_37"
-      elif (last_rsi_3_lt_15) and (last_willr_14 < -85.0) and (last_rsi_3_4h_gt_90) and (last_stochrsi_k_4h_lt_80):
+      elif (last_rsi_3_lt_15) and (last_willr_14_lt_neg_85) and (last_rsi_3_4h_gt_90) and (last_stochrsi_k_4h_lt_80):
         return True, f"exit_{mode_name}_d_1_38"
-      elif (last_rsi_3_lt_5) and (last_willr_14 < -95.0) and (last_cmf_20_4h > 0.0) and (last_rsi_3_4h_gt_90):
+      elif (last_rsi_3_lt_5) and (last_willr_14_lt_neg_95) and (last_cmf_20_4h_gt_0) and (last_rsi_3_4h_gt_90):
         return True, f"exit_{mode_name}_d_1_39"
       elif (
         (last_rsi_3_lt_15)
-        and (last_willr_14 < -85.0)
+        and (last_willr_14_lt_neg_85)
         and (last_rsi_3_1h_gt_70)
         and (last_stochrsi_k_1h_lt_70)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 10.0))
@@ -53467,7 +53514,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_1_40"
       elif (
         (last_rsi_3_lt_5)
-        and (last_willr_14 < -90.0)
+        and (last_willr_14_lt_neg_90)
         and (last_rsi_3_1h_gt_70)
         and (last_stochrsi_k_4h_lt_75)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -50.0))
@@ -53475,7 +53522,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_1_41"
       elif (
         (last_rsi_3_lt_10)
-        and (last_willr_14 < -75.0)
+        and (last_willr_14_lt_neg_75)
         and (last_stochrsi_k_4h_lt_70)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -40.0))
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 30.0))
@@ -53491,13 +53538,13 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_1_43"
       elif (
         (last_rsi_3_lt_35)
-        and (last_willr_14 < -95.0)
+        and (last_willr_14_lt_neg_95)
         and (last_rsi_3_4h_gt_70)
         and (last_rsi_3_1d > 25.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
       ):
         return True, f"exit_{mode_name}_d_1_44"
-      elif (last_rsi_3_lt_6) and (last_willr_14 < -94.0) and (last_rsi_3_1h_gt_90):
+      elif (last_rsi_3_lt_6) and (last_willr_14_lt_neg_94) and (last_rsi_3_1h_gt_90):
         return True, f"exit_{mode_name}_d_1_45"
       elif (last_rsi_3_lt_30) and (last_rsi_3_1h_gt_85) and (last_rsi_3_4h_gt_90) and (last_roc_2_1d > 20.0):
         return True, f"exit_{mode_name}_d_1_46"
@@ -53519,20 +53566,20 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_1_48"
       elif (
         (last_rsi_3_lt_10)
-        and (last_willr_14 < -96.0)
+        and (last_willr_14_lt_neg_96)
         and (last_rsi_3_4h_gt_80)
         and (last_change_pct_1d_gt_5)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 50.0))
       ):
         return True, f"exit_{mode_name}_d_1_49"
-      elif (last_rsi_3_lt_20) and (last_willr_14 < -96.0) and (last_rsi_3_1d > 90.0) and (last_stochrsi_k_1h < 10.0):
+      elif (last_rsi_3_lt_20) and (last_willr_14_lt_neg_96) and (last_rsi_3_1d > 90.0) and (last_stochrsi_k_1h_lt_10):
         return True, f"exit_{mode_name}_d_1_50"
       elif (last_rsi_3_lt_34) and (last_rsi_14_gt_54) and (last_rsi_3_4h_gt_80) and (last_stochrsi_k_1h_lt_50):
         return True, f"exit_{mode_name}_d_1_51"
       elif (
         (last_rsi_3_lt_20)
         and (last_rsi_14 < 40.0)
-        and (last_willr_14 < -90.0)
+        and (last_willr_14_lt_neg_90)
         and (last_stochrsi_k_1h_lt_30)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 15.0))
       ):
@@ -53540,7 +53587,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3_lt_30)
         and (last_rsi_14_gt_50)
-        and (last_willr_14 < -75.0)
+        and (last_willr_14_lt_neg_75)
         and (last_rsi_3_1h_gt_80)
         and (last_stochrsi_k_4h_lt_50)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 50.0))
@@ -53550,14 +53597,14 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3_lt_22)
         and (last_rsi_14_gt_54)
         and (last_stochrsi_k_1h_lt_50)
-        and (last_roc_9_4h > 10.0)
+        and (last_roc_9_4h_gt_10)
         and (last_change_pct_1d > 10.0)
       ):
         return True, f"exit_{mode_name}_d_1_54"
       elif (
         (last_rsi_3_lt_6)
-        and (last_willr_14 < -86.0)
-        and (last_roc_9_4h > 5.0)
+        and (last_willr_14_lt_neg_86)
+        and (last_roc_9_4h_gt_5)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -10.0))
         and (last_stochrsi_k_1h_lt_50)
       ):
@@ -53568,14 +53615,14 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_3_1h_gt_70)
         and (last_rsi_3_4h_gt_75)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
-        and (last_stochrsi_k_4h < 90.0)
+        and (last_stochrsi_k_4h_lt_90)
       ):
         return True, f"exit_{mode_name}_d_1_56"
       elif (
         (last_rsi_3_lt_50)
         and (last_rsi_14 > 64.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
-        and (last_stochrsi_k_4h < 30.0)
+        and (last_stochrsi_k_4h_lt_30)
       ):
         return True, f"exit_{mode_name}_d_1_57"
       elif (
@@ -53588,7 +53635,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_1_58"
       elif (
         (last_rsi_3_lt_15)
-        and (last_willr_14 < -88.0)
+        and (last_willr_14_lt_neg_88)
         and (last_rsi_3_4h_gt_75)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 15.0))
         and (last_stochrsi_k_4h_lt_60)
@@ -53599,14 +53646,14 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14_gt_60)
         and (last_rsi_14_4h < 35.0)
         and (last_stochrsi_k_4h_lt_50)
-        and (last_stochrsi_k_1d < 50.0)
+        and (last_stochrsi_k_1d_lt_50)
       ):
         return True, f"exit_{mode_name}_d_1_60"
-      elif (last_rsi_3_lt_10) and (last_willr_14 < -75.0) and (last_rsi_3_4h_gt_90) and (last_stochrsi_k_1h_lt_70):
+      elif (last_rsi_3_lt_10) and (last_willr_14_lt_neg_75) and (last_rsi_3_4h_gt_90) and (last_stochrsi_k_1h_lt_70):
         return True, f"exit_{mode_name}_d_1_61"
       elif (
         (last_rsi_3_lt_14)
-        and (last_willr_14 < -98.0)
+        and (last_willr_14_lt_neg_98)
         and (last_rsi_3_1h_gt_70)
         and (last_rsi_3_4h_gt_80)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -20.0))
@@ -53629,7 +53676,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3_lt_50)
         and (last_rsi_14_gt_58)
-        and (last_stochrsi_k_4h < 20.0)
+        and (last_stochrsi_k_4h_lt_20)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 25.0))
       ):
         return True, f"exit_{mode_name}_d_1_67"
@@ -53637,7 +53684,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3_lt_16)
         and (last_rsi_14_gt_52)
         and (last_rsi_3_1h_gt_75)
-        and (last_roc_2_4h > 30.0)
+        and (last_roc_2_4h_gt_30)
         and (last_stochrsi_k_4h_lt_75)
       ):
         return True, f"exit_{mode_name}_d_1_68"
@@ -53645,7 +53692,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_1_69"
       elif (last_rsi_3_lt_34) and (last_rsi_14_gt_60) and (last_rsi_3_1h_gt_75) and (last_stochrsi_k_4h_lt_80):
         return True, f"exit_{mode_name}_d_1_70"
-      elif (last_rsi_3 < 36.0) and (last_rsi_14_gt_56) and (last_rsi_3_4h_gt_75) and (last_stochrsi_k_1h < 80.0):
+      elif (last_rsi_3 < 36.0) and (last_rsi_14_gt_56) and (last_rsi_3_4h_gt_75) and (last_stochrsi_k_1h_lt_80):
         return True, f"exit_{mode_name}_d_1_71"
       elif (last_rsi_3_lt_22) and (last_rsi_14_gt_58) and (last_rsi_3_1h_gt_90) and (last_aroond_14_4h_gt_25):
         return True, f"exit_{mode_name}_d_1_72"
@@ -53653,16 +53700,16 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3_lt_22)
         and (last_rsi_3_1h_gt_75)
         and (last_rsi_3_4h_gt_85)
-        and (last_roc_9_4h > 20.0)
+        and (last_roc_9_4h_gt_20)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 25.0))
       ):
         return True, f"exit_{mode_name}_d_1_73"
       elif (
         (last_rsi_3_lt_2)
-        and (last_willr_14 < -90.0)
+        and (last_willr_14_lt_neg_90)
         and (last_rsi_3_4h_gt_75)
         and (last_rsi_3_1d_gt_75)
-        and (last_stochrsi_k_1h > 50.0)
+        and (last_stochrsi_k_1h_gt_50)
       ):
         return True, f"exit_{mode_name}_d_1_74"
       elif (
@@ -53672,7 +53719,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 50.0))
       ):
         return True, f"exit_{mode_name}_d_1_75"
-      elif (last_rsi_3_lt_32) and (last_rsi_14_gt_50) and (last_roc_9_1h < -80.0) and (last_stochrsi_k_4h < 20.0):
+      elif (last_rsi_3_lt_32) and (last_rsi_14_gt_50) and (last_roc_9_1h < -80.0) and (last_stochrsi_k_4h_lt_20):
         return True, f"exit_{mode_name}_d_1_76"
       elif (
         (last_rsi_3_lt_24)
@@ -53683,13 +53730,13 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_1_77"
       elif (
         (last_rsi_3_lt_14)
-        and (last_willr_14 < -84.0)
+        and (last_willr_14_lt_neg_84)
         and (last_rsi_3_1h_gt_70)
         and (last_rsi_3_4h_gt_80)
         and (last_rsi_3_1d > 80.0)
       ):
         return True, f"exit_{mode_name}_d_1_78"
-      elif (last_rsi_3 < 8.0) and (last_willr_14 < -98.0) and (last_rsi_3_1h_gt_70) and (last_rsi_3_4h_gt_90):
+      elif (last_rsi_3 < 8.0) and (last_willr_14_lt_neg_98) and (last_rsi_3_1h_gt_70) and (last_rsi_3_4h_gt_90):
         return True, f"exit_{mode_name}_d_1_79"
       elif (
         (last_rsi_3_lt_28)
@@ -53701,7 +53748,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_1_80"
       elif (
         (last_rsi_3_lt_16)
-        and (last_willr_14 < -90.0)
+        and (last_willr_14_lt_neg_90)
         and (last_rsi_3_1h_gt_75)
         and (last_rsi_3_4h_gt_75)
         and (isinstance(last_rsi_14_1d, np.float64) and (last_rsi_14_1d < 50.0))
@@ -53709,7 +53756,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_1_81"
       elif (
         (last_rsi_3_lt_18)
-        and (last_willr_14 < -90.0)
+        and (last_willr_14_lt_neg_90)
         and (last_rsi_3_4h_gt_70)
         and (last_rsi_3_1d > 85.0)
         and (last_stochrsi_k_4h_lt_60)
@@ -53723,11 +53770,11 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_stochrsi_k_4h_lt_60)
       ):
         return True, f"exit_{mode_name}_d_1_83"
-      elif (last_rsi_3_lt_10) and (last_willr_14 < -98.0) and (last_rsi_3_4h_gt_70) and (last_stochrsi_k_1h < 80.0):
+      elif (last_rsi_3_lt_10) and (last_willr_14_lt_neg_98) and (last_rsi_3_4h_gt_70) and (last_stochrsi_k_1h_lt_80):
         return True, f"exit_{mode_name}_d_1_84"
       elif (
         (last_rsi_3_lt_12)
-        and (last_willr_14 < -92.0)
+        and (last_willr_14_lt_neg_92)
         and (last_rsi_3_1h_gt_70)
         and (last_rsi_3_4h_gt_60)
         and (last_stochrsi_k_4h_lt_50)
@@ -53751,7 +53798,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_1_87"
       elif (
         (last_rsi_3_lt_12)
-        and (last_willr_14 < -80.0)
+        and (last_willr_14_lt_neg_80)
         and (last_stochrsi_k_1h_lt_60)
         and (last_stochrsi_k_4h_lt_50)
         and (last_change_pct_1h > 2.0)
@@ -53760,13 +53807,13 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3_lt_22)
         and (last_rsi_14_gt_60)
-        and (last_roc_9_1h > 5.0)
+        and (last_roc_9_1h_gt_5)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -25.0))
       ):
         return True, f"exit_{mode_name}_d_1_89"
       elif (
         (last_rsi_3 < 8.0)
-        and (last_willr_14 < -75.0)
+        and (last_willr_14_lt_neg_75)
         and (last_rsi_3_1h_gt_50)
         and (last_rsi_3_4h_gt_70)
         and (last_aroonu_14_4h_lt_50)
@@ -53786,7 +53833,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3_lt_20)
         and (last_rsi_14_gt_52)
         and (last_rsi_3_1h_gt_60)
-        and (last_stochrsi_k_1h < 75.0)
+        and (last_stochrsi_k_1h_lt_75)
         and (last_stochrsi_k_4h_lt_50)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 25.0))
       ):
@@ -53813,10 +53860,10 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_1_94"
       elif (
         (last_rsi_3_lt_16)
-        and (last_willr_14 < -88.0)
+        and (last_willr_14_lt_neg_88)
         and (last_rsi_3_1h_gt_55)
         and (last_rsi_3_4h_gt_60)
-        and (last_stochrsi_k_4h < 90.0)
+        and (last_stochrsi_k_4h_lt_90)
         and (isinstance(last_aroond_14_1d, np.float64) and (last_aroond_14_1d > 75.0))
       ):
         return True, f"exit_{mode_name}_d_1_95"
@@ -53851,15 +53898,15 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_3_1h > 35.0)
         and (last_rsi_3_4h_gt_40)
         and (last_aroond_14_4h_gt_50)
-        and (last_stoch_k_4h < 60.0)
+        and (last_stoch_k_4h_lt_60)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -80.0))
       ):
         return True, f"exit_{mode_name}_d_1_99"
-      elif (last_rsi_3_lt_2) and (last_rsi_14 < 24.0) and (last_rsi_3_15m < 30.0) and (last_rsi_3_4h > 20.0):
+      elif (last_rsi_3_lt_2) and (last_rsi_14 < 24.0) and (last_rsi_3_15m_lt_30) and (last_rsi_3_4h > 20.0):
         return True, f"exit_{mode_name}_d_1_100"
       elif (
         (last_rsi_3_lt_16)
-        and (last_willr_14 < -84.0)
+        and (last_willr_14_lt_neg_84)
         and (last_rsi_3_1h_gt_50)
         and (last_stochrsi_k_4h_lt_60)
         and (isinstance(last_roc_9_4h, np.float64) and (last_roc_9_4h < -40.0))
@@ -53870,7 +53917,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14_gt_52)
         and (last_rsi_3_1h_gt_40)
         and (last_rsi_3_4h_gt_60)
-        and (last_stochrsi_k_4h > 70.0)
+        and (last_stochrsi_k_4h_gt_70)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -40.0))
       ):
         return True, f"exit_{mode_name}_d_1_102"
@@ -53888,7 +53935,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_3_1h_gt_40)
         and (last_stochrsi_k_1h_lt_60)
         and (last_stochrsi_k_4h_lt_10)
-        and (last_roc_9_4h < -40.0)
+        and (last_roc_9_4h_lt_neg_40)
       ):
         return True, f"exit_{mode_name}_d_1_104"
       elif (
@@ -53896,7 +53943,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14_gt_52)
         and (last_rsi_3_15m > 45.0)
         and (last_stochrsi_k_4h_lt_10)
-        and (last_roc_9_4h < -25.0)
+        and (last_roc_9_4h_lt_neg_25)
       ):
         return True, f"exit_{mode_name}_d_1_105"
       elif (
@@ -53905,7 +53952,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_3_1h_gt_50)
         and (last_stochrsi_k_1h_lt_50)
         and (last_rsi_14_4h_lt_30)
-        and (last_roc_9_4h < -40.0)
+        and (last_roc_9_4h_lt_neg_40)
       ):
         return True, f"exit_{mode_name}_d_1_106"
       elif (
@@ -53916,17 +53963,17 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14_4h < 50.0)
       ):
         return True, f"exit_{mode_name}_d_1_107"
-      elif (last_rsi_3 < 44.0) and (last_rsi_14_gt_52) and (last_rsi_3_1h_gt_40) and (last_stochrsi_k_1h_lt_20):
+      elif (last_rsi_3_lt_44) and (last_rsi_14_gt_52) and (last_rsi_3_1h_gt_40) and (last_stochrsi_k_1h_lt_20):
         return True, f"exit_{mode_name}_d_1_108"
       elif (
         (last_rsi_3_lt_24)
-        and (last_willr_14 < -92.0)
+        and (last_willr_14_lt_neg_92)
         and (last_rsi_3_1h_gt_50)
         and (last_rsi_3_4h_gt_80)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -50.0))
       ):
         return True, f"exit_{mode_name}_d_1_109"
-      elif (last_rsi_3_lt_28) and (last_rsi_3_4h > 35.0) and (last_stochrsi_k_4h_lt_50) and (last_roc_9_4h < -25.0):
+      elif (last_rsi_3_lt_28) and (last_rsi_3_4h > 35.0) and (last_stochrsi_k_4h_lt_50) and (last_roc_9_4h_lt_neg_25):
         return True, f"exit_{mode_name}_d_1_110"
       elif (
         (last_rsi_3_lt_50)
@@ -53940,17 +53987,17 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_1_111"
       elif (
         (last_rsi_3_lt_20)
-        and (last_willr_14 < -75.0)
+        and (last_willr_14_lt_neg_75)
         and (last_rsi_14 > 48.0)
         and (last_rsi_3_1h_gt_65)
-        and (last_rsi_3_4h > 65.0)
+        and (last_rsi_3_4h_gt_65)
         and (last_rsi_3_1d > 40.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
       ):
         return True, f"exit_{mode_name}_d_1_112"
       elif (
         (last_rsi_3_lt_16)
-        and (last_willr_14 < -98.0)
+        and (last_willr_14_lt_neg_98)
         and (last_rsi_3_1d_gt_70)
         and (last_stochrsi_k_4h_lt_50)
         and (isinstance(last_roc_9_4h, np.float64) and (last_roc_9_4h < -10.0))
@@ -53968,7 +54015,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3_lt_22)
         and (last_rsi_14_gt_52)
-        and (last_rsi_3_15m > 70.0)
+        and (last_rsi_3_15m_gt_70)
         and (last_stochrsi_k_1h_lt_50)
         and (last_stochrsi_k_4h_lt_50)
       ):
@@ -53981,7 +54028,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_1_118"
       elif (
         (last_rsi_3_lt_14)
-        and (last_willr_14 < -80.0)
+        and (last_willr_14_lt_neg_80)
         and (last_rsi_3_1h_gt_40)
         and (last_rsi_3_4h_gt_40)
         and (last_stochrsi_k_1h_lt_60)
@@ -53991,9 +54038,9 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_1_120"
       elif (last_rsi_3_lt_40) and (last_rsi_14_gt_54) and (last_rsi_3_1h_gt_50) and (last_rsi_14_4h < 15.0):
         return True, f"exit_{mode_name}_d_1_121"
-      elif (last_rsi_3 < 42.0) and (last_rsi_14_gt_56) and (last_rsi_3_4h_gt_70) and (last_stochrsi_k_1h_lt_50):
+      elif (last_rsi_3_lt_42) and (last_rsi_14_gt_56) and (last_rsi_3_4h_gt_70) and (last_stochrsi_k_1h_lt_50):
         return True, f"exit_{mode_name}_d_1_122"
-      elif (last_rsi_3_lt_12) and (last_willr_14 < -96.0) and (last_rsi_3_1h_gt_90) and (last_rsi_3_1d_gt_70):
+      elif (last_rsi_3_lt_12) and (last_willr_14_lt_neg_96) and (last_rsi_3_1h_gt_90) and (last_rsi_3_1d_gt_70):
         return True, f"exit_{mode_name}_d_1_123"
       elif (
         (last_rsi_3_lt_12)
@@ -54003,16 +54050,16 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_1_124"
       elif (
         (last_rsi_3_lt_24)
-        and (last_willr_14 < -96.0)
+        and (last_willr_14_lt_neg_96)
         and (last_rsi_3_1h_gt_90)
         and (last_rsi_3_4h_gt_60)
-        and (last_rsi_3_1d > 60.0)
+        and (last_rsi_3_1d_gt_60)
         and (last_close > (last_low_min_30_1d * 2.0))
       ):
         return True, f"exit_{mode_name}_d_1_125"
       elif (last_rsi_3_lt_10) and (last_rsi_3_1h_gt_85) and (last_rsi_3_4h_gt_60) and (last_stochrsi_k_4h_lt_50):
         return True, f"exit_{mode_name}_d_1_126"
-      elif (last_rsi_3_lt_10) and (last_rsi_3_1h_gt_90) and (last_rsi_3_4h_gt_70) and (last_rsi_3_1d > 60.0):
+      elif (last_rsi_3_lt_10) and (last_rsi_3_1h_gt_90) and (last_rsi_3_4h_gt_70) and (last_rsi_3_1d_gt_60):
         return True, f"exit_{mode_name}_d_1_127"
       elif (last_rsi_3_lt_6) and (last_rsi_3_4h_gt_70) and (last_aroond_14_4h > 85.0):
         return True, f"exit_{mode_name}_d_1_128"
@@ -54034,7 +54081,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3_lt_20)
         and (last_rsi_3_1h_gt_65)
-        and (last_rsi_3_4h > 65.0)
+        and (last_rsi_3_4h_gt_65)
         and (last_aroond_14_1h > 50.0)
         and (last_stochrsi_k_1h_lt_60)
       ):
@@ -54107,7 +54154,7 @@ class NostalgiaForInfinityX7(IStrategy):
       last_rsi_14_4h_lt_30 = last_rsi_14_4h < 30.0
       last_rsi_3_1d_gt_70 = last_rsi_3_1d > 70.0
       if (
-        (last_willr_14 < -99.0)
+        (last_willr_14_lt_neg_99)
         and (last_rsi_14 < 22.0)
         and (isinstance(last_ema_200_1h, np.float64) and (last_ema_12_1h > last_ema_200_1h))
         and (isinstance(last_ema_200_4h, np.float64) and (last_ema_12_4h > last_ema_200_4h))
@@ -54116,35 +54163,35 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_2_1"
       elif (
-        (last_willr_14 < -99.0)
+        (last_willr_14_lt_neg_99)
         and (last_rsi_14 < 34.0)
-        and (last_cmf_20_1h > 0.0)
+        and (last_cmf_20_1h_gt_0)
         and (isinstance(last_ema_200_1h, np.float64) and (last_ema_12_1h > last_ema_200_1h))
         and (isinstance(last_ema_200_4h, np.float64) and (last_ema_12_4h > last_ema_200_4h))
       ):
         return True, f"exit_{mode_name}_d_2_2"
       elif (
-        (last_willr_14 < -90.0)
+        (last_willr_14_lt_neg_90)
         and (last_stochrsi_k < 1.0)
-        and (last_cmf_20_1h > 0.0)
-        and (last_cmf_20_4h > 0.0)
-        and ((last_stochrsi_k_4h_lt_80) and (last_stochrsi_k_change_pct_4h > 10.0))
+        and (last_cmf_20_1h_gt_0)
+        and (last_cmf_20_4h_gt_0)
+        and ((last_stochrsi_k_4h_lt_80) and (last_stochrsi_k_change_pct_4h_gt_10))
       ):
         return True, f"exit_{mode_name}_d_2_3"
       elif (
-        (last_willr_14 < -70.0)
+        (last_willr_14_lt_neg_70)
         and (last_rsi_14 < 35.0)
         and (last_stochrsi_k < 5.0)
-        and (last_stochrsi_k_4h < 30.0)
+        and (last_stochrsi_k_4h_lt_30)
         and (isinstance(last_ema_200_1h, np.float64) and (last_ema_12_1h > last_ema_200_1h))
         and (isinstance(last_ema_200_4h, np.float64) and (last_ema_12_4h > last_ema_200_4h))
       ):
         return True, f"exit_{mode_name}_d_2_4"
-      elif (last_willr_14 < -96.0) and (last_rsi_14_lt_30) and (last_roc_9_1h > 5.0) and (last_roc_9_4h > 5.0):
+      elif (last_willr_14_lt_neg_96) and (last_rsi_14_lt_30) and (last_roc_9_1h_gt_5) and (last_roc_9_4h_gt_5):
         return True, f"exit_{mode_name}_d_2_5"
       elif (
         (last_rsi_3_lt_30)
-        and (last_stochrsi_k < 30.0)
+        and (last_stochrsi_k_lt_30)
         and (last_rsi_14 > 60.0)
         and (last_roc_9_1h_gt_10)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -50.0))
@@ -54152,13 +54199,13 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_2_6"
       elif (
         (last_rsi_14_gt_50)
-        and (last_stochrsi_k < 30.0)
+        and (last_stochrsi_k_lt_30)
         and (last_stochrsi_k_4h_lt_50)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 40.0))
       ):
         return True, f"exit_{mode_name}_d_2_7"
       elif (
-        (last_willr_14 < -96.0)
+        (last_willr_14_lt_neg_96)
         and (last_stochrsi_k < 5.0)
         and (last_cmf_20_1h > 0.1)
         and (last_cmf_20_4h > 0.1)
@@ -54167,17 +54214,17 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_2_8"
       elif (
-        (last_willr_14 < -96.0)
+        (last_willr_14_lt_neg_96)
         and (last_rsi_3 < 5.0)
         and (last_change_pct_4h_gt_5)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
       ):
         return True, f"exit_{mode_name}_d_2_9"
       elif (
-        (last_willr_14 < -80.0)
+        (last_willr_14_lt_neg_80)
         and (last_rsi_14_gt_50)
         and (last_roc_9_1h_gt_10)
-        and (last_roc_9_4h > 10.0)
+        and (last_roc_9_4h_gt_10)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -10.0))
       ):
         return True, f"exit_{mode_name}_d_2_10"
@@ -54194,26 +54241,26 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14_gt_50)
         and (last_rsi_3_4h_gt_90)
         and (last_roc_9_1h > 20.0)
-        and (last_roc_9_4h > 20.0)
+        and (last_roc_9_4h_gt_20)
       ):
         return True, f"exit_{mode_name}_d_2_12"
-      elif (last_rsi_3_lt_20) and (last_rsi_3_4h > 95.0) and (last_roc_9_4h > 25.0):
+      elif (last_rsi_3_lt_20) and (last_rsi_3_4h_gt_95) and (last_roc_9_4h_gt_25):
         return True, f"exit_{mode_name}_d_2_13"
-      elif (last_rsi_3_lt_10) and (last_willr_14 < -94.0) and (last_rsi_3_4h > 95.0) and (last_aroond_14_4h_gt_25):
+      elif (last_rsi_3_lt_10) and (last_willr_14_lt_neg_94) and (last_rsi_3_4h_gt_95) and (last_aroond_14_4h_gt_25):
         return True, f"exit_{mode_name}_d_2_14"
       elif (last_rsi_3_lt_8) and (last_rsi_14_lt_30) and (last_roc_9_4h > 30.0):
         return True, f"exit_{mode_name}_d_2_15"
       elif (
         (last_rsi_3_lt_30)
         and (last_aroond_14_4h_gt_25)
-        and (last_roc_9_4h > 25.0)
+        and (last_roc_9_4h_gt_25)
         and (last_aroond_14_1d > 50.0)
         and (last_change_pct_1d > 15.0)
       ):
         return True, f"exit_{mode_name}_d_2_16"
       elif (
         (last_rsi_3_lt_20)
-        and (last_willr_14 < -80.0)
+        and (last_willr_14_lt_neg_80)
         and (last_rsi_3_1h_gt_90)
         and (last_stochrsi_k_4h_lt_10)
         and (last_roc_9_4h < -30.0)
@@ -54234,31 +54281,31 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_2_21"
       elif (
         (last_rsi_3 < 4.0)
-        and (last_willr_14 < -96.0)
+        and (last_willr_14_lt_neg_96)
         and (last_change_pct_4h_gt_5)
         and (last_stochrsi_k_4h_lt_50)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
       ):
         return True, f"exit_{mode_name}_d_2_22"
-      elif (last_rsi_3_lt_10) and (last_willr_14 < -85.0) and (last_rsi_3_1h_gt_85) and (last_rsi_3_1d > 95.0):
+      elif (last_rsi_3_lt_10) and (last_willr_14_lt_neg_85) and (last_rsi_3_1h_gt_85) and (last_rsi_3_1d > 95.0):
         return True, f"exit_{mode_name}_d_2_23"
       elif (
         (last_rsi_3_lt_10)
         and (last_rsi_14_lt_30)
-        and (last_willr_14 < -80.0)
+        and (last_willr_14_lt_neg_80)
         and (last_rsi_3_4h_gt_70)
         and (last_aroond_14_4h_gt_75)
       ):
         return True, f"exit_{mode_name}_d_2_24"
       elif (
         (last_rsi_3_lt_15)
-        and (last_willr_14 < -94.0)
+        and (last_willr_14_lt_neg_94)
         and (last_rsi_3_4h_gt_90)
         and (last_roc_9_4h > 15.0)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 50.0))
       ):
         return True, f"exit_{mode_name}_d_2_25"
-      elif (last_rsi_3_lt_20) and (last_willr_14 < -94.0) and (last_rsi_3_4h_gt_85) and (last_roc_9_4h > 20.0):
+      elif (last_rsi_3_lt_20) and (last_willr_14_lt_neg_94) and (last_rsi_3_4h_gt_85) and (last_roc_9_4h_gt_20):
         return True, f"exit_{mode_name}_d_2_26"
       elif (
         (last_rsi_3_lt_35)
@@ -54285,27 +54332,27 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14_gt_50)
         and (last_rsi_3_1h_gt_85)
         and (last_rsi_3_4h_gt_85)
-        and (last_stochrsi_k_1h < 75.0)
+        and (last_stochrsi_k_1h_lt_75)
       ):
         return True, f"exit_{mode_name}_d_2_31"
-      elif (last_rsi_3_lt_15) and (last_rsi_3_1h_gt_85) and (last_roc_2_4h > 30.0) and (last_stochrsi_k_4h_lt_70):
+      elif (last_rsi_3_lt_15) and (last_rsi_3_1h_gt_85) and (last_roc_2_4h_gt_30) and (last_stochrsi_k_4h_lt_70):
         return True, f"exit_{mode_name}_d_2_32"
       elif (
         (last_rsi_3_lt_15)
-        and (last_willr_14 < -96.0)
+        and (last_willr_14_lt_neg_96)
         and (last_roc_2_1h > 10.0)
         and (last_roc_9_1h < -30.0)
         and (last_stochrsi_k_1h_lt_50)
       ):
         return True, f"exit_{mode_name}_d_2_33"
-      elif (last_rsi_3_lt_35) and (last_rsi_3_15m > 70.0) and (last_rsi_14_1h < 20.0) and (last_roc_9_1h < -40.0):
+      elif (last_rsi_3_lt_35) and (last_rsi_3_15m_gt_70) and (last_rsi_14_1h < 20.0) and (last_roc_9_1h < -40.0):
         return True, f"exit_{mode_name}_d_2_34"
-      elif (last_rsi_3_lt_14) and (last_willr_14 < -93.0) and (last_rsi_3_1d_gt_75) and (last_stochrsi_k_1h < 25.0):
+      elif (last_rsi_3_lt_14) and (last_willr_14 < -93.0) and (last_rsi_3_1d_gt_75) and (last_stochrsi_k_1h_lt_25):
         return True, f"exit_{mode_name}_d_2_35"
       elif (
         (last_rsi_3_lt_20)
-        and (last_willr_14 < -80.0)
-        and (last_roc_9_4h > 25.0)
+        and (last_willr_14_lt_neg_80)
+        and (last_roc_9_4h_gt_25)
         and (last_rsi_3_1d_gt_75)
         and (last_stochrsi_k_1h_lt_50)
       ):
@@ -54318,13 +54365,13 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_stochrsi_k_4h_lt_50)
       ):
         return True, f"exit_{mode_name}_d_2_37"
-      elif (last_rsi_3_lt_20) and (last_willr_14 < -80.0) and (last_rsi_3_4h_gt_90) and (last_stochrsi_k_4h_lt_80):
+      elif (last_rsi_3_lt_20) and (last_willr_14_lt_neg_80) and (last_rsi_3_4h_gt_90) and (last_stochrsi_k_4h_lt_80):
         return True, f"exit_{mode_name}_d_2_38"
-      elif (last_rsi_3 < 6.0) and (last_willr_14 < -94.0) and (last_cmf_20_4h > 0.0) and (last_rsi_3_4h_gt_90):
+      elif (last_rsi_3 < 6.0) and (last_willr_14_lt_neg_94) and (last_cmf_20_4h_gt_0) and (last_rsi_3_4h_gt_90):
         return True, f"exit_{mode_name}_d_2_39"
       elif (
         (last_rsi_3_lt_20)
-        and (last_willr_14 < -80.0)
+        and (last_willr_14_lt_neg_80)
         and (last_rsi_3_1h_gt_70)
         and (last_stochrsi_k_1h_lt_70)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 10.0))
@@ -54332,7 +54379,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_2_40"
       elif (
         (last_rsi_3_lt_10)
-        and (last_willr_14 < -85.0)
+        and (last_willr_14_lt_neg_85)
         and (last_rsi_3_1h_gt_70)
         and (last_stochrsi_k_4h_lt_75)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -50.0))
@@ -54340,7 +54387,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_2_41"
       elif (
         (last_rsi_3_lt_15)
-        and (last_willr_14 < -70.0)
+        and (last_willr_14_lt_neg_70)
         and (last_stochrsi_k_4h_lt_70)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -40.0))
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 30.0))
@@ -54356,13 +54403,13 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_2_43"
       elif (
         (last_rsi_3_lt_40)
-        and (last_willr_14 < -90.0)
+        and (last_willr_14_lt_neg_90)
         and (last_rsi_3_4h_gt_70)
         and (last_rsi_3_1d > 25.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
       ):
         return True, f"exit_{mode_name}_d_2_44"
-      elif (last_rsi_3_lt_8) and (last_willr_14 < -92.0) and (last_rsi_3_1h_gt_90):
+      elif (last_rsi_3_lt_8) and (last_willr_14_lt_neg_92) and (last_rsi_3_1h_gt_90):
         return True, f"exit_{mode_name}_d_2_45"
       elif (last_rsi_3_lt_30) and (last_rsi_3_1h_gt_85) and (last_rsi_3_4h_gt_90) and (last_roc_2_1d > 20.0):
         return True, f"exit_{mode_name}_d_2_46"
@@ -54384,20 +54431,20 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_2_48"
       elif (
         (last_rsi_3_lt_15)
-        and (last_willr_14 < -94.0)
+        and (last_willr_14_lt_neg_94)
         and (last_rsi_3_4h_gt_80)
         and (last_change_pct_1d_gt_5)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 50.0))
       ):
         return True, f"exit_{mode_name}_d_2_49"
-      elif (last_rsi_3_lt_20) and (last_willr_14 < -94.0) and (last_rsi_3_1d > 90.0) and (last_stochrsi_k_1h < 10.0):
+      elif (last_rsi_3_lt_20) and (last_willr_14_lt_neg_94) and (last_rsi_3_1d > 90.0) and (last_stochrsi_k_1h_lt_10):
         return True, f"exit_{mode_name}_d_2_50"
       elif (last_rsi_3_lt_36) and (last_rsi_14_gt_52) and (last_rsi_3_4h_gt_80) and (last_stochrsi_k_1h_lt_50):
         return True, f"exit_{mode_name}_d_2_51"
       elif (
         (last_rsi_3_lt_22)
         and (last_rsi_14 < 42.0)
-        and (last_willr_14 < -90.0)
+        and (last_willr_14_lt_neg_90)
         and (last_stochrsi_k_1h_lt_30)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 15.0))
       ):
@@ -54405,7 +54452,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3_lt_30)
         and (last_rsi_14_gt_50)
-        and (last_willr_14 < -75.0)
+        and (last_willr_14_lt_neg_75)
         and (last_rsi_3_1h_gt_80)
         and (last_stochrsi_k_4h_lt_50)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 50.0))
@@ -54415,14 +54462,14 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3_lt_24)
         and (last_rsi_14_gt_52)
         and (last_stochrsi_k_1h_lt_50)
-        and (last_roc_9_4h > 10.0)
+        and (last_roc_9_4h_gt_10)
         and (last_change_pct_1d > 10.0)
       ):
         return True, f"exit_{mode_name}_d_2_54"
       elif (
         (last_rsi_3_lt_8)
-        and (last_willr_14 < -84.0)
-        and (last_roc_9_4h > 5.0)
+        and (last_willr_14_lt_neg_84)
+        and (last_roc_9_4h_gt_5)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -10.0))
         and (last_stochrsi_k_1h_lt_50)
       ):
@@ -54433,14 +54480,14 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_3_1h_gt_70)
         and (last_rsi_3_4h_gt_75)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
-        and (last_stochrsi_k_4h < 90.0)
+        and (last_stochrsi_k_4h_lt_90)
       ):
         return True, f"exit_{mode_name}_d_2_56"
       elif (
         (last_rsi_3 < 50.0)
         and (last_rsi_14 > 62.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
-        and (last_stochrsi_k_4h < 30.0)
+        and (last_stochrsi_k_4h_lt_30)
       ):
         return True, f"exit_{mode_name}_d_2_57"
       elif (
@@ -54453,7 +54500,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_2_58"
       elif (
         (last_rsi_3_lt_15)
-        and (last_willr_14 < -86.0)
+        and (last_willr_14_lt_neg_86)
         and (last_rsi_3_4h_gt_75)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 15.0))
         and (last_stochrsi_k_4h_lt_60)
@@ -54464,14 +54511,14 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14_gt_58)
         and (last_rsi_14_4h < 35.0)
         and (last_stochrsi_k_4h_lt_50)
-        and (last_stochrsi_k_1d < 50.0)
+        and (last_stochrsi_k_1d_lt_50)
       ):
         return True, f"exit_{mode_name}_d_2_60"
-      elif (last_rsi_3_lt_10) and (last_willr_14 < -75.0) and (last_rsi_3_4h_gt_90) and (last_stochrsi_k_1h_lt_70):
+      elif (last_rsi_3_lt_10) and (last_willr_14_lt_neg_75) and (last_rsi_3_4h_gt_90) and (last_stochrsi_k_1h_lt_70):
         return True, f"exit_{mode_name}_d_2_61"
       elif (
         (last_rsi_3_lt_16)
-        and (last_willr_14 < -96.0)
+        and (last_willr_14_lt_neg_96)
         and (last_rsi_3_1h_gt_70)
         and (last_rsi_3_4h_gt_80)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -20.0))
@@ -54494,7 +54541,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 50.0)
         and (last_rsi_14_gt_56)
-        and (last_stochrsi_k_4h < 20.0)
+        and (last_stochrsi_k_4h_lt_20)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 25.0))
       ):
         return True, f"exit_{mode_name}_d_2_67"
@@ -54502,7 +54549,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3_lt_18)
         and (last_rsi_14_gt_50)
         and (last_rsi_3_1h_gt_75)
-        and (last_roc_2_4h > 30.0)
+        and (last_roc_2_4h_gt_30)
         and (last_stochrsi_k_4h_lt_75)
       ):
         return True, f"exit_{mode_name}_d_2_68"
@@ -54510,7 +54557,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_2_69"
       elif (last_rsi_3_lt_36) and (last_rsi_14_gt_58) and (last_rsi_3_1h_gt_75) and (last_stochrsi_k_4h_lt_80):
         return True, f"exit_{mode_name}_d_2_70"
-      elif (last_rsi_3 < 38.0) and (last_rsi_14_gt_54) and (last_rsi_3_4h_gt_75) and (last_stochrsi_k_1h < 80.0):
+      elif (last_rsi_3 < 38.0) and (last_rsi_14_gt_54) and (last_rsi_3_4h_gt_75) and (last_stochrsi_k_1h_lt_80):
         return True, f"exit_{mode_name}_d_2_71"
       elif (last_rsi_3_lt_24) and (last_rsi_14_gt_56) and (last_rsi_3_1h_gt_90) and (last_aroond_14_4h_gt_25):
         return True, f"exit_{mode_name}_d_2_72"
@@ -54518,16 +54565,16 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3_lt_24)
         and (last_rsi_3_1h_gt_75)
         and (last_rsi_3_4h_gt_85)
-        and (last_roc_9_4h > 20.0)
+        and (last_roc_9_4h_gt_20)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 25.0))
       ):
         return True, f"exit_{mode_name}_d_2_73"
       elif (
         (last_rsi_3 < 3.0)
-        and (last_willr_14 < -90.0)
+        and (last_willr_14_lt_neg_90)
         and (last_rsi_3_4h_gt_75)
         and (last_rsi_3_1d_gt_75)
-        and (last_stochrsi_k_1h > 50.0)
+        and (last_stochrsi_k_1h_gt_50)
       ):
         return True, f"exit_{mode_name}_d_2_74"
       elif (
@@ -54537,7 +54584,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 50.0))
       ):
         return True, f"exit_{mode_name}_d_2_75"
-      elif (last_rsi_3_lt_34) and (last_rsi_14_gt_48) and (last_roc_9_1h < -80.0) and (last_stochrsi_k_4h < 20.0):
+      elif (last_rsi_3_lt_34) and (last_rsi_14_gt_48) and (last_roc_9_1h < -80.0) and (last_stochrsi_k_4h_lt_20):
         return True, f"exit_{mode_name}_d_2_76"
       elif (
         (last_rsi_3_lt_26)
@@ -54548,13 +54595,13 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_2_77"
       elif (
         (last_rsi_3_lt_16)
-        and (last_willr_14 < -82.0)
+        and (last_willr_14_lt_neg_82)
         and (last_rsi_3_1h_gt_70)
         and (last_rsi_3_4h_gt_80)
         and (last_rsi_3_1d > 80.0)
       ):
         return True, f"exit_{mode_name}_d_2_78"
-      elif (last_rsi_3_lt_10) and (last_willr_14 < -96.0) and (last_rsi_3_1h_gt_70) and (last_rsi_3_4h_gt_90):
+      elif (last_rsi_3_lt_10) and (last_willr_14_lt_neg_96) and (last_rsi_3_1h_gt_70) and (last_rsi_3_4h_gt_90):
         return True, f"exit_{mode_name}_d_2_79"
       elif (
         (last_rsi_3_lt_30)
@@ -54566,7 +54613,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_2_80"
       elif (
         (last_rsi_3_lt_18)
-        and (last_willr_14 < -88.0)
+        and (last_willr_14_lt_neg_88)
         and (last_rsi_3_1h_gt_75)
         and (last_rsi_3_4h_gt_75)
         and (isinstance(last_rsi_14_1d, np.float64) and (last_rsi_14_1d < 50.0))
@@ -54574,7 +54621,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_2_81"
       elif (
         (last_rsi_3_lt_20)
-        and (last_willr_14 < -88.0)
+        and (last_willr_14_lt_neg_88)
         and (last_rsi_3_4h_gt_70)
         and (last_rsi_3_1d > 85.0)
         and (last_stochrsi_k_4h_lt_60)
@@ -54588,11 +54635,11 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_stochrsi_k_4h_lt_60)
       ):
         return True, f"exit_{mode_name}_d_2_83"
-      elif (last_rsi_3_lt_12) and (last_willr_14 < -96.0) and (last_rsi_3_4h_gt_70) and (last_stochrsi_k_1h < 80.0):
+      elif (last_rsi_3_lt_12) and (last_willr_14_lt_neg_96) and (last_rsi_3_4h_gt_70) and (last_stochrsi_k_1h_lt_80):
         return True, f"exit_{mode_name}_d_2_84"
       elif (
         (last_rsi_3_lt_14)
-        and (last_willr_14 < -90.0)
+        and (last_willr_14_lt_neg_90)
         and (last_rsi_3_1h_gt_70)
         and (last_rsi_3_4h_gt_60)
         and (last_stochrsi_k_4h_lt_50)
@@ -54625,13 +54672,13 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3_lt_24)
         and (last_rsi_14_gt_58)
-        and (last_roc_9_1h > 5.0)
+        and (last_roc_9_1h_gt_5)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -25.0))
       ):
         return True, f"exit_{mode_name}_d_2_89"
       elif (
         (last_rsi_3_lt_10)
-        and (last_willr_14 < -75.0)
+        and (last_willr_14_lt_neg_75)
         and (last_rsi_3_1h_gt_50)
         and (last_rsi_3_4h_gt_70)
         and (last_aroonu_14_4h_lt_50)
@@ -54651,7 +54698,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3_lt_22)
         and (last_rsi_14_gt_50)
         and (last_rsi_3_1h_gt_60)
-        and (last_stochrsi_k_1h < 75.0)
+        and (last_stochrsi_k_1h_lt_75)
         and (last_stochrsi_k_4h_lt_50)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 25.0))
       ):
@@ -54678,10 +54725,10 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_2_94"
       elif (
         (last_rsi_3_lt_18)
-        and (last_willr_14 < -86.0)
+        and (last_willr_14_lt_neg_86)
         and (last_rsi_3_1h_gt_55)
         and (last_rsi_3_4h_gt_60)
-        and (last_stochrsi_k_4h < 90.0)
+        and (last_stochrsi_k_4h_lt_90)
         and (isinstance(last_aroond_14_1d, np.float64) and (last_aroond_14_1d > 75.0))
       ):
         return True, f"exit_{mode_name}_d_2_95"
@@ -54703,7 +54750,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_2_97"
       elif (
         (last_rsi_3_lt_12)
-        and (last_rsi_3_15m < 30.0)
+        and (last_rsi_3_15m_lt_30)
         and (last_rsi_3_1h_gt_40)
         and (last_rsi_3_4h_gt_40)
         and (last_rsi_3_1d < 20.0)
@@ -54711,20 +54758,20 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_2_98"
       elif (
-        (last_rsi_3 < 42.0)
+        (last_rsi_3_lt_42)
         and (last_rsi_14 > 46.0)
         and (last_rsi_3_1h > 35.0)
         and (last_rsi_3_4h_gt_40)
         and (last_aroond_14_4h_gt_50)
-        and (last_stoch_k_4h < 60.0)
+        and (last_stoch_k_4h_lt_60)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -80.0))
       ):
         return True, f"exit_{mode_name}_d_2_99"
-      elif (last_rsi_3 < 4.0) and (last_rsi_14 < 26.0) and (last_rsi_3_15m < 30.0) and (last_rsi_3_4h > 20.0):
+      elif (last_rsi_3 < 4.0) and (last_rsi_14 < 26.0) and (last_rsi_3_15m_lt_30) and (last_rsi_3_4h > 20.0):
         return True, f"exit_{mode_name}_d_2_100"
       elif (
         (last_rsi_3_lt_18)
-        and (last_willr_14 < -82.0)
+        and (last_willr_14_lt_neg_82)
         and (last_rsi_3_1h_gt_50)
         and (last_stochrsi_k_4h_lt_60)
         and (isinstance(last_roc_9_4h, np.float64) and (last_roc_9_4h < -40.0))
@@ -54735,7 +54782,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14_gt_50)
         and (last_rsi_3_1h_gt_40)
         and (last_rsi_3_4h_gt_60)
-        and (last_stochrsi_k_4h > 70.0)
+        and (last_stochrsi_k_4h_gt_70)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -40.0))
       ):
         return True, f"exit_{mode_name}_d_2_102"
@@ -54753,7 +54800,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_3_1h_gt_40)
         and (last_stochrsi_k_1h_lt_60)
         and (last_stochrsi_k_4h_lt_10)
-        and (last_roc_9_4h < -40.0)
+        and (last_roc_9_4h_lt_neg_40)
       ):
         return True, f"exit_{mode_name}_d_2_104"
       elif (
@@ -54761,7 +54808,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14_gt_50)
         and (last_rsi_3_15m > 45.0)
         and (last_stochrsi_k_4h_lt_10)
-        and (last_roc_9_4h < -25.0)
+        and (last_roc_9_4h_lt_neg_25)
       ):
         return True, f"exit_{mode_name}_d_2_105"
       elif (
@@ -54770,7 +54817,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_3_1h_gt_50)
         and (last_stochrsi_k_1h_lt_50)
         and (last_rsi_14_4h_lt_30)
-        and (last_roc_9_4h < -40.0)
+        and (last_roc_9_4h_lt_neg_40)
       ):
         return True, f"exit_{mode_name}_d_2_106"
       elif (
@@ -54785,13 +54832,13 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_2_108"
       elif (
         (last_rsi_3_lt_26)
-        and (last_willr_14 < -90.0)
+        and (last_willr_14_lt_neg_90)
         and (last_rsi_3_1h_gt_50)
         and (last_rsi_3_4h_gt_80)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -50.0))
       ):
         return True, f"exit_{mode_name}_d_2_109"
-      elif (last_rsi_3_lt_30) and (last_rsi_3_4h > 35.0) and (last_stochrsi_k_4h_lt_50) and (last_roc_9_4h < -25.0):
+      elif (last_rsi_3_lt_30) and (last_rsi_3_4h > 35.0) and (last_stochrsi_k_4h_lt_50) and (last_roc_9_4h_lt_neg_25):
         return True, f"exit_{mode_name}_d_2_110"
       elif (
         (last_rsi_3 < 52.0)
@@ -54805,17 +54852,17 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_2_111"
       elif (
         (last_rsi_3_lt_22)
-        and (last_willr_14 < -70.0)
+        and (last_willr_14_lt_neg_70)
         and (last_rsi_14 > 46.0)
         and (last_rsi_3_1h_gt_65)
-        and (last_rsi_3_4h > 65.0)
+        and (last_rsi_3_4h_gt_65)
         and (last_rsi_3_1d > 40.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
       ):
         return True, f"exit_{mode_name}_d_2_112"
       elif (
         (last_rsi_3_lt_18)
-        and (last_willr_14 < -96.0)
+        and (last_willr_14_lt_neg_96)
         and (last_rsi_3_1d_gt_70)
         and (last_stochrsi_k_4h_lt_50)
         and (isinstance(last_roc_9_4h, np.float64) and (last_roc_9_4h < -10.0))
@@ -54833,7 +54880,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3_lt_24)
         and (last_rsi_14_gt_50)
-        and (last_rsi_3_15m > 70.0)
+        and (last_rsi_3_15m_gt_70)
         and (last_stochrsi_k_1h_lt_50)
         and (last_stochrsi_k_4h_lt_50)
       ):
@@ -54846,7 +54893,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_2_118"
       elif (
         (last_rsi_3_lt_16)
-        and (last_willr_14 < -80.0)
+        and (last_willr_14_lt_neg_80)
         and (last_rsi_3_1h_gt_40)
         and (last_rsi_3_4h_gt_40)
         and (last_stochrsi_k_1h_lt_60)
@@ -54854,11 +54901,11 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_2_119"
       elif (last_rsi_3 < 48.0) and (last_rsi_14_gt_50) and (last_rsi_3_1h_gt_60) and (last_aroond_14_4h_gt_75):
         return True, f"exit_{mode_name}_d_2_120"
-      elif (last_rsi_3 < 42.0) and (last_rsi_14_gt_52) and (last_rsi_3_1h_gt_50) and (last_rsi_14_4h < 15.0):
+      elif (last_rsi_3_lt_42) and (last_rsi_14_gt_52) and (last_rsi_3_1h_gt_50) and (last_rsi_14_4h < 15.0):
         return True, f"exit_{mode_name}_d_2_121"
-      elif (last_rsi_3 < 44.0) and (last_rsi_14_gt_54) and (last_rsi_3_4h_gt_70) and (last_stochrsi_k_1h_lt_50):
+      elif (last_rsi_3_lt_44) and (last_rsi_14_gt_54) and (last_rsi_3_4h_gt_70) and (last_stochrsi_k_1h_lt_50):
         return True, f"exit_{mode_name}_d_2_122"
-      elif (last_rsi_3_lt_14) and (last_willr_14 < -94.0) and (last_rsi_3_1h_gt_90) and (last_rsi_3_1d_gt_70):
+      elif (last_rsi_3_lt_14) and (last_willr_14_lt_neg_94) and (last_rsi_3_1h_gt_90) and (last_rsi_3_1d_gt_70):
         return True, f"exit_{mode_name}_d_2_123"
       elif (
         (last_rsi_3_lt_14)
@@ -54868,16 +54915,16 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_2_124"
       elif (
         (last_rsi_3_lt_26)
-        and (last_willr_14 < -94.0)
+        and (last_willr_14_lt_neg_94)
         and (last_rsi_3_1h_gt_90)
         and (last_rsi_3_4h_gt_60)
-        and (last_rsi_3_1d > 60.0)
+        and (last_rsi_3_1d_gt_60)
         and (last_close > (last_low_min_30_1d * 2.0))
       ):
         return True, f"exit_{mode_name}_d_2_125"
       elif (last_rsi_3_lt_12) and (last_rsi_3_1h_gt_85) and (last_rsi_3_4h_gt_60) and (last_stochrsi_k_4h_lt_50):
         return True, f"exit_{mode_name}_d_2_126"
-      elif (last_rsi_3_lt_12) and (last_rsi_3_1h_gt_90) and (last_rsi_3_4h_gt_70) and (last_rsi_3_1d > 60.0):
+      elif (last_rsi_3_lt_12) and (last_rsi_3_1h_gt_90) and (last_rsi_3_4h_gt_70) and (last_rsi_3_1d_gt_60):
         return True, f"exit_{mode_name}_d_2_127"
       elif (last_rsi_3_lt_8) and (last_rsi_3_4h_gt_70) and (last_aroond_14_4h > 85.0):
         return True, f"exit_{mode_name}_d_2_128"
@@ -54899,7 +54946,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3_lt_22)
         and (last_rsi_3_1h_gt_65)
-        and (last_rsi_3_4h > 65.0)
+        and (last_rsi_3_4h_gt_65)
         and (last_aroond_14_1h > 50.0)
         and (last_stochrsi_k_1h_lt_60)
       ):
@@ -54976,7 +55023,7 @@ class NostalgiaForInfinityX7(IStrategy):
       last_rsi_14_4h_lt_30 = last_rsi_14_4h < 30.0
       last_rsi_3_1d_gt_70 = last_rsi_3_1d > 70.0
       if (
-        (last_willr_14 < -99.0)
+        (last_willr_14_lt_neg_99)
         and (last_rsi_14 < 22.0)
         and (isinstance(last_ema_200_1h, np.float64) and (last_ema_12_1h > last_ema_200_1h))
         and (isinstance(last_ema_200_4h, np.float64) and (last_ema_12_4h > last_ema_200_4h))
@@ -54985,35 +55032,35 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_3_1"
       elif (
-        (last_willr_14 < -99.0)
+        (last_willr_14_lt_neg_99)
         and (last_rsi_14 < 36.0)
-        and (last_cmf_20_1h > 0.0)
+        and (last_cmf_20_1h_gt_0)
         and (isinstance(last_ema_200_1h, np.float64) and (last_ema_12_1h > last_ema_200_1h))
         and (isinstance(last_ema_200_4h, np.float64) and (last_ema_12_4h > last_ema_200_4h))
       ):
         return True, f"exit_{mode_name}_d_3_2"
       elif (
-        (last_willr_14 < -80.0)
+        (last_willr_14_lt_neg_80)
         and (last_stochrsi_k_lt_5)
-        and (last_cmf_20_1h > 0.0)
-        and (last_cmf_20_4h > 0.0)
-        and ((last_stochrsi_k_4h_lt_80) and (last_stochrsi_k_change_pct_4h > 10.0))
+        and (last_cmf_20_1h_gt_0)
+        and (last_cmf_20_4h_gt_0)
+        and ((last_stochrsi_k_4h_lt_80) and (last_stochrsi_k_change_pct_4h_gt_10))
       ):
         return True, f"exit_{mode_name}_d_3_3"
       elif (
-        (last_willr_14 < -70.0)
+        (last_willr_14_lt_neg_70)
         and (last_rsi_14 < 35.0)
         and (last_stochrsi_k_lt_5)
-        and (last_stochrsi_k_4h < 30.0)
+        and (last_stochrsi_k_4h_lt_30)
         and (isinstance(last_ema_200_1h, np.float64) and (last_ema_12_1h > last_ema_200_1h))
         and (isinstance(last_ema_200_4h, np.float64) and (last_ema_12_4h > last_ema_200_4h))
       ):
         return True, f"exit_{mode_name}_d_3_4"
-      elif (last_willr_14 < -94.0) and (last_rsi_14_lt_32) and (last_roc_9_1h > 5.0) and (last_roc_9_4h > 5.0):
+      elif (last_willr_14_lt_neg_94) and (last_rsi_14_lt_32) and (last_roc_9_1h_gt_5) and (last_roc_9_4h_gt_5):
         return True, f"exit_{mode_name}_d_3_5"
       elif (
         (last_rsi_3_lt_30)
-        and (last_stochrsi_k < 30.0)
+        and (last_stochrsi_k_lt_30)
         and (last_rsi_14 > 60.0)
         and (last_roc_9_1h_gt_10)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -50.0))
@@ -55021,13 +55068,13 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_3_6"
       elif (
         (last_rsi_14_gt_50)
-        and (last_stochrsi_k < 30.0)
+        and (last_stochrsi_k_lt_30)
         and (last_stochrsi_k_4h_lt_50)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 40.0))
       ):
         return True, f"exit_{mode_name}_d_3_7"
       elif (
-        (last_willr_14 < -94.0)
+        (last_willr_14_lt_neg_94)
         and (last_stochrsi_k_lt_5)
         and (last_cmf_20_1h > 0.1)
         and (last_cmf_20_4h > 0.1)
@@ -55036,17 +55083,17 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_3_8"
       elif (
-        (last_willr_14 < -94.0)
+        (last_willr_14_lt_neg_94)
         and (last_rsi_3 < 5.0)
         and (last_change_pct_4h_gt_5)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
       ):
         return True, f"exit_{mode_name}_d_3_9"
       elif (
-        (last_willr_14 < -80.0)
+        (last_willr_14_lt_neg_80)
         and (last_rsi_14_gt_50)
         and (last_roc_9_1h_gt_10)
-        and (last_roc_9_4h > 10.0)
+        and (last_roc_9_4h_gt_10)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -10.0))
       ):
         return True, f"exit_{mode_name}_d_3_10"
@@ -55063,26 +55110,26 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14_gt_50)
         and (last_rsi_3_4h_gt_90)
         and (last_roc_9_1h > 20.0)
-        and (last_roc_9_4h > 20.0)
+        and (last_roc_9_4h_gt_20)
       ):
         return True, f"exit_{mode_name}_d_3_12"
-      elif (last_rsi_3_lt_20) and (last_rsi_3_4h > 95.0) and (last_roc_9_4h > 25.0):
+      elif (last_rsi_3_lt_20) and (last_rsi_3_4h_gt_95) and (last_roc_9_4h_gt_25):
         return True, f"exit_{mode_name}_d_3_13"
-      elif (last_rsi_3_lt_10) and (last_willr_14 < -92.0) and (last_rsi_3_4h > 95.0) and (last_aroond_14_4h_gt_25):
+      elif (last_rsi_3_lt_10) and (last_willr_14_lt_neg_92) and (last_rsi_3_4h_gt_95) and (last_aroond_14_4h_gt_25):
         return True, f"exit_{mode_name}_d_3_14"
       elif (last_rsi_3_lt_10) and (last_rsi_14 < 35.0) and (last_roc_9_4h > 30.0):
         return True, f"exit_{mode_name}_d_3_15"
       elif (
         (last_rsi_3_lt_30)
         and (last_aroond_14_4h_gt_25)
-        and (last_roc_9_4h > 25.0)
+        and (last_roc_9_4h_gt_25)
         and (last_aroond_14_1d > 50.0)
         and (last_change_pct_1d > 15.0)
       ):
         return True, f"exit_{mode_name}_d_3_16"
       elif (
         (last_rsi_3_lt_20)
-        and (last_willr_14 < -75.0)
+        and (last_willr_14_lt_neg_75)
         and (last_rsi_3_1h_gt_90)
         and (last_stochrsi_k_4h_lt_10)
         and (last_roc_9_4h < -30.0)
@@ -55103,31 +55150,31 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_3_21"
       elif (
         (last_rsi_3_lt_6)
-        and (last_willr_14 < -94.0)
+        and (last_willr_14_lt_neg_94)
         and (last_change_pct_4h_gt_5)
         and (last_stochrsi_k_4h_lt_50)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
       ):
         return True, f"exit_{mode_name}_d_3_22"
-      elif (last_rsi_3_lt_15) and (last_willr_14 < -80.0) and (last_rsi_3_1h_gt_85) and (last_rsi_3_1d > 95.0):
+      elif (last_rsi_3_lt_15) and (last_willr_14_lt_neg_80) and (last_rsi_3_1h_gt_85) and (last_rsi_3_1d > 95.0):
         return True, f"exit_{mode_name}_d_3_23"
       elif (
         (last_rsi_3_lt_12)
         and (last_rsi_14_lt_32)
-        and (last_willr_14 < -75.0)
+        and (last_willr_14_lt_neg_75)
         and (last_rsi_3_4h_gt_70)
         and (last_aroond_14_4h_gt_75)
       ):
         return True, f"exit_{mode_name}_d_3_24"
       elif (
         (last_rsi_3_lt_20)
-        and (last_willr_14 < -92.0)
+        and (last_willr_14_lt_neg_92)
         and (last_rsi_3_4h_gt_90)
         and (last_roc_9_4h > 15.0)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 50.0))
       ):
         return True, f"exit_{mode_name}_d_3_25"
-      elif (last_rsi_3_lt_25) and (last_willr_14 < -92.0) and (last_rsi_3_4h_gt_85) and (last_roc_9_4h > 20.0):
+      elif (last_rsi_3_lt_25) and (last_willr_14_lt_neg_92) and (last_rsi_3_4h_gt_85) and (last_roc_9_4h_gt_20):
         return True, f"exit_{mode_name}_d_3_26"
       elif (
         (last_rsi_3_lt_35)
@@ -55154,27 +55201,27 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14_gt_50)
         and (last_rsi_3_1h_gt_85)
         and (last_rsi_3_4h_gt_85)
-        and (last_stochrsi_k_1h < 75.0)
+        and (last_stochrsi_k_1h_lt_75)
       ):
         return True, f"exit_{mode_name}_d_3_31"
-      elif (last_rsi_3_lt_20) and (last_rsi_3_1h_gt_85) and (last_roc_2_4h > 30.0) and (last_stochrsi_k_4h_lt_70):
+      elif (last_rsi_3_lt_20) and (last_rsi_3_1h_gt_85) and (last_roc_2_4h_gt_30) and (last_stochrsi_k_4h_lt_70):
         return True, f"exit_{mode_name}_d_3_32"
       elif (
         (last_rsi_3_lt_20)
-        and (last_willr_14 < -94.0)
+        and (last_willr_14_lt_neg_94)
         and (last_roc_2_1h > 10.0)
         and (last_roc_9_1h < -30.0)
         and (last_stochrsi_k_1h_lt_50)
       ):
         return True, f"exit_{mode_name}_d_3_33"
-      elif (last_rsi_3_lt_35) and (last_rsi_3_15m > 70.0) and (last_rsi_14_1h < 20.0) and (last_roc_9_1h < -40.0):
+      elif (last_rsi_3_lt_35) and (last_rsi_3_15m_gt_70) and (last_rsi_14_1h < 20.0) and (last_roc_9_1h < -40.0):
         return True, f"exit_{mode_name}_d_3_34"
-      elif (last_rsi_3_lt_16) and (last_willr_14 < -92.0) and (last_rsi_3_1d_gt_75) and (last_stochrsi_k_1h < 25.0):
+      elif (last_rsi_3_lt_16) and (last_willr_14_lt_neg_92) and (last_rsi_3_1d_gt_75) and (last_stochrsi_k_1h_lt_25):
         return True, f"exit_{mode_name}_d_3_35"
       elif (
         (last_rsi_3_lt_25)
-        and (last_willr_14 < -75.0)
-        and (last_roc_9_4h > 25.0)
+        and (last_willr_14_lt_neg_75)
+        and (last_roc_9_4h_gt_25)
         and (last_rsi_3_1d_gt_75)
         and (last_stochrsi_k_1h_lt_50)
       ):
@@ -55187,13 +55234,13 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_stochrsi_k_4h_lt_50)
       ):
         return True, f"exit_{mode_name}_d_3_37"
-      elif (last_rsi_3_lt_25) and (last_willr_14 < -75.0) and (last_rsi_3_4h_gt_90) and (last_stochrsi_k_4h_lt_80):
+      elif (last_rsi_3_lt_25) and (last_willr_14_lt_neg_75) and (last_rsi_3_4h_gt_90) and (last_stochrsi_k_4h_lt_80):
         return True, f"exit_{mode_name}_d_3_38"
-      elif (last_rsi_3 < 7.0) and (last_willr_14 < -93.0) and (last_cmf_20_4h > 0.0) and (last_rsi_3_4h_gt_90):
+      elif (last_rsi_3 < 7.0) and (last_willr_14 < -93.0) and (last_cmf_20_4h_gt_0) and (last_rsi_3_4h_gt_90):
         return True, f"exit_{mode_name}_d_3_39"
       elif (
         (last_rsi_3_lt_25)
-        and (last_willr_14 < -75.0)
+        and (last_willr_14_lt_neg_75)
         and (last_rsi_3_1h_gt_70)
         and (last_stochrsi_k_1h_lt_70)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 10.0))
@@ -55201,7 +55248,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_3_40"
       elif (
         (last_rsi_3_lt_15)
-        and (last_willr_14 < -80.0)
+        and (last_willr_14_lt_neg_80)
         and (last_rsi_3_1h_gt_70)
         and (last_stochrsi_k_4h_lt_75)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -50.0))
@@ -55225,13 +55272,13 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_3_43"
       elif (
         (last_rsi_3 < 45.0)
-        and (last_willr_14 < -85.0)
+        and (last_willr_14_lt_neg_85)
         and (last_rsi_3_4h_gt_70)
         and (last_rsi_3_1d > 25.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
       ):
         return True, f"exit_{mode_name}_d_3_44"
-      elif (last_rsi_3_lt_10) and (last_willr_14 < -90.0) and (last_rsi_3_1h_gt_90):
+      elif (last_rsi_3_lt_10) and (last_willr_14_lt_neg_90) and (last_rsi_3_1h_gt_90):
         return True, f"exit_{mode_name}_d_3_45"
       elif (last_rsi_3_lt_30) and (last_rsi_3_1h_gt_85) and (last_rsi_3_4h_gt_90) and (last_roc_2_1d > 20.0):
         return True, f"exit_{mode_name}_d_3_46"
@@ -55253,20 +55300,20 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_3_48"
       elif (
         (last_rsi_3_lt_20)
-        and (last_willr_14 < -92.0)
+        and (last_willr_14_lt_neg_92)
         and (last_rsi_3_4h_gt_80)
         and (last_change_pct_1d_gt_5)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 50.0))
       ):
         return True, f"exit_{mode_name}_d_3_49"
-      elif (last_rsi_3_lt_20) and (last_willr_14 < -92.0) and (last_rsi_3_1d > 90.0) and (last_stochrsi_k_1h < 10.0):
+      elif (last_rsi_3_lt_20) and (last_willr_14_lt_neg_92) and (last_rsi_3_1d > 90.0) and (last_stochrsi_k_1h_lt_10):
         return True, f"exit_{mode_name}_d_3_50"
       elif (last_rsi_3_lt_38) and (last_rsi_14_gt_50) and (last_rsi_3_4h_gt_80) and (last_stochrsi_k_1h_lt_50):
         return True, f"exit_{mode_name}_d_3_51"
       elif (
         (last_rsi_3_lt_24)
         and (last_rsi_14 < 44.0)
-        and (last_willr_14 < -90.0)
+        and (last_willr_14_lt_neg_90)
         and (last_stochrsi_k_1h_lt_30)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 15.0))
       ):
@@ -55274,7 +55321,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3_lt_30)
         and (last_rsi_14_gt_50)
-        and (last_willr_14 < -75.0)
+        and (last_willr_14_lt_neg_75)
         and (last_rsi_3_1h_gt_80)
         and (last_stochrsi_k_4h_lt_50)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 50.0))
@@ -55284,14 +55331,14 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3_lt_26)
         and (last_rsi_14_gt_50)
         and (last_stochrsi_k_1h_lt_50)
-        and (last_roc_9_4h > 10.0)
+        and (last_roc_9_4h_gt_10)
         and (last_change_pct_1d > 10.0)
       ):
         return True, f"exit_{mode_name}_d_3_54"
       elif (
         (last_rsi_3_lt_10)
-        and (last_willr_14 < -82.0)
-        and (last_roc_9_4h > 5.0)
+        and (last_willr_14_lt_neg_82)
+        and (last_roc_9_4h_gt_5)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -10.0))
         and (last_stochrsi_k_1h_lt_50)
       ):
@@ -55302,14 +55349,14 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_3_1h_gt_70)
         and (last_rsi_3_4h_gt_75)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
-        and (last_stochrsi_k_4h < 90.0)
+        and (last_stochrsi_k_4h_lt_90)
       ):
         return True, f"exit_{mode_name}_d_3_56"
       elif (
         (last_rsi_3_lt_50)
         and (last_rsi_14 > 60.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
-        and (last_stochrsi_k_4h < 30.0)
+        and (last_stochrsi_k_4h_lt_30)
       ):
         return True, f"exit_{mode_name}_d_3_57"
       elif (
@@ -55322,7 +55369,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_3_58"
       elif (
         (last_rsi_3_lt_15)
-        and (last_willr_14 < -84.0)
+        and (last_willr_14_lt_neg_84)
         and (last_rsi_3_4h_gt_75)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 15.0))
         and (last_stochrsi_k_4h_lt_60)
@@ -55333,14 +55380,14 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14_gt_56)
         and (last_rsi_14_4h < 35.0)
         and (last_stochrsi_k_4h_lt_50)
-        and (last_stochrsi_k_1d < 50.0)
+        and (last_stochrsi_k_1d_lt_50)
       ):
         return True, f"exit_{mode_name}_d_3_60"
-      elif (last_rsi_3_lt_10) and (last_willr_14 < -75.0) and (last_rsi_3_4h_gt_90) and (last_stochrsi_k_1h_lt_70):
+      elif (last_rsi_3_lt_10) and (last_willr_14_lt_neg_75) and (last_rsi_3_4h_gt_90) and (last_stochrsi_k_1h_lt_70):
         return True, f"exit_{mode_name}_d_3_61"
       elif (
         (last_rsi_3_lt_18)
-        and (last_willr_14 < -94.0)
+        and (last_willr_14_lt_neg_94)
         and (last_rsi_3_1h_gt_70)
         and (last_rsi_3_4h_gt_80)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -20.0))
@@ -55363,7 +55410,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3_lt_50)
         and (last_rsi_14_gt_54)
-        and (last_stochrsi_k_4h < 20.0)
+        and (last_stochrsi_k_4h_lt_20)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 25.0))
       ):
         return True, f"exit_{mode_name}_d_3_67"
@@ -55371,7 +55418,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3_lt_20)
         and (last_rsi_14_gt_48)
         and (last_rsi_3_1h_gt_75)
-        and (last_roc_2_4h > 30.0)
+        and (last_roc_2_4h_gt_30)
         and (last_stochrsi_k_4h_lt_75)
       ):
         return True, f"exit_{mode_name}_d_3_68"
@@ -55379,7 +55426,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_3_69"
       elif (last_rsi_3_lt_38) and (last_rsi_14_gt_56) and (last_rsi_3_1h_gt_75) and (last_stochrsi_k_4h_lt_80):
         return True, f"exit_{mode_name}_d_3_70"
-      elif (last_rsi_3_lt_40) and (last_rsi_14_gt_52) and (last_rsi_3_4h_gt_75) and (last_stochrsi_k_1h < 80.0):
+      elif (last_rsi_3_lt_40) and (last_rsi_14_gt_52) and (last_rsi_3_4h_gt_75) and (last_stochrsi_k_1h_lt_80):
         return True, f"exit_{mode_name}_d_3_71"
       elif (last_rsi_3_lt_26) and (last_rsi_14_gt_54) and (last_rsi_3_1h_gt_90) and (last_aroond_14_4h_gt_25):
         return True, f"exit_{mode_name}_d_3_72"
@@ -55387,16 +55434,16 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3_lt_26)
         and (last_rsi_3_1h_gt_75)
         and (last_rsi_3_4h_gt_85)
-        and (last_roc_9_4h > 20.0)
+        and (last_roc_9_4h_gt_20)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 25.0))
       ):
         return True, f"exit_{mode_name}_d_3_73"
       elif (
         (last_rsi_3 < 4.0)
-        and (last_willr_14 < -90.0)
+        and (last_willr_14_lt_neg_90)
         and (last_rsi_3_4h_gt_75)
         and (last_rsi_3_1d_gt_75)
-        and (last_stochrsi_k_1h > 50.0)
+        and (last_stochrsi_k_1h_gt_50)
       ):
         return True, f"exit_{mode_name}_d_3_74"
       elif (
@@ -55406,7 +55453,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 50.0))
       ):
         return True, f"exit_{mode_name}_d_3_75"
-      elif (last_rsi_3_lt_36) and (last_rsi_14_gt_46) and (last_roc_9_1h < -80.0) and (last_stochrsi_k_4h < 20.0):
+      elif (last_rsi_3_lt_36) and (last_rsi_14_gt_46) and (last_roc_9_1h < -80.0) and (last_stochrsi_k_4h_lt_20):
         return True, f"exit_{mode_name}_d_3_76"
       elif (
         (last_rsi_3_lt_28)
@@ -55417,13 +55464,13 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_3_77"
       elif (
         (last_rsi_3_lt_18)
-        and (last_willr_14 < -80.0)
+        and (last_willr_14_lt_neg_80)
         and (last_rsi_3_1h_gt_70)
         and (last_rsi_3_4h_gt_80)
         and (last_rsi_3_1d > 80.0)
       ):
         return True, f"exit_{mode_name}_d_3_78"
-      elif (last_rsi_3_lt_12) and (last_willr_14 < -94.0) and (last_rsi_3_1h_gt_70) and (last_rsi_3_4h_gt_90):
+      elif (last_rsi_3_lt_12) and (last_willr_14_lt_neg_94) and (last_rsi_3_1h_gt_70) and (last_rsi_3_4h_gt_90):
         return True, f"exit_{mode_name}_d_3_79"
       elif (
         (last_rsi_3_lt_32)
@@ -55435,7 +55482,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_3_80"
       elif (
         (last_rsi_3_lt_20)
-        and (last_willr_14 < -86.0)
+        and (last_willr_14_lt_neg_86)
         and (last_rsi_3_1h_gt_75)
         and (last_rsi_3_4h_gt_75)
         and (isinstance(last_rsi_14_1d, np.float64) and (last_rsi_14_1d < 50.0))
@@ -55443,7 +55490,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_3_81"
       elif (
         (last_rsi_3_lt_22)
-        and (last_willr_14 < -86.0)
+        and (last_willr_14_lt_neg_86)
         and (last_rsi_3_4h_gt_70)
         and (last_rsi_3_1d > 85.0)
         and (last_stochrsi_k_4h_lt_60)
@@ -55457,11 +55504,11 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_stochrsi_k_4h_lt_60)
       ):
         return True, f"exit_{mode_name}_d_3_83"
-      elif (last_rsi_3_lt_14) and (last_willr_14 < -94.0) and (last_rsi_3_4h_gt_70) and (last_stochrsi_k_1h < 80.0):
+      elif (last_rsi_3_lt_14) and (last_willr_14_lt_neg_94) and (last_rsi_3_4h_gt_70) and (last_stochrsi_k_1h_lt_80):
         return True, f"exit_{mode_name}_d_3_84"
       elif (
         (last_rsi_3_lt_16)
-        and (last_willr_14 < -88.0)
+        and (last_willr_14_lt_neg_88)
         and (last_rsi_3_1h_gt_70)
         and (last_rsi_3_4h_gt_60)
         and (last_stochrsi_k_4h_lt_50)
@@ -55494,13 +55541,13 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3_lt_26)
         and (last_rsi_14_gt_56)
-        and (last_roc_9_1h > 5.0)
+        and (last_roc_9_1h_gt_5)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -25.0))
       ):
         return True, f"exit_{mode_name}_d_3_89"
       elif (
         (last_rsi_3_lt_12)
-        and (last_willr_14 < -75.0)
+        and (last_willr_14_lt_neg_75)
         and (last_rsi_3_1h_gt_50)
         and (last_rsi_3_4h_gt_70)
         and (last_aroonu_14_4h_lt_50)
@@ -55520,7 +55567,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3_lt_24)
         and (last_rsi_14_gt_48)
         and (last_rsi_3_1h_gt_60)
-        and (last_stochrsi_k_1h < 75.0)
+        and (last_stochrsi_k_1h_lt_75)
         and (last_stochrsi_k_4h_lt_50)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 25.0))
       ):
@@ -55547,15 +55594,15 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_3_94"
       elif (
         (last_rsi_3_lt_20)
-        and (last_willr_14 < -84.0)
+        and (last_willr_14_lt_neg_84)
         and (last_rsi_3_1h_gt_55)
         and (last_rsi_3_4h_gt_60)
-        and (last_stochrsi_k_4h < 90.0)
+        and (last_stochrsi_k_4h_lt_90)
         and (isinstance(last_aroond_14_1d, np.float64) and (last_aroond_14_1d > 75.0))
       ):
         return True, f"exit_{mode_name}_d_3_95"
       elif (
-        (last_rsi_3 < 42.0)
+        (last_rsi_3_lt_42)
         and (last_rsi_14_gt_50)
         and (last_rsi_3_1h_gt_55)
         and (last_rsi_3_1d > 55.0)
@@ -55580,20 +55627,20 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_3_98"
       elif (
-        (last_rsi_3 < 44.0)
+        (last_rsi_3_lt_44)
         and (last_rsi_14 > 44.0)
         and (last_rsi_3_1h > 35.0)
         and (last_rsi_3_4h_gt_40)
         and (last_aroond_14_4h_gt_50)
-        and (last_stoch_k_4h < 60.0)
+        and (last_stoch_k_4h_lt_60)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -80.0))
       ):
         return True, f"exit_{mode_name}_d_3_99"
-      elif (last_rsi_3_lt_6) and (last_rsi_14 < 28.0) and (last_rsi_3_15m < 30.0) and (last_rsi_3_4h > 20.0):
+      elif (last_rsi_3_lt_6) and (last_rsi_14 < 28.0) and (last_rsi_3_15m_lt_30) and (last_rsi_3_4h > 20.0):
         return True, f"exit_{mode_name}_d_3_100"
       elif (
         (last_rsi_3_lt_20)
-        and (last_willr_14 < -80.0)
+        and (last_willr_14_lt_neg_80)
         and (last_rsi_3_1h_gt_50)
         and (last_stochrsi_k_4h_lt_60)
         and (isinstance(last_roc_9_4h, np.float64) and (last_roc_9_4h < -40.0))
@@ -55604,7 +55651,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14_gt_48)
         and (last_rsi_3_1h_gt_40)
         and (last_rsi_3_4h_gt_60)
-        and (last_stochrsi_k_4h > 70.0)
+        and (last_stochrsi_k_4h_gt_70)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -40.0))
       ):
         return True, f"exit_{mode_name}_d_3_102"
@@ -55622,7 +55669,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_3_1h_gt_40)
         and (last_stochrsi_k_1h_lt_60)
         and (last_stochrsi_k_4h_lt_10)
-        and (last_roc_9_4h < -40.0)
+        and (last_roc_9_4h_lt_neg_40)
       ):
         return True, f"exit_{mode_name}_d_3_104"
       elif (
@@ -55630,7 +55677,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14_gt_48)
         and (last_rsi_3_15m > 45.0)
         and (last_stochrsi_k_4h_lt_10)
-        and (last_roc_9_4h < -25.0)
+        and (last_roc_9_4h_lt_neg_25)
       ):
         return True, f"exit_{mode_name}_d_3_105"
       elif (
@@ -55639,7 +55686,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_3_1h_gt_50)
         and (last_stochrsi_k_1h_lt_50)
         and (last_rsi_14_4h_lt_30)
-        and (last_roc_9_4h < -40.0)
+        and (last_roc_9_4h_lt_neg_40)
       ):
         return True, f"exit_{mode_name}_d_3_106"
       elif (
@@ -55654,13 +55701,13 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_3_108"
       elif (
         (last_rsi_3_lt_28)
-        and (last_willr_14 < -88.0)
+        and (last_willr_14_lt_neg_88)
         and (last_rsi_3_1h_gt_50)
         and (last_rsi_3_4h_gt_80)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -50.0))
       ):
         return True, f"exit_{mode_name}_d_3_109"
-      elif (last_rsi_3_lt_32) and (last_rsi_3_4h > 35.0) and (last_stochrsi_k_4h_lt_50) and (last_roc_9_4h < -25.0):
+      elif (last_rsi_3_lt_32) and (last_rsi_3_4h > 35.0) and (last_stochrsi_k_4h_lt_50) and (last_roc_9_4h_lt_neg_25):
         return True, f"exit_{mode_name}_d_3_110"
       elif (
         (last_rsi_3 < 54.0)
@@ -55677,14 +55724,14 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_willr_14 < -65.0)
         and (last_rsi_14 > 44.0)
         and (last_rsi_3_1h_gt_65)
-        and (last_rsi_3_4h > 65.0)
+        and (last_rsi_3_4h_gt_65)
         and (last_rsi_3_1d > 40.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
       ):
         return True, f"exit_{mode_name}_d_3_112"
       elif (
         (last_rsi_3_lt_20)
-        and (last_willr_14 < -94.0)
+        and (last_willr_14_lt_neg_94)
         and (last_rsi_3_1d_gt_70)
         and (last_stochrsi_k_4h_lt_50)
         and (isinstance(last_roc_9_4h, np.float64) and (last_roc_9_4h < -10.0))
@@ -55702,7 +55749,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3_lt_26)
         and (last_rsi_14_gt_48)
-        and (last_rsi_3_15m > 70.0)
+        and (last_rsi_3_15m_gt_70)
         and (last_stochrsi_k_1h_lt_50)
         and (last_stochrsi_k_4h_lt_50)
       ):
@@ -55715,7 +55762,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_3_118"
       elif (
         (last_rsi_3_lt_18)
-        and (last_willr_14 < -80.0)
+        and (last_willr_14_lt_neg_80)
         and (last_rsi_3_1h_gt_40)
         and (last_rsi_3_4h_gt_40)
         and (last_stochrsi_k_1h_lt_60)
@@ -55723,11 +55770,11 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_3_119"
       elif (last_rsi_3_lt_50) and (last_rsi_14_gt_48) and (last_rsi_3_1h_gt_60) and (last_aroond_14_4h_gt_75):
         return True, f"exit_{mode_name}_d_3_120"
-      elif (last_rsi_3 < 44.0) and (last_rsi_14_gt_50) and (last_rsi_3_1h_gt_50) and (last_rsi_14_4h < 15.0):
+      elif (last_rsi_3_lt_44) and (last_rsi_14_gt_50) and (last_rsi_3_1h_gt_50) and (last_rsi_14_4h < 15.0):
         return True, f"exit_{mode_name}_d_3_121"
       elif (last_rsi_3 < 46.0) and (last_rsi_14_gt_52) and (last_rsi_3_4h_gt_70) and (last_stochrsi_k_1h_lt_50):
         return True, f"exit_{mode_name}_d_3_122"
-      elif (last_rsi_3_lt_16) and (last_willr_14 < -92.0) and (last_rsi_3_1h_gt_90) and (last_rsi_3_1d_gt_70):
+      elif (last_rsi_3_lt_16) and (last_willr_14_lt_neg_92) and (last_rsi_3_1h_gt_90) and (last_rsi_3_1d_gt_70):
         return True, f"exit_{mode_name}_d_3_123"
       elif (
         (last_rsi_3_lt_16)
@@ -55737,16 +55784,16 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_3_124"
       elif (
         (last_rsi_3_lt_28)
-        and (last_willr_14 < -92.0)
+        and (last_willr_14_lt_neg_92)
         and (last_rsi_3_1h_gt_90)
         and (last_rsi_3_4h_gt_60)
-        and (last_rsi_3_1d > 60.0)
+        and (last_rsi_3_1d_gt_60)
         and (last_close > (last_low_min_30_1d * 2.0))
       ):
         return True, f"exit_{mode_name}_d_3_125"
       elif (last_rsi_3_lt_14) and (last_rsi_3_1h_gt_85) and (last_rsi_3_4h_gt_60) and (last_stochrsi_k_4h_lt_50):
         return True, f"exit_{mode_name}_d_3_126"
-      elif (last_rsi_3_lt_14) and (last_rsi_3_1h_gt_90) and (last_rsi_3_4h_gt_70) and (last_rsi_3_1d > 60.0):
+      elif (last_rsi_3_lt_14) and (last_rsi_3_1h_gt_90) and (last_rsi_3_4h_gt_70) and (last_rsi_3_1d_gt_60):
         return True, f"exit_{mode_name}_d_3_127"
       elif (last_rsi_3_lt_10) and (last_rsi_3_4h_gt_70) and (last_aroond_14_4h > 85.0):
         return True, f"exit_{mode_name}_d_3_128"
@@ -55768,7 +55815,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3_lt_24)
         and (last_rsi_3_1h_gt_65)
-        and (last_rsi_3_4h > 65.0)
+        and (last_rsi_3_4h_gt_65)
         and (last_aroond_14_1h > 50.0)
         and (last_stochrsi_k_1h_lt_60)
       ):
@@ -55843,7 +55890,7 @@ class NostalgiaForInfinityX7(IStrategy):
       last_rsi_14_4h_lt_30 = last_rsi_14_4h < 30.0
       last_rsi_3_1d_gt_70 = last_rsi_3_1d > 70.0
       if (
-        (last_willr_14 < -99.0)
+        (last_willr_14_lt_neg_99)
         and (last_rsi_14 < 22.0)
         and (isinstance(last_ema_200_1h, np.float64) and (last_ema_12_1h > last_ema_200_1h))
         and (isinstance(last_ema_200_4h, np.float64) and (last_ema_12_4h > last_ema_200_4h))
@@ -55852,35 +55899,35 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_4_1"
       elif (
-        (last_willr_14 < -99.0)
+        (last_willr_14_lt_neg_99)
         and (last_rsi_14 < 38.0)
-        and (last_cmf_20_1h > 0.0)
+        and (last_cmf_20_1h_gt_0)
         and (isinstance(last_ema_200_1h, np.float64) and (last_ema_12_1h > last_ema_200_1h))
         and (isinstance(last_ema_200_4h, np.float64) and (last_ema_12_4h > last_ema_200_4h))
       ):
         return True, f"exit_{mode_name}_d_4_2"
       elif (
-        (last_willr_14 < -80.0)
+        (last_willr_14_lt_neg_80)
         and (last_stochrsi_k_lt_5)
-        and (last_cmf_20_1h > 0.0)
-        and (last_cmf_20_4h > 0.0)
-        and ((last_stochrsi_k_4h_lt_80) and (last_stochrsi_k_change_pct_4h > 10.0))
+        and (last_cmf_20_1h_gt_0)
+        and (last_cmf_20_4h_gt_0)
+        and ((last_stochrsi_k_4h_lt_80) and (last_stochrsi_k_change_pct_4h_gt_10))
       ):
         return True, f"exit_{mode_name}_d_4_3"
       elif (
-        (last_willr_14 < -70.0)
+        (last_willr_14_lt_neg_70)
         and (last_rsi_14 < 35.0)
         and (last_stochrsi_k_lt_5)
-        and (last_stochrsi_k_4h < 30.0)
+        and (last_stochrsi_k_4h_lt_30)
         and (isinstance(last_ema_200_1h, np.float64) and (last_ema_12_1h > last_ema_200_1h))
         and (isinstance(last_ema_200_4h, np.float64) and (last_ema_12_4h > last_ema_200_4h))
       ):
         return True, f"exit_{mode_name}_d_4_4"
-      elif (last_willr_14 < -92.0) and (last_rsi_14_lt_34) and (last_roc_9_1h > 5.0) and (last_roc_9_4h > 5.0):
+      elif (last_willr_14_lt_neg_92) and (last_rsi_14_lt_34) and (last_roc_9_1h_gt_5) and (last_roc_9_4h_gt_5):
         return True, f"exit_{mode_name}_d_4_5"
       elif (
         (last_rsi_3_lt_30)
-        and (last_stochrsi_k < 30.0)
+        and (last_stochrsi_k_lt_30)
         and (last_rsi_14 > 60.0)
         and (last_roc_9_1h_gt_10)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -50.0))
@@ -55888,13 +55935,13 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_4_6"
       elif (
         (last_rsi_14_gt_50)
-        and (last_stochrsi_k < 30.0)
+        and (last_stochrsi_k_lt_30)
         and (last_stochrsi_k_4h_lt_50)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 40.0))
       ):
         return True, f"exit_{mode_name}_d_4_7"
       elif (
-        (last_willr_14 < -92.0)
+        (last_willr_14_lt_neg_92)
         and (last_stochrsi_k_lt_5)
         and (last_cmf_20_1h > 0.1)
         and (last_cmf_20_4h > 0.1)
@@ -55910,10 +55957,10 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_4_9"
       elif (
-        (last_willr_14 < -80.0)
+        (last_willr_14_lt_neg_80)
         and (last_rsi_14_gt_50)
         and (last_roc_9_1h_gt_10)
-        and (last_roc_9_4h > 10.0)
+        and (last_roc_9_4h_gt_10)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -10.0))
       ):
         return True, f"exit_{mode_name}_d_4_10"
@@ -55930,26 +55977,26 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14_gt_50)
         and (last_rsi_3_4h_gt_90)
         and (last_roc_9_1h > 20.0)
-        and (last_roc_9_4h > 20.0)
+        and (last_roc_9_4h_gt_20)
       ):
         return True, f"exit_{mode_name}_d_4_12"
-      elif (last_rsi_3_lt_20) and (last_rsi_3_4h > 95.0) and (last_roc_9_4h > 25.0):
+      elif (last_rsi_3_lt_20) and (last_rsi_3_4h_gt_95) and (last_roc_9_4h_gt_25):
         return True, f"exit_{mode_name}_d_4_13"
-      elif (last_rsi_3_lt_10) and (last_willr_14 < -90.0) and (last_rsi_3_4h > 95.0) and (last_aroond_14_4h_gt_25):
+      elif (last_rsi_3_lt_10) and (last_willr_14_lt_neg_90) and (last_rsi_3_4h_gt_95) and (last_aroond_14_4h_gt_25):
         return True, f"exit_{mode_name}_d_4_14"
       elif (last_rsi_3_lt_12) and (last_rsi_14 < 40.0) and (last_roc_9_4h > 30.0):
         return True, f"exit_{mode_name}_d_4_15"
       elif (
         (last_rsi_3_lt_30)
         and (last_aroond_14_4h_gt_25)
-        and (last_roc_9_4h > 25.0)
+        and (last_roc_9_4h_gt_25)
         and (last_aroond_14_1d > 50.0)
         and (last_change_pct_1d > 15.0)
       ):
         return True, f"exit_{mode_name}_d_4_16"
       elif (
         (last_rsi_3_lt_20)
-        and (last_willr_14 < -70.0)
+        and (last_willr_14_lt_neg_70)
         and (last_rsi_3_1h_gt_90)
         and (last_stochrsi_k_4h_lt_10)
         and (last_roc_9_4h < -30.0)
@@ -55970,31 +56017,31 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_4_21"
       elif (
         (last_rsi_3_lt_8)
-        and (last_willr_14 < -92.0)
+        and (last_willr_14_lt_neg_92)
         and (last_change_pct_4h_gt_5)
         and (last_stochrsi_k_4h_lt_50)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
       ):
         return True, f"exit_{mode_name}_d_4_22"
-      elif (last_rsi_3_lt_20) and (last_willr_14 < -75.0) and (last_rsi_3_1h_gt_85) and (last_rsi_3_1d > 95.0):
+      elif (last_rsi_3_lt_20) and (last_willr_14_lt_neg_75) and (last_rsi_3_1h_gt_85) and (last_rsi_3_1d > 95.0):
         return True, f"exit_{mode_name}_d_4_23"
       elif (
         (last_rsi_3_lt_14)
         and (last_rsi_14_lt_34)
-        and (last_willr_14 < -70.0)
+        and (last_willr_14_lt_neg_70)
         and (last_rsi_3_4h_gt_70)
         and (last_aroond_14_4h_gt_75)
       ):
         return True, f"exit_{mode_name}_d_4_24"
       elif (
         (last_rsi_3_lt_25)
-        and (last_willr_14 < -90.0)
+        and (last_willr_14_lt_neg_90)
         and (last_rsi_3_4h_gt_90)
         and (last_roc_9_4h > 15.0)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 50.0))
       ):
         return True, f"exit_{mode_name}_d_4_25"
-      elif (last_rsi_3_lt_30) and (last_willr_14 < -90.0) and (last_rsi_3_4h_gt_85) and (last_roc_9_4h > 20.0):
+      elif (last_rsi_3_lt_30) and (last_willr_14_lt_neg_90) and (last_rsi_3_4h_gt_85) and (last_roc_9_4h_gt_20):
         return True, f"exit_{mode_name}_d_4_26"
       elif (
         (last_rsi_3_lt_35)
@@ -56021,27 +56068,27 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14_gt_50)
         and (last_rsi_3_1h_gt_85)
         and (last_rsi_3_4h_gt_85)
-        and (last_stochrsi_k_1h < 75.0)
+        and (last_stochrsi_k_1h_lt_75)
       ):
         return True, f"exit_{mode_name}_d_4_31"
-      elif (last_rsi_3_lt_25) and (last_rsi_3_1h_gt_85) and (last_roc_2_4h > 30.0) and (last_stochrsi_k_4h_lt_70):
+      elif (last_rsi_3_lt_25) and (last_rsi_3_1h_gt_85) and (last_roc_2_4h_gt_30) and (last_stochrsi_k_4h_lt_70):
         return True, f"exit_{mode_name}_d_4_32"
       elif (
         (last_rsi_3_lt_25)
-        and (last_willr_14 < -92.0)
+        and (last_willr_14_lt_neg_92)
         and (last_roc_2_1h > 10.0)
         and (last_roc_9_1h < -30.0)
         and (last_stochrsi_k_1h_lt_50)
       ):
         return True, f"exit_{mode_name}_d_4_33"
-      elif (last_rsi_3_lt_35) and (last_rsi_3_15m > 70.0) and (last_rsi_14_1h < 20.0) and (last_roc_9_1h < -40.0):
+      elif (last_rsi_3_lt_35) and (last_rsi_3_15m_gt_70) and (last_rsi_14_1h < 20.0) and (last_roc_9_1h < -40.0):
         return True, f"exit_{mode_name}_d_4_34"
-      elif (last_rsi_3_lt_18) and (last_willr_14 < -91.0) and (last_rsi_3_1d_gt_75) and (last_stochrsi_k_1h < 25.0):
+      elif (last_rsi_3_lt_18) and (last_willr_14 < -91.0) and (last_rsi_3_1d_gt_75) and (last_stochrsi_k_1h_lt_25):
         return True, f"exit_{mode_name}_d_4_35"
       elif (
         (last_rsi_3_lt_30)
-        and (last_willr_14 < -70.0)
-        and (last_roc_9_4h > 25.0)
+        and (last_willr_14_lt_neg_70)
+        and (last_roc_9_4h_gt_25)
         and (last_rsi_3_1d_gt_75)
         and (last_stochrsi_k_1h_lt_50)
       ):
@@ -56054,13 +56101,13 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_stochrsi_k_4h_lt_50)
       ):
         return True, f"exit_{mode_name}_d_4_37"
-      elif (last_rsi_3_lt_30) and (last_willr_14 < -70.0) and (last_rsi_3_4h_gt_90) and (last_stochrsi_k_4h_lt_80):
+      elif (last_rsi_3_lt_30) and (last_willr_14_lt_neg_70) and (last_rsi_3_4h_gt_90) and (last_stochrsi_k_4h_lt_80):
         return True, f"exit_{mode_name}_d_4_38"
-      elif (last_rsi_3_lt_8) and (last_willr_14 < -92.0) and (last_cmf_20_4h > 0.0) and (last_rsi_3_4h_gt_90):
+      elif (last_rsi_3_lt_8) and (last_willr_14_lt_neg_92) and (last_cmf_20_4h_gt_0) and (last_rsi_3_4h_gt_90):
         return True, f"exit_{mode_name}_d_4_39"
       elif (
         (last_rsi_3_lt_30)
-        and (last_willr_14 < -70.0)
+        and (last_willr_14_lt_neg_70)
         and (last_rsi_3_1h_gt_70)
         and (last_stochrsi_k_1h_lt_70)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 10.0))
@@ -56068,7 +56115,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_4_40"
       elif (
         (last_rsi_3_lt_20)
-        and (last_willr_14 < -75.0)
+        and (last_willr_14_lt_neg_75)
         and (last_rsi_3_1h_gt_70)
         and (last_stochrsi_k_4h_lt_75)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -50.0))
@@ -56092,13 +56139,13 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_4_43"
       elif (
         (last_rsi_3_lt_50)
-        and (last_willr_14 < -80.0)
+        and (last_willr_14_lt_neg_80)
         and (last_rsi_3_4h_gt_70)
         and (last_rsi_3_1d > 25.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
       ):
         return True, f"exit_{mode_name}_d_4_44"
-      elif (last_rsi_3_lt_12) and (last_willr_14 < -88.0) and (last_rsi_3_1h_gt_90):
+      elif (last_rsi_3_lt_12) and (last_willr_14_lt_neg_88) and (last_rsi_3_1h_gt_90):
         return True, f"exit_{mode_name}_d_4_45"
       elif (last_rsi_3_lt_30) and (last_rsi_3_1h_gt_85) and (last_rsi_3_4h_gt_90) and (last_roc_2_1d > 20.0):
         return True, f"exit_{mode_name}_d_4_46"
@@ -56120,20 +56167,20 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_4_48"
       elif (
         (last_rsi_3_lt_25)
-        and (last_willr_14 < -90.0)
+        and (last_willr_14_lt_neg_90)
         and (last_rsi_3_4h_gt_80)
         and (last_change_pct_1d_gt_5)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 50.0))
       ):
         return True, f"exit_{mode_name}_d_4_49"
-      elif (last_rsi_3_lt_20) and (last_willr_14 < -90.0) and (last_rsi_3_1d > 90.0) and (last_stochrsi_k_1h < 10.0):
+      elif (last_rsi_3_lt_20) and (last_willr_14_lt_neg_90) and (last_rsi_3_1d > 90.0) and (last_stochrsi_k_1h_lt_10):
         return True, f"exit_{mode_name}_d_4_50"
       elif (last_rsi_3_lt_40) and (last_rsi_14_gt_48) and (last_rsi_3_4h_gt_80) and (last_stochrsi_k_1h_lt_50):
         return True, f"exit_{mode_name}_d_4_51"
       elif (
         (last_rsi_3_lt_26)
         and (last_rsi_14 < 46.0)
-        and (last_willr_14 < -90.0)
+        and (last_willr_14_lt_neg_90)
         and (last_stochrsi_k_1h_lt_30)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 15.0))
       ):
@@ -56141,7 +56188,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3_lt_30)
         and (last_rsi_14_gt_50)
-        and (last_willr_14 < -75.0)
+        and (last_willr_14_lt_neg_75)
         and (last_rsi_3_1h_gt_80)
         and (last_stochrsi_k_4h_lt_50)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 50.0))
@@ -56151,14 +56198,14 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3_lt_28)
         and (last_rsi_14_gt_48)
         and (last_stochrsi_k_1h_lt_50)
-        and (last_roc_9_4h > 10.0)
+        and (last_roc_9_4h_gt_10)
         and (last_change_pct_1d > 10.0)
       ):
         return True, f"exit_{mode_name}_d_4_54"
       elif (
         (last_rsi_3_lt_12)
-        and (last_willr_14 < -80.0)
-        and (last_roc_9_4h > 5.0)
+        and (last_willr_14_lt_neg_80)
+        and (last_roc_9_4h_gt_5)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -10.0))
         and (last_stochrsi_k_1h_lt_50)
       ):
@@ -56169,14 +56216,14 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_3_1h_gt_70)
         and (last_rsi_3_4h_gt_75)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
-        and (last_stochrsi_k_4h < 90.0)
+        and (last_stochrsi_k_4h_lt_90)
       ):
         return True, f"exit_{mode_name}_d_4_56"
       elif (
         (last_rsi_3_lt_50)
         and (last_rsi_14 > 58.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
-        and (last_stochrsi_k_4h < 30.0)
+        and (last_stochrsi_k_4h_lt_30)
       ):
         return True, f"exit_{mode_name}_d_4_57"
       elif (
@@ -56189,7 +56236,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_4_58"
       elif (
         (last_rsi_3 < 15.0)
-        and (last_willr_14 < -82.0)
+        and (last_willr_14_lt_neg_82)
         and (last_rsi_3_4h_gt_75)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 15.0))
         and (last_stochrsi_k_4h_lt_60)
@@ -56200,14 +56247,14 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14_gt_54)
         and (last_rsi_14_4h < 35.0)
         and (last_stochrsi_k_4h_lt_50)
-        and (last_stochrsi_k_1d < 50.0)
+        and (last_stochrsi_k_1d_lt_50)
       ):
         return True, f"exit_{mode_name}_d_4_60"
-      elif (last_rsi_3_lt_10) and (last_willr_14 < -75.0) and (last_rsi_3_4h_gt_90) and (last_stochrsi_k_1h_lt_70):
+      elif (last_rsi_3_lt_10) and (last_willr_14_lt_neg_75) and (last_rsi_3_4h_gt_90) and (last_stochrsi_k_1h_lt_70):
         return True, f"exit_{mode_name}_d_4_61"
       elif (
         (last_rsi_3_lt_20)
-        and (last_willr_14 < -92.0)
+        and (last_willr_14_lt_neg_92)
         and (last_rsi_3_1h_gt_70)
         and (last_rsi_3_4h_gt_80)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -20.0))
@@ -56230,7 +56277,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3_lt_50)
         and (last_rsi_14_gt_52)
-        and (last_stochrsi_k_4h < 20.0)
+        and (last_stochrsi_k_4h_lt_20)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 25.0))
       ):
         return True, f"exit_{mode_name}_d_4_67"
@@ -56238,7 +56285,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3_lt_22)
         and (last_rsi_14_gt_46)
         and (last_rsi_3_1h_gt_75)
-        and (last_roc_2_4h > 30.0)
+        and (last_roc_2_4h_gt_30)
         and (last_stochrsi_k_4h_lt_75)
       ):
         return True, f"exit_{mode_name}_d_4_68"
@@ -56246,7 +56293,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_4_69"
       elif (last_rsi_3_lt_40) and (last_rsi_14_gt_54) and (last_rsi_3_1h_gt_75) and (last_stochrsi_k_4h_lt_80):
         return True, f"exit_{mode_name}_d_4_70"
-      elif (last_rsi_3 < 42.0) and (last_rsi_14_gt_50) and (last_rsi_3_4h_gt_75) and (last_stochrsi_k_1h < 80.0):
+      elif (last_rsi_3_lt_42) and (last_rsi_14_gt_50) and (last_rsi_3_4h_gt_75) and (last_stochrsi_k_1h_lt_80):
         return True, f"exit_{mode_name}_d_4_71"
       elif (last_rsi_3_lt_28) and (last_rsi_14_gt_52) and (last_rsi_3_1h_gt_90) and (last_aroond_14_4h_gt_25):
         return True, f"exit_{mode_name}_d_4_72"
@@ -56254,16 +56301,16 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3_lt_28)
         and (last_rsi_3_1h_gt_75)
         and (last_rsi_3_4h_gt_85)
-        and (last_roc_9_4h > 20.0)
+        and (last_roc_9_4h_gt_20)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 25.0))
       ):
         return True, f"exit_{mode_name}_d_4_73"
       elif (
         (last_rsi_3 < 5.0)
-        and (last_willr_14 < -90.0)
+        and (last_willr_14_lt_neg_90)
         and (last_rsi_3_4h_gt_75)
         and (last_rsi_3_1d_gt_75)
-        and (last_stochrsi_k_1h > 50.0)
+        and (last_stochrsi_k_1h_gt_50)
       ):
         return True, f"exit_{mode_name}_d_4_74"
       elif (
@@ -56273,7 +56320,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 50.0))
       ):
         return True, f"exit_{mode_name}_d_4_75"
-      elif (last_rsi_3_lt_38) and (last_rsi_14_gt_44) and (last_roc_9_1h < -80.0) and (last_stochrsi_k_4h < 20.0):
+      elif (last_rsi_3_lt_38) and (last_rsi_14_gt_44) and (last_roc_9_1h < -80.0) and (last_stochrsi_k_4h_lt_20):
         return True, f"exit_{mode_name}_d_4_76"
       elif (
         (last_rsi_3_lt_30)
@@ -56290,7 +56337,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_3_1d > 80.0)
       ):
         return True, f"exit_{mode_name}_d_4_78"
-      elif (last_rsi_3_lt_14) and (last_willr_14 < -92.0) and (last_rsi_3_1h_gt_70) and (last_rsi_3_4h_gt_90):
+      elif (last_rsi_3_lt_14) and (last_willr_14_lt_neg_92) and (last_rsi_3_1h_gt_70) and (last_rsi_3_4h_gt_90):
         return True, f"exit_{mode_name}_d_4_79"
       elif (
         (last_rsi_3_lt_34)
@@ -56302,7 +56349,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_4_80"
       elif (
         (last_rsi_3_lt_22)
-        and (last_willr_14 < -84.0)
+        and (last_willr_14_lt_neg_84)
         and (last_rsi_3_1h_gt_75)
         and (last_rsi_3_4h_gt_75)
         and (isinstance(last_rsi_14_1d, np.float64) and (last_rsi_14_1d < 50.0))
@@ -56310,7 +56357,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_4_81"
       elif (
         (last_rsi_3_lt_24)
-        and (last_willr_14 < -84.0)
+        and (last_willr_14_lt_neg_84)
         and (last_rsi_3_4h_gt_70)
         and (last_rsi_3_1d > 85.0)
         and (last_stochrsi_k_4h_lt_60)
@@ -56324,11 +56371,11 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_stochrsi_k_4h_lt_60)
       ):
         return True, f"exit_{mode_name}_d_4_83"
-      elif (last_rsi_3_lt_16) and (last_willr_14 < -92.0) and (last_rsi_3_4h_gt_70) and (last_stochrsi_k_1h < 80.0):
+      elif (last_rsi_3_lt_16) and (last_willr_14_lt_neg_92) and (last_rsi_3_4h_gt_70) and (last_stochrsi_k_1h_lt_80):
         return True, f"exit_{mode_name}_d_4_84"
       elif (
         (last_rsi_3_lt_18)
-        and (last_willr_14 < -86.0)
+        and (last_willr_14_lt_neg_86)
         and (last_rsi_3_1h_gt_70)
         and (last_rsi_3_4h_gt_60)
         and (last_stochrsi_k_4h_lt_50)
@@ -56361,13 +56408,13 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3_lt_28)
         and (last_rsi_14_gt_54)
-        and (last_roc_9_1h > 5.0)
+        and (last_roc_9_1h_gt_5)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -25.0))
       ):
         return True, f"exit_{mode_name}_d_4_89"
       elif (
         (last_rsi_3_lt_14)
-        and (last_willr_14 < -75.0)
+        and (last_willr_14_lt_neg_75)
         and (last_rsi_3_1h_gt_50)
         and (last_rsi_3_4h_gt_70)
         and (last_aroonu_14_4h_lt_50)
@@ -56387,7 +56434,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3_lt_26)
         and (last_rsi_14_gt_46)
         and (last_rsi_3_1h_gt_60)
-        and (last_stochrsi_k_1h < 75.0)
+        and (last_stochrsi_k_1h_lt_75)
         and (last_stochrsi_k_4h_lt_50)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 25.0))
       ):
@@ -56414,15 +56461,15 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_4_94"
       elif (
         (last_rsi_3_lt_22)
-        and (last_willr_14 < -82.0)
+        and (last_willr_14_lt_neg_82)
         and (last_rsi_3_1h_gt_55)
         and (last_rsi_3_4h_gt_60)
-        and (last_stochrsi_k_4h < 90.0)
+        and (last_stochrsi_k_4h_lt_90)
         and (isinstance(last_aroond_14_1d, np.float64) and (last_aroond_14_1d > 75.0))
       ):
         return True, f"exit_{mode_name}_d_4_95"
       elif (
-        (last_rsi_3 < 44.0)
+        (last_rsi_3_lt_44)
         and (last_rsi_14_gt_48)
         and (last_rsi_3_1h_gt_55)
         and (last_rsi_3_1d > 55.0)
@@ -56452,11 +56499,11 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_3_1h > 35.0)
         and (last_rsi_3_4h_gt_40)
         and (last_aroond_14_4h_gt_50)
-        and (last_stoch_k_4h < 60.0)
+        and (last_stoch_k_4h_lt_60)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -80.0))
       ):
         return True, f"exit_{mode_name}_d_4_99"
-      elif (last_rsi_3_lt_8) and (last_rsi_14 < 30.0) and (last_rsi_3_15m < 30.0) and (last_rsi_3_4h > 20.0):
+      elif (last_rsi_3_lt_8) and (last_rsi_14 < 30.0) and (last_rsi_3_15m_lt_30) and (last_rsi_3_4h > 20.0):
         return True, f"exit_{mode_name}_d_4_100"
       elif (
         (last_rsi_3_lt_22)
@@ -56471,7 +56518,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14_gt_46)
         and (last_rsi_3_1h_gt_40)
         and (last_rsi_3_4h_gt_60)
-        and (last_stochrsi_k_4h > 70.0)
+        and (last_stochrsi_k_4h_gt_70)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -40.0))
       ):
         return True, f"exit_{mode_name}_d_4_102"
@@ -56484,12 +56531,12 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_4_103"
       elif (
-        (last_rsi_3 < 42.0)
+        (last_rsi_3_lt_42)
         and (last_rsi_14_gt_46)
         and (last_rsi_3_1h_gt_40)
         and (last_stochrsi_k_1h_lt_60)
         and (last_stochrsi_k_4h_lt_10)
-        and (last_roc_9_4h < -40.0)
+        and (last_roc_9_4h_lt_neg_40)
       ):
         return True, f"exit_{mode_name}_d_4_104"
       elif (
@@ -56497,7 +56544,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14_gt_46)
         and (last_rsi_3_15m > 45.0)
         and (last_stochrsi_k_4h_lt_10)
-        and (last_roc_9_4h < -25.0)
+        and (last_roc_9_4h_lt_neg_25)
       ):
         return True, f"exit_{mode_name}_d_4_105"
       elif (
@@ -56506,7 +56553,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_3_1h_gt_50)
         and (last_stochrsi_k_1h_lt_50)
         and (last_rsi_14_4h_lt_30)
-        and (last_roc_9_4h < -40.0)
+        and (last_roc_9_4h_lt_neg_40)
       ):
         return True, f"exit_{mode_name}_d_4_106"
       elif (
@@ -56521,13 +56568,13 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_4_108"
       elif (
         (last_rsi_3_lt_30)
-        and (last_willr_14 < -86.0)
+        and (last_willr_14_lt_neg_86)
         and (last_rsi_3_1h_gt_50)
         and (last_rsi_3_4h_gt_80)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -50.0))
       ):
         return True, f"exit_{mode_name}_d_4_109"
-      elif (last_rsi_3_lt_34) and (last_rsi_3_4h > 35.0) and (last_stochrsi_k_4h_lt_50) and (last_roc_9_4h < -25.0):
+      elif (last_rsi_3_lt_34) and (last_rsi_3_4h > 35.0) and (last_stochrsi_k_4h_lt_50) and (last_roc_9_4h_lt_neg_25):
         return True, f"exit_{mode_name}_d_4_110"
       elif (
         (last_rsi_3 < 56.0)
@@ -56544,14 +56591,14 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_willr_14 < -60.0)
         and (last_rsi_14 > 42.0)
         and (last_rsi_3_1h_gt_65)
-        and (last_rsi_3_4h > 65.0)
+        and (last_rsi_3_4h_gt_65)
         and (last_rsi_3_1d > 40.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
       ):
         return True, f"exit_{mode_name}_d_4_112"
       elif (
         (last_rsi_3_lt_22)
-        and (last_willr_14 < -92.0)
+        and (last_willr_14_lt_neg_92)
         and (last_rsi_3_1d_gt_70)
         and (last_stochrsi_k_4h_lt_50)
         and (isinstance(last_roc_9_4h, np.float64) and (last_roc_9_4h < -10.0))
@@ -56569,7 +56616,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3_lt_28)
         and (last_rsi_14_gt_46)
-        and (last_rsi_3_15m > 70.0)
+        and (last_rsi_3_15m_gt_70)
         and (last_stochrsi_k_1h_lt_50)
         and (last_stochrsi_k_4h_lt_50)
       ):
@@ -56582,7 +56629,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_4_118"
       elif (
         (last_rsi_3_lt_20)
-        and (last_willr_14 < -80.0)
+        and (last_willr_14_lt_neg_80)
         and (last_rsi_3_1h_gt_40)
         and (last_rsi_3_4h_gt_40)
         and (last_stochrsi_k_1h_lt_60)
@@ -56594,7 +56641,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_4_121"
       elif (last_rsi_3 < 48.0) and (last_rsi_14_gt_50) and (last_rsi_3_4h_gt_70) and (last_stochrsi_k_1h_lt_50):
         return True, f"exit_{mode_name}_d_4_122"
-      elif (last_rsi_3_lt_18) and (last_willr_14 < -90.0) and (last_rsi_3_1h_gt_90) and (last_rsi_3_1d_gt_70):
+      elif (last_rsi_3_lt_18) and (last_willr_14_lt_neg_90) and (last_rsi_3_1h_gt_90) and (last_rsi_3_1d_gt_70):
         return True, f"exit_{mode_name}_d_4_123"
       elif (
         (last_rsi_3_lt_18)
@@ -56604,16 +56651,16 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_4_124"
       elif (
         (last_rsi_3_lt_30)
-        and (last_willr_14 < -90.0)
+        and (last_willr_14_lt_neg_90)
         and (last_rsi_3_1h_gt_90)
         and (last_rsi_3_4h_gt_60)
-        and (last_rsi_3_1d > 60.0)
+        and (last_rsi_3_1d_gt_60)
         and (last_close > (last_low_min_30_1d * 2.0))
       ):
         return True, f"exit_{mode_name}_d_4_125"
       elif (last_rsi_3_lt_16) and (last_rsi_3_1h_gt_85) and (last_rsi_3_4h_gt_60) and (last_stochrsi_k_4h_lt_50):
         return True, f"exit_{mode_name}_d_4_126"
-      elif (last_rsi_3_lt_16) and (last_rsi_3_1h_gt_90) and (last_rsi_3_4h_gt_70) and (last_rsi_3_1d > 60.0):
+      elif (last_rsi_3_lt_16) and (last_rsi_3_1h_gt_90) and (last_rsi_3_4h_gt_70) and (last_rsi_3_1d_gt_60):
         return True, f"exit_{mode_name}_d_4_127"
       elif (last_rsi_3_lt_12) and (last_rsi_3_4h_gt_70) and (last_aroond_14_4h > 85.0):
         return True, f"exit_{mode_name}_d_4_128"
@@ -56635,7 +56682,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3_lt_26)
         and (last_rsi_3_1h_gt_65)
-        and (last_rsi_3_4h > 65.0)
+        and (last_rsi_3_4h_gt_65)
         and (last_aroond_14_1h > 50.0)
         and (last_stochrsi_k_1h_lt_60)
       ):
@@ -56649,7 +56696,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_4_133"
     elif 0.06 > current_profit >= 0.05:
       if (
-        (last_willr_14 < -99.0)
+        (last_willr_14_lt_neg_99)
         and (last_rsi_14 < 22.0)
         and (isinstance(last_ema_200_1h, np.float64) and (last_ema_12_1h > last_ema_200_1h))
         and (isinstance(last_ema_200_4h, np.float64) and (last_ema_12_4h > last_ema_200_4h))
@@ -56658,35 +56705,35 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_5_1"
       elif (
-        (last_willr_14 < -99.0)
+        (last_willr_14_lt_neg_99)
         and (last_rsi_14 < 40.0)
-        and (last_cmf_20_1h > 0.0)
+        and (last_cmf_20_1h_gt_0)
         and (isinstance(last_ema_200_1h, np.float64) and (last_ema_12_1h > last_ema_200_1h))
         and (isinstance(last_ema_200_4h, np.float64) and (last_ema_12_4h > last_ema_200_4h))
       ):
         return True, f"exit_{mode_name}_d_5_2"
       elif (
-        (last_willr_14 < -80.0)
+        (last_willr_14_lt_neg_80)
         and (last_stochrsi_k < 5.0)
-        and (last_cmf_20_1h > 0.0)
-        and (last_cmf_20_4h > 0.0)
-        and ((last_stochrsi_k_4h < 80.0) and (last_stochrsi_k_change_pct_4h > 10.0))
+        and (last_cmf_20_1h_gt_0)
+        and (last_cmf_20_4h_gt_0)
+        and ((last_stochrsi_k_4h < 80.0) and (last_stochrsi_k_change_pct_4h_gt_10))
       ):
         return True, f"exit_{mode_name}_d_5_3"
       elif (
-        (last_willr_14 < -70.0)
+        (last_willr_14_lt_neg_70)
         and (last_rsi_14 < 35.0)
         and (last_stochrsi_k < 5.0)
-        and (last_stochrsi_k_4h < 30.0)
+        and (last_stochrsi_k_4h_lt_30)
         and (isinstance(last_ema_200_1h, np.float64) and (last_ema_12_1h > last_ema_200_1h))
         and (isinstance(last_ema_200_4h, np.float64) and (last_ema_12_4h > last_ema_200_4h))
       ):
         return True, f"exit_{mode_name}_d_5_4"
-      elif (last_willr_14 < -90.0) and (last_rsi_14 < 36.0) and (last_roc_9_1h > 5.0) and (last_roc_9_4h > 5.0):
+      elif (last_willr_14_lt_neg_90) and (last_rsi_14 < 36.0) and (last_roc_9_1h_gt_5) and (last_roc_9_4h_gt_5):
         return True, f"exit_{mode_name}_d_5_5"
       elif (
         (last_rsi_3 < 30.0)
-        and (last_stochrsi_k < 30.0)
+        and (last_stochrsi_k_lt_30)
         and (last_rsi_14 > 60.0)
         and (last_roc_9_1h > 10.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -50.0))
@@ -56694,13 +56741,13 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_5_6"
       elif (
         (last_rsi_14_gt_50)
-        and (last_stochrsi_k < 30.0)
+        and (last_stochrsi_k_lt_30)
         and (last_stochrsi_k_4h_lt_50)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 40.0))
       ):
         return True, f"exit_{mode_name}_d_5_7"
       elif (
-        (last_willr_14 < -90.0)
+        (last_willr_14_lt_neg_90)
         and (last_stochrsi_k < 5.0)
         and (last_cmf_20_1h > 0.1)
         and (last_cmf_20_4h > 0.1)
@@ -56709,17 +56756,17 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_5_8"
       elif (
-        (last_willr_14 < -92.0)
+        (last_willr_14_lt_neg_92)
         and (last_rsi_3 < 5.0)
         and (last_change_pct_4h > 5.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
       ):
         return True, f"exit_{mode_name}_d_5_9"
       elif (
-        (last_willr_14 < -80.0)
+        (last_willr_14_lt_neg_80)
         and (last_rsi_14_gt_50)
         and (last_roc_9_1h > 10.0)
-        and (last_roc_9_4h > 10.0)
+        and (last_roc_9_4h_gt_10)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -10.0))
       ):
         return True, f"exit_{mode_name}_d_5_10"
@@ -56736,19 +56783,19 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14_gt_50)
         and (last_rsi_3_4h > 90.0)
         and (last_roc_9_1h > 20.0)
-        and (last_roc_9_4h > 20.0)
+        and (last_roc_9_4h_gt_20)
       ):
         return True, f"exit_{mode_name}_d_5_12"
-      elif (last_rsi_3 < 20.0) and (last_rsi_3_4h > 95.0) and (last_roc_9_4h > 25.0):
+      elif (last_rsi_3 < 20.0) and (last_rsi_3_4h_gt_95) and (last_roc_9_4h_gt_25):
         return True, f"exit_{mode_name}_d_5_13"
-      elif (last_rsi_3 < 10.0) and (last_willr_14 < -88.0) and (last_rsi_3_4h > 95.0) and (last_aroond_14_4h > 25.0):
+      elif (last_rsi_3 < 10.0) and (last_willr_14_lt_neg_88) and (last_rsi_3_4h_gt_95) and (last_aroond_14_4h > 25.0):
         return True, f"exit_{mode_name}_d_5_14"
       elif (last_rsi_3 < 14.0) and (last_rsi_14 > 58.0) and (last_roc_9_4h > 30.0):
         return True, f"exit_{mode_name}_d_5_15"
       elif (
         (last_rsi_3 < 30.0)
         and (last_aroond_14_4h > 25.0)
-        and (last_roc_9_4h > 25.0)
+        and (last_roc_9_4h_gt_25)
         and (last_aroond_14_1d > 50.0)
         and (last_change_pct_1d > 15.0)
       ):
@@ -56776,13 +56823,13 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_5_21"
       elif (
         (last_rsi_3 < 10.0)
-        and (last_willr_14 < -90.0)
+        and (last_willr_14_lt_neg_90)
         and (last_change_pct_4h > 5.0)
         and (last_stochrsi_k_4h_lt_50)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
       ):
         return True, f"exit_{mode_name}_d_5_22"
-      elif (last_rsi_3 < 25.0) and (last_willr_14 < -70.0) and (last_rsi_3_1h > 85.0) and (last_rsi_3_1d > 95.0):
+      elif (last_rsi_3 < 25.0) and (last_willr_14_lt_neg_70) and (last_rsi_3_1h > 85.0) and (last_rsi_3_1d > 95.0):
         return True, f"exit_{mode_name}_d_5_23"
       elif (
         (last_rsi_3 < 16.0)
@@ -56794,13 +56841,13 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_5_24"
       elif (
         (last_rsi_3 < 30.0)
-        and (last_willr_14 < -88.0)
+        and (last_willr_14_lt_neg_88)
         and (last_rsi_3_4h > 90.0)
         and (last_roc_9_4h > 15.0)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 50.0))
       ):
         return True, f"exit_{mode_name}_d_5_25"
-      elif (last_rsi_3 < 35.0) and (last_willr_14 < -88.0) and (last_rsi_3_4h > 85.0) and (last_roc_9_4h > 20.0):
+      elif (last_rsi_3 < 35.0) and (last_willr_14_lt_neg_88) and (last_rsi_3_4h > 85.0) and (last_roc_9_4h_gt_20):
         return True, f"exit_{mode_name}_d_5_26"
       elif (
         (last_rsi_3 < 35.0)
@@ -56827,27 +56874,27 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14_gt_50)
         and (last_rsi_3_1h > 85.0)
         and (last_rsi_3_4h > 85.0)
-        and (last_stochrsi_k_1h < 75.0)
+        and (last_stochrsi_k_1h_lt_75)
       ):
         return True, f"exit_{mode_name}_d_5_31"
-      elif (last_rsi_3 < 30.0) and (last_rsi_3_1h > 85.0) and (last_roc_2_4h > 30.0) and (last_stochrsi_k_4h < 70.0):
+      elif (last_rsi_3 < 30.0) and (last_rsi_3_1h > 85.0) and (last_roc_2_4h_gt_30) and (last_stochrsi_k_4h < 70.0):
         return True, f"exit_{mode_name}_d_5_32"
       elif (
         (last_rsi_3 < 30.0)
-        and (last_willr_14 < -90.0)
+        and (last_willr_14_lt_neg_90)
         and (last_roc_2_1h > 10.0)
         and (last_roc_9_1h < -30.0)
         and (last_stochrsi_k_1h_lt_50)
       ):
         return True, f"exit_{mode_name}_d_5_33"
-      elif (last_rsi_3 < 35.0) and (last_rsi_3_15m > 70.0) and (last_rsi_14_1h < 20.0) and (last_roc_9_1h < -40.0):
+      elif (last_rsi_3 < 35.0) and (last_rsi_3_15m_gt_70) and (last_rsi_14_1h < 20.0) and (last_roc_9_1h < -40.0):
         return True, f"exit_{mode_name}_d_5_34"
-      elif (last_rsi_3 < 20.0) and (last_willr_14 < -90.0) and (last_rsi_3_1d > 75.0) and (last_stochrsi_k_1h < 25.0):
+      elif (last_rsi_3 < 20.0) and (last_willr_14_lt_neg_90) and (last_rsi_3_1d > 75.0) and (last_stochrsi_k_1h_lt_25):
         return True, f"exit_{mode_name}_d_5_35"
       elif (
         (last_rsi_3 < 35.0)
         and (last_willr_14 < -65.0)
-        and (last_roc_9_4h > 25.0)
+        and (last_roc_9_4h_gt_25)
         and (last_rsi_3_1d > 75.0)
         and (last_stochrsi_k_1h_lt_50)
       ):
@@ -56862,7 +56909,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_5_37"
       elif (last_rsi_3 < 35.0) and (last_willr_14 < -65.0) and (last_rsi_3_4h > 90.0) and (last_stochrsi_k_4h < 80.0):
         return True, f"exit_{mode_name}_d_5_38"
-      elif (last_rsi_3 < 9.0) and (last_willr_14 < -91.0) and (last_cmf_20_4h > 0.0) and (last_rsi_3_4h > 90.0):
+      elif (last_rsi_3 < 9.0) and (last_willr_14 < -91.0) and (last_cmf_20_4h_gt_0) and (last_rsi_3_4h > 90.0):
         return True, f"exit_{mode_name}_d_5_39"
       elif (
         (last_rsi_3 < 35.0)
@@ -56874,7 +56921,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_5_40"
       elif (
         (last_rsi_3 < 25.0)
-        and (last_willr_14 < -70.0)
+        and (last_willr_14_lt_neg_70)
         and (last_rsi_3_1h_gt_70)
         and (last_stochrsi_k_4h < 75.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -50.0))
@@ -56898,13 +56945,13 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_5_43"
       elif (
         (last_rsi_3 < 50.0)
-        and (last_willr_14 < -75.0)
+        and (last_willr_14_lt_neg_75)
         and (last_rsi_3_4h_gt_70)
         and (last_rsi_3_1d > 25.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
       ):
         return True, f"exit_{mode_name}_d_5_44"
-      elif (last_rsi_3 < 14.0) and (last_willr_14 < -86.0) and (last_rsi_3_1h > 90.0):
+      elif (last_rsi_3 < 14.0) and (last_willr_14_lt_neg_86) and (last_rsi_3_1h > 90.0):
         return True, f"exit_{mode_name}_d_5_45"
       elif (last_rsi_3 < 30.0) and (last_rsi_3_1h > 85.0) and (last_rsi_3_4h > 90.0) and (last_roc_2_1d > 20.0):
         return True, f"exit_{mode_name}_d_5_46"
@@ -56926,20 +56973,20 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_5_48"
       elif (
         (last_rsi_3 < 30.0)
-        and (last_willr_14 < -88.0)
+        and (last_willr_14_lt_neg_88)
         and (last_rsi_3_4h > 80.0)
         and (last_change_pct_1d > 5.0)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 50.0))
       ):
         return True, f"exit_{mode_name}_d_5_49"
-      elif (last_rsi_3 < 20.0) and (last_willr_14 < -88.0) and (last_rsi_3_1d > 90.0) and (last_stochrsi_k_1h < 10.0):
+      elif (last_rsi_3 < 20.0) and (last_willr_14_lt_neg_88) and (last_rsi_3_1d > 90.0) and (last_stochrsi_k_1h_lt_10):
         return True, f"exit_{mode_name}_d_5_50"
-      elif (last_rsi_3 < 42.0) and (last_rsi_14 > 46.0) and (last_rsi_3_4h > 80.0) and (last_stochrsi_k_1h_lt_50):
+      elif (last_rsi_3_lt_42) and (last_rsi_14 > 46.0) and (last_rsi_3_4h > 80.0) and (last_stochrsi_k_1h_lt_50):
         return True, f"exit_{mode_name}_d_5_51"
       elif (
         (last_rsi_3 < 28.0)
         and (last_rsi_14 < 48.0)
-        and (last_willr_14 < -90.0)
+        and (last_willr_14_lt_neg_90)
         and (last_stochrsi_k_1h < 30.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 15.0))
       ):
@@ -56947,7 +56994,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 30.0)
         and (last_rsi_14_gt_50)
-        and (last_willr_14 < -75.0)
+        and (last_willr_14_lt_neg_75)
         and (last_rsi_3_1h > 80.0)
         and (last_stochrsi_k_4h_lt_50)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 50.0))
@@ -56957,14 +57004,14 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 30.0)
         and (last_rsi_14 > 46.0)
         and (last_stochrsi_k_1h_lt_50)
-        and (last_roc_9_4h > 10.0)
+        and (last_roc_9_4h_gt_10)
         and (last_change_pct_1d > 10.0)
       ):
         return True, f"exit_{mode_name}_d_5_54"
       elif (
         (last_rsi_3 < 14.0)
         and (last_willr_14 < -78.0)
-        and (last_roc_9_4h > 5.0)
+        and (last_roc_9_4h_gt_5)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -10.0))
         and (last_stochrsi_k_1h_lt_50)
       ):
@@ -56975,14 +57022,14 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_3_1h_gt_70)
         and (last_rsi_3_4h > 75.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
-        and (last_stochrsi_k_4h < 90.0)
+        and (last_stochrsi_k_4h_lt_90)
       ):
         return True, f"exit_{mode_name}_d_5_56"
       elif (
         (last_rsi_3 < 50.0)
         and (last_rsi_14 > 56.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
-        and (last_stochrsi_k_4h < 30.0)
+        and (last_stochrsi_k_4h_lt_30)
       ):
         return True, f"exit_{mode_name}_d_5_57"
       elif (
@@ -56995,7 +57042,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_5_58"
       elif (
         (last_rsi_3 < 15.0)
-        and (last_willr_14 < -80.0)
+        and (last_willr_14_lt_neg_80)
         and (last_rsi_3_4h > 75.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 15.0))
         and (last_stochrsi_k_4h < 60.0)
@@ -57006,14 +57053,16 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 > 52.0)
         and (last_rsi_14_4h < 35.0)
         and (last_stochrsi_k_4h_lt_50)
-        and (last_stochrsi_k_1d < 50.0)
+        and (last_stochrsi_k_1d_lt_50)
       ):
         return True, f"exit_{mode_name}_d_5_60"
-      elif (last_rsi_3 < 10.0) and (last_willr_14 < -75.0) and (last_rsi_3_4h > 90.0) and (last_stochrsi_k_1h < 70.0):
+      elif (
+        (last_rsi_3 < 10.0) and (last_willr_14_lt_neg_75) and (last_rsi_3_4h > 90.0) and (last_stochrsi_k_1h < 70.0)
+      ):
         return True, f"exit_{mode_name}_d_5_61"
       elif (
         (last_rsi_3 < 22.0)
-        and (last_willr_14 < -90.0)
+        and (last_willr_14_lt_neg_90)
         and (last_rsi_3_1h_gt_70)
         and (last_rsi_3_4h > 80.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -20.0))
@@ -57038,7 +57087,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 50.0)
         and (last_rsi_14_gt_50)
-        and (last_stochrsi_k_4h < 20.0)
+        and (last_stochrsi_k_4h_lt_20)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 25.0))
       ):
         return True, f"exit_{mode_name}_d_5_67"
@@ -57046,7 +57095,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 24.0)
         and (last_rsi_14 > 44.0)
         and (last_rsi_3_1h > 75.0)
-        and (last_roc_2_4h > 30.0)
+        and (last_roc_2_4h_gt_30)
         and (last_stochrsi_k_4h < 75.0)
       ):
         return True, f"exit_{mode_name}_d_5_68"
@@ -57054,9 +57103,9 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 8.0) and (last_roc_9_4h < -20.0) and (last_stochrsi_k_4h_lt_50) and (last_change_pct_4h > 5.0)
       ):
         return True, f"exit_{mode_name}_d_5_69"
-      elif (last_rsi_3 < 42.0) and (last_rsi_14 > 52.0) and (last_rsi_3_1h > 75.0) and (last_stochrsi_k_4h < 80.0):
+      elif (last_rsi_3_lt_42) and (last_rsi_14 > 52.0) and (last_rsi_3_1h > 75.0) and (last_stochrsi_k_4h < 80.0):
         return True, f"exit_{mode_name}_d_5_70"
-      elif (last_rsi_3 < 44.0) and (last_rsi_14 > 48.0) and (last_rsi_3_4h > 75.0) and (last_stochrsi_k_1h < 80.0):
+      elif (last_rsi_3_lt_44) and (last_rsi_14 > 48.0) and (last_rsi_3_4h > 75.0) and (last_stochrsi_k_1h_lt_80):
         return True, f"exit_{mode_name}_d_5_71"
       elif (last_rsi_3 < 30.0) and (last_rsi_14_gt_50) and (last_rsi_3_1h > 90.0) and (last_aroond_14_4h > 25.0):
         return True, f"exit_{mode_name}_d_5_72"
@@ -57064,16 +57113,16 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 30.0)
         and (last_rsi_3_1h > 75.0)
         and (last_rsi_3_4h > 85.0)
-        and (last_roc_9_4h > 20.0)
+        and (last_roc_9_4h_gt_20)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 25.0))
       ):
         return True, f"exit_{mode_name}_d_5_73"
       elif (
         (last_rsi_3 < 6.0)
-        and (last_willr_14 < -90.0)
+        and (last_willr_14_lt_neg_90)
         and (last_rsi_3_4h > 75.0)
         and (last_rsi_3_1d > 75.0)
-        and (last_stochrsi_k_1h > 50.0)
+        and (last_stochrsi_k_1h_gt_50)
       ):
         return True, f"exit_{mode_name}_d_5_74"
       elif (
@@ -57083,7 +57132,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 50.0))
       ):
         return True, f"exit_{mode_name}_d_5_75"
-      elif (last_rsi_3 < 40.0) and (last_rsi_14 > 42.0) and (last_roc_9_1h < -80.0) and (last_stochrsi_k_4h < 20.0):
+      elif (last_rsi_3 < 40.0) and (last_rsi_14 > 42.0) and (last_roc_9_1h < -80.0) and (last_stochrsi_k_4h_lt_20):
         return True, f"exit_{mode_name}_d_5_76"
       elif (
         (last_rsi_3 < 32.0)
@@ -57100,7 +57149,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_3_1d > 80.0)
       ):
         return True, f"exit_{mode_name}_d_5_78"
-      elif (last_rsi_3 < 16.0) and (last_willr_14 < -90.0) and (last_rsi_3_1h_gt_70) and (last_rsi_3_4h > 90.0):
+      elif (last_rsi_3 < 16.0) and (last_willr_14_lt_neg_90) and (last_rsi_3_1h_gt_70) and (last_rsi_3_4h > 90.0):
         return True, f"exit_{mode_name}_d_5_79"
       elif (
         (last_rsi_3 < 36.0)
@@ -57112,7 +57161,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_5_80"
       elif (
         (last_rsi_3 < 24.0)
-        and (last_willr_14 < -82.0)
+        and (last_willr_14_lt_neg_82)
         and (last_rsi_3_1h > 75.0)
         and (last_rsi_3_4h > 75.0)
         and (isinstance(last_rsi_14_1d, np.float64) and (last_rsi_14_1d < 50.0))
@@ -57120,7 +57169,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_5_81"
       elif (
         (last_rsi_3 < 26.0)
-        and (last_willr_14 < -82.0)
+        and (last_willr_14_lt_neg_82)
         and (last_rsi_3_4h_gt_70)
         and (last_rsi_3_1d > 85.0)
         and (last_stochrsi_k_4h < 60.0)
@@ -57134,11 +57183,11 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_stochrsi_k_4h < 60.0)
       ):
         return True, f"exit_{mode_name}_d_5_83"
-      elif (last_rsi_3 < 18.0) and (last_willr_14 < -90.0) and (last_rsi_3_4h_gt_70) and (last_stochrsi_k_1h < 80.0):
+      elif (last_rsi_3 < 18.0) and (last_willr_14_lt_neg_90) and (last_rsi_3_4h_gt_70) and (last_stochrsi_k_1h_lt_80):
         return True, f"exit_{mode_name}_d_5_84"
       elif (
         (last_rsi_3 < 20.0)
-        and (last_willr_14 < -84.0)
+        and (last_willr_14_lt_neg_84)
         and (last_rsi_3_1h_gt_70)
         and (last_rsi_3_4h > 60.0)
         and (last_stochrsi_k_4h_lt_50)
@@ -57153,7 +57202,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_5_86"
       elif (
-        (last_rsi_3 < 42.0)
+        (last_rsi_3_lt_42)
         and (last_rsi_14 > 48.0)
         and (last_rsi_3_1h > 55.0)
         and (last_rsi_3_4h > 50.0)
@@ -57171,13 +57220,13 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 30.0)
         and (last_rsi_14 > 52.0)
-        and (last_roc_9_1h > 5.0)
+        and (last_roc_9_1h_gt_5)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -25.0))
       ):
         return True, f"exit_{mode_name}_d_5_89"
       elif (
         (last_rsi_3 < 16.0)
-        and (last_willr_14 < -75.0)
+        and (last_willr_14_lt_neg_75)
         and (last_rsi_3_1h > 50.0)
         and (last_rsi_3_4h_gt_70)
         and (last_aroonu_14_4h < 50.0)
@@ -57197,7 +57246,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 28.0)
         and (last_rsi_14 > 44.0)
         and (last_rsi_3_1h > 60.0)
-        and (last_stochrsi_k_1h < 75.0)
+        and (last_stochrsi_k_1h_lt_75)
         and (last_stochrsi_k_4h_lt_50)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 25.0))
       ):
@@ -57224,10 +57273,10 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_5_94"
       elif (
         (last_rsi_3 < 24.0)
-        and (last_willr_14 < -80.0)
+        and (last_willr_14_lt_neg_80)
         and (last_rsi_3_1h > 55.0)
         and (last_rsi_3_4h > 60.0)
-        and (last_stochrsi_k_4h < 90.0)
+        and (last_stochrsi_k_4h_lt_90)
         and (isinstance(last_aroond_14_1d, np.float64) and (last_aroond_14_1d > 75.0))
       ):
         return True, f"exit_{mode_name}_d_5_95"
@@ -57262,11 +57311,11 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_3_1h > 35.0)
         and (last_rsi_3_4h > 40.0)
         and (last_aroond_14_4h > 50.0)
-        and (last_stoch_k_4h < 60.0)
+        and (last_stoch_k_4h_lt_60)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -80.0))
       ):
         return True, f"exit_{mode_name}_d_5_99"
-      elif (last_rsi_3 < 10.0) and (last_rsi_14 < 32.0) and (last_rsi_3_15m < 30.0) and (last_rsi_3_4h > 20.0):
+      elif (last_rsi_3 < 10.0) and (last_rsi_14 < 32.0) and (last_rsi_3_15m_lt_30) and (last_rsi_3_4h > 20.0):
         return True, f"exit_{mode_name}_d_5_100"
       elif (
         (last_rsi_3 < 24.0)
@@ -57281,7 +57330,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 > 44.0)
         and (last_rsi_3_1h > 40.0)
         and (last_rsi_3_4h > 60.0)
-        and (last_stochrsi_k_4h > 70.0)
+        and (last_stochrsi_k_4h_gt_70)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -40.0))
       ):
         return True, f"exit_{mode_name}_d_5_102"
@@ -57294,12 +57343,12 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_5_103"
       elif (
-        (last_rsi_3 < 44.0)
+        (last_rsi_3_lt_44)
         and (last_rsi_14 > 44.0)
         and (last_rsi_3_1h > 40.0)
         and (last_stochrsi_k_1h < 60.0)
         and (last_stochrsi_k_4h < 10.0)
-        and (last_roc_9_4h < -40.0)
+        and (last_roc_9_4h_lt_neg_40)
       ):
         return True, f"exit_{mode_name}_d_5_104"
       elif (
@@ -57307,7 +57356,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 > 44.0)
         and (last_rsi_3_15m > 45.0)
         and (last_stochrsi_k_4h < 10.0)
-        and (last_roc_9_4h < -25.0)
+        and (last_roc_9_4h_lt_neg_25)
       ):
         return True, f"exit_{mode_name}_d_5_105"
       elif (
@@ -57316,7 +57365,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_3_1h > 50.0)
         and (last_stochrsi_k_1h_lt_50)
         and (last_rsi_14_4h < 30.0)
-        and (last_roc_9_4h < -40.0)
+        and (last_roc_9_4h_lt_neg_40)
       ):
         return True, f"exit_{mode_name}_d_5_106"
       elif (
@@ -57331,13 +57380,13 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_5_108"
       elif (
         (last_rsi_3 < 32.0)
-        and (last_willr_14 < -84.0)
+        and (last_willr_14_lt_neg_84)
         and (last_rsi_3_1h > 50.0)
         and (last_rsi_3_4h > 80.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -50.0))
       ):
         return True, f"exit_{mode_name}_d_5_109"
-      elif (last_rsi_3 < 36.0) and (last_rsi_3_4h > 35.0) and (last_stochrsi_k_4h_lt_50) and (last_roc_9_4h < -25.0):
+      elif (last_rsi_3 < 36.0) and (last_rsi_3_4h > 35.0) and (last_stochrsi_k_4h_lt_50) and (last_roc_9_4h_lt_neg_25):
         return True, f"exit_{mode_name}_d_5_110"
       elif (
         (last_rsi_3 < 58.0)
@@ -57354,14 +57403,14 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_willr_14 < -55.0)
         and (last_rsi_14 > 40.0)
         and (last_rsi_3_1h > 65.0)
-        and (last_rsi_3_4h > 65.0)
+        and (last_rsi_3_4h_gt_65)
         and (last_rsi_3_1d > 40.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
       ):
         return True, f"exit_{mode_name}_d_5_112"
       elif (
         (last_rsi_3 < 24.0)
-        and (last_willr_14 < -90.0)
+        and (last_willr_14_lt_neg_90)
         and (last_rsi_3_1d > 70.0)
         and (last_stochrsi_k_4h_lt_50)
         and (isinstance(last_roc_9_4h, np.float64) and (last_roc_9_4h < -10.0))
@@ -57379,7 +57428,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 30.0)
         and (last_rsi_14 > 44.0)
-        and (last_rsi_3_15m > 70.0)
+        and (last_rsi_3_15m_gt_70)
         and (last_stochrsi_k_1h_lt_50)
         and (last_stochrsi_k_4h_lt_50)
       ):
@@ -57394,7 +57443,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_5_118"
       elif (
         (last_rsi_3 < 22.0)
-        and (last_willr_14 < -80.0)
+        and (last_willr_14_lt_neg_80)
         and (last_rsi_3_1h > 40.0)
         and (last_rsi_3_4h > 40.0)
         and (last_stochrsi_k_1h < 60.0)
@@ -57406,7 +57455,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_5_121"
       elif (last_rsi_3 < 50.0) and (last_rsi_14 > 48.0) and (last_rsi_3_4h_gt_70) and (last_stochrsi_k_1h_lt_50):
         return True, f"exit_{mode_name}_d_5_122"
-      elif (last_rsi_3 < 20.0) and (last_willr_14 < -88.0) and (last_rsi_3_1h > 90.0) and (last_rsi_3_1d > 70.0):
+      elif (last_rsi_3 < 20.0) and (last_willr_14_lt_neg_88) and (last_rsi_3_1h > 90.0) and (last_rsi_3_1d > 70.0):
         return True, f"exit_{mode_name}_d_5_123"
       elif (
         (last_rsi_3 < 20.0)
@@ -57416,16 +57465,16 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_5_124"
       elif (
         (last_rsi_3 < 32.0)
-        and (last_willr_14 < -88.0)
+        and (last_willr_14_lt_neg_88)
         and (last_rsi_3_1h > 90.0)
         and (last_rsi_3_4h > 60.0)
-        and (last_rsi_3_1d > 60.0)
+        and (last_rsi_3_1d_gt_60)
         and (last_close > (last_low_min_30_1d * 2.0))
       ):
         return True, f"exit_{mode_name}_d_5_125"
       elif (last_rsi_3 < 18.0) and (last_rsi_3_1h > 85.0) and (last_rsi_3_4h > 60.0) and (last_stochrsi_k_4h_lt_50):
         return True, f"exit_{mode_name}_d_5_126"
-      elif (last_rsi_3 < 18.0) and (last_rsi_3_1h > 90.0) and (last_rsi_3_4h_gt_70) and (last_rsi_3_1d > 60.0):
+      elif (last_rsi_3 < 18.0) and (last_rsi_3_1h > 90.0) and (last_rsi_3_4h_gt_70) and (last_rsi_3_1d_gt_60):
         return True, f"exit_{mode_name}_d_5_127"
       elif (last_rsi_3 < 14.0) and (last_rsi_3_4h_gt_70) and (last_aroond_14_4h > 85.0):
         return True, f"exit_{mode_name}_d_5_128"
@@ -57447,7 +57496,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 28.0)
         and (last_rsi_3_1h > 65.0)
-        and (last_rsi_3_4h > 65.0)
+        and (last_rsi_3_4h_gt_65)
         and (last_aroond_14_1h > 50.0)
         and (last_stochrsi_k_1h < 60.0)
       ):
@@ -57461,7 +57510,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_5_133"
     elif 0.07 > current_profit >= 0.06:
       if (
-        (last_willr_14 < -99.0)
+        (last_willr_14_lt_neg_99)
         and (last_rsi_14 < 22.0)
         and (isinstance(last_ema_200_1h, np.float64) and (last_ema_12_1h > last_ema_200_1h))
         and (isinstance(last_ema_200_4h, np.float64) and (last_ema_12_4h > last_ema_200_4h))
@@ -57470,35 +57519,35 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_6_1"
       elif (
-        (last_willr_14 < -99.0)
+        (last_willr_14_lt_neg_99)
         and (last_rsi_14 < 38.0)
-        and (last_cmf_20_1h > 0.0)
+        and (last_cmf_20_1h_gt_0)
         and (isinstance(last_ema_200_1h, np.float64) and (last_ema_12_1h > last_ema_200_1h))
         and (isinstance(last_ema_200_4h, np.float64) and (last_ema_12_4h > last_ema_200_4h))
       ):
         return True, f"exit_{mode_name}_d_6_2"
       elif (
-        (last_willr_14 < -85.0)
+        (last_willr_14_lt_neg_85)
         and (last_stochrsi_k < 2.0)
-        and (last_cmf_20_1h > 0.0)
-        and (last_cmf_20_4h > 0.0)
-        and ((last_stochrsi_k_4h < 80.0) and (last_stochrsi_k_change_pct_4h > 10.0))
+        and (last_cmf_20_1h_gt_0)
+        and (last_cmf_20_4h_gt_0)
+        and ((last_stochrsi_k_4h < 80.0) and (last_stochrsi_k_change_pct_4h_gt_10))
       ):
         return True, f"exit_{mode_name}_d_6_3"
       elif (
-        (last_willr_14 < -75.0)
+        (last_willr_14_lt_neg_75)
         and (last_rsi_14 < 32.0)
         and (last_stochrsi_k < 5.0)
-        and (last_stochrsi_k_4h < 30.0)
+        and (last_stochrsi_k_4h_lt_30)
         and (isinstance(last_ema_200_1h, np.float64) and (last_ema_12_1h > last_ema_200_1h))
         and (isinstance(last_ema_200_4h, np.float64) and (last_ema_12_4h > last_ema_200_4h))
       ):
         return True, f"exit_{mode_name}_d_6_4"
-      elif (last_willr_14 < -92.0) and (last_rsi_14 < 34.0) and (last_roc_9_1h > 5.0) and (last_roc_9_4h > 5.0):
+      elif (last_willr_14_lt_neg_92) and (last_rsi_14 < 34.0) and (last_roc_9_1h_gt_5) and (last_roc_9_4h_gt_5):
         return True, f"exit_{mode_name}_d_6_5"
       elif (
         (last_rsi_3 < 30.0)
-        and (last_stochrsi_k < 30.0)
+        and (last_stochrsi_k_lt_30)
         and (last_rsi_14 > 60.0)
         and (last_roc_9_1h > 10.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -50.0))
@@ -57506,13 +57555,13 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_6_6"
       elif (
         (last_rsi_14_gt_50)
-        and (last_stochrsi_k < 30.0)
+        and (last_stochrsi_k_lt_30)
         and (last_stochrsi_k_4h_lt_50)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 40.0))
       ):
         return True, f"exit_{mode_name}_d_6_7"
       elif (
-        (last_willr_14 < -92.0)
+        (last_willr_14_lt_neg_92)
         and (last_stochrsi_k < 5.0)
         and (last_cmf_20_1h > 0.1)
         and (last_cmf_20_4h > 0.1)
@@ -57528,10 +57577,10 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_6_9"
       elif (
-        (last_willr_14 < -85.0)
+        (last_willr_14_lt_neg_85)
         and (last_rsi_14_gt_50)
         and (last_roc_9_1h > 10.0)
-        and (last_roc_9_4h > 10.0)
+        and (last_roc_9_4h_gt_10)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -10.0))
       ):
         return True, f"exit_{mode_name}_d_6_10"
@@ -57548,26 +57597,26 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14_gt_50)
         and (last_rsi_3_4h > 90.0)
         and (last_roc_9_1h > 20.0)
-        and (last_roc_9_4h > 20.0)
+        and (last_roc_9_4h_gt_20)
       ):
         return True, f"exit_{mode_name}_d_6_12"
-      elif (last_rsi_3 < 15.0) and (last_rsi_3_4h > 95.0) and (last_roc_9_4h > 25.0):
+      elif (last_rsi_3 < 15.0) and (last_rsi_3_4h_gt_95) and (last_roc_9_4h_gt_25):
         return True, f"exit_{mode_name}_d_6_13"
-      elif (last_rsi_3 < 10.0) and (last_willr_14 < -90.0) and (last_rsi_3_4h > 95.0) and (last_aroond_14_4h > 25.0):
+      elif (last_rsi_3 < 10.0) and (last_willr_14_lt_neg_90) and (last_rsi_3_4h_gt_95) and (last_aroond_14_4h > 25.0):
         return True, f"exit_{mode_name}_d_6_14"
       elif (last_rsi_3 < 12.0) and (last_rsi_14 < 40.0) and (last_roc_9_4h > 30.0):
         return True, f"exit_{mode_name}_d_6_15"
       elif (
         (last_rsi_3 < 25.0)
         and (last_aroond_14_4h > 25.0)
-        and (last_roc_9_4h > 25.0)
+        and (last_roc_9_4h_gt_25)
         and (last_aroond_14_1d > 50.0)
         and (last_change_pct_1d > 15.0)
       ):
         return True, f"exit_{mode_name}_d_6_16"
       elif (
         (last_rsi_3 < 15.0)
-        and (last_willr_14 < -70.0)
+        and (last_willr_14_lt_neg_70)
         and (last_rsi_3_1h > 90.0)
         and (last_stochrsi_k_4h < 10.0)
         and (last_roc_9_4h < -30.0)
@@ -57588,31 +57637,31 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_6_21"
       elif (
         (last_rsi_3 < 8.0)
-        and (last_willr_14 < -92.0)
+        and (last_willr_14_lt_neg_92)
         and (last_change_pct_4h > 5.0)
         and (last_stochrsi_k_4h_lt_50)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
       ):
         return True, f"exit_{mode_name}_d_6_22"
-      elif (last_rsi_3 < 20.0) and (last_willr_14 < -75.0) and (last_rsi_3_1h > 85.0) and (last_rsi_3_1d > 95.0):
+      elif (last_rsi_3 < 20.0) and (last_willr_14_lt_neg_75) and (last_rsi_3_1h > 85.0) and (last_rsi_3_1d > 95.0):
         return True, f"exit_{mode_name}_d_6_23"
       elif (
         (last_rsi_3 < 14.0)
         and (last_rsi_14 < 34.0)
-        and (last_willr_14 < -70.0)
+        and (last_willr_14_lt_neg_70)
         and (last_rsi_3_4h_gt_70)
         and (last_aroond_14_4h > 75.0)
       ):
         return True, f"exit_{mode_name}_d_6_24"
       elif (
         (last_rsi_3 < 25.0)
-        and (last_willr_14 < -90.0)
+        and (last_willr_14_lt_neg_90)
         and (last_rsi_3_4h > 90.0)
         and (last_roc_9_4h > 15.0)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 50.0))
       ):
         return True, f"exit_{mode_name}_d_6_25"
-      elif (last_rsi_3 < 30.0) and (last_willr_14 < -90.0) and (last_rsi_3_4h > 85.0) and (last_roc_9_4h > 20.0):
+      elif (last_rsi_3 < 30.0) and (last_willr_14_lt_neg_90) and (last_rsi_3_4h > 85.0) and (last_roc_9_4h_gt_20):
         return True, f"exit_{mode_name}_d_6_26"
       elif (
         (last_rsi_3 < 30.0)
@@ -57639,27 +57688,27 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14_gt_50)
         and (last_rsi_3_1h > 85.0)
         and (last_rsi_3_4h > 85.0)
-        and (last_stochrsi_k_1h < 75.0)
+        and (last_stochrsi_k_1h_lt_75)
       ):
         return True, f"exit_{mode_name}_d_6_31"
-      elif (last_rsi_3 < 25.0) and (last_rsi_3_1h > 85.0) and (last_roc_2_4h > 30.0) and (last_stochrsi_k_4h < 70.0):
+      elif (last_rsi_3 < 25.0) and (last_rsi_3_1h > 85.0) and (last_roc_2_4h_gt_30) and (last_stochrsi_k_4h < 70.0):
         return True, f"exit_{mode_name}_d_6_32"
       elif (
         (last_rsi_3 < 25.0)
-        and (last_willr_14 < -92.0)
+        and (last_willr_14_lt_neg_92)
         and (last_roc_2_1h > 10.0)
         and (last_roc_9_1h < -30.0)
         and (last_stochrsi_k_1h_lt_50)
       ):
         return True, f"exit_{mode_name}_d_6_33"
-      elif (last_rsi_3 < 35.0) and (last_rsi_3_15m > 70.0) and (last_rsi_14_1h < 20.0) and (last_roc_9_1h < -40.0):
+      elif (last_rsi_3 < 35.0) and (last_rsi_3_15m_gt_70) and (last_rsi_14_1h < 20.0) and (last_roc_9_1h < -40.0):
         return True, f"exit_{mode_name}_d_6_34"
-      elif (last_rsi_3 < 18.0) and (last_willr_14 < -91.0) and (last_rsi_3_1d > 75.0) and (last_stochrsi_k_1h < 25.0):
+      elif (last_rsi_3 < 18.0) and (last_willr_14 < -91.0) and (last_rsi_3_1d > 75.0) and (last_stochrsi_k_1h_lt_25):
         return True, f"exit_{mode_name}_d_6_35"
       elif (
         (last_rsi_3 < 30.0)
-        and (last_willr_14 < -70.0)
-        and (last_roc_9_4h > 25.0)
+        and (last_willr_14_lt_neg_70)
+        and (last_roc_9_4h_gt_25)
         and (last_rsi_3_1d > 75.0)
         and (last_stochrsi_k_1h_lt_50)
       ):
@@ -57672,13 +57721,15 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_stochrsi_k_4h_lt_50)
       ):
         return True, f"exit_{mode_name}_d_6_37"
-      elif (last_rsi_3 < 30.0) and (last_willr_14 < -70.0) and (last_rsi_3_4h > 90.0) and (last_stochrsi_k_4h < 80.0):
+      elif (
+        (last_rsi_3 < 30.0) and (last_willr_14_lt_neg_70) and (last_rsi_3_4h > 90.0) and (last_stochrsi_k_4h < 80.0)
+      ):
         return True, f"exit_{mode_name}_d_6_38"
-      elif (last_rsi_3 < 8.0) and (last_willr_14 < -92.0) and (last_cmf_20_4h > 0.0) and (last_rsi_3_4h > 90.0):
+      elif (last_rsi_3 < 8.0) and (last_willr_14_lt_neg_92) and (last_cmf_20_4h_gt_0) and (last_rsi_3_4h > 90.0):
         return True, f"exit_{mode_name}_d_6_39"
       elif (
         (last_rsi_3 < 30.0)
-        and (last_willr_14 < -70.0)
+        and (last_willr_14_lt_neg_70)
         and (last_rsi_3_1h_gt_70)
         and (last_stochrsi_k_1h < 70.0)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 10.0))
@@ -57686,7 +57737,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_6_40"
       elif (
         (last_rsi_3 < 20.0)
-        and (last_willr_14 < -75.0)
+        and (last_willr_14_lt_neg_75)
         and (last_rsi_3_1h_gt_70)
         and (last_stochrsi_k_4h < 75.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -50.0))
@@ -57710,13 +57761,13 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_6_43"
       elif (
         (last_rsi_3 < 45.0)
-        and (last_willr_14 < -80.0)
+        and (last_willr_14_lt_neg_80)
         and (last_rsi_3_4h_gt_70)
         and (last_rsi_3_1d > 25.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
       ):
         return True, f"exit_{mode_name}_d_6_44"
-      elif (last_rsi_3 < 12.0) and (last_willr_14 < -88.0) and (last_rsi_3_1h > 90.0):
+      elif (last_rsi_3 < 12.0) and (last_willr_14_lt_neg_88) and (last_rsi_3_1h > 90.0):
         return True, f"exit_{mode_name}_d_6_45"
       elif (last_rsi_3 < 25.0) and (last_rsi_3_1h > 85.0) and (last_rsi_3_4h > 90.0) and (last_roc_2_1d > 20.0):
         return True, f"exit_{mode_name}_d_6_46"
@@ -57738,20 +57789,20 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_6_48"
       elif (
         (last_rsi_3 < 25.0)
-        and (last_willr_14 < -90.0)
+        and (last_willr_14_lt_neg_90)
         and (last_rsi_3_4h > 80.0)
         and (last_change_pct_1d > 5.0)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 50.0))
       ):
         return True, f"exit_{mode_name}_d_6_49"
-      elif (last_rsi_3 < 20.0) and (last_willr_14 < -90.0) and (last_rsi_3_1d > 90.0) and (last_stochrsi_k_1h < 10.0):
+      elif (last_rsi_3 < 20.0) and (last_willr_14_lt_neg_90) and (last_rsi_3_1d > 90.0) and (last_stochrsi_k_1h_lt_10):
         return True, f"exit_{mode_name}_d_6_50"
       elif (last_rsi_3 < 40.0) and (last_rsi_14 > 48.0) and (last_rsi_3_4h > 80.0) and (last_stochrsi_k_1h_lt_50):
         return True, f"exit_{mode_name}_d_6_51"
       elif (
         (last_rsi_3 < 26.0)
         and (last_rsi_14 < 46.0)
-        and (last_willr_14 < -90.0)
+        and (last_willr_14_lt_neg_90)
         and (last_stochrsi_k_1h < 30.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 15.0))
       ):
@@ -57759,7 +57810,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 30.0)
         and (last_rsi_14_gt_50)
-        and (last_willr_14 < -75.0)
+        and (last_willr_14_lt_neg_75)
         and (last_rsi_3_1h > 80.0)
         and (last_stochrsi_k_4h_lt_50)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 50.0))
@@ -57769,14 +57820,14 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 28.0)
         and (last_rsi_14 > 48.0)
         and (last_stochrsi_k_1h_lt_50)
-        and (last_roc_9_4h > 10.0)
+        and (last_roc_9_4h_gt_10)
         and (last_change_pct_1d > 10.0)
       ):
         return True, f"exit_{mode_name}_d_6_54"
       elif (
         (last_rsi_3 < 12.0)
-        and (last_willr_14 < -80.0)
-        and (last_roc_9_4h > 5.0)
+        and (last_willr_14_lt_neg_80)
+        and (last_roc_9_4h_gt_5)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -10.0))
         and (last_stochrsi_k_1h_lt_50)
       ):
@@ -57787,14 +57838,14 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_3_1h_gt_70)
         and (last_rsi_3_4h > 75.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
-        and (last_stochrsi_k_4h < 90.0)
+        and (last_stochrsi_k_4h_lt_90)
       ):
         return True, f"exit_{mode_name}_d_6_56"
       elif (
         (last_rsi_3 < 50.0)
         and (last_rsi_14 > 58.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
-        and (last_stochrsi_k_4h < 30.0)
+        and (last_stochrsi_k_4h_lt_30)
       ):
         return True, f"exit_{mode_name}_d_6_57"
       elif (
@@ -57807,7 +57858,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_6_58"
       elif (
         (last_rsi_3 < 15.0)
-        and (last_willr_14 < -82.0)
+        and (last_willr_14_lt_neg_82)
         and (last_rsi_3_4h > 75.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 15.0))
         and (last_stochrsi_k_4h < 60.0)
@@ -57818,14 +57869,16 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 > 54.0)
         and (last_rsi_14_4h < 35.0)
         and (last_stochrsi_k_4h_lt_50)
-        and (last_stochrsi_k_1d < 50.0)
+        and (last_stochrsi_k_1d_lt_50)
       ):
         return True, f"exit_{mode_name}_d_6_60"
-      elif (last_rsi_3 < 10.0) and (last_willr_14 < -75.0) and (last_rsi_3_4h > 90.0) and (last_stochrsi_k_1h < 70.0):
+      elif (
+        (last_rsi_3 < 10.0) and (last_willr_14_lt_neg_75) and (last_rsi_3_4h > 90.0) and (last_stochrsi_k_1h < 70.0)
+      ):
         return True, f"exit_{mode_name}_d_6_61"
       elif (
         (last_rsi_3 < 20.0)
-        and (last_willr_14 < -92.0)
+        and (last_willr_14_lt_neg_92)
         and (last_rsi_3_1h_gt_70)
         and (last_rsi_3_4h > 80.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -20.0))
@@ -57850,7 +57903,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 50.0)
         and (last_rsi_14 > 52.0)
-        and (last_stochrsi_k_4h < 20.0)
+        and (last_stochrsi_k_4h_lt_20)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 25.0))
       ):
         return True, f"exit_{mode_name}_d_6_67"
@@ -57858,7 +57911,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 22.0)
         and (last_rsi_14 > 46.0)
         and (last_rsi_3_1h > 75.0)
-        and (last_roc_2_4h > 30.0)
+        and (last_roc_2_4h_gt_30)
         and (last_stochrsi_k_4h < 75.0)
       ):
         return True, f"exit_{mode_name}_d_6_68"
@@ -57868,7 +57921,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_6_69"
       elif (last_rsi_3 < 40.0) and (last_rsi_14 > 54.0) and (last_rsi_3_1h > 75.0) and (last_stochrsi_k_4h < 80.0):
         return True, f"exit_{mode_name}_d_6_70"
-      elif (last_rsi_3 < 42.0) and (last_rsi_14_gt_50) and (last_rsi_3_4h > 75.0) and (last_stochrsi_k_1h < 80.0):
+      elif (last_rsi_3_lt_42) and (last_rsi_14_gt_50) and (last_rsi_3_4h > 75.0) and (last_stochrsi_k_1h_lt_80):
         return True, f"exit_{mode_name}_d_6_71"
       elif (last_rsi_3 < 28.0) and (last_rsi_14 > 52.0) and (last_rsi_3_1h > 90.0) and (last_aroond_14_4h > 25.0):
         return True, f"exit_{mode_name}_d_6_72"
@@ -57876,16 +57929,16 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 28.0)
         and (last_rsi_3_1h > 75.0)
         and (last_rsi_3_4h > 85.0)
-        and (last_roc_9_4h > 20.0)
+        and (last_roc_9_4h_gt_20)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 25.0))
       ):
         return True, f"exit_{mode_name}_d_6_73"
       elif (
         (last_rsi_3 < 5.0)
-        and (last_willr_14 < -90.0)
+        and (last_willr_14_lt_neg_90)
         and (last_rsi_3_4h > 75.0)
         and (last_rsi_3_1d > 75.0)
-        and (last_stochrsi_k_1h > 50.0)
+        and (last_stochrsi_k_1h_gt_50)
       ):
         return True, f"exit_{mode_name}_d_6_74"
       elif (
@@ -57895,7 +57948,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 50.0))
       ):
         return True, f"exit_{mode_name}_d_6_75"
-      elif (last_rsi_3 < 38.0) and (last_rsi_14 > 44.0) and (last_roc_9_1h < -80.0) and (last_stochrsi_k_4h < 20.0):
+      elif (last_rsi_3 < 38.0) and (last_rsi_14 > 44.0) and (last_roc_9_1h < -80.0) and (last_stochrsi_k_4h_lt_20):
         return True, f"exit_{mode_name}_d_6_76"
       elif (
         (last_rsi_3 < 30.0)
@@ -57912,7 +57965,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_3_1d > 80.0)
       ):
         return True, f"exit_{mode_name}_d_6_78"
-      elif (last_rsi_3 < 14.0) and (last_willr_14 < -92.0) and (last_rsi_3_1h_gt_70) and (last_rsi_3_4h > 90.0):
+      elif (last_rsi_3 < 14.0) and (last_willr_14_lt_neg_92) and (last_rsi_3_1h_gt_70) and (last_rsi_3_4h > 90.0):
         return True, f"exit_{mode_name}_d_6_79"
       elif (
         (last_rsi_3 < 34.0)
@@ -57924,7 +57977,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_6_80"
       elif (
         (last_rsi_3 < 22.0)
-        and (last_willr_14 < -84.0)
+        and (last_willr_14_lt_neg_84)
         and (last_rsi_3_1h > 75.0)
         and (last_rsi_3_4h > 75.0)
         and (isinstance(last_rsi_14_1d, np.float64) and (last_rsi_14_1d < 50.0))
@@ -57932,7 +57985,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_6_81"
       elif (
         (last_rsi_3 < 24.0)
-        and (last_willr_14 < -84.0)
+        and (last_willr_14_lt_neg_84)
         and (last_rsi_3_4h_gt_70)
         and (last_rsi_3_1d > 85.0)
         and (last_stochrsi_k_4h < 60.0)
@@ -57946,11 +57999,11 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_stochrsi_k_4h < 60.0)
       ):
         return True, f"exit_{mode_name}_d_6_83"
-      elif (last_rsi_3 < 16.0) and (last_willr_14 < -92.0) and (last_rsi_3_4h_gt_70) and (last_stochrsi_k_1h < 80.0):
+      elif (last_rsi_3 < 16.0) and (last_willr_14_lt_neg_92) and (last_rsi_3_4h_gt_70) and (last_stochrsi_k_1h_lt_80):
         return True, f"exit_{mode_name}_d_6_84"
       elif (
         (last_rsi_3 < 18.0)
-        and (last_willr_14 < -86.0)
+        and (last_willr_14_lt_neg_86)
         and (last_rsi_3_1h_gt_70)
         and (last_rsi_3_4h > 60.0)
         and (last_stochrsi_k_4h_lt_50)
@@ -57983,13 +58036,13 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 28.0)
         and (last_rsi_14 > 54.0)
-        and (last_roc_9_1h > 5.0)
+        and (last_roc_9_1h_gt_5)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -25.0))
       ):
         return True, f"exit_{mode_name}_d_6_89"
       elif (
         (last_rsi_3 < 14.0)
-        and (last_willr_14 < -75.0)
+        and (last_willr_14_lt_neg_75)
         and (last_rsi_3_1h > 50.0)
         and (last_rsi_3_4h_gt_70)
         and (last_aroonu_14_4h < 50.0)
@@ -58009,7 +58062,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 26.0)
         and (last_rsi_14 > 46.0)
         and (last_rsi_3_1h > 60.0)
-        and (last_stochrsi_k_1h < 75.0)
+        and (last_stochrsi_k_1h_lt_75)
         and (last_stochrsi_k_4h_lt_50)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 25.0))
       ):
@@ -58036,15 +58089,15 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_6_94"
       elif (
         (last_rsi_3 < 22.0)
-        and (last_willr_14 < -82.0)
+        and (last_willr_14_lt_neg_82)
         and (last_rsi_3_1h > 55.0)
         and (last_rsi_3_4h > 60.0)
-        and (last_stochrsi_k_4h < 90.0)
+        and (last_stochrsi_k_4h_lt_90)
         and (isinstance(last_aroond_14_1d, np.float64) and (last_aroond_14_1d > 75.0))
       ):
         return True, f"exit_{mode_name}_d_6_95"
       elif (
-        (last_rsi_3 < 44.0)
+        (last_rsi_3_lt_44)
         and (last_rsi_14 > 48.0)
         and (last_rsi_3_1h > 55.0)
         and (last_rsi_3_1d > 55.0)
@@ -58074,11 +58127,11 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_3_1h > 35.0)
         and (last_rsi_3_4h > 40.0)
         and (last_aroond_14_4h > 50.0)
-        and (last_stoch_k_4h < 60.0)
+        and (last_stoch_k_4h_lt_60)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -80.0))
       ):
         return True, f"exit_{mode_name}_d_6_99"
-      elif (last_rsi_3 < 8.0) and (last_rsi_14 < 30.0) and (last_rsi_3_15m < 30.0) and (last_rsi_3_4h > 20.0):
+      elif (last_rsi_3 < 8.0) and (last_rsi_14 < 30.0) and (last_rsi_3_15m_lt_30) and (last_rsi_3_4h > 20.0):
         return True, f"exit_{mode_name}_d_6_100"
       elif (
         (last_rsi_3 < 22.0)
@@ -58093,7 +58146,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 > 46.0)
         and (last_rsi_3_1h > 40.0)
         and (last_rsi_3_4h > 60.0)
-        and (last_stochrsi_k_4h > 70.0)
+        and (last_stochrsi_k_4h_gt_70)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -40.0))
       ):
         return True, f"exit_{mode_name}_d_6_102"
@@ -58106,12 +58159,12 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_6_103"
       elif (
-        (last_rsi_3 < 42.0)
+        (last_rsi_3_lt_42)
         and (last_rsi_14 > 46.0)
         and (last_rsi_3_1h > 40.0)
         and (last_stochrsi_k_1h < 60.0)
         and (last_stochrsi_k_4h < 10.0)
-        and (last_roc_9_4h < -40.0)
+        and (last_roc_9_4h_lt_neg_40)
       ):
         return True, f"exit_{mode_name}_d_6_104"
       elif (
@@ -58119,7 +58172,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 > 46.0)
         and (last_rsi_3_15m > 45.0)
         and (last_stochrsi_k_4h < 10.0)
-        and (last_roc_9_4h < -25.0)
+        and (last_roc_9_4h_lt_neg_25)
       ):
         return True, f"exit_{mode_name}_d_6_105"
       elif (
@@ -58128,7 +58181,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_3_1h > 50.0)
         and (last_stochrsi_k_1h_lt_50)
         and (last_rsi_14_4h < 30.0)
-        and (last_roc_9_4h < -40.0)
+        and (last_roc_9_4h_lt_neg_40)
       ):
         return True, f"exit_{mode_name}_d_6_106"
       elif (
@@ -58143,13 +58196,13 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_6_108"
       elif (
         (last_rsi_3 < 30.0)
-        and (last_willr_14 < -86.0)
+        and (last_willr_14_lt_neg_86)
         and (last_rsi_3_1h > 50.0)
         and (last_rsi_3_4h > 80.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -50.0))
       ):
         return True, f"exit_{mode_name}_d_6_109"
-      elif (last_rsi_3 < 34.0) and (last_rsi_3_4h > 35.0) and (last_stochrsi_k_4h_lt_50) and (last_roc_9_4h < -25.0):
+      elif (last_rsi_3 < 34.0) and (last_rsi_3_4h > 35.0) and (last_stochrsi_k_4h_lt_50) and (last_roc_9_4h_lt_neg_25):
         return True, f"exit_{mode_name}_d_6_110"
       elif (
         (last_rsi_3 < 56.0)
@@ -58166,14 +58219,14 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_willr_14 < -60.0)
         and (last_rsi_14 > 42.0)
         and (last_rsi_3_1h > 65.0)
-        and (last_rsi_3_4h > 65.0)
+        and (last_rsi_3_4h_gt_65)
         and (last_rsi_3_1d > 40.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
       ):
         return True, f"exit_{mode_name}_d_6_112"
       elif (
         (last_rsi_3 < 22.0)
-        and (last_willr_14 < -92.0)
+        and (last_willr_14_lt_neg_92)
         and (last_rsi_3_1d > 70.0)
         and (last_stochrsi_k_4h_lt_50)
         and (isinstance(last_roc_9_4h, np.float64) and (last_roc_9_4h < -10.0))
@@ -58191,7 +58244,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 28.0)
         and (last_rsi_14 > 46.0)
-        and (last_rsi_3_15m > 70.0)
+        and (last_rsi_3_15m_gt_70)
         and (last_stochrsi_k_1h_lt_50)
         and (last_stochrsi_k_4h_lt_50)
       ):
@@ -58206,7 +58259,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_6_118"
       elif (
         (last_rsi_3 < 20.0)
-        and (last_willr_14 < -80.0)
+        and (last_willr_14_lt_neg_80)
         and (last_rsi_3_1h > 40.0)
         and (last_rsi_3_4h > 40.0)
         and (last_stochrsi_k_1h < 60.0)
@@ -58218,7 +58271,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_6_121"
       elif (last_rsi_3 < 48.0) and (last_rsi_14_gt_50) and (last_rsi_3_4h_gt_70) and (last_stochrsi_k_1h_lt_50):
         return True, f"exit_{mode_name}_d_6_122"
-      elif (last_rsi_3 < 18.0) and (last_willr_14 < -90.0) and (last_rsi_3_1h > 90.0) and (last_rsi_3_1d > 70.0):
+      elif (last_rsi_3 < 18.0) and (last_willr_14_lt_neg_90) and (last_rsi_3_1h > 90.0) and (last_rsi_3_1d > 70.0):
         return True, f"exit_{mode_name}_d_6_123"
       elif (
         (last_rsi_3 < 18.0)
@@ -58228,16 +58281,16 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_6_124"
       elif (
         (last_rsi_3 < 30.0)
-        and (last_willr_14 < -90.0)
+        and (last_willr_14_lt_neg_90)
         and (last_rsi_3_1h > 90.0)
         and (last_rsi_3_4h > 60.0)
-        and (last_rsi_3_1d > 60.0)
+        and (last_rsi_3_1d_gt_60)
         and (last_close > (last_low_min_30_1d * 2.0))
       ):
         return True, f"exit_{mode_name}_d_6_125"
       elif (last_rsi_3 < 16.0) and (last_rsi_3_1h > 85.0) and (last_rsi_3_4h > 60.0) and (last_stochrsi_k_4h_lt_50):
         return True, f"exit_{mode_name}_d_6_126"
-      elif (last_rsi_3 < 16.0) and (last_rsi_3_1h > 90.0) and (last_rsi_3_4h_gt_70) and (last_rsi_3_1d > 60.0):
+      elif (last_rsi_3 < 16.0) and (last_rsi_3_1h > 90.0) and (last_rsi_3_4h_gt_70) and (last_rsi_3_1d_gt_60):
         return True, f"exit_{mode_name}_d_6_127"
       elif (last_rsi_3 < 12.0) and (last_rsi_3_4h_gt_70) and (last_aroond_14_4h > 85.0):
         return True, f"exit_{mode_name}_d_6_128"
@@ -58259,7 +58312,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 26.0)
         and (last_rsi_3_1h > 65.0)
-        and (last_rsi_3_4h > 65.0)
+        and (last_rsi_3_4h_gt_65)
         and (last_aroond_14_1h > 50.0)
         and (last_stochrsi_k_1h < 60.0)
       ):
@@ -58273,7 +58326,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_6_133"
     elif 0.08 > current_profit >= 0.07:
       if (
-        (last_willr_14 < -99.0)
+        (last_willr_14_lt_neg_99)
         and (last_rsi_14 < 22.0)
         and (isinstance(last_ema_200_1h, np.float64) and (last_ema_12_1h > last_ema_200_1h))
         and (isinstance(last_ema_200_4h, np.float64) and (last_ema_12_4h > last_ema_200_4h))
@@ -58282,35 +58335,35 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_7_1"
       elif (
-        (last_willr_14 < -99.0)
+        (last_willr_14_lt_neg_99)
         and (last_rsi_14 < 36.0)
-        and (last_cmf_20_1h > 0.0)
+        and (last_cmf_20_1h_gt_0)
         and (isinstance(last_ema_200_1h, np.float64) and (last_ema_12_1h > last_ema_200_1h))
         and (isinstance(last_ema_200_4h, np.float64) and (last_ema_12_4h > last_ema_200_4h))
       ):
         return True, f"exit_{mode_name}_d_7_2"
       elif (
-        (last_willr_14 < -90.0)
+        (last_willr_14_lt_neg_90)
         and (last_stochrsi_k < 2.0)
-        and (last_cmf_20_1h > 0.0)
-        and (last_cmf_20_4h > 0.0)
-        and ((last_stochrsi_k_4h < 80.0) and (last_stochrsi_k_change_pct_4h > 10.0))
+        and (last_cmf_20_1h_gt_0)
+        and (last_cmf_20_4h_gt_0)
+        and ((last_stochrsi_k_4h < 80.0) and (last_stochrsi_k_change_pct_4h_gt_10))
       ):
         return True, f"exit_{mode_name}_d_7_3"
       elif (
-        (last_willr_14 < -80.0)
+        (last_willr_14_lt_neg_80)
         and (last_rsi_14 < 30.0)
         and (last_stochrsi_k < 5.0)
-        and (last_stochrsi_k_4h < 30.0)
+        and (last_stochrsi_k_4h_lt_30)
         and (isinstance(last_ema_200_1h, np.float64) and (last_ema_12_1h > last_ema_200_1h))
         and (isinstance(last_ema_200_4h, np.float64) and (last_ema_12_4h > last_ema_200_4h))
       ):
         return True, f"exit_{mode_name}_d_7_4"
-      elif (last_willr_14 < -94.0) and (last_rsi_14 < 32.0) and (last_roc_9_1h > 5.0) and (last_roc_9_4h > 5.0):
+      elif (last_willr_14_lt_neg_94) and (last_rsi_14 < 32.0) and (last_roc_9_1h_gt_5) and (last_roc_9_4h_gt_5):
         return True, f"exit_{mode_name}_d_7_5"
       elif (
         (last_rsi_3 < 30.0)
-        and (last_stochrsi_k < 30.0)
+        and (last_stochrsi_k_lt_30)
         and (last_rsi_14 > 60.0)
         and (last_roc_9_1h > 10.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -50.0))
@@ -58318,13 +58371,13 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_7_6"
       elif (
         (last_rsi_14_gt_50)
-        and (last_stochrsi_k < 30.0)
+        and (last_stochrsi_k_lt_30)
         and (last_stochrsi_k_4h_lt_50)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 40.0))
       ):
         return True, f"exit_{mode_name}_d_7_7"
       elif (
-        (last_willr_14 < -94.0)
+        (last_willr_14_lt_neg_94)
         and (last_stochrsi_k < 5.0)
         and (last_cmf_20_1h > 0.1)
         and (last_cmf_20_4h > 0.1)
@@ -58333,17 +58386,17 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_7_8"
       elif (
-        (last_willr_14 < -94.0)
+        (last_willr_14_lt_neg_94)
         and (last_rsi_3 < 5.0)
         and (last_change_pct_4h > 5.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
       ):
         return True, f"exit_{mode_name}_d_7_9"
       elif (
-        (last_willr_14 < -90.0)
+        (last_willr_14_lt_neg_90)
         and (last_rsi_14_gt_50)
         and (last_roc_9_1h > 10.0)
-        and (last_roc_9_4h > 10.0)
+        and (last_roc_9_4h_gt_10)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -10.0))
       ):
         return True, f"exit_{mode_name}_d_7_10"
@@ -58360,26 +58413,26 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14_gt_50)
         and (last_rsi_3_4h > 90.0)
         and (last_roc_9_1h > 20.0)
-        and (last_roc_9_4h > 20.0)
+        and (last_roc_9_4h_gt_20)
       ):
         return True, f"exit_{mode_name}_d_7_12"
-      elif (last_rsi_3 < 10.0) and (last_rsi_3_4h > 95.0) and (last_roc_9_4h > 25.0):
+      elif (last_rsi_3 < 10.0) and (last_rsi_3_4h_gt_95) and (last_roc_9_4h_gt_25):
         return True, f"exit_{mode_name}_d_7_13"
-      elif (last_rsi_3 < 10.0) and (last_willr_14 < -92.0) and (last_rsi_3_4h > 95.0) and (last_aroond_14_4h > 25.0):
+      elif (last_rsi_3 < 10.0) and (last_willr_14_lt_neg_92) and (last_rsi_3_4h_gt_95) and (last_aroond_14_4h > 25.0):
         return True, f"exit_{mode_name}_d_7_14"
       elif (last_rsi_3 < 10.0) and (last_rsi_14 < 38.0) and (last_roc_9_4h > 30.0):
         return True, f"exit_{mode_name}_d_7_15"
       elif (
         (last_rsi_3 < 20.0)
         and (last_aroond_14_4h > 25.0)
-        and (last_roc_9_4h > 25.0)
+        and (last_roc_9_4h_gt_25)
         and (last_aroond_14_1d > 50.0)
         and (last_change_pct_1d > 15.0)
       ):
         return True, f"exit_{mode_name}_d_7_16"
       elif (
         (last_rsi_3 < 10.0)
-        and (last_willr_14 < -75.0)
+        and (last_willr_14_lt_neg_75)
         and (last_rsi_3_1h > 90.0)
         and (last_stochrsi_k_4h < 10.0)
         and (last_roc_9_4h < -30.0)
@@ -58400,31 +58453,31 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_7_21"
       elif (
         (last_rsi_3 < 6.0)
-        and (last_willr_14 < -94.0)
+        and (last_willr_14_lt_neg_94)
         and (last_change_pct_4h > 5.0)
         and (last_stochrsi_k_4h_lt_50)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
       ):
         return True, f"exit_{mode_name}_d_7_22"
-      elif (last_rsi_3 < 15.0) and (last_willr_14 < -80.0) and (last_rsi_3_1h > 85.0) and (last_rsi_3_1d > 95.0):
+      elif (last_rsi_3 < 15.0) and (last_willr_14_lt_neg_80) and (last_rsi_3_1h > 85.0) and (last_rsi_3_1d > 95.0):
         return True, f"exit_{mode_name}_d_7_23"
       elif (
         (last_rsi_3 < 12.0)
         and (last_rsi_14 < 32.0)
-        and (last_willr_14 < -75.0)
+        and (last_willr_14_lt_neg_75)
         and (last_rsi_3_4h_gt_70)
         and (last_aroond_14_4h > 75.0)
       ):
         return True, f"exit_{mode_name}_d_7_24"
       elif (
         (last_rsi_3 < 20.0)
-        and (last_willr_14 < -92.0)
+        and (last_willr_14_lt_neg_92)
         and (last_rsi_3_4h > 90.0)
         and (last_roc_9_4h > 15.0)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 50.0))
       ):
         return True, f"exit_{mode_name}_d_7_25"
-      elif (last_rsi_3 < 25.0) and (last_willr_14 < -92.0) and (last_rsi_3_4h > 85.0) and (last_roc_9_4h > 20.0):
+      elif (last_rsi_3 < 25.0) and (last_willr_14_lt_neg_92) and (last_rsi_3_4h > 85.0) and (last_roc_9_4h_gt_20):
         return True, f"exit_{mode_name}_d_7_26"
       elif (
         (last_rsi_3 < 25.0)
@@ -58451,27 +58504,27 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14_gt_50)
         and (last_rsi_3_1h > 85.0)
         and (last_rsi_3_4h > 85.0)
-        and (last_stochrsi_k_1h < 75.0)
+        and (last_stochrsi_k_1h_lt_75)
       ):
         return True, f"exit_{mode_name}_d_7_31"
-      elif (last_rsi_3 < 20.0) and (last_rsi_3_1h > 85.0) and (last_roc_2_4h > 30.0) and (last_stochrsi_k_4h < 70.0):
+      elif (last_rsi_3 < 20.0) and (last_rsi_3_1h > 85.0) and (last_roc_2_4h_gt_30) and (last_stochrsi_k_4h < 70.0):
         return True, f"exit_{mode_name}_d_7_32"
       elif (
         (last_rsi_3 < 20.0)
-        and (last_willr_14 < -94.0)
+        and (last_willr_14_lt_neg_94)
         and (last_roc_2_1h > 10.0)
         and (last_roc_9_1h < -30.0)
         and (last_stochrsi_k_1h_lt_50)
       ):
         return True, f"exit_{mode_name}_d_7_33"
-      elif (last_rsi_3 < 35.0) and (last_rsi_3_15m > 70.0) and (last_rsi_14_1h < 20.0) and (last_roc_9_1h < -40.0):
+      elif (last_rsi_3 < 35.0) and (last_rsi_3_15m_gt_70) and (last_rsi_14_1h < 20.0) and (last_roc_9_1h < -40.0):
         return True, f"exit_{mode_name}_d_7_34"
-      elif (last_rsi_3 < 16.0) and (last_willr_14 < -92.0) and (last_rsi_3_1d > 75.0) and (last_stochrsi_k_1h < 25.0):
+      elif (last_rsi_3 < 16.0) and (last_willr_14_lt_neg_92) and (last_rsi_3_1d > 75.0) and (last_stochrsi_k_1h_lt_25):
         return True, f"exit_{mode_name}_d_7_35"
       elif (
         (last_rsi_3 < 25.0)
-        and (last_willr_14 < -75.0)
-        and (last_roc_9_4h > 25.0)
+        and (last_willr_14_lt_neg_75)
+        and (last_roc_9_4h_gt_25)
         and (last_rsi_3_1d > 75.0)
         and (last_stochrsi_k_1h_lt_50)
       ):
@@ -58484,13 +58537,15 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_stochrsi_k_4h_lt_50)
       ):
         return True, f"exit_{mode_name}_d_7_37"
-      elif (last_rsi_3 < 25.0) and (last_willr_14 < -75.0) and (last_rsi_3_4h > 90.0) and (last_stochrsi_k_4h < 80.0):
+      elif (
+        (last_rsi_3 < 25.0) and (last_willr_14_lt_neg_75) and (last_rsi_3_4h > 90.0) and (last_stochrsi_k_4h < 80.0)
+      ):
         return True, f"exit_{mode_name}_d_7_38"
-      elif (last_rsi_3 < 7.0) and (last_willr_14 < -93.0) and (last_cmf_20_4h > 0.0) and (last_rsi_3_4h > 90.0):
+      elif (last_rsi_3 < 7.0) and (last_willr_14 < -93.0) and (last_cmf_20_4h_gt_0) and (last_rsi_3_4h > 90.0):
         return True, f"exit_{mode_name}_d_7_39"
       elif (
         (last_rsi_3 < 25.0)
-        and (last_willr_14 < -75.0)
+        and (last_willr_14_lt_neg_75)
         and (last_rsi_3_1h_gt_70)
         and (last_stochrsi_k_1h < 70.0)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 10.0))
@@ -58498,7 +58553,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_7_40"
       elif (
         (last_rsi_3 < 15.0)
-        and (last_willr_14 < -80.0)
+        and (last_willr_14_lt_neg_80)
         and (last_rsi_3_1h_gt_70)
         and (last_stochrsi_k_4h < 75.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -50.0))
@@ -58522,13 +58577,13 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_7_43"
       elif (
         (last_rsi_3 < 40.0)
-        and (last_willr_14 < -85.0)
+        and (last_willr_14_lt_neg_85)
         and (last_rsi_3_4h_gt_70)
         and (last_rsi_3_1d > 25.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
       ):
         return True, f"exit_{mode_name}_d_7_44"
-      elif (last_rsi_3 < 10.0) and (last_willr_14 < -90.0) and (last_rsi_3_1h > 90.0):
+      elif (last_rsi_3 < 10.0) and (last_willr_14_lt_neg_90) and (last_rsi_3_1h > 90.0):
         return True, f"exit_{mode_name}_d_7_45"
       elif (last_rsi_3 < 20.0) and (last_rsi_3_1h > 85.0) and (last_rsi_3_4h > 90.0) and (last_roc_2_1d > 20.0):
         return True, f"exit_{mode_name}_d_7_46"
@@ -58550,20 +58605,20 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_7_48"
       elif (
         (last_rsi_3 < 20.0)
-        and (last_willr_14 < -92.0)
+        and (last_willr_14_lt_neg_92)
         and (last_rsi_3_4h > 80.0)
         and (last_change_pct_1d > 5.0)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 50.0))
       ):
         return True, f"exit_{mode_name}_d_7_49"
-      elif (last_rsi_3 < 20.0) and (last_willr_14 < -92.0) and (last_rsi_3_1d > 90.0) and (last_stochrsi_k_1h < 10.0):
+      elif (last_rsi_3 < 20.0) and (last_willr_14_lt_neg_92) and (last_rsi_3_1d > 90.0) and (last_stochrsi_k_1h_lt_10):
         return True, f"exit_{mode_name}_d_7_50"
       elif (last_rsi_3 < 38.0) and (last_rsi_14_gt_50) and (last_rsi_3_4h > 80.0) and (last_stochrsi_k_1h_lt_50):
         return True, f"exit_{mode_name}_d_7_51"
       elif (
         (last_rsi_3 < 24.0)
         and (last_rsi_14 < 44.0)
-        and (last_willr_14 < -90.0)
+        and (last_willr_14_lt_neg_90)
         and (last_stochrsi_k_1h < 30.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 15.0))
       ):
@@ -58571,7 +58626,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 30.0)
         and (last_rsi_14_gt_50)
-        and (last_willr_14 < -75.0)
+        and (last_willr_14_lt_neg_75)
         and (last_rsi_3_1h > 80.0)
         and (last_stochrsi_k_4h_lt_50)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 50.0))
@@ -58581,14 +58636,14 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 26.0)
         and (last_rsi_14_gt_50)
         and (last_stochrsi_k_1h_lt_50)
-        and (last_roc_9_4h > 10.0)
+        and (last_roc_9_4h_gt_10)
         and (last_change_pct_1d > 10.0)
       ):
         return True, f"exit_{mode_name}_d_7_54"
       elif (
         (last_rsi_3 < 10.0)
-        and (last_willr_14 < -82.0)
-        and (last_roc_9_4h > 5.0)
+        and (last_willr_14_lt_neg_82)
+        and (last_roc_9_4h_gt_5)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -10.0))
         and (last_stochrsi_k_1h_lt_50)
       ):
@@ -58599,14 +58654,14 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_3_1h_gt_70)
         and (last_rsi_3_4h > 75.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
-        and (last_stochrsi_k_4h < 90.0)
+        and (last_stochrsi_k_4h_lt_90)
       ):
         return True, f"exit_{mode_name}_d_7_56"
       elif (
         (last_rsi_3 < 50.0)
         and (last_rsi_14 > 60.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
-        and (last_stochrsi_k_4h < 30.0)
+        and (last_stochrsi_k_4h_lt_30)
       ):
         return True, f"exit_{mode_name}_d_7_57"
       elif (
@@ -58619,7 +58674,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_7_58"
       elif (
         (last_rsi_3 < 15.0)
-        and (last_willr_14 < -84.0)
+        and (last_willr_14_lt_neg_84)
         and (last_rsi_3_4h > 75.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 15.0))
         and (last_stochrsi_k_4h < 60.0)
@@ -58630,14 +58685,16 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 > 56.0)
         and (last_rsi_14_4h < 35.0)
         and (last_stochrsi_k_4h_lt_50)
-        and (last_stochrsi_k_1d < 50.0)
+        and (last_stochrsi_k_1d_lt_50)
       ):
         return True, f"exit_{mode_name}_d_7_60"
-      elif (last_rsi_3 < 10.0) and (last_willr_14 < -75.0) and (last_rsi_3_4h > 90.0) and (last_stochrsi_k_1h < 70.0):
+      elif (
+        (last_rsi_3 < 10.0) and (last_willr_14_lt_neg_75) and (last_rsi_3_4h > 90.0) and (last_stochrsi_k_1h < 70.0)
+      ):
         return True, f"exit_{mode_name}_d_7_61"
       elif (
         (last_rsi_3 < 18.0)
-        and (last_willr_14 < -94.0)
+        and (last_willr_14_lt_neg_94)
         and (last_rsi_3_1h_gt_70)
         and (last_rsi_3_4h > 80.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -20.0))
@@ -58662,7 +58719,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 50.0)
         and (last_rsi_14 > 54.0)
-        and (last_stochrsi_k_4h < 20.0)
+        and (last_stochrsi_k_4h_lt_20)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 25.0))
       ):
         return True, f"exit_{mode_name}_d_7_67"
@@ -58670,7 +58727,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 20.0)
         and (last_rsi_14 > 48.0)
         and (last_rsi_3_1h > 75.0)
-        and (last_roc_2_4h > 30.0)
+        and (last_roc_2_4h_gt_30)
         and (last_stochrsi_k_4h < 75.0)
       ):
         return True, f"exit_{mode_name}_d_7_68"
@@ -58680,7 +58737,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_7_69"
       elif (last_rsi_3 < 38.0) and (last_rsi_14 > 56.0) and (last_rsi_3_1h > 75.0) and (last_stochrsi_k_4h < 80.0):
         return True, f"exit_{mode_name}_d_7_70"
-      elif (last_rsi_3 < 40.0) and (last_rsi_14 > 52.0) and (last_rsi_3_4h > 75.0) and (last_stochrsi_k_1h < 80.0):
+      elif (last_rsi_3 < 40.0) and (last_rsi_14 > 52.0) and (last_rsi_3_4h > 75.0) and (last_stochrsi_k_1h_lt_80):
         return True, f"exit_{mode_name}_d_7_71"
       elif (last_rsi_3 < 26.0) and (last_rsi_14 > 54.0) and (last_rsi_3_1h > 90.0) and (last_aroond_14_4h > 25.0):
         return True, f"exit_{mode_name}_d_7_72"
@@ -58688,16 +58745,16 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 26.0)
         and (last_rsi_3_1h > 75.0)
         and (last_rsi_3_4h > 85.0)
-        and (last_roc_9_4h > 20.0)
+        and (last_roc_9_4h_gt_20)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 25.0))
       ):
         return True, f"exit_{mode_name}_d_7_73"
       elif (
         (last_rsi_3 < 4.0)
-        and (last_willr_14 < -90.0)
+        and (last_willr_14_lt_neg_90)
         and (last_rsi_3_4h > 75.0)
         and (last_rsi_3_1d > 75.0)
-        and (last_stochrsi_k_1h > 50.0)
+        and (last_stochrsi_k_1h_gt_50)
       ):
         return True, f"exit_{mode_name}_d_7_74"
       elif (
@@ -58707,7 +58764,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 50.0))
       ):
         return True, f"exit_{mode_name}_d_7_75"
-      elif (last_rsi_3 < 36.0) and (last_rsi_14 > 46.0) and (last_roc_9_1h < -80.0) and (last_stochrsi_k_4h < 20.0):
+      elif (last_rsi_3 < 36.0) and (last_rsi_14 > 46.0) and (last_roc_9_1h < -80.0) and (last_stochrsi_k_4h_lt_20):
         return True, f"exit_{mode_name}_d_7_76"
       elif (
         (last_rsi_3 < 28.0)
@@ -58718,13 +58775,13 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_7_77"
       elif (
         (last_rsi_3 < 18.0)
-        and (last_willr_14 < -80.0)
+        and (last_willr_14_lt_neg_80)
         and (last_rsi_3_1h_gt_70)
         and (last_rsi_3_4h > 80.0)
         and (last_rsi_3_1d > 80.0)
       ):
         return True, f"exit_{mode_name}_d_7_78"
-      elif (last_rsi_3 < 12.0) and (last_willr_14 < -94.0) and (last_rsi_3_1h_gt_70) and (last_rsi_3_4h > 90.0):
+      elif (last_rsi_3 < 12.0) and (last_willr_14_lt_neg_94) and (last_rsi_3_1h_gt_70) and (last_rsi_3_4h > 90.0):
         return True, f"exit_{mode_name}_d_7_79"
       elif (
         (last_rsi_3 < 32.0)
@@ -58736,7 +58793,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_7_80"
       elif (
         (last_rsi_3 < 20.0)
-        and (last_willr_14 < -86.0)
+        and (last_willr_14_lt_neg_86)
         and (last_rsi_3_1h > 75.0)
         and (last_rsi_3_4h > 75.0)
         and (isinstance(last_rsi_14_1d, np.float64) and (last_rsi_14_1d < 50.0))
@@ -58744,7 +58801,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_7_81"
       elif (
         (last_rsi_3 < 22.0)
-        and (last_willr_14 < -86.0)
+        and (last_willr_14_lt_neg_86)
         and (last_rsi_3_4h_gt_70)
         and (last_rsi_3_1d > 85.0)
         and (last_stochrsi_k_4h < 60.0)
@@ -58758,11 +58815,11 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_stochrsi_k_4h < 60.0)
       ):
         return True, f"exit_{mode_name}_d_7_83"
-      elif (last_rsi_3 < 14.0) and (last_willr_14 < -94.0) and (last_rsi_3_4h_gt_70) and (last_stochrsi_k_1h < 80.0):
+      elif (last_rsi_3 < 14.0) and (last_willr_14_lt_neg_94) and (last_rsi_3_4h_gt_70) and (last_stochrsi_k_1h_lt_80):
         return True, f"exit_{mode_name}_d_7_84"
       elif (
         (last_rsi_3 < 16.0)
-        and (last_willr_14 < -88.0)
+        and (last_willr_14_lt_neg_88)
         and (last_rsi_3_1h_gt_70)
         and (last_rsi_3_4h > 60.0)
         and (last_stochrsi_k_4h_lt_50)
@@ -58795,13 +58852,13 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 26.0)
         and (last_rsi_14 > 56.0)
-        and (last_roc_9_1h > 5.0)
+        and (last_roc_9_1h_gt_5)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -25.0))
       ):
         return True, f"exit_{mode_name}_d_7_89"
       elif (
         (last_rsi_3 < 12.0)
-        and (last_willr_14 < -75.0)
+        and (last_willr_14_lt_neg_75)
         and (last_rsi_3_1h > 50.0)
         and (last_rsi_3_4h_gt_70)
         and (last_aroonu_14_4h < 50.0)
@@ -58821,7 +58878,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 24.0)
         and (last_rsi_14 > 48.0)
         and (last_rsi_3_1h > 60.0)
-        and (last_stochrsi_k_1h < 75.0)
+        and (last_stochrsi_k_1h_lt_75)
         and (last_stochrsi_k_4h_lt_50)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 25.0))
       ):
@@ -58848,15 +58905,15 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_7_94"
       elif (
         (last_rsi_3 < 20.0)
-        and (last_willr_14 < -84.0)
+        and (last_willr_14_lt_neg_84)
         and (last_rsi_3_1h > 55.0)
         and (last_rsi_3_4h > 60.0)
-        and (last_stochrsi_k_4h < 90.0)
+        and (last_stochrsi_k_4h_lt_90)
         and (isinstance(last_aroond_14_1d, np.float64) and (last_aroond_14_1d > 75.0))
       ):
         return True, f"exit_{mode_name}_d_7_95"
       elif (
-        (last_rsi_3 < 42.0)
+        (last_rsi_3_lt_42)
         and (last_rsi_14_gt_50)
         and (last_rsi_3_1h > 55.0)
         and (last_rsi_3_1d > 55.0)
@@ -58881,20 +58938,20 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_7_98"
       elif (
-        (last_rsi_3 < 44.0)
+        (last_rsi_3_lt_44)
         and (last_rsi_14 > 44.0)
         and (last_rsi_3_1h > 35.0)
         and (last_rsi_3_4h > 40.0)
         and (last_aroond_14_4h > 50.0)
-        and (last_stoch_k_4h < 60.0)
+        and (last_stoch_k_4h_lt_60)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -80.0))
       ):
         return True, f"exit_{mode_name}_d_7_99"
-      elif (last_rsi_3 < 6.0) and (last_rsi_14 < 28.0) and (last_rsi_3_15m < 30.0) and (last_rsi_3_4h > 20.0):
+      elif (last_rsi_3 < 6.0) and (last_rsi_14 < 28.0) and (last_rsi_3_15m_lt_30) and (last_rsi_3_4h > 20.0):
         return True, f"exit_{mode_name}_d_7_100"
       elif (
         (last_rsi_3 < 20.0)
-        and (last_willr_14 < -80.0)
+        and (last_willr_14_lt_neg_80)
         and (last_rsi_3_1h > 50.0)
         and (last_stochrsi_k_4h < 60.0)
         and (isinstance(last_roc_9_4h, np.float64) and (last_roc_9_4h < -40.0))
@@ -58905,7 +58962,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 > 48.0)
         and (last_rsi_3_1h > 40.0)
         and (last_rsi_3_4h > 60.0)
-        and (last_stochrsi_k_4h > 70.0)
+        and (last_stochrsi_k_4h_gt_70)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -40.0))
       ):
         return True, f"exit_{mode_name}_d_7_102"
@@ -58923,7 +58980,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_3_1h > 40.0)
         and (last_stochrsi_k_1h < 60.0)
         and (last_stochrsi_k_4h < 10.0)
-        and (last_roc_9_4h < -40.0)
+        and (last_roc_9_4h_lt_neg_40)
       ):
         return True, f"exit_{mode_name}_d_7_104"
       elif (
@@ -58931,7 +58988,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 > 48.0)
         and (last_rsi_3_15m > 45.0)
         and (last_stochrsi_k_4h < 10.0)
-        and (last_roc_9_4h < -25.0)
+        and (last_roc_9_4h_lt_neg_25)
       ):
         return True, f"exit_{mode_name}_d_7_105"
       elif (
@@ -58940,7 +58997,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_3_1h > 50.0)
         and (last_stochrsi_k_1h_lt_50)
         and (last_rsi_14_4h < 30.0)
-        and (last_roc_9_4h < -40.0)
+        and (last_roc_9_4h_lt_neg_40)
       ):
         return True, f"exit_{mode_name}_d_7_106"
       elif (
@@ -58955,13 +59012,13 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_7_108"
       elif (
         (last_rsi_3 < 28.0)
-        and (last_willr_14 < -88.0)
+        and (last_willr_14_lt_neg_88)
         and (last_rsi_3_1h > 50.0)
         and (last_rsi_3_4h > 80.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -50.0))
       ):
         return True, f"exit_{mode_name}_d_7_109"
-      elif (last_rsi_3 < 32.0) and (last_rsi_3_4h > 35.0) and (last_stochrsi_k_4h_lt_50) and (last_roc_9_4h < -25.0):
+      elif (last_rsi_3 < 32.0) and (last_rsi_3_4h > 35.0) and (last_stochrsi_k_4h_lt_50) and (last_roc_9_4h_lt_neg_25):
         return True, f"exit_{mode_name}_d_7_110"
       elif (
         (last_rsi_3 < 54.0)
@@ -58978,14 +59035,14 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_willr_14 < -65.0)
         and (last_rsi_14 > 44.0)
         and (last_rsi_3_1h > 65.0)
-        and (last_rsi_3_4h > 65.0)
+        and (last_rsi_3_4h_gt_65)
         and (last_rsi_3_1d > 40.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
       ):
         return True, f"exit_{mode_name}_d_7_112"
       elif (
         (last_rsi_3 < 20.0)
-        and (last_willr_14 < -94.0)
+        and (last_willr_14_lt_neg_94)
         and (last_rsi_3_1d > 70.0)
         and (last_stochrsi_k_4h_lt_50)
         and (isinstance(last_roc_9_4h, np.float64) and (last_roc_9_4h < -10.0))
@@ -59003,7 +59060,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 26.0)
         and (last_rsi_14 > 48.0)
-        and (last_rsi_3_15m > 70.0)
+        and (last_rsi_3_15m_gt_70)
         and (last_stochrsi_k_1h_lt_50)
         and (last_stochrsi_k_4h_lt_50)
       ):
@@ -59018,7 +59075,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_7_118"
       elif (
         (last_rsi_3 < 18.0)
-        and (last_willr_14 < -80.0)
+        and (last_willr_14_lt_neg_80)
         and (last_rsi_3_1h > 40.0)
         and (last_rsi_3_4h > 40.0)
         and (last_stochrsi_k_1h < 60.0)
@@ -59026,11 +59083,11 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_7_119"
       elif (last_rsi_3 < 50.0) and (last_rsi_14 > 48.0) and (last_rsi_3_1h > 60.0) and (last_aroond_14_4h > 75.0):
         return True, f"exit_{mode_name}_d_7_120"
-      elif (last_rsi_3 < 44.0) and (last_rsi_14_gt_50) and (last_rsi_3_1h > 50.0) and (last_rsi_14_4h < 15.0):
+      elif (last_rsi_3_lt_44) and (last_rsi_14_gt_50) and (last_rsi_3_1h > 50.0) and (last_rsi_14_4h < 15.0):
         return True, f"exit_{mode_name}_d_7_121"
       elif (last_rsi_3 < 46.0) and (last_rsi_14 > 52.0) and (last_rsi_3_4h_gt_70) and (last_stochrsi_k_1h_lt_50):
         return True, f"exit_{mode_name}_d_7_122"
-      elif (last_rsi_3 < 16.0) and (last_willr_14 < -92.0) and (last_rsi_3_1h > 90.0) and (last_rsi_3_1d > 70.0):
+      elif (last_rsi_3 < 16.0) and (last_willr_14_lt_neg_92) and (last_rsi_3_1h > 90.0) and (last_rsi_3_1d > 70.0):
         return True, f"exit_{mode_name}_d_7_123"
       elif (
         (last_rsi_3 < 16.0)
@@ -59040,16 +59097,16 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_7_124"
       elif (
         (last_rsi_3 < 28.0)
-        and (last_willr_14 < -92.0)
+        and (last_willr_14_lt_neg_92)
         and (last_rsi_3_1h > 90.0)
         and (last_rsi_3_4h > 60.0)
-        and (last_rsi_3_1d > 60.0)
+        and (last_rsi_3_1d_gt_60)
         and (last_close > (last_low_min_30_1d * 2.0))
       ):
         return True, f"exit_{mode_name}_d_7_125"
       elif (last_rsi_3 < 14.0) and (last_rsi_3_1h > 85.0) and (last_rsi_3_4h > 60.0) and (last_stochrsi_k_4h_lt_50):
         return True, f"exit_{mode_name}_d_7_126"
-      elif (last_rsi_3 < 14.0) and (last_rsi_3_1h > 90.0) and (last_rsi_3_4h_gt_70) and (last_rsi_3_1d > 60.0):
+      elif (last_rsi_3 < 14.0) and (last_rsi_3_1h > 90.0) and (last_rsi_3_4h_gt_70) and (last_rsi_3_1d_gt_60):
         return True, f"exit_{mode_name}_d_7_127"
       elif (last_rsi_3 < 10.0) and (last_rsi_3_4h_gt_70) and (last_aroond_14_4h > 85.0):
         return True, f"exit_{mode_name}_d_7_128"
@@ -59071,7 +59128,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 24.0)
         and (last_rsi_3_1h > 65.0)
-        and (last_rsi_3_4h > 65.0)
+        and (last_rsi_3_4h_gt_65)
         and (last_aroond_14_1h > 50.0)
         and (last_stochrsi_k_1h < 60.0)
       ):
@@ -59085,7 +59142,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_7_133"
     elif 0.09 > current_profit >= 0.08:
       if (
-        (last_willr_14 < -99.0)
+        (last_willr_14_lt_neg_99)
         and (last_rsi_14 < 22.0)
         and (isinstance(last_ema_200_1h, np.float64) and (last_ema_12_1h > last_ema_200_1h))
         and (isinstance(last_ema_200_4h, np.float64) and (last_ema_12_4h > last_ema_200_4h))
@@ -59094,35 +59151,35 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_8_1"
       elif (
-        (last_willr_14 < -99.0)
+        (last_willr_14_lt_neg_99)
         and (last_rsi_14 < 34.0)
-        and (last_cmf_20_1h > 0.0)
+        and (last_cmf_20_1h_gt_0)
         and (isinstance(last_ema_200_1h, np.float64) and (last_ema_12_1h > last_ema_200_1h))
         and (isinstance(last_ema_200_4h, np.float64) and (last_ema_12_4h > last_ema_200_4h))
       ):
         return True, f"exit_{mode_name}_d_8_2"
       elif (
-        (last_willr_14 < -92.0)
+        (last_willr_14_lt_neg_92)
         and (last_stochrsi_k < 2.0)
-        and (last_cmf_20_1h > 0.0)
-        and (last_cmf_20_4h > 0.0)
-        and ((last_stochrsi_k_4h < 80.0) and (last_stochrsi_k_change_pct_4h > 10.0))
+        and (last_cmf_20_1h_gt_0)
+        and (last_cmf_20_4h_gt_0)
+        and ((last_stochrsi_k_4h < 80.0) and (last_stochrsi_k_change_pct_4h_gt_10))
       ):
         return True, f"exit_{mode_name}_d_8_3"
       elif (
-        (last_willr_14 < -85.0)
+        (last_willr_14_lt_neg_85)
         and (last_rsi_14 < 28.0)
         and (last_stochrsi_k < 5.0)
-        and (last_stochrsi_k_4h < 30.0)
+        and (last_stochrsi_k_4h_lt_30)
         and (isinstance(last_ema_200_1h, np.float64) and (last_ema_12_1h > last_ema_200_1h))
         and (isinstance(last_ema_200_4h, np.float64) and (last_ema_12_4h > last_ema_200_4h))
       ):
         return True, f"exit_{mode_name}_d_8_4"
-      elif (last_willr_14 < -96.0) and (last_rsi_14 < 30.0) and (last_roc_9_1h > 5.0) and (last_roc_9_4h > 5.0):
+      elif (last_willr_14_lt_neg_96) and (last_rsi_14 < 30.0) and (last_roc_9_1h_gt_5) and (last_roc_9_4h_gt_5):
         return True, f"exit_{mode_name}_d_8_5"
       elif (
         (last_rsi_3 < 30.0)
-        and (last_stochrsi_k < 30.0)
+        and (last_stochrsi_k_lt_30)
         and (last_rsi_14 > 60.0)
         and (last_roc_9_1h > 10.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -50.0))
@@ -59130,13 +59187,13 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_8_6"
       elif (
         (last_rsi_14_gt_50)
-        and (last_stochrsi_k < 30.0)
+        and (last_stochrsi_k_lt_30)
         and (last_stochrsi_k_4h_lt_50)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 40.0))
       ):
         return True, f"exit_{mode_name}_d_8_7"
       elif (
-        (last_willr_14 < -96.0)
+        (last_willr_14_lt_neg_96)
         and (last_stochrsi_k < 5.0)
         and (last_cmf_20_1h > 0.1)
         and (last_cmf_20_4h > 0.1)
@@ -59145,17 +59202,17 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_8_8"
       elif (
-        (last_willr_14 < -95.0)
+        (last_willr_14_lt_neg_95)
         and (last_rsi_3 < 5.0)
         and (last_change_pct_4h > 5.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
       ):
         return True, f"exit_{mode_name}_d_8_9"
       elif (
-        (last_willr_14 < -92.0)
+        (last_willr_14_lt_neg_92)
         and (last_rsi_14_gt_50)
         and (last_roc_9_1h > 10.0)
-        and (last_roc_9_4h > 10.0)
+        and (last_roc_9_4h_gt_10)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -10.0))
       ):
         return True, f"exit_{mode_name}_d_8_10"
@@ -59172,26 +59229,26 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14_gt_50)
         and (last_rsi_3_4h > 90.0)
         and (last_roc_9_1h > 20.0)
-        and (last_roc_9_4h > 20.0)
+        and (last_roc_9_4h_gt_20)
       ):
         return True, f"exit_{mode_name}_d_8_12"
-      elif (last_rsi_3 < 5.0) and (last_rsi_3_4h > 95.0) and (last_roc_9_4h > 25.0):
+      elif (last_rsi_3 < 5.0) and (last_rsi_3_4h_gt_95) and (last_roc_9_4h_gt_25):
         return True, f"exit_{mode_name}_d_8_13"
-      elif (last_rsi_3 < 10.0) and (last_willr_14 < -94.0) and (last_rsi_3_4h > 95.0) and (last_aroond_14_4h > 25.0):
+      elif (last_rsi_3 < 10.0) and (last_willr_14_lt_neg_94) and (last_rsi_3_4h_gt_95) and (last_aroond_14_4h > 25.0):
         return True, f"exit_{mode_name}_d_8_14"
       elif (last_rsi_3 < 8.0) and (last_rsi_14 < 36.0) and (last_roc_9_4h > 30.0):
         return True, f"exit_{mode_name}_d_8_15"
       elif (
         (last_rsi_3 < 15.0)
         and (last_aroond_14_4h > 25.0)
-        and (last_roc_9_4h > 25.0)
+        and (last_roc_9_4h_gt_25)
         and (last_aroond_14_1d > 50.0)
         and (last_change_pct_1d > 15.0)
       ):
         return True, f"exit_{mode_name}_d_8_16"
       elif (
         (last_rsi_3 < 5.0)
-        and (last_willr_14 < -80.0)
+        and (last_willr_14_lt_neg_80)
         and (last_rsi_3_1h > 90.0)
         and (last_stochrsi_k_4h < 10.0)
         and (last_roc_9_4h < -30.0)
@@ -59212,31 +59269,31 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_8_21"
       elif (
         (last_rsi_3 < 4.0)
-        and (last_willr_14 < -96.0)
+        and (last_willr_14_lt_neg_96)
         and (last_change_pct_4h > 5.0)
         and (last_stochrsi_k_4h_lt_50)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
       ):
         return True, f"exit_{mode_name}_d_8_22"
-      elif (last_rsi_3 < 10.0) and (last_willr_14 < -85.0) and (last_rsi_3_1h > 85.0) and (last_rsi_3_1d > 95.0):
+      elif (last_rsi_3 < 10.0) and (last_willr_14_lt_neg_85) and (last_rsi_3_1h > 85.0) and (last_rsi_3_1d > 95.0):
         return True, f"exit_{mode_name}_d_8_23"
       elif (
         (last_rsi_3 < 10.0)
         and (last_rsi_14 < 30.0)
-        and (last_willr_14 < -80.0)
+        and (last_willr_14_lt_neg_80)
         and (last_rsi_3_4h_gt_70)
         and (last_aroond_14_4h > 75.0)
       ):
         return True, f"exit_{mode_name}_d_8_24"
       elif (
         (last_rsi_3 < 15.0)
-        and (last_willr_14 < -94.0)
+        and (last_willr_14_lt_neg_94)
         and (last_rsi_3_4h > 90.0)
         and (last_roc_9_4h > 15.0)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 50.0))
       ):
         return True, f"exit_{mode_name}_d_8_25"
-      elif (last_rsi_3 < 20.0) and (last_willr_14 < -94.0) and (last_rsi_3_4h > 85.0) and (last_roc_9_4h > 20.0):
+      elif (last_rsi_3 < 20.0) and (last_willr_14_lt_neg_94) and (last_rsi_3_4h > 85.0) and (last_roc_9_4h_gt_20):
         return True, f"exit_{mode_name}_d_8_26"
       elif (
         (last_rsi_3 < 20.0)
@@ -59263,27 +59320,27 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14_gt_50)
         and (last_rsi_3_1h > 85.0)
         and (last_rsi_3_4h > 85.0)
-        and (last_stochrsi_k_1h < 75.0)
+        and (last_stochrsi_k_1h_lt_75)
       ):
         return True, f"exit_{mode_name}_d_8_31"
-      elif (last_rsi_3 < 15.0) and (last_rsi_3_1h > 85.0) and (last_roc_2_4h > 30.0) and (last_stochrsi_k_4h < 70.0):
+      elif (last_rsi_3 < 15.0) and (last_rsi_3_1h > 85.0) and (last_roc_2_4h_gt_30) and (last_stochrsi_k_4h < 70.0):
         return True, f"exit_{mode_name}_d_8_32"
       elif (
         (last_rsi_3 < 15.0)
-        and (last_willr_14 < -96.0)
+        and (last_willr_14_lt_neg_96)
         and (last_roc_2_1h > 10.0)
         and (last_roc_9_1h < -30.0)
         and (last_stochrsi_k_1h_lt_50)
       ):
         return True, f"exit_{mode_name}_d_8_33"
-      elif (last_rsi_3 < 35.0) and (last_rsi_3_15m > 70.0) and (last_rsi_14_1h < 20.0) and (last_roc_9_1h < -40.0):
+      elif (last_rsi_3 < 35.0) and (last_rsi_3_15m_gt_70) and (last_rsi_14_1h < 20.0) and (last_roc_9_1h < -40.0):
         return True, f"exit_{mode_name}_d_8_34"
-      elif (last_rsi_3 < 14.0) and (last_willr_14 < -93.0) and (last_rsi_3_1d > 75.0) and (last_stochrsi_k_1h < 25.0):
+      elif (last_rsi_3 < 14.0) and (last_willr_14 < -93.0) and (last_rsi_3_1d > 75.0) and (last_stochrsi_k_1h_lt_25):
         return True, f"exit_{mode_name}_d_8_35"
       elif (
         (last_rsi_3 < 20.0)
-        and (last_willr_14 < -80.0)
-        and (last_roc_9_4h > 25.0)
+        and (last_willr_14_lt_neg_80)
+        and (last_roc_9_4h_gt_25)
         and (last_rsi_3_1d > 75.0)
         and (last_stochrsi_k_1h_lt_50)
       ):
@@ -59296,13 +59353,15 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_stochrsi_k_4h_lt_50)
       ):
         return True, f"exit_{mode_name}_d_8_37"
-      elif (last_rsi_3 < 20.0) and (last_willr_14 < -80.0) and (last_rsi_3_4h > 90.0) and (last_stochrsi_k_4h < 80.0):
+      elif (
+        (last_rsi_3 < 20.0) and (last_willr_14_lt_neg_80) and (last_rsi_3_4h > 90.0) and (last_stochrsi_k_4h < 80.0)
+      ):
         return True, f"exit_{mode_name}_d_8_38"
-      elif (last_rsi_3 < 6.0) and (last_willr_14 < -94.0) and (last_cmf_20_4h > 0.0) and (last_rsi_3_4h > 90.0):
+      elif (last_rsi_3 < 6.0) and (last_willr_14_lt_neg_94) and (last_cmf_20_4h_gt_0) and (last_rsi_3_4h > 90.0):
         return True, f"exit_{mode_name}_d_8_39"
       elif (
         (last_rsi_3 < 20.0)
-        and (last_willr_14 < -80.0)
+        and (last_willr_14_lt_neg_80)
         and (last_rsi_3_1h_gt_70)
         and (last_stochrsi_k_1h < 70.0)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 10.0))
@@ -59310,7 +59369,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_8_40"
       elif (
         (last_rsi_3 < 10.0)
-        and (last_willr_14 < -85.0)
+        and (last_willr_14_lt_neg_85)
         and (last_rsi_3_1h_gt_70)
         and (last_stochrsi_k_4h < 75.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -50.0))
@@ -59318,7 +59377,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_8_41"
       elif (
         (last_rsi_3 < 15.0)
-        and (last_willr_14 < -70.0)
+        and (last_willr_14_lt_neg_70)
         and (last_stochrsi_k_4h < 70.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -40.0))
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 30.0))
@@ -59334,13 +59393,13 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_8_43"
       elif (
         (last_rsi_3 < 35.0)
-        and (last_willr_14 < -90.0)
+        and (last_willr_14_lt_neg_90)
         and (last_rsi_3_4h_gt_70)
         and (last_rsi_3_1d > 25.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
       ):
         return True, f"exit_{mode_name}_d_8_44"
-      elif (last_rsi_3 < 8.0) and (last_willr_14 < -92.0) and (last_rsi_3_1h > 90.0):
+      elif (last_rsi_3 < 8.0) and (last_willr_14_lt_neg_92) and (last_rsi_3_1h > 90.0):
         return True, f"exit_{mode_name}_d_8_45"
       elif (last_rsi_3 < 15.0) and (last_rsi_3_1h > 85.0) and (last_rsi_3_4h > 90.0) and (last_roc_2_1d > 20.0):
         return True, f"exit_{mode_name}_d_8_46"
@@ -59362,20 +59421,20 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_8_48"
       elif (
         (last_rsi_3 < 15.0)
-        and (last_willr_14 < -94.0)
+        and (last_willr_14_lt_neg_94)
         and (last_rsi_3_4h > 80.0)
         and (last_change_pct_1d > 5.0)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 50.0))
       ):
         return True, f"exit_{mode_name}_d_8_49"
-      elif (last_rsi_3 < 20.0) and (last_willr_14 < -94.0) and (last_rsi_3_1d > 90.0) and (last_stochrsi_k_1h < 10.0):
+      elif (last_rsi_3 < 20.0) and (last_willr_14_lt_neg_94) and (last_rsi_3_1d > 90.0) and (last_stochrsi_k_1h_lt_10):
         return True, f"exit_{mode_name}_d_8_50"
       elif (last_rsi_3 < 36.0) and (last_rsi_14 > 52.0) and (last_rsi_3_4h > 80.0) and (last_stochrsi_k_1h_lt_50):
         return True, f"exit_{mode_name}_d_8_51"
       elif (
         (last_rsi_3 < 22.0)
         and (last_rsi_14 < 42.0)
-        and (last_willr_14 < -90.0)
+        and (last_willr_14_lt_neg_90)
         and (last_stochrsi_k_1h < 30.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 15.0))
       ):
@@ -59383,7 +59442,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 30.0)
         and (last_rsi_14_gt_50)
-        and (last_willr_14 < -75.0)
+        and (last_willr_14_lt_neg_75)
         and (last_rsi_3_1h > 80.0)
         and (last_stochrsi_k_4h_lt_50)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 50.0))
@@ -59393,14 +59452,14 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 24.0)
         and (last_rsi_14 > 52.0)
         and (last_stochrsi_k_1h_lt_50)
-        and (last_roc_9_4h > 10.0)
+        and (last_roc_9_4h_gt_10)
         and (last_change_pct_1d > 10.0)
       ):
         return True, f"exit_{mode_name}_d_8_54"
       elif (
         (last_rsi_3 < 8.0)
-        and (last_willr_14 < -84.0)
-        and (last_roc_9_4h > 5.0)
+        and (last_willr_14_lt_neg_84)
+        and (last_roc_9_4h_gt_5)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -10.0))
         and (last_stochrsi_k_1h_lt_50)
       ):
@@ -59411,14 +59470,14 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_3_1h_gt_70)
         and (last_rsi_3_4h > 75.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
-        and (last_stochrsi_k_4h < 90.0)
+        and (last_stochrsi_k_4h_lt_90)
       ):
         return True, f"exit_{mode_name}_d_8_56"
       elif (
         (last_rsi_3 < 50.0)
         and (last_rsi_14 > 62.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
-        and (last_stochrsi_k_4h < 30.0)
+        and (last_stochrsi_k_4h_lt_30)
       ):
         return True, f"exit_{mode_name}_d_8_57"
       elif (
@@ -59431,7 +59490,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_8_58"
       elif (
         (last_rsi_3 < 15.0)
-        and (last_willr_14 < -86.0)
+        and (last_willr_14_lt_neg_86)
         and (last_rsi_3_4h > 75.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 15.0))
         and (last_stochrsi_k_4h < 60.0)
@@ -59442,14 +59501,16 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 > 58.0)
         and (last_rsi_14_4h < 35.0)
         and (last_stochrsi_k_4h_lt_50)
-        and (last_stochrsi_k_1d < 50.0)
+        and (last_stochrsi_k_1d_lt_50)
       ):
         return True, f"exit_{mode_name}_d_8_60"
-      elif (last_rsi_3 < 10.0) and (last_willr_14 < -75.0) and (last_rsi_3_4h > 90.0) and (last_stochrsi_k_1h < 70.0):
+      elif (
+        (last_rsi_3 < 10.0) and (last_willr_14_lt_neg_75) and (last_rsi_3_4h > 90.0) and (last_stochrsi_k_1h < 70.0)
+      ):
         return True, f"exit_{mode_name}_d_8_61"
       elif (
         (last_rsi_3 < 16.0)
-        and (last_willr_14 < -96.0)
+        and (last_willr_14_lt_neg_96)
         and (last_rsi_3_1h_gt_70)
         and (last_rsi_3_4h > 80.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -20.0))
@@ -59474,7 +59535,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 50.0)
         and (last_rsi_14 > 56.0)
-        and (last_stochrsi_k_4h < 20.0)
+        and (last_stochrsi_k_4h_lt_20)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 25.0))
       ):
         return True, f"exit_{mode_name}_d_8_67"
@@ -59482,7 +59543,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 18.0)
         and (last_rsi_14_gt_50)
         and (last_rsi_3_1h > 75.0)
-        and (last_roc_2_4h > 30.0)
+        and (last_roc_2_4h_gt_30)
         and (last_stochrsi_k_4h < 75.0)
       ):
         return True, f"exit_{mode_name}_d_8_68"
@@ -59492,7 +59553,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_8_69"
       elif (last_rsi_3 < 36.0) and (last_rsi_14 > 58.0) and (last_rsi_3_1h > 75.0) and (last_stochrsi_k_4h < 80.0):
         return True, f"exit_{mode_name}_d_8_70"
-      elif (last_rsi_3 < 38.0) and (last_rsi_14 > 54.0) and (last_rsi_3_4h > 75.0) and (last_stochrsi_k_1h < 80.0):
+      elif (last_rsi_3 < 38.0) and (last_rsi_14 > 54.0) and (last_rsi_3_4h > 75.0) and (last_stochrsi_k_1h_lt_80):
         return True, f"exit_{mode_name}_d_8_71"
       elif (last_rsi_3 < 24.0) and (last_rsi_14 > 56.0) and (last_rsi_3_1h > 90.0) and (last_aroond_14_4h > 25.0):
         return True, f"exit_{mode_name}_d_8_72"
@@ -59500,16 +59561,16 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 24.0)
         and (last_rsi_3_1h > 75.0)
         and (last_rsi_3_4h > 85.0)
-        and (last_roc_9_4h > 20.0)
+        and (last_roc_9_4h_gt_20)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 25.0))
       ):
         return True, f"exit_{mode_name}_d_8_73"
       elif (
         (last_rsi_3 < 3.0)
-        and (last_willr_14 < -90.0)
+        and (last_willr_14_lt_neg_90)
         and (last_rsi_3_4h > 75.0)
         and (last_rsi_3_1d > 75.0)
-        and (last_stochrsi_k_1h > 50.0)
+        and (last_stochrsi_k_1h_gt_50)
       ):
         return True, f"exit_{mode_name}_d_8_74"
       elif (
@@ -59519,7 +59580,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 50.0))
       ):
         return True, f"exit_{mode_name}_d_8_75"
-      elif (last_rsi_3 < 34.0) and (last_rsi_14 > 48.0) and (last_roc_9_1h < -80.0) and (last_stochrsi_k_4h < 20.0):
+      elif (last_rsi_3 < 34.0) and (last_rsi_14 > 48.0) and (last_roc_9_1h < -80.0) and (last_stochrsi_k_4h_lt_20):
         return True, f"exit_{mode_name}_d_8_76"
       elif (
         (last_rsi_3 < 26.0)
@@ -59530,13 +59591,13 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_8_77"
       elif (
         (last_rsi_3 < 16.0)
-        and (last_willr_14 < -82.0)
+        and (last_willr_14_lt_neg_82)
         and (last_rsi_3_1h_gt_70)
         and (last_rsi_3_4h > 80.0)
         and (last_rsi_3_1d > 80.0)
       ):
         return True, f"exit_{mode_name}_d_8_78"
-      elif (last_rsi_3 < 10.0) and (last_willr_14 < -96.0) and (last_rsi_3_1h_gt_70) and (last_rsi_3_4h > 90.0):
+      elif (last_rsi_3 < 10.0) and (last_willr_14_lt_neg_96) and (last_rsi_3_1h_gt_70) and (last_rsi_3_4h > 90.0):
         return True, f"exit_{mode_name}_d_8_79"
       elif (
         (last_rsi_3 < 30.0)
@@ -59548,7 +59609,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_8_80"
       elif (
         (last_rsi_3 < 18.0)
-        and (last_willr_14 < -88.0)
+        and (last_willr_14_lt_neg_88)
         and (last_rsi_3_1h > 75.0)
         and (last_rsi_3_4h > 75.0)
         and (isinstance(last_rsi_14_1d, np.float64) and (last_rsi_14_1d < 50.0))
@@ -59556,7 +59617,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_8_81"
       elif (
         (last_rsi_3 < 20.0)
-        and (last_willr_14 < -88.0)
+        and (last_willr_14_lt_neg_88)
         and (last_rsi_3_4h_gt_70)
         and (last_rsi_3_1d > 85.0)
         and (last_stochrsi_k_4h < 60.0)
@@ -59570,11 +59631,11 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_stochrsi_k_4h < 60.0)
       ):
         return True, f"exit_{mode_name}_d_8_83"
-      elif (last_rsi_3 < 12.0) and (last_willr_14 < -96.0) and (last_rsi_3_4h_gt_70) and (last_stochrsi_k_1h < 80.0):
+      elif (last_rsi_3 < 12.0) and (last_willr_14_lt_neg_96) and (last_rsi_3_4h_gt_70) and (last_stochrsi_k_1h_lt_80):
         return True, f"exit_{mode_name}_d_8_84"
       elif (
         (last_rsi_3 < 14.0)
-        and (last_willr_14 < -90.0)
+        and (last_willr_14_lt_neg_90)
         and (last_rsi_3_1h_gt_70)
         and (last_rsi_3_4h > 60.0)
         and (last_stochrsi_k_4h_lt_50)
@@ -59607,13 +59668,13 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 24.0)
         and (last_rsi_14 > 58.0)
-        and (last_roc_9_1h > 5.0)
+        and (last_roc_9_1h_gt_5)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -25.0))
       ):
         return True, f"exit_{mode_name}_d_8_89"
       elif (
         (last_rsi_3 < 10.0)
-        and (last_willr_14 < -75.0)
+        and (last_willr_14_lt_neg_75)
         and (last_rsi_3_1h > 50.0)
         and (last_rsi_3_4h_gt_70)
         and (last_aroonu_14_4h < 50.0)
@@ -59633,7 +59694,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 22.0)
         and (last_rsi_14_gt_50)
         and (last_rsi_3_1h > 60.0)
-        and (last_stochrsi_k_1h < 75.0)
+        and (last_stochrsi_k_1h_lt_75)
         and (last_stochrsi_k_4h_lt_50)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 25.0))
       ):
@@ -59660,10 +59721,10 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_8_94"
       elif (
         (last_rsi_3 < 18.0)
-        and (last_willr_14 < -86.0)
+        and (last_willr_14_lt_neg_86)
         and (last_rsi_3_1h > 55.0)
         and (last_rsi_3_4h > 60.0)
-        and (last_stochrsi_k_4h < 90.0)
+        and (last_stochrsi_k_4h_lt_90)
         and (isinstance(last_aroond_14_1d, np.float64) and (last_aroond_14_1d > 75.0))
       ):
         return True, f"exit_{mode_name}_d_8_95"
@@ -59685,7 +59746,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_8_97"
       elif (
         (last_rsi_3 < 12.0)
-        and (last_rsi_3_15m < 30.0)
+        and (last_rsi_3_15m_lt_30)
         and (last_rsi_3_1h > 40.0)
         and (last_rsi_3_4h > 40.0)
         and (last_rsi_3_1d < 20.0)
@@ -59693,20 +59754,20 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_8_98"
       elif (
-        (last_rsi_3 < 42.0)
+        (last_rsi_3_lt_42)
         and (last_rsi_14 > 46.0)
         and (last_rsi_3_1h > 35.0)
         and (last_rsi_3_4h > 40.0)
         and (last_aroond_14_4h > 50.0)
-        and (last_stoch_k_4h < 60.0)
+        and (last_stoch_k_4h_lt_60)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -80.0))
       ):
         return True, f"exit_{mode_name}_d_8_99"
-      elif (last_rsi_3 < 4.0) and (last_rsi_14 < 26.0) and (last_rsi_3_15m < 30.0) and (last_rsi_3_4h > 20.0):
+      elif (last_rsi_3 < 4.0) and (last_rsi_14 < 26.0) and (last_rsi_3_15m_lt_30) and (last_rsi_3_4h > 20.0):
         return True, f"exit_{mode_name}_d_8_100"
       elif (
         (last_rsi_3 < 18.0)
-        and (last_willr_14 < -82.0)
+        and (last_willr_14_lt_neg_82)
         and (last_rsi_3_1h > 50.0)
         and (last_stochrsi_k_4h < 60.0)
         and (isinstance(last_roc_9_4h, np.float64) and (last_roc_9_4h < -40.0))
@@ -59717,7 +59778,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14_gt_50)
         and (last_rsi_3_1h > 40.0)
         and (last_rsi_3_4h > 60.0)
-        and (last_stochrsi_k_4h > 70.0)
+        and (last_stochrsi_k_4h_gt_70)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -40.0))
       ):
         return True, f"exit_{mode_name}_d_8_102"
@@ -59735,7 +59796,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_3_1h > 40.0)
         and (last_stochrsi_k_1h < 60.0)
         and (last_stochrsi_k_4h < 10.0)
-        and (last_roc_9_4h < -40.0)
+        and (last_roc_9_4h_lt_neg_40)
       ):
         return True, f"exit_{mode_name}_d_8_104"
       elif (
@@ -59743,7 +59804,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14_gt_50)
         and (last_rsi_3_15m > 45.0)
         and (last_stochrsi_k_4h < 10.0)
-        and (last_roc_9_4h < -25.0)
+        and (last_roc_9_4h_lt_neg_25)
       ):
         return True, f"exit_{mode_name}_d_8_105"
       elif (
@@ -59752,7 +59813,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_3_1h > 50.0)
         and (last_stochrsi_k_1h_lt_50)
         and (last_rsi_14_4h < 30.0)
-        and (last_roc_9_4h < -40.0)
+        and (last_roc_9_4h_lt_neg_40)
       ):
         return True, f"exit_{mode_name}_d_8_106"
       elif (
@@ -59767,13 +59828,13 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_8_108"
       elif (
         (last_rsi_3 < 26.0)
-        and (last_willr_14 < -90.0)
+        and (last_willr_14_lt_neg_90)
         and (last_rsi_3_1h > 50.0)
         and (last_rsi_3_4h > 80.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -50.0))
       ):
         return True, f"exit_{mode_name}_d_8_109"
-      elif (last_rsi_3 < 30.0) and (last_rsi_3_4h > 35.0) and (last_stochrsi_k_4h_lt_50) and (last_roc_9_4h < -25.0):
+      elif (last_rsi_3 < 30.0) and (last_rsi_3_4h > 35.0) and (last_stochrsi_k_4h_lt_50) and (last_roc_9_4h_lt_neg_25):
         return True, f"exit_{mode_name}_d_8_110"
       elif (
         (last_rsi_3 < 52.0)
@@ -59787,17 +59848,17 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_8_111"
       elif (
         (last_rsi_3 < 22.0)
-        and (last_willr_14 < -70.0)
+        and (last_willr_14_lt_neg_70)
         and (last_rsi_14 > 46.0)
         and (last_rsi_3_1h > 65.0)
-        and (last_rsi_3_4h > 65.0)
+        and (last_rsi_3_4h_gt_65)
         and (last_rsi_3_1d > 40.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
       ):
         return True, f"exit_{mode_name}_d_8_112"
       elif (
         (last_rsi_3 < 18.0)
-        and (last_willr_14 < -96.0)
+        and (last_willr_14_lt_neg_96)
         and (last_rsi_3_1d > 70.0)
         and (last_stochrsi_k_4h_lt_50)
         and (isinstance(last_roc_9_4h, np.float64) and (last_roc_9_4h < -10.0))
@@ -59815,7 +59876,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 24.0)
         and (last_rsi_14_gt_50)
-        and (last_rsi_3_15m > 70.0)
+        and (last_rsi_3_15m_gt_70)
         and (last_stochrsi_k_1h_lt_50)
         and (last_stochrsi_k_4h_lt_50)
       ):
@@ -59830,7 +59891,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_8_118"
       elif (
         (last_rsi_3 < 16.0)
-        and (last_willr_14 < -80.0)
+        and (last_willr_14_lt_neg_80)
         and (last_rsi_3_1h > 40.0)
         and (last_rsi_3_4h > 40.0)
         and (last_stochrsi_k_1h < 60.0)
@@ -59838,11 +59899,11 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_8_119"
       elif (last_rsi_3 < 48.0) and (last_rsi_14_gt_50) and (last_rsi_3_1h > 60.0) and (last_aroond_14_4h > 75.0):
         return True, f"exit_{mode_name}_d_8_120"
-      elif (last_rsi_3 < 42.0) and (last_rsi_14 > 52.0) and (last_rsi_3_1h > 50.0) and (last_rsi_14_4h < 15.0):
+      elif (last_rsi_3_lt_42) and (last_rsi_14 > 52.0) and (last_rsi_3_1h > 50.0) and (last_rsi_14_4h < 15.0):
         return True, f"exit_{mode_name}_d_8_121"
-      elif (last_rsi_3 < 44.0) and (last_rsi_14 > 54.0) and (last_rsi_3_4h_gt_70) and (last_stochrsi_k_1h_lt_50):
+      elif (last_rsi_3_lt_44) and (last_rsi_14 > 54.0) and (last_rsi_3_4h_gt_70) and (last_stochrsi_k_1h_lt_50):
         return True, f"exit_{mode_name}_d_8_122"
-      elif (last_rsi_3 < 14.0) and (last_willr_14 < -94.0) and (last_rsi_3_1h > 90.0) and (last_rsi_3_1d > 70.0):
+      elif (last_rsi_3 < 14.0) and (last_willr_14_lt_neg_94) and (last_rsi_3_1h > 90.0) and (last_rsi_3_1d > 70.0):
         return True, f"exit_{mode_name}_d_8_123"
       elif (
         (last_rsi_3 < 14.0)
@@ -59852,16 +59913,16 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_8_124"
       elif (
         (last_rsi_3 < 26.0)
-        and (last_willr_14 < -94.0)
+        and (last_willr_14_lt_neg_94)
         and (last_rsi_3_1h > 90.0)
         and (last_rsi_3_4h > 60.0)
-        and (last_rsi_3_1d > 60.0)
+        and (last_rsi_3_1d_gt_60)
         and (last_close > (last_low_min_30_1d * 2.0))
       ):
         return True, f"exit_{mode_name}_d_8_125"
       elif (last_rsi_3 < 12.0) and (last_rsi_3_1h > 85.0) and (last_rsi_3_4h > 60.0) and (last_stochrsi_k_4h_lt_50):
         return True, f"exit_{mode_name}_d_8_126"
-      elif (last_rsi_3 < 12.0) and (last_rsi_3_1h > 90.0) and (last_rsi_3_4h_gt_70) and (last_rsi_3_1d > 60.0):
+      elif (last_rsi_3 < 12.0) and (last_rsi_3_1h > 90.0) and (last_rsi_3_4h_gt_70) and (last_rsi_3_1d_gt_60):
         return True, f"exit_{mode_name}_d_8_127"
       elif (last_rsi_3 < 8.0) and (last_rsi_3_4h_gt_70) and (last_aroond_14_4h > 85.0):
         return True, f"exit_{mode_name}_d_8_128"
@@ -59883,7 +59944,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 22.0)
         and (last_rsi_3_1h > 65.0)
-        and (last_rsi_3_4h > 65.0)
+        and (last_rsi_3_4h_gt_65)
         and (last_aroond_14_1h > 50.0)
         and (last_stochrsi_k_1h < 60.0)
       ):
@@ -59897,7 +59958,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_8_133"
     elif 0.1 > current_profit >= 0.09:
       if (
-        (last_willr_14 < -99.0)
+        (last_willr_14_lt_neg_99)
         and (last_rsi_14 < 22.0)
         and (isinstance(last_ema_200_1h, np.float64) and (last_ema_12_1h > last_ema_200_1h))
         and (isinstance(last_ema_200_4h, np.float64) and (last_ema_12_4h > last_ema_200_4h))
@@ -59906,35 +59967,35 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_9_1"
       elif (
-        (last_willr_14 < -99.0)
+        (last_willr_14_lt_neg_99)
         and (last_rsi_14 < 32.0)
-        and (last_cmf_20_1h > 0.0)
+        and (last_cmf_20_1h_gt_0)
         and (isinstance(last_ema_200_1h, np.float64) and (last_ema_12_1h > last_ema_200_1h))
         and (isinstance(last_ema_200_4h, np.float64) and (last_ema_12_4h > last_ema_200_4h))
       ):
         return True, f"exit_{mode_name}_d_9_2"
       elif (
-        (last_willr_14 < -94.0)
+        (last_willr_14_lt_neg_94)
         and (last_stochrsi_k < 2.0)
-        and (last_cmf_20_1h > 0.0)
-        and (last_cmf_20_4h > 0.0)
-        and ((last_stochrsi_k_4h < 80.0) and (last_stochrsi_k_change_pct_4h > 10.0))
+        and (last_cmf_20_1h_gt_0)
+        and (last_cmf_20_4h_gt_0)
+        and ((last_stochrsi_k_4h < 80.0) and (last_stochrsi_k_change_pct_4h_gt_10))
       ):
         return True, f"exit_{mode_name}_d_9_3"
       elif (
-        (last_willr_14 < -90.0)
+        (last_willr_14_lt_neg_90)
         and (last_rsi_14 < 26.0)
         and (last_stochrsi_k < 5.0)
-        and (last_stochrsi_k_4h < 30.0)
+        and (last_stochrsi_k_4h_lt_30)
         and (isinstance(last_ema_200_1h, np.float64) and (last_ema_12_1h > last_ema_200_1h))
         and (isinstance(last_ema_200_4h, np.float64) and (last_ema_12_4h > last_ema_200_4h))
       ):
         return True, f"exit_{mode_name}_d_9_4"
-      elif (last_willr_14 < -98.0) and (last_rsi_14 < 28.0) and (last_roc_9_1h > 5.0) and (last_roc_9_4h > 5.0):
+      elif (last_willr_14_lt_neg_98) and (last_rsi_14 < 28.0) and (last_roc_9_1h_gt_5) and (last_roc_9_4h_gt_5):
         return True, f"exit_{mode_name}_d_9_5"
       elif (
         (last_rsi_3 < 30.0)
-        and (last_stochrsi_k < 30.0)
+        and (last_stochrsi_k_lt_30)
         and (last_rsi_14 > 60.0)
         and (last_roc_9_1h > 10.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -50.0))
@@ -59942,13 +60003,13 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_9_6"
       elif (
         (last_rsi_14_gt_50)
-        and (last_stochrsi_k < 30.0)
+        and (last_stochrsi_k_lt_30)
         and (last_stochrsi_k_4h_lt_50)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 40.0))
       ):
         return True, f"exit_{mode_name}_d_9_7"
       elif (
-        (last_willr_14 < -98.0)
+        (last_willr_14_lt_neg_98)
         and (last_stochrsi_k < 5.0)
         and (last_cmf_20_1h > 0.1)
         and (last_cmf_20_4h > 0.1)
@@ -59957,17 +60018,17 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_9_8"
       elif (
-        (last_willr_14 < -96.0)
+        (last_willr_14_lt_neg_96)
         and (last_rsi_3 < 5.0)
         and (last_change_pct_4h > 5.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
       ):
         return True, f"exit_{mode_name}_d_9_9"
       elif (
-        (last_willr_14 < -94.0)
+        (last_willr_14_lt_neg_94)
         and (last_rsi_14_gt_50)
         and (last_roc_9_1h > 10.0)
-        and (last_roc_9_4h > 10.0)
+        and (last_roc_9_4h_gt_10)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -10.0))
       ):
         return True, f"exit_{mode_name}_d_9_10"
@@ -59984,26 +60045,26 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14_gt_50)
         and (last_rsi_3_4h > 90.0)
         and (last_roc_9_1h > 20.0)
-        and (last_roc_9_4h > 20.0)
+        and (last_roc_9_4h_gt_20)
       ):
         return True, f"exit_{mode_name}_d_9_12"
-      elif (last_rsi_3 < 4.0) and (last_rsi_3_4h > 95.0) and (last_roc_9_4h > 25.0):
+      elif (last_rsi_3 < 4.0) and (last_rsi_3_4h_gt_95) and (last_roc_9_4h_gt_25):
         return True, f"exit_{mode_name}_d_9_13"
-      elif (last_rsi_3 < 10.0) and (last_willr_14 < -96.0) and (last_rsi_3_4h > 95.0) and (last_aroond_14_4h > 25.0):
+      elif (last_rsi_3 < 10.0) and (last_willr_14_lt_neg_96) and (last_rsi_3_4h_gt_95) and (last_aroond_14_4h > 25.0):
         return True, f"exit_{mode_name}_d_9_14"
       elif (last_rsi_3 < 6.0) and (last_rsi_14 < 34.0) and (last_roc_9_4h > 30.0):
         return True, f"exit_{mode_name}_d_9_15"
       elif (
         (last_rsi_3 < 10.0)
         and (last_aroond_14_4h > 25.0)
-        and (last_roc_9_4h > 25.0)
+        and (last_roc_9_4h_gt_25)
         and (last_aroond_14_1d > 50.0)
         and (last_change_pct_1d > 15.0)
       ):
         return True, f"exit_{mode_name}_d_9_16"
       elif (
         (last_rsi_3 < 4.0)
-        and (last_willr_14 < -85.0)
+        and (last_willr_14_lt_neg_85)
         and (last_rsi_3_1h > 90.0)
         and (last_stochrsi_k_4h < 10.0)
         and (last_roc_9_4h < -30.0)
@@ -60024,31 +60085,31 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_9_21"
       elif (
         (last_rsi_3 < 2.0)
-        and (last_willr_14 < -98.0)
+        and (last_willr_14_lt_neg_98)
         and (last_change_pct_4h > 5.0)
         and (last_stochrsi_k_4h_lt_50)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
       ):
         return True, f"exit_{mode_name}_d_9_22"
-      elif (last_rsi_3 < 8.0) and (last_willr_14 < -90.0) and (last_rsi_3_1h > 85.0) and (last_rsi_3_1d > 95.0):
+      elif (last_rsi_3 < 8.0) and (last_willr_14_lt_neg_90) and (last_rsi_3_1h > 85.0) and (last_rsi_3_1d > 95.0):
         return True, f"exit_{mode_name}_d_9_23"
       elif (
         (last_rsi_3 < 8.0)
         and (last_rsi_14 < 28.0)
-        and (last_willr_14 < -85.0)
+        and (last_willr_14_lt_neg_85)
         and (last_rsi_3_4h_gt_70)
         and (last_aroond_14_4h > 75.0)
       ):
         return True, f"exit_{mode_name}_d_9_24"
       elif (
         (last_rsi_3 < 10.0)
-        and (last_willr_14 < -96.0)
+        and (last_willr_14_lt_neg_96)
         and (last_rsi_3_4h > 90.0)
         and (last_roc_9_4h > 15.0)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 50.0))
       ):
         return True, f"exit_{mode_name}_d_9_25"
-      elif (last_rsi_3 < 15.0) and (last_willr_14 < -96.0) and (last_rsi_3_4h > 85.0) and (last_roc_9_4h > 20.0):
+      elif (last_rsi_3 < 15.0) and (last_willr_14_lt_neg_96) and (last_rsi_3_4h > 85.0) and (last_roc_9_4h_gt_20):
         return True, f"exit_{mode_name}_d_9_26"
       elif (
         (last_rsi_3 < 15.0)
@@ -60075,27 +60136,27 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14_gt_50)
         and (last_rsi_3_1h > 85.0)
         and (last_rsi_3_4h > 85.0)
-        and (last_stochrsi_k_1h < 75.0)
+        and (last_stochrsi_k_1h_lt_75)
       ):
         return True, f"exit_{mode_name}_d_9_31"
-      elif (last_rsi_3 < 10.0) and (last_rsi_3_1h > 85.0) and (last_roc_2_4h > 30.0) and (last_stochrsi_k_4h < 70.0):
+      elif (last_rsi_3 < 10.0) and (last_rsi_3_1h > 85.0) and (last_roc_2_4h_gt_30) and (last_stochrsi_k_4h < 70.0):
         return True, f"exit_{mode_name}_d_9_32"
       elif (
         (last_rsi_3 < 10.0)
-        and (last_willr_14 < -98.0)
+        and (last_willr_14_lt_neg_98)
         and (last_roc_2_1h > 10.0)
         and (last_roc_9_1h < -30.0)
         and (last_stochrsi_k_1h_lt_50)
       ):
         return True, f"exit_{mode_name}_d_9_33"
-      elif (last_rsi_3 < 35.0) and (last_rsi_3_15m > 70.0) and (last_rsi_14_1h < 20.0) and (last_roc_9_1h < -40.0):
+      elif (last_rsi_3 < 35.0) and (last_rsi_3_15m_gt_70) and (last_rsi_14_1h < 20.0) and (last_roc_9_1h < -40.0):
         return True, f"exit_{mode_name}_d_9_34"
-      elif (last_rsi_3 < 12.0) and (last_willr_14 < -94.0) and (last_rsi_3_1d > 75.0) and (last_stochrsi_k_1h < 25.0):
+      elif (last_rsi_3 < 12.0) and (last_willr_14_lt_neg_94) and (last_rsi_3_1d > 75.0) and (last_stochrsi_k_1h_lt_25):
         return True, f"exit_{mode_name}_d_9_35"
       elif (
         (last_rsi_3 < 15.0)
-        and (last_willr_14 < -85.0)
-        and (last_roc_9_4h > 25.0)
+        and (last_willr_14_lt_neg_85)
+        and (last_roc_9_4h_gt_25)
         and (last_rsi_3_1d > 75.0)
         and (last_stochrsi_k_1h_lt_50)
       ):
@@ -60108,13 +60169,15 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_stochrsi_k_4h_lt_50)
       ):
         return True, f"exit_{mode_name}_d_9_37"
-      elif (last_rsi_3 < 15.0) and (last_willr_14 < -85.0) and (last_rsi_3_4h > 90.0) and (last_stochrsi_k_4h < 80.0):
+      elif (
+        (last_rsi_3 < 15.0) and (last_willr_14_lt_neg_85) and (last_rsi_3_4h > 90.0) and (last_stochrsi_k_4h < 80.0)
+      ):
         return True, f"exit_{mode_name}_d_9_38"
-      elif (last_rsi_3 < 5.0) and (last_willr_14 < -95.0) and (last_cmf_20_4h > 0.0) and (last_rsi_3_4h > 90.0):
+      elif (last_rsi_3 < 5.0) and (last_willr_14_lt_neg_95) and (last_cmf_20_4h_gt_0) and (last_rsi_3_4h > 90.0):
         return True, f"exit_{mode_name}_d_9_39"
       elif (
         (last_rsi_3 < 15.0)
-        and (last_willr_14 < -85.0)
+        and (last_willr_14_lt_neg_85)
         and (last_rsi_3_1h_gt_70)
         and (last_stochrsi_k_1h < 70.0)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 10.0))
@@ -60122,7 +60185,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_9_40"
       elif (
         (last_rsi_3 < 5.0)
-        and (last_willr_14 < -90.0)
+        and (last_willr_14_lt_neg_90)
         and (last_rsi_3_1h_gt_70)
         and (last_stochrsi_k_4h < 75.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -50.0))
@@ -60130,7 +60193,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_9_41"
       elif (
         (last_rsi_3 < 10.0)
-        and (last_willr_14 < -75.0)
+        and (last_willr_14_lt_neg_75)
         and (last_stochrsi_k_4h < 70.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -40.0))
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 30.0))
@@ -60146,13 +60209,13 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_9_43"
       elif (
         (last_rsi_3 < 30.0)
-        and (last_willr_14 < -95.0)
+        and (last_willr_14_lt_neg_95)
         and (last_rsi_3_4h_gt_70)
         and (last_rsi_3_1d > 25.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
       ):
         return True, f"exit_{mode_name}_d_9_44"
-      elif (last_rsi_3 < 6.0) and (last_willr_14 < -94.0) and (last_rsi_3_1h > 90.0):
+      elif (last_rsi_3 < 6.0) and (last_willr_14_lt_neg_94) and (last_rsi_3_1h > 90.0):
         return True, f"exit_{mode_name}_d_9_45"
       elif (last_rsi_3 < 10.0) and (last_rsi_3_1h > 85.0) and (last_rsi_3_4h > 90.0) and (last_roc_2_1d > 20.0):
         return True, f"exit_{mode_name}_d_9_46"
@@ -60174,20 +60237,20 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_9_48"
       elif (
         (last_rsi_3 < 10.0)
-        and (last_willr_14 < -96.0)
+        and (last_willr_14_lt_neg_96)
         and (last_rsi_3_4h > 80.0)
         and (last_change_pct_1d > 5.0)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 50.0))
       ):
         return True, f"exit_{mode_name}_d_9_49"
-      elif (last_rsi_3 < 20.0) and (last_willr_14 < -96.0) and (last_rsi_3_1d > 90.0) and (last_stochrsi_k_1h < 10.0):
+      elif (last_rsi_3 < 20.0) and (last_willr_14_lt_neg_96) and (last_rsi_3_1d > 90.0) and (last_stochrsi_k_1h_lt_10):
         return True, f"exit_{mode_name}_d_9_50"
       elif (last_rsi_3 < 34.0) and (last_rsi_14 > 54.0) and (last_rsi_3_4h > 80.0) and (last_stochrsi_k_1h_lt_50):
         return True, f"exit_{mode_name}_d_9_51"
       elif (
         (last_rsi_3 < 20.0)
         and (last_rsi_14 < 40.0)
-        and (last_willr_14 < -90.0)
+        and (last_willr_14_lt_neg_90)
         and (last_stochrsi_k_1h < 30.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 15.0))
       ):
@@ -60195,7 +60258,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 30.0)
         and (last_rsi_14_gt_50)
-        and (last_willr_14 < -75.0)
+        and (last_willr_14_lt_neg_75)
         and (last_rsi_3_1h > 80.0)
         and (last_stochrsi_k_4h_lt_50)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 50.0))
@@ -60205,14 +60268,14 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 22.0)
         and (last_rsi_14 > 54.0)
         and (last_stochrsi_k_1h_lt_50)
-        and (last_roc_9_4h > 10.0)
+        and (last_roc_9_4h_gt_10)
         and (last_change_pct_1d > 10.0)
       ):
         return True, f"exit_{mode_name}_d_9_54"
       elif (
         (last_rsi_3 < 6.0)
-        and (last_willr_14 < -86.0)
-        and (last_roc_9_4h > 5.0)
+        and (last_willr_14_lt_neg_86)
+        and (last_roc_9_4h_gt_5)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -10.0))
         and (last_stochrsi_k_1h_lt_50)
       ):
@@ -60223,14 +60286,14 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_3_1h_gt_70)
         and (last_rsi_3_4h > 75.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
-        and (last_stochrsi_k_4h < 90.0)
+        and (last_stochrsi_k_4h_lt_90)
       ):
         return True, f"exit_{mode_name}_d_9_56"
       elif (
         (last_rsi_3 < 50.0)
         and (last_rsi_14 > 64.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
-        and (last_stochrsi_k_4h < 30.0)
+        and (last_stochrsi_k_4h_lt_30)
       ):
         return True, f"exit_{mode_name}_d_9_57"
       elif (
@@ -60243,7 +60306,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_9_58"
       elif (
         (last_rsi_3 < 15.0)
-        and (last_willr_14 < -88.0)
+        and (last_willr_14_lt_neg_88)
         and (last_rsi_3_4h > 75.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 15.0))
         and (last_stochrsi_k_4h < 60.0)
@@ -60254,14 +60317,14 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 > 60.0)
         and (last_rsi_14_4h < 35.0)
         and (last_stochrsi_k_4h_lt_50)
-        and (last_stochrsi_k_1d < 50.0)
+        and (last_stochrsi_k_1d_lt_50)
       ):
         return True, f"exit_{mode_name}_d_9_60"
-      elif (last_rsi_3 < 8.0) and (last_willr_14 < -80.0) and (last_rsi_3_4h > 90.0) and (last_stochrsi_k_1h < 70.0):
+      elif (last_rsi_3 < 8.0) and (last_willr_14_lt_neg_80) and (last_rsi_3_4h > 90.0) and (last_stochrsi_k_1h < 70.0):
         return True, f"exit_{mode_name}_d_9_61"
       elif (
         (last_rsi_3 < 14.0)
-        and (last_willr_14 < -98.0)
+        and (last_willr_14_lt_neg_98)
         and (last_rsi_3_1h_gt_70)
         and (last_rsi_3_4h > 80.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -20.0))
@@ -60286,7 +60349,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 50.0)
         and (last_rsi_14 > 58.0)
-        and (last_stochrsi_k_4h < 20.0)
+        and (last_stochrsi_k_4h_lt_20)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 25.0))
       ):
         return True, f"exit_{mode_name}_d_9_67"
@@ -60294,7 +60357,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 16.0)
         and (last_rsi_14 > 52.0)
         and (last_rsi_3_1h > 75.0)
-        and (last_roc_2_4h > 30.0)
+        and (last_roc_2_4h_gt_30)
         and (last_stochrsi_k_4h < 75.0)
       ):
         return True, f"exit_{mode_name}_d_9_68"
@@ -60304,7 +60367,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_9_69"
       elif (last_rsi_3 < 34.0) and (last_rsi_14 > 60.0) and (last_rsi_3_1h > 75.0) and (last_stochrsi_k_4h < 80.0):
         return True, f"exit_{mode_name}_d_9_70"
-      elif (last_rsi_3 < 36.0) and (last_rsi_14 > 56.0) and (last_rsi_3_4h > 75.0) and (last_stochrsi_k_1h < 80.0):
+      elif (last_rsi_3 < 36.0) and (last_rsi_14 > 56.0) and (last_rsi_3_4h > 75.0) and (last_stochrsi_k_1h_lt_80):
         return True, f"exit_{mode_name}_d_9_71"
       elif (last_rsi_3 < 22.0) and (last_rsi_14 > 58.0) and (last_rsi_3_1h > 90.0) and (last_aroond_14_4h > 25.0):
         return True, f"exit_{mode_name}_d_9_72"
@@ -60312,16 +60375,16 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 22.0)
         and (last_rsi_3_1h > 75.0)
         and (last_rsi_3_4h > 85.0)
-        and (last_roc_9_4h > 20.0)
+        and (last_roc_9_4h_gt_20)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 25.0))
       ):
         return True, f"exit_{mode_name}_d_9_73"
       elif (
         (last_rsi_3 < 2.0)
-        and (last_willr_14 < -90.0)
+        and (last_willr_14_lt_neg_90)
         and (last_rsi_3_4h > 75.0)
         and (last_rsi_3_1d > 75.0)
-        and (last_stochrsi_k_1h > 50.0)
+        and (last_stochrsi_k_1h_gt_50)
       ):
         return True, f"exit_{mode_name}_d_9_74"
       elif (
@@ -60331,7 +60394,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 50.0))
       ):
         return True, f"exit_{mode_name}_d_9_75"
-      elif (last_rsi_3 < 32.0) and (last_rsi_14_gt_50) and (last_roc_9_1h < -80.0) and (last_stochrsi_k_4h < 20.0):
+      elif (last_rsi_3 < 32.0) and (last_rsi_14_gt_50) and (last_roc_9_1h < -80.0) and (last_stochrsi_k_4h_lt_20):
         return True, f"exit_{mode_name}_d_9_76"
       elif (
         (last_rsi_3 < 24.0)
@@ -60342,13 +60405,13 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_9_77"
       elif (
         (last_rsi_3 < 14.0)
-        and (last_willr_14 < -84.0)
+        and (last_willr_14_lt_neg_84)
         and (last_rsi_3_1h_gt_70)
         and (last_rsi_3_4h > 80.0)
         and (last_rsi_3_1d > 80.0)
       ):
         return True, f"exit_{mode_name}_d_9_78"
-      elif (last_rsi_3 < 8.0) and (last_willr_14 < -98.0) and (last_rsi_3_1h_gt_70) and (last_rsi_3_4h > 90.0):
+      elif (last_rsi_3 < 8.0) and (last_willr_14_lt_neg_98) and (last_rsi_3_1h_gt_70) and (last_rsi_3_4h > 90.0):
         return True, f"exit_{mode_name}_d_9_79"
       elif (
         (last_rsi_3 < 28.0)
@@ -60360,7 +60423,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_9_80"
       elif (
         (last_rsi_3 < 16.0)
-        and (last_willr_14 < -90.0)
+        and (last_willr_14_lt_neg_90)
         and (last_rsi_3_1h > 75.0)
         and (last_rsi_3_4h > 75.0)
         and (isinstance(last_rsi_14_1d, np.float64) and (last_rsi_14_1d < 50.0))
@@ -60368,7 +60431,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_9_81"
       elif (
         (last_rsi_3 < 18.0)
-        and (last_willr_14 < -90.0)
+        and (last_willr_14_lt_neg_90)
         and (last_rsi_3_4h_gt_70)
         and (last_rsi_3_1d > 85.0)
         and (last_stochrsi_k_4h < 60.0)
@@ -60382,11 +60445,11 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_stochrsi_k_4h < 60.0)
       ):
         return True, f"exit_{mode_name}_d_9_83"
-      elif (last_rsi_3 < 10.0) and (last_willr_14 < -98.0) and (last_rsi_3_4h_gt_70) and (last_stochrsi_k_1h < 80.0):
+      elif (last_rsi_3 < 10.0) and (last_willr_14_lt_neg_98) and (last_rsi_3_4h_gt_70) and (last_stochrsi_k_1h_lt_80):
         return True, f"exit_{mode_name}_d_9_84"
       elif (
         (last_rsi_3 < 12.0)
-        and (last_willr_14 < -92.0)
+        and (last_willr_14_lt_neg_92)
         and (last_rsi_3_1h_gt_70)
         and (last_rsi_3_4h > 60.0)
         and (last_stochrsi_k_4h_lt_50)
@@ -60410,7 +60473,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_9_87"
       elif (
         (last_rsi_3 < 12.0)
-        and (last_willr_14 < -80.0)
+        and (last_willr_14_lt_neg_80)
         and (last_stochrsi_k_1h < 60.0)
         and (last_stochrsi_k_4h_lt_50)
         and (last_change_pct_1h > 2.0)
@@ -60419,13 +60482,13 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 22.0)
         and (last_rsi_14 > 60.0)
-        and (last_roc_9_1h > 5.0)
+        and (last_roc_9_1h_gt_5)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -25.0))
       ):
         return True, f"exit_{mode_name}_d_9_89"
       elif (
         (last_rsi_3 < 8.0)
-        and (last_willr_14 < -75.0)
+        and (last_willr_14_lt_neg_75)
         and (last_rsi_3_1h > 50.0)
         and (last_rsi_3_4h_gt_70)
         and (last_aroonu_14_4h < 50.0)
@@ -60445,7 +60508,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 20.0)
         and (last_rsi_14 > 52.0)
         and (last_rsi_3_1h > 60.0)
-        and (last_stochrsi_k_1h < 75.0)
+        and (last_stochrsi_k_1h_lt_75)
         and (last_stochrsi_k_4h_lt_50)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 25.0))
       ):
@@ -60472,10 +60535,10 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_9_94"
       elif (
         (last_rsi_3 < 16.0)
-        and (last_willr_14 < -88.0)
+        and (last_willr_14_lt_neg_88)
         and (last_rsi_3_1h > 55.0)
         and (last_rsi_3_4h > 60.0)
-        and (last_stochrsi_k_4h < 90.0)
+        and (last_stochrsi_k_4h_lt_90)
         and (isinstance(last_aroond_14_1d, np.float64) and (last_aroond_14_1d > 75.0))
       ):
         return True, f"exit_{mode_name}_d_9_95"
@@ -60510,15 +60573,15 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_3_1h > 35.0)
         and (last_rsi_3_4h > 40.0)
         and (last_aroond_14_4h > 50.0)
-        and (last_stoch_k_4h < 60.0)
+        and (last_stoch_k_4h_lt_60)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -80.0))
       ):
         return True, f"exit_{mode_name}_d_9_99"
-      elif (last_rsi_3 < 2.0) and (last_rsi_14 < 24.0) and (last_rsi_3_15m < 30.0) and (last_rsi_3_4h > 20.0):
+      elif (last_rsi_3 < 2.0) and (last_rsi_14 < 24.0) and (last_rsi_3_15m_lt_30) and (last_rsi_3_4h > 20.0):
         return True, f"exit_{mode_name}_d_9_100"
       elif (
         (last_rsi_3 < 16.0)
-        and (last_willr_14 < -84.0)
+        and (last_willr_14_lt_neg_84)
         and (last_rsi_3_1h > 50.0)
         and (last_stochrsi_k_4h < 60.0)
         and (isinstance(last_roc_9_4h, np.float64) and (last_roc_9_4h < -40.0))
@@ -60529,7 +60592,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 > 52.0)
         and (last_rsi_3_1h > 40.0)
         and (last_rsi_3_4h > 60.0)
-        and (last_stochrsi_k_4h > 70.0)
+        and (last_stochrsi_k_4h_gt_70)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -40.0))
       ):
         return True, f"exit_{mode_name}_d_9_102"
@@ -60547,7 +60610,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_3_1h > 40.0)
         and (last_stochrsi_k_1h < 60.0)
         and (last_stochrsi_k_4h < 10.0)
-        and (last_roc_9_4h < -40.0)
+        and (last_roc_9_4h_lt_neg_40)
       ):
         return True, f"exit_{mode_name}_d_9_104"
       elif (
@@ -60555,7 +60618,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 > 52.0)
         and (last_rsi_3_15m > 45.0)
         and (last_stochrsi_k_4h < 10.0)
-        and (last_roc_9_4h < -25.0)
+        and (last_roc_9_4h_lt_neg_25)
       ):
         return True, f"exit_{mode_name}_d_9_105"
       elif (
@@ -60564,7 +60627,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_3_1h > 50.0)
         and (last_stochrsi_k_1h_lt_50)
         and (last_rsi_14_4h < 30.0)
-        and (last_roc_9_4h < -40.0)
+        and (last_roc_9_4h_lt_neg_40)
       ):
         return True, f"exit_{mode_name}_d_9_106"
       elif (
@@ -60575,17 +60638,17 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14_4h < 50.0)
       ):
         return True, f"exit_{mode_name}_d_9_107"
-      elif (last_rsi_3 < 44.0) and (last_rsi_14 > 52.0) and (last_rsi_3_1h > 40.0) and (last_stochrsi_k_1h < 20.0):
+      elif (last_rsi_3_lt_44) and (last_rsi_14 > 52.0) and (last_rsi_3_1h > 40.0) and (last_stochrsi_k_1h < 20.0):
         return True, f"exit_{mode_name}_d_9_108"
       elif (
         (last_rsi_3 < 24.0)
-        and (last_willr_14 < -92.0)
+        and (last_willr_14_lt_neg_92)
         and (last_rsi_3_1h > 50.0)
         and (last_rsi_3_4h > 80.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -50.0))
       ):
         return True, f"exit_{mode_name}_d_9_109"
-      elif (last_rsi_3 < 28.0) and (last_rsi_3_4h > 35.0) and (last_stochrsi_k_4h_lt_50) and (last_roc_9_4h < -25.0):
+      elif (last_rsi_3 < 28.0) and (last_rsi_3_4h > 35.0) and (last_stochrsi_k_4h_lt_50) and (last_roc_9_4h_lt_neg_25):
         return True, f"exit_{mode_name}_d_9_110"
       elif (
         (last_rsi_3 < 50.0)
@@ -60599,17 +60662,17 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_9_111"
       elif (
         (last_rsi_3 < 20.0)
-        and (last_willr_14 < -75.0)
+        and (last_willr_14_lt_neg_75)
         and (last_rsi_14 > 48.0)
         and (last_rsi_3_1h > 65.0)
-        and (last_rsi_3_4h > 65.0)
+        and (last_rsi_3_4h_gt_65)
         and (last_rsi_3_1d > 40.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
       ):
         return True, f"exit_{mode_name}_d_9_112"
       elif (
         (last_rsi_3 < 16.0)
-        and (last_willr_14 < -98.0)
+        and (last_willr_14_lt_neg_98)
         and (last_rsi_3_1d > 70.0)
         and (last_stochrsi_k_4h_lt_50)
         and (isinstance(last_roc_9_4h, np.float64) and (last_roc_9_4h < -10.0))
@@ -60627,7 +60690,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 22.0)
         and (last_rsi_14 > 52.0)
-        and (last_rsi_3_15m > 70.0)
+        and (last_rsi_3_15m_gt_70)
         and (last_stochrsi_k_1h_lt_50)
         and (last_stochrsi_k_4h_lt_50)
       ):
@@ -60642,7 +60705,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_9_118"
       elif (
         (last_rsi_3 < 14.0)
-        and (last_willr_14 < -80.0)
+        and (last_willr_14_lt_neg_80)
         and (last_rsi_3_1h > 40.0)
         and (last_rsi_3_4h > 40.0)
         and (last_stochrsi_k_1h < 60.0)
@@ -60652,9 +60715,9 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_9_120"
       elif (last_rsi_3 < 40.0) and (last_rsi_14 > 54.0) and (last_rsi_3_1h > 50.0) and (last_rsi_14_4h < 15.0):
         return True, f"exit_{mode_name}_d_9_121"
-      elif (last_rsi_3 < 42.0) and (last_rsi_14 > 56.0) and (last_rsi_3_4h_gt_70) and (last_stochrsi_k_1h_lt_50):
+      elif (last_rsi_3_lt_42) and (last_rsi_14 > 56.0) and (last_rsi_3_4h_gt_70) and (last_stochrsi_k_1h_lt_50):
         return True, f"exit_{mode_name}_d_9_122"
-      elif (last_rsi_3 < 12.0) and (last_willr_14 < -96.0) and (last_rsi_3_1h > 90.0) and (last_rsi_3_1d > 70.0):
+      elif (last_rsi_3 < 12.0) and (last_willr_14_lt_neg_96) and (last_rsi_3_1h > 90.0) and (last_rsi_3_1d > 70.0):
         return True, f"exit_{mode_name}_d_9_123"
       elif (
         (last_rsi_3 < 12.0)
@@ -60664,16 +60727,16 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_9_124"
       elif (
         (last_rsi_3 < 24.0)
-        and (last_willr_14 < -96.0)
+        and (last_willr_14_lt_neg_96)
         and (last_rsi_3_1h > 90.0)
         and (last_rsi_3_4h > 60.0)
-        and (last_rsi_3_1d > 60.0)
+        and (last_rsi_3_1d_gt_60)
         and (last_close > (last_low_min_30_1d * 2.0))
       ):
         return True, f"exit_{mode_name}_d_9_125"
       elif (last_rsi_3 < 10.0) and (last_rsi_3_1h > 85.0) and (last_rsi_3_4h > 60.0) and (last_stochrsi_k_4h_lt_50):
         return True, f"exit_{mode_name}_d_9_126"
-      elif (last_rsi_3 < 10.0) and (last_rsi_3_1h > 90.0) and (last_rsi_3_4h_gt_70) and (last_rsi_3_1d > 60.0):
+      elif (last_rsi_3 < 10.0) and (last_rsi_3_1h > 90.0) and (last_rsi_3_4h_gt_70) and (last_rsi_3_1d_gt_60):
         return True, f"exit_{mode_name}_d_9_127"
       elif (last_rsi_3 < 6.0) and (last_rsi_3_4h_gt_70) and (last_aroond_14_4h > 85.0):
         return True, f"exit_{mode_name}_d_9_128"
@@ -60695,7 +60758,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 20.0)
         and (last_rsi_3_1h > 65.0)
-        and (last_rsi_3_4h > 65.0)
+        and (last_rsi_3_4h_gt_65)
         and (last_aroond_14_1h > 50.0)
         and (last_stochrsi_k_1h < 60.0)
       ):
@@ -60709,7 +60772,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_9_133"
     elif 0.12 > current_profit >= 0.1:
       if (
-        (last_willr_14 < -99.0)
+        (last_willr_14_lt_neg_99)
         and (last_rsi_14 < 22.0)
         and (isinstance(last_ema_200_1h, np.float64) and (last_ema_12_1h > last_ema_200_1h))
         and (isinstance(last_ema_200_4h, np.float64) and (last_ema_12_4h > last_ema_200_4h))
@@ -60718,35 +60781,35 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_10_1"
       elif (
-        (last_willr_14 < -99.0)
+        (last_willr_14_lt_neg_99)
         and (last_rsi_14 < 30.0)
-        and (last_cmf_20_1h > 0.0)
+        and (last_cmf_20_1h_gt_0)
         and (isinstance(last_ema_200_1h, np.float64) and (last_ema_12_1h > last_ema_200_1h))
         and (isinstance(last_ema_200_4h, np.float64) and (last_ema_12_4h > last_ema_200_4h))
       ):
         return True, f"exit_{mode_name}_d_10_2"
       elif (
-        (last_willr_14 < -96.0)
+        (last_willr_14_lt_neg_96)
         and (last_stochrsi_k < 2.0)
-        and (last_cmf_20_1h > 0.0)
-        and (last_cmf_20_4h > 0.0)
-        and ((last_stochrsi_k_4h < 80.0) and (last_stochrsi_k_change_pct_4h > 10.0))
+        and (last_cmf_20_1h_gt_0)
+        and (last_cmf_20_4h_gt_0)
+        and ((last_stochrsi_k_4h < 80.0) and (last_stochrsi_k_change_pct_4h_gt_10))
       ):
         return True, f"exit_{mode_name}_d_10_3"
       elif (
-        (last_willr_14 < -95.0)
+        (last_willr_14_lt_neg_95)
         and (last_rsi_14 < 24.0)
         and (last_stochrsi_k < 5.0)
-        and (last_stochrsi_k_4h < 30.0)
+        and (last_stochrsi_k_4h_lt_30)
         and (isinstance(last_ema_200_1h, np.float64) and (last_ema_12_1h > last_ema_200_1h))
         and (isinstance(last_ema_200_4h, np.float64) and (last_ema_12_4h > last_ema_200_4h))
       ):
         return True, f"exit_{mode_name}_d_10_4"
-      elif (last_willr_14 < -99.0) and (last_rsi_14 < 26.0) and (last_roc_9_1h > 5.0) and (last_roc_9_4h > 5.0):
+      elif (last_willr_14_lt_neg_99) and (last_rsi_14 < 26.0) and (last_roc_9_1h_gt_5) and (last_roc_9_4h_gt_5):
         return True, f"exit_{mode_name}_d_10_5"
       elif (
         (last_rsi_3 < 30.0)
-        and (last_stochrsi_k < 30.0)
+        and (last_stochrsi_k_lt_30)
         and (last_rsi_14 > 60.0)
         and (last_roc_9_1h > 10.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -50.0))
@@ -60754,13 +60817,13 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_10_6"
       elif (
         (last_rsi_14_gt_50)
-        and (last_stochrsi_k < 30.0)
+        and (last_stochrsi_k_lt_30)
         and (last_stochrsi_k_4h_lt_50)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 40.0))
       ):
         return True, f"exit_{mode_name}_d_10_7"
       elif (
-        (last_willr_14 < -99.0)
+        (last_willr_14_lt_neg_99)
         and (last_stochrsi_k < 5.0)
         and (last_cmf_20_1h > 0.1)
         and (last_cmf_20_4h > 0.1)
@@ -60776,10 +60839,10 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_10_9"
       elif (
-        (last_willr_14 < -96.0)
+        (last_willr_14_lt_neg_96)
         and (last_rsi_14_gt_50)
         and (last_roc_9_1h > 10.0)
-        and (last_roc_9_4h > 10.0)
+        and (last_roc_9_4h_gt_10)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -10.0))
       ):
         return True, f"exit_{mode_name}_d_10_10"
@@ -60796,26 +60859,26 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14_gt_50)
         and (last_rsi_3_4h > 90.0)
         and (last_roc_9_1h > 20.0)
-        and (last_roc_9_4h > 20.0)
+        and (last_roc_9_4h_gt_20)
       ):
         return True, f"exit_{mode_name}_d_10_12"
-      elif (last_rsi_3 < 4.0) and (last_rsi_3_4h > 95.0) and (last_roc_9_4h > 25.0):
+      elif (last_rsi_3 < 4.0) and (last_rsi_3_4h_gt_95) and (last_roc_9_4h_gt_25):
         return True, f"exit_{mode_name}_d_10_13"
-      elif (last_rsi_3 < 10.0) and (last_willr_14 < -98.0) and (last_rsi_3_4h > 95.0) and (last_aroond_14_4h > 25.0):
+      elif (last_rsi_3 < 10.0) and (last_willr_14_lt_neg_98) and (last_rsi_3_4h_gt_95) and (last_aroond_14_4h > 25.0):
         return True, f"exit_{mode_name}_d_10_14"
       elif (last_rsi_3 < 4.0) and (last_rsi_14 < 32.0) and (last_roc_9_4h > 30.0):
         return True, f"exit_{mode_name}_d_10_15"
       elif (
         (last_rsi_3 < 5.0)
         and (last_aroond_14_4h > 25.0)
-        and (last_roc_9_4h > 25.0)
+        and (last_roc_9_4h_gt_25)
         and (last_aroond_14_1d > 50.0)
         and (last_change_pct_1d > 15.0)
       ):
         return True, f"exit_{mode_name}_d_10_16"
       elif (
         (last_rsi_3 < 3.0)
-        and (last_willr_14 < -90.0)
+        and (last_willr_14_lt_neg_90)
         and (last_rsi_3_1h > 90.0)
         and (last_stochrsi_k_4h < 10.0)
         and (last_roc_9_4h < -30.0)
@@ -60836,31 +60899,31 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_10_21"
       elif (
         (last_rsi_3 < 1.0)
-        and (last_willr_14 < -99.0)
+        and (last_willr_14_lt_neg_99)
         and (last_change_pct_4h > 5.0)
         and (last_stochrsi_k_4h_lt_50)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
       ):
         return True, f"exit_{mode_name}_d_10_22"
-      elif (last_rsi_3 < 5.0) and (last_willr_14 < -95.0) and (last_rsi_3_1h > 85.0) and (last_rsi_3_1d > 95.0):
+      elif (last_rsi_3 < 5.0) and (last_willr_14_lt_neg_95) and (last_rsi_3_1h > 85.0) and (last_rsi_3_1d > 95.0):
         return True, f"exit_{mode_name}_d_10_23"
       elif (
         (last_rsi_3 < 6.0)
         and (last_rsi_14 < 26.0)
-        and (last_willr_14 < -90.0)
+        and (last_willr_14_lt_neg_90)
         and (last_rsi_3_4h_gt_70)
         and (last_aroond_14_4h > 75.0)
       ):
         return True, f"exit_{mode_name}_d_10_24"
       elif (
         (last_rsi_3 < 5.0)
-        and (last_willr_14 < -98.0)
+        and (last_willr_14_lt_neg_98)
         and (last_rsi_3_4h > 90.0)
         and (last_roc_9_4h > 15.0)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 50.0))
       ):
         return True, f"exit_{mode_name}_d_10_25"
-      elif (last_rsi_3 < 10.0) and (last_willr_14 < -98.0) and (last_rsi_3_4h > 85.0) and (last_roc_9_4h > 20.0):
+      elif (last_rsi_3 < 10.0) and (last_willr_14_lt_neg_98) and (last_rsi_3_4h > 85.0) and (last_roc_9_4h_gt_20):
         return True, f"exit_{mode_name}_d_10_26"
       elif (
         (last_rsi_3 < 10.0)
@@ -60887,27 +60950,27 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14_gt_50)
         and (last_rsi_3_1h > 85.0)
         and (last_rsi_3_4h > 85.0)
-        and (last_stochrsi_k_1h < 75.0)
+        and (last_stochrsi_k_1h_lt_75)
       ):
         return True, f"exit_{mode_name}_d_10_31"
-      elif (last_rsi_3 < 5.0) and (last_rsi_3_1h > 85.0) and (last_roc_2_4h > 30.0) and (last_stochrsi_k_4h < 70.0):
+      elif (last_rsi_3 < 5.0) and (last_rsi_3_1h > 85.0) and (last_roc_2_4h_gt_30) and (last_stochrsi_k_4h < 70.0):
         return True, f"exit_{mode_name}_d_10_32"
       elif (
         (last_rsi_3 < 5.0)
-        and (last_willr_14 < -99.0)
+        and (last_willr_14_lt_neg_99)
         and (last_roc_2_1h > 10.0)
         and (last_roc_9_1h < -30.0)
         and (last_stochrsi_k_1h_lt_50)
       ):
         return True, f"exit_{mode_name}_d_10_33"
-      elif (last_rsi_3 < 35.0) and (last_rsi_3_15m > 70.0) and (last_rsi_14_1h < 20.0) and (last_roc_9_1h < -40.0):
+      elif (last_rsi_3 < 35.0) and (last_rsi_3_15m_gt_70) and (last_rsi_14_1h < 20.0) and (last_roc_9_1h < -40.0):
         return True, f"exit_{mode_name}_d_10_34"
-      elif (last_rsi_3 < 10.0) and (last_willr_14 < -95.0) and (last_rsi_3_1d > 75.0) and (last_stochrsi_k_1h < 25.0):
+      elif (last_rsi_3 < 10.0) and (last_willr_14_lt_neg_95) and (last_rsi_3_1d > 75.0) and (last_stochrsi_k_1h_lt_25):
         return True, f"exit_{mode_name}_d_10_35"
       elif (
         (last_rsi_3 < 10.0)
-        and (last_willr_14 < -90.0)
-        and (last_roc_9_4h > 25.0)
+        and (last_willr_14_lt_neg_90)
+        and (last_roc_9_4h_gt_25)
         and (last_rsi_3_1d > 75.0)
         and (last_stochrsi_k_1h_lt_50)
       ):
@@ -60920,13 +60983,15 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_stochrsi_k_4h_lt_50)
       ):
         return True, f"exit_{mode_name}_d_10_37"
-      elif (last_rsi_3 < 10.0) and (last_willr_14 < -90.0) and (last_rsi_3_4h > 90.0) and (last_stochrsi_k_4h < 80.0):
+      elif (
+        (last_rsi_3 < 10.0) and (last_willr_14_lt_neg_90) and (last_rsi_3_4h > 90.0) and (last_stochrsi_k_4h < 80.0)
+      ):
         return True, f"exit_{mode_name}_d_10_38"
-      elif (last_rsi_3 < 4.0) and (last_willr_14 < -96.0) and (last_cmf_20_4h > 0.0) and (last_rsi_3_4h > 90.0):
+      elif (last_rsi_3 < 4.0) and (last_willr_14_lt_neg_96) and (last_cmf_20_4h_gt_0) and (last_rsi_3_4h > 90.0):
         return True, f"exit_{mode_name}_d_10_39"
       elif (
         (last_rsi_3 < 10.0)
-        and (last_willr_14 < -90.0)
+        and (last_willr_14_lt_neg_90)
         and (last_rsi_3_1h_gt_70)
         and (last_stochrsi_k_1h < 70.0)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 10.0))
@@ -60934,7 +60999,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_10_40"
       elif (
         (last_rsi_3 < 4.0)
-        and (last_willr_14 < -92.0)
+        and (last_willr_14_lt_neg_92)
         and (last_rsi_3_1h_gt_70)
         and (last_stochrsi_k_4h < 75.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -50.0))
@@ -60942,7 +61007,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_10_41"
       elif (
         (last_rsi_3 < 5.0)
-        and (last_willr_14 < -80.0)
+        and (last_willr_14_lt_neg_80)
         and (last_stochrsi_k_4h < 70.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -40.0))
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 30.0))
@@ -60958,13 +61023,13 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_10_43"
       elif (
         (last_rsi_3 < 25.0)
-        and (last_willr_14 < -98.0)
+        and (last_willr_14_lt_neg_98)
         and (last_rsi_3_4h_gt_70)
         and (last_rsi_3_1d > 25.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
       ):
         return True, f"exit_{mode_name}_d_10_44"
-      elif (last_rsi_3 < 4.0) and (last_willr_14 < -96.0) and (last_rsi_3_1h > 90.0):
+      elif (last_rsi_3 < 4.0) and (last_willr_14_lt_neg_96) and (last_rsi_3_1h > 90.0):
         return True, f"exit_{mode_name}_d_10_45"
       elif (last_rsi_3 < 8.0) and (last_rsi_3_1h > 85.0) and (last_rsi_3_4h > 90.0) and (last_roc_2_1d > 20.0):
         return True, f"exit_{mode_name}_d_10_46"
@@ -60986,20 +61051,20 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_10_48"
       elif (
         (last_rsi_3 < 5.0)
-        and (last_willr_14 < -98.0)
+        and (last_willr_14_lt_neg_98)
         and (last_rsi_3_4h > 80.0)
         and (last_change_pct_1d > 5.0)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 50.0))
       ):
         return True, f"exit_{mode_name}_d_10_49"
-      elif (last_rsi_3 < 20.0) and (last_willr_14 < -98.0) and (last_rsi_3_1d > 90.0) and (last_stochrsi_k_1h < 10.0):
+      elif (last_rsi_3 < 20.0) and (last_willr_14_lt_neg_98) and (last_rsi_3_1d > 90.0) and (last_stochrsi_k_1h_lt_10):
         return True, f"exit_{mode_name}_d_10_50"
       elif (last_rsi_3 < 32.0) and (last_rsi_14 > 56.0) and (last_rsi_3_4h > 80.0) and (last_stochrsi_k_1h_lt_50):
         return True, f"exit_{mode_name}_d_10_51"
       elif (
         (last_rsi_3 < 18.0)
         and (last_rsi_14 < 38.0)
-        and (last_willr_14 < -90.0)
+        and (last_willr_14_lt_neg_90)
         and (last_stochrsi_k_1h < 30.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 15.0))
       ):
@@ -61007,7 +61072,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 30.0)
         and (last_rsi_14_gt_50)
-        and (last_willr_14 < -75.0)
+        and (last_willr_14_lt_neg_75)
         and (last_rsi_3_1h > 80.0)
         and (last_stochrsi_k_4h_lt_50)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 50.0))
@@ -61017,14 +61082,14 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 20.0)
         and (last_rsi_14 > 56.0)
         and (last_stochrsi_k_1h_lt_50)
-        and (last_roc_9_4h > 10.0)
+        and (last_roc_9_4h_gt_10)
         and (last_change_pct_1d > 10.0)
       ):
         return True, f"exit_{mode_name}_d_10_54"
       elif (
         (last_rsi_3 < 4.0)
-        and (last_willr_14 < -88.0)
-        and (last_roc_9_4h > 5.0)
+        and (last_willr_14_lt_neg_88)
+        and (last_roc_9_4h_gt_5)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -10.0))
         and (last_stochrsi_k_1h_lt_50)
       ):
@@ -61035,14 +61100,14 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_3_1h_gt_70)
         and (last_rsi_3_4h > 75.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
-        and (last_stochrsi_k_4h < 90.0)
+        and (last_stochrsi_k_4h_lt_90)
       ):
         return True, f"exit_{mode_name}_d_10_56"
       elif (
         (last_rsi_3 < 50.0)
         and (last_rsi_14 > 66.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
-        and (last_stochrsi_k_4h < 30.0)
+        and (last_stochrsi_k_4h_lt_30)
       ):
         return True, f"exit_{mode_name}_d_10_57"
       elif (
@@ -61055,7 +61120,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_10_58"
       elif (
         (last_rsi_3 < 15.0)
-        and (last_willr_14 < -90.0)
+        and (last_willr_14_lt_neg_90)
         and (last_rsi_3_4h > 75.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 15.0))
         and (last_stochrsi_k_4h < 60.0)
@@ -61066,14 +61131,14 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 > 62.0)
         and (last_rsi_14_4h < 35.0)
         and (last_stochrsi_k_4h_lt_50)
-        and (last_stochrsi_k_1d < 50.0)
+        and (last_stochrsi_k_1d_lt_50)
       ):
         return True, f"exit_{mode_name}_d_10_60"
-      elif (last_rsi_3 < 6.0) and (last_willr_14 < -85.0) and (last_rsi_3_4h > 90.0) and (last_stochrsi_k_1h < 70.0):
+      elif (last_rsi_3 < 6.0) and (last_willr_14_lt_neg_85) and (last_rsi_3_4h > 90.0) and (last_stochrsi_k_1h < 70.0):
         return True, f"exit_{mode_name}_d_10_61"
       elif (
         (last_rsi_3 < 12.0)
-        and (last_willr_14 < -98.0)
+        and (last_willr_14_lt_neg_98)
         and (last_rsi_3_1h_gt_70)
         and (last_rsi_3_4h > 80.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -20.0))
@@ -61098,7 +61163,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 50.0)
         and (last_rsi_14 > 60.0)
-        and (last_stochrsi_k_4h < 20.0)
+        and (last_stochrsi_k_4h_lt_20)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 25.0))
       ):
         return True, f"exit_{mode_name}_d_10_67"
@@ -61106,7 +61171,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 14.0)
         and (last_rsi_14 > 54.0)
         and (last_rsi_3_1h > 75.0)
-        and (last_roc_2_4h > 30.0)
+        and (last_roc_2_4h_gt_30)
         and (last_stochrsi_k_4h < 75.0)
       ):
         return True, f"exit_{mode_name}_d_10_68"
@@ -61116,7 +61181,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_10_69"
       elif (last_rsi_3 < 32.0) and (last_rsi_14 > 62.0) and (last_rsi_3_1h > 75.0) and (last_stochrsi_k_4h < 80.0):
         return True, f"exit_{mode_name}_d_10_70"
-      elif (last_rsi_3 < 34.0) and (last_rsi_14 > 58.0) and (last_rsi_3_4h > 75.0) and (last_stochrsi_k_1h < 80.0):
+      elif (last_rsi_3 < 34.0) and (last_rsi_14 > 58.0) and (last_rsi_3_4h > 75.0) and (last_stochrsi_k_1h_lt_80):
         return True, f"exit_{mode_name}_d_10_71"
       elif (last_rsi_3 < 20.0) and (last_rsi_14 > 60.0) and (last_rsi_3_1h > 90.0) and (last_aroond_14_4h > 25.0):
         return True, f"exit_{mode_name}_d_10_72"
@@ -61124,16 +61189,16 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 20.0)
         and (last_rsi_3_1h > 75.0)
         and (last_rsi_3_4h > 85.0)
-        and (last_roc_9_4h > 20.0)
+        and (last_roc_9_4h_gt_20)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 25.0))
       ):
         return True, f"exit_{mode_name}_d_10_73"
       elif (
         (last_rsi_3 < 1.0)
-        and (last_willr_14 < -90.0)
+        and (last_willr_14_lt_neg_90)
         and (last_rsi_3_4h > 75.0)
         and (last_rsi_3_1d > 75.0)
-        and (last_stochrsi_k_1h > 50.0)
+        and (last_stochrsi_k_1h_gt_50)
       ):
         return True, f"exit_{mode_name}_d_10_74"
       elif (
@@ -61143,7 +61208,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 50.0))
       ):
         return True, f"exit_{mode_name}_d_10_75"
-      elif (last_rsi_3 < 30.0) and (last_rsi_14 > 52.0) and (last_roc_9_1h < -80.0) and (last_stochrsi_k_4h < 20.0):
+      elif (last_rsi_3 < 30.0) and (last_rsi_14 > 52.0) and (last_roc_9_1h < -80.0) and (last_stochrsi_k_4h_lt_20):
         return True, f"exit_{mode_name}_d_10_76"
       elif (
         (last_rsi_3 < 22.0)
@@ -61154,13 +61219,13 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_10_77"
       elif (
         (last_rsi_3 < 12.0)
-        and (last_willr_14 < -86.0)
+        and (last_willr_14_lt_neg_86)
         and (last_rsi_3_1h_gt_70)
         and (last_rsi_3_4h > 80.0)
         and (last_rsi_3_1d > 80.0)
       ):
         return True, f"exit_{mode_name}_d_10_78"
-      elif (last_rsi_3 < 6.0) and (last_willr_14 < -99.0) and (last_rsi_3_1h_gt_70) and (last_rsi_3_4h > 90.0):
+      elif (last_rsi_3 < 6.0) and (last_willr_14_lt_neg_99) and (last_rsi_3_1h_gt_70) and (last_rsi_3_4h > 90.0):
         return True, f"exit_{mode_name}_d_10_79"
       elif (
         (last_rsi_3 < 26.0)
@@ -61172,7 +61237,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_10_80"
       elif (
         (last_rsi_3 < 14.0)
-        and (last_willr_14 < -92.0)
+        and (last_willr_14_lt_neg_92)
         and (last_rsi_3_1h > 75.0)
         and (last_rsi_3_4h > 75.0)
         and (isinstance(last_rsi_14_1d, np.float64) and (last_rsi_14_1d < 50.0))
@@ -61180,7 +61245,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_10_81"
       elif (
         (last_rsi_3 < 16.0)
-        and (last_willr_14 < -92.0)
+        and (last_willr_14_lt_neg_92)
         and (last_rsi_3_4h_gt_70)
         and (last_rsi_3_1d > 85.0)
         and (last_stochrsi_k_4h < 60.0)
@@ -61194,11 +61259,11 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_stochrsi_k_4h < 60.0)
       ):
         return True, f"exit_{mode_name}_d_10_83"
-      elif (last_rsi_3 < 8.0) and (last_willr_14 < -99.0) and (last_rsi_3_4h_gt_70) and (last_stochrsi_k_1h < 80.0):
+      elif (last_rsi_3 < 8.0) and (last_willr_14_lt_neg_99) and (last_rsi_3_4h_gt_70) and (last_stochrsi_k_1h_lt_80):
         return True, f"exit_{mode_name}_d_10_84"
       elif (
         (last_rsi_3 < 10.0)
-        and (last_willr_14 < -94.0)
+        and (last_willr_14_lt_neg_94)
         and (last_rsi_3_1h_gt_70)
         and (last_rsi_3_4h > 60.0)
         and (last_stochrsi_k_4h_lt_50)
@@ -61222,7 +61287,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_10_87"
       elif (
         (last_rsi_3 < 10.0)
-        and (last_willr_14 < -82.0)
+        and (last_willr_14_lt_neg_82)
         and (last_stochrsi_k_1h < 60.0)
         and (last_stochrsi_k_4h_lt_50)
         and (last_change_pct_1h > 2.0)
@@ -61231,13 +61296,13 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 20.0)
         and (last_rsi_14 > 62.0)
-        and (last_roc_9_1h > 5.0)
+        and (last_roc_9_1h_gt_5)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -25.0))
       ):
         return True, f"exit_{mode_name}_d_10_89"
       elif (
         (last_rsi_3 < 6.0)
-        and (last_willr_14 < -75.0)
+        and (last_willr_14_lt_neg_75)
         and (last_rsi_3_1h > 50.0)
         and (last_rsi_3_4h_gt_70)
         and (last_aroonu_14_4h < 50.0)
@@ -61257,7 +61322,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 18.0)
         and (last_rsi_14 > 54.0)
         and (last_rsi_3_1h > 60.0)
-        and (last_stochrsi_k_1h < 75.0)
+        and (last_stochrsi_k_1h_lt_75)
         and (last_stochrsi_k_4h_lt_50)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 25.0))
       ):
@@ -61284,10 +61349,10 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_10_94"
       elif (
         (last_rsi_3 < 14.0)
-        and (last_willr_14 < -90.0)
+        and (last_willr_14_lt_neg_90)
         and (last_rsi_3_1h > 55.0)
         and (last_rsi_3_4h > 60.0)
-        and (last_stochrsi_k_4h < 90.0)
+        and (last_stochrsi_k_4h_lt_90)
         and (isinstance(last_aroond_14_1d, np.float64) and (last_aroond_14_1d > 75.0))
       ):
         return True, f"exit_{mode_name}_d_10_95"
@@ -61322,15 +61387,15 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_3_1h > 35.0)
         and (last_rsi_3_4h > 40.0)
         and (last_aroond_14_4h > 50.0)
-        and (last_stoch_k_4h < 60.0)
+        and (last_stoch_k_4h_lt_60)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -80.0))
       ):
         return True, f"exit_{mode_name}_d_10_99"
-      elif (last_rsi_3 < 1.0) and (last_rsi_14 < 22.0) and (last_rsi_3_15m < 30.0) and (last_rsi_3_4h > 20.0):
+      elif (last_rsi_3 < 1.0) and (last_rsi_14 < 22.0) and (last_rsi_3_15m_lt_30) and (last_rsi_3_4h > 20.0):
         return True, f"exit_{mode_name}_d_10_100"
       elif (
         (last_rsi_3 < 14.0)
-        and (last_willr_14 < -86.0)
+        and (last_willr_14_lt_neg_86)
         and (last_rsi_3_1h > 50.0)
         and (last_stochrsi_k_4h < 60.0)
         and (isinstance(last_roc_9_4h, np.float64) and (last_roc_9_4h < -40.0))
@@ -61341,7 +61406,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 > 54.0)
         and (last_rsi_3_1h > 40.0)
         and (last_rsi_3_4h > 60.0)
-        and (last_stochrsi_k_4h > 70.0)
+        and (last_stochrsi_k_4h_gt_70)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -40.0))
       ):
         return True, f"exit_{mode_name}_d_10_102"
@@ -61359,7 +61424,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_3_1h > 40.0)
         and (last_stochrsi_k_1h < 60.0)
         and (last_stochrsi_k_4h < 10.0)
-        and (last_roc_9_4h < -40.0)
+        and (last_roc_9_4h_lt_neg_40)
       ):
         return True, f"exit_{mode_name}_d_10_104"
       elif (
@@ -61367,7 +61432,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 > 54.0)
         and (last_rsi_3_15m > 45.0)
         and (last_stochrsi_k_4h < 10.0)
-        and (last_roc_9_4h < -25.0)
+        and (last_roc_9_4h_lt_neg_25)
       ):
         return True, f"exit_{mode_name}_d_10_105"
       elif (
@@ -61376,7 +61441,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_3_1h > 50.0)
         and (last_stochrsi_k_1h_lt_50)
         and (last_rsi_14_4h < 30.0)
-        and (last_roc_9_4h < -40.0)
+        and (last_roc_9_4h_lt_neg_40)
       ):
         return True, f"exit_{mode_name}_d_10_106"
       elif (
@@ -61387,17 +61452,17 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14_4h < 50.0)
       ):
         return True, f"exit_{mode_name}_d_10_107"
-      elif (last_rsi_3 < 42.0) and (last_rsi_14 > 54.0) and (last_rsi_3_1h > 40.0) and (last_stochrsi_k_1h < 20.0):
+      elif (last_rsi_3_lt_42) and (last_rsi_14 > 54.0) and (last_rsi_3_1h > 40.0) and (last_stochrsi_k_1h < 20.0):
         return True, f"exit_{mode_name}_d_10_108"
       elif (
         (last_rsi_3 < 22.0)
-        and (last_willr_14 < -94.0)
+        and (last_willr_14_lt_neg_94)
         and (last_rsi_3_1h > 50.0)
         and (last_rsi_3_4h > 80.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -50.0))
       ):
         return True, f"exit_{mode_name}_d_10_109"
-      elif (last_rsi_3 < 26.0) and (last_rsi_3_4h > 35.0) and (last_stochrsi_k_4h_lt_50) and (last_roc_9_4h < -25.0):
+      elif (last_rsi_3 < 26.0) and (last_rsi_3_4h > 35.0) and (last_stochrsi_k_4h_lt_50) and (last_roc_9_4h_lt_neg_25):
         return True, f"exit_{mode_name}_d_10_110"
       elif (
         (last_rsi_3 < 48.0)
@@ -61411,17 +61476,17 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_10_111"
       elif (
         (last_rsi_3 < 18.0)
-        and (last_willr_14 < -80.0)
+        and (last_willr_14_lt_neg_80)
         and (last_rsi_14_gt_50)
         and (last_rsi_3_1h > 65.0)
-        and (last_rsi_3_4h > 65.0)
+        and (last_rsi_3_4h_gt_65)
         and (last_rsi_3_1d > 40.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
       ):
         return True, f"exit_{mode_name}_d_10_112"
       elif (
         (last_rsi_3 < 14.0)
-        and (last_willr_14 < -99.0)
+        and (last_willr_14_lt_neg_99)
         and (last_rsi_3_1d > 70.0)
         and (last_stochrsi_k_4h_lt_50)
         and (isinstance(last_roc_9_4h, np.float64) and (last_roc_9_4h < -10.0))
@@ -61439,7 +61504,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 20.0)
         and (last_rsi_14 > 54.0)
-        and (last_rsi_3_15m > 70.0)
+        and (last_rsi_3_15m_gt_70)
         and (last_stochrsi_k_1h_lt_50)
         and (last_stochrsi_k_4h_lt_50)
       ):
@@ -61454,19 +61519,19 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_10_118"
       elif (
         (last_rsi_3 < 12.0)
-        and (last_willr_14 < -80.0)
+        and (last_willr_14_lt_neg_80)
         and (last_rsi_3_1h > 40.0)
         and (last_rsi_3_4h > 40.0)
         and (last_stochrsi_k_1h < 60.0)
       ):
         return True, f"exit_{mode_name}_d_10_119"
-      elif (last_rsi_3 < 44.0) and (last_rsi_14 > 54.0) and (last_rsi_3_1h > 60.0) and (last_aroond_14_4h > 75.0):
+      elif (last_rsi_3_lt_44) and (last_rsi_14 > 54.0) and (last_rsi_3_1h > 60.0) and (last_aroond_14_4h > 75.0):
         return True, f"exit_{mode_name}_d_10_120"
       elif (last_rsi_3 < 38.0) and (last_rsi_14 > 56.0) and (last_rsi_3_1h > 50.0) and (last_rsi_14_4h < 15.0):
         return True, f"exit_{mode_name}_d_10_121"
       elif (last_rsi_3 < 40.0) and (last_rsi_14 > 58.0) and (last_rsi_3_4h_gt_70) and (last_stochrsi_k_1h_lt_50):
         return True, f"exit_{mode_name}_d_10_122"
-      elif (last_rsi_3 < 10.0) and (last_willr_14 < -98.0) and (last_rsi_3_1h > 90.0) and (last_rsi_3_1d > 70.0):
+      elif (last_rsi_3 < 10.0) and (last_willr_14_lt_neg_98) and (last_rsi_3_1h > 90.0) and (last_rsi_3_1d > 70.0):
         return True, f"exit_{mode_name}_d_10_123"
       elif (
         (last_rsi_3 < 10.0)
@@ -61476,16 +61541,16 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_10_124"
       elif (
         (last_rsi_3 < 22.0)
-        and (last_willr_14 < -98.0)
+        and (last_willr_14_lt_neg_98)
         and (last_rsi_3_1h > 90.0)
         and (last_rsi_3_4h > 60.0)
-        and (last_rsi_3_1d > 60.0)
+        and (last_rsi_3_1d_gt_60)
         and (last_close > (last_low_min_30_1d * 2.0))
       ):
         return True, f"exit_{mode_name}_d_10_125"
       elif (last_rsi_3 < 8.0) and (last_rsi_3_1h > 85.0) and (last_rsi_3_4h > 60.0) and (last_stochrsi_k_4h_lt_50):
         return True, f"exit_{mode_name}_d_10_126"
-      elif (last_rsi_3 < 8.0) and (last_rsi_3_1h > 90.0) and (last_rsi_3_4h_gt_70) and (last_rsi_3_1d > 60.0):
+      elif (last_rsi_3 < 8.0) and (last_rsi_3_1h > 90.0) and (last_rsi_3_4h_gt_70) and (last_rsi_3_1d_gt_60):
         return True, f"exit_{mode_name}_d_10_127"
       elif (last_rsi_3 < 4.0) and (last_rsi_3_4h_gt_70) and (last_aroond_14_4h > 85.0):
         return True, f"exit_{mode_name}_d_10_128"
@@ -61507,7 +61572,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 18.0)
         and (last_rsi_3_1h > 65.0)
-        and (last_rsi_3_4h > 65.0)
+        and (last_rsi_3_4h_gt_65)
         and (last_aroond_14_1h > 50.0)
         and (last_stochrsi_k_1h < 60.0)
       ):
@@ -61521,7 +61586,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_10_133"
     elif 0.2 > current_profit >= 0.12:
       if (
-        (last_willr_14 < -99.0)
+        (last_willr_14_lt_neg_99)
         and (last_rsi_14 < 22.0)
         and (isinstance(last_ema_200_1h, np.float64) and (last_ema_12_1h > last_ema_200_1h))
         and (isinstance(last_ema_200_4h, np.float64) and (last_ema_12_4h > last_ema_200_4h))
@@ -61530,35 +61595,35 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_11_1"
       elif (
-        (last_willr_14 < -99.0)
+        (last_willr_14_lt_neg_99)
         and (last_rsi_14 < 26.0)
-        and (last_cmf_20_1h > 0.0)
+        and (last_cmf_20_1h_gt_0)
         and (isinstance(last_ema_200_1h, np.float64) and (last_ema_12_1h > last_ema_200_1h))
         and (isinstance(last_ema_200_4h, np.float64) and (last_ema_12_4h > last_ema_200_4h))
       ):
         return True, f"exit_{mode_name}_d_11_2"
       elif (
-        (last_willr_14 < -98.0)
+        (last_willr_14_lt_neg_98)
         and (last_stochrsi_k < 1.0)
-        and (last_cmf_20_1h > 0.0)
-        and (last_cmf_20_4h > 0.0)
-        and ((last_stochrsi_k_4h < 80.0) and (last_stochrsi_k_change_pct_4h > 10.0))
+        and (last_cmf_20_1h_gt_0)
+        and (last_cmf_20_4h_gt_0)
+        and ((last_stochrsi_k_4h < 80.0) and (last_stochrsi_k_change_pct_4h_gt_10))
       ):
         return True, f"exit_{mode_name}_d_11_3"
       elif (
-        (last_willr_14 < -98.0)
+        (last_willr_14_lt_neg_98)
         and (last_rsi_14 < 22.0)
         and (last_stochrsi_k < 5.0)
-        and (last_stochrsi_k_4h < 30.0)
+        and (last_stochrsi_k_4h_lt_30)
         and (isinstance(last_ema_200_1h, np.float64) and (last_ema_12_1h > last_ema_200_1h))
         and (isinstance(last_ema_200_4h, np.float64) and (last_ema_12_4h > last_ema_200_4h))
       ):
         return True, f"exit_{mode_name}_d_11_4"
-      elif (last_willr_14 < -99.0) and (last_rsi_14 < 24.0) and (last_roc_9_1h > 5.0) and (last_roc_9_4h > 5.0):
+      elif (last_willr_14_lt_neg_99) and (last_rsi_14 < 24.0) and (last_roc_9_1h_gt_5) and (last_roc_9_4h_gt_5):
         return True, f"exit_{mode_name}_d_11_5"
       elif (
         (last_rsi_3 < 30.0)
-        and (last_stochrsi_k < 30.0)
+        and (last_stochrsi_k_lt_30)
         and (last_rsi_14 > 60.0)
         and (last_roc_9_1h > 10.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -50.0))
@@ -61566,13 +61631,13 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_11_6"
       elif (
         (last_rsi_14_gt_50)
-        and (last_stochrsi_k < 30.0)
+        and (last_stochrsi_k_lt_30)
         and (last_stochrsi_k_4h_lt_50)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 40.0))
       ):
         return True, f"exit_{mode_name}_d_11_7"
       elif (
-        (last_willr_14 < -99.0)
+        (last_willr_14_lt_neg_99)
         and (last_stochrsi_k < 2.0)
         and (last_cmf_20_1h > 0.1)
         and (last_cmf_20_4h > 0.1)
@@ -61581,17 +61646,17 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_11_8"
       elif (
-        (last_willr_14 < -98.0)
+        (last_willr_14_lt_neg_98)
         and (last_rsi_3 < 5.0)
         and (last_change_pct_4h > 5.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
       ):
         return True, f"exit_{mode_name}_d_11_9"
       elif (
-        (last_willr_14 < -98.0)
+        (last_willr_14_lt_neg_98)
         and (last_rsi_14_gt_50)
         and (last_roc_9_1h > 10.0)
-        and (last_roc_9_4h > 10.0)
+        and (last_roc_9_4h_gt_10)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -10.0))
       ):
         return True, f"exit_{mode_name}_d_11_10"
@@ -61608,26 +61673,26 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14_gt_50)
         and (last_rsi_3_4h > 90.0)
         and (last_roc_9_1h > 20.0)
-        and (last_roc_9_4h > 20.0)
+        and (last_roc_9_4h_gt_20)
       ):
         return True, f"exit_{mode_name}_d_11_12"
-      elif (last_rsi_3 < 2.0) and (last_rsi_3_4h > 95.0) and (last_roc_9_4h > 25.0):
+      elif (last_rsi_3 < 2.0) and (last_rsi_3_4h_gt_95) and (last_roc_9_4h_gt_25):
         return True, f"exit_{mode_name}_d_11_13"
-      elif (last_rsi_3 < 5.0) and (last_willr_14 < -99.0) and (last_rsi_3_4h > 95.0) and (last_aroond_14_4h > 25.0):
+      elif (last_rsi_3 < 5.0) and (last_willr_14_lt_neg_99) and (last_rsi_3_4h_gt_95) and (last_aroond_14_4h > 25.0):
         return True, f"exit_{mode_name}_d_11_14"
       elif (last_rsi_3 < 2.0) and (last_rsi_14 < 30.0) and (last_roc_9_4h > 30.0):
         return True, f"exit_{mode_name}_d_11_15"
       elif (
         (last_rsi_3 < 2.0)
         and (last_aroond_14_4h > 25.0)
-        and (last_roc_9_4h > 25.0)
+        and (last_roc_9_4h_gt_25)
         and (last_aroond_14_1d > 50.0)
         and (last_change_pct_1d > 15.0)
       ):
         return True, f"exit_{mode_name}_d_11_16"
       elif (
         (last_rsi_3 < 2.0)
-        and (last_willr_14 < -95.0)
+        and (last_willr_14_lt_neg_95)
         and (last_rsi_3_1h > 90.0)
         and (last_stochrsi_k_4h < 10.0)
         and (last_roc_9_4h < -30.0)
@@ -61648,31 +61713,31 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_11_21"
       elif (
         (last_rsi_3 < 1.0)
-        and (last_willr_14 < -99.0)
+        and (last_willr_14_lt_neg_99)
         and (last_change_pct_4h > 5.0)
         and (last_stochrsi_k_4h_lt_50)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
       ):
         return True, f"exit_{mode_name}_d_11_22"
-      elif (last_rsi_3 < 2.0) and (last_willr_14 < -98.0) and (last_rsi_3_1h > 85.0) and (last_rsi_3_1d > 95.0):
+      elif (last_rsi_3 < 2.0) and (last_willr_14_lt_neg_98) and (last_rsi_3_1h > 85.0) and (last_rsi_3_1d > 95.0):
         return True, f"exit_{mode_name}_d_11_23"
       elif (
         (last_rsi_3 < 4.0)
         and (last_rsi_14 < 24.0)
-        and (last_willr_14 < -95.0)
+        and (last_willr_14_lt_neg_95)
         and (last_rsi_3_4h_gt_70)
         and (last_aroond_14_4h > 75.0)
       ):
         return True, f"exit_{mode_name}_d_11_24"
       elif (
         (last_rsi_3 < 3.0)
-        and (last_willr_14 < -99.0)
+        and (last_willr_14_lt_neg_99)
         and (last_rsi_3_4h > 90.0)
         and (last_roc_9_4h > 15.0)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 50.0))
       ):
         return True, f"exit_{mode_name}_d_11_25"
-      elif (last_rsi_3 < 5.0) and (last_willr_14 < -99.0) and (last_rsi_3_4h > 85.0) and (last_roc_9_4h > 20.0):
+      elif (last_rsi_3 < 5.0) and (last_willr_14_lt_neg_99) and (last_rsi_3_4h > 85.0) and (last_roc_9_4h_gt_20):
         return True, f"exit_{mode_name}_d_11_26"
       elif (
         (last_rsi_3 < 5.0)
@@ -61699,27 +61764,27 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14_gt_50)
         and (last_rsi_3_1h > 85.0)
         and (last_rsi_3_4h > 85.0)
-        and (last_stochrsi_k_1h < 75.0)
+        and (last_stochrsi_k_1h_lt_75)
       ):
         return True, f"exit_{mode_name}_d_11_31"
-      elif (last_rsi_3 < 2.0) and (last_rsi_3_1h > 85.0) and (last_roc_2_4h > 30.0) and (last_stochrsi_k_4h < 70.0):
+      elif (last_rsi_3 < 2.0) and (last_rsi_3_1h > 85.0) and (last_roc_2_4h_gt_30) and (last_stochrsi_k_4h < 70.0):
         return True, f"exit_{mode_name}_d_11_32"
       elif (
         (last_rsi_3 < 2.0)
-        and (last_willr_14 < -99.0)
+        and (last_willr_14_lt_neg_99)
         and (last_roc_2_1h > 10.0)
         and (last_roc_9_1h < -30.0)
         and (last_stochrsi_k_1h_lt_50)
       ):
         return True, f"exit_{mode_name}_d_11_33"
-      elif (last_rsi_3 < 35.0) and (last_rsi_3_15m > 70.0) and (last_rsi_14_1h < 20.0) and (last_roc_9_1h < -40.0):
+      elif (last_rsi_3 < 35.0) and (last_rsi_3_15m_gt_70) and (last_rsi_14_1h < 20.0) and (last_roc_9_1h < -40.0):
         return True, f"exit_{mode_name}_d_11_34"
-      elif (last_rsi_3 < 8.0) and (last_willr_14 < -96.0) and (last_rsi_3_1d > 75.0) and (last_stochrsi_k_1h < 25.0):
+      elif (last_rsi_3 < 8.0) and (last_willr_14_lt_neg_96) and (last_rsi_3_1d > 75.0) and (last_stochrsi_k_1h_lt_25):
         return True, f"exit_{mode_name}_d_11_35"
       elif (
         (last_rsi_3 < 5.0)
-        and (last_willr_14 < -95.0)
-        and (last_roc_9_4h > 25.0)
+        and (last_willr_14_lt_neg_95)
+        and (last_roc_9_4h_gt_25)
         and (last_rsi_3_1d > 75.0)
         and (last_stochrsi_k_1h_lt_50)
       ):
@@ -61732,13 +61797,13 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_stochrsi_k_4h_lt_50)
       ):
         return True, f"exit_{mode_name}_d_11_37"
-      elif (last_rsi_3 < 5.0) and (last_willr_14 < -95.0) and (last_rsi_3_4h > 90.0) and (last_stochrsi_k_4h < 80.0):
+      elif (last_rsi_3 < 5.0) and (last_willr_14_lt_neg_95) and (last_rsi_3_4h > 90.0) and (last_stochrsi_k_4h < 80.0):
         return True, f"exit_{mode_name}_d_11_38"
-      elif (last_rsi_3 < 3.0) and (last_willr_14 < -97.0) and (last_cmf_20_4h > 0.0) and (last_rsi_3_4h > 90.0):
+      elif (last_rsi_3 < 3.0) and (last_willr_14 < -97.0) and (last_cmf_20_4h_gt_0) and (last_rsi_3_4h > 90.0):
         return True, f"exit_{mode_name}_d_11_39"
       elif (
         (last_rsi_3 < 5.0)
-        and (last_willr_14 < -95.0)
+        and (last_willr_14_lt_neg_95)
         and (last_rsi_3_1h_gt_70)
         and (last_stochrsi_k_1h < 70.0)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 10.0))
@@ -61746,7 +61811,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_11_40"
       elif (
         (last_rsi_3 < 3.0)
-        and (last_willr_14 < -96.0)
+        and (last_willr_14_lt_neg_96)
         and (last_rsi_3_1h_gt_70)
         and (last_stochrsi_k_4h < 75.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -50.0))
@@ -61754,7 +61819,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_11_41"
       elif (
         (last_rsi_3 < 4.0)
-        and (last_willr_14 < -85.0)
+        and (last_willr_14_lt_neg_85)
         and (last_stochrsi_k_4h < 70.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -40.0))
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 30.0))
@@ -61770,13 +61835,13 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_11_43"
       elif (
         (last_rsi_3 < 20.0)
-        and (last_willr_14 < -98.0)
+        and (last_willr_14_lt_neg_98)
         and (last_rsi_3_4h_gt_70)
         and (last_rsi_3_1d > 25.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
       ):
         return True, f"exit_{mode_name}_d_11_44"
-      elif (last_rsi_3 < 2.0) and (last_willr_14 < -98.0) and (last_rsi_3_1h > 90.0):
+      elif (last_rsi_3 < 2.0) and (last_willr_14_lt_neg_98) and (last_rsi_3_1h > 90.0):
         return True, f"exit_{mode_name}_d_11_45"
       elif (last_rsi_3 < 6.0) and (last_rsi_3_1h > 85.0) and (last_rsi_3_4h > 90.0) and (last_roc_2_1d > 20.0):
         return True, f"exit_{mode_name}_d_11_46"
@@ -61798,20 +61863,20 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_11_48"
       elif (
         (last_rsi_3 < 4.0)
-        and (last_willr_14 < -98.0)
+        and (last_willr_14_lt_neg_98)
         and (last_rsi_3_4h > 80.0)
         and (last_change_pct_1d > 5.0)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 50.0))
       ):
         return True, f"exit_{mode_name}_d_11_49"
-      elif (last_rsi_3 < 15.0) and (last_willr_14 < -98.0) and (last_rsi_3_1d > 90.0) and (last_stochrsi_k_1h < 10.0):
+      elif (last_rsi_3 < 15.0) and (last_willr_14_lt_neg_98) and (last_rsi_3_1d > 90.0) and (last_stochrsi_k_1h_lt_10):
         return True, f"exit_{mode_name}_d_11_50"
       elif (last_rsi_3 < 30.0) and (last_rsi_14 > 58.0) and (last_rsi_3_4h > 80.0) and (last_stochrsi_k_1h_lt_50):
         return True, f"exit_{mode_name}_d_11_51"
       elif (
         (last_rsi_3 < 16.0)
         and (last_rsi_14 < 36.0)
-        and (last_willr_14 < -90.0)
+        and (last_willr_14_lt_neg_90)
         and (last_stochrsi_k_1h < 30.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 15.0))
       ):
@@ -61819,7 +61884,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 30.0)
         and (last_rsi_14_gt_50)
-        and (last_willr_14 < -75.0)
+        and (last_willr_14_lt_neg_75)
         and (last_rsi_3_1h > 80.0)
         and (last_stochrsi_k_4h_lt_50)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 50.0))
@@ -61829,14 +61894,14 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 18.0)
         and (last_rsi_14 > 58.0)
         and (last_stochrsi_k_1h_lt_50)
-        and (last_roc_9_4h > 10.0)
+        and (last_roc_9_4h_gt_10)
         and (last_change_pct_1d > 10.0)
       ):
         return True, f"exit_{mode_name}_d_11_54"
       elif (
         (last_rsi_3 < 2.0)
-        and (last_willr_14 < -90.0)
-        and (last_roc_9_4h > 5.0)
+        and (last_willr_14_lt_neg_90)
+        and (last_roc_9_4h_gt_5)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -10.0))
         and (last_stochrsi_k_1h_lt_50)
       ):
@@ -61847,14 +61912,14 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_3_1h_gt_70)
         and (last_rsi_3_4h > 75.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
-        and (last_stochrsi_k_4h < 90.0)
+        and (last_stochrsi_k_4h_lt_90)
       ):
         return True, f"exit_{mode_name}_d_11_56"
       elif (
         (last_rsi_3 < 50.0)
         and (last_rsi_14 > 68.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
-        and (last_stochrsi_k_4h < 30.0)
+        and (last_stochrsi_k_4h_lt_30)
       ):
         return True, f"exit_{mode_name}_d_11_57"
       elif (
@@ -61867,7 +61932,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_11_58"
       elif (
         (last_rsi_3 < 10.0)
-        and (last_willr_14 < -92.0)
+        and (last_willr_14_lt_neg_92)
         and (last_rsi_3_4h > 75.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 15.0))
         and (last_stochrsi_k_4h < 60.0)
@@ -61878,14 +61943,14 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 > 64.0)
         and (last_rsi_14_4h < 35.0)
         and (last_stochrsi_k_4h_lt_50)
-        and (last_stochrsi_k_1d < 50.0)
+        and (last_stochrsi_k_1d_lt_50)
       ):
         return True, f"exit_{mode_name}_d_11_60"
-      elif (last_rsi_3 < 4.0) and (last_willr_14 < -90.0) and (last_rsi_3_4h > 90.0) and (last_stochrsi_k_1h < 70.0):
+      elif (last_rsi_3 < 4.0) and (last_willr_14_lt_neg_90) and (last_rsi_3_4h > 90.0) and (last_stochrsi_k_1h < 70.0):
         return True, f"exit_{mode_name}_d_11_61"
       elif (
         (last_rsi_3 < 10.0)
-        and (last_willr_14 < -98.0)
+        and (last_willr_14_lt_neg_98)
         and (last_rsi_3_1h_gt_70)
         and (last_rsi_3_4h > 80.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -20.0))
@@ -61910,7 +61975,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 50.0)
         and (last_rsi_14 > 62.0)
-        and (last_stochrsi_k_4h < 20.0)
+        and (last_stochrsi_k_4h_lt_20)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 25.0))
       ):
         return True, f"exit_{mode_name}_d_11_67"
@@ -61918,7 +61983,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 12.0)
         and (last_rsi_14 > 56.0)
         and (last_rsi_3_1h > 75.0)
-        and (last_roc_2_4h > 30.0)
+        and (last_roc_2_4h_gt_30)
         and (last_stochrsi_k_4h < 75.0)
       ):
         return True, f"exit_{mode_name}_d_11_68"
@@ -61928,7 +61993,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_11_69"
       elif (last_rsi_3 < 30.0) and (last_rsi_14 > 64.0) and (last_rsi_3_1h > 75.0) and (last_stochrsi_k_4h < 80.0):
         return True, f"exit_{mode_name}_d_11_70"
-      elif (last_rsi_3 < 32.0) and (last_rsi_14 > 60.0) and (last_rsi_3_4h > 75.0) and (last_stochrsi_k_1h < 80.0):
+      elif (last_rsi_3 < 32.0) and (last_rsi_14 > 60.0) and (last_rsi_3_4h > 75.0) and (last_stochrsi_k_1h_lt_80):
         return True, f"exit_{mode_name}_d_11_71"
       elif (last_rsi_3 < 18.0) and (last_rsi_14 > 62.0) and (last_rsi_3_1h > 90.0) and (last_aroond_14_4h > 25.0):
         return True, f"exit_{mode_name}_d_11_72"
@@ -61936,16 +62001,16 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 18.0)
         and (last_rsi_3_1h > 75.0)
         and (last_rsi_3_4h > 85.0)
-        and (last_roc_9_4h > 20.0)
+        and (last_roc_9_4h_gt_20)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 25.0))
       ):
         return True, f"exit_{mode_name}_d_11_73"
       elif (
         (last_rsi_3 < 1.0)
-        and (last_willr_14 < -90.0)
+        and (last_willr_14_lt_neg_90)
         and (last_rsi_3_4h > 75.0)
         and (last_rsi_3_1d > 75.0)
-        and (last_stochrsi_k_1h > 50.0)
+        and (last_stochrsi_k_1h_gt_50)
       ):
         return True, f"exit_{mode_name}_d_11_74"
       elif (
@@ -61955,7 +62020,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 50.0))
       ):
         return True, f"exit_{mode_name}_d_11_75"
-      elif (last_rsi_3 < 28.0) and (last_rsi_14 > 54.0) and (last_roc_9_1h < -80.0) and (last_stochrsi_k_4h < 20.0):
+      elif (last_rsi_3 < 28.0) and (last_rsi_14 > 54.0) and (last_roc_9_1h < -80.0) and (last_stochrsi_k_4h_lt_20):
         return True, f"exit_{mode_name}_d_11_76"
       elif (
         (last_rsi_3 < 20.0)
@@ -61966,13 +62031,13 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_11_77"
       elif (
         (last_rsi_3 < 10.0)
-        and (last_willr_14 < -88.0)
+        and (last_willr_14_lt_neg_88)
         and (last_rsi_3_1h_gt_70)
         and (last_rsi_3_4h > 80.0)
         and (last_rsi_3_1d > 80.0)
       ):
         return True, f"exit_{mode_name}_d_11_78"
-      elif (last_rsi_3 < 4.0) and (last_willr_14 < -99.0) and (last_rsi_3_1h_gt_70) and (last_rsi_3_4h > 90.0):
+      elif (last_rsi_3 < 4.0) and (last_willr_14_lt_neg_99) and (last_rsi_3_1h_gt_70) and (last_rsi_3_4h > 90.0):
         return True, f"exit_{mode_name}_d_11_79"
       elif (
         (last_rsi_3 < 24.0)
@@ -61984,7 +62049,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_11_80"
       elif (
         (last_rsi_3 < 12.0)
-        and (last_willr_14 < -94.0)
+        and (last_willr_14_lt_neg_94)
         and (last_rsi_3_1h > 75.0)
         and (last_rsi_3_4h > 75.0)
         and (isinstance(last_rsi_14_1d, np.float64) and (last_rsi_14_1d < 50.0))
@@ -61992,7 +62057,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_11_81"
       elif (
         (last_rsi_3 < 14.0)
-        and (last_willr_14 < -94.0)
+        and (last_willr_14_lt_neg_94)
         and (last_rsi_3_4h_gt_70)
         and (last_rsi_3_1d > 85.0)
         and (last_stochrsi_k_4h < 60.0)
@@ -62006,11 +62071,11 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_stochrsi_k_4h < 60.0)
       ):
         return True, f"exit_{mode_name}_d_11_83"
-      elif (last_rsi_3 < 6.0) and (last_willr_14 < -99.0) and (last_rsi_3_4h_gt_70) and (last_stochrsi_k_1h < 80.0):
+      elif (last_rsi_3 < 6.0) and (last_willr_14_lt_neg_99) and (last_rsi_3_4h_gt_70) and (last_stochrsi_k_1h_lt_80):
         return True, f"exit_{mode_name}_d_11_84"
       elif (
         (last_rsi_3 < 8.0)
-        and (last_willr_14 < -96.0)
+        and (last_willr_14_lt_neg_96)
         and (last_rsi_3_1h_gt_70)
         and (last_rsi_3_4h > 60.0)
         and (last_stochrsi_k_4h_lt_50)
@@ -62034,7 +62099,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_11_87"
       elif (
         (last_rsi_3 < 8.0)
-        and (last_willr_14 < -84.0)
+        and (last_willr_14_lt_neg_84)
         and (last_stochrsi_k_1h < 60.0)
         and (last_stochrsi_k_4h_lt_50)
         and (last_change_pct_1h > 2.0)
@@ -62043,13 +62108,13 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 18.0)
         and (last_rsi_14 > 64.0)
-        and (last_roc_9_1h > 5.0)
+        and (last_roc_9_1h_gt_5)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -25.0))
       ):
         return True, f"exit_{mode_name}_d_11_89"
       elif (
         (last_rsi_3 < 4.0)
-        and (last_willr_14 < -75.0)
+        and (last_willr_14_lt_neg_75)
         and (last_rsi_3_1h > 50.0)
         and (last_rsi_3_4h_gt_70)
         and (last_aroonu_14_4h < 50.0)
@@ -62069,7 +62134,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 16.0)
         and (last_rsi_14 > 56.0)
         and (last_rsi_3_1h > 60.0)
-        and (last_stochrsi_k_1h < 75.0)
+        and (last_stochrsi_k_1h_lt_75)
         and (last_stochrsi_k_4h_lt_50)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 25.0))
       ):
@@ -62096,10 +62161,10 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_11_94"
       elif (
         (last_rsi_3 < 12.0)
-        and (last_willr_14 < -92.0)
+        and (last_willr_14_lt_neg_92)
         and (last_rsi_3_1h > 55.0)
         and (last_rsi_3_4h > 60.0)
-        and (last_stochrsi_k_4h < 90.0)
+        and (last_stochrsi_k_4h_lt_90)
         and (isinstance(last_aroond_14_1d, np.float64) and (last_aroond_14_1d > 75.0))
       ):
         return True, f"exit_{mode_name}_d_11_95"
@@ -62134,15 +62199,15 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_3_1h > 35.0)
         and (last_rsi_3_4h > 40.0)
         and (last_aroond_14_4h > 50.0)
-        and (last_stoch_k_4h < 60.0)
+        and (last_stoch_k_4h_lt_60)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -80.0))
       ):
         return True, f"exit_{mode_name}_d_11_99"
-      elif (last_rsi_3 < 1.0) and (last_rsi_14 < 20.0) and (last_rsi_3_15m < 30.0) and (last_rsi_3_4h > 20.0):
+      elif (last_rsi_3 < 1.0) and (last_rsi_14 < 20.0) and (last_rsi_3_15m_lt_30) and (last_rsi_3_4h > 20.0):
         return True, f"exit_{mode_name}_d_11_100"
       elif (
         (last_rsi_3 < 12.0)
-        and (last_willr_14 < -88.0)
+        and (last_willr_14_lt_neg_88)
         and (last_rsi_3_1h > 50.0)
         and (last_stochrsi_k_4h < 60.0)
         and (isinstance(last_roc_9_4h, np.float64) and (last_roc_9_4h < -40.0))
@@ -62153,7 +62218,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 > 56.0)
         and (last_rsi_3_1h > 40.0)
         and (last_rsi_3_4h > 60.0)
-        and (last_stochrsi_k_4h > 70.0)
+        and (last_stochrsi_k_4h_gt_70)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -40.0))
       ):
         return True, f"exit_{mode_name}_d_11_102"
@@ -62171,7 +62236,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_3_1h > 40.0)
         and (last_stochrsi_k_1h < 60.0)
         and (last_stochrsi_k_4h < 10.0)
-        and (last_roc_9_4h < -40.0)
+        and (last_roc_9_4h_lt_neg_40)
       ):
         return True, f"exit_{mode_name}_d_11_104"
       elif (
@@ -62179,7 +62244,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 > 56.0)
         and (last_rsi_3_15m > 45.0)
         and (last_stochrsi_k_4h < 10.0)
-        and (last_roc_9_4h < -25.0)
+        and (last_roc_9_4h_lt_neg_25)
       ):
         return True, f"exit_{mode_name}_d_11_105"
       elif (
@@ -62188,7 +62253,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_3_1h > 50.0)
         and (last_stochrsi_k_1h_lt_50)
         and (last_rsi_14_4h < 30.0)
-        and (last_roc_9_4h < -40.0)
+        and (last_roc_9_4h_lt_neg_40)
       ):
         return True, f"exit_{mode_name}_d_11_106"
       elif (
@@ -62203,13 +62268,13 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_11_108"
       elif (
         (last_rsi_3 < 20.0)
-        and (last_willr_14 < -96.0)
+        and (last_willr_14_lt_neg_96)
         and (last_rsi_3_1h > 50.0)
         and (last_rsi_3_4h > 80.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -50.0))
       ):
         return True, f"exit_{mode_name}_d_11_109"
-      elif (last_rsi_3 < 24.0) and (last_rsi_3_4h > 35.0) and (last_stochrsi_k_4h_lt_50) and (last_roc_9_4h < -25.0):
+      elif (last_rsi_3 < 24.0) and (last_rsi_3_4h > 35.0) and (last_stochrsi_k_4h_lt_50) and (last_roc_9_4h_lt_neg_25):
         return True, f"exit_{mode_name}_d_11_110"
       elif (
         (last_rsi_3 < 46.0)
@@ -62223,17 +62288,17 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_11_111"
       elif (
         (last_rsi_3 < 16.0)
-        and (last_willr_14 < -85.0)
+        and (last_willr_14_lt_neg_85)
         and (last_rsi_14 > 52.0)
         and (last_rsi_3_1h > 65.0)
-        and (last_rsi_3_4h > 65.0)
+        and (last_rsi_3_4h_gt_65)
         and (last_rsi_3_1d > 40.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
       ):
         return True, f"exit_{mode_name}_d_11_112"
       elif (
         (last_rsi_3 < 12.0)
-        and (last_willr_14 < -99.0)
+        and (last_willr_14_lt_neg_99)
         and (last_rsi_3_1d > 70.0)
         and (last_stochrsi_k_4h_lt_50)
         and (isinstance(last_roc_9_4h, np.float64) and (last_roc_9_4h < -10.0))
@@ -62251,7 +62316,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 18.0)
         and (last_rsi_14 > 56.0)
-        and (last_rsi_3_15m > 70.0)
+        and (last_rsi_3_15m_gt_70)
         and (last_stochrsi_k_1h_lt_50)
         and (last_stochrsi_k_4h_lt_50)
       ):
@@ -62266,19 +62331,19 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_11_118"
       elif (
         (last_rsi_3 < 10.0)
-        and (last_willr_14 < -80.0)
+        and (last_willr_14_lt_neg_80)
         and (last_rsi_3_1h > 40.0)
         and (last_rsi_3_4h > 40.0)
         and (last_stochrsi_k_1h < 60.0)
       ):
         return True, f"exit_{mode_name}_d_11_119"
-      elif (last_rsi_3 < 42.0) and (last_rsi_14 > 56.0) and (last_rsi_3_1h > 60.0) and (last_aroond_14_4h > 75.0):
+      elif (last_rsi_3_lt_42) and (last_rsi_14 > 56.0) and (last_rsi_3_1h > 60.0) and (last_aroond_14_4h > 75.0):
         return True, f"exit_{mode_name}_d_11_120"
       elif (last_rsi_3 < 36.0) and (last_rsi_14 > 58.0) and (last_rsi_3_1h > 50.0) and (last_rsi_14_4h < 15.0):
         return True, f"exit_{mode_name}_d_11_121"
       elif (last_rsi_3 < 38.0) and (last_rsi_14 > 60.0) and (last_rsi_3_4h_gt_70) and (last_stochrsi_k_1h_lt_50):
         return True, f"exit_{mode_name}_d_11_122"
-      elif (last_rsi_3 < 8.0) and (last_willr_14 < -99.0) and (last_rsi_3_1h > 90.0) and (last_rsi_3_1d > 70.0):
+      elif (last_rsi_3 < 8.0) and (last_willr_14_lt_neg_99) and (last_rsi_3_1h > 90.0) and (last_rsi_3_1d > 70.0):
         return True, f"exit_{mode_name}_d_11_123"
       elif (
         (last_rsi_3 < 8.0)
@@ -62288,16 +62353,16 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_11_124"
       elif (
         (last_rsi_3 < 20.0)
-        and (last_willr_14 < -99.0)
+        and (last_willr_14_lt_neg_99)
         and (last_rsi_3_1h > 90.0)
         and (last_rsi_3_4h > 60.0)
-        and (last_rsi_3_1d > 60.0)
+        and (last_rsi_3_1d_gt_60)
         and (last_close > (last_low_min_30_1d * 2.0))
       ):
         return True, f"exit_{mode_name}_d_11_125"
       elif (last_rsi_3 < 6.0) and (last_rsi_3_1h > 85.0) and (last_rsi_3_4h > 60.0) and (last_stochrsi_k_4h_lt_50):
         return True, f"exit_{mode_name}_d_11_126"
-      elif (last_rsi_3 < 6.0) and (last_rsi_3_1h > 90.0) and (last_rsi_3_4h_gt_70) and (last_rsi_3_1d > 60.0):
+      elif (last_rsi_3 < 6.0) and (last_rsi_3_1h > 90.0) and (last_rsi_3_4h_gt_70) and (last_rsi_3_1d_gt_60):
         return True, f"exit_{mode_name}_d_11_127"
       elif (last_rsi_3 < 2.0) and (last_rsi_3_4h_gt_70) and (last_aroond_14_4h > 85.0):
         return True, f"exit_{mode_name}_d_11_128"
@@ -62319,7 +62384,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 16.0)
         and (last_rsi_3_1h > 65.0)
-        and (last_rsi_3_4h > 65.0)
+        and (last_rsi_3_4h_gt_65)
         and (last_aroond_14_1h > 50.0)
         and (last_stochrsi_k_1h < 60.0)
       ):
@@ -62333,7 +62398,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_11_133"
     elif current_profit >= 0.2:
       if (
-        (last_willr_14 < -99.0)
+        (last_willr_14_lt_neg_99)
         and (last_rsi_14 < 22.0)
         and (isinstance(last_ema_200_1h, np.float64) and (last_ema_12_1h > last_ema_200_1h))
         and (isinstance(last_ema_200_4h, np.float64) and (last_ema_12_4h > last_ema_200_4h))
@@ -62342,35 +62407,35 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_12_1"
       elif (
-        (last_willr_14 < -99.0)
+        (last_willr_14_lt_neg_99)
         and (last_rsi_14 < 22.0)
-        and (last_cmf_20_1h > 0.0)
+        and (last_cmf_20_1h_gt_0)
         and (isinstance(last_ema_200_1h, np.float64) and (last_ema_12_1h > last_ema_200_1h))
         and (isinstance(last_ema_200_4h, np.float64) and (last_ema_12_4h > last_ema_200_4h))
       ):
         return True, f"exit_{mode_name}_d_12_2"
       elif (
-        (last_willr_14 < -99.0)
+        (last_willr_14_lt_neg_99)
         and (last_stochrsi_k < 1.0)
-        and (last_cmf_20_1h > 0.0)
-        and (last_cmf_20_4h > 0.0)
-        and ((last_stochrsi_k_4h < 80.0) and (last_stochrsi_k_change_pct_4h > 10.0))
+        and (last_cmf_20_1h_gt_0)
+        and (last_cmf_20_4h_gt_0)
+        and ((last_stochrsi_k_4h < 80.0) and (last_stochrsi_k_change_pct_4h_gt_10))
       ):
         return True, f"exit_{mode_name}_d_12_3"
       elif (
-        (last_willr_14 < -99.0)
+        (last_willr_14_lt_neg_99)
         and (last_rsi_14 < 20.0)
         and (last_stochrsi_k < 5.0)
-        and (last_stochrsi_k_4h < 30.0)
+        and (last_stochrsi_k_4h_lt_30)
         and (isinstance(last_ema_200_1h, np.float64) and (last_ema_12_1h > last_ema_200_1h))
         and (isinstance(last_ema_200_4h, np.float64) and (last_ema_12_4h > last_ema_200_4h))
       ):
         return True, f"exit_{mode_name}_d_12_4"
-      elif (last_willr_14 < -99.0) and (last_rsi_14 < 22.0) and (last_roc_9_1h > 5.0) and (last_roc_9_4h > 5.0):
+      elif (last_willr_14_lt_neg_99) and (last_rsi_14 < 22.0) and (last_roc_9_1h_gt_5) and (last_roc_9_4h_gt_5):
         return True, f"exit_{mode_name}_d_12_5"
       elif (
         (last_rsi_3 < 30.0)
-        and (last_stochrsi_k < 30.0)
+        and (last_stochrsi_k_lt_30)
         and (last_rsi_14 > 60.0)
         and (last_roc_9_1h > 10.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -50.0))
@@ -62384,7 +62449,7 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_12_7"
       elif (
-        (last_willr_14 < -99.0)
+        (last_willr_14_lt_neg_99)
         and (last_stochrsi_k < 1.0)
         and (last_cmf_20_1h > 0.1)
         and (last_cmf_20_4h > 0.1)
@@ -62393,17 +62458,17 @@ class NostalgiaForInfinityX7(IStrategy):
       ):
         return True, f"exit_{mode_name}_d_12_8"
       elif (
-        (last_willr_14 < -99.0)
+        (last_willr_14_lt_neg_99)
         and (last_rsi_3 < 1.0)
         and (last_change_pct_4h > 5.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
       ):
         return True, f"exit_{mode_name}_d_12_9"
       elif (
-        (last_willr_14 < -99.0)
+        (last_willr_14_lt_neg_99)
         and (last_rsi_14_gt_50)
         and (last_roc_9_1h > 10.0)
-        and (last_roc_9_4h > 10.0)
+        and (last_roc_9_4h_gt_10)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -10.0))
       ):
         return True, f"exit_{mode_name}_d_12_10"
@@ -62420,26 +62485,26 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14_gt_50)
         and (last_rsi_3_4h > 90.0)
         and (last_roc_9_1h > 20.0)
-        and (last_roc_9_4h > 20.0)
+        and (last_roc_9_4h_gt_20)
       ):
         return True, f"exit_{mode_name}_d_12_12"
-      elif (last_rsi_3 < 1.0) and (last_rsi_3_4h > 95.0) and (last_roc_9_4h > 25.0):
+      elif (last_rsi_3 < 1.0) and (last_rsi_3_4h_gt_95) and (last_roc_9_4h_gt_25):
         return True, f"exit_{mode_name}_d_12_13"
-      elif (last_rsi_3 < 1.0) and (last_willr_14 < -99.0) and (last_rsi_3_4h > 95.0) and (last_aroond_14_4h > 25.0):
+      elif (last_rsi_3 < 1.0) and (last_willr_14_lt_neg_99) and (last_rsi_3_4h_gt_95) and (last_aroond_14_4h > 25.0):
         return True, f"exit_{mode_name}_d_12_14"
       elif (last_rsi_3 < 1.0) and (last_rsi_14 < 25.0) and (last_roc_9_4h > 30.0):
         return True, f"exit_{mode_name}_d_12_15"
       elif (
         (last_rsi_3 < 1.0)
         and (last_aroond_14_4h > 25.0)
-        and (last_roc_9_4h > 25.0)
+        and (last_roc_9_4h_gt_25)
         and (last_aroond_14_1d > 50.0)
         and (last_change_pct_1d > 15.0)
       ):
         return True, f"exit_{mode_name}_d_12_16"
       elif (
         (last_rsi_3 < 1.0)
-        and (last_willr_14 < -99.0)
+        and (last_willr_14_lt_neg_99)
         and (last_rsi_3_1h > 90.0)
         and (last_stochrsi_k_4h < 10.0)
         and (last_roc_9_4h < -30.0)
@@ -62460,31 +62525,31 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_12_21"
       elif (
         (last_rsi_3 < 1.0)
-        and (last_willr_14 < -99.0)
+        and (last_willr_14_lt_neg_99)
         and (last_change_pct_4h > 5.0)
         and (last_stochrsi_k_4h_lt_50)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
       ):
         return True, f"exit_{mode_name}_d_12_22"
-      elif (last_rsi_3 < 1.0) and (last_willr_14 < -99.0) and (last_rsi_3_1h > 85.0) and (last_rsi_3_1d > 95.0):
+      elif (last_rsi_3 < 1.0) and (last_willr_14_lt_neg_99) and (last_rsi_3_1h > 85.0) and (last_rsi_3_1d > 95.0):
         return True, f"exit_{mode_name}_d_12_23"
       elif (
         (last_rsi_3 < 2.0)
         and (last_rsi_14 < 22.0)
-        and (last_willr_14 < -99.0)
+        and (last_willr_14_lt_neg_99)
         and (last_rsi_3_4h_gt_70)
         and (last_aroond_14_4h > 75.0)
       ):
         return True, f"exit_{mode_name}_d_12_24"
       elif (
         (last_rsi_3 < 1.0)
-        and (last_willr_14 < -99.0)
+        and (last_willr_14_lt_neg_99)
         and (last_rsi_3_4h > 90.0)
         and (last_roc_9_4h > 15.0)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 50.0))
       ):
         return True, f"exit_{mode_name}_d_12_25"
-      elif (last_rsi_3 < 1.0) and (last_willr_14 < -99.0) and (last_rsi_3_4h > 85.0) and (last_roc_9_4h > 20.0):
+      elif (last_rsi_3 < 1.0) and (last_willr_14_lt_neg_99) and (last_rsi_3_4h > 85.0) and (last_roc_9_4h_gt_20):
         return True, f"exit_{mode_name}_d_12_26"
       elif (
         (last_rsi_3 < 1.0)
@@ -62511,27 +62576,27 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14_gt_50)
         and (last_rsi_3_1h > 85.0)
         and (last_rsi_3_4h > 85.0)
-        and (last_stochrsi_k_1h < 75.0)
+        and (last_stochrsi_k_1h_lt_75)
       ):
         return True, f"exit_{mode_name}_d_12_31"
-      elif (last_rsi_3 < 1.0) and (last_rsi_3_1h > 85.0) and (last_roc_2_4h > 30.0) and (last_stochrsi_k_4h < 70.0):
+      elif (last_rsi_3 < 1.0) and (last_rsi_3_1h > 85.0) and (last_roc_2_4h_gt_30) and (last_stochrsi_k_4h < 70.0):
         return True, f"exit_{mode_name}_d_12_32"
       elif (
         (last_rsi_3 < 1.0)
-        and (last_willr_14 < -99.0)
+        and (last_willr_14_lt_neg_99)
         and (last_roc_2_1h > 10.0)
         and (last_roc_9_1h < -30.0)
         and (last_stochrsi_k_1h_lt_50)
       ):
         return True, f"exit_{mode_name}_d_12_33"
-      elif (last_rsi_3 < 35.0) and (last_rsi_3_15m > 70.0) and (last_rsi_14_1h < 20.0) and (last_roc_9_1h < -40.0):
+      elif (last_rsi_3 < 35.0) and (last_rsi_3_15m_gt_70) and (last_rsi_14_1h < 20.0) and (last_roc_9_1h < -40.0):
         return True, f"exit_{mode_name}_d_12_34"
-      elif (last_rsi_3 < 6.0) and (last_willr_14 < -98.0) and (last_rsi_3_1d > 75.0) and (last_stochrsi_k_1h < 25.0):
+      elif (last_rsi_3 < 6.0) and (last_willr_14_lt_neg_98) and (last_rsi_3_1d > 75.0) and (last_stochrsi_k_1h_lt_25):
         return True, f"exit_{mode_name}_d_12_35"
       elif (
         (last_rsi_3 < 1.0)
-        and (last_willr_14 < -99.0)
-        and (last_roc_9_4h > 25.0)
+        and (last_willr_14_lt_neg_99)
+        and (last_roc_9_4h_gt_25)
         and (last_rsi_3_1d > 75.0)
         and (last_stochrsi_k_1h_lt_50)
       ):
@@ -62544,13 +62609,13 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_stochrsi_k_4h_lt_50)
       ):
         return True, f"exit_{mode_name}_d_12_37"
-      elif (last_rsi_3 < 1.0) and (last_willr_14 < -99.0) and (last_rsi_3_4h > 90.0) and (last_stochrsi_k_4h < 80.0):
+      elif (last_rsi_3 < 1.0) and (last_willr_14_lt_neg_99) and (last_rsi_3_4h > 90.0) and (last_stochrsi_k_4h < 80.0):
         return True, f"exit_{mode_name}_d_12_38"
-      elif (last_rsi_3 < 2.0) and (last_willr_14 < -98.0) and (last_cmf_20_4h > 0.0) and (last_rsi_3_4h > 90.0):
+      elif (last_rsi_3 < 2.0) and (last_willr_14_lt_neg_98) and (last_cmf_20_4h_gt_0) and (last_rsi_3_4h > 90.0):
         return True, f"exit_{mode_name}_d_12_39"
       elif (
         (last_rsi_3 < 2.0)
-        and (last_willr_14 < -98.0)
+        and (last_willr_14_lt_neg_98)
         and (last_rsi_3_1h_gt_70)
         and (last_stochrsi_k_1h < 70.0)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 10.0))
@@ -62558,7 +62623,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_12_40"
       elif (
         (last_rsi_3 < 2.0)
-        and (last_willr_14 < -98.0)
+        and (last_willr_14_lt_neg_98)
         and (last_rsi_3_1h_gt_70)
         and (last_stochrsi_k_4h < 75.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -50.0))
@@ -62566,7 +62631,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_12_41"
       elif (
         (last_rsi_3 < 2.0)
-        and (last_willr_14 < -90.0)
+        and (last_willr_14_lt_neg_90)
         and (last_stochrsi_k_4h < 70.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -40.0))
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 30.0))
@@ -62582,13 +62647,13 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_12_43"
       elif (
         (last_rsi_3 < 15.0)
-        and (last_willr_14 < -98.0)
+        and (last_willr_14_lt_neg_98)
         and (last_rsi_3_4h_gt_70)
         and (last_rsi_3_1d > 25.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
       ):
         return True, f"exit_{mode_name}_d_12_44"
-      elif (last_rsi_3 < 1.0) and (last_willr_14 < -99.0) and (last_rsi_3_1h > 90.0):
+      elif (last_rsi_3 < 1.0) and (last_willr_14_lt_neg_99) and (last_rsi_3_1h > 90.0):
         return True, f"exit_{mode_name}_d_12_45"
       elif (last_rsi_3 < 4.0) and (last_rsi_3_1h > 85.0) and (last_rsi_3_4h > 90.0) and (last_roc_2_1d > 20.0):
         return True, f"exit_{mode_name}_d_12_46"
@@ -62610,20 +62675,20 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_12_48"
       elif (
         (last_rsi_3 < 2.0)
-        and (last_willr_14 < -98.0)
+        and (last_willr_14_lt_neg_98)
         and (last_rsi_3_4h > 80.0)
         and (last_change_pct_1d > 5.0)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 50.0))
       ):
         return True, f"exit_{mode_name}_d_12_49"
-      elif (last_rsi_3 < 10.0) and (last_willr_14 < -98.0) and (last_rsi_3_1d > 90.0) and (last_stochrsi_k_1h < 10.0):
+      elif (last_rsi_3 < 10.0) and (last_willr_14_lt_neg_98) and (last_rsi_3_1d > 90.0) and (last_stochrsi_k_1h_lt_10):
         return True, f"exit_{mode_name}_d_12_50"
       elif (last_rsi_3 < 28.0) and (last_rsi_14 > 60.0) and (last_rsi_3_4h > 80.0) and (last_stochrsi_k_1h_lt_50):
         return True, f"exit_{mode_name}_d_12_51"
       elif (
         (last_rsi_3 < 14.0)
         and (last_rsi_14 < 34.0)
-        and (last_willr_14 < -90.0)
+        and (last_willr_14_lt_neg_90)
         and (last_stochrsi_k_1h < 30.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 15.0))
       ):
@@ -62631,7 +62696,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 30.0)
         and (last_rsi_14_gt_50)
-        and (last_willr_14 < -75.0)
+        and (last_willr_14_lt_neg_75)
         and (last_rsi_3_1h > 80.0)
         and (last_stochrsi_k_4h_lt_50)
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 50.0))
@@ -62641,14 +62706,14 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 16.0)
         and (last_rsi_14 > 60.0)
         and (last_stochrsi_k_1h_lt_50)
-        and (last_roc_9_4h > 10.0)
+        and (last_roc_9_4h_gt_10)
         and (last_change_pct_1d > 10.0)
       ):
         return True, f"exit_{mode_name}_d_12_54"
       elif (
         (last_rsi_3 < 1.0)
-        and (last_willr_14 < -92.0)
-        and (last_roc_9_4h > 5.0)
+        and (last_willr_14_lt_neg_92)
+        and (last_roc_9_4h_gt_5)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -10.0))
         and (last_stochrsi_k_1h_lt_50)
       ):
@@ -62659,14 +62724,14 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_3_1h_gt_70)
         and (last_rsi_3_4h > 75.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
-        and (last_stochrsi_k_4h < 90.0)
+        and (last_stochrsi_k_4h_lt_90)
       ):
         return True, f"exit_{mode_name}_d_12_56"
       elif (
         (last_rsi_3 < 50.0)
         and (last_rsi_14 > 70.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 30.0))
-        and (last_stochrsi_k_4h < 30.0)
+        and (last_stochrsi_k_4h_lt_30)
       ):
         return True, f"exit_{mode_name}_d_12_57"
       elif (
@@ -62679,7 +62744,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_12_58"
       elif (
         (last_rsi_3 < 5.0)
-        and (last_willr_14 < -94.0)
+        and (last_willr_14_lt_neg_94)
         and (last_rsi_3_4h > 75.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 15.0))
         and (last_stochrsi_k_4h < 60.0)
@@ -62690,14 +62755,14 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 > 66.0)
         and (last_rsi_14_4h < 35.0)
         and (last_stochrsi_k_4h_lt_50)
-        and (last_stochrsi_k_1d < 50.0)
+        and (last_stochrsi_k_1d_lt_50)
       ):
         return True, f"exit_{mode_name}_d_12_60"
-      elif (last_rsi_3 < 2.0) and (last_willr_14 < -95.0) and (last_rsi_3_4h > 90.0) and (last_stochrsi_k_1h < 70.0):
+      elif (last_rsi_3 < 2.0) and (last_willr_14_lt_neg_95) and (last_rsi_3_4h > 90.0) and (last_stochrsi_k_1h < 70.0):
         return True, f"exit_{mode_name}_d_12_61"
       elif (
         (last_rsi_3 < 8.0)
-        and (last_willr_14 < -98.0)
+        and (last_willr_14_lt_neg_98)
         and (last_rsi_3_1h_gt_70)
         and (last_rsi_3_4h > 80.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -20.0))
@@ -62722,7 +62787,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 50.0)
         and (last_rsi_14 > 64.0)
-        and (last_stochrsi_k_4h < 20.0)
+        and (last_stochrsi_k_4h_lt_20)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 25.0))
       ):
         return True, f"exit_{mode_name}_d_12_67"
@@ -62730,7 +62795,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 10.0)
         and (last_rsi_14 > 58.0)
         and (last_rsi_3_1h > 75.0)
-        and (last_roc_2_4h > 30.0)
+        and (last_roc_2_4h_gt_30)
         and (last_stochrsi_k_4h < 75.0)
       ):
         return True, f"exit_{mode_name}_d_12_68"
@@ -62740,7 +62805,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_12_69"
       elif (last_rsi_3 < 28.0) and (last_rsi_14 > 66.0) and (last_rsi_3_1h > 75.0) and (last_stochrsi_k_4h < 80.0):
         return True, f"exit_{mode_name}_d_12_70"
-      elif (last_rsi_3 < 30.0) and (last_rsi_14 > 62.0) and (last_rsi_3_4h > 75.0) and (last_stochrsi_k_1h < 80.0):
+      elif (last_rsi_3 < 30.0) and (last_rsi_14 > 62.0) and (last_rsi_3_4h > 75.0) and (last_stochrsi_k_1h_lt_80):
         return True, f"exit_{mode_name}_d_12_71"
       elif (last_rsi_3 < 16.0) and (last_rsi_14 > 64.0) and (last_rsi_3_1h > 90.0) and (last_aroond_14_4h > 25.0):
         return True, f"exit_{mode_name}_d_12_72"
@@ -62748,16 +62813,16 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 16.0)
         and (last_rsi_3_1h > 75.0)
         and (last_rsi_3_4h > 85.0)
-        and (last_roc_9_4h > 20.0)
+        and (last_roc_9_4h_gt_20)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 25.0))
       ):
         return True, f"exit_{mode_name}_d_12_73"
       elif (
         (last_rsi_3 < 1.0)
-        and (last_willr_14 < -90.0)
+        and (last_willr_14_lt_neg_90)
         and (last_rsi_3_4h > 75.0)
         and (last_rsi_3_1d > 75.0)
-        and (last_stochrsi_k_1h > 50.0)
+        and (last_stochrsi_k_1h_gt_50)
       ):
         return True, f"exit_{mode_name}_d_12_74"
       elif (
@@ -62767,7 +62832,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (isinstance(last_stochrsi_k_1d, np.float64) and (last_stochrsi_k_1d < 50.0))
       ):
         return True, f"exit_{mode_name}_d_12_75"
-      elif (last_rsi_3 < 26.0) and (last_rsi_14 > 56.0) and (last_roc_9_1h < -80.0) and (last_stochrsi_k_4h < 20.0):
+      elif (last_rsi_3 < 26.0) and (last_rsi_14 > 56.0) and (last_roc_9_1h < -80.0) and (last_stochrsi_k_4h_lt_20):
         return True, f"exit_{mode_name}_d_12_76"
       elif (
         (last_rsi_3 < 18.0)
@@ -62778,13 +62843,13 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_12_77"
       elif (
         (last_rsi_3 < 8.0)
-        and (last_willr_14 < -90.0)
+        and (last_willr_14_lt_neg_90)
         and (last_rsi_3_1h_gt_70)
         and (last_rsi_3_4h > 80.0)
         and (last_rsi_3_1d > 80.0)
       ):
         return True, f"exit_{mode_name}_d_12_78"
-      elif (last_rsi_3 < 2.0) and (last_willr_14 < -99.0) and (last_rsi_3_1h_gt_70) and (last_rsi_3_4h > 90.0):
+      elif (last_rsi_3 < 2.0) and (last_willr_14_lt_neg_99) and (last_rsi_3_1h_gt_70) and (last_rsi_3_4h > 90.0):
         return True, f"exit_{mode_name}_d_12_79"
       elif (
         (last_rsi_3 < 22.0)
@@ -62796,7 +62861,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_12_80"
       elif (
         (last_rsi_3 < 10.0)
-        and (last_willr_14 < -96.0)
+        and (last_willr_14_lt_neg_96)
         and (last_rsi_3_1h > 75.0)
         and (last_rsi_3_4h > 75.0)
         and (isinstance(last_rsi_14_1d, np.float64) and (last_rsi_14_1d < 50.0))
@@ -62804,7 +62869,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_12_81"
       elif (
         (last_rsi_3 < 12.0)
-        and (last_willr_14 < -96.0)
+        and (last_willr_14_lt_neg_96)
         and (last_rsi_3_4h_gt_70)
         and (last_rsi_3_1d > 85.0)
         and (last_stochrsi_k_4h < 60.0)
@@ -62818,11 +62883,11 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_stochrsi_k_4h < 60.0)
       ):
         return True, f"exit_{mode_name}_d_12_83"
-      elif (last_rsi_3 < 4.0) and (last_willr_14 < -99.0) and (last_rsi_3_4h_gt_70) and (last_stochrsi_k_1h < 80.0):
+      elif (last_rsi_3 < 4.0) and (last_willr_14_lt_neg_99) and (last_rsi_3_4h_gt_70) and (last_stochrsi_k_1h_lt_80):
         return True, f"exit_{mode_name}_d_12_84"
       elif (
         (last_rsi_3 < 6.0)
-        and (last_willr_14 < -98.0)
+        and (last_willr_14_lt_neg_98)
         and (last_rsi_3_1h_gt_70)
         and (last_rsi_3_4h > 60.0)
         and (last_stochrsi_k_4h_lt_50)
@@ -62846,7 +62911,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_12_87"
       elif (
         (last_rsi_3 < 6.0)
-        and (last_willr_14 < -86.0)
+        and (last_willr_14_lt_neg_86)
         and (last_stochrsi_k_1h < 60.0)
         and (last_stochrsi_k_4h_lt_50)
         and (last_change_pct_1h > 2.0)
@@ -62855,13 +62920,13 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 16.0)
         and (last_rsi_14 > 66.0)
-        and (last_roc_9_1h > 5.0)
+        and (last_roc_9_1h_gt_5)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -25.0))
       ):
         return True, f"exit_{mode_name}_d_12_89"
       elif (
         (last_rsi_3 < 2.0)
-        and (last_willr_14 < -75.0)
+        and (last_willr_14_lt_neg_75)
         and (last_rsi_3_1h > 50.0)
         and (last_rsi_3_4h_gt_70)
         and (last_aroonu_14_4h < 50.0)
@@ -62881,7 +62946,7 @@ class NostalgiaForInfinityX7(IStrategy):
         (last_rsi_3 < 14.0)
         and (last_rsi_14 > 58.0)
         and (last_rsi_3_1h > 60.0)
-        and (last_stochrsi_k_1h < 75.0)
+        and (last_stochrsi_k_1h_lt_75)
         and (last_stochrsi_k_4h_lt_50)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d > 25.0))
       ):
@@ -62908,10 +62973,10 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_12_94"
       elif (
         (last_rsi_3 < 10.0)
-        and (last_willr_14 < -94.0)
+        and (last_willr_14_lt_neg_94)
         and (last_rsi_3_1h > 55.0)
         and (last_rsi_3_4h > 60.0)
-        and (last_stochrsi_k_4h < 90.0)
+        and (last_stochrsi_k_4h_lt_90)
         and (isinstance(last_aroond_14_1d, np.float64) and (last_aroond_14_1d > 75.0))
       ):
         return True, f"exit_{mode_name}_d_12_95"
@@ -62946,15 +63011,15 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_3_1h > 35.0)
         and (last_rsi_3_4h > 40.0)
         and (last_aroond_14_4h > 50.0)
-        and (last_stoch_k_4h < 60.0)
+        and (last_stoch_k_4h_lt_60)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -80.0))
       ):
         return True, f"exit_{mode_name}_d_12_99"
-      elif (last_rsi_3 < 1.0) and (last_rsi_14 < 18.0) and (last_rsi_3_15m < 30.0) and (last_rsi_3_4h > 20.0):
+      elif (last_rsi_3 < 1.0) and (last_rsi_14 < 18.0) and (last_rsi_3_15m_lt_30) and (last_rsi_3_4h > 20.0):
         return True, f"exit_{mode_name}_d_12_100"
       elif (
         (last_rsi_3 < 10.0)
-        and (last_willr_14 < -90.0)
+        and (last_willr_14_lt_neg_90)
         and (last_rsi_3_1h > 50.0)
         and (last_stochrsi_k_4h < 60.0)
         and (isinstance(last_roc_9_4h, np.float64) and (last_roc_9_4h < -40.0))
@@ -62965,7 +63030,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 > 58.0)
         and (last_rsi_3_1h > 40.0)
         and (last_rsi_3_4h > 60.0)
-        and (last_stochrsi_k_4h > 70.0)
+        and (last_stochrsi_k_4h_gt_70)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -40.0))
       ):
         return True, f"exit_{mode_name}_d_12_102"
@@ -62983,7 +63048,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_3_1h > 40.0)
         and (last_stochrsi_k_1h < 60.0)
         and (last_stochrsi_k_4h < 10.0)
-        and (last_roc_9_4h < -40.0)
+        and (last_roc_9_4h_lt_neg_40)
       ):
         return True, f"exit_{mode_name}_d_12_104"
       elif (
@@ -62991,7 +63056,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_14 > 58.0)
         and (last_rsi_3_15m > 45.0)
         and (last_stochrsi_k_4h < 10.0)
-        and (last_roc_9_4h < -25.0)
+        and (last_roc_9_4h_lt_neg_25)
       ):
         return True, f"exit_{mode_name}_d_12_105"
       elif (
@@ -63000,7 +63065,7 @@ class NostalgiaForInfinityX7(IStrategy):
         and (last_rsi_3_1h > 50.0)
         and (last_stochrsi_k_1h_lt_50)
         and (last_rsi_14_4h < 30.0)
-        and (last_roc_9_4h < -40.0)
+        and (last_roc_9_4h_lt_neg_40)
       ):
         return True, f"exit_{mode_name}_d_12_106"
       elif (
@@ -63015,16 +63080,16 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_12_108"
       elif (
         (last_rsi_3 < 18.0)
-        and (last_willr_14 < -98.0)
+        and (last_willr_14_lt_neg_98)
         and (last_rsi_3_1h > 50.0)
         and (last_rsi_3_4h > 80.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -50.0))
       ):
         return True, f"exit_{mode_name}_d_12_109"
-      elif (last_rsi_3 < 22.0) and (last_rsi_3_4h > 35.0) and (last_stochrsi_k_4h_lt_50) and (last_roc_9_4h < -25.0):
+      elif (last_rsi_3 < 22.0) and (last_rsi_3_4h > 35.0) and (last_stochrsi_k_4h_lt_50) and (last_roc_9_4h_lt_neg_25):
         return True, f"exit_{mode_name}_d_12_110"
       elif (
-        (last_rsi_3 < 44.0)
+        (last_rsi_3_lt_44)
         and (last_rsi_14 > 62.0)
         and (last_rsi_3_1h > 50.0)
         and (last_rsi_14_4h < 30.0)
@@ -63035,17 +63100,17 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_12_111"
       elif (
         (last_rsi_3 < 14.0)
-        and (last_willr_14 < -90.0)
+        and (last_willr_14_lt_neg_90)
         and (last_rsi_14 > 54.0)
         and (last_rsi_3_1h > 65.0)
-        and (last_rsi_3_4h > 65.0)
+        and (last_rsi_3_4h_gt_65)
         and (last_rsi_3_1d > 40.0)
         and (isinstance(last_roc_9_1d, np.float64) and (last_roc_9_1d < -30.0))
       ):
         return True, f"exit_{mode_name}_d_12_112"
       elif (
         (last_rsi_3 < 10.0)
-        and (last_willr_14 < -99.0)
+        and (last_willr_14_lt_neg_99)
         and (last_rsi_3_1d > 70.0)
         and (last_stochrsi_k_4h_lt_50)
         and (isinstance(last_roc_9_4h, np.float64) and (last_roc_9_4h < -10.0))
@@ -63063,7 +63128,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 16.0)
         and (last_rsi_14 > 58.0)
-        and (last_rsi_3_15m > 70.0)
+        and (last_rsi_3_15m_gt_70)
         and (last_stochrsi_k_1h_lt_50)
         and (last_stochrsi_k_4h_lt_50)
       ):
@@ -63076,7 +63141,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_12_118"
       elif (
         (last_rsi_3 < 8.0)
-        and (last_willr_14 < -80.0)
+        and (last_willr_14_lt_neg_80)
         and (last_rsi_3_1h > 40.0)
         and (last_rsi_3_4h > 40.0)
         and (last_stochrsi_k_1h < 60.0)
@@ -63088,7 +63153,7 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_12_121"
       elif (last_rsi_3 < 36.0) and (last_rsi_14 > 62.0) and (last_rsi_3_4h_gt_70) and (last_stochrsi_k_1h_lt_50):
         return True, f"exit_{mode_name}_d_12_122"
-      elif (last_rsi_3 < 6.0) and (last_willr_14 < -99.0) and (last_rsi_3_1h > 90.0) and (last_rsi_3_1d > 70.0):
+      elif (last_rsi_3 < 6.0) and (last_willr_14_lt_neg_99) and (last_rsi_3_1h > 90.0) and (last_rsi_3_1d > 70.0):
         return True, f"exit_{mode_name}_d_12_123"
       elif (
         (last_rsi_3 < 6.0)
@@ -63098,16 +63163,16 @@ class NostalgiaForInfinityX7(IStrategy):
         return True, f"exit_{mode_name}_d_12_124"
       elif (
         (last_rsi_3 < 18.0)
-        and (last_willr_14 < -99.0)
+        and (last_willr_14_lt_neg_99)
         and (last_rsi_3_1h > 90.0)
         and (last_rsi_3_4h > 60.0)
-        and (last_rsi_3_1d > 60.0)
+        and (last_rsi_3_1d_gt_60)
         and (last_close > (last_low_min_30_1d * 2.0))
       ):
         return True, f"exit_{mode_name}_d_12_125"
       elif (last_rsi_3 < 4.0) and (last_rsi_3_1h > 85.0) and (last_rsi_3_4h > 60.0) and (last_stochrsi_k_4h_lt_50):
         return True, f"exit_{mode_name}_d_12_126"
-      elif (last_rsi_3 < 4.0) and (last_rsi_3_1h > 90.0) and (last_rsi_3_4h_gt_70) and (last_rsi_3_1d > 60.0):
+      elif (last_rsi_3 < 4.0) and (last_rsi_3_1h > 90.0) and (last_rsi_3_4h_gt_70) and (last_rsi_3_1d_gt_60):
         return True, f"exit_{mode_name}_d_12_127"
       elif (last_rsi_3 < 1.0) and (last_rsi_3_4h_gt_70) and (last_aroond_14_4h > 85.0):
         return True, f"exit_{mode_name}_d_12_128"
@@ -63129,7 +63194,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (
         (last_rsi_3 < 14.0)
         and (last_rsi_3_1h > 65.0)
-        and (last_rsi_3_4h > 65.0)
+        and (last_rsi_3_4h_gt_65)
         and (last_aroond_14_1h > 50.0)
         and (last_stochrsi_k_1h < 60.0)
       ):


### PR DESCRIPTION
## Summary
- Hoists repeated short DEC exit threshold checks into local booleans.
- This branch is independent on latest upstream `main`.

## Safety
- Only already-read values are reused inside the same call.
- Indicator formulas, candle selection, order classification, profit arithmetic, thresholds, condition order, and return values are unchanged.
- No v3 grind-entry code is touched.
- Touched function(s): `short_exit_dec`.

## Backtest scope
- Full backtesting was not required because this patch only reuses already-read local values inside the same call. Indicators, candle selection, order classification, profit arithmetic, thresholds, and trading conditions are unchanged.

## Checks
- `python3 ~/.codex/skills/nfi-upstream-pr/scripts/validate_nfi_pr.py --base origin/main`
- `git merge-tree` conflict simulation against `origin/main` (via validator)
- AST undefined-local scan for introduced `last_*` / `previous_*` / `current_*` locals (via validator)
- `git diff --check` (via validator)
- `ruff format --check NostalgiaForInfinityX7.py` (via validator)
- `ruff check NostalgiaForInfinityX7.py` (via validator)
- `PYTHONDONTWRITEBYTECODE=1 python3 -m py_compile NostalgiaForInfinityX7.py` (via validator)
