### PR TITLE
Reuse X7 entry-trend RSI/ROC masks

### DIFF
--- a/NostalgiaForInfinityX7.py
+++ b/NostalgiaForInfinityX7.py
@@ -12692,6 +12692,58 @@ class NostalgiaForInfinityX7(IStrategy):
     roc_9_1d_lt_50 = roc_9_1d < 50.0
     roc_9_1d_lt_100 = roc_9_1d < 100.0
 
+    # Reused entry-trend RSI and ROC masks
+    rsi_3_15m_gt_10 = rsi_3_15m > 10.0
+    rsi_3_15m_gt_15 = rsi_3_15m > 15.0
+    rsi_3_1h_gt_30 = rsi_3_1h > 30.0
+    rsi_3_1h_gt_25 = rsi_3_1h > 25.0
+    rsi_3_15m_gt_5 = rsi_3_15m > 5.0
+    rsi_3_15m_gt_20 = rsi_3_15m > 20.0
+    rsi_3_4h_gt_30 = rsi_3_4h > 30.0
+    rsi_3_4h_gt_25 = rsi_3_4h > 25.0
+    rsi_3_1h_gt_5 = rsi_3_1h > 5.0
+    aroonu_14_15m_lt_70 = aroonu_14_15m < 70.0
+    rsi_3_1h_gt_35 = rsi_3_1h > 35.0
+    rsi_3_15m_gt_25 = rsi_3_15m > 25.0
+    roc_9_4h_lt_10 = roc_9_4h < 10.0
+    rsi_3_1h_gt_40 = rsi_3_1h > 40.0
+    aroonu_14_4h_lt_90 = aroonu_14_4h < 90.0
+    rsi_3_1h_gt_3 = rsi_3_1h > 3.0
+    aroonu_14_1d_lt_90 = aroonu_14_1d < 90.0
+    roc_9_1d_lt_20 = roc_9_1d < 20.0
+    roc_9_1d_lt_40 = roc_9_1d < 40.0
+    aroonu_14_1d_lt_80 = aroonu_14_1d < 80.0
+    rsi_3_4h_gt_35 = rsi_3_4h > 35.0
+    aroonu_14_4h_lt_50 = aroonu_14_4h < 50.0
+    roc_9_1d_gt_neg_40 = roc_9_1d > -40.0
+    aroonu_14_1d_lt_70 = aroonu_14_1d < 70.0
+    rsi_3_gt_3 = rsi_3 > 3.0
+    rsi_3_4h_gt_40 = rsi_3_4h > 40.0
+    aroonu_14_15m_lt_50 = aroonu_14_15m < 50.0
+    roc_9_4h_lt_30 = roc_9_4h < 30.0
+    aroonu_14_1h_lt_50 = aroonu_14_1h < 50.0
+    stochrsi_k_4h_lt_50 = stochrsi_k_4h < 50.0
+    rsi_3_1d_gt_20 = rsi_3_1d > 20.0
+    roc_9_1d_lt_30 = roc_9_1d < 30.0
+    aroonu_14_1h_lt_90 = aroonu_14_1h < 90.0
+    rsi_3_4h_gt_50 = rsi_3_4h > 50.0
+    rsi_3_4h_gt_5 = rsi_3_4h > 5.0
+    roc_9_1h_lt_10 = roc_9_1h < 10.0
+    stochrsi_k_4h_lt_70 = stochrsi_k_4h < 70.0
+    rsi_3_1d_gt_15 = rsi_3_1d > 15.0
+    stochrsi_k_1d_lt_90 = stochrsi_k_1d < 90.0
+    rsi_3_1h_gt_50 = rsi_3_1h > 50.0
+    rsi_3_1d_gt_25 = rsi_3_1d > 25.0
+    rsi_3_1h_gt_45 = rsi_3_1h > 45.0
+    rsi_3_1d_gt_10 = rsi_3_1d > 10.0
+    aroonu_14_4h_lt_40 = aroonu_14_4h < 40.0
+    roc_9_1d_lt_80 = roc_9_1d < 80.0
+    aroonu_14_4h_lt_60 = aroonu_14_4h < 60.0
+    rsi_3_15m_gt_30 = rsi_3_15m > 30.0
+    aroonu_14_1h_lt_100 = aroonu_14_1h < 100.0
+    roc_9_4h_gt_neg_30 = roc_9_4h > -30.0
+    roc_9_4h_lt_40 = roc_9_4h < 40.0
+
     is_backtest = self.dp.runmode.value in ["backtest", "hyperopt", "plot", "webserver"]
     # the number of free slots
     current_free_slots = config["max_open_trades"]
@@ -12749,223 +12801,223 @@ class NostalgiaForInfinityX7(IStrategy):
 
           long_entry_logic.append(
             # 5m & 15m & 1h down move
-            ((rsi_3 > 3.0) | rsi_3_15m_gt_3 | (rsi_3_change_pct_1h > -50.0))
+            ((rsi_3_gt_3) | rsi_3_15m_gt_3 | (rsi_3_change_pct_1h > -50.0))
             # 5m & 15m down move, 5h high
-            & ((rsi_3 > 3.0) | (rsi_3_15m > 5.0) | (rsi_14_4h < 60.0))
+            & ((rsi_3_gt_3) | (rsi_3_15m_gt_5) | (rsi_14_4h < 60.0))
             # 5m & 15m down move, 4h high
-            & ((rsi_3 > 3.0) | (rsi_3_15m > 10.0) | aroonu_14_4h_lt_100)
+            & ((rsi_3_gt_3) | (rsi_3_15m_gt_10) | aroonu_14_4h_lt_100)
             # 5m & 1h down move
-            & ((rsi_3 > 3.0) | (rsi_3_1h > 5.0))
+            & ((rsi_3_gt_3) | (rsi_3_1h_gt_5))
             # 5m & 1h down move, 15m still not low enough
             & ((rsi_3 > 5.0) | (rsi_3_1h_gt_10) | (aroonu_14_15m < 30.0))
             # 5m & 1h down move, 4h high
-            & ((rsi_3 > 3.0) | (rsi_3_1h > 25.0) | (stochrsi_k_4h_lt_80))
+            & ((rsi_3_gt_3) | (rsi_3_1h_gt_25) | (stochrsi_k_4h_lt_80))
             # 15m & 1h down move, 1d still high
-            & (rsi_3_15m_gt_3 | (rsi_3_1h > 3.0) | (stochrsi_k_1d < 50.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_3) | (stochrsi_k_1d < 50.0))
             # 5m & 1h down move, 15m still not low enough
-            & ((rsi_3 > 3.0) | (rsi_3_1h_gt_15) | (aroonu_14_15m < 30.0))
+            & ((rsi_3_gt_3) | (rsi_3_1h_gt_15) | (aroonu_14_15m < 30.0))
             # 5m & 4h down move, 4h high
-            & ((rsi_3 > 3.0) | (rsi_3_4h > 25.0) | aroonu_14_4h_lt_70)
+            & ((rsi_3_gt_3) | (rsi_3_4h_gt_25) | aroonu_14_4h_lt_70)
             # 5m down move, 15m high
-            & ((rsi_3 > 3.0) | (aroonu_14_15m < 80.0))
+            & ((rsi_3_gt_3) | (aroonu_14_15m < 80.0))
             # 5m down move, 1h high, 4h overbought
-            & ((rsi_3 > 3.0) | (stochrsi_k_1h < 80.0) | (roc_9_4h_lt_20))
+            & ((rsi_3_gt_3) | (stochrsi_k_1h < 80.0) | (roc_9_4h_lt_20))
             # 5m & 4h down move, 4h high
-            & ((rsi_3 > 5.0) | (rsi_3_4h > 35.0) | aroonu_14_4h_lt_70)
+            & ((rsi_3 > 5.0) | (rsi_3_4h_gt_35) | aroonu_14_4h_lt_70)
             # 15m down move, 1h downtrend, 1h high
             & ((rsi_3_15m > 1.0) | (cmf_20_1h > -0.1) | aroonu_14_1h_lt_70)
             # 15m & 1h & 4h down move
             & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_10) | (rsi_3_4h_gt_15))
             # 15m & 1h down move, 1h still high
-            & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_10) | (aroonu_14_1h < 50.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_10) | (aroonu_14_1h_lt_50))
             # 15m & 1h down move, 1d high
             & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_10) | (aroonu_14_1d < 100.0))
             # 15m & 1h down move, 1h still high
             & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_10) | (stochrsi_k_1h < 40.0))
             # 15m & 1h & 4h & 1d down move
-            & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_15) | (rsi_3_4h_gt_15) | (rsi_3_1d > 15.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_15) | (rsi_3_4h_gt_15) | (rsi_3_1d_gt_15))
             # 15m & 1h down move, 15m still high
             & (rsi_3_15m_gt_3 | rsi_3_1h_gt_20 | (aroonu_14_15m < 40.0))
             # 15m & 1h down move, 1h high
             & (rsi_3_15m_gt_3 | rsi_3_1h_gt_20 | aroonu_14_1h_lt_70)
             # 15m & 1h down move, 1h high
-            & (rsi_3_15m_gt_3 | (rsi_3_1h > 30.0) | aroonu_14_1h_lt_80)
+            & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_30) | aroonu_14_1h_lt_80)
             # 15m & 1h down move, 1h still high
-            & (rsi_3_15m_gt_3 | (rsi_3_1h > 35.0) | (stochrsi_k_4h < 50.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_35) | (stochrsi_k_4h_lt_50))
             # 15m & 1h down move, 1h high
-            & (rsi_3_15m_gt_3 | (rsi_3_1h > 40.0) | (stochrsi_k_1h_lt_70))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_40) | (stochrsi_k_1h_lt_70))
             # 15m & 1h down move, 1h high
-            & (rsi_3_15m_gt_3 | (rsi_3_1h > 45.0) | aroonu_14_1h_lt_80)
+            & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_45) | aroonu_14_1h_lt_80)
             # 15m & 4h down move, 1d high
-            & (rsi_3_15m_gt_3 | (rsi_3_4h_gt_15) | (stochrsi_k_1d < 90.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_4h_gt_15) | (stochrsi_k_1d_lt_90))
             # 15m & 4h down move, 4h high
-            & (rsi_3_15m_gt_3 | (rsi_3_4h > 25.0) | (aroonu_14_4h < 60.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_4h_gt_25) | (aroonu_14_4h_lt_60))
             # 15m & 4h down move, 1d downtrend
-            & (rsi_3_15m_gt_3 | (rsi_3_4h > 30.0) | roc_9_1d_gt_neg_50)
+            & (rsi_3_15m_gt_3 | (rsi_3_4h_gt_30) | roc_9_1d_gt_neg_50)
             # 15m & 4h down move, 4h still high
-            & (rsi_3_15m_gt_3 | (rsi_3_4h > 35.0) | (stochrsi_k_4h < 50.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_4h_gt_35) | (stochrsi_k_4h_lt_50))
             # 15m down move, 15m downtrend
             & (rsi_3_15m_gt_3 | (cmf_20_15m > -0.40) | (roc_9_15m > -20.0))
             # 15m down move, 15m still high, 15m downtrend
             & (rsi_3_15m_gt_3 | (aroonu_14_15m < 40.0) | (roc_9_15m > -20.0))
             # 15m down move, 1h & 4h high
-            & (rsi_3_15m_gt_3 | (aroonu_14_1h < 85.0) | (aroonu_14_4h < 90.0))
+            & (rsi_3_15m_gt_3 | (aroonu_14_1h < 85.0) | (aroonu_14_4h_lt_90))
             # 15m down move, 4h high, 15m downtrend
             & (rsi_3_15m_gt_3 | aroonu_14_4h_lt_70 | (roc_9_15m > -20.0))
             # 15m down move, 4h high, 1d overbought
             & (rsi_3_15m_gt_3 | (aroonu_14_4h < 85.0) | (roc_9_1d_lt_100))
             # 15m down move, 1h high, 4h overbought
-            & (rsi_3_15m_gt_3 | (stochrsi_k_1h < 90.0) | (roc_9_4h < 10.0))
+            & (rsi_3_15m_gt_3 | (stochrsi_k_1h < 90.0) | (roc_9_4h_lt_10))
             # 15m down move, 4h high & overbought
-            & (rsi_3_15m_gt_3 | (stochrsi_k_4h_lt_80) | (roc_9_4h < 30.0))
+            & (rsi_3_15m_gt_3 | (stochrsi_k_4h_lt_80) | (roc_9_4h_lt_30))
             # 15m down move, drop in last half hour, 15m downtrend
             & (rsi_3_15m_gt_3 | (close > (df["close_max_6"] * 0.75)) | (roc_9_15m > -20.0))
             # 15m & 1h down move, 1h still high
-            & ((rsi_3_15m > 5.0) | (rsi_3_1h > 5.0) | (aroonu_14_1h < 50.0))
+            & ((rsi_3_15m_gt_5) | (rsi_3_1h_gt_5) | (aroonu_14_1h_lt_50))
             # 15m & 1h down move, 4h high
-            & ((rsi_3_15m > 5.0) | (rsi_3_1h > 5.0) | aroonu_14_4h_lt_70)
+            & ((rsi_3_15m_gt_5) | (rsi_3_1h_gt_5) | aroonu_14_4h_lt_70)
             # 15m & 1h down move, 1d overbought
-            & ((rsi_3_15m > 5.0) | (rsi_3_1h > 5.0) | (roc_9_1d < 40.0))
+            & ((rsi_3_15m_gt_5) | (rsi_3_1h_gt_5) | (roc_9_1d_lt_40))
             # 5m & 1h down move, 1h overbought
-            & ((rsi_3_15m > 5.0) | (rsi_3_1h > 60.0) | (roc_9_1h < 40.0))
+            & ((rsi_3_15m_gt_5) | (rsi_3_1h > 60.0) | (roc_9_1h < 40.0))
             # 15m & 4h down move, 1d still high
-            & ((rsi_3_15m > 5.0) | (rsi_3_4h > 5.0) | (stochrsi_k_1d < 40.0))
+            & ((rsi_3_15m_gt_5) | (rsi_3_4h_gt_5) | (stochrsi_k_1d < 40.0))
             # 15m & 4h down move, 1d downtrend
-            & ((rsi_3_15m > 5.0) | (rsi_3_4h > 5.0) | (roc_9_1d_gt_neg_20))
+            & ((rsi_3_15m_gt_5) | (rsi_3_4h_gt_5) | (roc_9_1d_gt_neg_20))
             # 15m & 4h down move, 1h still high
-            & ((rsi_3_15m > 5.0) | (rsi_3_4h_gt_10) | (stochrsi_k_1h < 50.0))
+            & ((rsi_3_15m_gt_5) | (rsi_3_4h_gt_10) | (stochrsi_k_1h < 50.0))
             # 15m & 4h down move, 1d high
-            & ((rsi_3_15m > 5.0) | (rsi_3_4h_gt_15) | (stochrsi_k_1d < 60.0))
+            & ((rsi_3_15m_gt_5) | (rsi_3_4h_gt_15) | (stochrsi_k_1d < 60.0))
             # 15m & 4h down move, 15m still high
-            & ((rsi_3_15m > 5.0) | (rsi_3_4h > 30.0) | (stochrsi_k_15m < 50.0))
+            & ((rsi_3_15m_gt_5) | (rsi_3_4h_gt_30) | (stochrsi_k_15m < 50.0))
             # 15m down move, 15m & 4h still high
-            & ((rsi_3_15m > 5.0) | (aroonu_14_15m < 50.0) | (aroonu_14_4h < 60.0))
+            & ((rsi_3_15m_gt_5) | (aroonu_14_15m_lt_50) | (aroonu_14_4h_lt_60))
             # 15m down move, 15m still high, 1d overbought
-            & ((rsi_3_15m > 5.0) | (aroonu_14_15m < 50.0) | (roc_9_1d < 80.0))
+            & ((rsi_3_15m_gt_5) | (aroonu_14_15m_lt_50) | (roc_9_1d_lt_80))
             # 15m down move, 15m high
-            & ((rsi_3_15m > 5.0) | (aroonu_14_15m < 80.0))
+            & ((rsi_3_15m_gt_5) | (aroonu_14_15m < 80.0))
             # 15m down move, 4h high, 1d overbought
-            & ((rsi_3_15m > 5.0) | (aroonu_14_4h < 60.0) | (roc_9_1d < 80.0))
+            & ((rsi_3_15m_gt_5) | (aroonu_14_4h_lt_60) | (roc_9_1d_lt_80))
             # 15m & 1h down move, 1h still high
-            & ((rsi_3_15m > 10.0) | (rsi_3_1h_gt_10) | (stochrsi_k_1h < 40.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_10) | (stochrsi_k_1h < 40.0))
             # 15m & 1h down move, 4h high
-            & ((rsi_3_15m > 10.0) | (rsi_3_1h_gt_10) | (stochrsi_k_4h < 70.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_10) | (stochrsi_k_4h_lt_70))
             # 15m & 1h down move, 1h still high
-            & ((rsi_3_15m > 10.0) | (rsi_3_1h_gt_15) | (stochrsi_k_1h < 50.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_15) | (stochrsi_k_1h < 50.0))
             # 15m & 1h down move, 1d downtrend
-            & ((rsi_3_15m > 10.0) | (rsi_3_1h_gt_15) | (roc_9_1d > -40.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_15) | (roc_9_1d_gt_neg_40))
             # 15m & 1h down move, 4h high
-            & ((rsi_3_15m > 10.0) | rsi_3_1h_gt_20 | (rsi_14_4h < 80.0))
+            & ((rsi_3_15m_gt_10) | rsi_3_1h_gt_20 | (rsi_14_4h < 80.0))
             # 15m & 1h down move, 15m still high
-            & ((rsi_3_15m > 10.0) | rsi_3_1h_gt_20 | (aroonu_14_15m < 50.0))
+            & ((rsi_3_15m_gt_10) | rsi_3_1h_gt_20 | (aroonu_14_15m_lt_50))
             # 15m & 1h down move, 4h overbought
-            & ((rsi_3_15m > 10.0) | (rsi_3_1h > 25.0) | (roc_9_4h < 80.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_25) | (roc_9_4h < 80.0))
             # 15m & 4h down move, 1h high
-            & ((rsi_3_15m > 10.0) | (rsi_3_4h_gt_10) | (aroonu_14_1h < 75.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_4h_gt_10) | (aroonu_14_1h < 75.0))
             # 15m & 4h down move, 15m still high
-            & ((rsi_3_15m > 10.0) | (rsi_3_4h_gt_10) | (stochrsi_k_15m < 50.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_4h_gt_10) | (stochrsi_k_15m < 50.0))
             # 15m & 4h down move, 1h still high
-            & ((rsi_3_15m > 10.0) | (rsi_3_4h_gt_10) | (stochrsi_k_1h < 40.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_4h_gt_10) | (stochrsi_k_1h < 40.0))
             # 15m & 4h down move, 4h downtrend
-            & ((rsi_3_15m > 10.0) | (rsi_3_4h_gt_10) | (roc_9_4h > -20.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_4h_gt_10) | (roc_9_4h > -20.0))
             # 15m & 4h down move, 1d overbought
-            & ((rsi_3_15m > 10.0) | (rsi_3_4h > 25.0) | (roc_9_1d < 30.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_4h_gt_25) | (roc_9_1d_lt_30))
             # 15m & 4h down move, 1h high
-            & ((rsi_3_15m > 10.0) | (rsi_3_4h > 30.0) | (aroonu_14_1h < 85.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_4h_gt_30) | (aroonu_14_1h < 85.0))
             # 15m & 4h down move, 4h high
-            & ((rsi_3_15m > 10.0) | (rsi_3_4h > 60.0) | (stochrsi_k_4h_lt_90))
+            & ((rsi_3_15m_gt_10) | (rsi_3_4h > 60.0) | (stochrsi_k_4h_lt_90))
             # 15m & 1d down move, 1d high
-            & ((rsi_3_15m > 10.0) | (rsi_3_1d > 50.0) | (stochrsi_k_1d < 80.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_1d > 50.0) | (stochrsi_k_1d < 80.0))
             # 15m down move & downtrend, 4h high
-            & ((rsi_3_15m > 10.0) | (cmf_20_15m > -0.3) | aroonu_14_4h_lt_100)
+            & ((rsi_3_15m_gt_10) | (cmf_20_15m > -0.3) | aroonu_14_4h_lt_100)
             # 15m down move, 15m & 4h high
-            & ((rsi_3_15m > 10.0) | (aroonu_14_15m < 70.0) | aroonu_14_4h_lt_80)
+            & ((rsi_3_15m_gt_10) | (aroonu_14_15m_lt_70) | aroonu_14_4h_lt_80)
             # 15m down move, 1h high & overbought
-            & ((rsi_3_15m > 10.0) | (aroonu_14_1h < 90.0) | (roc_9_1h < 20.0))
+            & ((rsi_3_15m_gt_10) | (aroonu_14_1h_lt_90) | (roc_9_1h < 20.0))
             # 15m down move, 1h high, 1d downtrend
-            & ((rsi_3_15m > 10.0) | (aroonu_14_1h < 90.0) | (roc_9_1d > -40.0))
+            & ((rsi_3_15m_gt_10) | (aroonu_14_1h_lt_90) | (roc_9_1d_gt_neg_40))
             # 15m down move, 1h high, 1d overbought
-            & ((rsi_3_15m > 10.0) | (aroonu_14_1h < 100.0) | (roc_9_1d < 80.0))
+            & ((rsi_3_15m_gt_10) | (aroonu_14_1h_lt_100) | (roc_9_1d_lt_80))
             # 15m down move, 1h high, 4h downtrend
-            & ((rsi_3_15m > 10.0) | (stochrsi_k_1h_lt_70) | (roc_9_4h > -25.0))
+            & ((rsi_3_15m_gt_10) | (stochrsi_k_1h_lt_70) | (roc_9_4h > -25.0))
             # 15m down move, 1h high, 1d downtrend
-            & ((rsi_3_15m > 10.0) | (stochrsi_k_1h_lt_70) | roc_9_1d_gt_neg_50)
+            & ((rsi_3_15m_gt_10) | (stochrsi_k_1h_lt_70) | roc_9_1d_gt_neg_50)
             # 15m down move, 1h high & overbought
-            & ((rsi_3_15m > 10.0) | (stochrsi_k_1h < 90.0) | (roc_9_1h < 20.0))
+            & ((rsi_3_15m_gt_10) | (stochrsi_k_1h < 90.0) | (roc_9_1h < 20.0))
             # 15m down move, 1h & 1d overbought
-            & ((rsi_3_15m > 10.0) | (roc_9_1h < 10.0) | (roc_9_1d < 80.0))
+            & ((rsi_3_15m_gt_10) | (roc_9_1h_lt_10) | (roc_9_1d_lt_80))
             # 15m down move, 4h high
-            & ((rsi_3_15m > 10.0) | (roc_9_4h < 60.0))
+            & ((rsi_3_15m_gt_10) | (roc_9_4h < 60.0))
             # 15m & 1h down move, 1h high
-            & ((rsi_3_15m > 15.0) | rsi_3_1h_gt_20 | aroonu_14_1h_lt_80)
+            & ((rsi_3_15m_gt_15) | rsi_3_1h_gt_20 | aroonu_14_1h_lt_80)
             # 15m down move, 15m still high, 4h overbought
-            & ((rsi_3_15m > 15.0) | (rsi_14_15m < 50.0) | (roc_9_4h < 50.0))
+            & ((rsi_3_15m_gt_15) | (rsi_14_15m < 50.0) | (roc_9_4h < 50.0))
             # 15m down move, 15m & 1h high
-            & ((rsi_3_15m > 15.0) | (aroonu_14_15m < 70.0) | (aroonu_14_1h < 100.0))
+            & ((rsi_3_15m_gt_15) | (aroonu_14_15m_lt_70) | (aroonu_14_1h_lt_100))
             # 15m down move, 15m & 1h high
-            & ((rsi_3_15m > 15.0) | (aroonu_14_15m < 80.0) | (aroonu_14_1h < 90.0))
+            & ((rsi_3_15m_gt_15) | (aroonu_14_15m < 80.0) | (aroonu_14_1h_lt_90))
             # 15m & 4h down move, 15m still high
-            & ((rsi_3_15m > 20.0) | (rsi_3_4h > 35.0) | (aroonu_14_15m < 40.0))
+            & ((rsi_3_15m_gt_20) | (rsi_3_4h_gt_35) | (aroonu_14_15m < 40.0))
             # 15m down move, 1h & 4h high
-            & ((rsi_3_15m > 20.0) | (aroonu_14_1h < 100.0) | aroonu_14_4h_lt_100)
+            & ((rsi_3_15m_gt_20) | (aroonu_14_1h_lt_100) | aroonu_14_4h_lt_100)
             # 15m down move, 1h high & overbought
-            & ((rsi_3_15m > 20.0) | (aroonu_14_1h < 100.0) | (roc_9_1h < 20.0))
+            & ((rsi_3_15m_gt_20) | (aroonu_14_1h_lt_100) | (roc_9_1h < 20.0))
             # 15m down move, 4h high & overbought
-            & ((rsi_3_15m > 25.0) | aroonu_14_4h_lt_100 | (roc_9_4h < 10.0))
+            & ((rsi_3_15m_gt_25) | aroonu_14_4h_lt_100 | (roc_9_4h_lt_10))
             # 15m down move, 1d overbought
-            & ((rsi_3_15m > 30.0) | (roc_9_1d < 80.0))
+            & ((rsi_3_15m_gt_30) | (roc_9_1d_lt_80))
             # 15m & 4h down move, 15m high
             & ((rsi_3_15m > 40.0) | (rsi_3_4h > 45.0) | (stochrsi_k_15m < 70.0))
             # 1h & 4h down move, 4h downtrend
-            & ((rsi_3_1h > 3.0) | (rsi_3_4h_gt_10) | (roc_9_4h > -10.0))
+            & ((rsi_3_1h_gt_3) | (rsi_3_4h_gt_10) | (roc_9_4h > -10.0))
             # 1h & 4h down move, 1h still high
-            & ((rsi_3_1h > 3.0) | (rsi_3_4h_gt_15) | (aroonu_14_1h < 50.0))
+            & ((rsi_3_1h_gt_3) | (rsi_3_4h_gt_15) | (aroonu_14_1h_lt_50))
             # 1h & 4h down move, 1d high
-            & ((rsi_3_1h > 3.0) | (rsi_3_4h_gt_15) | (aroonu_14_1d < 90.0))
+            & ((rsi_3_1h_gt_3) | (rsi_3_4h_gt_15) | (aroonu_14_1d_lt_90))
             # 1h & 4h down move, 1d high
-            & ((rsi_3_1h > 3.0) | (rsi_3_4h > 25.0) | aroonu_14_1d_lt_100)
+            & ((rsi_3_1h_gt_3) | (rsi_3_4h_gt_25) | aroonu_14_1d_lt_100)
             # 1h & 1d down move, 4h still high
-            & ((rsi_3_1h > 3.0) | (rsi_3_1d > 15.0) | (stochrsi_k_4h < 50.0))
+            & ((rsi_3_1h_gt_3) | (rsi_3_1d_gt_15) | (stochrsi_k_4h_lt_50))
             # 1h & 4h down move, 1d overbought
-            & ((rsi_3_1h > 5.0) | (rsi_3_4h > 5.0) | (roc_9_1d < 10.0))
+            & ((rsi_3_1h_gt_5) | (rsi_3_4h_gt_5) | (roc_9_1d < 10.0))
             # 1h & 4h down move, 4h still high
-            & ((rsi_3_1h > 5.0) | (rsi_3_4h_gt_10) | (aroonu_14_4h < 40.0))
+            & ((rsi_3_1h_gt_5) | (rsi_3_4h_gt_10) | (aroonu_14_4h_lt_40))
             # 1h & 4h down move, 1h downtrend
-            & ((rsi_3_1h > 5.0) | (rsi_3_4h_gt_10) | (cmf_20_1h > -0.3))
+            & ((rsi_3_1h_gt_5) | (rsi_3_4h_gt_10) | (cmf_20_1h > -0.3))
             # 1h & 4h down move, 1d downtrend
-            & ((rsi_3_1h > 5.0) | (rsi_3_4h_gt_10) | (roc_9_1d > -40.0))
+            & ((rsi_3_1h_gt_5) | (rsi_3_4h_gt_10) | (roc_9_1d_gt_neg_40))
             # 1h & 4h down move, 4h still not low enough
-            & ((rsi_3_1h > 5.0) | (rsi_3_4h_gt_15) | (aroonu_14_4h < 30.0))
+            & ((rsi_3_1h_gt_5) | (rsi_3_4h_gt_15) | (aroonu_14_4h < 30.0))
             # 1h & 4h down move, 4h high
-            & ((rsi_3_1h > 5.0) | (rsi_3_4h > 50.0) | aroonu_14_4h_lt_70)
+            & ((rsi_3_1h_gt_5) | (rsi_3_4h_gt_50) | aroonu_14_4h_lt_70)
             # 1h & 4h down move, 1d overbought
-            & ((rsi_3_1h > 5.0) | rsi_3_4h_gt_20 | (roc_9_1d < 40.0))
+            & ((rsi_3_1h_gt_5) | rsi_3_4h_gt_20 | (roc_9_1d_lt_40))
             # 1h & 1d down move, 1d downtrend
-            & ((rsi_3_1h > 5.0) | (rsi_3_1d > 5.0) | (roc_9_1d_gt_neg_30))
+            & ((rsi_3_1h_gt_5) | (rsi_3_1d > 5.0) | (roc_9_1d_gt_neg_30))
             # 1h down move, 1h still high, 4h high
-            & ((rsi_3_1h > 5.0) | (aroonu_14_1h < 50.0) | (aroonu_14_4h < 90.0))
+            & ((rsi_3_1h_gt_5) | (aroonu_14_1h_lt_50) | (aroonu_14_4h_lt_90))
             # 1h down move, 1d high, 4h downtrend
-            & ((rsi_3_1h > 5.0) | (aroonu_14_1d < 90.0) | (roc_9_4h > -30.0))
+            & ((rsi_3_1h_gt_5) | (aroonu_14_1d_lt_90) | (roc_9_4h_gt_neg_30))
             # 1h & 4h down move, 15m still not low enough
             & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_10) | (aroonu_14_15m < 30.0))
             # 1h & 4h down move, 1h still high
             & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_10) | (stochrsi_k_1h < 50.0))
             # 1h & 1d down move, 4h high
-            & ((rsi_3_1h_gt_10) | (rsi_3_1d > 20.0) | (aroonu_14_4h < 80.0))
+            & ((rsi_3_1h_gt_10) | (rsi_3_1d_gt_20) | (aroonu_14_4h < 80.0))
             # 1h down move, 4h high
             & ((rsi_3_1h_gt_10) | (rsi_14_4h < 75.0))
             # 1h down move, 15m downtrend, 1d high
-            & ((rsi_3_1h_gt_10) | (cmf_20_15m > -0.40) | (aroonu_14_1d < 70.0))
+            & ((rsi_3_1h_gt_10) | (cmf_20_15m > -0.40) | (aroonu_14_1d_lt_70))
             # 1h down move, 1h high, 4h overbought
-            & ((rsi_3_1h_gt_10) | (aroonu_14_1h < 70.0) | (roc_9_4h < 10.0))
+            & ((rsi_3_1h_gt_10) | (aroonu_14_1h < 70.0) | (roc_9_4h_lt_10))
             # 1h down move, 4h overbought
             & ((rsi_3_1h_gt_10) | (roc_9_4h < 50.0))
             # 1h & 4h down move, 4h still high
-            & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_15) | (aroonu_14_4h < 40.0))
+            & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_15) | (aroonu_14_4h_lt_40))
             # 1h & 4h down move, 4h high
             & ((rsi_3_1h_gt_15) | rsi_3_4h_gt_20 | (aroonu_14_4h < 80.0))
             # 1h & 4h down move, 1d overbought
-            & ((rsi_3_1h_gt_15) | (rsi_3_4h > 25.0) | (roc_9_1d < 40.0))
+            & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_25) | (roc_9_1d_lt_40))
             # 15m down move, 1h high, 1d downtrend
             & ((rsi_3_1h_gt_15) | (aroonu_14_1h < 70.0) | (roc_9_1d > -20.0))
             # 1h down move, 1h high, 1d overbought
@@ -12973,141 +13025,141 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h high
             & ((rsi_3_1h_gt_15) | (aroonu_14_1h < 80.0))
             # 1h down mve, 4h high, 1d overbought
-            & ((rsi_3_1h_gt_15) | (aroonu_14_4h < 80.0) | (roc_9_1d < 30.0))
+            & ((rsi_3_1h_gt_15) | (aroonu_14_4h < 80.0) | (roc_9_1d_lt_30))
             # 1h down move, 1d high & overbought
-            & ((rsi_3_1h_gt_15) | (aroonu_14_1d < 80.0) | (roc_9_1d < 40.0))
+            & ((rsi_3_1h_gt_15) | (aroonu_14_1d_lt_80) | (roc_9_1d_lt_40))
             # 1h down move, 1h & 4h downtrend
-            & ((rsi_3_1h_gt_15) | (roc_9_1h > -30.0) | (roc_9_4h > -30.0))
+            & ((rsi_3_1h_gt_15) | (roc_9_1h > -30.0) | (roc_9_4h_gt_neg_30))
             # 1h & 4h down move, 4h overbought
-            & (rsi_3_1h_gt_20 | (rsi_3_4h > 50.0) | (roc_9_4h < 80.0))
+            & (rsi_3_1h_gt_20 | (rsi_3_4h_gt_50) | (roc_9_4h < 80.0))
             # 1h down move, 1h still high, 4h downtrend
-            & (rsi_3_1h_gt_20 | (aroonu_14_1h < 40.0) | (roc_9_4h > -30.0))
+            & (rsi_3_1h_gt_20 | (aroonu_14_1h < 40.0) | (roc_9_4h_gt_neg_30))
             # 1h down move, 4h high, 1d overbought
             & (rsi_3_1h_gt_20 | aroonu_14_4h_lt_70 | (roc_9_1d < 200.0))
             # 1h down move, 4h high, 1d overbought
-            & (rsi_3_1h_gt_20 | (aroonu_14_4h < 90.0) | (roc_9_1d < 60.0))
+            & (rsi_3_1h_gt_20 | (aroonu_14_4h_lt_90) | (roc_9_1d < 60.0))
             # 1h down move, 4h high & overbought
             & (rsi_3_1h_gt_20 | aroonu_14_4h_lt_100 | (roc_9_4h < 50.0))
             # 1h down move, 1d high & overbought
-            & (rsi_3_1h_gt_20 | (stochrsi_k_1d < 90.0) | (roc_9_1d < 80.0))
+            & (rsi_3_1h_gt_20 | (stochrsi_k_1d_lt_90) | (roc_9_1d_lt_80))
             # 1h down move, 1h high, 15n downtrend
-            & ((rsi_3_1h > 25.0) | aroonu_14_1h_lt_70 | (roc_9_15m > -20.0))
+            & ((rsi_3_1h_gt_25) | aroonu_14_1h_lt_70 | (roc_9_15m > -20.0))
             # 1h down move, 1h still high, 1d overbought
-            & ((rsi_3_1h > 25.0) | (stochrsi_k_1h_lt_50) | (roc_9_1d < 40.0))
+            & ((rsi_3_1h_gt_25) | (stochrsi_k_1h_lt_50) | (roc_9_1d_lt_40))
             # 1h down move, 4h & 1d overbought
-            & ((rsi_3_1h > 25.0) | (roc_9_4h < 80.0) | (roc_9_1d_lt_100))
+            & ((rsi_3_1h_gt_25) | (roc_9_4h < 80.0) | (roc_9_1d_lt_100))
             # 1h & 4h down move, 4h downtrend
-            & ((rsi_3_1h > 30.0) | (rsi_3_4h > 30.0) | (roc_9_4h_gt_neg_20))
+            & ((rsi_3_1h_gt_30) | (rsi_3_4h_gt_30) | (roc_9_4h_gt_neg_20))
             # 1h down move, 4h high, 1d downtrend
-            & ((rsi_3_1h > 35.0) | (aroonu_14_4h < 90.0) | (roc_9_1d_gt_neg_20))
+            & ((rsi_3_1h_gt_35) | (aroonu_14_4h_lt_90) | (roc_9_1d_gt_neg_20))
             # 1h down move, 1d high & overbought
-            & ((rsi_3_1h > 35.0) | (aroonu_14_1d < 90.0) | (roc_9_1d < 80.0))
+            & ((rsi_3_1h_gt_35) | (aroonu_14_1d_lt_90) | (roc_9_1d_lt_80))
             # 1h down move, 4h & 1d overbought
-            & ((rsi_3_1h > 35.0) | (roc_9_4h < 40.0) | (roc_9_1d < 80.0))
+            & ((rsi_3_1h_gt_35) | (roc_9_4h_lt_40) | (roc_9_1d_lt_80))
             # 1h down move, 1h downtrend, 1h high
-            & ((rsi_3_1h > 40.0) | (cmf_20_1h > -0.25) | (aroonu_14_1h < 90.0))
+            & ((rsi_3_1h_gt_40) | (cmf_20_1h > -0.25) | (aroonu_14_1h_lt_90))
             # 1h down move, 1h & 4h high
-            & ((rsi_3_1h > 40.0) | (aroonu_14_1h < 60.0) | aroonu_14_4h_lt_100)
+            & ((rsi_3_1h_gt_40) | (aroonu_14_1h < 60.0) | aroonu_14_4h_lt_100)
             # 1h down move, 1h high, 15m downtrend
-            & ((rsi_3_1h > 40.0) | aroonu_14_1h_lt_80 | (roc_9_15m > -15.0))
+            & ((rsi_3_1h_gt_40) | aroonu_14_1h_lt_80 | (roc_9_15m > -15.0))
             # 1h down move, 1h high, 1d overbought
-            & ((rsi_3_1h > 40.0) | aroonu_14_1h_lt_80 | (roc_9_1d < 100.0))
+            & ((rsi_3_1h_gt_40) | aroonu_14_1h_lt_80 | (roc_9_1d < 100.0))
             # 1h down move, 1h high, 4h overbought
-            & ((rsi_3_1h > 40.0) | (stochrsi_k_1h < 80.0) | (roc_9_4h_lt_20))
+            & ((rsi_3_1h_gt_40) | (stochrsi_k_1h < 80.0) | (roc_9_4h_lt_20))
             # 1h down move, 1h & 4h high
-            & ((rsi_3_1h > 45.0) | aroonu_14_1h_lt_80 | aroonu_14_4h_lt_100)
+            & ((rsi_3_1h_gt_45) | aroonu_14_1h_lt_80 | aroonu_14_4h_lt_100)
             # 1h down move, 1h high & overbought
-            & ((rsi_3_1h > 50.0) | (aroonu_14_1h < 90.0) | (roc_9_1h < 20.0))
+            & ((rsi_3_1h_gt_50) | (aroonu_14_1h_lt_90) | (roc_9_1h < 20.0))
             # 1h down move, 1h still high, 4h high
-            & ((rsi_3_1h > 60.0) | (aroonu_14_1h < 50.0) | (rsi_14_4h < 90.0))
+            & ((rsi_3_1h > 60.0) | (aroonu_14_1h_lt_50) | (rsi_14_4h < 90.0))
             # 4h & 1d down move, 1d high
-            & ((rsi_3_4h > 5.0) | (rsi_3_1d > 20.0) | (aroonu_14_1d < 40.0))
+            & ((rsi_3_4h_gt_5) | (rsi_3_1d_gt_20) | (aroonu_14_1d < 40.0))
             # 4h down move, 4h & 1d downtrend
-            & ((rsi_3_4h > 5.0) | (roc_9_4h > -30.0) | (roc_9_1d > -40.0))
+            & ((rsi_3_4h_gt_5) | (roc_9_4h_gt_neg_30) | (roc_9_1d_gt_neg_40))
             # 4h & 1d down move, 4h still not low enough
-            & ((rsi_3_4h_gt_10) | (rsi_3_1d > 15.0) | (aroonu_14_4h < 20.0))
+            & ((rsi_3_4h_gt_10) | (rsi_3_1d_gt_15) | (aroonu_14_4h < 20.0))
             # 4h & 1d down move, 1d still high
-            & ((rsi_3_4h_gt_10) | (rsi_3_1d > 25.0) | (stochrsi_k_1d < 50.0))
+            & ((rsi_3_4h_gt_10) | (rsi_3_1d_gt_25) | (stochrsi_k_1d < 50.0))
             # 4h down move, 4h still high
-            & ((rsi_3_4h_gt_10) | (aroonu_14_4h < 50.0))
+            & ((rsi_3_4h_gt_10) | (aroonu_14_4h_lt_50))
             # 4h down move, 1d high
             & ((rsi_3_4h_gt_10) | (aroonu_14_1d < 100.0))
             # 4h down move, 1h high, 1d downtrend
-            & ((rsi_3_4h_gt_10) | (stochrsi_k_1h < 60.0) | (roc_9_1d > -40.0))
+            & ((rsi_3_4h_gt_10) | (stochrsi_k_1h < 60.0) | (roc_9_1d_gt_neg_40))
             # 4h down move, 4h still not low enough, 1d downtrend
             & ((rsi_3_4h_gt_10) | (stochrsi_k_4h < 30.0) | (roc_9_1d > -20.0))
             # 4h down move, 1h & 4h downtrend
-            & ((rsi_3_4h_gt_10) | (roc_9_1h > -30.0) | (roc_9_4h > -30.0))
+            & ((rsi_3_4h_gt_10) | (roc_9_1h > -30.0) | (roc_9_4h_gt_neg_30))
             # 4h down move, 4h & 1d downtrend
             & ((rsi_3_4h_gt_15) | (roc_9_4h > -20.0) | (roc_9_1d > -30.0))
             # 4h down move, 1d high & overbought
-            & (rsi_3_4h_gt_20 | (aroonu_14_1d < 80.0) | (roc_9_1d < 80.0))
+            & (rsi_3_4h_gt_20 | (aroonu_14_1d_lt_80) | (roc_9_1d_lt_80))
             # 4h down move, 4h still high, 1d downtrend
-            & ((rsi_3_4h > 25.0) | (aroonu_14_4h < 50.0) | (roc_9_1d > -40.0))
+            & ((rsi_3_4h_gt_25) | (aroonu_14_4h_lt_50) | (roc_9_1d_gt_neg_40))
             # 4h down move, 4h high, 1d overbought
-            & ((rsi_3_4h > 30.0) | aroonu_14_4h_lt_80 | roc_9_1d_lt_50)
+            & ((rsi_3_4h_gt_30) | aroonu_14_4h_lt_80 | roc_9_1d_lt_50)
             # 4h down move, 1d overbought
-            & ((rsi_3_4h > 45.0) | (roc_9_1d < 80.0))
+            & ((rsi_3_4h > 45.0) | (roc_9_1d_lt_80))
             # 4h down move, 4h high, 1d overbought
-            & ((rsi_3_4h > 50.0) | aroonu_14_4h_lt_70 | (roc_9_1d < 40.0))
+            & ((rsi_3_4h_gt_50) | aroonu_14_4h_lt_70 | (roc_9_1d_lt_40))
             # 4h down move, 1h high, 1d overbought
             & ((rsi_3_4h > 60.0) | (stochrsi_k_1h < 90.0) | (roc_9_1d < 60.0))
             # 1d down move, 1h high, 1d downtrend
             & ((rsi_3_1d > 5.0) | (stochrsi_k_1h < 90.0) | (roc_9_1d_gt_neg_20))
             # 1d down move, 1h still high, 4h high
-            & ((rsi_3_1d > 20.0) | (aroonu_14_1h < 50.0) | (aroonu_14_4h < 90.0))
+            & ((rsi_3_1d_gt_20) | (aroonu_14_1h_lt_50) | (aroonu_14_4h_lt_90))
             # 1d down move, 1h & 4h high
-            & ((rsi_3_1d > 25.0) | aroonu_14_1h_lt_80 | (aroonu_14_4h < 90.0))
+            & ((rsi_3_1d_gt_25) | aroonu_14_1h_lt_80 | (aroonu_14_4h_lt_90))
             # 1d down move, 1d high
-            & ((rsi_3_1d > 40.0) | (aroonu_14_1d < 80.0))
+            & ((rsi_3_1d > 40.0) | (aroonu_14_1d_lt_80))
             # 1d down move, 4h still high, 1d overbought
-            & ((rsi_3_1d > 50.0) | (aroonu_14_4h < 50.0) | (roc_9_1d < 200.0))
+            & ((rsi_3_1d > 50.0) | (aroonu_14_4h_lt_50) | (roc_9_1d < 200.0))
             # 1d down move, 1d high & overbought
-            & ((rsi_3_1d > 60.0) | (aroonu_14_1d < 80.0) | roc_9_1d_lt_50)
+            & ((rsi_3_1d > 60.0) | (aroonu_14_1d_lt_80) | roc_9_1d_lt_50)
             # 1h down move, 4h high, 1d overbought
-            & ((rsi_3_change_pct_1h > -75.0) | (aroonu_14_4h < 90.0) | (roc_9_1d_lt_100))
+            & ((rsi_3_change_pct_1h > -75.0) | (aroonu_14_4h_lt_90) | (roc_9_1d_lt_100))
             # 15m & 1h & 4h downtrend
             & ((cmf_20_15m > -0.3) | (cmf_20_1h > -0.3) | (cmf_20_4h > -0.3))
             # 15m high, 1d overbought
-            & ((aroonu_14_15m < 70.0) | (roc_9_1d < 80.0))
+            & ((aroonu_14_15m_lt_70) | (roc_9_1d_lt_80))
             # 1h still high, 1h & 4h downtrend
-            & ((aroonu_14_1h < 40.0) | (roc_9_1h > -20.0) | (roc_9_4h > -30.0))
+            & ((aroonu_14_1h < 40.0) | (roc_9_1h > -20.0) | (roc_9_4h_gt_neg_30))
             # 1h & 4h high, 1h overbought
-            & ((aroonu_14_1h < 85.0) | (aroonu_14_4h < 90.0) | (roc_9_1h < 20.0))
+            & ((aroonu_14_1h < 85.0) | (aroonu_14_4h_lt_90) | (roc_9_1h < 20.0))
             # 1h high, 1h & 4h overbought
-            & ((aroonu_14_1h < 85.0) | (roc_9_1h < 10.0) | (roc_9_1d < 30.0))
+            & ((aroonu_14_1h < 85.0) | (roc_9_1h_lt_10) | (roc_9_1d_lt_30))
             # 1h high, 1h overbought, 1d downtrend
-            & ((aroonu_14_1h < 85.0) | (roc_9_1h < 20.0) | (roc_9_1d > -40.0))
+            & ((aroonu_14_1h < 85.0) | (roc_9_1h < 20.0) | (roc_9_1d_gt_neg_40))
             # 4h & 1d high, 1d overbought
             & (aroonu_14_4h_lt_80 | aroonu_14_1d_lt_100 | roc_9_1d_lt_50)
             # 4h high, 1h downtrend
             & (aroonu_14_4h_lt_80 | (roc_9_1h > -15.0))
             # 4h high, 1d downtrend
-            & (aroonu_14_4h_lt_80 | (roc_9_1d > -40.0))
+            & (aroonu_14_4h_lt_80 | (roc_9_1d_gt_neg_40))
             # 1d high, 4h downtrend, 1d overbought
             & ((aroonu_14_1d < 85.0) | (roc_9_4h > -25.0) | roc_9_1d_lt_50)
             # 1d high, 1h & 4h downtrend
-            & ((aroonu_14_1d < 90.0) | (roc_9_1h > -10.0) | (roc_9_4h_gt_neg_20))
+            & ((aroonu_14_1d_lt_90) | (roc_9_1h > -10.0) | (roc_9_4h_gt_neg_20))
             # 1d high, 4h & 1d overbought
-            & ((aroonu_14_1d < 90.0) | (roc_9_4h < 40.0) | (roc_9_1d < 80.0))
+            & ((aroonu_14_1d_lt_90) | (roc_9_4h_lt_40) | (roc_9_1d_lt_80))
             # 1h high, 4h overbought
             & ((stochrsi_k_1h_lt_80) | (roc_9_4h < 80.0))
             # 4h high, 1h downtrend
-            & ((stochrsi_k_4h < 70.0) | (roc_9_1h > -15.0))
+            & ((stochrsi_k_4h_lt_70) | (roc_9_1h > -15.0))
             # 4h high, 1d downtrend
-            & ((stochrsi_k_4h < 70.0) | (roc_9_1d > -40.0))
+            & ((stochrsi_k_4h_lt_70) | (roc_9_1d_gt_neg_40))
             # 5m down move, 15m still not low enough, 1h high
             & ((roc_2 > -10.0) | (aroonu_14_15m < 30.0) | aroonu_14_1h_lt_80)
             # 5m down move, 15m still high
-            & ((roc_2 > -10.0) | (aroonu_14_15m < 50.0))
+            & ((roc_2 > -10.0) | (aroonu_14_15m_lt_50))
             # 5m down move, 15m & 1h down move, 15m still high
-            & ((roc_9 > -15.0) | (rsi_3_15m > 5.0) | (rsi_3_1h > 35.0) | (aroonu_14_15m < 50.0))
+            & ((roc_9 > -15.0) | (rsi_3_15m_gt_5) | (rsi_3_1h_gt_35) | (aroonu_14_15m_lt_50))
             # 5m down move, 4h down move, 15m downtrend, 1h high
             & ((roc_9 > -15.0) | (rsi_3_4h > 45.0) | (cmf_20_15m > -0.3) | (aroonu_14_1h < 60.0))
             # 1h downtrend, 4h high & overbought
             & ((roc_9_1h > -25.0) | aroonu_14_4h_lt_80 | (roc_9_4h < 80.0))
             # 1h & 4h overbought, 1d downtrend
-            & ((roc_9_1h < 20.0) | (roc_9_4h_lt_20) | (roc_9_1d > -40.0))
+            & ((roc_9_1h < 20.0) | (roc_9_4h_lt_20) | (roc_9_1d_gt_neg_40))
             # 1d P&D, 1d downtrend
             & ((change_pct_1d > -5.0) | (change_pct_1d.shift(288) < 30.0) | (cmf_20_1d > -0.0))
             # 1d green with top wick, 1h down move
@@ -13115,7 +13167,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1d green with top wick, 4h high
             & ((change_pct_1d < 25.0) | (top_wick_pct_1d < 25.0) | aroonu_14_4h_lt_80)
             # 1d green, 1h down move, 1d downtrend
-            & ((change_pct_1d < 40.0) | (rsi_3_1h > 25.0) | (cmf_20_1d > -0.2))
+            & ((change_pct_1d < 40.0) | (rsi_3_1h_gt_25) | (cmf_20_1d > -0.2))
             # 1d green with top wick, 4h overbought
             & ((change_pct_1d < 50.0) | (top_wick_pct_1d < 30.0) | (roc_9_4h < 80.0))
             # big drop in the last hour, 15m downtrend
@@ -13146,43 +13198,43 @@ class NostalgiaForInfinityX7(IStrategy):
 
           long_entry_logic.append(
             # 5m & 1h down move, 1h still not low enough
-            ((rsi_3 > 3.0) | (rsi_3_1h_gt_10) | (aroonu_14_1h < 30.0))
+            ((rsi_3_gt_3) | (rsi_3_1h_gt_10) | (aroonu_14_1h < 30.0))
             # 5m & 1h down move, 1d high
-            & ((rsi_3 > 3.0) | rsi_3_1h_gt_20 | aroonu_14_1d_lt_100)
+            & ((rsi_3_gt_3) | rsi_3_1h_gt_20 | aroonu_14_1d_lt_100)
             # 5m & 1h down move, 1h still high
-            & ((rsi_3 > 3.0) | (rsi_3_1h > 30.0) | (stochrsi_k_1h_lt_50))
+            & ((rsi_3_gt_3) | (rsi_3_1h_gt_30) | (stochrsi_k_1h_lt_50))
             # 5m & 1h down move, 1d high
-            & ((rsi_3 > 3.0) | (rsi_3_1h > 35.0) | aroonu_14_1d_lt_100)
+            & ((rsi_3_gt_3) | (rsi_3_1h_gt_35) | aroonu_14_1d_lt_100)
             # 5m & 4h down move, 15m still not low enough
-            & ((rsi_3 > 3.0) | (rsi_3_4h > 3.0) | (stochrsi_k_15m < 30.0))
+            & ((rsi_3_gt_3) | (rsi_3_4h > 3.0) | (stochrsi_k_15m < 30.0))
             # 5m & 4h down move, 1d downtrend
-            & ((rsi_3 > 3.0) | (rsi_3_4h_gt_15) | (roc_9_1d > -30.0))
+            & ((rsi_3_gt_3) | (rsi_3_4h_gt_15) | (roc_9_1d > -30.0))
             # 5m & 4h down move, 4h high
-            & ((rsi_3 > 3.0) | (rsi_3_4h > 45.0) | (stochrsi_k_4h_lt_80))
+            & ((rsi_3_gt_3) | (rsi_3_4h > 45.0) | (stochrsi_k_4h_lt_80))
             # 5m & 4h down move, 15m still high
-            & ((rsi_3 > 5.0) | (rsi_3_4h > 25.0) | (stochrsi_k_15m < 50.0))
+            & ((rsi_3 > 5.0) | (rsi_3_4h_gt_25) | (stochrsi_k_15m < 50.0))
             # 5m & 1d down move, 1h still high
-            & ((rsi_3 > 3.0) | (rsi_3_1d > 10.0) | (aroonu_14_1h < 40.0))
+            & ((rsi_3_gt_3) | (rsi_3_1d_gt_10) | (aroonu_14_1h < 40.0))
             # 5m & 1d down move, 1h still high
-            & ((rsi_3 > 3.0) | (rsi_3_1d > 10.0) | (stochrsi_k_1h_lt_50))
+            & ((rsi_3_gt_3) | (rsi_3_1d_gt_10) | (stochrsi_k_1h_lt_50))
             # 5m & 1d down move, 1d downtrend
-            & ((rsi_3 > 3.0) | (rsi_3_1d > 15.0) | (cmf_20_1d > -0.25))
+            & ((rsi_3_gt_3) | (rsi_3_1d_gt_15) | (cmf_20_1d > -0.25))
             # 5m & 1d down move, 15m still high
-            & ((rsi_3 > 3.0) | (rsi_3_1d > 20.0) | (stochrsi_k_15m < 40.0))
+            & ((rsi_3_gt_3) | (rsi_3_1d_gt_20) | (stochrsi_k_15m < 40.0))
             # 5m down move, 1h high
-            & ((rsi_3 > 3.0) | aroonu_14_1h_lt_80)
+            & ((rsi_3_gt_3) | aroonu_14_1h_lt_80)
             # 5m down move, 4h high, 1d overbought
-            & ((rsi_3 > 3.0) | aroonu_14_4h_lt_80 | (roc_9_1d < 30.0))
+            & ((rsi_3_gt_3) | aroonu_14_4h_lt_80 | (roc_9_1d_lt_30))
             # 5m down move, 4h high & overbought
-            & ((rsi_3 > 3.0) | aroonu_14_4h_lt_100 | (roc_9_4h < 20.0))
+            & ((rsi_3_gt_3) | aroonu_14_4h_lt_100 | (roc_9_4h < 20.0))
             # 5m down move, 4h & 1d overbought
-            & ((rsi_3 > 3.0) | (roc_9_4h_lt_20) | (roc_9_1d < 40.0))
+            & ((rsi_3_gt_3) | (roc_9_4h_lt_20) | (roc_9_1d_lt_40))
             # 5m down move, 1d downtrend
-            & ((rsi_3 > 3.0) | (roc_9_1d > -40.0))
+            & ((rsi_3_gt_3) | (roc_9_1d_gt_neg_40))
             # 5m & 15m down move, 15m still high
-            & ((rsi_3 > 5.0) | (rsi_3_15m > 10.0) | (stochrsi_k_15m < 40.0))
+            & ((rsi_3 > 5.0) | (rsi_3_15m_gt_10) | (stochrsi_k_15m < 40.0))
             # 5m & 15m down move, 1h high
-            & ((rsi_3 > 5.0) | (rsi_3_15m > 30.0) | (stochrsi_k_1h_lt_80))
+            & ((rsi_3 > 5.0) | (rsi_3_15m_gt_30) | (stochrsi_k_1h_lt_80))
             # 5m & 4h down move, 1d downtrend
             & ((rsi_3 > 5.0) | (rsi_3_4h_gt_10) | (roc_9_1d > -20.0))
             # 5m & 4h down move, 4h still not low enough
@@ -13190,29 +13242,29 @@ class NostalgiaForInfinityX7(IStrategy):
             # 5m down move, 4h high, 1h overbought
             & ((rsi_3 > 10.0) | aroonu_14_4h_lt_100 | (roc_9_1h < 30.0))
             # 15m & 1h down move, 1h still high
-            & ((rsi_3_15m > 1.0) | (rsi_3_1h > 25.0) | (stochrsi_k_1h < 40.0))
+            & ((rsi_3_15m > 1.0) | (rsi_3_1h_gt_25) | (stochrsi_k_1h < 40.0))
             # 15m & 1h & 4h down move
-            & (rsi_3_15m_gt_3 | (rsi_3_1h > 3.0) | (rsi_3_4h_gt_15))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_3) | (rsi_3_4h_gt_15))
             # 15m & 1h down move, 4h still high
-            & (rsi_3_15m_gt_3 | (rsi_3_1h > 3.0) | (aroonu_14_4h < 50.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_3) | (aroonu_14_4h_lt_50))
             # 15m & 1h down move, 15m downtrend
-            & (rsi_3_15m_gt_3 | (rsi_3_1h > 5.0) | (cmf_20_15m > -0.30))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_5) | (cmf_20_15m > -0.30))
             # 15m & 1h down move, 15m still not low enough
-            & (rsi_3_15m_gt_3 | (rsi_3_1h > 5.0) | (aroonu_14_15m < 30.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_5) | (aroonu_14_15m < 30.0))
             # 15m & 1h down move, 1h still not low enough
-            & (rsi_3_15m_gt_3 | (rsi_3_1h > 5.0) | (aroonu_14_1h < 25.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_5) | (aroonu_14_1h < 25.0))
             # 15m & 1h down move, 1h still not low enough
-            & (rsi_3_15m_gt_3 | (rsi_3_1h > 5.0) | (stochrsi_k_1h < 30.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_5) | (stochrsi_k_1h < 30.0))
             # 15m & 1h & 4h down move
             & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_10) | (rsi_3_4h_gt_10))
             # 15m & 1h down move, 1h high
             & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_10) | (stochrsi_k_1h < 30.0))
             # 15m & 1h down move, 1d downtrend
-            & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_10) | (roc_9_1d > -40.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_10) | (roc_9_1d_gt_neg_40))
             # 15m & 1h down move, 15m downtrend
             & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_15) | (cmf_20_15m > -0.40))
             # 15m & 1h down move, 4h still high
-            & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_15) | (stochrsi_k_4h < 50.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_15) | (stochrsi_k_4h_lt_50))
             # 15m & 1h down move, 1h high
             & (rsi_3_15m_gt_3 | rsi_3_1h_gt_20 | aroonu_14_1h_lt_70)
             # 15m & 1h down move, 1h still high
@@ -13220,315 +13272,315 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 4h high
             & (rsi_3_15m_gt_3 | rsi_3_1h_gt_20 | (stochrsi_k_4h < 60.0))
             # 15m & 1h down move, 1h high
-            & (rsi_3_15m_gt_3 | (rsi_3_1h > 30.0) | (aroonu_14_1h < 60.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_30) | (aroonu_14_1h < 60.0))
             # 15m & 1h down move, 1h high
-            & (rsi_3_15m_gt_3 | (rsi_3_1h > 30.0) | (stochrsi_k_1h_lt_70))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_30) | (stochrsi_k_1h_lt_70))
             # 15m & 1h down move, 1h still high
-            & (rsi_3_15m_gt_3 | (rsi_3_1h > 35.0) | (aroonu_14_1h < 40.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_35) | (aroonu_14_1h < 40.0))
             # 15m & 1h down move, 1d high
-            & (rsi_3_15m_gt_3 | (rsi_3_1h > 35.0) | (stochrsi_k_1d < 70.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_35) | (stochrsi_k_1d < 70.0))
             # 15m & 1h down move, 1h high
-            & (rsi_3_15m_gt_3 | (rsi_3_1h > 40.0) | aroonu_14_1h_lt_70)
+            & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_40) | aroonu_14_1h_lt_70)
             # 15m & 1h down move, 4h high
-            & (rsi_3_15m_gt_3 | (rsi_3_1h > 40.0) | (stochrsi_k_4h_lt_80))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_40) | (stochrsi_k_4h_lt_80))
             # 15m & 1h down move, 1h high
-            & (rsi_3_15m_gt_3 | (rsi_3_1h > 45.0) | (aroonu_14_1h < 85.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_45) | (aroonu_14_1h < 85.0))
             # 15m & 1h down move, 1h high
             & (rsi_3_15m_gt_3 | (rsi_3_1h > 60.0) | (stochrsi_k_1h_lt_80))
             # 15m & 4h down move, 4h still not low enough
-            & (rsi_3_15m_gt_3 | (rsi_3_4h > 5.0) | (rsi_14_4h < 30.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_4h_gt_5) | (rsi_14_4h < 30.0))
             # 15m & 4h down move, 4h downtrend
-            & (rsi_3_15m_gt_3 | (rsi_3_4h > 5.0) | (cmf_20_4h > -0.35))
+            & (rsi_3_15m_gt_3 | (rsi_3_4h_gt_5) | (cmf_20_4h > -0.35))
             # 15m & 4h down move, 1d high
-            & (rsi_3_15m_gt_3 | (rsi_3_4h_gt_10) | (aroonu_14_1d < 80.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_4h_gt_10) | (aroonu_14_1d_lt_80))
             # 15m & 4h down move, 1d downtrend
             & (rsi_3_15m_gt_3 | (rsi_3_4h_gt_10) | (roc_9_1d > -20.0))
             # 15m & 4h down move, 4h still high
-            & (rsi_3_15m_gt_3 | (rsi_3_4h > 30.0) | (stochrsi_k_4h < 40.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_4h_gt_30) | (stochrsi_k_4h < 40.0))
             # 15m & 4h down move, 4h still high
-            & (rsi_3_15m_gt_3 | (rsi_3_4h > 35.0) | (stochrsi_k_4h < 50.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_4h_gt_35) | (stochrsi_k_4h_lt_50))
             # 15m down move, 15m still not low enough, 1h high
             & (rsi_3_15m_gt_3 | (aroonu_14_15m < 20.0) | (stochrsi_k_1h < 60.0))
             # 15m down move, 15m still not low enough, 1h still high
             & (rsi_3_15m_gt_3 | (aroonu_14_15m < 30.0) | (stochrsi_k_1h_lt_50))
             # 15m down move, 1h high, 1d overbought
-            & (rsi_3_15m_gt_3 | aroonu_14_1h_lt_70 | (roc_9_1d < 20.0))
+            & (rsi_3_15m_gt_3 | aroonu_14_1h_lt_70 | (roc_9_1d_lt_20))
             # 15m down move, 4h still high, 15m downtrend
-            & (rsi_3_15m_gt_3 | (aroonu_14_4h < 40.0) | (cmf_20_15m > -0.35))
+            & (rsi_3_15m_gt_3 | (aroonu_14_4h_lt_40) | (cmf_20_15m > -0.35))
             # 15m down move, 4h high, 1d overbought
-            & (rsi_3_15m_gt_3 | aroonu_14_4h_lt_70 | (roc_9_1d < 30.0))
+            & (rsi_3_15m_gt_3 | aroonu_14_4h_lt_70 | (roc_9_1d_lt_30))
             # 15m down move, 4h & 1d downtrend
-            & (rsi_3_15m_gt_3 | (roc_9_4h > -30.0) | roc_9_1d_gt_neg_50)
+            & (rsi_3_15m_gt_3 | (roc_9_4h_gt_neg_30) | roc_9_1d_gt_neg_50)
             # 15m & 1h & 4h down move
-            & ((rsi_3_15m > 5.0) | (rsi_3_1h > 5.0) | (rsi_3_4h_gt_10))
+            & ((rsi_3_15m_gt_5) | (rsi_3_1h_gt_5) | (rsi_3_4h_gt_10))
             # 15m & 1h down move, 4h still high
-            & ((rsi_3_15m > 5.0) | (rsi_3_1h_gt_10) | (rsi_14_4h < 40.0))
+            & ((rsi_3_15m_gt_5) | (rsi_3_1h_gt_10) | (rsi_14_4h < 40.0))
             # 15m & 1h down move, 1h still high
-            & ((rsi_3_15m > 5.0) | (rsi_3_1h_gt_10) | (aroonu_14_1h < 40.0))
+            & ((rsi_3_15m_gt_5) | (rsi_3_1h_gt_10) | (aroonu_14_1h < 40.0))
             # 15m & 1h down move, 4h high
-            & ((rsi_3_15m > 5.0) | (rsi_3_1h_gt_10) | (aroonu_14_4h < 100.0))
+            & ((rsi_3_15m_gt_5) | (rsi_3_1h_gt_10) | (aroonu_14_4h < 100.0))
             # 15m & 1h down move, 4h high
-            & ((rsi_3_15m > 5.0) | (rsi_3_1h_gt_15) | (stochrsi_k_4h < 60.0))
+            & ((rsi_3_15m_gt_5) | (rsi_3_1h_gt_15) | (stochrsi_k_4h < 60.0))
             # 1d down move, 1d still high, 4h still high
-            & ((rsi_3_1d > 50.0) | (rsi_14_1d < 50.0) | (stochrsi_k_4h < 50.0))
+            & ((rsi_3_1d > 50.0) | (rsi_14_1d < 50.0) | (stochrsi_k_4h_lt_50))
             # 15m & 1h down move, 1h high
-            & ((rsi_3_15m > 5.0) | (rsi_3_1h > 40.0) | (stochrsi_k_4h_lt_80))
+            & ((rsi_3_15m_gt_5) | (rsi_3_1h_gt_40) | (stochrsi_k_4h_lt_80))
             # 15m & 1h down move, 1h high
-            & ((rsi_3_15m > 5.0) | (rsi_3_1h > 45.0) | aroonu_14_1h_lt_80)
+            & ((rsi_3_15m_gt_5) | (rsi_3_1h_gt_45) | aroonu_14_1h_lt_80)
             # 15m & 4h down move, 1d still high
-            & ((rsi_3_15m > 5.0) | (rsi_3_4h > 5.0) | (stochrsi_k_1d < 40.0))
+            & ((rsi_3_15m_gt_5) | (rsi_3_4h_gt_5) | (stochrsi_k_1d < 40.0))
             # 15m & 4h down move, 15m still not low enough
-            & ((rsi_3_15m > 5.0) | (rsi_3_4h_gt_10) | (stochrsi_k_15m < 30.0))
+            & ((rsi_3_15m_gt_5) | (rsi_3_4h_gt_10) | (stochrsi_k_15m < 30.0))
             # 15m & 4h down move, 1d high
-            & ((rsi_3_15m > 5.0) | (rsi_3_4h_gt_10) | (stochrsi_k_1d < 70.0))
+            & ((rsi_3_15m_gt_5) | (rsi_3_4h_gt_10) | (stochrsi_k_1d < 70.0))
             # 15m & 4h down move, 15m still high
-            & ((rsi_3_15m > 5.0) | (rsi_3_4h_gt_15) | (aroonu_14_15m < 40.0))
+            & ((rsi_3_15m_gt_5) | (rsi_3_4h_gt_15) | (aroonu_14_15m < 40.0))
             # 15m & 4h down move, 1h still high
-            & ((rsi_3_15m > 5.0) | (rsi_3_4h_gt_15) | (stochrsi_k_1h < 50.0))
+            & ((rsi_3_15m_gt_5) | (rsi_3_4h_gt_15) | (stochrsi_k_1h < 50.0))
             # 15m & 4h down move, 4h still high
-            & ((rsi_3_15m > 5.0) | (rsi_3_4h_gt_15) | (stochrsi_k_4h < 50.0))
+            & ((rsi_3_15m_gt_5) | (rsi_3_4h_gt_15) | (stochrsi_k_4h_lt_50))
             # 15m & 4h down move, 1d overbought
-            & ((rsi_3_15m > 5.0) | rsi_3_4h_gt_20 | (roc_9_1d < 10.0))
+            & ((rsi_3_15m_gt_5) | rsi_3_4h_gt_20 | (roc_9_1d < 10.0))
             # 15m & 4h down move, 4h still high
-            & ((rsi_3_15m > 5.0) | (rsi_3_4h > 45.0) | (aroonu_14_4h < 40.0))
+            & ((rsi_3_15m_gt_5) | (rsi_3_4h > 45.0) | (aroonu_14_4h_lt_40))
             # 15m & 1d down move, 15m still not low enough
-            & ((rsi_3_15m > 5.0) | (rsi_3_1d > 10.0) | (aroonu_14_15m < 30.0))
+            & ((rsi_3_15m_gt_5) | (rsi_3_1d_gt_10) | (aroonu_14_15m < 30.0))
             # 15m & 1d down move, 1h high
-            & ((rsi_3_15m > 5.0) | (rsi_3_1d > 40.0) | (stochrsi_k_1h < 90.0))
+            & ((rsi_3_15m_gt_5) | (rsi_3_1d > 40.0) | (stochrsi_k_1h < 90.0))
             # 15m down move, 15m downtrend, 4h still not low enough
-            & ((rsi_3_15m > 5.0) | (cmf_20_15m > -0.30) | (stochrsi_k_4h < 30.0))
+            & ((rsi_3_15m_gt_5) | (cmf_20_15m > -0.30) | (stochrsi_k_4h < 30.0))
             # 15m down move, 15m still not low enough, 4h high
-            & ((rsi_3_15m > 5.0) | (aroonu_14_15m < 20.0) | (stochrsi_k_4h < 70.0))
+            & ((rsi_3_15m_gt_5) | (aroonu_14_15m < 20.0) | (stochrsi_k_4h_lt_70))
             # 15m down move, 15m stil high, 1h still high
-            & ((rsi_3_15m > 5.0) | (aroonu_14_15m < 40.0) | (stochrsi_k_1h_lt_50))
+            & ((rsi_3_15m_gt_5) | (aroonu_14_15m < 40.0) | (stochrsi_k_1h_lt_50))
             # 15m down move, 1d high & overbought
-            & ((rsi_3_15m > 5.0) | (aroonu_14_1d < 80.0) | (roc_9_1d < 20.0))
+            & ((rsi_3_15m_gt_5) | (aroonu_14_1d_lt_80) | (roc_9_1d_lt_20))
             # 15m down move, 15m still not low enough, 1h still high
-            & ((rsi_3_15m > 5.0) | (stochrsi_k_15m < 20.0) | (stochrsi_k_1h_lt_50))
+            & ((rsi_3_15m_gt_5) | (stochrsi_k_15m < 20.0) | (stochrsi_k_1h_lt_50))
             # 15m down move, 1h still high, 4h overbought
-            & ((rsi_3_15m > 5.0) | (stochrsi_k_1h_lt_50) | (roc_9_4h < 30.0))
+            & ((rsi_3_15m_gt_5) | (stochrsi_k_1h_lt_50) | (roc_9_4h_lt_30))
             # 15m down move, 1h high & overbought
-            & ((rsi_3_15m > 5.0) | (stochrsi_k_1h_lt_80) | (roc_9_1h < 20.0))
+            & ((rsi_3_15m_gt_5) | (stochrsi_k_1h_lt_80) | (roc_9_1h < 20.0))
             # 15m & 1h down move, 15m high
-            & ((rsi_3_15m > 10.0) | (rsi_3_1h_gt_10) | (stochrsi_k_15m < 50.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_10) | (stochrsi_k_15m < 50.0))
             # 15m & 1h down move, 1h still high
-            & ((rsi_3_15m > 10.0) | (rsi_3_1h_gt_10) | (aroonu_14_1h < 50.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_10) | (aroonu_14_1h_lt_50))
             # 15m & 1h down move, 4h high
-            & ((rsi_3_15m > 10.0) | (rsi_3_1h_gt_10) | (aroonu_14_4h < 60.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_10) | (aroonu_14_4h_lt_60))
             # 15m & 1h down move, 1d high
-            & ((rsi_3_15m > 10.0) | (rsi_3_1h_gt_10) | (stochrsi_k_1d < 70.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_10) | (stochrsi_k_1d < 70.0))
             # 15m & 1h down move, 1h high
-            & ((rsi_3_15m > 10.0) | (rsi_3_1h_gt_15) | (aroonu_14_1h < 80.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_15) | (aroonu_14_1h < 80.0))
             # 15m & 1h down move, 4h high
-            & ((rsi_3_15m > 10.0) | rsi_3_1h_gt_20 | (stochrsi_k_4h < 70.0))
+            & ((rsi_3_15m_gt_10) | rsi_3_1h_gt_20 | (stochrsi_k_4h_lt_70))
             # 15m & 1h down move, 4h high
-            & ((rsi_3_15m > 10.0) | (rsi_3_1h > 25.0) | (aroonu_14_4h < 75.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_25) | (aroonu_14_4h < 75.0))
             # 15m & 1h down move, 4h still high
-            & ((rsi_3_15m > 10.0) | (rsi_3_1h > 25.0) | (aroonu_14_4h < 50.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_25) | (aroonu_14_4h_lt_50))
             # 15m & 1h down move, 1d downtrend
-            & ((rsi_3_15m > 10.0) | (rsi_3_1h > 25.0) | roc_9_1d_gt_neg_50)
+            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_25) | roc_9_1d_gt_neg_50)
             # 15m & 1h down move, 1d overbought
-            & ((rsi_3_15m > 10.0) | (rsi_3_1h > 30.0) | (roc_9_1d < 30.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_30) | (roc_9_1d_lt_30))
             # 15m & 1h down move, 4h still high
-            & ((rsi_3_15m > 10.0) | (rsi_3_1h > 35.0) | (rsi_14_4h < 50.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_35) | (rsi_14_4h < 50.0))
             # 15m & 1h down move, 1h high
-            & ((rsi_3_15m > 10.0) | (rsi_3_1h > 35.0) | (stochrsi_k_1h < 60.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_35) | (stochrsi_k_1h < 60.0))
             # 15m & 1h down move, 4h high
-            & ((rsi_3_15m > 10.0) | (rsi_3_1h > 40.0) | (stochrsi_k_4h_lt_80))
+            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_40) | (stochrsi_k_4h_lt_80))
             # 15m & 1h down move, 1h high
-            & ((rsi_3_15m > 10.0) | (rsi_3_1h > 50.0) | (stochrsi_k_1h_lt_70))
+            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_50) | (stochrsi_k_1h_lt_70))
             # 15m & 1h down move, 4h high
-            & ((rsi_3_15m > 10.0) | (rsi_3_1h > 50.0) | (stochrsi_k_4h_lt_80))
+            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_50) | (stochrsi_k_4h_lt_80))
             # 16m & 1h down move, 1h high
-            & ((rsi_3_15m > 10.0) | (rsi_3_1h > 55.0) | (stochrsi_k_1h_lt_70))
+            & ((rsi_3_15m_gt_10) | (rsi_3_1h > 55.0) | (stochrsi_k_1h_lt_70))
             # 15m & 1h down move, 4h high
-            & ((rsi_3_15m > 10.0) | (rsi_3_1h > 55.0) | (stochrsi_k_4h_lt_90))
+            & ((rsi_3_15m_gt_10) | (rsi_3_1h > 55.0) | (stochrsi_k_4h_lt_90))
             # 15m & 1h down move, 1h high
-            & ((rsi_3_15m > 10.0) | (rsi_3_1h > 40.0) | aroonu_14_1h_lt_70)
+            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_40) | aroonu_14_1h_lt_70)
             # 15m & 4h down move, 4h still not low enough
-            & ((rsi_3_15m > 10.0) | (rsi_3_4h_gt_10) | (stochrsi_k_4h < 30.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_4h_gt_10) | (stochrsi_k_4h < 30.0))
             # 15m & 4h down move, 1d high
-            & ((rsi_3_15m > 10.0) | (rsi_3_4h_gt_10) | (stochrsi_k_1d < 80.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_4h_gt_10) | (stochrsi_k_1d < 80.0))
             # 15m & 4h down move, 1d overbought
-            & ((rsi_3_15m > 10.0) | (rsi_3_4h_gt_10) | (roc_9_1d < 20.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_4h_gt_10) | (roc_9_1d_lt_20))
             # 15m & 4h down move, 4h still not low enough
-            & ((rsi_3_15m > 10.0) | rsi_3_4h_gt_20 | (stochrsi_k_4h < 30.0))
+            & ((rsi_3_15m_gt_10) | rsi_3_4h_gt_20 | (stochrsi_k_4h < 30.0))
             # 15m & 4h down move, 1d high
-            & ((rsi_3_15m > 10.0) | (rsi_3_4h > 30.0) | (aroonu_14_1d < 90.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_4h_gt_30) | (aroonu_14_1d_lt_90))
             # 15m & 4h down move, 1d high
-            & ((rsi_3_15m > 10.0) | (rsi_3_4h > 30.0) | (stochrsi_k_1d < 90.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_4h_gt_30) | (stochrsi_k_1d_lt_90))
             # 15m & 4h down move, 1d overbought
-            & ((rsi_3_15m > 10.0) | (rsi_3_4h > 30.0) | (roc_9_1d < 30.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_4h_gt_30) | (roc_9_1d_lt_30))
             # 15m & 4h down move, 4h overbought
-            & ((rsi_3_15m > 10.0) | (rsi_3_4h > 55.0) | (roc_9_4h < 50.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_4h > 55.0) | (roc_9_4h < 50.0))
             # 15m & 1d down move, 1d still high
-            & ((rsi_3_15m > 10.0) | (rsi_3_1d > 10.0) | (rsi_14_1d < 40.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_1d_gt_10) | (rsi_14_1d < 40.0))
             # 15m & 1d down move, 1h high
-            & ((rsi_3_15m > 10.0) | (rsi_3_1d > 10.0) | (stochrsi_k_1h < 90.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_1d_gt_10) | (stochrsi_k_1h < 90.0))
             # 15m & 1d down move, 4h high
-            & ((rsi_3_15m > 10.0) | (rsi_3_1d > 15.0) | (stochrsi_k_4h_lt_90))
+            & ((rsi_3_15m_gt_10) | (rsi_3_1d_gt_15) | (stochrsi_k_4h_lt_90))
             # 15m down move, 15m downtrend, 1h high
-            & ((rsi_3_15m > 10.0) | (cmf_20_15m > -0.40) | aroonu_14_1h_lt_80)
+            & ((rsi_3_15m_gt_10) | (cmf_20_15m > -0.40) | aroonu_14_1h_lt_80)
             # 15m down move, 1h high, 1d overbought
-            & ((rsi_3_15m > 10.0) | aroonu_14_1h_lt_80 | (roc_9_1d < 20.0))
+            & ((rsi_3_15m_gt_10) | aroonu_14_1h_lt_80 | (roc_9_1d_lt_20))
             # 15m down move, 4h & 1d high
-            & ((rsi_3_15m > 10.0) | aroonu_14_4h_lt_70 | aroonu_14_1d_lt_100)
+            & ((rsi_3_15m_gt_10) | aroonu_14_4h_lt_70 | aroonu_14_1d_lt_100)
             # 15m down move, 4h high & overbought
-            & ((rsi_3_15m > 10.0) | aroonu_14_4h_lt_70 | (roc_9_4h < 10.0))
+            & ((rsi_3_15m_gt_10) | aroonu_14_4h_lt_70 | (roc_9_4h_lt_10))
             # 15m down move, 15m still not low enough, 4h high
-            & ((rsi_3_15m > 10.0) | (stochrsi_k_15m < 20.0) | aroonu_14_4h_lt_70)
+            & ((rsi_3_15m_gt_10) | (stochrsi_k_15m < 20.0) | aroonu_14_4h_lt_70)
             # 15m down move, 15m sill high, 4h high
-            & ((rsi_3_15m > 10.0) | (stochrsi_k_15m < 40.0) | (aroonu_14_4h < 60.0))
+            & ((rsi_3_15m_gt_10) | (stochrsi_k_15m < 40.0) | (aroonu_14_4h_lt_60))
             # 15m down move, 4h high, 1d downtrend
-            & ((rsi_3_15m > 10.0) | (stochrsi_k_4h < 80.0) | (roc_9_1d_gt_neg_30))
+            & ((rsi_3_15m_gt_10) | (stochrsi_k_4h < 80.0) | (roc_9_1d_gt_neg_30))
             # 15m & 1h down move, 4h downtrend
-            & ((rsi_3_15m > 15.0) | (rsi_3_1h_gt_15) | (roc_9_4h > -20.0))
+            & ((rsi_3_15m_gt_15) | (rsi_3_1h_gt_15) | (roc_9_4h > -20.0))
             # 15m & 1h down move, 1h downtrend
-            & ((rsi_3_15m > 15.0) | rsi_3_1h_gt_20 | (cmf_20_1h > -0.30))
+            & ((rsi_3_15m_gt_15) | rsi_3_1h_gt_20 | (cmf_20_1h > -0.30))
             # 15m & 1h down move, 1d overbought
-            & ((rsi_3_15m > 15.0) | (rsi_3_1h > 25.0) | (roc_9_1d_lt_100))
+            & ((rsi_3_15m_gt_15) | (rsi_3_1h_gt_25) | (roc_9_1d_lt_100))
             # 15m & 1h down move, 4h high
-            & ((rsi_3_15m > 15.0) | (rsi_3_1h > 30.0) | aroonu_14_4h_lt_80)
+            & ((rsi_3_15m_gt_15) | (rsi_3_1h_gt_30) | aroonu_14_4h_lt_80)
             # 15m & 1h down move, 1h high
-            & ((rsi_3_15m > 15.0) | (rsi_3_1h > 40.0) | aroonu_14_1h_lt_70)
+            & ((rsi_3_15m_gt_15) | (rsi_3_1h_gt_40) | aroonu_14_1h_lt_70)
             # 15m & 1h down move, 1d high
-            & ((rsi_3_15m > 15.0) | (rsi_3_1h > 40.0) | (aroonu_14_1d < 90.0))
+            & ((rsi_3_15m_gt_15) | (rsi_3_1h_gt_40) | (aroonu_14_1d_lt_90))
             # 15m & 1h down move, 4h high
-            & ((rsi_3_15m > 15.0) | (rsi_3_1h > 45.0) | (stochrsi_k_4h < 70.0))
+            & ((rsi_3_15m_gt_15) | (rsi_3_1h_gt_45) | (stochrsi_k_4h_lt_70))
             # 15m & 4h down move, 1h high
-            & ((rsi_3_15m > 15.0) | (rsi_3_4h_gt_15) | (aroonu_14_1h < 70.0))
+            & ((rsi_3_15m_gt_15) | (rsi_3_4h_gt_15) | (aroonu_14_1h < 70.0))
             # 15m & 4h down move, 4h downtrend
-            & ((rsi_3_15m > 15.0) | (rsi_3_4h_gt_15) | (roc_9_4h > -20.0))
+            & ((rsi_3_15m_gt_15) | (rsi_3_4h_gt_15) | (roc_9_4h > -20.0))
             # 15m & 4h down move, 1d high
-            & ((rsi_3_15m > 15.0) | rsi_3_4h_gt_20 | (aroonu_14_1d < 90.0))
+            & ((rsi_3_15m_gt_15) | rsi_3_4h_gt_20 | (aroonu_14_1d_lt_90))
             # 15m & 1d down move, 1h still high
-            & ((rsi_3_15m > 15.0) | (rsi_3_1d > 15.0) | (aroonu_14_1h < 40.0))
+            & ((rsi_3_15m_gt_15) | (rsi_3_1d_gt_15) | (aroonu_14_1h < 40.0))
             # 15m & 1d down move, 4h high
-            & ((rsi_3_15m > 15.0) | (rsi_3_1d > 30.0) | (aroonu_14_4h < 90.0))
+            & ((rsi_3_15m_gt_15) | (rsi_3_1d > 30.0) | (aroonu_14_4h_lt_90))
             # 15m down move, 15m still not low enough, 4h high
-            & ((rsi_3_15m > 15.0) | (aroonu_14_15m < 25.0) | (aroonu_14_4h < 60.0))
+            & ((rsi_3_15m_gt_15) | (aroonu_14_15m < 25.0) | (aroonu_14_4h_lt_60))
             # 15m down move, 15m still not low enough, 1h high
-            & ((rsi_3_15m > 15.0) | (aroonu_14_15m < 30.0) | aroonu_14_1h_lt_70)
+            & ((rsi_3_15m_gt_15) | (aroonu_14_15m < 30.0) | aroonu_14_1h_lt_70)
             # 15m down move, 15m & 4h still high
-            & ((rsi_3_15m > 15.0) | (aroonu_14_15m < 40.0) | (aroonu_14_4h < 40.0))
+            & ((rsi_3_15m_gt_15) | (aroonu_14_15m < 40.0) | (aroonu_14_4h_lt_40))
             # 15m down move, 1h still high, 4h overbought
-            & ((rsi_3_15m > 15.0) | (aroonu_14_1h < 50.0) | (roc_9_4h < 60.0))
+            & ((rsi_3_15m_gt_15) | (aroonu_14_1h_lt_50) | (roc_9_4h < 60.0))
             # 15m down move, 1h & 4h high
-            & ((rsi_3_15m > 15.0) | (aroonu_14_1h < 60.0) | (aroonu_14_4h < 90.0))
+            & ((rsi_3_15m_gt_15) | (aroonu_14_1h < 60.0) | (aroonu_14_4h_lt_90))
             # 15m down move, 1h & 1d high
-            & ((rsi_3_15m > 15.0) | aroonu_14_1h_lt_70 | (aroonu_14_1d < 90.0))
+            & ((rsi_3_15m_gt_15) | aroonu_14_1h_lt_70 | (aroonu_14_1d_lt_90))
             # 15m down move, 4h high, 4h downtrend
-            & ((rsi_3_15m > 15.0) | (aroonu_14_4h < 60.0) | (roc_9_4h_gt_neg_20))
+            & ((rsi_3_15m_gt_15) | (aroonu_14_4h_lt_60) | (roc_9_4h_gt_neg_20))
             # 15m down move, 4h & 1d high
-            & ((rsi_3_15m > 15.0) | (aroonu_14_4h < 75.0) | aroonu_14_1d_lt_100)
+            & ((rsi_3_15m_gt_15) | (aroonu_14_4h < 75.0) | aroonu_14_1d_lt_100)
             # 15m down move, 4h high & overbought
-            & ((rsi_3_15m > 15.0) | aroonu_14_4h_lt_80 | (roc_9_4h < 10.0))
+            & ((rsi_3_15m_gt_15) | aroonu_14_4h_lt_80 | (roc_9_4h_lt_10))
             # 15m down move, 15m still high, 1d overbought
-            & ((rsi_3_15m > 15.0) | (stochrsi_k_15m < 50.0) | (roc_9_1d_lt_100))
+            & ((rsi_3_15m_gt_15) | (stochrsi_k_15m < 50.0) | (roc_9_1d_lt_100))
             # 15m down move, 1h high & overbought
-            & ((rsi_3_15m > 15.0) | (stochrsi_k_1h < 90.0) | (roc_9_1h < 10.0))
+            & ((rsi_3_15m_gt_15) | (stochrsi_k_1h < 90.0) | (roc_9_1h_lt_10))
             # 15m down move, 4h high, 1d overbought
-            & ((rsi_3_15m > 15.0) | (stochrsi_k_4h < 70.0) | (roc_9_1d < 10.0))
+            & ((rsi_3_15m_gt_15) | (stochrsi_k_4h_lt_70) | (roc_9_1d < 10.0))
             # 15m & 1h down move, 15m still not low enough
-            & ((rsi_3_15m > 20.0) | rsi_3_1h_gt_20 | (aroonu_14_15m < 30.0))
+            & ((rsi_3_15m_gt_20) | rsi_3_1h_gt_20 | (aroonu_14_15m < 30.0))
             # 15m & 1h down move, 4h overbought
-            & ((rsi_3_15m > 20.0) | rsi_3_1h_gt_20 | (roc_9_4h < 50.0))
+            & ((rsi_3_15m_gt_20) | rsi_3_1h_gt_20 | (roc_9_4h < 50.0))
             # 15m & 1h down move, 15m high
-            & ((rsi_3_15m > 20.0) | (rsi_3_1h > 25.0) | (stochrsi_k_15m < 80.0))
+            & ((rsi_3_15m_gt_20) | (rsi_3_1h_gt_25) | (stochrsi_k_15m < 80.0))
             # 15m & 1h down move, 4h high
-            & ((rsi_3_15m > 20.0) | (rsi_3_1h > 25.0) | (stochrsi_k_4h_lt_80))
+            & ((rsi_3_15m_gt_20) | (rsi_3_1h_gt_25) | (stochrsi_k_4h_lt_80))
             # 15m & 1h down move, 1h high
-            & ((rsi_3_15m > 20.0) | (rsi_3_1h > 30.0) | aroonu_14_1h_lt_70)
+            & ((rsi_3_15m_gt_20) | (rsi_3_1h_gt_30) | aroonu_14_1h_lt_70)
             # 15m & 1h down move, 1h high
-            & ((rsi_3_15m > 20.0) | (rsi_3_1h > 45.0) | (stochrsi_k_1h_lt_80))
+            & ((rsi_3_15m_gt_20) | (rsi_3_1h_gt_45) | (stochrsi_k_1h_lt_80))
             # 15m & 4h down move, 1h high
-            & ((rsi_3_15m > 20.0) | rsi_3_4h_gt_20 | (stochrsi_k_1h_lt_80))
+            & ((rsi_3_15m_gt_20) | rsi_3_4h_gt_20 | (stochrsi_k_1h_lt_80))
             # 15m & 4h down move, 4h high
-            & ((rsi_3_15m > 20.0) | (rsi_3_4h > 40.0) | aroonu_14_4h_lt_80)
+            & ((rsi_3_15m_gt_20) | (rsi_3_4h_gt_40) | aroonu_14_4h_lt_80)
             # 15m down move, 1h & 4h high
-            & ((rsi_3_15m > 20.0) | aroonu_14_1h_lt_80 | aroonu_14_4h_lt_80)
+            & ((rsi_3_15m_gt_20) | aroonu_14_1h_lt_80 | aroonu_14_4h_lt_80)
             # 15m down move, 1h & 1d high
-            & ((rsi_3_15m > 20.0) | aroonu_14_1h_lt_80 | (aroonu_14_1d < 80.0))
+            & ((rsi_3_15m_gt_20) | aroonu_14_1h_lt_80 | (aroonu_14_1d_lt_80))
             # 15m down move, 1h high, 1d downtrend
-            & ((rsi_3_15m > 20.0) | (aroonu_14_1h < 90.0) | (roc_9_1d_gt_neg_30))
+            & ((rsi_3_15m_gt_20) | (aroonu_14_1h_lt_90) | (roc_9_1d_gt_neg_30))
             # 15m down move, 1h high, 1d overbought
-            & ((rsi_3_15m > 20.0) | (stochrsi_k_1h < 70.0) | (roc_9_1d_lt_100))
+            & ((rsi_3_15m_gt_20) | (stochrsi_k_1h < 70.0) | (roc_9_1d_lt_100))
             # 15m down move, 1h high, 1d downtrend
-            & ((rsi_3_15m > 20.0) | (stochrsi_k_1h < 80.0) | (roc_9_1d_gt_neg_20))
+            & ((rsi_3_15m_gt_20) | (stochrsi_k_1h < 80.0) | (roc_9_1d_gt_neg_20))
             # 15m down move, 1h high & overbought
-            & ((rsi_3_15m > 20.0) | (stochrsi_k_1h < 90.0) | (roc_9_1h < 10.0))
+            & ((rsi_3_15m_gt_20) | (stochrsi_k_1h < 90.0) | (roc_9_1h_lt_10))
             # 15m & 1h down move, 1d overbought
-            & ((rsi_3_15m > 25.0) | (rsi_3_1h > 40.0) | (roc_9_1d < 80.0))
+            & ((rsi_3_15m_gt_25) | (rsi_3_1h_gt_40) | (roc_9_1d_lt_80))
             # 15m & 4h down move, 1h overbought
-            & ((rsi_3_15m > 25.0) | (rsi_3_4h > 35.0) | (roc_9_1h < 100.0))
+            & ((rsi_3_15m_gt_25) | (rsi_3_4h_gt_35) | (roc_9_1h < 100.0))
             # 15m down move, 15m still not low enough, 1h high
-            & ((rsi_3_15m > 25.0) | (aroonu_14_15m < 20.0) | (stochrsi_k_1h < 90.0))
+            & ((rsi_3_15m_gt_25) | (aroonu_14_15m < 20.0) | (stochrsi_k_1h < 90.0))
             # 15m down move, 1h & 4h high
-            & ((rsi_3_15m > 25.0) | aroonu_14_1h_lt_70 | aroonu_14_4h_lt_100)
+            & ((rsi_3_15m_gt_25) | aroonu_14_1h_lt_70 | aroonu_14_4h_lt_100)
             # 15m down move, 1h high, 1d overbought
-            & ((rsi_3_15m > 25.0) | aroonu_14_1h_lt_70 | roc_9_1d_lt_50)
+            & ((rsi_3_15m_gt_25) | aroonu_14_1h_lt_70 | roc_9_1d_lt_50)
             # 15m down move, 4h high, 1d overbought
-            & ((rsi_3_15m > 25.0) | aroonu_14_4h_lt_70 | roc_9_1d_lt_50)
+            & ((rsi_3_15m_gt_25) | aroonu_14_4h_lt_70 | roc_9_1d_lt_50)
             # 15m down move, 4h high, 1h overbought
-            & ((rsi_3_15m > 25.0) | aroonu_14_4h_lt_80 | (roc_9_1h < 50.0))
+            & ((rsi_3_15m_gt_25) | aroonu_14_4h_lt_80 | (roc_9_1h < 50.0))
             # 15m down move, 4h high & overbought
-            & ((rsi_3_15m > 30.0) | aroonu_14_4h_lt_70 | (roc_9_4h < 50.0))
+            & ((rsi_3_15m_gt_30) | aroonu_14_4h_lt_70 | (roc_9_4h < 50.0))
             # 15m down move, 1h high, 1d downtrend
-            & ((rsi_3_15m > 30.0) | (stochrsi_k_1h < 80.0) | (roc_9_1d_gt_neg_20))
+            & ((rsi_3_15m_gt_30) | (stochrsi_k_1h < 80.0) | (roc_9_1d_gt_neg_20))
             # 15m down move, 4h high & overbought
-            & ((rsi_3_15m > 30.0) | (stochrsi_k_4h_lt_80) | (roc_9_4h < 30.0))
+            & ((rsi_3_15m_gt_30) | (stochrsi_k_4h_lt_80) | (roc_9_4h_lt_30))
             # 15m down move, 1h high, 4h overbought
             & ((rsi_3_15m > 35.0) | aroonu_14_1h_lt_80 | (roc_9_4h < 80.0))
             # 15m down move, 4h high & overbought
-            & ((rsi_3_15m > 35.0) | (aroonu_14_4h < 90.0) | (roc_9_4h < 50.0))
+            & ((rsi_3_15m > 35.0) | (aroonu_14_4h_lt_90) | (roc_9_4h < 50.0))
             # 15m down move, 4h high, 1d overbought
             & ((rsi_3_15m > 35.0) | aroonu_14_4h_lt_100 | (roc_9_1h < 20.0))
             # 15m down move, 1h high, 1d overbought
-            & ((rsi_3_15m > 35.0) | (stochrsi_k_1h_lt_80) | (roc_9_1d < 80.0))
+            & ((rsi_3_15m > 35.0) | (stochrsi_k_1h_lt_80) | (roc_9_1d_lt_80))
             # 15m down move, 4h high & overbought
-            & ((rsi_3_15m > 40.0) | aroonu_14_4h_lt_100 | (roc_9_4h < 40.0))
+            & ((rsi_3_15m > 40.0) | aroonu_14_4h_lt_100 | (roc_9_4h_lt_40))
             # 1h & 4h down move, 1d downtrend
             & ((rsi_3_1h > 1.0) | (rsi_3_4h_gt_15) | (roc_9_1d > -10.0))
             # 1h down move, 15m downtrend, 1h still high
-            & ((rsi_3_1h > 3.0) | (cmf_20_15m > -0.40) | (aroonu_14_1h < 40.0))
+            & ((rsi_3_1h_gt_3) | (cmf_20_15m > -0.40) | (aroonu_14_1h < 40.0))
             # 1h & 4h down move, 15m downtrend
-            & ((rsi_3_1h > 3.0) | (rsi_3_4h > 3.0) | (roc_9_15m > -30.0))
+            & ((rsi_3_1h_gt_3) | (rsi_3_4h > 3.0) | (roc_9_15m > -30.0))
             # 1h & 4h down move, 4h still high
-            & ((rsi_3_1h > 3.0) | (rsi_3_4h > 5.0) | (aroonu_14_4h < 40.0))
+            & ((rsi_3_1h_gt_3) | (rsi_3_4h_gt_5) | (aroonu_14_4h_lt_40))
             # 1h & 4h down move, 1d still high
-            & ((rsi_3_1h > 3.0) | (rsi_3_4h_gt_10) | (stochrsi_k_1d < 40.0))
+            & ((rsi_3_1h_gt_3) | (rsi_3_4h_gt_10) | (stochrsi_k_1d < 40.0))
             # 1h & 4h down move, 4h still high
-            & ((rsi_3_1h > 3.0) | (rsi_3_4h_gt_15) | (rsi_14_4h < 40.0))
+            & ((rsi_3_1h_gt_3) | (rsi_3_4h_gt_15) | (rsi_14_4h < 40.0))
             # 1h & 4h down move, 1h still not low enough
-            & ((rsi_3_1h > 3.0) | rsi_3_4h_gt_20 | (aroonu_14_1h < 20.0))
+            & ((rsi_3_1h_gt_3) | rsi_3_4h_gt_20 | (aroonu_14_1h < 20.0))
             # 1h & 4h down move, 1d high
-            & ((rsi_3_1h > 3.0) | rsi_3_4h_gt_20 | (aroonu_14_1d < 80.0))
+            & ((rsi_3_1h_gt_3) | rsi_3_4h_gt_20 | (aroonu_14_1d_lt_80))
             # 1h & 4h down move, 1d overbought
-            & ((rsi_3_1h > 3.0) | (rsi_3_4h > 25.0) | (roc_9_1d < 10.0))
+            & ((rsi_3_1h_gt_3) | (rsi_3_4h_gt_25) | (roc_9_1d < 10.0))
             # 1h & 4h down move, 4h high
-            & ((rsi_3_1h > 3.0) | (rsi_3_4h > 50.0) | aroonu_14_4h_lt_70)
+            & ((rsi_3_1h_gt_3) | (rsi_3_4h_gt_50) | aroonu_14_4h_lt_70)
             # 1h & 1d down move, 15m still high
-            & ((rsi_3_1h > 3.0) | (rsi_3_1d > 10.0) | (stochrsi_k_15m < 50.0))
+            & ((rsi_3_1h_gt_3) | (rsi_3_1d_gt_10) | (stochrsi_k_15m < 50.0))
             # 1h & 4h down move, 4h high
-            & ((rsi_3_1h > 5.0) | (rsi_3_4h > 5.0) | (stochrsi_k_4h < 40.0))
+            & ((rsi_3_1h_gt_5) | (rsi_3_4h_gt_5) | (stochrsi_k_4h < 40.0))
             # 1h & 4h down move, 1d still high
-            & ((rsi_3_1h > 5.0) | (rsi_3_4h > 5.0) | (stochrsi_k_1d < 50.0))
+            & ((rsi_3_1h_gt_5) | (rsi_3_4h_gt_5) | (stochrsi_k_1d < 50.0))
             # 1h & 4h down move, 1d downtrend
-            & ((rsi_3_1h > 5.0) | (rsi_3_4h > 5.0) | (roc_9_1d_gt_neg_30))
+            & ((rsi_3_1h_gt_5) | (rsi_3_4h_gt_5) | (roc_9_1d_gt_neg_30))
             # 1h % 4h down move, 4h downtrend
-            & ((rsi_3_1h > 5.0) | (rsi_3_4h_gt_10) | (cmf_20_4h > -0.30))
+            & ((rsi_3_1h_gt_5) | (rsi_3_4h_gt_10) | (cmf_20_4h > -0.30))
             # 1h & 4h down move, 4h still high
-            & ((rsi_3_1h > 5.0) | (rsi_3_4h > 60.0) | (stochrsi_k_4h < 50.0))
+            & ((rsi_3_1h_gt_5) | (rsi_3_4h > 60.0) | (stochrsi_k_4h_lt_50))
             # 1h & 4h down move, 15m high
-            & ((rsi_3_1h > 5.0) | (rsi_3_4h_gt_10) | (stochrsi_k_15m < 70.0))
+            & ((rsi_3_1h_gt_5) | (rsi_3_4h_gt_10) | (stochrsi_k_15m < 70.0))
             # 1h & 4h down move, 1h still high
-            & ((rsi_3_1h > 5.0) | (rsi_3_4h_gt_15) | (aroonu_14_1h < 50.0))
+            & ((rsi_3_1h_gt_5) | (rsi_3_4h_gt_15) | (aroonu_14_1h_lt_50))
             # 1h & 4h down move, 4h downtrend
-            & ((rsi_3_1h > 5.0) | (rsi_3_4h_gt_15) | (roc_9_4h > -30.0))
+            & ((rsi_3_1h_gt_5) | (rsi_3_4h_gt_15) | (roc_9_4h_gt_neg_30))
             # 1h down move, 4h still high, 1d downtrend
-            & ((rsi_3_1h > 5.0) | (stochrsi_k_4h < 50.0) | roc_9_1d_gt_neg_50)
+            & ((rsi_3_1h_gt_5) | (stochrsi_k_4h_lt_50) | roc_9_1d_gt_neg_50)
             # 1h & 4h & 1d down move
-            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_10) | (rsi_3_1d > 15.0))
+            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_10) | (rsi_3_1d_gt_15))
             # 1h & 4h down move, 1d still high
             & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_10) | (aroonu_14_1d < 40.0))
             # 1h & 4h down move, 1h still not low enough
@@ -13538,13 +13590,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 15m high
             & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_15) | (stochrsi_k_15m < 70.0))
             # 1h & 4h down move, 1d downtrend
-            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_15) | (roc_9_1d > -40.0))
+            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_15) | (roc_9_1d_gt_neg_40))
             # 1h & 4h down move, 4h still high
-            & ((rsi_3_1h_gt_10) | (rsi_3_4h > 30.0) | (stochrsi_k_4h < 50.0))
+            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_30) | (stochrsi_k_4h_lt_50))
             # 1h & 1d down move, 15m still high
-            & ((rsi_3_1h_gt_10) | (rsi_3_1d > 15.0) | (stochrsi_k_15m < 40.0))
+            & ((rsi_3_1h_gt_10) | (rsi_3_1d_gt_15) | (stochrsi_k_15m < 40.0))
             # 1h & 4h down move, 4h still high
-            & ((rsi_3_1h_gt_10) | (rsi_3_4h > 35.0) | (rsi_14_4h < 40.0))
+            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_35) | (rsi_14_4h < 40.0))
             # 1h down move, 1h still not low enough 1d overbought
             & ((rsi_3_1h_gt_10) | (aroonu_14_1h < 30.0) | (roc_9_1d < 100.0))
             # 1h & 4h down move, 1d high
@@ -13558,133 +13610,133 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 4h still high
             & ((rsi_3_1h_gt_15) | rsi_3_4h_gt_20 | (rsi_14_4h < 40.0))
             # 1h & 4h down move, 4h still not low enough
-            & ((rsi_3_1h_gt_15) | (rsi_3_4h > 25.0) | (stochrsi_k_4h < 30.0))
+            & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_25) | (stochrsi_k_4h < 30.0))
             # 1h & 4h down move, 1d high
-            & ((rsi_3_1h_gt_15) | (rsi_3_4h > 30.0) | (stochrsi_k_1d < 80.0))
+            & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_30) | (stochrsi_k_1d < 80.0))
             # 1h & 4h down move, 4h downtrend
-            & ((rsi_3_1h_gt_15) | (rsi_3_4h > 30.0) | (roc_9_4h > -30.0))
+            & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_30) | (roc_9_4h_gt_neg_30))
             # 1h & 4h down move, 4h high
-            & ((rsi_3_1h_gt_15) | (rsi_3_4h > 40.0) | aroonu_14_4h_lt_70)
+            & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_40) | aroonu_14_4h_lt_70)
             # 1h & 4h down move, 4h still high
-            & ((rsi_3_1h_gt_15) | (rsi_3_4h > 40.0) | (stochrsi_k_4h < 50.0))
+            & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_40) | (stochrsi_k_4h_lt_50))
             # 1h & 1d down move, 1d high
-            & ((rsi_3_1h_gt_15) | (rsi_3_1d > 25.0) | (aroonu_14_1d < 80.0))
+            & ((rsi_3_1h_gt_15) | (rsi_3_1d_gt_25) | (aroonu_14_1d_lt_80))
             # 1h & 1d down move, 1d overbought
             & ((rsi_3_1h_gt_15) | (rsi_3_1d > 35.0) | (roc_9_1d < 10.0))
             # 1h down move, 1h still high, 1d downtrend
-            & ((rsi_3_1h_gt_15) | (aroonu_14_1h < 40.0) | (roc_9_1d > -40.0))
+            & ((rsi_3_1h_gt_15) | (aroonu_14_1h < 40.0) | (roc_9_1d_gt_neg_40))
             # 1h down move, 4h high, 1d high
-            & ((rsi_3_1h_gt_15) | (aroonu_14_4h < 60.0) | (aroonu_14_1d < 100.0))
+            & ((rsi_3_1h_gt_15) | (aroonu_14_4h_lt_60) | (aroonu_14_1d < 100.0))
             # 1h down move, 4h high, 1d overbought
-            & ((rsi_3_1h_gt_15) | (aroonu_14_4h < 60.0) | roc_9_1d_lt_50)
+            & ((rsi_3_1h_gt_15) | (aroonu_14_4h_lt_60) | roc_9_1d_lt_50)
             # 1h down move, 4h high & overbought
-            & ((rsi_3_1h_gt_15) | (stochrsi_k_4h < 60.0) | (roc_9_4h < 10.0))
+            & ((rsi_3_1h_gt_15) | (stochrsi_k_4h < 60.0) | (roc_9_4h_lt_10))
             # 1h down move, 1d high & overbought
-            & ((rsi_3_1h_gt_15) | (stochrsi_k_1d < 90.0) | (roc_9_1d < 40.0))
+            & ((rsi_3_1h_gt_15) | (stochrsi_k_1d_lt_90) | (roc_9_1d_lt_40))
             # 1h down move, 4h & 1d downtrend
             & ((rsi_3_1h_gt_15) | (roc_9_4h > -20.0) | (roc_9_1d > -20.0))
             # 1h & 4h down move, 1d overbought
-            & (rsi_3_1h_gt_20 | rsi_3_4h_gt_20 | (roc_9_1d < 20.0))
+            & (rsi_3_1h_gt_20 | rsi_3_4h_gt_20 | (roc_9_1d_lt_20))
             # 1h & 4h down move, 4h still high
-            & (rsi_3_1h_gt_20 | (rsi_3_4h > 35.0) | (stochrsi_k_4h < 50.0))
+            & (rsi_3_1h_gt_20 | (rsi_3_4h_gt_35) | (stochrsi_k_4h_lt_50))
             # 1h & 4h down move, 4h high
-            & (rsi_3_1h_gt_20 | (rsi_3_4h > 50.0) | (aroonu_14_4h < 85.0))
+            & (rsi_3_1h_gt_20 | (rsi_3_4h_gt_50) | (aroonu_14_4h < 85.0))
             # 1h & 1d down move, 1h still high
             & (rsi_3_1h_gt_20 | (rsi_3_1d > 30.0) | (stochrsi_k_1h_lt_50))
             # 1h down move, 1h high, 4h downtrend
             & (rsi_3_1h_gt_20 | aroonu_14_1h_lt_70 | (roc_9_4h > -10.0))
             # 1h down move, 1h high, 4h overbought
-            & (rsi_3_1h_gt_20 | aroonu_14_1h_lt_70 | (roc_9_4h < 10.0))
+            & (rsi_3_1h_gt_20 | aroonu_14_1h_lt_70 | (roc_9_4h_lt_10))
             # 1h down move, 1h high, 1h still not low enough
-            & (rsi_3_1h_gt_20 | (aroonu_14_1d < 80.0) | (stochrsi_k_1h < 20.0))
+            & (rsi_3_1h_gt_20 | (aroonu_14_1d_lt_80) | (stochrsi_k_1h < 20.0))
             # 1h down move, 1d high & overbought
-            & (rsi_3_1h_gt_20 | aroonu_14_1d_lt_100 | (roc_9_1d < 20.0))
+            & (rsi_3_1h_gt_20 | aroonu_14_1d_lt_100 | (roc_9_1d_lt_20))
             # 1h down move, 1d high, 4h downtrend
             & (rsi_3_1h_gt_20 | (stochrsi_k_1d < 80.0) | (roc_9_4h_gt_neg_20))
             # 1h & 4h down move, 4h high
-            & ((rsi_3_1h > 25.0) | (rsi_3_4h > 30.0) | (aroonu_14_4h < 60.0))
+            & ((rsi_3_1h_gt_25) | (rsi_3_4h_gt_30) | (aroonu_14_4h_lt_60))
             # 1h & 4h down move, 1d downtrend
-            & ((rsi_3_1h > 25.0) | (rsi_3_4h > 30.0) | (roc_9_1d_gt_neg_30))
+            & ((rsi_3_1h_gt_25) | (rsi_3_4h_gt_30) | (roc_9_1d_gt_neg_30))
             # 1h down move, 1h & 4h high
-            & ((rsi_3_1h > 25.0) | (aroonu_14_1h < 60.0) | (aroonu_14_4h < 90.0))
+            & ((rsi_3_1h_gt_25) | (aroonu_14_1h < 60.0) | (aroonu_14_4h_lt_90))
             # 1h down move, 1h high
-            & ((rsi_3_1h > 25.0) | (aroonu_14_1h < 85.0))
+            & ((rsi_3_1h_gt_25) | (aroonu_14_1h < 85.0))
             # 1h down move, 4h high, 4h downtrend
-            & ((rsi_3_1h > 25.0) | aroonu_14_4h_lt_70 | (cmf_20_4h > -0.50))
+            & ((rsi_3_1h_gt_25) | aroonu_14_4h_lt_70 | (cmf_20_4h > -0.50))
             # 1h down move, 1d high & overbought
-            & ((rsi_3_1h > 25.0) | (aroonu_14_1d < 80.0) | (roc_9_1d < 40.0))
+            & ((rsi_3_1h_gt_25) | (aroonu_14_1d_lt_80) | (roc_9_1d_lt_40))
             # 1h down move, 4h & 1d overbought
-            & ((rsi_3_1h > 25.0) | (roc_9_4h < 30.0) | (roc_9_1d_lt_100))
+            & ((rsi_3_1h_gt_25) | (roc_9_4h_lt_30) | (roc_9_1d_lt_100))
             # 1h & 4h down move, 4h downtrend
-            & ((rsi_3_1h > 30.0) | (rsi_3_4h > 30.0) | (roc_9_4h_gt_neg_20))
+            & ((rsi_3_1h_gt_30) | (rsi_3_4h_gt_30) | (roc_9_4h_gt_neg_20))
             # 1h down move, 1h & 4h high
-            & ((rsi_3_1h > 30.0) | (aroonu_14_1h < 60.0) | aroonu_14_4h_lt_100)
+            & ((rsi_3_1h_gt_30) | (aroonu_14_1h < 60.0) | aroonu_14_4h_lt_100)
             # 1h down move, 1h high, 4h overbought
-            & ((rsi_3_1h > 30.0) | aroonu_14_1h_lt_70 | (roc_9_4h < 10.0))
+            & ((rsi_3_1h_gt_30) | aroonu_14_1h_lt_70 | (roc_9_4h_lt_10))
             # 1h down move, 4h & 1d high
-            & ((rsi_3_1h > 30.0) | aroonu_14_4h_lt_80 | aroonu_14_1d_lt_100)
+            & ((rsi_3_1h_gt_30) | aroonu_14_4h_lt_80 | aroonu_14_1d_lt_100)
             # 1h down move, 4h high, 1d overbought
-            & ((rsi_3_1h > 30.0) | aroonu_14_4h_lt_80 | (roc_9_1d < 30.0))
+            & ((rsi_3_1h_gt_30) | aroonu_14_4h_lt_80 | (roc_9_1d_lt_30))
             # 1h down move, 4h downtrend, 1d overbought
-            & ((rsi_3_1h > 30.0) | (roc_9_4h > -30.0) | (roc_9_1d < 200.0))
+            & ((rsi_3_1h_gt_30) | (roc_9_4h_gt_neg_30) | (roc_9_1d < 200.0))
             # 1h down move, 4h & 1d downtrend
-            & ((rsi_3_1h > 30.0) | (roc_9_4h > -25.0) | (roc_9_1d > -60.0))
+            & ((rsi_3_1h_gt_30) | (roc_9_4h > -25.0) | (roc_9_1d > -60.0))
             # 1h & 4h down move, 1h still high
-            & ((rsi_3_1h > 35.0) | (rsi_3_4h > 35.0) | (stochrsi_k_1h < 40.0))
+            & ((rsi_3_1h_gt_35) | (rsi_3_4h_gt_35) | (stochrsi_k_1h < 40.0))
             # 1h down move, 1h still high, 4h downtrend
-            & ((rsi_3_1h > 35.0) | (aroonu_14_1h < 50.0) | (roc_9_4h_gt_neg_20))
+            & ((rsi_3_1h_gt_35) | (aroonu_14_1h_lt_50) | (roc_9_4h_gt_neg_20))
             # 1h down move, 1h high, 1d downtrend
-            & ((rsi_3_1h > 35.0) | aroonu_14_1h_lt_70 | (roc_9_1d > -25.0))
+            & ((rsi_3_1h_gt_35) | aroonu_14_1h_lt_70 | (roc_9_1d > -25.0))
             # 1h down move, 4h high & overbought
-            & ((rsi_3_1h > 35.0) | (aroonu_14_4h < 85.0) | (roc_9_4h < 100.0))
+            & ((rsi_3_1h_gt_35) | (aroonu_14_4h < 85.0) | (roc_9_4h < 100.0))
             # 1h down move, 4h high, 1d overbought
-            & ((rsi_3_1h > 35.0) | (aroonu_14_4h < 85.0) | (roc_9_1d_lt_100))
+            & ((rsi_3_1h_gt_35) | (aroonu_14_4h < 85.0) | (roc_9_1d_lt_100))
             # 1h down move, 1d high, 4h overbought
-            & ((rsi_3_1h > 35.0) | aroonu_14_1d_lt_100 | (roc_9_4h < 40.0))
+            & ((rsi_3_1h_gt_35) | aroonu_14_1d_lt_100 | (roc_9_4h_lt_40))
             # 1h down move, 1h still high, 1d overbought
-            & ((rsi_3_1h > 35.0) | (stochrsi_k_1h_lt_50) | (roc_9_1d < 200.0))
+            & ((rsi_3_1h_gt_35) | (stochrsi_k_1h_lt_50) | (roc_9_1d < 200.0))
             # 1h down move, 1h & 4h high
-            & ((rsi_3_1h > 40.0) | aroonu_14_1h_lt_70 | aroonu_14_4h_lt_100)
+            & ((rsi_3_1h_gt_40) | aroonu_14_1h_lt_70 | aroonu_14_4h_lt_100)
             # 1h down move, 1h & 1d high
-            & ((rsi_3_1h > 40.0) | aroonu_14_1h_lt_80 | (aroonu_14_1d < 80.0))
+            & ((rsi_3_1h_gt_40) | aroonu_14_1h_lt_80 | (aroonu_14_1d_lt_80))
             # 1h down move, 1h high, 1d overbought
-            & ((rsi_3_1h > 40.0) | aroonu_14_1h_lt_80 | (roc_9_1d < 10.0))
+            & ((rsi_3_1h_gt_40) | aroonu_14_1h_lt_80 | (roc_9_1d < 10.0))
             # 1h down move, 4h still high, 1d overbought
-            & ((rsi_3_1h > 40.0) | (aroonu_14_4h < 40.0) | (roc_9_1d_lt_100))
+            & ((rsi_3_1h_gt_40) | (aroonu_14_4h_lt_40) | (roc_9_1d_lt_100))
             # 1h & 4h down move, 4h high
-            & ((rsi_3_1h > 45.0) | (rsi_3_4h > 60.0) | aroonu_14_4h_lt_100)
+            & ((rsi_3_1h_gt_45) | (rsi_3_4h > 60.0) | aroonu_14_4h_lt_100)
             # 1h & 4h down move, 1d overbought
-            & ((rsi_3_1h > 45.0) | (rsi_3_4h > 65.0) | (roc_9_1d < 200.0))
+            & ((rsi_3_1h_gt_45) | (rsi_3_4h > 65.0) | (roc_9_1d < 200.0))
             # 1h down move, 1h high & overbought
-            & ((rsi_3_1h > 50.0) | aroonu_14_1h_lt_80 | (roc_9_1h < 10.0))
+            & ((rsi_3_1h_gt_50) | aroonu_14_1h_lt_80 | (roc_9_1h_lt_10))
             # 1h down move, 4h high, 1h overbought
-            & ((rsi_3_1h > 50.0) | (aroonu_14_4h < 85.0) | (roc_9_1h < 20.0))
+            & ((rsi_3_1h_gt_50) | (aroonu_14_4h < 85.0) | (roc_9_1h < 20.0))
             # 1h down move, 4h high, 1d downtrend
-            & ((rsi_3_1h > 50.0) | (stochrsi_k_4h < 60.0) | (roc_9_1d > -60.0))
+            & ((rsi_3_1h_gt_50) | (stochrsi_k_4h < 60.0) | (roc_9_1d > -60.0))
             # 1h down move, 4h high & overbought
-            & ((rsi_3_1h > 50.0) | (stochrsi_k_4h_lt_80) | (roc_9_4h < 100.0))
+            & ((rsi_3_1h_gt_50) | (stochrsi_k_4h_lt_80) | (roc_9_4h < 100.0))
             # 1h down move, 1h & 4h overbought
-            & ((rsi_3_1h > 50.0) | (roc_9_1h < 10.0) | (roc_9_4h < 100.0))
+            & ((rsi_3_1h_gt_50) | (roc_9_1h_lt_10) | (roc_9_4h < 100.0))
             # 1h down move, 1h high & overbought
-            & ((rsi_3_1h > 55.0) | (aroonu_14_1h < 90.0) | (roc_9_1h < 10.0))
+            & ((rsi_3_1h > 55.0) | (aroonu_14_1h_lt_90) | (roc_9_1h_lt_10))
             # 1h down move, 4h high & overbought
-            & ((rsi_3_1h > 55.0) | aroonu_14_4h_lt_100 | (roc_9_4h < 10.0))
+            & ((rsi_3_1h > 55.0) | aroonu_14_4h_lt_100 | (roc_9_4h_lt_10))
             # 1h down move, 1h high & overbought
-            & ((rsi_3_1h > 55.0) | (stochrsi_k_1h_lt_80) | (roc_9_1h < 10.0))
+            & ((rsi_3_1h > 55.0) | (stochrsi_k_1h_lt_80) | (roc_9_1h_lt_10))
             # 4h & 1d down move, 1d still high
-            & ((rsi_3_4h > 3.0) | (rsi_3_1d > 15.0) | (aroonu_14_1d < 40.0))
+            & ((rsi_3_4h > 3.0) | (rsi_3_1d_gt_15) | (aroonu_14_1d < 40.0))
             # 4h & 1d down move, 1d still high
-            & ((rsi_3_4h > 3.0) | (rsi_3_1d > 20.0) | (stochrsi_k_1d < 40.0))
+            & ((rsi_3_4h > 3.0) | (rsi_3_1d_gt_20) | (stochrsi_k_1d < 40.0))
             # 4h & 1d down move, 1d downtrend
-            & ((rsi_3_4h > 5.0) | (rsi_3_1d > 15.0) | (roc_9_1d_gt_neg_20))
+            & ((rsi_3_4h_gt_5) | (rsi_3_1d_gt_15) | (roc_9_1d_gt_neg_20))
             # 4h down move, 15m still high
-            & ((rsi_3_4h > 5.0) | (stochrsi_k_15m < 50.0))
+            & ((rsi_3_4h_gt_5) | (stochrsi_k_15m < 50.0))
             # 4h & 1d down move, 1h still not low enough
-            & ((rsi_3_4h_gt_10) | (rsi_3_1d > 10.0) | (stochrsi_k_1h < 20.0))
+            & ((rsi_3_4h_gt_10) | (rsi_3_1d_gt_10) | (stochrsi_k_1h < 20.0))
             # 4h & 1d down move, 1d still high
-            & ((rsi_3_4h_gt_10) | (rsi_3_1d > 15.0) | (stochrsi_k_1d < 40.0))
+            & ((rsi_3_4h_gt_10) | (rsi_3_1d_gt_15) | (stochrsi_k_1d < 40.0))
             # 4h & 1d down move, 1d downtrend
-            & ((rsi_3_4h_gt_10) | (rsi_3_1d > 20.0) | (roc_9_1d > -25.0))
+            & ((rsi_3_4h_gt_10) | (rsi_3_1d_gt_20) | (roc_9_1d > -25.0))
             # 4h & 1d down move, 1d high
             & ((rsi_3_4h_gt_10) | (rsi_3_1d > 35.0) | (aroonu_14_1d < 100.0))
             # 4h & 1d down move, 1d overbought
@@ -13692,121 +13744,121 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 1d still high, 1d downtrend
             & ((rsi_3_4h_gt_10) | (aroonu_14_1d < 40.0) | (roc_9_1d > -20.0))
             # 4h down move, 1d high & overbought
-            & ((rsi_3_4h_gt_10) | (aroonu_14_1d < 90.0) | (roc_9_1d < 40.0))
+            & ((rsi_3_4h_gt_10) | (aroonu_14_1d_lt_90) | (roc_9_1d_lt_40))
             # 4h down move, 4h still high, 1d downtrend
             & ((rsi_3_4h_gt_10) | (stochrsi_k_4h < 40.0) | (roc_9_1d > -20.0))
             # 4h & 1d down move, 1d high
-            & ((rsi_3_4h_gt_15) | (rsi_3_1d > 20.0) | (aroonu_14_1d < 60.0))
+            & ((rsi_3_4h_gt_15) | (rsi_3_1d_gt_20) | (aroonu_14_1d < 60.0))
             # 4h down move, 4h still high, 1d downtrend
-            & ((rsi_3_4h_gt_15) | (aroonu_14_4h < 50.0) | (roc_9_1d > -20.0))
+            & ((rsi_3_4h_gt_15) | (aroonu_14_4h_lt_50) | (roc_9_1d > -20.0))
             # 4h & 1d down move, 4h still high
-            & (rsi_3_4h_gt_20 | (rsi_3_1d > 20.0) | (stochrsi_k_4h < 40.0))
+            & (rsi_3_4h_gt_20 | (rsi_3_1d_gt_20) | (stochrsi_k_4h < 40.0))
             # 4h & 1d down move, 1d high
-            & (rsi_3_4h_gt_20 | (rsi_3_1d > 20.0) | (stochrsi_k_1d < 80.0))
+            & (rsi_3_4h_gt_20 | (rsi_3_1d_gt_20) | (stochrsi_k_1d < 80.0))
             # 4h down move, 1h high, 1d downtrend
-            & ((rsi_3_4h_gt_15) | (aroonu_14_1h < 90.0) | (roc_9_1d > -10.0))
+            & ((rsi_3_4h_gt_15) | (aroonu_14_1h_lt_90) | (roc_9_1d > -10.0))
             # 4h down move, 4h still high, 4h downtrend
-            & ((rsi_3_4h_gt_15) | (aroonu_14_4h < 50.0) | (roc_9_4h > -20.0))
+            & ((rsi_3_4h_gt_15) | (aroonu_14_4h_lt_50) | (roc_9_4h > -20.0))
             # 4h down move, 1d high & overbought
-            & (rsi_3_4h_gt_20 | (aroonu_14_1d < 70.0) | roc_9_1d_lt_50)
+            & (rsi_3_4h_gt_20 | (aroonu_14_1d_lt_70) | roc_9_1d_lt_50)
             # 4h & 1d down move, 1d overbought
-            & ((rsi_3_4h > 25.0) | (rsi_3_1d > 40.0) | (roc_9_1d < 30.0))
+            & ((rsi_3_4h_gt_25) | (rsi_3_1d > 40.0) | (roc_9_1d_lt_30))
             # 4h down move, 4h still high, 1d overbought
-            & ((rsi_3_4h > 25.0) | (aroonu_14_4h < 40.0) | (roc_9_1d_lt_100))
+            & ((rsi_3_4h_gt_25) | (aroonu_14_4h_lt_40) | (roc_9_1d_lt_100))
             # 4h down move, 4h still high. 4h downtrend
-            & ((rsi_3_4h > 25.0) | (aroonu_14_4h < 50.0) | (cmf_20_4h > -0.40))
+            & ((rsi_3_4h_gt_25) | (aroonu_14_4h_lt_50) | (cmf_20_4h > -0.40))
             # 4h down move, 4h still high, 1d downtrend
-            & ((rsi_3_4h > 25.0) | (aroonu_14_4h < 50.0) | (roc_9_1d > -40.0))
+            & ((rsi_3_4h_gt_25) | (aroonu_14_4h_lt_50) | (roc_9_1d_gt_neg_40))
             # 4h down move, 4h high, 4h downtrend
-            & ((rsi_3_4h > 25.0) | aroonu_14_4h_lt_70 | (roc_9_4h > -30.0))
+            & ((rsi_3_4h_gt_25) | aroonu_14_4h_lt_70 | (roc_9_4h_gt_neg_30))
             # 4h & 1d down move, 1d overbought
-            & ((rsi_3_4h > 30.0) | (rsi_3_1d > 60.0) | (roc_9_1d < 60.0))
+            & ((rsi_3_4h_gt_30) | (rsi_3_1d > 60.0) | (roc_9_1d < 60.0))
             # 4h down move, 1d downtrend
-            & ((rsi_3_4h > 30.0) | roc_9_1d_gt_neg_50)
+            & ((rsi_3_4h_gt_30) | roc_9_1d_gt_neg_50)
             # 4h down move, 4h & 1d overbought
-            & ((rsi_3_4h > 35.0) | (roc_9_4h < 30.0) | (roc_9_1d < 200.0))
+            & ((rsi_3_4h_gt_35) | (roc_9_4h_lt_30) | (roc_9_1d < 200.0))
             # 4h down move, 1h high, 1d overbought
-            & ((rsi_3_4h > 40.0) | aroonu_14_1h_lt_70 | (roc_9_1d < 40.0))
+            & ((rsi_3_4h_gt_40) | aroonu_14_1h_lt_70 | (roc_9_1d_lt_40))
             # 4h down move, 4h & 1d downtrend
-            & ((rsi_3_4h > 40.0) | aroonu_14_4h_lt_80 | aroonu_14_1d_lt_100)
+            & ((rsi_3_4h_gt_40) | aroonu_14_4h_lt_80 | aroonu_14_1d_lt_100)
             # 4h down move, 4h still high, 1d overbought
-            & ((rsi_3_4h > 40.0) | (stochrsi_k_4h < 40.0) | roc_9_1d_lt_50)
+            & ((rsi_3_4h_gt_40) | (stochrsi_k_4h < 40.0) | roc_9_1d_lt_50)
             # 4h down move, 4h high, 1d downtrend
-            & ((rsi_3_4h > 40.0) | (stochrsi_k_4h < 70.0) | (roc_9_1d > -60.0))
+            & ((rsi_3_4h_gt_40) | (stochrsi_k_4h_lt_70) | (roc_9_1d > -60.0))
             # 4h down move, 1d high & overbought
-            & ((rsi_3_4h > 40.0) | (stochrsi_k_1d < 90.0) | (roc_9_1d_lt_100))
+            & ((rsi_3_4h_gt_40) | (stochrsi_k_1d_lt_90) | (roc_9_1d_lt_100))
             # 4h & 1d down move, 1d high
             & ((rsi_3_4h > 45.0) | (rsi_3_1d > 45.0) | aroonu_14_1d_lt_100)
             # 4h down move, 4h high, 1d downtrend
             & ((rsi_3_4h > 45.0) | aroonu_14_4h_lt_70 | (roc_9_1d_gt_neg_30))
             # 4h down move, 4h high & overbought
-            & ((rsi_3_4h > 50.0) | aroonu_14_4h_lt_70 | (roc_9_4h < 10.0))
+            & ((rsi_3_4h_gt_50) | aroonu_14_4h_lt_70 | (roc_9_4h_lt_10))
             # 4h down move, 1d high & overbought
-            & ((rsi_3_4h > 50.0) | (aroonu_14_1d < 85.0) | (roc_9_1d < 80.0))
+            & ((rsi_3_4h_gt_50) | (aroonu_14_1d < 85.0) | (roc_9_1d_lt_80))
             # 4h down move, 1d high, 4h overbought
-            & ((rsi_3_4h > 55.0) | (stochrsi_k_1d < 90.0) | (roc_9_4h < 10.0))
+            & ((rsi_3_4h > 55.0) | (stochrsi_k_1d_lt_90) | (roc_9_4h_lt_10))
             # 4h down move, 4h high & overbought
             & ((rsi_3_4h > 60.0) | aroonu_14_4h_lt_70 | (roc_9_4h_lt_20))
             # 4h down move, 1d high & overbought
             & ((rsi_3_4h > 60.0) | aroonu_14_1d_lt_100 | (roc_9_1d < 200.0))
             # 4h down move, 4h & 1d overbought
-            & ((rsi_3_4h > 60.0) | (roc_9_4h_lt_20) | (roc_9_1d < 20.0))
+            & ((rsi_3_4h > 60.0) | (roc_9_4h_lt_20) | (roc_9_1d_lt_20))
             # 4h down move, 4h overbought
             & ((rsi_3_4h > 60.0) | (roc_9_4h < 60.0))
             # 1d down move, 1d high, 1d downtrend
-            & ((rsi_3_1d > 5.0) | (aroonu_14_1d < 80.0) | (roc_9_1d_gt_neg_20))
+            & ((rsi_3_1d > 5.0) | (aroonu_14_1d_lt_80) | (roc_9_1d_gt_neg_20))
             # 1d down move, 1h & 4h high
-            & ((rsi_3_1d > 10.0) | (aroonu_14_1h < 50.0) | (aroonu_14_4h < 90.0))
+            & ((rsi_3_1d_gt_10) | (aroonu_14_1h_lt_50) | (aroonu_14_4h_lt_90))
             # 1d down move, 1h high
-            & ((rsi_3_1d > 10.0) | aroonu_14_1h_lt_70)
+            & ((rsi_3_1d_gt_10) | aroonu_14_1h_lt_70)
             # 1d down move, 1h high, 1d downtrend
-            & ((rsi_3_1d > 10.0) | (stochrsi_k_1h < 80.0) | (roc_9_1d_gt_neg_20))
+            & ((rsi_3_1d_gt_10) | (stochrsi_k_1h < 80.0) | (roc_9_1d_gt_neg_20))
             # 1d down move, 1h overbought, 1d downtrend
-            & ((rsi_3_1d > 15.0) | (roc_9_1h < 20.0) | roc_9_1d_gt_neg_50)
+            & ((rsi_3_1d_gt_15) | (roc_9_1h < 20.0) | roc_9_1d_gt_neg_50)
             # 1d down move, 1h high, 1d downtrend
-            & ((rsi_3_1d > 20.0) | (stochrsi_k_1h < 90.0) | (roc_9_1d > -10.0))
+            & ((rsi_3_1d_gt_20) | (stochrsi_k_1h < 90.0) | (roc_9_1d > -10.0))
             # 1d down move, 1h high, 1d overbought
-            & ((rsi_3_1d > 25.0) | aroonu_14_1h_lt_70 | (roc_9_1d < 25.0))
+            & ((rsi_3_1d_gt_25) | aroonu_14_1h_lt_70 | (roc_9_1d < 25.0))
             # 1d down move, 1d still high, 1d downtrend
-            & ((rsi_3_1d > 25.0) | (stochrsi_k_1d < 50.0) | (roc_9_1d_gt_neg_20))
+            & ((rsi_3_1d_gt_25) | (stochrsi_k_1d < 50.0) | (roc_9_1d_gt_neg_20))
             # 1d down move, 1h high & overbought
-            & ((rsi_3_1d > 40.0) | (aroonu_14_1d < 70.0) | (roc_9_1d < 80.0))
+            & ((rsi_3_1d > 40.0) | (aroonu_14_1d_lt_70) | (roc_9_1d_lt_80))
             # 1d down move, 4h high & overbought
             & ((rsi_3_1d > 45.0) | (stochrsi_k_4h_lt_90) | (roc_9_4h < 60.0))
             # 1d downtrend, 1d high & overbought
-            & ((cmf_20_1d > -0.40) | (aroonu_14_1d < 85.0) | (roc_9_1d < 20.0))
+            & ((cmf_20_1d > -0.40) | (aroonu_14_1d < 85.0) | (roc_9_1d_lt_20))
             # 1h high, 4h & 1d overbought
             & (aroonu_14_1h_lt_70 | (roc_9_4h < 50.0) | (roc_9_1d < 200.0))
             # 1h & 4h high, 1d overbought
-            & (aroonu_14_1h_lt_70 | (aroonu_14_4h < 90.0) | roc_9_1d_lt_50)
+            & (aroonu_14_1h_lt_70 | (aroonu_14_4h_lt_90) | roc_9_1d_lt_50)
             # 1h & 4h high, 1d downtrend
-            & (aroonu_14_1h_lt_70 | aroonu_14_4h_lt_100 | (roc_9_1d > -40.0))
+            & (aroonu_14_1h_lt_70 | aroonu_14_4h_lt_100 | (roc_9_1d_gt_neg_40))
             # 1h high, 4h & 1d downtrend
-            & (aroonu_14_1h_lt_70 | (roc_9_4h > -30.0) | roc_9_1d_gt_neg_50)
+            & (aroonu_14_1h_lt_70 | (roc_9_4h_gt_neg_30) | roc_9_1d_gt_neg_50)
             # 1h & 4h high, 1h overbought
-            & (aroonu_14_1h_lt_80 | (aroonu_14_4h < 90.0) | (roc_9_1h < 30.0))
+            & (aroonu_14_1h_lt_80 | (aroonu_14_4h_lt_90) | (roc_9_1h < 30.0))
             # 1h & 4high, 1d downtrend
             & (aroonu_14_1h_lt_80 | aroonu_14_4h_lt_100 | (roc_9_1d > -20.0))
             # 1h & 4h high, 1d overbought
-            & (aroonu_14_1h_lt_80 | aroonu_14_4h_lt_100 | (roc_9_1d < 80.0))
+            & (aroonu_14_1h_lt_80 | aroonu_14_4h_lt_100 | (roc_9_1d_lt_80))
             # 1h & 1d high, 1d overbought
-            & (aroonu_14_1h_lt_80 | aroonu_14_1d_lt_100 | (roc_9_1d < 30.0))
+            & (aroonu_14_1h_lt_80 | aroonu_14_1d_lt_100 | (roc_9_1d_lt_30))
             # 1h high, 1d downtrend
-            & (aroonu_14_1h_lt_80 | (roc_9_1d > -40.0))
+            & (aroonu_14_1h_lt_80 | (roc_9_1d_gt_neg_40))
             # 1h & 4h high, 1d overbought
-            & ((aroonu_14_1h < 90.0) | aroonu_14_4h_lt_100 | (roc_9_1d < 30.0))
+            & ((aroonu_14_1h_lt_90) | aroonu_14_4h_lt_100 | (roc_9_1d_lt_30))
             # 1h high, 4h & 1d overbought
-            & ((aroonu_14_1h < 90.0) | (roc_9_4h < 40.0) | (roc_9_1d < 40.0))
+            & ((aroonu_14_1h_lt_90) | (roc_9_4h_lt_40) | (roc_9_1d_lt_40))
             # 4h still high, 5m downtrend
-            & ((aroonu_14_4h < 40.0) | (roc_9 > -40.0))
+            & ((aroonu_14_4h_lt_40) | (roc_9 > -40.0))
             # 4h high & overbought
             & (aroonu_14_4h_lt_70 | (roc_9_4h < 80.0))
             # 4h & 1d high, 1d overbought
-            & (aroonu_14_4h_lt_80 | aroonu_14_1d_lt_100 | (roc_9_1d < 40.0))
+            & (aroonu_14_4h_lt_80 | aroonu_14_1d_lt_100 | (roc_9_1d_lt_40))
             # 4h high, 1h & 4h overbought
-            & (aroonu_14_4h_lt_100 | (roc_9_1h < 10.0) | (roc_9_4h < 20.0))
+            & (aroonu_14_4h_lt_100 | (roc_9_1h_lt_10) | (roc_9_4h < 20.0))
             # 1d high, 1d downtrend
-            & ((aroonu_14_1d < 80.0) | (roc_9_1d_gt_neg_30))
+            & ((aroonu_14_1d_lt_80) | (roc_9_1d_gt_neg_30))
             # 1d high, 1h & 4h downtrend
             & ((aroonu_14_1d < 85.0) | (roc_9_1h > -30.0) | (roc_9_4h > -50.0))
             # 1d high, 4h & 1d overbought
@@ -13818,15 +13870,15 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h high, 1d downtrend
             & ((stochrsi_k_1h_lt_70) | roc_9_1d_gt_neg_50)
             # 1h high, 1d overbought
-            & ((stochrsi_k_1h_lt_70) | (roc_9_1d < 40.0))
+            & ((stochrsi_k_1h_lt_70) | (roc_9_1d_lt_40))
             # 1h high, 4h downtrend
             & ((stochrsi_k_1h < 80.0) | (roc_9_4h_gt_neg_20))
             # 1h high, 4h overbought
             & ((stochrsi_k_1h_lt_80) | (roc_9_4h < 80.0))
             # 4h high, 1h & 4h overbought
-            & ((stochrsi_k_4h < 80.0) | (roc_9_1h < 10.0) | (roc_9_4h_lt_20))
+            & ((stochrsi_k_4h < 80.0) | (roc_9_1h_lt_10) | (roc_9_4h_lt_20))
             # 1d high, 1h & 1d overbought
-            & ((stochrsi_k_1d < 80.0) | (roc_9_1h < 10.0) | (roc_9_1d < 80.0))
+            & ((stochrsi_k_1d < 80.0) | (roc_9_1h_lt_10) | (roc_9_1d_lt_80))
             # 1d high, 4h & 1d overbought
             & ((stochrsi_k_1d < 80.0) | (roc_9_4h < 60.0) | (roc_9_1d < 60.0))
             # big drop in the last 20 days, 1d high, 1d downtrend
@@ -13843,7 +13895,7 @@ class NostalgiaForInfinityX7(IStrategy):
             (aroonu_14 < 30.0)
             & (stochrsi_k < 30.0)
             # & (rsi_3_15m > 5.0)
-            & (aroonu_14_15m < 50.0)
+            & (aroonu_14_15m_lt_50)
             & (close < (ema_20 * 0.948))
           )
 
@@ -13857,7 +13909,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 5m & 4h down move, 1h still high
             ((rsi_3 > 5.0) | (rsi_3_4h_gt_15) | (stochrsi_k_1h < 50.0))
             # 5m down move, 15m high, 1d overbought
-            & ((rsi_3 > 5.0) | (aroonu_14_15m < 70.0) | (roc_9_1d < 40.0))
+            & ((rsi_3 > 5.0) | (aroonu_14_15m_lt_70) | (roc_9_1d_lt_40))
             # 5m down move, 15m still high, 1d downtrend
             & ((rsi_3 > 5.0) | (stochrsi_k_15m < 50.0) | (roc_9_1d_gt_neg_20))
             # 5m down move, 1h still high, 4h downtrend
@@ -13865,201 +13917,201 @@ class NostalgiaForInfinityX7(IStrategy):
             # 5m down move, 1h high. 1d downtrend
             & ((rsi_3 > 5.0) | (stochrsi_k_1h < 80.0) | (roc_9_1d_gt_neg_30))
             # 5m down move, 15m & 1h high
-            & ((rsi_3 > 10.0) | (aroonu_14_15m < 70.0) | (aroonu_14_1h < 100.0))
+            & ((rsi_3 > 10.0) | (aroonu_14_15m_lt_70) | (aroonu_14_1h_lt_100))
             # 5m down move, 15m & 1d high
-            & ((rsi_3 > 10.0) | (aroonu_14_15m < 70.0) | aroonu_14_1d_lt_100)
+            & ((rsi_3 > 10.0) | (aroonu_14_15m_lt_70) | aroonu_14_1d_lt_100)
             # 5m down move, 1h & 1d high
-            & ((rsi_3 > 15.0) | aroonu_14_1h_lt_80 | (aroonu_14_1d < 90.0))
+            & ((rsi_3 > 15.0) | aroonu_14_1h_lt_80 | (aroonu_14_1d_lt_90))
             # 15m & 1h dowbn move, 1d high
-            & ((rsi_3_15m > 5.0) | (rsi_3_1h > 25.0) | (stochrsi_k_1d < 90.0))
+            & ((rsi_3_15m_gt_5) | (rsi_3_1h_gt_25) | (stochrsi_k_1d_lt_90))
             # 15m & 1d down move, 1h high
-            & ((rsi_3_15m > 5.0) | (rsi_3_1d > 15.0) | (stochrsi_k_1h < 60.0))
+            & ((rsi_3_15m_gt_5) | (rsi_3_1d_gt_15) | (stochrsi_k_1h < 60.0))
             # 15m & 1h down move, 15m still high
-            & ((rsi_3_15m > 10.0) | (rsi_3_1h > 35.0) | (aroonu_14_15m < 50.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_35) | (aroonu_14_15m_lt_50))
             # 15m & 1h down move, 1h still high
-            & ((rsi_3_15m > 10.0) | (rsi_3_4h_gt_10) | (stochrsi_k_1h < 40.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_4h_gt_10) | (stochrsi_k_1h < 40.0))
             # 15m & 4h down move, 15m still high
-            & ((rsi_3_15m > 10.0) | rsi_3_4h_gt_20 | (aroonu_14_15m < 50.0))
+            & ((rsi_3_15m_gt_10) | rsi_3_4h_gt_20 | (aroonu_14_15m_lt_50))
             # 15m down move, 15m still high, 1h high
-            & ((rsi_3_15m > 10.0) | (aroonu_14_15m < 40.0) | (stochrsi_k_1h < 90.0))
+            & ((rsi_3_15m_gt_10) | (aroonu_14_15m < 40.0) | (stochrsi_k_1h < 90.0))
             # 15m down move, 15m still high, 1h high
-            & ((rsi_3_15m > 10.0) | (aroonu_14_15m < 50.0) | (stochrsi_k_1h_lt_80))
+            & ((rsi_3_15m_gt_10) | (aroonu_14_15m_lt_50) | (stochrsi_k_1h_lt_80))
             # 15m down move, 15m still high, 1d overbought
-            & ((rsi_3_15m > 10.0) | (aroonu_14_15m < 50.0) | (roc_9_1d_lt_100))
+            & ((rsi_3_15m_gt_10) | (aroonu_14_15m_lt_50) | (roc_9_1d_lt_100))
             # 15m down move, 15m high, 1d overbought
-            & ((rsi_3_15m > 10.0) | (aroonu_14_15m < 60.0) | roc_9_1d_lt_50)
+            & ((rsi_3_15m_gt_10) | (aroonu_14_15m < 60.0) | roc_9_1d_lt_50)
             # 15m down move, 4h high, 1d downtrend
-            & ((rsi_3_15m > 10.0) | (stochrsi_k_4h < 80.0) | (roc_9_1d_gt_neg_20))
+            & ((rsi_3_15m_gt_10) | (stochrsi_k_4h < 80.0) | (roc_9_1d_gt_neg_20))
             # 15m & 1h down move, 4h still high
-            & ((rsi_3_15m > 15.0) | (rsi_3_1h > 35.0) | (aroonu_14_4h < 50.0))
+            & ((rsi_3_15m_gt_15) | (rsi_3_1h_gt_35) | (aroonu_14_4h_lt_50))
             # 15m & 1h down move, 1h high
-            & ((rsi_3_15m > 15.0) | (rsi_3_1h > 35.0) | (stochrsi_k_1h < 60.0))
+            & ((rsi_3_15m_gt_15) | (rsi_3_1h_gt_35) | (stochrsi_k_1h < 60.0))
             # 15m & 1h down move, 1h high
-            & ((rsi_3_15m > 15.0) | (rsi_3_1h > 45.0) | (stochrsi_k_1h_lt_80))
+            & ((rsi_3_15m_gt_15) | (rsi_3_1h_gt_45) | (stochrsi_k_1h_lt_80))
             # 15m & 1h down move, 1h high
-            & ((rsi_3_15m > 15.0) | (rsi_3_1h > 50.0) | (aroonu_14_1h < 75.0))
+            & ((rsi_3_15m_gt_15) | (rsi_3_1h_gt_50) | (aroonu_14_1h < 75.0))
             # 15m & 4h down move, 4h high
-            & ((rsi_3_15m > 15.0) | (rsi_3_4h_gt_15) | aroonu_14_4h_lt_70)
+            & ((rsi_3_15m_gt_15) | (rsi_3_4h_gt_15) | aroonu_14_4h_lt_70)
             # 15m & 4h down move, 1d downtrend
-            & ((rsi_3_15m > 15.0) | (rsi_3_4h_gt_15) | (roc_9_1d > -30.0))
+            & ((rsi_3_15m_gt_15) | (rsi_3_4h_gt_15) | (roc_9_1d > -30.0))
             # 15m & 4h down move, 15m still high
-            & ((rsi_3_15m > 15.0) | (rsi_3_4h_gt_15) | (stochrsi_k_15m < 50.0))
+            & ((rsi_3_15m_gt_15) | (rsi_3_4h_gt_15) | (stochrsi_k_15m < 50.0))
             # 15m & 4h down move, 1d high
-            & ((rsi_3_15m > 15.0) | rsi_3_4h_gt_20 | aroonu_14_1d_lt_100)
+            & ((rsi_3_15m_gt_15) | rsi_3_4h_gt_20 | aroonu_14_1d_lt_100)
             # 15m & 1d down move, 15m high
-            & ((rsi_3_15m > 15.0) | (rsi_3_1d > 15.0) | (aroonu_14_15m < 70.0))
+            & ((rsi_3_15m_gt_15) | (rsi_3_1d_gt_15) | (aroonu_14_15m_lt_70))
             # 15m down move, 4h downtrend. 15m high
-            & ((rsi_3_15m > 15.0) | (cmf_20_4h > -0.30) | (aroonu_14_15m < 60.0))
+            & ((rsi_3_15m_gt_15) | (cmf_20_4h > -0.30) | (aroonu_14_15m < 60.0))
             # 15m down move, 15m still high, 1h still high
-            & ((rsi_3_15m > 15.0) | (aroonu_14_15m < 40.0) | (aroonu_14_1h < 50.0))
+            & ((rsi_3_15m_gt_15) | (aroonu_14_15m < 40.0) | (aroonu_14_1h_lt_50))
             # 15m down move, 15m high, 4h downtrend
-            & ((rsi_3_15m > 15.0) | (aroonu_14_15m < 60.0) | (roc_9_4h_gt_neg_20))
+            & ((rsi_3_15m_gt_15) | (aroonu_14_15m < 60.0) | (roc_9_4h_gt_neg_20))
             # 15m down move, 15m high, 1d downtrend
-            & ((rsi_3_15m > 15.0) | (aroonu_14_15m < 60.0) | (roc_9_1d > -70.0))
+            & ((rsi_3_15m_gt_15) | (aroonu_14_15m < 60.0) | (roc_9_1d > -70.0))
             # 15m down move, 15m high, 1d overbought
-            & ((rsi_3_15m > 15.0) | (aroonu_14_15m < 60.0) | (roc_9_1d_lt_100))
+            & ((rsi_3_15m_gt_15) | (aroonu_14_15m < 60.0) | (roc_9_1d_lt_100))
             # 15m down move, 15m & 1h high
-            & ((rsi_3_15m > 15.0) | (aroonu_14_15m < 70.0) | aroonu_14_1h_lt_70)
+            & ((rsi_3_15m_gt_15) | (aroonu_14_15m_lt_70) | aroonu_14_1h_lt_70)
             # 15m down move, 15m & 4h high
-            & ((rsi_3_15m > 15.0) | (aroonu_14_15m < 70.0) | aroonu_14_4h_lt_70)
+            & ((rsi_3_15m_gt_15) | (aroonu_14_15m_lt_70) | aroonu_14_4h_lt_70)
             # 15m down move, 15m & 1d high
-            & ((rsi_3_15m > 15.0) | (aroonu_14_15m < 70.0) | aroonu_14_1d_lt_100)
+            & ((rsi_3_15m_gt_15) | (aroonu_14_15m_lt_70) | aroonu_14_1d_lt_100)
             # 15m down move, 15m still high, 4h high
-            & ((rsi_3_15m > 15.0) | (aroonu_14_15m < 70.0) | (stochrsi_k_4h_lt_80))
+            & ((rsi_3_15m_gt_15) | (aroonu_14_15m_lt_70) | (stochrsi_k_4h_lt_80))
             # 15m down move, 15m high, 1d overbought
-            & ((rsi_3_15m > 15.0) | (aroonu_14_15m < 70.0) | roc_9_1d_lt_50)
+            & ((rsi_3_15m_gt_15) | (aroonu_14_15m_lt_70) | roc_9_1d_lt_50)
             # 15m down move, 4h high, 1d downtrend
-            & ((rsi_3_15m > 15.0) | (aroonu_14_4h < 50.0) | (roc_9_1d > -40.0))
+            & ((rsi_3_15m_gt_15) | (aroonu_14_4h_lt_50) | (roc_9_1d_gt_neg_40))
             # 15m down move, 1h high, 1d overbought
-            & ((rsi_3_15m > 15.0) | (stochrsi_k_1h_lt_80) | (roc_9_1d < 20.0))
+            & ((rsi_3_15m_gt_15) | (stochrsi_k_1h_lt_80) | (roc_9_1d_lt_20))
             # 15m down move, 4h & 1d overbought
-            & ((rsi_3_15m > 15.0) | (roc_9_4h < 25.0) | (roc_9_1d_lt_100))
+            & ((rsi_3_15m_gt_15) | (roc_9_4h < 25.0) | (roc_9_1d_lt_100))
             # 15m & 1h down move, 1h still high
-            & ((rsi_3_15m > 20.0) | (rsi_3_1h > 25.0) | (aroonu_14_1h < 40.0))
+            & ((rsi_3_15m_gt_20) | (rsi_3_1h_gt_25) | (aroonu_14_1h < 40.0))
             # 15m & 1h down move, 1h high
-            & ((rsi_3_15m > 20.0) | (rsi_3_1h > 45.0) | (aroonu_14_1h < 85.0))
+            & ((rsi_3_15m_gt_20) | (rsi_3_1h_gt_45) | (aroonu_14_1h < 85.0))
             # 15m & 1h down move, 4h high
-            & ((rsi_3_15m > 20.0) | (rsi_3_1h > 45.0) | aroonu_14_4h_lt_80)
+            & ((rsi_3_15m_gt_20) | (rsi_3_1h_gt_45) | aroonu_14_4h_lt_80)
             # 15m & 1h down move, 1d high
-            & ((rsi_3_15m > 20.0) | (rsi_3_1h > 45.0) | aroonu_14_1d_lt_100)
+            & ((rsi_3_15m_gt_20) | (rsi_3_1h_gt_45) | aroonu_14_1d_lt_100)
             # 15m & 4h down move, 15m high
-            & ((rsi_3_15m > 20.0) | rsi_3_4h_gt_20 | (aroonu_14_15m < 60.0))
+            & ((rsi_3_15m_gt_20) | rsi_3_4h_gt_20 | (aroonu_14_15m < 60.0))
             # 15m & 4h down move, 15m high
-            & ((rsi_3_15m > 20.0) | (rsi_3_4h > 30.0) | (aroonu_14_15m < 75.0))
+            & ((rsi_3_15m_gt_20) | (rsi_3_4h_gt_30) | (aroonu_14_15m < 75.0))
             # 15m & 4h down move, 1d high
-            & ((rsi_3_15m > 20.0) | (rsi_3_4h > 30.0) | (stochrsi_k_1d < 90.0))
+            & ((rsi_3_15m_gt_20) | (rsi_3_4h_gt_30) | (stochrsi_k_1d_lt_90))
             # 15m & 4h down move, 4h high
-            & ((rsi_3_15m > 20.0) | (rsi_3_4h > 60.0) | aroonu_14_4h_lt_70)
+            & ((rsi_3_15m_gt_20) | (rsi_3_4h > 60.0) | aroonu_14_4h_lt_70)
             # 15m & 1h down move, 15m still high
-            & ((rsi_3_15m > 20.0) | (rsi_3_1d > 25.0) | (stochrsi_k_15m < 50.0))
+            & ((rsi_3_15m_gt_20) | (rsi_3_1d_gt_25) | (stochrsi_k_15m < 50.0))
             # 15m & 1d down move, 1h still high
-            & ((rsi_3_15m > 20.0) | (rsi_3_1d > 25.0) | (stochrsi_k_1h_lt_50))
+            & ((rsi_3_15m_gt_20) | (rsi_3_1d_gt_25) | (stochrsi_k_1h_lt_50))
             # 15m & 1d down move, 1h high
-            & ((rsi_3_15m > 20.0) | (rsi_3_1d > 40.0) | (aroonu_14_1h < 90.0))
+            & ((rsi_3_15m_gt_20) | (rsi_3_1d > 40.0) | (aroonu_14_1h_lt_90))
             # 15m &1d down move, 1d overbought
-            & ((rsi_3_15m > 20.0) | (rsi_3_1d > 50.0) | (roc_9_1d < 20.0))
+            & ((rsi_3_15m_gt_20) | (rsi_3_1d > 50.0) | (roc_9_1d_lt_20))
             # 15m down move, 15m still not low enough, 4h overbought
-            & ((rsi_3_15m > 20.0) | (aroonu_14_15m < 30.0) | (roc_9_4h < 60.0))
+            & ((rsi_3_15m_gt_20) | (aroonu_14_15m < 30.0) | (roc_9_4h < 60.0))
             # 15m down move, 15m still high, 4h high
-            & ((rsi_3_15m > 20.0) | (aroonu_14_15m < 40.0) | (stochrsi_k_4h_lt_90))
+            & ((rsi_3_15m_gt_20) | (aroonu_14_15m < 40.0) | (stochrsi_k_4h_lt_90))
             # 15m down move, 15m still high, 1h high
-            & ((rsi_3_15m > 20.0) | (aroonu_14_15m < 50.0) | (aroonu_14_1h < 100.0))
+            & ((rsi_3_15m_gt_20) | (aroonu_14_15m_lt_50) | (aroonu_14_1h_lt_100))
             # 15m down move, 15m still high, 4h high
-            & ((rsi_3_15m > 20.0) | (aroonu_14_15m < 50.0) | aroonu_14_4h_lt_70)
+            & ((rsi_3_15m_gt_20) | (aroonu_14_15m_lt_50) | aroonu_14_4h_lt_70)
             # 15m down move, 15m still high, 1d overbought
-            & ((rsi_3_15m > 20.0) | (aroonu_14_15m < 50.0) | roc_9_1d_lt_50)
+            & ((rsi_3_15m_gt_20) | (aroonu_14_15m_lt_50) | roc_9_1d_lt_50)
             # 15m down move, 15m high, 4h downtrend
-            & ((rsi_3_15m > 20.0) | (aroonu_14_15m < 60.0) | (roc_9_4h > -40.0))
+            & ((rsi_3_15m_gt_20) | (aroonu_14_15m < 60.0) | (roc_9_4h > -40.0))
             # 15m down move, 15m high, 4h overbought
-            & ((rsi_3_15m > 20.0) | (aroonu_14_15m < 60.0) | (roc_9_4h < 10.0))
+            & ((rsi_3_15m_gt_20) | (aroonu_14_15m < 60.0) | (roc_9_4h_lt_10))
             # 15m down move, 15m high, 4h overbought
-            & ((rsi_3_15m > 20.0) | (aroonu_14_15m < 70.0) | (roc_9_4h_lt_20))
+            & ((rsi_3_15m_gt_20) | (aroonu_14_15m_lt_70) | (roc_9_4h_lt_20))
             # 15m down move, 15m high, 4h downtrend
-            & ((rsi_3_15m > 20.0) | (aroonu_14_15m < 70.0) | (roc_9_4h > -10.0))
+            & ((rsi_3_15m_gt_20) | (aroonu_14_15m_lt_70) | (roc_9_4h > -10.0))
             # 15m down move, 15m high, 1d downtrend
-            & ((rsi_3_15m > 20.0) | (aroonu_14_15m < 70.0) | (roc_9_1d_gt_neg_20))
+            & ((rsi_3_15m_gt_20) | (aroonu_14_15m_lt_70) | (roc_9_1d_gt_neg_20))
             # 15m down move, 15m high, 1d overbought
-            & ((rsi_3_15m > 20.0) | (aroonu_14_15m < 70.0) | roc_9_1d_lt_50)
+            & ((rsi_3_15m_gt_20) | (aroonu_14_15m_lt_70) | roc_9_1d_lt_50)
             # 15m down move, 1h high, 4h overbought
-            & ((rsi_3_15m > 20.0) | aroonu_14_1h_lt_80 | (roc_9_4h < 20.0))
+            & ((rsi_3_15m_gt_20) | aroonu_14_1h_lt_80 | (roc_9_4h < 20.0))
             # 15m down move, 4h high & overbought
-            & ((rsi_3_15m > 20.0) | aroonu_14_4h_lt_70 | (roc_9_4h < 50.0))
+            & ((rsi_3_15m_gt_20) | aroonu_14_4h_lt_70 | (roc_9_4h < 50.0))
             # 15m down move, 1h high, 4h downtrend
-            & ((rsi_3_15m > 20.0) | (stochrsi_k_1h < 60.0) | (roc_9_4h_gt_neg_20))
+            & ((rsi_3_15m_gt_20) | (stochrsi_k_1h < 60.0) | (roc_9_4h_gt_neg_20))
             # 15m down move, 1h high, 1d overbought
-            & ((rsi_3_15m > 20.0) | (stochrsi_k_1h_lt_80) | (roc_9_1d < 30.0))
+            & ((rsi_3_15m_gt_20) | (stochrsi_k_1h_lt_80) | (roc_9_1d_lt_30))
             # 15m down move, 1h high
-            & ((rsi_3_15m > 20.0) | (stochrsi_k_1h < 90.0))
+            & ((rsi_3_15m_gt_20) | (stochrsi_k_1h < 90.0))
             # 15m down move, 4h still high, 1d downtrend
-            & ((rsi_3_15m > 20.0) | (stochrsi_k_4h < 40.0) | (roc_9_1d_gt_neg_20))
+            & ((rsi_3_15m_gt_20) | (stochrsi_k_4h < 40.0) | (roc_9_1d_gt_neg_20))
             # 15m down move, 4h high, 1d downtrend
-            & ((rsi_3_15m > 20.0) | (stochrsi_k_4h < 80.0) | (roc_9_1d_gt_neg_30))
+            & ((rsi_3_15m_gt_20) | (stochrsi_k_4h < 80.0) | (roc_9_1d_gt_neg_30))
             # 15m down move, 4h & 1d overbought
-            & ((rsi_3_15m > 20.0) | (roc_9_4h < 25.0) | (roc_9_1d_lt_100))
+            & ((rsi_3_15m_gt_20) | (roc_9_4h < 25.0) | (roc_9_1d_lt_100))
             # 15m & 1h down move, 15m high
-            & ((rsi_3_15m > 25.0) | (rsi_3_1h > 30.0) | (aroonu_14_15m < 70.0))
+            & ((rsi_3_15m_gt_25) | (rsi_3_1h_gt_30) | (aroonu_14_15m_lt_70))
             # 15m & 4h down move, 15m high
-            & ((rsi_3_15m > 25.0) | (rsi_3_4h > 40.0) | (aroonu_14_15m < 75.0))
+            & ((rsi_3_15m_gt_25) | (rsi_3_4h_gt_40) | (aroonu_14_15m < 75.0))
             # 15m & 4h down move, 1h high
-            & ((rsi_3_15m > 25.0) | (rsi_3_4h > 50.0) | (aroonu_14_1h < 100.0))
+            & ((rsi_3_15m_gt_25) | (rsi_3_4h_gt_50) | (aroonu_14_1h_lt_100))
             # 15m & 4h down move, 1h high
-            & ((rsi_3_15m > 25.0) | (rsi_3_4h > 60.0) | (aroonu_14_1h < 100.0))
+            & ((rsi_3_15m_gt_25) | (rsi_3_4h > 60.0) | (aroonu_14_1h_lt_100))
             # 15m & 4h down move, 4h high
-            & ((rsi_3_15m > 25.0) | (rsi_3_4h > 60.0) | aroonu_14_4h_lt_80)
+            & ((rsi_3_15m_gt_25) | (rsi_3_4h > 60.0) | aroonu_14_4h_lt_80)
             # 15m & 1d down move, 1d high
-            & ((rsi_3_15m > 25.0) | (rsi_3_1d > 30.0) | (aroonu_14_1d < 75.0))
+            & ((rsi_3_15m_gt_25) | (rsi_3_1d > 30.0) | (aroonu_14_1d < 75.0))
             # 15m & 1d down move, 1d high
-            & ((rsi_3_15m > 25.0) | (rsi_3_1d > 45.0) | (aroonu_14_1d < 90.0))
+            & ((rsi_3_15m_gt_25) | (rsi_3_1d > 45.0) | (aroonu_14_1d_lt_90))
             # 15m down move, 15m high, 4h downtrend
-            & ((rsi_3_15m > 25.0) | (aroonu_14_15m < 70.0) | (roc_9_4h_gt_neg_20))
+            & ((rsi_3_15m_gt_25) | (aroonu_14_15m_lt_70) | (roc_9_4h_gt_neg_20))
             # 15m down move, 15m high, 4h overbought
-            & ((rsi_3_15m > 25.0) | (aroonu_14_15m < 70.0) | (roc_9_4h < 10.0))
+            & ((rsi_3_15m_gt_25) | (aroonu_14_15m_lt_70) | (roc_9_4h_lt_10))
             # 15m down move, 15m high, 1d overbought
-            & ((rsi_3_15m > 25.0) | (aroonu_14_15m < 70.0) | (roc_9_1d < 60.0))
+            & ((rsi_3_15m_gt_25) | (aroonu_14_15m_lt_70) | (roc_9_1d < 60.0))
             # 15m down move, 1h & 4h high
-            & ((rsi_3_15m > 25.0) | aroonu_14_1h_lt_70 | aroonu_14_4h_lt_70)
+            & ((rsi_3_15m_gt_25) | aroonu_14_1h_lt_70 | aroonu_14_4h_lt_70)
             # 15m down move, 1h high, 1d downtrend
-            & ((rsi_3_15m > 25.0) | aroonu_14_1h_lt_70 | (roc_9_4h > -10.0))
+            & ((rsi_3_15m_gt_25) | aroonu_14_1h_lt_70 | (roc_9_4h > -10.0))
             # 15m down move, 1h high, 1d overbought
-            & ((rsi_3_15m > 25.0) | (aroonu_14_1h < 90.0) | (roc_9_1d < 20.0))
+            & ((rsi_3_15m_gt_25) | (aroonu_14_1h_lt_90) | (roc_9_1d_lt_20))
             # 15m down move, 4h high, 1d high
-            & ((rsi_3_15m > 25.0) | (aroonu_14_4h < 60.0) | (stochrsi_k_1d < 90.0))
+            & ((rsi_3_15m_gt_25) | (aroonu_14_4h_lt_60) | (stochrsi_k_1d_lt_90))
             # 15m down move, 4h high & overbought
-            & ((rsi_3_15m > 25.0) | aroonu_14_4h_lt_80 | (roc_9_4h < 10.0))
+            & ((rsi_3_15m_gt_25) | aroonu_14_4h_lt_80 | (roc_9_4h_lt_10))
             # 15m down move, 15m still high, 1h still high
-            & ((rsi_3_15m > 25.0) | (stochrsi_k_15m < 50.0) | (aroonu_14_1h < 50.0))
+            & ((rsi_3_15m_gt_25) | (stochrsi_k_15m < 50.0) | (aroonu_14_1h_lt_50))
             # 15m down move, 1h high, 4h high
-            & ((rsi_3_15m > 25.0) | (stochrsi_k_1h < 70.0) | aroonu_14_4h_lt_100)
+            & ((rsi_3_15m_gt_25) | (stochrsi_k_1h < 70.0) | aroonu_14_4h_lt_100)
             # 15m down move, 4h & 1d overbought
-            & ((rsi_3_15m > 25.0) | (roc_9_4h < 50.0) | roc_9_1d_lt_50)
+            & ((rsi_3_15m_gt_25) | (roc_9_4h < 50.0) | roc_9_1d_lt_50)
             # 15m & 1h down move, 1h high
-            & ((rsi_3_15m > 30.0) | (rsi_3_1h > 30.0) | aroonu_14_1h_lt_80)
+            & ((rsi_3_15m_gt_30) | (rsi_3_1h_gt_30) | aroonu_14_1h_lt_80)
             # 15m & 1h down move, 1d overbought
-            & ((rsi_3_15m > 30.0) | (rsi_3_1h > 30.0) | (roc_9_1d < 40.0))
+            & ((rsi_3_15m_gt_30) | (rsi_3_1h_gt_30) | (roc_9_1d_lt_40))
             # 15m & 4h down move, 4h high
-            & ((rsi_3_15m > 30.0) | (rsi_3_4h > 35.0) | aroonu_14_4h_lt_70)
+            & ((rsi_3_15m_gt_30) | (rsi_3_4h_gt_35) | aroonu_14_4h_lt_70)
             # 15m down move, 1d high, 15m high
-            & ((rsi_3_15m > 30.0) | (rsi_14_1d < 70.0) | (aroonu_14_15m < 70.0))
+            & ((rsi_3_15m_gt_30) | (rsi_14_1d < 70.0) | (aroonu_14_15m_lt_70))
             # 15m down move, 15m high, 1d downtrend
-            & ((rsi_3_15m > 30.0) | (aroonu_14_15m < 60.0) | (roc_9_1d > -40.0))
+            & ((rsi_3_15m_gt_30) | (aroonu_14_15m < 60.0) | (roc_9_1d_gt_neg_40))
             # 15m down move, 15m high, 15m downtrend
-            & ((rsi_3_15m > 30.0) | (aroonu_14_15m < 70.0) | (cmf_20_15m > -0.30))
+            & ((rsi_3_15m_gt_30) | (aroonu_14_15m_lt_70) | (cmf_20_15m > -0.30))
             # 15m down move, 15m high, 1d overbought
-            & ((rsi_3_15m > 30.0) | (aroonu_14_15m < 70.0) | (roc_9_1d < 70.0))
+            & ((rsi_3_15m_gt_30) | (aroonu_14_15m_lt_70) | (roc_9_1d < 70.0))
             # 15m down move, 1h high, 1d overbought
-            & ((rsi_3_15m > 30.0) | (aroonu_14_1h < 100.0) | (roc_9_1d < 30.0))
+            & ((rsi_3_15m_gt_30) | (aroonu_14_1h_lt_100) | (roc_9_1d_lt_30))
             # 15m down move, 4h high & overbought
-            & ((rsi_3_15m > 30.0) | aroonu_14_4h_lt_70 | (roc_9_4h < 60.0))
+            & ((rsi_3_15m_gt_30) | aroonu_14_4h_lt_70 | (roc_9_4h < 60.0))
             # 15m down move, 15m high, 4h overbought
-            & ((rsi_3_15m > 30.0) | (stochrsi_k_15m < 70.0) | (roc_9_4h < 70.0))
+            & ((rsi_3_15m_gt_30) | (stochrsi_k_15m < 70.0) | (roc_9_4h < 70.0))
             # 15m down move, 1h high, 1d overbought
-            & ((rsi_3_15m > 30.0) | (stochrsi_k_1h < 90.0) | roc_9_1d_lt_50)
+            & ((rsi_3_15m_gt_30) | (stochrsi_k_1h < 90.0) | roc_9_1d_lt_50)
             # 15m down move, 15m high, 4h high
             & ((rsi_3_15m > 35.0) | (aroonu_14_15m < 60.0) | (stochrsi_k_4h_lt_90))
             # 15m down move, 15m high, 4h overbought
-            & ((rsi_3_15m > 35.0) | (aroonu_14_15m < 70.0) | (roc_9_4h < 80.0))
+            & ((rsi_3_15m > 35.0) | (aroonu_14_15m_lt_70) | (roc_9_4h < 80.0))
             # 15m down move, 1h high, 4h overbought
-            & ((rsi_3_15m > 35.0) | (aroonu_14_1h < 90.0) | (roc_9_4h < 100.0))
+            & ((rsi_3_15m > 35.0) | (aroonu_14_1h_lt_90) | (roc_9_4h < 100.0))
             # 15m down move, 4h high, 1d overbought
             & ((rsi_3_15m > 35.0) | aroonu_14_4h_lt_80 | (roc_9_1d < 200.0))
             # 15m down move, 1h high, 1d downtrend
@@ -14067,133 +14119,133 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 4h high & overbought
             & ((rsi_3_15m > 35.0) | (stochrsi_k_4h < 90.0) | (roc_9_4h_lt_20))
             # 15m down move, 15m high, 1h downtrend
-            & ((rsi_3_15m > 40.0) | (aroonu_14_15m < 70.0) | (roc_9_1h > -20.0))
+            & ((rsi_3_15m > 40.0) | (aroonu_14_15m_lt_70) | (roc_9_1h > -20.0))
             # 15m down move, 15m & 4h high
             & ((rsi_3_15m > 40.0) | (aroonu_14_15m < 75.0) | (aroonu_14_4h < 75.0))
             # 15m down move, 4h high & overbought
-            & ((rsi_3_15m > 40.0) | (stochrsi_k_4h_lt_80) | (roc_9_4h < 30.0))
+            & ((rsi_3_15m > 40.0) | (stochrsi_k_4h_lt_80) | (roc_9_4h_lt_30))
             # 1h & 4h down move, 15m still high
-            & ((rsi_3_1h > 5.0) | (rsi_3_4h_gt_10) | (stochrsi_k_15m < 50.0))
+            & ((rsi_3_1h_gt_5) | (rsi_3_4h_gt_10) | (stochrsi_k_15m < 50.0))
             # 1h & 4h down move, 4h still high
-            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_10) | (aroonu_14_4h < 50.0))
+            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_10) | (aroonu_14_4h_lt_50))
             # 1h down move, 4h still high, 4h downtrend
-            & ((rsi_3_1h_gt_10) | (aroonu_14_4h < 40.0) | (roc_9_4h > -20.0))
+            & ((rsi_3_1h_gt_10) | (aroonu_14_4h_lt_40) | (roc_9_4h > -20.0))
             # 1h down move, 4h high & overbought
             & ((rsi_3_1h_gt_10) | aroonu_14_4h_lt_70 | (roc_9_4h < 20.0))
             # 1h & 4h down move, 1d high
             & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_15) | (rsi_14_1d < 60.0))
             # 1h & 4h down move, 15m high
-            & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_15) | (aroonu_14_15m < 70.0))
+            & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_15) | (aroonu_14_15m_lt_70))
             # 1h & 4h down move, 1d downtrend
             & ((rsi_3_1h_gt_15) | rsi_3_4h_gt_20 | (roc_9_1d > -30.0))
             # 1h & 1d down move, 1d overbought
             & ((rsi_3_1h_gt_15) | (rsi_3_1d > 35.0) | (roc_9_1d < 10.0))
             # 1h & 1d down move, 1d overbought
-            & ((rsi_3_1h_gt_15) | (rsi_3_1d > 60.0) | (roc_9_1d < 40.0))
+            & ((rsi_3_1h_gt_15) | (rsi_3_1d > 60.0) | (roc_9_1d_lt_40))
             # 1h down move, 1h still not low enough, 1d downtrend
             & ((rsi_3_1h_gt_15) | (stochrsi_k_1h < 30.0) | (roc_9_1d > -30.0))
             # 1h & 4h down move, 1d high
-            & (rsi_3_1h_gt_20 | (rsi_3_4h > 25.0) | (aroonu_14_1d < 80.0))
+            & (rsi_3_1h_gt_20 | (rsi_3_4h_gt_25) | (aroonu_14_1d_lt_80))
             # 1h & 4h down move, 1d overbought
-            & (rsi_3_1h_gt_20 | (rsi_3_4h > 25.0) | (roc_9_1d < 30.0))
+            & (rsi_3_1h_gt_20 | (rsi_3_4h_gt_25) | (roc_9_1d_lt_30))
             # 1h down move, 4h high, 1d overbought
             & (rsi_3_1h_gt_20 | aroonu_14_4h_lt_80 | (roc_9_1d < 100.0))
             # 1h & 4h down move, 4h high
-            & ((rsi_3_1h > 25.0) | (rsi_3_4h > 40.0) | aroonu_14_4h_lt_80)
+            & ((rsi_3_1h_gt_25) | (rsi_3_4h_gt_40) | aroonu_14_4h_lt_80)
             # 1h & 1d down move, 1d still high
-            & ((rsi_3_1h > 25.0) | (rsi_3_1d > 40.0) | (stochrsi_k_1d < 50.0))
+            & ((rsi_3_1h_gt_25) | (rsi_3_1d > 40.0) | (stochrsi_k_1d < 50.0))
             # 1h down move, 1h high, 1d overbought
-            & ((rsi_3_1h > 25.0) | aroonu_14_1h_lt_70 | (roc_9_1d < 20.0))
+            & ((rsi_3_1h_gt_25) | aroonu_14_1h_lt_70 | (roc_9_1d_lt_20))
             # 1h down move, 1d high & overbought
-            & ((rsi_3_1h > 25.0) | (aroonu_14_1d < 80.0) | (roc_9_1d < 20.0))
+            & ((rsi_3_1h_gt_25) | (aroonu_14_1d_lt_80) | (roc_9_1d_lt_20))
             # 1h down move, 4h high, 1d downtrend
-            & ((rsi_3_1h > 25.0) | (stochrsi_k_4h < 60.0) | (roc_9_1d_gt_neg_20))
+            & ((rsi_3_1h_gt_25) | (stochrsi_k_4h < 60.0) | (roc_9_1d_gt_neg_20))
             # 1h down move, 4h downtrend, 1d overbought
-            & ((rsi_3_1h > 25.0) | (roc_9_4h > -40.0) | roc_9_1d_lt_50)
+            & ((rsi_3_1h_gt_25) | (roc_9_4h > -40.0) | roc_9_1d_lt_50)
             # 1h down move, 15m & 1h still high
-            & ((rsi_3_1h > 30.0) | (aroonu_14_15m < 40.0) | (aroonu_14_1h < 50.0))
+            & ((rsi_3_1h_gt_30) | (aroonu_14_15m < 40.0) | (aroonu_14_1h_lt_50))
             # 1h down move, 1h still high 1d overbought
-            & ((rsi_3_1h > 30.0) | (aroonu_14_1h < 50.0) | (roc_9_1d < 200.0))
+            & ((rsi_3_1h_gt_30) | (aroonu_14_1h_lt_50) | (roc_9_1d < 200.0))
             # 1h down move, 1h high, 4h downtrend
-            & ((rsi_3_1h > 30.0) | (aroonu_14_1h < 60.0) | (roc_9_4h_gt_neg_20))
+            & ((rsi_3_1h_gt_30) | (aroonu_14_1h < 60.0) | (roc_9_4h_gt_neg_20))
             # 1h down move, 1h high, 1d overbought
-            & ((rsi_3_1h > 30.0) | aroonu_14_1h_lt_70 | (roc_9_1d < 30.0))
+            & ((rsi_3_1h_gt_30) | aroonu_14_1h_lt_70 | (roc_9_1d_lt_30))
             # 1h down move, 4h high & overbought
-            & ((rsi_3_1h > 30.0) | (stochrsi_k_4h < 60.0) | (roc_9_4h_lt_20))
+            & ((rsi_3_1h_gt_30) | (stochrsi_k_4h < 60.0) | (roc_9_4h_lt_20))
             # 1h down move, 4h & 1h overbought
-            & ((rsi_3_1h > 30.0) | (roc_9_4h < 30.0) | (roc_9_1d < 40.0))
+            & ((rsi_3_1h_gt_30) | (roc_9_4h_lt_30) | (roc_9_1d_lt_40))
             # 1h & 1d down move, 1h high
-            & ((rsi_3_1h > 35.0) | (rsi_3_1d > 35.0) | (aroonu_14_1h < 75.0))
+            & ((rsi_3_1h_gt_35) | (rsi_3_1d > 35.0) | (aroonu_14_1h < 75.0))
             # 1h down move, 15m still high, 4h  high
-            & ((rsi_3_1h > 35.0) | (aroonu_14_15m < 40.0) | aroonu_14_4h_lt_80)
+            & ((rsi_3_1h_gt_35) | (aroonu_14_15m < 40.0) | aroonu_14_4h_lt_80)
             # 1h down move, 15m still high, 4h high
-            & ((rsi_3_1h > 35.0) | (aroonu_14_15m < 40.0) | (stochrsi_k_4h < 70.0))
+            & ((rsi_3_1h_gt_35) | (aroonu_14_15m < 40.0) | (stochrsi_k_4h_lt_70))
             # 1h down move, 15m still high, 4h high
-            & ((rsi_3_1h > 35.0) | (aroonu_14_15m < 50.0) | aroonu_14_4h_lt_70)
+            & ((rsi_3_1h_gt_35) | (aroonu_14_15m_lt_50) | aroonu_14_4h_lt_70)
             # 1h down move, 15m & 1d high
-            & ((rsi_3_1h > 35.0) | (aroonu_14_15m < 60.0) | (aroonu_14_1d < 80.0))
+            & ((rsi_3_1h_gt_35) | (aroonu_14_15m < 60.0) | (aroonu_14_1d_lt_80))
             # 1h down move, 1h & 4h high
-            & ((rsi_3_1h > 35.0) | aroonu_14_1h_lt_70 | (stochrsi_k_4h < 90.0))
+            & ((rsi_3_1h_gt_35) | aroonu_14_1h_lt_70 | (stochrsi_k_4h < 90.0))
             # 1h down move, 1h & 1d high
-            & ((rsi_3_1h > 35.0) | aroonu_14_1h_lt_80 | (aroonu_14_1d < 90.0))
+            & ((rsi_3_1h_gt_35) | aroonu_14_1h_lt_80 | (aroonu_14_1d_lt_90))
             # 1h down move, 1h downtrend, 4h overbought
-            & ((rsi_3_1h > 35.0) | (cmf_20_1h > -0.30) | (roc_9_4h_lt_20))
+            & ((rsi_3_1h_gt_35) | (cmf_20_1h > -0.30) | (roc_9_4h_lt_20))
             # 1h down move, 1h high, 1d downtrend
-            & ((rsi_3_1h > 35.0) | aroonu_14_1h_lt_70 | (roc_9_1d > -80.0))
+            & ((rsi_3_1h_gt_35) | aroonu_14_1h_lt_70 | (roc_9_1d > -80.0))
             # 1h down move, 1h high, 1d overbought
-            & ((rsi_3_1h > 35.0) | aroonu_14_1h_lt_80 | roc_9_1d_lt_50)
+            & ((rsi_3_1h_gt_35) | aroonu_14_1h_lt_80 | roc_9_1d_lt_50)
             # 1h down move, 4h high, 1d downtrend
-            & ((rsi_3_1h > 35.0) | (stochrsi_k_4h_lt_80) | roc_9_1d_gt_neg_50)
+            & ((rsi_3_1h_gt_35) | (stochrsi_k_4h_lt_80) | roc_9_1d_gt_neg_50)
             # 1h & 4h down move, 1h high
-            & ((rsi_3_1h > 40.0) | (rsi_3_4h > 50.0) | (stochrsi_k_1h_lt_70))
+            & ((rsi_3_1h_gt_40) | (rsi_3_4h_gt_50) | (stochrsi_k_1h_lt_70))
             # 1h & 4h down move, 4h high
-            & ((rsi_3_1h > 40.0) | (rsi_3_4h > 50.0) | (stochrsi_k_4h < 60.0))
+            & ((rsi_3_1h_gt_40) | (rsi_3_4h_gt_50) | (stochrsi_k_4h < 60.0))
             # 1h down move, 15m still high, 4h downtrend
-            & ((rsi_3_1h > 40.0) | (stochrsi_k_15m < 40.0) | (roc_9_4h > -15.0))
+            & ((rsi_3_1h_gt_40) | (stochrsi_k_15m < 40.0) | (roc_9_4h > -15.0))
             # 1h down move, 15m still high, 1d overbought
-            & ((rsi_3_1h > 40.0) | (aroonu_14_15m < 50.0) | roc_9_1d_lt_50)
+            & ((rsi_3_1h_gt_40) | (aroonu_14_15m_lt_50) | roc_9_1d_lt_50)
             # 1h down move, 15m & 4h high
-            & ((rsi_3_1h > 40.0) | (aroonu_14_15m < 70.0) | aroonu_14_4h_lt_70)
+            & ((rsi_3_1h_gt_40) | (aroonu_14_15m_lt_70) | aroonu_14_4h_lt_70)
             # 1h down move, 1h still high, 4h high
-            & ((rsi_3_1h > 40.0) | (aroonu_14_1h < 50.0) | (stochrsi_k_4h_lt_80))
+            & ((rsi_3_1h_gt_40) | (aroonu_14_1h_lt_50) | (stochrsi_k_4h_lt_80))
             # 1h down move, 1h still high, 1d overbought
-            & ((rsi_3_1h > 40.0) | (aroonu_14_1h < 50.0) | (roc_9_1d_lt_100))
+            & ((rsi_3_1h_gt_40) | (aroonu_14_1h_lt_50) | (roc_9_1d_lt_100))
             # 1h down move, 1h high, 4h overbought
-            & ((rsi_3_1h > 40.0) | aroonu_14_1h_lt_70 | (roc_9_4h < 20.0))
+            & ((rsi_3_1h_gt_40) | aroonu_14_1h_lt_70 | (roc_9_4h < 20.0))
             # 1h down move, 1h high, 1d downtrend
-            & ((rsi_3_1h > 40.0) | (aroonu_14_1h < 85.0) | (roc_9_1d > -60.0))
+            & ((rsi_3_1h_gt_40) | (aroonu_14_1h < 85.0) | (roc_9_1d > -60.0))
             # 1h down move, 1h & 4h high
-            & ((rsi_3_1h > 40.0) | (aroonu_14_1h < 90.0) | aroonu_14_4h_lt_100)
+            & ((rsi_3_1h_gt_40) | (aroonu_14_1h_lt_90) | aroonu_14_4h_lt_100)
             # 1h down move, 1h high, 1d downtrend
-            & ((rsi_3_1h > 40.0) | (stochrsi_k_1h_lt_80) | (cmf_20_1d > -0.20))
+            & ((rsi_3_1h_gt_40) | (stochrsi_k_1h_lt_80) | (cmf_20_1d > -0.20))
             # 1h down move, 4h & 1d overbought
-            & ((rsi_3_1h > 40.0) | (roc_9_4h < 10.0) | roc_9_1d_lt_50)
+            & ((rsi_3_1h_gt_40) | (roc_9_4h_lt_10) | roc_9_1d_lt_50)
             # 1h down move, 15m high, 4h overbought
-            & ((rsi_3_1h > 45.0) | (aroonu_14_15m < 70.0) | (roc_9_4h < 30.0))
+            & ((rsi_3_1h_gt_45) | (aroonu_14_15m_lt_70) | (roc_9_4h_lt_30))
             # 1h down move, 1h high, 4h overbought
-            & ((rsi_3_1h > 45.0) | (aroonu_14_1h < 100.0) | (roc_9_4h_lt_20))
+            & ((rsi_3_1h_gt_45) | (aroonu_14_1h_lt_100) | (roc_9_4h_lt_20))
             # 1h down move, 4h high & overbought
-            & ((rsi_3_1h > 45.0) | aroonu_14_4h_lt_80 | (roc_9_4h < 20.0))
+            & ((rsi_3_1h_gt_45) | aroonu_14_4h_lt_80 | (roc_9_4h < 20.0))
             # 1h down move, 4h high & overbought
-            & ((rsi_3_1h > 45.0) | aroonu_14_4h_lt_80 | (roc_9_4h < 40.0))
+            & ((rsi_3_1h_gt_45) | aroonu_14_4h_lt_80 | (roc_9_4h_lt_40))
             # 1h down move, 1d high & overbought
-            & ((rsi_3_1h > 45.0) | aroonu_14_1d_lt_100 | (roc_9_1d < 30.0))
+            & ((rsi_3_1h_gt_45) | aroonu_14_1d_lt_100 | (roc_9_1d_lt_30))
             # 1h down move, 1h still high, 1d overbought
-            & ((rsi_3_1h > 45.0) | (stochrsi_k_1h < 40.0) | (roc_9_1d < 200.0))
+            & ((rsi_3_1h_gt_45) | (stochrsi_k_1h < 40.0) | (roc_9_1d < 200.0))
             # 1h down move, 1d high & overbought
-            & ((rsi_3_1h > 45.0) | (stochrsi_k_1d < 80.0) | (roc_9_1d < 10.0))
+            & ((rsi_3_1h_gt_45) | (stochrsi_k_1d < 80.0) | (roc_9_1d < 10.0))
             # 1h down move, 15m & 1h high
-            & ((rsi_3_1h > 50.0) | (aroonu_14_15m < 70.0) | (aroonu_14_1h < 100.0))
+            & ((rsi_3_1h_gt_50) | (aroonu_14_15m_lt_70) | (aroonu_14_1h_lt_100))
             # 1h down move, 1h high, 4h overbought
-            & ((rsi_3_1h > 50.0) | aroonu_14_1h_lt_80 | (roc_9_4h < 10.0))
+            & ((rsi_3_1h_gt_50) | aroonu_14_1h_lt_80 | (roc_9_4h_lt_10))
             # 1h down move, 4h still high, 1d overbought
-            & ((rsi_3_1h > 50.0) | (aroonu_14_4h < 50.0) | (roc_9_1d < 200.0))
+            & ((rsi_3_1h_gt_50) | (aroonu_14_4h_lt_50) | (roc_9_1d < 200.0))
             # 1h down move, 4h high & overbought
-            & ((rsi_3_1h > 50.0) | aroonu_14_4h_lt_100 | (roc_9_4h < 50.0))
+            & ((rsi_3_1h_gt_50) | aroonu_14_4h_lt_100 | (roc_9_4h < 50.0))
             # 1h down move, 1h & 4h high
-            & ((rsi_3_1h > 50.0) | (stochrsi_k_1h < 80.0) | aroonu_14_4h_lt_100)
+            & ((rsi_3_1h_gt_50) | (stochrsi_k_1h < 80.0) | aroonu_14_4h_lt_100)
             # 1h down move, 4h high & overbought
-            & ((rsi_3_1h > 50.0) | (stochrsi_k_4h < 70.0) | (roc_9_4h < 10.0))
+            & ((rsi_3_1h_gt_50) | (stochrsi_k_4h_lt_70) | (roc_9_4h_lt_10))
             # 1h down move, 1h high, 1d high
             & ((rsi_3_1h > 55.0) | (stochrsi_k_1h < 70.0) | aroonu_14_1d_lt_100)
             # 1h down move, 1h high, 1d downtrend
@@ -14203,31 +14255,31 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h high, 1d overbought
             & ((rsi_3_1h > 60.0) | (stochrsi_k_1h < 80.0) | (roc_9_1d_lt_100))
             # 1h down move, 15m & 1h high
-            & ((rsi_3_1h > 65.0) | (aroonu_14_15m < 70.0) | (aroonu_14_1h < 100.0))
+            & ((rsi_3_1h > 65.0) | (aroonu_14_15m_lt_70) | (aroonu_14_1h_lt_100))
             # 1h down move, 1h high & overbought
-            & ((rsi_3_1h > 65.0) | (stochrsi_k_1h_lt_80) | (roc_9_1h < 10.0))
+            & ((rsi_3_1h > 65.0) | (stochrsi_k_1h_lt_80) | (roc_9_1h_lt_10))
             # 4h down move, 1h still high, 1d downtrend
             & ((rsi_3_4h > 3.0) | (stochrsi_k_1h < 40.0) | (roc_9_1d_gt_neg_30))
             # 4h down move, 1h still high, 4h downtrend
-            & ((rsi_3_4h > 3.0) | (stochrsi_k_1h_lt_50) | (roc_9_4h > -30.0))
+            & ((rsi_3_4h > 3.0) | (stochrsi_k_1h_lt_50) | (roc_9_4h_gt_neg_30))
             # 4h down move, 4h & 1d downtrend
             & ((rsi_3_4h > 3.0) | (roc_9_4h_gt_neg_20) | (roc_9_1d_gt_neg_20))
             # 4h down move, 15m high, 1h still high
-            & ((rsi_3_4h > 5.0) | (aroonu_14_15m < 70.0) | (stochrsi_k_1h_lt_50))
+            & ((rsi_3_4h_gt_5) | (aroonu_14_15m_lt_70) | (stochrsi_k_1h_lt_50))
             # 4h down move, 15m high
-            & ((rsi_3_4h > 5.0) | (stochrsi_k_15m < 70.0))
+            & ((rsi_3_4h_gt_5) | (stochrsi_k_15m < 70.0))
             # 4h down move, 4h still high, 1d downtrend
-            & ((rsi_3_4h > 5.0) | (stochrsi_k_4h < 40.0) | (roc_9_1d_gt_neg_20))
+            & ((rsi_3_4h_gt_5) | (stochrsi_k_4h < 40.0) | (roc_9_1d_gt_neg_20))
             # 4h & 1d down move, 1d still high
-            & ((rsi_3_4h_gt_10) | (rsi_3_1d > 20.0) | (stochrsi_k_1d < 50.0))
+            & ((rsi_3_4h_gt_10) | (rsi_3_1d_gt_20) | (stochrsi_k_1d < 50.0))
             # 4h & 1d down move, 1d downtrend
-            & ((rsi_3_4h_gt_10) | (rsi_3_1d > 20.0) | (roc_9_1d > -20.0))
+            & ((rsi_3_4h_gt_10) | (rsi_3_1d_gt_20) | (roc_9_1d > -20.0))
             # 4h & 1d down move, 4h still high
-            & ((rsi_3_4h_gt_10) | (rsi_3_1d > 30.0) | (stochrsi_k_4h < 50.0))
+            & ((rsi_3_4h_gt_10) | (rsi_3_1d > 30.0) | (stochrsi_k_4h_lt_50))
             # 4h & 1d down move, 1d still high
             & ((rsi_3_4h_gt_10) | (rsi_3_1d > 35.0) | (stochrsi_k_1d < 40.0))
             # 4h down move, 15m still not low enough, 1d downtrend
-            & ((rsi_3_4h_gt_10) | (stochrsi_k_15m < 30.0) | (roc_9_1d > -40.0))
+            & ((rsi_3_4h_gt_10) | (stochrsi_k_15m < 30.0) | (roc_9_1d_gt_neg_40))
             # 4h down move, 15m high, 4h downtrend
             & ((rsi_3_4h_gt_10) | (stochrsi_k_15m < 60.0) | (roc_9_4h > -50.0))
             # 4h down move, 15m high
@@ -14235,205 +14287,205 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h & 1d down move, 15m high
             & ((rsi_3_4h_gt_15) | (rsi_3_1d > 35.0) | (stochrsi_k_15m < 70.0))
             # 4h & 1d down move, 4h high
-            & ((rsi_3_4h_gt_15) | (rsi_3_1d > 35.0) | (stochrsi_k_4h < 70.0))
+            & ((rsi_3_4h_gt_15) | (rsi_3_1d > 35.0) | (stochrsi_k_4h_lt_70))
             # 4h & 1d down move, 1d high
-            & ((rsi_3_4h_gt_15) | (rsi_3_1d > 40.0) | (aroonu_14_1d < 70.0))
+            & ((rsi_3_4h_gt_15) | (rsi_3_1d > 40.0) | (aroonu_14_1d_lt_70))
             # 4h down move, 15m still high, 1h high
-            & ((rsi_3_4h_gt_15) | (aroonu_14_15m < 50.0) | (stochrsi_k_1h < 60.0))
+            & ((rsi_3_4h_gt_15) | (aroonu_14_15m_lt_50) | (stochrsi_k_1h < 60.0))
             # 4h down move, 15m & 1d high
-            & ((rsi_3_4h_gt_15) | (aroonu_14_15m < 70.0) | (aroonu_14_1d < 80.0))
+            & ((rsi_3_4h_gt_15) | (aroonu_14_15m_lt_70) | (aroonu_14_1d_lt_80))
             # 4h down move, 15m high
             & ((rsi_3_4h_gt_15) | (stochrsi_k_15m < 80.0))
             # 4h down move, 1d high
             & ((rsi_3_4h_gt_15) | (stochrsi_k_1d < 80.0))
             # 4h down move, 1h & 4h downtrend
-            & ((rsi_3_4h_gt_15) | (roc_9_1h > -30.0) | (roc_9_4h > -30.0))
+            & ((rsi_3_4h_gt_15) | (roc_9_1h > -30.0) | (roc_9_4h_gt_neg_30))
             # 4h & 1d down move, 1h still high
-            & (rsi_3_4h_gt_20 | (rsi_3_1d > 20.0) | (aroonu_14_1h < 40.0))
+            & (rsi_3_4h_gt_20 | (rsi_3_1d_gt_20) | (aroonu_14_1h < 40.0))
             # 4h & 1d down move, 15m high
-            & (rsi_3_4h_gt_20 | (rsi_3_1d > 25.0) | (stochrsi_k_15m < 70.0))
+            & (rsi_3_4h_gt_20 | (rsi_3_1d_gt_25) | (stochrsi_k_15m < 70.0))
             # 4h & 1d down move, 1d overbought
             & (rsi_3_4h_gt_20 | (rsi_3_1d > 55.0) | roc_9_1d_lt_50)
             # 4h down move, 15m & 4h still high
-            & (rsi_3_4h_gt_20 | (aroonu_14_15m < 50.0) | (aroonu_14_4h < 50.0))
+            & (rsi_3_4h_gt_20 | (aroonu_14_15m_lt_50) | (aroonu_14_4h_lt_50))
             # 4h down move, 15m high, 1d high
-            & (rsi_3_4h_gt_20 | (aroonu_14_15m < 70.0) | (stochrsi_k_1d < 70.0))
+            & (rsi_3_4h_gt_20 | (aroonu_14_15m_lt_70) | (stochrsi_k_1d < 70.0))
             # 4h down move, 4h still high, 1d downtrend
-            & (rsi_3_4h_gt_20 | (aroonu_14_4h < 50.0) | (roc_9_1d > -40.0))
+            & (rsi_3_4h_gt_20 | (aroonu_14_4h_lt_50) | (roc_9_1d_gt_neg_40))
             # 4h down move, 1d high & overbought
-            & (rsi_3_4h_gt_20 | (aroonu_14_1d < 90.0) | (roc_9_1d < 10.0))
+            & (rsi_3_4h_gt_20 | (aroonu_14_1d_lt_90) | (roc_9_1d < 10.0))
             # 4h down move, 15m high, 4h downtrend
             & (rsi_3_4h_gt_20 | (stochrsi_k_15m < 80.0) | (roc_9_4h > -50.0))
             # 4h down move, 1h high, 1d downtrend
-            & (rsi_3_4h_gt_20 | (stochrsi_k_1h < 60.0) | (roc_9_1d > -40.0))
+            & (rsi_3_4h_gt_20 | (stochrsi_k_1h < 60.0) | (roc_9_1d_gt_neg_40))
             # 4h down move, 4h still not low enough, 4h downtrend
             & (rsi_3_4h_gt_20 | (stochrsi_k_4h < 30.0) | (roc_9_4h > -10.0))
             # 4h down move, 4h high, 1d downtrend
             & (rsi_3_4h_gt_20 | (stochrsi_k_4h < 60.0) | (roc_9_1d > -60.0))
             # 4h & 1d down move, 1d overbought
-            & ((rsi_3_4h > 25.0) | (rsi_3_1d > 40.0) | (roc_9_1d < 30.0))
+            & ((rsi_3_4h_gt_25) | (rsi_3_1d > 40.0) | (roc_9_1d_lt_30))
             # 4h & 1d down move, 1d high
-            & ((rsi_3_4h > 25.0) | (rsi_3_1d > 45.0) | (aroonu_14_1d < 80.0))
+            & ((rsi_3_4h_gt_25) | (rsi_3_1d > 45.0) | (aroonu_14_1d_lt_80))
             # 4h down move, 15m still high, 1h high
-            & ((rsi_3_4h > 25.0) | (aroonu_14_15m < 50.0) | (aroonu_14_1h < 100.0))
+            & ((rsi_3_4h_gt_25) | (aroonu_14_15m_lt_50) | (aroonu_14_1h_lt_100))
             # 4h down move, 15m & 4h still high
-            & ((rsi_3_4h > 25.0) | (aroonu_14_15m < 50.0) | (aroonu_14_4h < 50.0))
+            & ((rsi_3_4h_gt_25) | (aroonu_14_15m_lt_50) | (aroonu_14_4h_lt_50))
             # 4h down move, 15m high, 1d overbought
-            & ((rsi_3_4h > 25.0) | (aroonu_14_15m < 70.0) | (roc_9_1d_lt_100))
+            & ((rsi_3_4h_gt_25) | (aroonu_14_15m_lt_70) | (roc_9_1d_lt_100))
             # 4h down move, 1h high, 1d overbought
-            & ((rsi_3_4h > 25.0) | (aroonu_14_1h < 90.0) | roc_9_1d_lt_50)
+            & ((rsi_3_4h_gt_25) | (aroonu_14_1h_lt_90) | roc_9_1d_lt_50)
             # 4h down move, 4h & 1d high
-            & ((rsi_3_4h > 25.0) | (aroonu_14_4h < 60.0) | aroonu_14_1d_lt_100)
+            & ((rsi_3_4h_gt_25) | (aroonu_14_4h_lt_60) | aroonu_14_1d_lt_100)
             # 4h down move, 4h high, 1d downtrend
-            & ((rsi_3_4h > 25.0) | (aroonu_14_4h < 60.0) | (roc_9_1d > -70.0))
+            & ((rsi_3_4h_gt_25) | (aroonu_14_4h_lt_60) | (roc_9_1d > -70.0))
             # 4h down move, 4h high, 1d downtrend
-            & ((rsi_3_4h > 25.0) | aroonu_14_4h_lt_70 | (roc_9_1d_gt_neg_20))
+            & ((rsi_3_4h_gt_25) | aroonu_14_4h_lt_70 | (roc_9_1d_gt_neg_20))
             # 4h down move, 4h high, 1d overbought
-            & ((rsi_3_4h > 25.0) | aroonu_14_4h_lt_70 | (roc_9_1d < 40.0))
+            & ((rsi_3_4h_gt_25) | aroonu_14_4h_lt_70 | (roc_9_1d_lt_40))
             # 4h down move, 1h still high, 1d overbought
-            & ((rsi_3_4h > 25.0) | (stochrsi_k_1h < 50.0) | (roc_9_1d_lt_100))
+            & ((rsi_3_4h_gt_25) | (stochrsi_k_1h < 50.0) | (roc_9_1d_lt_100))
             # 4h down move, 4h high, 1d downtrend
-            & ((rsi_3_4h > 25.0) | (stochrsi_k_4h_lt_80) | roc_9_1d_gt_neg_50)
+            & ((rsi_3_4h_gt_25) | (stochrsi_k_4h_lt_80) | roc_9_1d_gt_neg_50)
             # 4h down move, 1h high, 1h downtrend
-            & ((rsi_3_4h > 30.0) | aroonu_14_1h_lt_70 | (roc_9_1h > -10.0))
+            & ((rsi_3_4h_gt_30) | aroonu_14_1h_lt_70 | (roc_9_1h > -10.0))
             # 4h & 1d down move, 1d overbought
-            & ((rsi_3_4h > 30.0) | (rsi_3_1d > 50.0) | (roc_9_1d_lt_100))
+            & ((rsi_3_4h_gt_30) | (rsi_3_1d > 50.0) | (roc_9_1d_lt_100))
             # 4h down move, 1d downtrend, 1d overbought
-            & ((rsi_3_4h > 30.0) | (cmf_20_1d > -0.30) | (roc_9_1d < 40.0))
+            & ((rsi_3_4h_gt_30) | (cmf_20_1d > -0.30) | (roc_9_1d_lt_40))
             # 4h down move, 15m high, 4h high
-            & ((rsi_3_4h > 30.0) | (aroonu_14_15m < 60.0) | (aroonu_14_4h < 90.0))
+            & ((rsi_3_4h_gt_30) | (aroonu_14_15m < 60.0) | (aroonu_14_4h_lt_90))
             # 4h down move, 1h high, 1d downtrend
-            & ((rsi_3_4h > 30.0) | (aroonu_14_1h < 90.0) | (roc_9_1d_gt_neg_20))
+            & ((rsi_3_4h_gt_30) | (aroonu_14_1h_lt_90) | (roc_9_1d_gt_neg_20))
             # 4h down move, 1h high, 1d downtrend
-            & ((rsi_3_4h > 30.0) | (stochrsi_k_1h_lt_80) | (roc_9_1d > -40.0))
+            & ((rsi_3_4h_gt_30) | (stochrsi_k_1h_lt_80) | (roc_9_1d_gt_neg_40))
             # 4h down move, 1h high, 1d overbought
-            & ((rsi_3_4h > 30.0) | (stochrsi_k_1h < 90.0) | roc_9_1d_lt_50)
+            & ((rsi_3_4h_gt_30) | (stochrsi_k_1h < 90.0) | roc_9_1d_lt_50)
             # 4h down move, 1d high & overbought
-            & ((rsi_3_4h > 30.0) | (stochrsi_k_1d < 80.0) | (roc_9_1d < 10.0))
+            & ((rsi_3_4h_gt_30) | (stochrsi_k_1d < 80.0) | (roc_9_1d < 10.0))
             # 4h down move, 15m still high, 1h high
-            & ((rsi_3_4h > 35.0) | (aroonu_14_15m < 40.0) | (stochrsi_k_1h < 90.0))
+            & ((rsi_3_4h_gt_35) | (aroonu_14_15m < 40.0) | (stochrsi_k_1h < 90.0))
             # 4h down move, 15m still high, 4h high
-            & ((rsi_3_4h > 35.0) | (aroonu_14_15m < 50.0) | aroonu_14_4h_lt_80)
+            & ((rsi_3_4h_gt_35) | (aroonu_14_15m_lt_50) | aroonu_14_4h_lt_80)
             # 4h down move, 15m high, 1h high
-            & ((rsi_3_4h > 35.0) | (aroonu_14_15m < 70.0) | (stochrsi_k_1h_lt_70))
+            & ((rsi_3_4h_gt_35) | (aroonu_14_15m_lt_70) | (stochrsi_k_1h_lt_70))
             # 4h down move, 4h & 1d high
-            & ((rsi_3_4h > 35.0) | aroonu_14_4h_lt_80 | aroonu_14_1d_lt_100)
+            & ((rsi_3_4h_gt_35) | aroonu_14_4h_lt_80 | aroonu_14_1d_lt_100)
             # 4h down move, 1d high, 1d downtrend
-            & ((rsi_3_4h > 35.0) | (stochrsi_k_1d < 60.0) | (roc_9_1d_gt_neg_30))
+            & ((rsi_3_4h_gt_35) | (stochrsi_k_1d < 60.0) | (roc_9_1d_gt_neg_30))
             # 4h down move, 1d high & overbought
-            & ((rsi_3_4h > 35.0) | (stochrsi_k_1d < 90.0) | (roc_9_1d < 40.0))
+            & ((rsi_3_4h_gt_35) | (stochrsi_k_1d_lt_90) | (roc_9_1d_lt_40))
             # 4h down move, 15m still high, 1d overbought
-            & ((rsi_3_4h > 40.0) | (aroonu_14_15m < 50.0) | roc_9_1d_lt_50)
+            & ((rsi_3_4h_gt_40) | (aroonu_14_15m_lt_50) | roc_9_1d_lt_50)
             # 4h down move, 15m high, 1d overbought
-            & ((rsi_3_4h > 40.0) | (aroonu_14_15m < 70.0) | (roc_9_1d < 200.0))
+            & ((rsi_3_4h_gt_40) | (aroonu_14_15m_lt_70) | (roc_9_1d < 200.0))
             # 4h down move, 1h & 4h high
-            & ((rsi_3_4h > 40.0) | aroonu_14_1h_lt_70 | aroonu_14_4h_lt_80)
+            & ((rsi_3_4h_gt_40) | aroonu_14_1h_lt_70 | aroonu_14_4h_lt_80)
             # 4h down move, 1d high & overbought
-            & ((rsi_3_4h > 40.0) | aroonu_14_1d_lt_100 | (roc_9_1d < 20.0))
+            & ((rsi_3_4h_gt_40) | aroonu_14_1d_lt_100 | (roc_9_1d_lt_20))
             # 4h down move, 15m high, 1h high
-            & ((rsi_3_4h > 40.0) | (stochrsi_k_15m < 70.0) | (aroonu_14_1h < 100.0))
+            & ((rsi_3_4h_gt_40) | (stochrsi_k_15m < 70.0) | (aroonu_14_1h_lt_100))
             # 4h down move, 1h high, 1d overbought
-            & ((rsi_3_4h > 40.0) | (stochrsi_k_1h_lt_70) | (roc_9_1d < 60.0))
+            & ((rsi_3_4h_gt_40) | (stochrsi_k_1h_lt_70) | (roc_9_1d < 60.0))
             # 4h down move, 4h & 1d overbought
-            & ((rsi_3_4h > 40.0) | (roc_9_4h < 10.0) | (roc_9_1d < 30.0))
+            & ((rsi_3_4h_gt_40) | (roc_9_4h_lt_10) | (roc_9_1d_lt_30))
             # 4h down move, 15m still high, 4h high
-            & ((rsi_3_4h > 45.0) | (aroonu_14_15m < 40.0) | (aroonu_14_4h < 90.0))
+            & ((rsi_3_4h > 45.0) | (aroonu_14_15m < 40.0) | (aroonu_14_4h_lt_90))
             # 45 down move, 15m high, 1h high
-            & ((rsi_3_4h > 45.0) | (aroonu_14_15m < 70.0) | (stochrsi_k_1h_lt_70))
+            & ((rsi_3_4h > 45.0) | (aroonu_14_15m_lt_70) | (stochrsi_k_1h_lt_70))
             # 4h down move, 15m high, 4h high
-            & ((rsi_3_4h > 45.0) | (aroonu_14_15m < 70.0) | (stochrsi_k_4h < 70.0))
+            & ((rsi_3_4h > 45.0) | (aroonu_14_15m_lt_70) | (stochrsi_k_4h_lt_70))
             # 4h down move, 4h high, 1d overbought
-            & ((rsi_3_4h > 45.0) | (aroonu_14_4h < 60.0) | (roc_9_1d_lt_100))
+            & ((rsi_3_4h > 45.0) | (aroonu_14_4h_lt_60) | (roc_9_1d_lt_100))
             # 4h down move, 4h high & overbought
-            & ((rsi_3_4h > 45.0) | aroonu_14_4h_lt_80 | (roc_9_4h < 30.0))
+            & ((rsi_3_4h > 45.0) | aroonu_14_4h_lt_80 | (roc_9_4h_lt_30))
             # 4h down move, 1d high & overbought
-            & ((rsi_3_4h > 45.0) | (aroonu_14_1d < 70.0) | (roc_9_1d < 30.0))
+            & ((rsi_3_4h > 45.0) | (aroonu_14_1d_lt_70) | (roc_9_1d_lt_30))
             # 4h down move, 1d high, 1d downtrend
-            & ((rsi_3_4h > 45.0) | (aroonu_14_1d < 80.0) | (roc_9_1d > -15.0))
+            & ((rsi_3_4h > 45.0) | (aroonu_14_1d_lt_80) | (roc_9_1d > -15.0))
             # 4h down move, 1d high, 4h overbought
-            & ((rsi_3_4h > 45.0) | (aroonu_14_1d < 90.0) | (roc_9_4h < 10.0))
+            & ((rsi_3_4h > 45.0) | (aroonu_14_1d_lt_90) | (roc_9_4h_lt_10))
             # 4h down move, 1d high & overbought
-            & ((rsi_3_4h > 45.0) | (stochrsi_k_1d < 90.0) | (roc_9_1d < 20.0))
+            & ((rsi_3_4h > 45.0) | (stochrsi_k_1d_lt_90) | (roc_9_1d_lt_20))
             # 4h down move, 4h & 1d overbought
-            & ((rsi_3_4h > 45.0) | (roc_9_4h < 30.0) | (roc_9_1d < 200.0))
+            & ((rsi_3_4h > 45.0) | (roc_9_4h_lt_30) | (roc_9_1d < 200.0))
             # 4h down move, 15m & 1h high
-            & ((rsi_3_4h > 50.0) | (aroonu_14_15m < 70.0) | (aroonu_14_1h < 100.0))
+            & ((rsi_3_4h_gt_50) | (aroonu_14_15m_lt_70) | (aroonu_14_1h_lt_100))
             # 4h down move, 4h still high, 1h high
-            & ((rsi_3_4h > 50.0) | (aroonu_14_4h < 40.0) | (stochrsi_k_1h_lt_70))
+            & ((rsi_3_4h_gt_50) | (aroonu_14_4h_lt_40) | (stochrsi_k_1h_lt_70))
             # 4h down move, 4h high, 1d overbought
-            & ((rsi_3_4h > 50.0) | aroonu_14_4h_lt_70 | (roc_9_1d < 40.0))
+            & ((rsi_3_4h_gt_50) | aroonu_14_4h_lt_70 | (roc_9_1d_lt_40))
             # 4h down move, 1d high & overbought
-            & ((rsi_3_4h > 50.0) | (aroonu_14_1d < 85.0) | (roc_9_1d < 80.0))
+            & ((rsi_3_4h_gt_50) | (aroonu_14_1d < 85.0) | (roc_9_1d_lt_80))
             # 4h down move, 1d high, 4h overbought
-            & ((rsi_3_4h > 50.0) | (aroonu_14_1d < 90.0) | (roc_9_4h < 10.0))
+            & ((rsi_3_4h_gt_50) | (aroonu_14_1d_lt_90) | (roc_9_4h_lt_10))
             # 4h down move, 4h high, 1d downtrend
-            & ((rsi_3_4h > 50.0) | (stochrsi_k_4h < 60.0) | (roc_9_1d_gt_neg_20))
+            & ((rsi_3_4h_gt_50) | (stochrsi_k_4h < 60.0) | (roc_9_1d_gt_neg_20))
             # 4h down move, 4h downtrend, 1d overbought
-            & ((rsi_3_4h > 50.0) | (roc_9_4h_gt_neg_20) | (roc_9_1d < 20.0))
+            & ((rsi_3_4h_gt_50) | (roc_9_4h_gt_neg_20) | (roc_9_1d_lt_20))
             # 4h down move, 1h high, 4h overbought
-            & ((rsi_3_4h > 55.0) | (aroonu_14_1h < 100.0) | (roc_9_4h_lt_20))
+            & ((rsi_3_4h > 55.0) | (aroonu_14_1h_lt_100) | (roc_9_4h_lt_20))
             # 4h down move, 4h high & overbought
             & ((rsi_3_4h > 55.0) | aroonu_14_4h_lt_70 | (roc_9_4h_lt_20))
             # 4h down move, 1d high & overbought
-            & ((rsi_3_4h > 55.0) | (aroonu_14_1d < 90.0) | (roc_9_1d < 60.0))
+            & ((rsi_3_4h > 55.0) | (aroonu_14_1d_lt_90) | (roc_9_1d < 60.0))
             # 4h down move, 4h high & overbought
-            & ((rsi_3_4h > 55.0) | (stochrsi_k_4h_lt_80) | (roc_9_4h < 10.0))
+            & ((rsi_3_4h > 55.0) | (stochrsi_k_4h_lt_80) | (roc_9_4h_lt_10))
             # 4h down move, 15m high, 1h high
             & ((rsi_3_4h > 60.0) | (aroonu_14_15m < 60.0) | (stochrsi_k_1h < 90.0))
             # 4h down move, 4h high & overbought
-            & ((rsi_3_4h > 60.0) | aroonu_14_4h_lt_70 | (roc_9_4h < 30.0))
+            & ((rsi_3_4h > 60.0) | aroonu_14_4h_lt_70 | (roc_9_4h_lt_30))
             # 4h down move, 4h still high, 1d downtrend
-            & ((rsi_3_4h > 60.0) | (stochrsi_k_4h < 50.0) | (roc_9_1d_gt_neg_30))
+            & ((rsi_3_4h > 60.0) | (stochrsi_k_4h_lt_50) | (roc_9_1d_gt_neg_30))
             # 4h down move, 4h & 1d overbought
-            & ((rsi_3_4h > 60.0) | (roc_9_4h < 30.0) | roc_9_1d_lt_50)
+            & ((rsi_3_4h > 60.0) | (roc_9_4h_lt_30) | roc_9_1d_lt_50)
             # 4h down move, 15m high, 4h high
-            & ((rsi_3_4h > 65.0) | (aroonu_14_15m < 70.0) | (aroonu_14_4h < 90.0))
+            & ((rsi_3_4h > 65.0) | (aroonu_14_15m_lt_70) | (aroonu_14_4h_lt_90))
             # 4h down move, 4h high & overbought
-            & ((rsi_3_4h > 65.0) | aroonu_14_4h_lt_80 | (roc_9_4h < 10.0))
+            & ((rsi_3_4h > 65.0) | aroonu_14_4h_lt_80 | (roc_9_4h_lt_10))
             # 1d down move, 4h & 1d downtrend
             & ((rsi_3_1d > 3.0) | (roc_9_4h > -40.0) | roc_9_1d_gt_neg_50)
             # 1d down move, 15m still high, 4h high
-            & ((rsi_3_1d > 10.0) | (aroonu_14_15m < 70.0) | (stochrsi_k_4h_lt_80))
+            & ((rsi_3_1d_gt_10) | (aroonu_14_15m_lt_70) | (stochrsi_k_4h_lt_80))
             # 1d down move, 4h & 1d downtrend
-            & ((rsi_3_1d > 10.0) | (roc_9_4h_gt_neg_20) | (roc_9_1d > -60.0))
+            & ((rsi_3_1d_gt_10) | (roc_9_4h_gt_neg_20) | (roc_9_1d > -60.0))
             # 1d down move, 4h & 1d downtrend
-            & ((rsi_3_1d > 10.0) | (roc_9_4h > -30.0) | roc_9_1d_gt_neg_50)
+            & ((rsi_3_1d_gt_10) | (roc_9_4h_gt_neg_30) | roc_9_1d_gt_neg_50)
             # 1d down move, 1h high, 1d downtrend
-            & ((rsi_3_1d > 15.0) | (aroonu_14_1h < 85.0) | (roc_9_1d_gt_neg_30))
+            & ((rsi_3_1d_gt_15) | (aroonu_14_1h < 85.0) | (roc_9_1d_gt_neg_30))
             # 1d down move, 4h & 1d downtrend
-            & ((rsi_3_1d > 15.0) | (roc_9_4h > -10.0) | (roc_9_1d > -40.0))
+            & ((rsi_3_1d_gt_15) | (roc_9_4h > -10.0) | (roc_9_1d_gt_neg_40))
             # 1d down move, 15m high, 1h high
-            & ((rsi_3_1d > 20.0) | (aroonu_14_15m < 60.0) | (stochrsi_k_1h_lt_80))
+            & ((rsi_3_1d_gt_20) | (aroonu_14_15m < 60.0) | (stochrsi_k_1h_lt_80))
             # 1d down move, 15m high, 1h high
-            & ((rsi_3_1d > 20.0) | (aroonu_14_15m < 70.0) | (aroonu_14_1h < 100.0))
+            & ((rsi_3_1d_gt_20) | (aroonu_14_15m_lt_70) | (aroonu_14_1h_lt_100))
             # 1d down move, 4h high, 4h downtrend
-            & ((rsi_3_1d > 20.0) | (stochrsi_k_4h < 70.0) | (roc_9_4h_gt_neg_20))
+            & ((rsi_3_1d_gt_20) | (stochrsi_k_4h_lt_70) | (roc_9_4h_gt_neg_20))
             # 1d down move, 15m high, 4h high
-            & ((rsi_3_1d > 25.0) | (aroonu_14_15m < 70.0) | (stochrsi_k_4h_lt_80))
+            & ((rsi_3_1d_gt_25) | (aroonu_14_15m_lt_70) | (stochrsi_k_4h_lt_80))
             # 1d down move, 15m high, 4h downtrend
-            & ((rsi_3_1d > 25.0) | (aroonu_14_15m < 70.0) | (roc_9_4h > -30.0))
+            & ((rsi_3_1d_gt_25) | (aroonu_14_15m_lt_70) | (roc_9_4h_gt_neg_30))
             # 1d down move, 1h & 1d high
-            & ((rsi_3_1d > 25.0) | aroonu_14_1h_lt_80 | (aroonu_14_1d < 80.0))
+            & ((rsi_3_1d_gt_25) | aroonu_14_1h_lt_80 | (aroonu_14_1d_lt_80))
             # 1d down move, 1d still high, 1d downtrend
-            & ((rsi_3_1d > 25.0) | (stochrsi_k_1d < 50.0) | (roc_9_1d_gt_neg_20))
+            & ((rsi_3_1d_gt_25) | (stochrsi_k_1d < 50.0) | (roc_9_1d_gt_neg_20))
             # 1d down move, 1d high & overbought
             & ((rsi_3_1d > 30.0) | (aroonu_14_1d < 60.0) | (roc_9_1d < 10.0))
             # 1d down move, 1h high, 1d downtrend
-            & ((rsi_3_1d > 30.0) | (stochrsi_k_1h_lt_70) | (roc_9_1d < 20.0))
+            & ((rsi_3_1d > 30.0) | (stochrsi_k_1h_lt_70) | (roc_9_1d_lt_20))
             # 1d down move, 1h & 1d high
-            & ((rsi_3_1d > 35.0) | aroonu_14_1h_lt_70 | (aroonu_14_1d < 90.0))
+            & ((rsi_3_1d > 35.0) | aroonu_14_1h_lt_70 | (aroonu_14_1d_lt_90))
             # 1d down move, 1h high, 1d overbought
-            & ((rsi_3_1d > 40.0) | (aroonu_14_1h < 90.0) | (roc_9_1d < 80.0))
+            & ((rsi_3_1d > 40.0) | (aroonu_14_1h_lt_90) | (roc_9_1d_lt_80))
             # 1d down move, 1d high & overbought
-            & ((rsi_3_1d > 40.0) | aroonu_14_1d_lt_100 | (roc_9_1d < 30.0))
+            & ((rsi_3_1d > 40.0) | aroonu_14_1d_lt_100 | (roc_9_1d_lt_30))
             # 1d down move, 1d high & overbought
-            & ((rsi_3_1d > 40.0) | (aroonu_14_1d < 80.0) | (roc_9_1d < 10.0))
+            & ((rsi_3_1d > 40.0) | (aroonu_14_1d_lt_80) | (roc_9_1d < 10.0))
             # 1d down move, 1h high, 1d overbought
             & ((rsi_3_1d > 40.0) | (stochrsi_k_1h_lt_70) | roc_9_1d_lt_50)
             # 15m still high, 4h high, 1d overbought
-            & ((aroonu_14_15m < 50.0) | (rsi_14_4h < 60.0) | (roc_9_1d < 70.0))
+            & ((aroonu_14_15m_lt_50) | (rsi_14_4h < 60.0) | (roc_9_1d < 70.0))
             # 15m still high, 1h downtrend, 4h overbought
-            & ((aroonu_14_15m < 50.0) | (roc_9_1h > -10.0) | (roc_9_4h < 40.0))
+            & ((aroonu_14_15m_lt_50) | (roc_9_1h > -10.0) | (roc_9_4h_lt_40))
             # 15m high, 4h high & overbought
             & ((aroonu_14_15m < 60.0) | aroonu_14_4h_lt_70 | (roc_9_4h_lt_20))
             # 15m & 4h high, 1d overbought
@@ -14441,73 +14493,73 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m high, 15m & 4h overbought
             & ((aroonu_14_15m < 60.0) | (roc_9_15m < 10.0) | (roc_9_4h_lt_20))
             # 15m high, 4h downtrend
-            & ((aroonu_14_15m < 60.0) | (roc_9_4h > -30.0))
+            & ((aroonu_14_15m < 60.0) | (roc_9_4h_gt_neg_30))
             # 15m & 1h & 4h high
-            & ((aroonu_14_15m < 70.0) | (aroonu_14_1h < 100.0) | aroonu_14_4h_lt_100)
+            & ((aroonu_14_15m_lt_70) | (aroonu_14_1h_lt_100) | aroonu_14_4h_lt_100)
             # 15m & 4h & 1d high
-            & ((aroonu_14_15m < 70.0) | aroonu_14_4h_lt_70 | (aroonu_14_1d < 90.0))
+            & ((aroonu_14_15m_lt_70) | aroonu_14_4h_lt_70 | (aroonu_14_1d_lt_90))
             # 15m & 4h high, 4h overbought
-            & ((aroonu_14_15m < 70.0) | aroonu_14_4h_lt_70 | (roc_9_4h < 10.0))
+            & ((aroonu_14_15m_lt_70) | aroonu_14_4h_lt_70 | (roc_9_4h_lt_10))
             # 15m & 4h high, 1d downtrend
-            & ((aroonu_14_15m < 70.0) | aroonu_14_4h_lt_70 | (roc_9_1d_gt_neg_20))
+            & ((aroonu_14_15m_lt_70) | aroonu_14_4h_lt_70 | (roc_9_1d_gt_neg_20))
             # 15m & 1d high, 1d overbought
-            & ((aroonu_14_15m < 70.0) | (aroonu_14_1d < 90.0) | (roc_9_1d_lt_100))
+            & ((aroonu_14_15m_lt_70) | (aroonu_14_1d_lt_90) | (roc_9_1d_lt_100))
             # 15m high, 4h downtrend, 1d overbought
-            & ((aroonu_14_15m < 70.0) | (roc_9_4h > -30.0) | (roc_9_1d < 200.0))
+            & ((aroonu_14_15m_lt_70) | (roc_9_4h_gt_neg_30) | (roc_9_1d < 200.0))
             # 4h down move, 1h still high, 1d downtrend
             & ((rsi_3_4h_gt_15) | (aroonu_14_1h < 40.0) | roc_9_1d_gt_neg_50)
             # 1h & 4h high, 4h overbought
-            & (aroonu_14_1h_lt_80 | aroonu_14_4h_lt_100 | (roc_9_4h < 10.0))
+            & (aroonu_14_1h_lt_80 | aroonu_14_4h_lt_100 | (roc_9_4h_lt_10))
             # 1h high, 1d high & overbought
-            & ((aroonu_14_1h < 90.0) | aroonu_14_1d_lt_100 | (roc_9_1d < 30.0))
+            & ((aroonu_14_1h_lt_90) | aroonu_14_1d_lt_100 | (roc_9_1d_lt_30))
             # 1h high, 4h downtrend
-            & ((aroonu_14_1h < 90.0) | (roc_9_4h_gt_neg_20))
+            & ((aroonu_14_1h_lt_90) | (roc_9_4h_gt_neg_20))
             # 1h high, 4h & 1d overbought
-            & ((aroonu_14_1h < 90.0) | (roc_9_4h < 10.0) | (roc_9_1d < 20.0))
+            & ((aroonu_14_1h_lt_90) | (roc_9_4h_lt_10) | (roc_9_1d_lt_20))
             # 4h & 1d high, 4h overbought
-            & (aroonu_14_4h_lt_80 | aroonu_14_1d_lt_100 | (roc_9_4h < 10.0))
+            & (aroonu_14_4h_lt_80 | aroonu_14_1d_lt_100 | (roc_9_4h_lt_10))
             # 4h & 1d high, 1d downtrend
             & (aroonu_14_4h_lt_80 | aroonu_14_1d_lt_100 | (roc_9_1d > -20.0))
             # 1d high, 4h & 1d downtrend
-            & ((aroonu_14_1d < 80.0) | (roc_9_4h_gt_neg_20) | (roc_9_1d_gt_neg_20))
+            & ((aroonu_14_1d_lt_80) | (roc_9_4h_gt_neg_20) | (roc_9_1d_gt_neg_20))
             # 1d high, 1h & 4h downtrend
             & ((aroonu_14_1d < 85.0) | (roc_9_1h > -30.0) | (roc_9_4h > -50.0))
             # 1d high, 4h downtrend
-            & ((aroonu_14_1d < 85.0) | (roc_9_4h > -30.0))
+            & ((aroonu_14_1d < 85.0) | (roc_9_4h_gt_neg_30))
             # 1d high, 4h downtrend, 1d overbought
-            & ((aroonu_14_1d < 85.0) | (roc_9_4h > -30.0) | (roc_9_1d < 70.0))
+            & ((aroonu_14_1d < 85.0) | (roc_9_4h_gt_neg_30) | (roc_9_1d < 70.0))
             # 1d high, 4h & 1d overbought
-            & (aroonu_14_1d_lt_100 | (roc_9_4h < 30.0) | (roc_9_1d < 40.0))
+            & (aroonu_14_1d_lt_100 | (roc_9_4h_lt_30) | (roc_9_1d_lt_40))
             # 15m & 1h high, 1d overbought
             & ((stochrsi_k_15m < 70.0) | (stochrsi_k_1h_lt_70) | roc_9_1d_lt_50)
             # 15m & 1d high
-            & ((stochrsi_k_15m < 90.0) | (stochrsi_k_1d < 90.0))
+            & ((stochrsi_k_15m < 90.0) | (stochrsi_k_1d_lt_90))
             # 1h high, 4h & 1d downtrend
-            & ((stochrsi_k_1h < 60.0) | (roc_9_4h > -30.0) | (roc_9_1d_gt_neg_30))
+            & ((stochrsi_k_1h < 60.0) | (roc_9_4h_gt_neg_30) | (roc_9_1d_gt_neg_30))
             # 1h high, 4h downtrend
-            & ((stochrsi_k_1h_lt_70) | (roc_9_4h > -30.0))
+            & ((stochrsi_k_1h_lt_70) | (roc_9_4h_gt_neg_30))
             # 1h high, 1d downtrend
             & ((stochrsi_k_1h < 70.0) | (roc_9_1d_gt_neg_20))
             # 4h high, 4h overbought, 1d downtrend
             & ((stochrsi_k_4h < 90.0) | (roc_9_4h_lt_20) | (roc_9_1d_gt_neg_20))
             # 1d still high, 4h & 1d downtrend
-            & ((stochrsi_k_1d < 50.0) | (roc_9_4h > -30.0) | (roc_9_1d_gt_neg_30))
+            & ((stochrsi_k_1d < 50.0) | (roc_9_4h_gt_neg_30) | (roc_9_1d_gt_neg_30))
             # 1d P&D, 4h downtrend
             & ((change_pct_1d > -50.0) | (change_pct_1d.shift(288) < 50.0) | (rsi_3_4h_gt_15))
             # 1d P&D, 15m high
-            & ((change_pct_1d > -20.0) | (change_pct_1d.shift(288) < 20.0) | (aroonu_14_15m < 70.0))
+            & ((change_pct_1d > -20.0) | (change_pct_1d.shift(288) < 20.0) | (aroonu_14_15m_lt_70))
             # 1d red with top wick, 4h high
             & ((change_pct_1d > -20.0) | (top_wick_pct_1d < 20.0) | aroonu_14_4h_lt_80)
             # 1d red, previous 1d top wick, 15m high
-            & ((change_pct_1d > -10.0) | (top_wick_pct_1d.shift(288) < 40.0) | (aroonu_14_15m < 70.0))
+            & ((change_pct_1d > -10.0) | (top_wick_pct_1d.shift(288) < 40.0) | (aroonu_14_15m_lt_70))
             # 1d green with top wick, 4h overbought
             & ((change_pct_1d < 15.0) | (top_wick_pct_1d < 15.0) | (roc_9_4h_lt_20))
             # 1d green, 15m down move, 1h high
-            & ((change_pct_1d < 50.0) | (rsi_3_15m > 25.0) | aroonu_14_1h_lt_70)
+            & ((change_pct_1d < 50.0) | (rsi_3_15m_gt_25) | aroonu_14_1h_lt_70)
             # 1d green, 4h down move, 4h still high
-            & ((change_pct_1d < 40.0) | (rsi_3_4h > 35.0) | (aroonu_14_4h < 40.0))
+            & ((change_pct_1d < 40.0) | (rsi_3_4h_gt_35) | (aroonu_14_4h_lt_40))
             # 1d top wick, 4h down move, 1d overbought
-            & ((top_wick_pct_1d < 50.0) | (rsi_3_4h > 35.0) | (roc_9_1d < 60.0))
+            & ((top_wick_pct_1d < 50.0) | (rsi_3_4h_gt_35) | (roc_9_1d < 60.0))
             # big drop in the last 20 days, 1d high, 1d downtrend
             & ((close > (high_max_20_1d * 0.20)) | (stochrsi_k_1d < 70.0) | (roc_9_1d > -15.0))
           )
@@ -14532,139 +14584,139 @@ class NostalgiaForInfinityX7(IStrategy):
           long_entry_logic.append(
             rsi_3_15m_gt_3
             # 5m & 1h down move, 1d still high
-            & ((rsi_3 > 3.0) | (rsi_3_1h > 3.0) | (aroonu_14_1d < 40.0))
+            & ((rsi_3_gt_3) | (rsi_3_1h_gt_3) | (aroonu_14_1d < 40.0))
             # 5m & 1h & 4h down move
-            & ((rsi_3 > 3.0) | (rsi_3_1h > 5.0) | (rsi_3_4h_gt_10))
+            & ((rsi_3_gt_3) | (rsi_3_1h_gt_5) | (rsi_3_4h_gt_10))
             # 5m & 1h down move, 1h still not low enough
-            & ((rsi_3 > 3.0) | (rsi_3_1h_gt_10) | (aroonu_14_1h < 30.0))
+            & ((rsi_3_gt_3) | (rsi_3_1h_gt_10) | (aroonu_14_1h < 30.0))
             # 5m & 1h down move, 1d high
-            & ((rsi_3 > 3.0) | (rsi_3_1h_gt_15) | (aroonu_14_1d < 80.0))
+            & ((rsi_3_gt_3) | (rsi_3_1h_gt_15) | (aroonu_14_1d_lt_80))
             # 5m & 1h down move, 1d high
-            & ((rsi_3 > 3.0) | rsi_3_1h_gt_20 | aroonu_14_1d_lt_100)
+            & ((rsi_3_gt_3) | rsi_3_1h_gt_20 | aroonu_14_1d_lt_100)
             # 5m & 1h down move, 1h high
-            & ((rsi_3 > 3.0) | (rsi_3_1h > 50.0) | aroonu_14_1h_lt_70)
+            & ((rsi_3_gt_3) | (rsi_3_1h_gt_50) | aroonu_14_1h_lt_70)
             # 5m & 1h down move, 1h still high
-            & ((rsi_3 > 3.0) | (rsi_3_1h > 30.0) | (stochrsi_k_1h_lt_50))
+            & ((rsi_3_gt_3) | (rsi_3_1h_gt_30) | (stochrsi_k_1h_lt_50))
             # 5m & 1h down move, 1d downtrend
-            & ((rsi_3 > 3.0) | (rsi_3_4h_gt_15) | (roc_9_1d > -30.0))
+            & ((rsi_3_gt_3) | (rsi_3_4h_gt_15) | (roc_9_1d > -30.0))
             # 5m & 4h down move, 4h high
-            & ((rsi_3 > 3.0) | (rsi_3_4h > 25.0) | aroonu_14_4h_lt_70)
+            & ((rsi_3_gt_3) | (rsi_3_4h_gt_25) | aroonu_14_4h_lt_70)
             # 5m & 1d down move, 15m still high
-            & ((rsi_3 > 3.0) | (rsi_3_1d > 20.0) | (stochrsi_k_15m < 40.0))
+            & ((rsi_3_gt_3) | (rsi_3_1d_gt_20) | (stochrsi_k_15m < 40.0))
             # 5m down move, 1h high, 4h overbought
-            & ((rsi_3 > 3.0) | (stochrsi_k_1h < 80.0) | (roc_9_4h_lt_20))
+            & ((rsi_3_gt_3) | (stochrsi_k_1h < 80.0) | (roc_9_4h_lt_20))
             # 5m & 4h down move, 15m still high
-            & ((rsi_3 > 5.0) | (rsi_3_4h > 25.0) | (stochrsi_k_15m < 50.0))
+            & ((rsi_3 > 5.0) | (rsi_3_4h_gt_25) | (stochrsi_k_15m < 50.0))
             # 5m down move, 4h high, 1h overbought
             & ((rsi_3 > 10.0) | aroonu_14_4h_lt_100 | (roc_9_1h < 30.0))
             # 15m & 1h down move, 1d still high
-            & ((rsi_3_15m > 5.0) | (rsi_3_1h > 5.0) | (aroonu_14_1d < 40.0))
+            & ((rsi_3_15m_gt_5) | (rsi_3_1h_gt_5) | (aroonu_14_1d < 40.0))
             # 15m & 1h down move, 1d still high
-            & ((rsi_3_15m > 5.0) | (rsi_3_1h_gt_10) | (aroonu_14_1d < 50.0))
+            & ((rsi_3_15m_gt_5) | (rsi_3_1h_gt_10) | (aroonu_14_1d < 50.0))
             # 15m & 1h down move, 1h still high
-            & ((rsi_3_15m > 5.0) | (rsi_3_1h > 30.0) | (stochrsi_k_1h < 40.0))
+            & ((rsi_3_15m_gt_5) | (rsi_3_1h_gt_30) | (stochrsi_k_1h < 40.0))
             # 15m & 1h down move, 1d overbought
-            & ((rsi_3_15m > 5.0) | (rsi_3_1h > 30.0) | roc_9_1d_lt_50)
+            & ((rsi_3_15m_gt_5) | (rsi_3_1h_gt_30) | roc_9_1d_lt_50)
             # 15m & 1h down move, 4h high
-            & ((rsi_3_15m > 5.0) | (rsi_3_1h > 40.0) | (stochrsi_k_4h < 70.0))
+            & ((rsi_3_15m_gt_5) | (rsi_3_1h_gt_40) | (stochrsi_k_4h_lt_70))
             # 15m & 4h down move, 1d overbought
-            & ((rsi_3_15m > 5.0) | (rsi_3_4h_gt_15) | (roc_9_1d < 70.0))
+            & ((rsi_3_15m_gt_5) | (rsi_3_4h_gt_15) | (roc_9_1d < 70.0))
             # 15m & 4h down move, 1d high
-            & ((rsi_3_15m > 5.0) | (rsi_3_4h > 30.0) | aroonu_14_1d_lt_100)
+            & ((rsi_3_15m_gt_5) | (rsi_3_4h_gt_30) | aroonu_14_1d_lt_100)
             # 15m down move, 1h high & overbought
-            & ((rsi_3_15m > 5.0) | aroonu_14_1h_lt_70 | (roc_9_1h < 10.0))
+            & ((rsi_3_15m_gt_5) | aroonu_14_1h_lt_70 | (roc_9_1h_lt_10))
             # 15m down move, 1h & 1d high
-            & ((rsi_3_15m > 5.0) | (roc_9_1h < 10.0) | (roc_9_1d < 40.0))
+            & ((rsi_3_15m_gt_5) | (roc_9_1h_lt_10) | (roc_9_1d_lt_40))
             # 15m & 1h down move, 15m stil high
-            & ((rsi_3_15m > 10.0) | (rsi_3_1h_gt_10) | (stochrsi_k_15m < 50.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_10) | (stochrsi_k_15m < 50.0))
             # 15m & 1h down move, 4h downtrend
-            & ((rsi_3_15m > 10.0) | (rsi_3_1h_gt_10) | (roc_9_4h > -40.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_10) | (roc_9_4h > -40.0))
             # 15m & 1h down move, 1h still high
-            & ((rsi_3_15m > 10.0) | (rsi_3_1h_gt_15) | (stochrsi_k_1h < 50.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_15) | (stochrsi_k_1h < 50.0))
             # 15m & 1h down move, 4h high
-            & ((rsi_3_15m > 10.0) | (rsi_3_1h_gt_15) | aroonu_14_4h_lt_70)
+            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_15) | aroonu_14_4h_lt_70)
             # 15m & 1h down move, 1d overbought
-            & ((rsi_3_15m > 10.0) | rsi_3_1h_gt_20 | (roc_9_1d < 40.0))
+            & ((rsi_3_15m_gt_10) | rsi_3_1h_gt_20 | (roc_9_1d_lt_40))
             # 15m & 1h down move, 1h high
-            & ((rsi_3_15m > 10.0) | (rsi_3_1h > 25.0) | aroonu_14_1h_lt_80)
+            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_25) | aroonu_14_1h_lt_80)
             # 15m down move, 4h high, 1d overbought
-            & ((rsi_3_15m > 10.0) | aroonu_14_4h_lt_70 | (roc_9_1d_lt_100))
+            & ((rsi_3_15m_gt_10) | aroonu_14_4h_lt_70 | (roc_9_1d_lt_100))
             # 15m down move, 4h & 1d high
-            & ((rsi_3_15m > 10.0) | (aroonu_14_4h < 90.0) | aroonu_14_1d_lt_100)
+            & ((rsi_3_15m_gt_10) | (aroonu_14_4h_lt_90) | aroonu_14_1d_lt_100)
             # 15m down move, 1h high, 1d downtrend
-            & ((rsi_3_15m > 10.0) | (stochrsi_k_1h_lt_70) | roc_9_1d_gt_neg_50)
+            & ((rsi_3_15m_gt_10) | (stochrsi_k_1h_lt_70) | roc_9_1d_gt_neg_50)
             # 15m down move, 1h high
-            & ((rsi_3_15m > 10.0) | (stochrsi_k_1h_lt_80))
+            & ((rsi_3_15m_gt_10) | (stochrsi_k_1h_lt_80))
             # 15m & 1h down move, 1h still high
-            & ((rsi_3_15m > 15.0) | (rsi_3_1h > 25.0) | (stochrsi_k_1h < 40.0))
+            & ((rsi_3_15m_gt_15) | (rsi_3_1h_gt_25) | (stochrsi_k_1h < 40.0))
             # 15m & 4h down move, 1d high
-            & ((rsi_3_15m > 15.0) | (rsi_3_4h_gt_15) | (stochrsi_k_1d < 80.0))
+            & ((rsi_3_15m_gt_15) | (rsi_3_4h_gt_15) | (stochrsi_k_1d < 80.0))
             # 15m down move, 4h high & overbought
-            & ((rsi_3_15m > 15.0) | aroonu_14_4h_lt_70 | (roc_9_4h_lt_20))
+            & ((rsi_3_15m_gt_15) | aroonu_14_4h_lt_70 | (roc_9_4h_lt_20))
             # 15m down move, 4h high & overbought
-            & ((rsi_3_15m > 15.0) | (stochrsi_k_4h_lt_90) | (roc_9_4h < 10.0))
+            & ((rsi_3_15m_gt_15) | (stochrsi_k_4h_lt_90) | (roc_9_4h_lt_10))
             # 15m down move, 4h & 1d downtrend
-            & ((rsi_3_15m > 15.0) | (roc_9_4h > -10.0) | (roc_9_1d > -40.0))
+            & ((rsi_3_15m_gt_15) | (roc_9_4h > -10.0) | (roc_9_1d_gt_neg_40))
             # 15m & 1h down move, 1h high
-            & ((rsi_3_15m > 20.0) | rsi_3_1h_gt_20 | aroonu_14_1h_lt_70)
+            & ((rsi_3_15m_gt_20) | rsi_3_1h_gt_20 | aroonu_14_1h_lt_70)
             # 15m down move, 4h high, 1d overbought
-            & ((rsi_3_15m > 20.0) | (aroonu_14_4h < 90.0) | (roc_9_1d_lt_100))
+            & ((rsi_3_15m_gt_20) | (aroonu_14_4h_lt_90) | (roc_9_1d_lt_100))
             # 15m down move, 4h high, 1h overbought
-            & ((rsi_3_15m > 20.0) | aroonu_14_4h_lt_100 | (roc_9_1h < 30.0))
+            & ((rsi_3_15m_gt_20) | aroonu_14_4h_lt_100 | (roc_9_1h < 30.0))
             # 15m down move, 1h high & overbought
-            & ((rsi_3_15m > 20.0) | (stochrsi_k_1h < 90.0) | (roc_9_1h < 10.0))
+            & ((rsi_3_15m_gt_20) | (stochrsi_k_1h < 90.0) | (roc_9_1h_lt_10))
             # 15m & 4h down move, 4h high
-            & ((rsi_3_15m > 25.0) | (rsi_3_4h > 50.0) | (stochrsi_k_4h_lt_80))
+            & ((rsi_3_15m_gt_25) | (rsi_3_4h_gt_50) | (stochrsi_k_4h_lt_80))
             # 15m down move, 4h high, 4h overbought
-            & ((rsi_3_15m > 25.0) | (aroonu_14_4h < 60.0) | (roc_9_4h < 50.0))
+            & ((rsi_3_15m_gt_25) | (aroonu_14_4h_lt_60) | (roc_9_4h < 50.0))
             # 15m & 1h down move, 4h high
-            & ((rsi_3_15m > 30.0) | (rsi_3_1h > 40.0) | (aroonu_14_4h < 85.0))
+            & ((rsi_3_15m_gt_30) | (rsi_3_1h_gt_40) | (aroonu_14_4h < 85.0))
             # 15m & 1h down move, 4h overbought
-            & ((rsi_3_15m > 40.0) | (rsi_3_1h > 50.0) | (roc_9_4h < 50.0))
+            & ((rsi_3_15m > 40.0) | (rsi_3_1h_gt_50) | (roc_9_4h < 50.0))
             # 1h & 4h down move, 15m downtrend
-            & ((rsi_3_1h > 3.0) | (rsi_3_4h > 3.0) | (roc_9_15m > -30.0))
+            & ((rsi_3_1h_gt_3) | (rsi_3_4h > 3.0) | (roc_9_15m > -30.0))
             # 1h & 4h down move, 15m downtrend
-            & ((rsi_3_1h > 3.0) | (rsi_3_4h_gt_10) | (cmf_20_15m > -0.40))
+            & ((rsi_3_1h_gt_3) | (rsi_3_4h_gt_10) | (cmf_20_15m > -0.40))
             # 1h & 4h down move, 1d high
-            & ((rsi_3_1h > 3.0) | rsi_3_4h_gt_20 | (stochrsi_k_1d < 70.0))
+            & ((rsi_3_1h_gt_3) | rsi_3_4h_gt_20 | (stochrsi_k_1d < 70.0))
             # 1h down move, 1h high, 4h high
-            & ((rsi_3_1h > 3.0) | aroonu_14_1h_lt_70 | (stochrsi_k_4h < 80.0))
+            & ((rsi_3_1h_gt_3) | aroonu_14_1h_lt_70 | (stochrsi_k_4h < 80.0))
             # 1h down move, 15m still high
-            & ((rsi_3_1h > 3.0) | (stochrsi_k_15m < 50.0))
+            & ((rsi_3_1h_gt_3) | (stochrsi_k_15m < 50.0))
             # 1h down move, 1h still high, 4h overbought
-            & ((rsi_3_1h > 3.0) | (stochrsi_k_1h < 50.0) | (roc_9_4h_lt_20))
+            & ((rsi_3_1h_gt_3) | (stochrsi_k_1h < 50.0) | (roc_9_4h_lt_20))
             # 1h & 4h & 1d down move
-            & ((rsi_3_1h > 5.0) | (rsi_3_4h > 5.0) | (rsi_3_1d > 10.0))
+            & ((rsi_3_1h_gt_5) | (rsi_3_4h_gt_5) | (rsi_3_1d_gt_10))
             # 1h & 4h down move, 1h downtrend
-            & ((rsi_3_1h > 5.0) | (rsi_3_4h > 5.0) | (roc_9_1h > -20.0))
+            & ((rsi_3_1h_gt_5) | (rsi_3_4h_gt_5) | (roc_9_1h > -20.0))
             # 1h & 4h down move, 1d downtrend
-            & ((rsi_3_1h > 5.0) | (rsi_3_4h_gt_10) | (roc_9_1d > -40.0))
+            & ((rsi_3_1h_gt_5) | (rsi_3_4h_gt_10) | (roc_9_1d_gt_neg_40))
             # 1h down move, 4h high, 1h downtrend
-            & ((rsi_3_1h > 5.0) | (stochrsi_k_4h < 70.0) | (roc_9_1h > -40.0))
+            & ((rsi_3_1h_gt_5) | (stochrsi_k_4h_lt_70) | (roc_9_1h > -40.0))
             # 1h down move, 4h high, 1h downtrend
-            & ((rsi_3_1h > 5.0) | (stochrsi_k_4h < 70.0) | (cmf_20_1h > -0.40))
+            & ((rsi_3_1h_gt_5) | (stochrsi_k_4h_lt_70) | (cmf_20_1h > -0.40))
             # 1h down move, 1d high & overbought
-            & ((rsi_3_1h > 5.0) | (stochrsi_k_1d < 90.0) | (roc_9_1d < 20.0))
+            & ((rsi_3_1h_gt_5) | (stochrsi_k_1d_lt_90) | (roc_9_1d_lt_20))
             # 1h down move, 1d overbought
-            & ((rsi_3_1h > 5.0) | (roc_9_1d_lt_100))
+            & ((rsi_3_1h_gt_5) | (roc_9_1d_lt_100))
             # 1h & 4h & 1d down move
-            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_10) | (rsi_3_1d > 15.0))
+            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_10) | (rsi_3_1d_gt_15))
             # 1h & 4h down move, 4h still high
             & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_15) | (rsi_14_4h < 40.0))
             # 1h & 4h down move, 1h downtrend
             & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_15) | (roc_9_1h > -20.0))
             # 1h & 4h down move, 1h still high
-            & ((rsi_3_1h_gt_10) | rsi_3_4h_gt_20 | (aroonu_14_1h < 50.0))
+            & ((rsi_3_1h_gt_10) | rsi_3_4h_gt_20 | (aroonu_14_1h_lt_50))
             # 1h & 4h down move, 4h still high
-            & ((rsi_3_1h_gt_10) | (rsi_3_4h > 35.0) | (rsi_14_4h < 40.0))
+            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_35) | (rsi_14_4h < 40.0))
             # 1h & 3h down move, 1d high
-            & ((rsi_3_1h_gt_10) | (rsi_3_4h > 40.0) | (aroonu_14_1d < 80.0))
+            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_40) | (aroonu_14_1d_lt_80))
             # 1h & 1d down move, 1d high
-            & ((rsi_3_1h_gt_10) | (rsi_3_1d > 45.0) | (aroonu_14_1d < 70.0))
+            & ((rsi_3_1h_gt_10) | (rsi_3_1d > 45.0) | (aroonu_14_1d_lt_70))
             # 1h down move, 4h high
             & ((rsi_3_1h_gt_10) | (aroonu_14_4h < 85.0))
             # 1h down move, 1d high, 15m downtrend
-            & ((rsi_3_1h_gt_10) | (aroonu_14_1d < 70.0) | (roc_9_15m > -50.0))
+            & ((rsi_3_1h_gt_10) | (aroonu_14_1d_lt_70) | (roc_9_15m > -50.0))
             # 1h down move, 4h & 1d downtrend
             & ((rsi_3_1h_gt_10) | (roc_9_4h > -15.0) | (roc_9_1d > -30.0))
             # 1h & 4h down move, 4h still high
@@ -14672,119 +14724,119 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 1h still not low enough
             & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_15) | (aroonu_14_1h < 20.0))
             # 1h & 4h down move, 4h still not low enough
-            & ((rsi_3_1h_gt_15) | (rsi_3_4h > 25.0) | (stochrsi_k_4h < 30.0))
+            & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_25) | (stochrsi_k_4h < 30.0))
             # 1h & 1d down move, 1d still high
-            & ((rsi_3_1h_gt_15) | (rsi_3_1d > 20.0) | (stochrsi_k_1d < 40.0))
+            & ((rsi_3_1h_gt_15) | (rsi_3_1d_gt_20) | (stochrsi_k_1d < 40.0))
             # 1h & 1d down move, 1d high
-            & ((rsi_3_1h_gt_15) | (rsi_3_1d > 25.0) | (aroonu_14_1d < 80.0))
+            & ((rsi_3_1h_gt_15) | (rsi_3_1d_gt_25) | (aroonu_14_1d_lt_80))
             # 1h down move, 1h still high, 4h downtrend
-            & ((rsi_3_1h_gt_15) | (aroonu_14_1h < 40.0) | (roc_9_4h > -30.0))
+            & ((rsi_3_1h_gt_15) | (aroonu_14_1h < 40.0) | (roc_9_4h_gt_neg_30))
             # 1h down move, 1d high, 4h downtrend
-            & ((rsi_3_1h_gt_15) | (aroonu_14_1d < 90.0) | (roc_9_4h > -20.0))
+            & ((rsi_3_1h_gt_15) | (aroonu_14_1d_lt_90) | (roc_9_4h > -20.0))
             # 1h down move, 1d high & overbought
-            & ((rsi_3_1h_gt_15) | (stochrsi_k_1d < 90.0) | (roc_9_1d < 40.0))
+            & ((rsi_3_1h_gt_15) | (stochrsi_k_1d_lt_90) | (roc_9_1d_lt_40))
             # 1h down move, 1h still high, 4h downtrend
-            & (rsi_3_1h_gt_20 | (aroonu_14_1h < 50.0) | (roc_9_4h > -50.0))
+            & (rsi_3_1h_gt_20 | (aroonu_14_1h_lt_50) | (roc_9_4h > -50.0))
             # 1h down move, 1h high
             & (rsi_3_1h_gt_20 | aroonu_14_1h_lt_80)
             # 1h & 4h down move, 1d overbought
-            & ((rsi_3_1h > 25.0) | (rsi_3_4h > 25.0) | (roc_9_1d < 20.0))
+            & ((rsi_3_1h_gt_25) | (rsi_3_4h_gt_25) | (roc_9_1d_lt_20))
             # 1h down move, 1h still high, 1d overbought
-            & ((rsi_3_1h > 25.0) | (stochrsi_k_1h_lt_50) | (roc_9_1d < 40.0))
+            & ((rsi_3_1h_gt_25) | (stochrsi_k_1h_lt_50) | (roc_9_1d_lt_40))
             # 1h down move, 1h & 4h high
-            & ((rsi_3_1h > 30.0) | aroonu_14_1h_lt_70 | aroonu_14_4h_lt_70)
+            & ((rsi_3_1h_gt_30) | aroonu_14_1h_lt_70 | aroonu_14_4h_lt_70)
             # 1h down move, 4h high, 1d overbought
-            & ((rsi_3_1h > 30.0) | aroonu_14_4h_lt_80 | (roc_9_1d < 30.0))
+            & ((rsi_3_1h_gt_30) | aroonu_14_4h_lt_80 | (roc_9_1d_lt_30))
             # 1h down move, 1d high & overbought
-            & ((rsi_3_1h > 30.0) | (aroonu_14_1d < 80.0) | (roc_9_1d < 200.0))
+            & ((rsi_3_1h_gt_30) | (aroonu_14_1d_lt_80) | (roc_9_1d < 200.0))
             # 1h & 4h down move, 1d overbought
-            & ((rsi_3_1h > 30.0) | (rsi_3_4h > 30.0) | (roc_9_1d < 40.0))
+            & ((rsi_3_1h_gt_30) | (rsi_3_4h_gt_30) | (roc_9_1d_lt_40))
             # 1h & 4h down move, 15m high
-            & ((rsi_3_1h > 30.0) | (rsi_3_4h > 40.0) | (stochrsi_k_15m < 80.0))
+            & ((rsi_3_1h_gt_30) | (rsi_3_4h_gt_40) | (stochrsi_k_15m < 80.0))
             # 1h & 4h down move, 1h high
-            & ((rsi_3_1h > 30.0) | (rsi_3_4h > 50.0) | (stochrsi_k_1h_lt_70))
+            & ((rsi_3_1h_gt_30) | (rsi_3_4h_gt_50) | (stochrsi_k_1h_lt_70))
             # 1h down move, 15m still high, 1h high
-            & ((rsi_3_1h > 30.0) | (stochrsi_k_15m < 40.0) | (aroonu_14_1h < 60.0))
+            & ((rsi_3_1h_gt_30) | (stochrsi_k_15m < 40.0) | (aroonu_14_1h < 60.0))
             # 1h down move, 1h still high, 4h high
-            & ((rsi_3_1h > 30.0) | (stochrsi_k_1h < 40.0) | (stochrsi_k_4h < 70.0))
+            & ((rsi_3_1h_gt_30) | (stochrsi_k_1h < 40.0) | (stochrsi_k_4h_lt_70))
             # 1h down move, 4h & 1d downtrend
-            & ((rsi_3_1h > 30.0) | (roc_9_4h > -25.0) | (roc_9_1d > -60.0))
+            & ((rsi_3_1h_gt_30) | (roc_9_4h > -25.0) | (roc_9_1d > -60.0))
             # 1h down move, 4h & 1d overbought
-            & ((rsi_3_1h > 30.0) | (roc_9_4h_lt_20) | (roc_9_1d_lt_100))
+            & ((rsi_3_1h_gt_30) | (roc_9_4h_lt_20) | (roc_9_1d_lt_100))
             # 1h down move, 1h high, 1d overbought
-            & ((rsi_3_1h > 35.0) | aroonu_14_1h_lt_70 | (roc_9_1d < 20.0))
+            & ((rsi_3_1h_gt_35) | aroonu_14_1h_lt_70 | (roc_9_1d_lt_20))
             # 1h down move, 4h high, 1d overbought
-            & ((rsi_3_1h > 35.0) | (aroonu_14_4h < 85.0) | (roc_9_1d_lt_100))
+            & ((rsi_3_1h_gt_35) | (aroonu_14_4h < 85.0) | (roc_9_1d_lt_100))
             # 1h down move, 1h still high, 1d overbought
-            & ((rsi_3_1h > 35.0) | (stochrsi_k_1h_lt_50) | (roc_9_1d < 200.0))
+            & ((rsi_3_1h_gt_35) | (stochrsi_k_1h_lt_50) | (roc_9_1d < 200.0))
             # 1h down move, 1h high, 4h downtrend
-            & ((rsi_3_1h > 35.0) | (stochrsi_k_1h < 70.0) | (roc_9_4h_gt_neg_20))
+            & ((rsi_3_1h_gt_35) | (stochrsi_k_1h < 70.0) | (roc_9_4h_gt_neg_20))
             # 1h down move, 1h high, 4h overbought
-            & ((rsi_3_1h > 40.0) | (stochrsi_k_1h < 80.0) | (roc_9_4h_lt_20))
+            & ((rsi_3_1h_gt_40) | (stochrsi_k_1h < 80.0) | (roc_9_4h_lt_20))
             # 1h down move, 1h & 4h high
-            & ((rsi_3_1h > 45.0) | aroonu_14_1h_lt_70 | aroonu_14_4h_lt_100)
+            & ((rsi_3_1h_gt_45) | aroonu_14_1h_lt_70 | aroonu_14_4h_lt_100)
             # 1h down move, 4h high, 1d downtrend
-            & ((rsi_3_1h > 50.0) | (stochrsi_k_4h < 60.0) | (roc_9_1d > -60.0))
+            & ((rsi_3_1h_gt_50) | (stochrsi_k_4h < 60.0) | (roc_9_1d > -60.0))
             # 1h down move, 4h high & overbought
-            & ((rsi_3_1h > 50.0) | (stochrsi_k_4h_lt_90) | (roc_9_4h < 40.0))
+            & ((rsi_3_1h_gt_50) | (stochrsi_k_4h_lt_90) | (roc_9_4h_lt_40))
             # 1h down move, 1h high & overbought
-            & ((rsi_3_1h > 55.0) | (stochrsi_k_1h_lt_80) | (roc_9_1h < 10.0))
+            & ((rsi_3_1h > 55.0) | (stochrsi_k_1h_lt_80) | (roc_9_1h_lt_10))
             # 1h down move, 4h & 1d overbought
-            & ((rsi_3_1h > 60.0) | (roc_9_4h < 30.0) | (roc_9_1d < 60.0))
+            & ((rsi_3_1h > 60.0) | (roc_9_4h_lt_30) | (roc_9_1d < 60.0))
             # 4h down move, 4h high, 4h downtrend
-            & ((rsi_3_4h > 3.0) | (aroonu_14_4h < 50.0) | (roc_9_4h > -40.0))
+            & ((rsi_3_4h > 3.0) | (aroonu_14_4h_lt_50) | (roc_9_4h > -40.0))
             # 4h & 1d down move, 1h still not low enough
-            & ((rsi_3_4h > 5.0) | (rsi_3_1d > 10.0) | (stochrsi_k_1h < 30.0))
+            & ((rsi_3_4h_gt_5) | (rsi_3_1d_gt_10) | (stochrsi_k_1h < 30.0))
             # 4h & 1d down move, 1d high
-            & ((rsi_3_4h > 5.0) | (rsi_3_1d > 45.0) | (aroonu_14_1d < 70.0))
+            & ((rsi_3_4h_gt_5) | (rsi_3_1d > 45.0) | (aroonu_14_1d_lt_70))
             # 4h down move, 4h & 1d downtrend
-            & ((rsi_3_4h > 5.0) | (roc_9_4h > -15.0) | (roc_9_1d_gt_neg_20))
+            & ((rsi_3_4h_gt_5) | (roc_9_4h > -15.0) | (roc_9_1d_gt_neg_20))
             # 4h & 1d down move, 1h still high
-            & ((rsi_3_4h_gt_10) | (rsi_3_1d > 10.0) | (aroonu_14_1h < 40.0))
+            & ((rsi_3_4h_gt_10) | (rsi_3_1d_gt_10) | (aroonu_14_1h < 40.0))
             # 4h & 1d down move, 1h high
-            & ((rsi_3_4h_gt_10) | (rsi_3_1d > 15.0) | (stochrsi_k_1h < 70.0))
+            & ((rsi_3_4h_gt_10) | (rsi_3_1d_gt_15) | (stochrsi_k_1h < 70.0))
             # 4h & 1d down move, 1d still high
-            & ((rsi_3_4h_gt_10) | (rsi_3_1d > 25.0) | (aroonu_14_1d < 40.0))
+            & ((rsi_3_4h_gt_10) | (rsi_3_1d_gt_25) | (aroonu_14_1d < 40.0))
             # 4h & 1d down move, 1d still high
-            & ((rsi_3_4h_gt_10) | (rsi_3_1d > 25.0) | (stochrsi_k_1d < 50.0))
+            & ((rsi_3_4h_gt_10) | (rsi_3_1d_gt_25) | (stochrsi_k_1d < 50.0))
             # 4h & 1d down move, 1d high
-            & ((rsi_3_4h_gt_15) | (rsi_3_1d > 20.0) | (aroonu_14_1d < 60.0))
+            & ((rsi_3_4h_gt_15) | (rsi_3_1d_gt_20) | (aroonu_14_1d < 60.0))
             # 4h & 1d down move, 4h high
-            & ((rsi_3_4h_gt_15) | (rsi_3_1d > 25.0) | aroonu_14_4h_lt_70)
+            & ((rsi_3_4h_gt_15) | (rsi_3_1d_gt_25) | aroonu_14_4h_lt_70)
             # 4h down move, 1d high & overbought
-            & ((rsi_3_4h_gt_15) | (aroonu_14_1d < 90.0) | (roc_9_1d < 20.0))
+            & ((rsi_3_4h_gt_15) | (aroonu_14_1d_lt_90) | (roc_9_1d_lt_20))
             # 4h down move, 4h still high, 1d downtrend
-            & (rsi_3_4h_gt_20 | (aroonu_14_4h < 50.0) | (roc_9_1d > -10.0))
+            & (rsi_3_4h_gt_20 | (aroonu_14_4h_lt_50) | (roc_9_1d > -10.0))
             # 4h down move, 1d high & overbought
-            & (rsi_3_4h_gt_20 | (aroonu_14_1d < 80.0) | (roc_9_1d < 80.0))
+            & (rsi_3_4h_gt_20 | (aroonu_14_1d_lt_80) | (roc_9_1d_lt_80))
             # 4h down move, 4h & 1d downtrend
             & (rsi_3_4h_gt_20 | (roc_9_4h_gt_neg_20) | (roc_9_1d_gt_neg_30))
             # 4h down move, 4h still high, 1d downtrend
-            & ((rsi_3_4h > 30.0) | (aroonu_14_4h < 50.0) | (roc_9_1d > -40.0))
+            & ((rsi_3_4h_gt_30) | (aroonu_14_4h_lt_50) | (roc_9_1d_gt_neg_40))
             # 4h down move, 1d high & overbought
-            & ((rsi_3_4h > 40.0) | (stochrsi_k_1d < 90.0) | (roc_9_1d < 200.0))
+            & ((rsi_3_4h_gt_40) | (stochrsi_k_1d_lt_90) | (roc_9_1d < 200.0))
             # 4h down move, 4h high, 1d downtrend
             & ((rsi_3_4h > 45.0) | aroonu_14_4h_lt_70 | (roc_9_1d_gt_neg_30))
             # 4h down move, 4h high & overbought
-            & ((rsi_3_4h > 60.0) | aroonu_14_4h_lt_70 | (roc_9_4h < 10.0))
+            & ((rsi_3_4h > 60.0) | aroonu_14_4h_lt_70 | (roc_9_4h_lt_10))
             # 4h down move, 4h & 1d overbought
-            & ((rsi_3_4h > 60.0) | (roc_9_4h_lt_20) | (roc_9_1d < 20.0))
+            & ((rsi_3_4h > 60.0) | (roc_9_4h_lt_20) | (roc_9_1d_lt_20))
             # 1h still high, 4h & 1d downtrend
-            & ((aroonu_14_1h < 40.0) | (roc_9_4h_gt_neg_20) | (roc_9_1d > -40.0))
+            & ((aroonu_14_1h < 40.0) | (roc_9_4h_gt_neg_20) | (roc_9_1d_gt_neg_40))
             # 1h & 4h high, 1h overbought
             & (aroonu_14_1h_lt_70 | aroonu_14_4h_lt_100 | (roc_9_1h < 80.0))
             # 1h high, 1d overbought
             & (aroonu_14_1h_lt_70 | (roc_9_1d < 70.0))
             # 1h & 4h high, 1h overbought
-            & (aroonu_14_1h_lt_80 | (aroonu_14_4h < 90.0) | (roc_9_1h < 30.0))
+            & (aroonu_14_1h_lt_80 | (aroonu_14_4h_lt_90) | (roc_9_1h < 30.0))
             # 1h & 1d high, 1h overbought
-            & (aroonu_14_1h_lt_80 | (aroonu_14_1d < 90.0) | (roc_9_1h < 30.0))
+            & (aroonu_14_1h_lt_80 | (aroonu_14_1d_lt_90) | (roc_9_1h < 30.0))
             # 4h still not low enough, 4h & 1d downtrend
-            & ((aroonu_14_4h < 30.0) | (roc_9_4h > -40.0) | (roc_9_1d > -40.0))
+            & ((aroonu_14_4h < 30.0) | (roc_9_4h > -40.0) | (roc_9_1d_gt_neg_40))
             # 4h still high, 5m downtrend
-            & ((aroonu_14_4h < 40.0) | (roc_9 > -40.0))
+            & ((aroonu_14_4h_lt_40) | (roc_9 > -40.0))
             # 4h high, 4h & 1d overbought
-            & ((aroonu_14_4h < 60.0) | (roc_9_4h < 30.0) | roc_9_1d_lt_50)
+            & ((aroonu_14_4h_lt_60) | (roc_9_4h_lt_30) | roc_9_1d_lt_50)
             # 4h & 1d high, 4h overbought
             & (aroonu_14_4h_lt_80 | aroonu_14_1d_lt_100 | (roc_9_4h < 50.0))
             # 4h high, 1h & 1d overbought
@@ -14792,11 +14844,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h high, 1h & 4h high
             & (aroonu_14_4h_lt_100 | (roc_9_1h < 50.0) | (roc_9_4h < 100.0))
             # 1d high, 4h & 1d downtrend
-            & ((aroonu_14_1d < 70.0) | (roc_9_4h > -40.0) | (roc_9_1d > -40.0))
+            & ((aroonu_14_1d_lt_70) | (roc_9_4h > -40.0) | (roc_9_1d_gt_neg_40))
             # 1d high, 1h & 1d overbought
-            & ((aroonu_14_1d < 80.0) | (roc_9_1h < 30.0) | (roc_9_1d < 200.0))
+            & ((aroonu_14_1d_lt_80) | (roc_9_1h < 30.0) | (roc_9_1d < 200.0))
             # 1d high, 4h & 1d overbought
-            & ((aroonu_14_1d < 90.0) | (roc_9_4h_lt_20) | roc_9_1d_lt_50)
+            & ((aroonu_14_1d_lt_90) | (roc_9_4h_lt_20) | roc_9_1d_lt_50)
             # 1h high, 4h overbought
             & ((stochrsi_k_1h_lt_80) | (roc_9_4h < 80.0))
             # 4h & 1d overbought
@@ -14819,93 +14871,93 @@ class NostalgiaForInfinityX7(IStrategy):
           long_entry_logic.append(protections_long_global == True)
 
           long_entry_logic.append(
-            (rsi_3_15m > 20.0)
+            (rsi_3_15m_gt_20)
             # 5m & 1h down move, 1h still not low enough
-            & ((rsi_3 > 3.0) | (rsi_3_1h_gt_10) | (aroonu_14_1h < 30.0))
+            & ((rsi_3_gt_3) | (rsi_3_1h_gt_10) | (aroonu_14_1h < 30.0))
             # 5m & 1h down move, 1d high
-            & ((rsi_3 > 3.0) | rsi_3_1h_gt_20 | aroonu_14_1d_lt_100)
+            & ((rsi_3_gt_3) | rsi_3_1h_gt_20 | aroonu_14_1d_lt_100)
             # 5m & 1h down move, 1h still high
-            & ((rsi_3 > 3.0) | (rsi_3_1h > 30.0) | (stochrsi_k_1h_lt_50))
+            & ((rsi_3_gt_3) | (rsi_3_1h_gt_30) | (stochrsi_k_1h_lt_50))
             # 5m & 4h down move, 15m still high
-            & ((rsi_3 > 3.0) | (rsi_3_4h > 3.0) | (stochrsi_k_15m < 40.0))
+            & ((rsi_3_gt_3) | (rsi_3_4h > 3.0) | (stochrsi_k_15m < 40.0))
             # 15m & 1h down move, 4h high
-            & ((rsi_3_15m > 10.0) | (rsi_3_1h > 30.0) | (stochrsi_k_4h < 60.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_30) | (stochrsi_k_4h < 60.0))
             # 15m & 1h down move, 1h still high
-            & ((rsi_3_15m > 25.0) | (rsi_3_1h > 25.0) | (stochrsi_k_1h_lt_50))
+            & ((rsi_3_15m_gt_25) | (rsi_3_1h_gt_25) | (stochrsi_k_1h_lt_50))
             # 1h & 4h down move, 4h high
-            & ((rsi_3_15m > 25.0) | (rsi_3_1h > 25.0) | (stochrsi_k_4h_lt_80))
+            & ((rsi_3_15m_gt_25) | (rsi_3_1h_gt_25) | (stochrsi_k_4h_lt_80))
             # 15m & 1h down move, 4h overbought
-            & ((rsi_3_15m > 25.0) | (rsi_3_1h > 30.0) | (roc_9_4h < 70.0))
+            & ((rsi_3_15m_gt_25) | (rsi_3_1h_gt_30) | (roc_9_4h < 70.0))
             # 15m & 1h down move, 1h high
-            & ((rsi_3_15m > 25.0) | (rsi_3_1h > 40.0) | aroonu_14_1h_lt_80)
+            & ((rsi_3_15m_gt_25) | (rsi_3_1h_gt_40) | aroonu_14_1h_lt_80)
             # 15m & 1h down move, 1h high
-            & ((rsi_3_15m > 25.0) | (rsi_3_1h > 50.0) | (aroonu_14_1h < 85.0))
+            & ((rsi_3_15m_gt_25) | (rsi_3_1h_gt_50) | (aroonu_14_1h < 85.0))
             # 15m & 1h down move, 1h high
-            & ((rsi_3_15m > 25.0) | (rsi_3_1h > 55.0) | (stochrsi_k_1h_lt_80))
+            & ((rsi_3_15m_gt_25) | (rsi_3_1h > 55.0) | (stochrsi_k_1h_lt_80))
             # 15m down move, 15m stil not low enough, 4h high
-            & ((rsi_3_15m > 25.0) | (aroonu_14_15m < 30.0) | (aroonu_14_4h < 60.0))
+            & ((rsi_3_15m_gt_25) | (aroonu_14_15m < 30.0) | (aroonu_14_4h_lt_60))
             # 15m down move, 15m high, 1h high
-            & ((rsi_3_15m > 25.0) | (aroonu_14_15m < 60.0) | (stochrsi_k_1h_lt_70))
+            & ((rsi_3_15m_gt_25) | (aroonu_14_15m < 60.0) | (stochrsi_k_1h_lt_70))
             # 15m down move, 1h & 4h overbought
-            & ((rsi_3_15m > 25.0) | (roc_9_1h < 40.0) | (roc_9_4h < 40.0))
+            & ((rsi_3_15m_gt_25) | (roc_9_1h < 40.0) | (roc_9_4h_lt_40))
             # 15m down move, 4h & 1d overbought
-            & ((rsi_3_15m > 25.0) | (roc_9_4h < 10.0) | roc_9_1d_lt_50)
+            & ((rsi_3_15m_gt_25) | (roc_9_4h_lt_10) | roc_9_1d_lt_50)
             # 15m & 4h down move, 4h high
-            & ((rsi_3_15m > 30.0) | (rsi_3_4h > 50.0) | aroonu_14_4h_lt_80)
+            & ((rsi_3_15m_gt_30) | (rsi_3_4h_gt_50) | aroonu_14_4h_lt_80)
             # 15m & 1h down move, 1h high
-            & ((rsi_3_15m > 30.0) | (rsi_3_1h > 30.0) | (aroonu_14_1h < 85.0))
+            & ((rsi_3_15m_gt_30) | (rsi_3_1h_gt_30) | (aroonu_14_1h < 85.0))
             # 15m down move, 15m still high, 1d high
-            & ((rsi_3_15m > 30.0) | (aroonu_14_15m < 50.0) | (stochrsi_k_1d < 70.0))
+            & ((rsi_3_15m_gt_30) | (aroonu_14_15m_lt_50) | (stochrsi_k_1d < 70.0))
             # 15m down move, 15m high, 4h high
-            & ((rsi_3_15m > 30.0) | (aroonu_14_15m < 60.0) | (stochrsi_k_4h < 70.0))
+            & ((rsi_3_15m_gt_30) | (aroonu_14_15m < 60.0) | (stochrsi_k_4h_lt_70))
             # 15m down move, 1h & 4h high
-            & ((rsi_3_15m > 30.0) | (aroonu_14_1h < 85.0) | aroonu_14_4h_lt_100)
+            & ((rsi_3_15m_gt_30) | (aroonu_14_1h < 85.0) | aroonu_14_4h_lt_100)
             # 15m down move, 4h & 1d high
-            & ((rsi_3_15m > 30.0) | aroonu_14_4h_lt_80 | aroonu_14_1d_lt_100)
+            & ((rsi_3_15m_gt_30) | aroonu_14_4h_lt_80 | aroonu_14_1d_lt_100)
             # 15m down move, 4h high, 1h downtrend
             & ((rsi_3_15m < 30.0) | (aroonu_14_4h < 85.0) | (roc_9_1h > -40.0))
             # 15m down move, 4h high & overbought
-            & ((rsi_3_15m > 30.0) | aroonu_14_4h_lt_100 | (roc_9_4h < 25.0))
+            & ((rsi_3_15m_gt_30) | aroonu_14_4h_lt_100 | (roc_9_4h < 25.0))
             # 15m & 4h down move, 4h high
-            & ((rsi_3_15m > 35.0) | (rsi_3_4h > 35.0) | (stochrsi_k_4h_lt_80))
+            & ((rsi_3_15m > 35.0) | (rsi_3_4h_gt_35) | (stochrsi_k_4h_lt_80))
             # 15m down move, 15m high, 4h overbought
-            & ((rsi_3_15m > 35.0) | (aroonu_14_15m < 70.0) | (roc_9_4h < 10.0))
+            & ((rsi_3_15m > 35.0) | (aroonu_14_15m_lt_70) | (roc_9_4h_lt_10))
             # 15m down move, 1h high, 4h overbought
             & ((rsi_3_15m > 35.0) | (aroonu_14_1h < 85.0) | (roc_9_4h < 80.0))
             # 15m down move, 4h high, 1h overbought
             & ((rsi_3_15m > 35.0) | aroonu_14_4h_lt_100 | (roc_9_1h < 20.0))
             # 15m & 1h down move, 1h high
-            & ((rsi_3_15m > 40.0) | (rsi_3_1h > 40.0) | (aroonu_14_1h < 100.0))
+            & ((rsi_3_15m > 40.0) | (rsi_3_1h_gt_40) | (aroonu_14_1h_lt_100))
             # 15m down move, 15m still high, 1h high
-            & ((rsi_3_15m > 45.0) | (aroonu_14_15m < 50.0) | (aroonu_14_1h < 85.0))
+            & ((rsi_3_15m > 45.0) | (aroonu_14_15m_lt_50) | (aroonu_14_1h < 85.0))
             # 1h & 4h down move, 1d high
-            & ((rsi_3_1h > 3.0) | (rsi_3_4h > 5.0) | (aroonu_14_1d < 70.0))
+            & ((rsi_3_1h_gt_3) | (rsi_3_4h_gt_5) | (aroonu_14_1d_lt_70))
             # 1h & 4h down move, 4h still high
-            & ((rsi_3_1h > 3.0) | (rsi_3_4h_gt_10) | (aroonu_14_4h < 40.0))
+            & ((rsi_3_1h_gt_3) | (rsi_3_4h_gt_10) | (aroonu_14_4h_lt_40))
             # 1h & 4h down move, 1d overbought
-            & ((rsi_3_1h > 3.0) | (rsi_3_4h_gt_10) | (roc_9_1d < 15.0))
+            & ((rsi_3_1h_gt_3) | (rsi_3_4h_gt_10) | (roc_9_1d < 15.0))
             # 1h & 4h down move, 4h downtrend
-            & ((rsi_3_1h > 3.0) | (rsi_3_4h_gt_15) | (roc_9_4h > -40.0))
+            & ((rsi_3_1h_gt_3) | (rsi_3_4h_gt_15) | (roc_9_4h > -40.0))
             # 1h & 4h down move, 1d downtrend
-            & ((rsi_3_1h > 3.0) | (rsi_3_4h > 25.0) | roc_9_1d_gt_neg_50)
+            & ((rsi_3_1h_gt_3) | (rsi_3_4h_gt_25) | roc_9_1d_gt_neg_50)
             # 1h & 1d down move, 1d high
-            & ((rsi_3_1h > 3.0) | (rsi_3_1d > 25.0) | (aroonu_14_1d < 80.0))
+            & ((rsi_3_1h_gt_3) | (rsi_3_1d_gt_25) | (aroonu_14_1d_lt_80))
             # 1h & 4h down move, 1h downtrend
-            & ((rsi_3_1h > 5.0) | rsi_3_4h_gt_20 | (roc_9_1h > -15.0))
+            & ((rsi_3_1h_gt_5) | rsi_3_4h_gt_20 | (roc_9_1h > -15.0))
             # 1h & 4h down move, 4h still high
-            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_10) | (aroonu_14_4h < 50.0))
+            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_10) | (aroonu_14_4h_lt_50))
             # 1h & 4h down move, 15m still high
             & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_10) | (stochrsi_k_15m < 50.0))
             # 1h & 4h down move, 1h downtrend
             & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_10) | (roc_9_1h > -20.0))
             # 1h & 4h & 1d down move
-            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_15) | (rsi_3_1d > 15.0))
+            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_15) | (rsi_3_1d_gt_15))
             # 1h & 4h down move, 15m high
             & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_15) | (stochrsi_k_15m < 70.0))
             # 1h & 4h down move, 4h high
-            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_15) | (aroonu_14_4h < 60.0))
+            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_15) | (aroonu_14_4h_lt_60))
             # 1h & 4h down move, 1d overbought
-            & ((rsi_3_1h_gt_10) | (rsi_3_4h > 30.0) | (roc_9_1d < 100.0))
+            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_30) | (roc_9_1d < 100.0))
             # 1h & 4h down move, 4h still high
             & ((rsi_3_1h_gt_10) | (rsi_3_4h > 45.0) | (stochrsi_k_4h < 40.0))
             # 1h down move, 4h downtrend. 4h still not low enough
@@ -14913,135 +14965,135 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 15m still high, 4h high
             & ((rsi_3_1h_gt_10) | (aroonu_14_15m < 40.0) | (stochrsi_k_4h < 90.0))
             # 1h down move, 15m high, 4h downtrend
-            & ((rsi_3_1h_gt_10) | (aroonu_14_15m < 70.0) | (roc_9_4h > -10.0))
+            & ((rsi_3_1h_gt_10) | (aroonu_14_15m_lt_70) | (roc_9_4h > -10.0))
             # 1h down move, 1h still high, 15m downtrend
             & ((rsi_3_1h_gt_10) | (aroonu_14_1h < 40.0) | (cmf_20_15m > -0.30))
             # 1h down move, 1d high, 4h overbought
             & ((rsi_3_1h_gt_10) | (aroonu_14_1d < 100.0) | (roc_9_4h < 20.0))
             # 1h down move, 1h still high, 1d downtrend
-            & ((rsi_3_1h_gt_10) | (stochrsi_k_1h < 50.0) | (roc_9_1d > -40.0))
+            & ((rsi_3_1h_gt_10) | (stochrsi_k_1h < 50.0) | (roc_9_1d_gt_neg_40))
             # 1h down move, 1d high & overbought
-            & ((rsi_3_1h_gt_10) | (stochrsi_k_1d < 80.0) | (roc_9_1d < 30.0))
+            & ((rsi_3_1h_gt_10) | (stochrsi_k_1d < 80.0) | (roc_9_1d_lt_30))
             # 1h & 4h down move, 1h still high
-            & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_15) | (aroonu_14_1h < 50.0))
+            & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_15) | (aroonu_14_1h_lt_50))
             # 1h & 4h down move, 1h still not low enough
             & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_15) | (stochrsi_k_1h < 30.0))
             # 1h & 4h down move, 1d downtrend
-            & ((rsi_3_1h_gt_15) | rsi_3_4h_gt_20 | (roc_9_1d > -40.0))
+            & ((rsi_3_1h_gt_15) | rsi_3_4h_gt_20 | (roc_9_1d_gt_neg_40))
             # 1h & 4h down move, 4h high
-            & ((rsi_3_1h_gt_15) | (rsi_3_4h > 50.0) | (aroonu_14_4h < 100.0))
+            & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_50) | (aroonu_14_4h < 100.0))
             # 1h & 1d down move, 4h high
-            & ((rsi_3_1h_gt_15) | (rsi_3_1d > 15.0) | (stochrsi_k_4h < 80.0))
+            & ((rsi_3_1h_gt_15) | (rsi_3_1d_gt_15) | (stochrsi_k_4h < 80.0))
             # 1h down move, 4h high, 1d overbought
-            & ((rsi_3_1h_gt_15) | (aroonu_14_4h < 60.0) | roc_9_1d_lt_50)
+            & ((rsi_3_1h_gt_15) | (aroonu_14_4h_lt_60) | roc_9_1d_lt_50)
             # 1h down move, 4h high, 1d high
             & ((rsi_3_1h_gt_15) | (aroonu_14_4h < 80.0) | (stochrsi_k_1d < 80.0))
             # 1h down move, 1d high, 1d downtrend
-            & ((rsi_3_1h_gt_15) | (aroonu_14_1d < 70.0) | (roc_9_1d > -20.0))
+            & ((rsi_3_1h_gt_15) | (aroonu_14_1d_lt_70) | (roc_9_1d > -20.0))
             # 1h down move, 1d high, 4h overbought
             & ((rsi_3_1h_gt_15) | (aroonu_14_1d < 100.0) | (roc_9_4h < 60.0))
             # 1h down move, 1d high & overbought
             & ((rsi_3_1h_gt_15) | (aroonu_14_1d < 100.0) | (roc_9_1d < 10.0))
             # 1h down move, 1h downtrend, 1d overbought
-            & ((rsi_3_1h_gt_15) | (roc_9_1h > -30.0) | (roc_9_1d < 80.0))
+            & ((rsi_3_1h_gt_15) | (roc_9_1h > -30.0) | (roc_9_1d_lt_80))
             # 1h down move, 4h & 1d overbought
-            & ((rsi_3_1h_gt_15) | (roc_9_4h < 10.0) | (roc_9_1d < 60.0))
+            & ((rsi_3_1h_gt_15) | (roc_9_4h_lt_10) | (roc_9_1d < 60.0))
             # 1h & 4h down move, 4h high
             & (rsi_3_1h_gt_20 | rsi_3_4h_gt_20 | aroonu_14_4h_lt_70)
             # 1h & 4h down move, 4h high
-            & (rsi_3_1h_gt_20 | (rsi_3_4h > 40.0) | aroonu_14_4h_lt_80)
+            & (rsi_3_1h_gt_20 | (rsi_3_4h_gt_40) | aroonu_14_4h_lt_80)
             # 1h & 1d down move, 1h still high
             & (rsi_3_1h_gt_20 | (rsi_3_1d > 30.0) | (stochrsi_k_1h_lt_50))
             # 1h & 4h down move, 15m high
-            & ((rsi_3_1h > 25.0) | (rsi_3_4h > 25.0) | (aroonu_14_15m < 70.0))
+            & ((rsi_3_1h_gt_25) | (rsi_3_4h_gt_25) | (aroonu_14_15m_lt_70))
             # 1h down move, 4h downtrend, 4h high
-            & ((rsi_3_1h > 25.0) | (cmf_20_4h > -0.50) | aroonu_14_4h_lt_70)
+            & ((rsi_3_1h_gt_25) | (cmf_20_4h > -0.50) | aroonu_14_4h_lt_70)
             # 1h down move, 1d high & overbought
-            & ((rsi_3_1h > 25.0) | (aroonu_14_1d < 90.0) | (roc_9_1d < 30.0))
+            & ((rsi_3_1h_gt_25) | (aroonu_14_1d_lt_90) | (roc_9_1d_lt_30))
             # 1h down move, 4h high, 1d downtrend
-            & ((rsi_3_1h > 25.0) | (stochrsi_k_4h < 80.0) | (roc_9_1d_gt_neg_30))
+            & ((rsi_3_1h_gt_25) | (stochrsi_k_4h < 80.0) | (roc_9_1d_gt_neg_30))
             # 1h & 4h down move, 4h high
-            & ((rsi_3_1h > 30.0) | (rsi_3_4h > 50.0) | (aroonu_14_4h < 85.0))
+            & ((rsi_3_1h_gt_30) | (rsi_3_4h_gt_50) | (aroonu_14_4h < 85.0))
             # 1h down move, 1h & 4h high
-            & ((rsi_3_1h > 30.0) | aroonu_14_1h_lt_70 | (aroonu_14_4h < 85.0))
+            & ((rsi_3_1h_gt_30) | aroonu_14_1h_lt_70 | (aroonu_14_4h < 85.0))
             # 1h down move, 1h high, 4h overbought
-            & ((rsi_3_1h > 30.0) | aroonu_14_1h_lt_70 | (roc_9_4h < 20.0))
+            & ((rsi_3_1h_gt_30) | aroonu_14_1h_lt_70 | (roc_9_4h < 20.0))
             # 1h down move, 4h high, 1d overbought
-            & ((rsi_3_1h > 30.0) | aroonu_14_4h_lt_80 | (roc_9_1d < 30.0))
+            & ((rsi_3_1h_gt_30) | aroonu_14_4h_lt_80 | (roc_9_1d_lt_30))
             # 1h down move, 4h high & overbought
-            & ((rsi_3_1h > 30.0) | (aroonu_14_4h < 90.0) | (roc_9_4h < 100.0))
+            & ((rsi_3_1h_gt_30) | (aroonu_14_4h_lt_90) | (roc_9_4h < 100.0))
             # 1h down move, 15m still high, 1h high
-            & ((rsi_3_1h > 30.0) | (stochrsi_k_15m < 40.0) | (aroonu_14_1h < 60.0))
+            & ((rsi_3_1h_gt_30) | (stochrsi_k_15m < 40.0) | (aroonu_14_1h < 60.0))
             # 1h down move, 1h high, 1d downtrend
-            & ((rsi_3_1h > 30.0) | (stochrsi_k_1h_lt_70) | (roc_9_1d > -40.0))
+            & ((rsi_3_1h_gt_30) | (stochrsi_k_1h_lt_70) | (roc_9_1d_gt_neg_40))
             # 1h down move, 4h high, 1d downtrend
-            & ((rsi_3_1h > 30.0) | (stochrsi_k_4h_lt_90) | roc_9_1d_gt_neg_50)
+            & ((rsi_3_1h_gt_30) | (stochrsi_k_4h_lt_90) | roc_9_1d_gt_neg_50)
             # 1h down move, 4h downtrend, 1d over
-            & ((rsi_3_1h > 30.0) | (roc_9_4h > -30.0) | roc_9_1d_lt_50)
+            & ((rsi_3_1h_gt_30) | (roc_9_4h_gt_neg_30) | roc_9_1d_lt_50)
             # 1h down move, 1h still high, 1d overbought
-            & ((rsi_3_1h > 35.0) | (aroonu_14_1h < 50.0) | (roc_9_1d < 20.0))
+            & ((rsi_3_1h_gt_35) | (aroonu_14_1h_lt_50) | (roc_9_1d_lt_20))
             # 1h down move, 1h & 4h high
-            & ((rsi_3_1h > 35.0) | aroonu_14_1h_lt_70 | aroonu_14_4h_lt_100)
+            & ((rsi_3_1h_gt_35) | aroonu_14_1h_lt_70 | aroonu_14_4h_lt_100)
             # 1h down move, 1h high, 1d downtrend
-            & ((rsi_3_1h > 35.0) | aroonu_14_1h_lt_70 | (roc_9_1d > -25.0))
+            & ((rsi_3_1h_gt_35) | aroonu_14_1h_lt_70 | (roc_9_1d > -25.0))
             # 1h down move, 1h high, 4h downtrend
-            & ((rsi_3_1h > 35.0) | aroonu_14_1h_lt_80 | (roc_9_4h > -20.0))
+            & ((rsi_3_1h_gt_35) | aroonu_14_1h_lt_80 | (roc_9_4h > -20.0))
             # 1h down move, 1h still high, 1d overbought
-            & ((rsi_3_1h > 35.0) | (stochrsi_k_1h_lt_50) | (roc_9_1d < 200.0))
+            & ((rsi_3_1h_gt_35) | (stochrsi_k_1h_lt_50) | (roc_9_1d < 200.0))
             # 1h down move, 15m high, 1h high
-            & ((rsi_3_1h > 40.0) | (aroonu_14_15m < 60.0) | aroonu_14_1h_lt_70)
+            & ((rsi_3_1h_gt_40) | (aroonu_14_15m < 60.0) | aroonu_14_1h_lt_70)
             # 1h down move, 1h still high, 1d overbought
-            & ((rsi_3_1h > 40.0) | (aroonu_14_1h < 40.0) | (roc_9_1d_lt_100))
+            & ((rsi_3_1h_gt_40) | (aroonu_14_1h < 40.0) | (roc_9_1d_lt_100))
             # 1h down move, 1h high, 4h overbought
-            & ((rsi_3_1h > 40.0) | aroonu_14_1h_lt_70 | (roc_9_4h < 30.0))
+            & ((rsi_3_1h_gt_40) | aroonu_14_1h_lt_70 | (roc_9_4h_lt_30))
             # 1h down move, 1h & 4h high
-            & ((rsi_3_1h > 40.0) | aroonu_14_1h_lt_80 | aroonu_14_4h_lt_100)
+            & ((rsi_3_1h_gt_40) | aroonu_14_1h_lt_80 | aroonu_14_4h_lt_100)
             # 1h down move, 1d high & overbought
-            & ((rsi_3_1h > 40.0) | (aroonu_14_1d < 80.0) | roc_9_1d_lt_50)
+            & ((rsi_3_1h_gt_40) | (aroonu_14_1d_lt_80) | roc_9_1d_lt_50)
             # 1h down move, 1h & 4h overbought
-            & ((rsi_3_1h > 40.0) | (roc_9_1h < 20.0) | (roc_9_4h_lt_20))
+            & ((rsi_3_1h_gt_40) | (roc_9_1h < 20.0) | (roc_9_4h_lt_20))
             # 1h down move, 1h overbought
-            & ((rsi_3_1h > 40.0) | (roc_9_1h < 30.0))
+            & ((rsi_3_1h_gt_40) | (roc_9_1h < 30.0))
             # 1h & 4h down move, 1d overbought
-            & ((rsi_3_1h > 45.0) | (rsi_3_4h > 65.0) | (roc_9_1d < 200.0))
+            & ((rsi_3_1h_gt_45) | (rsi_3_4h > 65.0) | (roc_9_1d < 200.0))
             # 1h down move, 15m still high, 1h high
-            & ((rsi_3_1h > 45.0) | (aroonu_14_15m < 50.0) | (aroonu_14_1h < 85.0))
+            & ((rsi_3_1h_gt_45) | (aroonu_14_15m_lt_50) | (aroonu_14_1h < 85.0))
             # 1h down move, 1h high, 4h overbought
-            & ((rsi_3_1h > 45.0) | aroonu_14_1h_lt_80 | (roc_9_4h < 50.0))
+            & ((rsi_3_1h_gt_45) | aroonu_14_1h_lt_80 | (roc_9_4h < 50.0))
             # 1h down move, 1h high, 1d overbought
-            & ((rsi_3_1h > 45.0) | (stochrsi_k_1h_lt_70) | roc_9_1d_lt_50)
+            & ((rsi_3_1h_gt_45) | (stochrsi_k_1h_lt_70) | roc_9_1d_lt_50)
             # 1h down move, 1h high, 1d downtrend
-            & ((rsi_3_1h > 50.0) | (aroonu_14_1h < 90.0) | (roc_9_1d_gt_neg_30))
+            & ((rsi_3_1h_gt_50) | (aroonu_14_1h_lt_90) | (roc_9_1d_gt_neg_30))
             # 1h down move, 4h high, 1h overbought
-            & ((rsi_3_1h > 50.0) | (aroonu_14_4h < 90.0) | (roc_9_1h < 40.0))
+            & ((rsi_3_1h_gt_50) | (aroonu_14_4h_lt_90) | (roc_9_1h < 40.0))
             # 1h down move, 4h & 1d high
-            & ((rsi_3_1h > 50.0) | aroonu_14_4h_lt_100 | aroonu_14_1d_lt_100)
+            & ((rsi_3_1h_gt_50) | aroonu_14_4h_lt_100 | aroonu_14_1d_lt_100)
             # 1h down move, 4h high, 1d downtrend
-            & ((rsi_3_1h > 50.0) | (stochrsi_k_4h < 60.0) | (roc_9_1d > -60.0))
+            & ((rsi_3_1h_gt_50) | (stochrsi_k_4h < 60.0) | (roc_9_1d > -60.0))
             # 1h down move, 4h & 1d overbought
-            & ((rsi_3_1h > 50.0) | (roc_9_4h_lt_20) | (roc_9_1d < 80.0))
+            & ((rsi_3_1h_gt_50) | (roc_9_4h_lt_20) | (roc_9_1d_lt_80))
             # 1h down move, 15m high, 1h high
             & ((rsi_3_1h > 55.0) | (aroonu_14_15m < 60.0) | (stochrsi_k_1h_lt_80))
             # 1h down move, 1h high & overbought
             & ((rsi_3_1h > 55.0) | (stochrsi_k_1h < 60.0) | (roc_9_1d < 10.0))
             # 1h down move, 4h & 1d overbought
-            & ((rsi_3_1h > 60.0) | (roc_9_4h < 10.0) | (roc_9_1d < 40.0))
+            & ((rsi_3_1h > 60.0) | (roc_9_4h_lt_10) | (roc_9_1d_lt_40))
             # 1h down move, 4h high, 1d overbought
-            & ((rsi_3_1h > 60.0) | aroonu_14_4h_lt_80 | (roc_9_1d < 40.0))
+            & ((rsi_3_1h > 60.0) | aroonu_14_4h_lt_80 | (roc_9_1d_lt_40))
             # 4h & 1d down move, 4h downtrend
-            & ((rsi_3_4h > 3.0) | (rsi_3_1d > 10.0) | (roc_9_4h_gt_neg_20))
+            & ((rsi_3_4h > 3.0) | (rsi_3_1d_gt_10) | (roc_9_4h_gt_neg_20))
             # 4h & 1d down move, 1h still not low enough
-            & ((rsi_3_4h > 5.0) | (rsi_3_1d > 10.0) | (stochrsi_k_1h < 30.0))
+            & ((rsi_3_4h_gt_5) | (rsi_3_1d_gt_10) | (stochrsi_k_1h < 30.0))
             # 4h down move, 1d high, 4h downtrend
-            & ((rsi_3_4h > 5.0) | (aroonu_14_1d < 80.0) | (roc_9_4h > -10.0))
+            & ((rsi_3_4h_gt_5) | (aroonu_14_1d_lt_80) | (roc_9_4h > -10.0))
             # 4h & 1d down move, 15m high
-            & ((rsi_3_4h_gt_10) | (rsi_3_1d > 15.0) | (stochrsi_k_15m < 80.0))
+            & ((rsi_3_4h_gt_10) | (rsi_3_1d_gt_15) | (stochrsi_k_15m < 80.0))
             # 4h & 1d down move, 1d downtrend
-            & ((rsi_3_4h_gt_10) | (rsi_3_1d > 15.0) | (roc_9_1d > -15.0))
+            & ((rsi_3_4h_gt_10) | (rsi_3_1d_gt_15) | (roc_9_1d > -15.0))
             # 4h & 1d down move, 1d still high
-            & ((rsi_3_4h_gt_10) | (rsi_3_1d > 25.0) | (stochrsi_k_1d < 50.0))
+            & ((rsi_3_4h_gt_10) | (rsi_3_1d_gt_25) | (stochrsi_k_1d < 50.0))
             # 4h down move, 15m downtrend, 1d high
-            & ((rsi_3_4h_gt_10) | (cmf_20_15m > -0.30) | (aroonu_14_1d < 80.0))
+            & ((rsi_3_4h_gt_10) | (cmf_20_15m > -0.30) | (aroonu_14_1d_lt_80))
             # 4h down move, 15m still high, 1d downtrend
             & ((rsi_3_4h_gt_10) | (stochrsi_k_15m < 50.0) | (roc_9_1d > -25.0))
             # 4h down move, 15m high
@@ -15051,81 +15103,81 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 4h still high, 1d downtrend
             & ((rsi_3_4h_gt_10) | (stochrsi_k_4h < 40.0) | (roc_9_1d > -20.0))
             # 4h down move, 4h downtrend, 1d overbought
-            & ((rsi_3_4h_gt_10) | (roc_9_4h > -20.0) | (roc_9_1d < 40.0))
+            & ((rsi_3_4h_gt_10) | (roc_9_4h > -20.0) | (roc_9_1d_lt_40))
             # 4h & 1d down move, 4h downtrend
-            & ((rsi_3_4h_gt_15) | (rsi_3_1d > 20.0) | (roc_9_4h > -40.0))
+            & ((rsi_3_4h_gt_15) | (rsi_3_1d_gt_20) | (roc_9_4h > -40.0))
             # 4h down move, 1h high, 1d downtrend
-            & ((rsi_3_4h_gt_15) | (aroonu_14_1h < 90.0) | (roc_9_1d > -10.0))
+            & ((rsi_3_4h_gt_15) | (aroonu_14_1h_lt_90) | (roc_9_1d > -10.0))
             # 4h down move, 4h still high, 1d downtrend
-            & ((rsi_3_4h_gt_15) | (stochrsi_k_4h < 50.0) | (roc_9_1d > -20.0))
+            & ((rsi_3_4h_gt_15) | (stochrsi_k_4h_lt_50) | (roc_9_1d > -20.0))
             # 4h down move, 1h & 4h downtrend
-            & ((rsi_3_4h_gt_15) | (roc_9_1h > -30.0) | (roc_9_4h > -30.0))
+            & ((rsi_3_4h_gt_15) | (roc_9_1h > -30.0) | (roc_9_4h_gt_neg_30))
             # 4h & 1ddown move, 1d high
-            & (rsi_3_4h_gt_20 | (rsi_3_1d > 20.0) | (aroonu_14_1d < 80.0))
+            & (rsi_3_4h_gt_20 | (rsi_3_1d_gt_20) | (aroonu_14_1d_lt_80))
             # 4h down move, 1d high, 1d downtrend
-            & (rsi_3_4h_gt_20 | (aroonu_14_1d < 80.0) | (roc_9_1d_gt_neg_30))
+            & (rsi_3_4h_gt_20 | (aroonu_14_1d_lt_80) | (roc_9_1d_gt_neg_30))
             # 4h down move, 1d high & overbought
-            & (rsi_3_4h_gt_20 | (aroonu_14_1d < 80.0) | (roc_9_1d < 70.0))
+            & (rsi_3_4h_gt_20 | (aroonu_14_1d_lt_80) | (roc_9_1d < 70.0))
             # 4h down move, 4h still high. 4h downtrend
-            & ((rsi_3_4h > 25.0) | (aroonu_14_4h < 50.0) | (cmf_20_4h > -0.40))
+            & ((rsi_3_4h_gt_25) | (aroonu_14_4h_lt_50) | (cmf_20_4h > -0.40))
             # 4h down move, 4h high, 1d downtrend
-            & ((rsi_3_4h > 25.0) | (stochrsi_k_4h < 60.0) | (roc_9_1d > -70.0))
+            & ((rsi_3_4h_gt_25) | (stochrsi_k_4h < 60.0) | (roc_9_1d > -70.0))
             # 4h down move, 1h high, 4h downtrend
-            & ((rsi_3_4h > 30.0) | aroonu_14_1h_lt_70 | (roc_9_4h > -10.0))
+            & ((rsi_3_4h_gt_30) | aroonu_14_1h_lt_70 | (roc_9_4h > -10.0))
             # 4h down move, 1h high, 1d downtrend
-            & ((rsi_3_4h > 30.0) | (stochrsi_k_1h < 60.0) | (roc_9_1d > -40.0))
+            & ((rsi_3_4h_gt_30) | (stochrsi_k_1h < 60.0) | (roc_9_1d_gt_neg_40))
             # 4h down move, 4h & 1d high
-            & ((rsi_3_4h > 35.0) | aroonu_14_4h_lt_70 | aroonu_14_1d_lt_100)
+            & ((rsi_3_4h_gt_35) | aroonu_14_4h_lt_70 | aroonu_14_1d_lt_100)
             # 4h down move, 4h high & overbought
-            & ((rsi_3_4h > 50.0) | aroonu_14_4h_lt_80 | (roc_9_4h < 10.0))
+            & ((rsi_3_4h_gt_50) | aroonu_14_4h_lt_80 | (roc_9_4h_lt_10))
             # 4h down move, 4h high, 1d overbought
-            & ((rsi_3_4h > 50.0) | aroonu_14_4h_lt_80 | (roc_9_1d < 40.0))
+            & ((rsi_3_4h_gt_50) | aroonu_14_4h_lt_80 | (roc_9_1d_lt_40))
             # 4h down move, 4h & 1d overbought
-            & ((rsi_3_4h > 50.0) | (roc_9_4h < 10.0) | (roc_9_1d < 40.0))
+            & ((rsi_3_4h_gt_50) | (roc_9_4h_lt_10) | (roc_9_1d_lt_40))
             # 1d down move, 1d high, 1d downtrend
-            & ((rsi_3_1d > 10.0) | (aroonu_14_1d < 70.0) | (roc_9_1d > -10.0))
+            & ((rsi_3_1d_gt_10) | (aroonu_14_1d_lt_70) | (roc_9_1d > -10.0))
             # 1d down move, 1h high, 4h downtrend
-            & ((rsi_3_1d > 30.0) | (stochrsi_k_1h < 90.0) | (roc_9_4h > -30.0))
+            & ((rsi_3_1d > 30.0) | (stochrsi_k_1h < 90.0) | (roc_9_4h_gt_neg_30))
             # 15m & 1h & 4h downtrend
             & ((cmf_20_15m > -0.30) | (cmf_20_1h > -0.30) | (cmf_20_4h > -0.30))
             # 1d downtrend, 1d high & overbought
-            & ((cmf_20_1d > -0.40) | (aroonu_14_1d < 85.0) | (roc_9_1d < 20.0))
+            & ((cmf_20_1d > -0.40) | (aroonu_14_1d < 85.0) | (roc_9_1d_lt_20))
             # 15m not low enough, 1h & 4h downtrend
             & ((aroonu_14_15m < 20.0) | (roc_9_1h > -30.0) | (roc_9_4h > -50.0))
             # 15m high, 1h high & overbought
-            & ((aroonu_14_15m < 70.0) | (aroonu_14_1h < 85.0) | (roc_9_1h < 10.0))
+            & ((aroonu_14_15m_lt_70) | (aroonu_14_1h < 85.0) | (roc_9_1h_lt_10))
             # 4h high, 4h & 1d overbought
-            & (aroonu_14_4h_lt_70 | (roc_9_4h < 60.0) | (roc_9_1d < 80.0))
+            & (aroonu_14_4h_lt_70 | (roc_9_4h < 60.0) | (roc_9_1d_lt_80))
             # 1h & 4h high, 4h overbought
-            & (aroonu_14_1h_lt_80 | aroonu_14_4h_lt_100 | (roc_9_4h < 10.0))
+            & (aroonu_14_1h_lt_80 | aroonu_14_4h_lt_100 | (roc_9_4h_lt_10))
             # 1h & 1d high, 1d overbought
-            & (aroonu_14_1h_lt_80 | (aroonu_14_1d < 80.0) | (roc_9_1d < 200.0))
+            & (aroonu_14_1h_lt_80 | (aroonu_14_1d_lt_80) | (roc_9_1d < 200.0))
             # 1h high, 1h overbought
-            & (aroonu_14_1h_lt_80 | (roc_9_1h < 10.0))
+            & (aroonu_14_1h_lt_80 | (roc_9_1h_lt_10))
             # 4h still high, 5m downtrend
-            & ((aroonu_14_4h < 40.0) | (roc_9 > -40.0))
+            & ((aroonu_14_4h_lt_40) | (roc_9 > -40.0))
             # 4h & 1d high, 4h overbought
             & (aroonu_14_4h_lt_80 | aroonu_14_1d_lt_100 | (roc_9_4h < 80.0))
             # 4h & 1d high, 1d overbought
-            & (aroonu_14_4h_lt_80 | aroonu_14_1d_lt_100 | (roc_9_1d < 80.0))
+            & (aroonu_14_4h_lt_80 | aroonu_14_1d_lt_100 | (roc_9_1d_lt_80))
             # 4h high, 1h & 4h overbought
             & ((aroonu_14_4h < 85.0) | (roc_9_1h < 80.0) | (roc_9_4h < 80.0))
             # 4h high, 4h & 1d overbought
-            & ((aroonu_14_4h < 85.0) | (roc_9_4h < 10.0) | (roc_9_1d < 40.0))
+            & ((aroonu_14_4h < 85.0) | (roc_9_4h_lt_10) | (roc_9_1d_lt_40))
             # 4h & 1d high, 4h overbought
-            & (aroonu_14_4h_lt_100 | aroonu_14_1d_lt_100 | (roc_9_4h < 40.0))
+            & (aroonu_14_4h_lt_100 | aroonu_14_1d_lt_100 | (roc_9_4h_lt_40))
             # 4h high, 1h & 1d overbought
             & (aroonu_14_4h_lt_100 | (roc_9_1h < 40.0) | (roc_9_1d < 100.0))
             # 4h high, 4h & 1d overbought
-            & (aroonu_14_4h_lt_100 | (roc_9_4h < 20.0) | (roc_9_1d < 80.0))
+            & (aroonu_14_4h_lt_100 | (roc_9_4h < 20.0) | (roc_9_1d_lt_80))
             # 1d high, 1h & 4h down move
             & (aroonu_14_1d_lt_100 | (roc_9_1h < 25.0) | (roc_9_4h < 60.0))
             # 1d high, 1h downtrend, 1d overbought
             & (aroonu_14_1d_lt_100 | (roc_9_1h > -30.0) | (roc_9_1d < 100.0))
             # 1d high, 4h & 1d overbought
-            & (aroonu_14_1d_lt_100 | (roc_9_4h < 20.0) | (roc_9_1d < 80.0))
+            & (aroonu_14_1d_lt_100 | (roc_9_4h < 20.0) | (roc_9_1d_lt_80))
             # 15m high, 4h & 1d downtrend
-            & ((stochrsi_k_15m < 70.0) | (roc_9_4h > -30.0) | (roc_9_1d_gt_neg_30))
+            & ((stochrsi_k_15m < 70.0) | (roc_9_4h_gt_neg_30) | (roc_9_1d_gt_neg_30))
             # 1h high, 4h & 1d overbought
             & ((stochrsi_k_1h < 90.0) | (roc_9_4h_lt_20) | (roc_9_1d_lt_100))
             # 4h high, 1h overbought, 1d downtrend
@@ -15133,11 +15185,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h high, 4h & 1d overbought
             & ((stochrsi_k_4h < 80.0) | (roc_9_4h < 80.0) | (roc_9_1d_lt_100))
             # 4h high, 1h & 4h overbought
-            & ((stochrsi_k_4h_lt_90) | (roc_9_1h < 10.0) | (roc_9_4h < 80.0))
+            & ((stochrsi_k_4h_lt_90) | (roc_9_1h_lt_10) | (roc_9_4h < 80.0))
             # 4h high, 1h & 4h overbought
             & ((stochrsi_k_4h_lt_90) | (roc_9_1h < 20.0) | (roc_9_4h < 50.0))
             # 1d high, 4h & 1d overbought
-            & ((stochrsi_k_1d < 90.0) | (roc_9_4h < 40.0) | (roc_9_1d_lt_100))
+            & ((stochrsi_k_1d_lt_90) | (roc_9_4h_lt_40) | (roc_9_1d_lt_100))
             # 1d P&D, dh downtrend
             & ((change_pct_1d > -50.0) | (change_pct_1d.shift(288) < 50.0) | (rsi_3_4h_gt_15))
             # big drop in the last 20 days, 1d high, 1d downtrend
@@ -15166,45 +15218,45 @@ class NostalgiaForInfinityX7(IStrategy):
 
           long_entry_logic.append(
             # 5m & 15m down move, 15m still high
-            ((rsi_3 > 3.0) | (rsi_3_15m > 10.0) | (stochrsi_k_15m < 40.0))
+            ((rsi_3_gt_3) | (rsi_3_15m_gt_10) | (stochrsi_k_15m < 40.0))
             # 5m & 15m down move, 15m still high
-            & ((rsi_3 > 3.0) | (rsi_3_15m > 15.0) | (aroonu_14_15m < 40.0))
+            & ((rsi_3_gt_3) | (rsi_3_15m_gt_15) | (aroonu_14_15m < 40.0))
             # 5m & 15m down move, 1d downtrend
-            & ((rsi_3 > 3.0) | (rsi_3_15m > 15.0) | (roc_9_1d_gt_neg_20))
+            & ((rsi_3_gt_3) | (rsi_3_15m_gt_15) | (roc_9_1d_gt_neg_20))
             # 5m & 15m down move, 1d downtrend
-            & ((rsi_3 > 3.0) | (rsi_3_15m > 25.0) | (roc_9_1d_gt_neg_30))
+            & ((rsi_3_gt_3) | (rsi_3_15m_gt_25) | (roc_9_1d_gt_neg_30))
             # 5m & 1h down move, 1h still not low enough
-            & ((rsi_3 > 3.0) | rsi_3_1h_gt_20 | (aroonu_14_1h < 30.0))
+            & ((rsi_3_gt_3) | rsi_3_1h_gt_20 | (aroonu_14_1h < 30.0))
             # 5m & 1h down move, 1h still high
-            & ((rsi_3 > 3.0) | (rsi_3_1h > 30.0) | (stochrsi_k_1h_lt_50))
+            & ((rsi_3_gt_3) | (rsi_3_1h_gt_30) | (stochrsi_k_1h_lt_50))
             # 5m & 4h down move, 4h still high
-            & ((rsi_3 > 3.0) | (rsi_3_4h_gt_15) | (stochrsi_k_4h < 50.0))
+            & ((rsi_3_gt_3) | (rsi_3_4h_gt_15) | (stochrsi_k_4h_lt_50))
             # 5m & 4h & 1d down move
-            & ((rsi_3 > 3.0) | rsi_3_4h_gt_20 | (rsi_3_1d > 35.0))
+            & ((rsi_3_gt_3) | rsi_3_4h_gt_20 | (rsi_3_1d > 35.0))
             # 5m & 4h down move, 4h high
-            & ((rsi_3 > 3.0) | (rsi_3_4h > 30.0) | (stochrsi_k_4h < 70.0))
+            & ((rsi_3_gt_3) | (rsi_3_4h_gt_30) | (stochrsi_k_4h_lt_70))
             # 5m & 4h down move, 4h still high
-            & ((rsi_3 > 3.0) | (rsi_3_4h > 55.0) | (aroonu_14_4h < 50.0))
+            & ((rsi_3_gt_3) | (rsi_3_4h > 55.0) | (aroonu_14_4h_lt_50))
             # 5m & 1d down move, 15m still high
-            & ((rsi_3 > 3.0) | (rsi_3_1d > 20.0) | (stochrsi_k_15m < 40.0))
+            & ((rsi_3_gt_3) | (rsi_3_1d_gt_20) | (stochrsi_k_15m < 40.0))
             # 5m down move, 4h & 1d overbought
-            & ((rsi_3 > 3.0) | (roc_9_4h_lt_20) | (roc_9_1d < 40.0))
+            & ((rsi_3_gt_3) | (roc_9_4h_lt_20) | (roc_9_1d_lt_40))
             # 5m & 1h down move, 4h high
-            & ((rsi_3 > 5.0) | (rsi_3_1h > 40.0) | (aroonu_14_4h < 60.0))
+            & ((rsi_3 > 5.0) | (rsi_3_1h_gt_40) | (aroonu_14_4h_lt_60))
             # 5m & 1h down move, 1h high
             & ((rsi_3 > 5.0) | (rsi_3_1h > 60.0) | aroonu_14_1h_lt_80)
             # 5m & 4h down move, 1d downtrend
-            & ((rsi_3 > 5.0) | (rsi_3_4h > 5.0) | (roc_9_1d_gt_neg_20))
+            & ((rsi_3 > 5.0) | (rsi_3_4h_gt_5) | (roc_9_1d_gt_neg_20))
             # 5m & 4h down move, 4h still high
-            & ((rsi_3 > 5.0) | (rsi_3_4h_gt_15) | (aroonu_14_4h < 40.0))
+            & ((rsi_3 > 5.0) | (rsi_3_4h_gt_15) | (aroonu_14_4h_lt_40))
             # 5m & 4h down move, 15m still high
-            & ((rsi_3 > 5.0) | (rsi_3_4h > 25.0) | (stochrsi_k_15m < 50.0))
+            & ((rsi_3 > 5.0) | (rsi_3_4h_gt_25) | (stochrsi_k_15m < 50.0))
             # 5m & 4h down move, 1d overbought
-            & ((rsi_3 > 5.0) | (rsi_3_4h > 30.0) | (roc_9_1d < 60.0))
+            & ((rsi_3 > 5.0) | (rsi_3_4h_gt_30) | (roc_9_1d < 60.0))
             # 5m & 4h down move, 4h high
             & ((rsi_3 > 5.0) | (rsi_3_4h > 60.0) | aroonu_14_4h_lt_80)
             # 5m down move, 15m still not low enough, 4h high
-            & ((rsi_3 > 5.0) | (aroonu_14_15m < 20.0) | (stochrsi_k_4h < 70.0))
+            & ((rsi_3 > 5.0) | (aroonu_14_15m < 20.0) | (stochrsi_k_4h_lt_70))
             # 5m down move, 1h & 1d high
             & ((rsi_3 > 5.0) | aroonu_14_1h_lt_70 | aroonu_14_1d_lt_100)
             # 5m down move, 4h high & overbought
@@ -15212,19 +15264,19 @@ class NostalgiaForInfinityX7(IStrategy):
             # 5m down move, 1h high
             & ((rsi_3 > 5.0) | (stochrsi_k_1h_lt_80))
             # 5m & 1d down move, 1d still high
-            & ((rsi_3 > 10.0) | (rsi_3_1d > 15.0) | (stochrsi_k_1d < 40.0))
+            & ((rsi_3 > 10.0) | (rsi_3_1d_gt_15) | (stochrsi_k_1d < 40.0))
             # 15m & 1h down move, 1h still high
-            & (rsi_3_15m_gt_3 | rsi_3_1h_gt_20 | (aroonu_14_1h < 50.0))
+            & (rsi_3_15m_gt_3 | rsi_3_1h_gt_20 | (aroonu_14_1h_lt_50))
             # 15m & 1h down move, 4h still not low enough
             & (rsi_3_15m_gt_3 | rsi_3_1h_gt_20 | (aroonu_14_4h < 20.0))
             # 15m & 1h & 4h down move, 1d downtrend
-            & (rsi_3_15m_gt_3 | (rsi_3_1h > 25.0) | (rsi_14_4h < 40.0) | (roc_9_1d > -10.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_25) | (rsi_14_4h < 40.0) | (roc_9_1d > -10.0))
             # 15m & 1h down move, 1h still not low enough
-            & (rsi_3_15m_gt_3 | (rsi_3_1h > 25.0) | (aroonu_14_1h < 20.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_25) | (aroonu_14_1h < 20.0))
             # 15m & 1h down move, 4h still high
-            & (rsi_3_15m_gt_3 | (rsi_3_1h > 25.0) | (stochrsi_k_4h < 40.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_25) | (stochrsi_k_4h < 40.0))
             # 15m & 1h down move, 4h high
-            & (rsi_3_15m_gt_3 | (rsi_3_1h > 40.0) | aroonu_14_4h_lt_70)
+            & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_40) | aroonu_14_4h_lt_70)
             # 15m & 4h down move, 1h still not low enough
             & (rsi_3_15m_gt_3 | (rsi_3_4h_gt_10) | (stochrsi_k_1h < 30.0))
             # 15m & 4h down move, 1d downtrend
@@ -15232,315 +15284,315 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 4h down move, 4h still not low enough
             & (rsi_3_15m_gt_3 | rsi_3_4h_gt_20 | (aroonu_14_4h < 20.0))
             # 15m & 4h down move, 15m still not low enough
-            & (rsi_3_15m_gt_3 | (rsi_3_4h > 30.0) | (aroonu_14_15m < 25.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_4h_gt_30) | (aroonu_14_15m < 25.0))
             # 15m & 4h down move, 1h still high
-            & (rsi_3_15m_gt_3 | (rsi_3_4h > 30.0) | (stochrsi_k_1h < 40.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_4h_gt_30) | (stochrsi_k_1h < 40.0))
             # 15m & 4h down move, 1h high
             & (rsi_3_15m_gt_3 | (rsi_3_4h > 45.0) | (stochrsi_k_1h < 60.0))
             # 15m & 1d down move, 15m still not low enough
-            & (rsi_3_15m_gt_3 | (rsi_3_1d > 10.0) | (aroonu_14_15m < 30.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1d_gt_10) | (aroonu_14_15m < 30.0))
             # 15m & 1d down move, 4h high
-            & (rsi_3_15m_gt_3 | (rsi_3_1d > 55.0) | (stochrsi_k_4h < 70.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1d > 55.0) | (stochrsi_k_4h_lt_70))
             # 1h & 1d downtrend, 1d high
-            & (rsi_3_15m_gt_3 | (aroonu_14_1d < 70.0) | (roc_9_1d < 10.0))
+            & (rsi_3_15m_gt_3 | (aroonu_14_1d_lt_70) | (roc_9_1d < 10.0))
             # 15m & 1h down move, 1h high
-            & ((rsi_3_15m > 5.0) | (rsi_3_1h > 25.0) | (aroonu_14_1h < 60.0))
+            & ((rsi_3_15m_gt_5) | (rsi_3_1h_gt_25) | (aroonu_14_1h < 60.0))
             # 15m & 1h down move, 1h still high
-            & ((rsi_3_15m > 5.0) | (rsi_3_1h > 25.0) | (stochrsi_k_1h < 40.0))
+            & ((rsi_3_15m_gt_5) | (rsi_3_1h_gt_25) | (stochrsi_k_1h < 40.0))
             # 15m & 1h down move, 4h still high
-            & ((rsi_3_15m > 5.0) | (rsi_3_1h > 25.0) | (stochrsi_k_4h < 30.0))
+            & ((rsi_3_15m_gt_5) | (rsi_3_1h_gt_25) | (stochrsi_k_4h < 30.0))
             # 15m & 1h down move, 4h high
-            & ((rsi_3_15m > 5.0) | (rsi_3_1h > 30.0) | (aroonu_14_4h < 90.0))
+            & ((rsi_3_15m_gt_5) | (rsi_3_1h_gt_30) | (aroonu_14_4h_lt_90))
             # 15m & 1h & 4h down move, 15m downtrend
-            & ((rsi_3_15m > 5.0) | (rsi_3_1h > 40.0) | (rsi_3_4h > 50.0) | (cmf_20_15m > -0.30))
+            & ((rsi_3_15m_gt_5) | (rsi_3_1h_gt_40) | (rsi_3_4h_gt_50) | (cmf_20_15m > -0.30))
             # 15m & 1h down move, 1h still high
-            & ((rsi_3_15m > 5.0) | (rsi_3_1h > 40.0) | (stochrsi_k_1h_lt_50))
+            & ((rsi_3_15m_gt_5) | (rsi_3_1h_gt_40) | (stochrsi_k_1h_lt_50))
             # 15m & 1h down move, 4h high
-            & ((rsi_3_15m > 5.0) | (rsi_3_1h > 55.0) | aroonu_14_4h_lt_100)
+            & ((rsi_3_15m_gt_5) | (rsi_3_1h > 55.0) | aroonu_14_4h_lt_100)
             # 15m & 4h down move, 15m still not low enough
-            & ((rsi_3_15m > 5.0) | rsi_3_4h_gt_20 | (aroonu_14_15m < 30.0))
+            & ((rsi_3_15m_gt_5) | rsi_3_4h_gt_20 | (aroonu_14_15m < 30.0))
             # 15m & 4h down move, 4h high
-            & ((rsi_3_15m > 5.0) | (rsi_3_4h > 35.0) | (stochrsi_k_4h < 60.0))
+            & ((rsi_3_15m_gt_5) | (rsi_3_4h_gt_35) | (stochrsi_k_4h < 60.0))
             # 15m down move, 15m still high, 1h still high
-            & ((rsi_3_15m > 5.0) | (aroonu_14_15m < 30.0) | (stochrsi_k_1h_lt_50))
+            & ((rsi_3_15m_gt_5) | (aroonu_14_15m < 30.0) | (stochrsi_k_1h_lt_50))
             # 15m down move, 1h still high, 1d high
-            & ((rsi_3_15m > 5.0) | (stochrsi_k_1h < 40.0) | (aroonu_14_1d < 70.0))
+            & ((rsi_3_15m_gt_5) | (stochrsi_k_1h < 40.0) | (aroonu_14_1d_lt_70))
             # 15m down move, 1h & 4h high
-            & ((rsi_3_15m > 5.0) | aroonu_14_1h_lt_70 | (aroonu_14_4h < 90.0))
+            & ((rsi_3_15m_gt_5) | aroonu_14_1h_lt_70 | (aroonu_14_4h_lt_90))
             # 15m down move, 15m & 1h still not low enough
-            & ((rsi_3_15m > 5.0) | (stochrsi_k_15m < 30.0) | (stochrsi_k_1h < 30.0))
+            & ((rsi_3_15m_gt_5) | (stochrsi_k_15m < 30.0) | (stochrsi_k_1h < 30.0))
             # 15m & 1h down move, 1h still high
-            & ((rsi_3_15m > 10.0) | rsi_3_1h_gt_20 | (stochrsi_k_1h_lt_50))
+            & ((rsi_3_15m_gt_10) | rsi_3_1h_gt_20 | (stochrsi_k_1h_lt_50))
             # 15m & 1h down move, 4h still high
-            & ((rsi_3_15m > 10.0) | rsi_3_1h_gt_20 | (aroonu_14_4h < 40.0))
+            & ((rsi_3_15m_gt_10) | rsi_3_1h_gt_20 | (aroonu_14_4h_lt_40))
             # 15m & 1h down move, 4h high
-            & ((rsi_3_15m > 10.0) | rsi_3_1h_gt_20 | (stochrsi_k_4h < 60.0))
+            & ((rsi_3_15m_gt_10) | rsi_3_1h_gt_20 | (stochrsi_k_4h < 60.0))
             # 15m & 1h down move, 4h still high
-            & ((rsi_3_15m > 10.0) | (rsi_3_1h > 25.0) | (aroonu_14_4h < 50.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_25) | (aroonu_14_4h_lt_50))
             # 15m & 1h down move, 4h high
-            & ((rsi_3_15m > 10.0) | (rsi_3_1h > 30.0) | (stochrsi_k_4h < 70.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_30) | (stochrsi_k_4h_lt_70))
             # 15m & 1h down move, 4h high
-            & ((rsi_3_15m > 10.0) | (rsi_3_1h > 30.0) | (stochrsi_k_4h < 60.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_30) | (stochrsi_k_4h < 60.0))
             # 15m & 1h down move, 1d overbought
-            & ((rsi_3_15m > 10.0) | (rsi_3_1h > 30.0) | (roc_9_1d < 30.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_30) | (roc_9_1d_lt_30))
             # 15m & 1h down move, 1d downtrend
-            & ((rsi_3_15m > 10.0) | (rsi_3_1h > 30.0) | (roc_9_1d > -40.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_30) | (roc_9_1d_gt_neg_40))
             # 15m & 1h down move, 1h still high
-            & ((rsi_3_15m > 10.0) | (rsi_3_1h > 35.0) | (stochrsi_k_1h < 40.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_35) | (stochrsi_k_1h < 40.0))
             # 15m & 1h down move, 1h still high
-            & ((rsi_3_15m > 10.0) | (rsi_3_1h > 45.0) | (stochrsi_k_1h < 40.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_45) | (stochrsi_k_1h < 40.0))
             # 15m & 1h down move, 1d overbought
-            & ((rsi_3_15m > 10.0) | (rsi_3_1h > 45.0) | (roc_9_1d < 150.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_45) | (roc_9_1d < 150.0))
             # 15m & 1h down move, 4h high
-            & ((rsi_3_15m > 10.0) | (rsi_3_1h > 50.0) | (stochrsi_k_4h_lt_80))
+            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_50) | (stochrsi_k_4h_lt_80))
             # 15m & 1h down move, 1h high
-            & ((rsi_3_15m > 10.0) | (rsi_3_1h > 55.0) | (stochrsi_k_1h < 60.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_1h > 55.0) | (stochrsi_k_1h < 60.0))
             # 15m & 1h down move, 1h high
-            & ((rsi_3_15m > 10.0) | (rsi_3_1h > 65.0) | aroonu_14_1h_lt_80)
+            & ((rsi_3_15m_gt_10) | (rsi_3_1h > 65.0) | aroonu_14_1h_lt_80)
             # 15m & 4h down move, 1d high
-            & ((rsi_3_15m > 10.0) | (rsi_3_4h_gt_10) | (aroonu_14_1d < 80.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_4h_gt_10) | (aroonu_14_1d_lt_80))
             # 15m & 4h down move, 4h still not low enough
-            & ((rsi_3_15m > 10.0) | (rsi_3_4h_gt_10) | (stochrsi_k_4h < 30.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_4h_gt_10) | (stochrsi_k_4h < 30.0))
             # 15m & 4h down move, 1d high
-            & ((rsi_3_15m > 10.0) | (rsi_3_4h_gt_10) | (stochrsi_k_1d < 70.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_4h_gt_10) | (stochrsi_k_1d < 70.0))
             # 15m & 4h down move, 1d high
-            & ((rsi_3_15m > 10.0) | (rsi_3_4h_gt_15) | (rsi_14_1d < 60.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_4h_gt_15) | (rsi_14_1d < 60.0))
             # 15m & 4h down move, 4h still high
-            & ((rsi_3_15m > 10.0) | rsi_3_4h_gt_20 | (aroonu_14_4h < 40.0))
+            & ((rsi_3_15m_gt_10) | rsi_3_4h_gt_20 | (aroonu_14_4h_lt_40))
             # 15m & 4h down move, 1d high
-            & ((rsi_3_15m > 10.0) | rsi_3_4h_gt_20 | (aroonu_14_1d < 90.0))
+            & ((rsi_3_15m_gt_10) | rsi_3_4h_gt_20 | (aroonu_14_1d_lt_90))
             # 15m & 4h down move, 1h still high
-            & ((rsi_3_15m > 10.0) | rsi_3_4h_gt_20 | (stochrsi_k_1h_lt_50))
+            & ((rsi_3_15m_gt_10) | rsi_3_4h_gt_20 | (stochrsi_k_1h_lt_50))
             # 15m & 4h down move, 4h still high
-            & ((rsi_3_15m > 10.0) | rsi_3_4h_gt_20 | (stochrsi_k_4h < 40.0))
+            & ((rsi_3_15m_gt_10) | rsi_3_4h_gt_20 | (stochrsi_k_4h < 40.0))
             # 15m & 4h down move, 1d high
-            & ((rsi_3_15m > 10.0) | rsi_3_4h_gt_20 | (stochrsi_k_1d < 90.0))
+            & ((rsi_3_15m_gt_10) | rsi_3_4h_gt_20 | (stochrsi_k_1d_lt_90))
             # 15m & 4h down move, 1d overbought
-            & ((rsi_3_15m > 10.0) | rsi_3_4h_gt_20 | (roc_9_1d < 20.0))
+            & ((rsi_3_15m_gt_10) | rsi_3_4h_gt_20 | (roc_9_1d_lt_20))
             # 15m & 4h down move, 4h downtrend
-            & ((rsi_3_15m > 10.0) | (rsi_3_4h > 25.0) | (cmf_20_4h > -0.30))
+            & ((rsi_3_15m_gt_10) | (rsi_3_4h_gt_25) | (cmf_20_4h > -0.30))
             # 15m & 4h down move, 1d overbought
-            & ((rsi_3_15m > 10.0) | (rsi_3_4h > 25.0) | (roc_9_1d < 30.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_4h_gt_25) | (roc_9_1d_lt_30))
             # 15m & 4h down move, 4h still high
-            & ((rsi_3_15m > 10.0) | (rsi_3_4h > 30.0) | (aroonu_14_4h < 50.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_4h_gt_30) | (aroonu_14_4h_lt_50))
             # 15m & 4h down move, 4h high
-            & ((rsi_3_15m > 10.0) | (rsi_3_4h > 45.0) | aroonu_14_4h_lt_70)
+            & ((rsi_3_15m_gt_10) | (rsi_3_4h > 45.0) | aroonu_14_4h_lt_70)
             # 15m & 4h down move, 4h high
-            & ((rsi_3_15m > 10.0) | (rsi_3_4h > 50.0) | (aroonu_14_4h < 75.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_4h_gt_50) | (aroonu_14_4h < 75.0))
             # 15m & 4h down move, 4h high
-            & ((rsi_3_15m > 10.0) | (rsi_3_4h > 60.0) | (stochrsi_k_4h_lt_80))
+            & ((rsi_3_15m_gt_10) | (rsi_3_4h > 60.0) | (stochrsi_k_4h_lt_80))
             # 15m & 1d down move, 1h still high
-            & ((rsi_3_15m > 10.0) | (rsi_3_1d > 10.0) | (stochrsi_k_1h < 40.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_1d_gt_10) | (stochrsi_k_1h < 40.0))
             # 15m & 1d down move, 1d high
-            & ((rsi_3_15m > 10.0) | (rsi_3_1d > 20.0) | (aroonu_14_1d < 75.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_1d_gt_20) | (aroonu_14_1d < 75.0))
             # 15m & 1d down move, 1d overbought
-            & ((rsi_3_15m > 10.0) | (rsi_3_1d > 50.0) | (roc_9_1d < 20.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_1d > 50.0) | (roc_9_1d_lt_20))
             # 15m down move, 15m downtrend, 4h still high
-            & ((rsi_3_15m > 10.0) | (cmf_20_15m > -0.40) | (stochrsi_k_4h < 50.0))
+            & ((rsi_3_15m_gt_10) | (cmf_20_15m > -0.40) | (stochrsi_k_4h_lt_50))
             # 15m down move, 1h downtrend, 4h still high
-            & ((rsi_3_15m > 10.0) | (cmf_20_1h > -0.30) | (stochrsi_k_4h < 40.0))
+            & ((rsi_3_15m_gt_10) | (cmf_20_1h > -0.30) | (stochrsi_k_4h < 40.0))
             # 15m down move, 15m still not low enough, 4h high
-            & ((rsi_3_15m > 10.0) | (aroonu_14_15m < 30.0) | (aroonu_14_4h < 60.0))
+            & ((rsi_3_15m_gt_10) | (aroonu_14_15m < 30.0) | (aroonu_14_4h_lt_60))
             # 15m down move, 15m still high, 1h still high
-            & ((rsi_3_15m > 10.0) | (aroonu_14_15m < 40.0) | (stochrsi_k_1h_lt_50))
+            & ((rsi_3_15m_gt_10) | (aroonu_14_15m < 40.0) | (stochrsi_k_1h_lt_50))
             # 15m down move, 4h high & overbought
-            & ((rsi_3_15m > 10.0) | (aroonu_14_4h < 90.0) | (roc_9_4h_lt_20))
+            & ((rsi_3_15m_gt_10) | (aroonu_14_4h_lt_90) | (roc_9_4h_lt_20))
             # 15m down move, 1h still not low enough, 1d overbought
-            & ((rsi_3_15m > 10.0) | (stochrsi_k_1h < 30.0) | (roc_9_1d_lt_100))
+            & ((rsi_3_15m_gt_10) | (stochrsi_k_1h < 30.0) | (roc_9_1d_lt_100))
             # 15m down move, 1h still high, 4h downtrend
-            & ((rsi_3_15m > 10.0) | (stochrsi_k_1h < 50.0) | (roc_9_4h_gt_neg_20))
+            & ((rsi_3_15m_gt_10) | (stochrsi_k_1h < 50.0) | (roc_9_4h_gt_neg_20))
             # 15m down move, 4h high & overbought
-            & ((rsi_3_15m > 10.0) | (stochrsi_k_4h < 70.0) | (roc_9_4h < 10.0))
+            & ((rsi_3_15m_gt_10) | (stochrsi_k_4h_lt_70) | (roc_9_4h_lt_10))
             # 15m down move, 4h high, 1d overbought
-            & ((rsi_3_15m > 10.0) | (stochrsi_k_4h < 70.0) | (roc_9_1d < 10.0))
+            & ((rsi_3_15m_gt_10) | (stochrsi_k_4h_lt_70) | (roc_9_1d < 10.0))
             # 15m & 1h & 4h down move
-            & ((rsi_3_15m > 15.0) | (rsi_3_1h_gt_15) | (rsi_3_1h_gt_15))
+            & ((rsi_3_15m_gt_15) | (rsi_3_1h_gt_15) | (rsi_3_1h_gt_15))
             # 15m & 1h down move, 1h still high
-            & ((rsi_3_15m > 15.0) | (rsi_3_1h_gt_15) | (aroonu_14_1h < 40.0))
+            & ((rsi_3_15m_gt_15) | (rsi_3_1h_gt_15) | (aroonu_14_1h < 40.0))
             # 15m & 1h down move, 1h downtrend
-            & ((rsi_3_15m > 15.0) | rsi_3_1h_gt_20 | (cmf_20_1h > -0.30))
+            & ((rsi_3_15m_gt_15) | rsi_3_1h_gt_20 | (cmf_20_1h > -0.30))
             # 15m & 1h down move, 1h still high
-            & ((rsi_3_15m > 15.0) | (rsi_3_1h > 25.0) | (aroonu_14_1h < 50.0))
+            & ((rsi_3_15m_gt_15) | (rsi_3_1h_gt_25) | (aroonu_14_1h_lt_50))
             # 15m & 1h down move, 4h high
-            & ((rsi_3_15m > 15.0) | (rsi_3_1h > 25.0) | aroonu_14_4h_lt_70)
+            & ((rsi_3_15m_gt_15) | (rsi_3_1h_gt_25) | aroonu_14_4h_lt_70)
             # 15m & 1h down move, 1h still high
-            & ((rsi_3_15m > 15.0) | (rsi_3_1h > 25.0) | (stochrsi_k_1h < 40.0))
+            & ((rsi_3_15m_gt_15) | (rsi_3_1h_gt_25) | (stochrsi_k_1h < 40.0))
             # 15m & 1h down move, 1d overbought
-            & ((rsi_3_15m > 15.0) | (rsi_3_1h > 25.0) | (roc_9_1d_lt_100))
+            & ((rsi_3_15m_gt_15) | (rsi_3_1h_gt_25) | (roc_9_1d_lt_100))
             # 15m & 1h down move, 1d high
-            & ((rsi_3_15m > 15.0) | (rsi_3_1h > 30.0) | (stochrsi_k_1d < 80.0))
+            & ((rsi_3_15m_gt_15) | (rsi_3_1h_gt_30) | (stochrsi_k_1d < 80.0))
             # 15m & 1h down move, 4h high
-            & ((rsi_3_15m > 15.0) | (rsi_3_1h > 50.0) | aroonu_14_4h_lt_100)
+            & ((rsi_3_15m_gt_15) | (rsi_3_1h_gt_50) | aroonu_14_4h_lt_100)
             # 15m & 1h down move, 1h high
-            & ((rsi_3_15m > 15.0) | (rsi_3_1h > 55.0) | (aroonu_14_1h < 90.0))
+            & ((rsi_3_15m_gt_15) | (rsi_3_1h > 55.0) | (aroonu_14_1h_lt_90))
             # 15m & 4h down move, 1d high
-            & ((rsi_3_15m > 15.0) | rsi_3_4h_gt_20 | (aroonu_14_1d < 90.0))
+            & ((rsi_3_15m_gt_15) | rsi_3_4h_gt_20 | (aroonu_14_1d_lt_90))
             # 15m & 4h down move, 15m still high
-            & ((rsi_3_15m > 15.0) | rsi_3_4h_gt_20 | (stochrsi_k_15m < 50.0))
+            & ((rsi_3_15m_gt_15) | rsi_3_4h_gt_20 | (stochrsi_k_15m < 50.0))
             # 15m & 4h down move, 1h high
-            & ((rsi_3_15m > 15.0) | (rsi_3_4h > 30.0) | (stochrsi_k_1h < 60.0))
+            & ((rsi_3_15m_gt_15) | (rsi_3_4h_gt_30) | (stochrsi_k_1h < 60.0))
             # 15m & 4h down move, 4h high
-            & ((rsi_3_15m > 15.0) | (rsi_3_4h > 35.0) | (aroonu_14_4h < 60.0))
+            & ((rsi_3_15m_gt_15) | (rsi_3_4h_gt_35) | (aroonu_14_4h_lt_60))
             # 15m & 4h down move, 4h high
-            & ((rsi_3_15m > 15.0) | (rsi_3_4h > 35.0) | (stochrsi_k_4h < 70.0))
+            & ((rsi_3_15m_gt_15) | (rsi_3_4h_gt_35) | (stochrsi_k_4h_lt_70))
             # 15m & 4h down move, 4h high
-            & ((rsi_3_15m > 15.0) | (rsi_3_4h > 40.0) | aroonu_14_4h_lt_80)
+            & ((rsi_3_15m_gt_15) | (rsi_3_4h_gt_40) | aroonu_14_4h_lt_80)
             # 15m & 4h down move, 1d overbought
-            & ((rsi_3_15m > 15.0) | (rsi_3_4h > 40.0) | (roc_9_1d < 40.0))
+            & ((rsi_3_15m_gt_15) | (rsi_3_4h_gt_40) | (roc_9_1d_lt_40))
             # 15m & 4h down move, 1d overbought
-            & ((rsi_3_15m > 15.0) | (rsi_3_4h > 45.0) | (roc_9_1d < 80.0))
+            & ((rsi_3_15m_gt_15) | (rsi_3_4h > 45.0) | (roc_9_1d_lt_80))
             # 15m & 4h down move, 4h high
-            & ((rsi_3_15m > 15.0) | (rsi_3_4h > 55.0) | (stochrsi_k_4h < 70.0))
+            & ((rsi_3_15m_gt_15) | (rsi_3_4h > 55.0) | (stochrsi_k_4h_lt_70))
             # 15m & 1d down move, 1h still high
-            & ((rsi_3_15m > 15.0) | (rsi_3_1d > 15.0) | (stochrsi_k_1h < 30.0))
+            & ((rsi_3_15m_gt_15) | (rsi_3_1d_gt_15) | (stochrsi_k_1h < 30.0))
             # 15m & 1d down move, 1h still high
-            & ((rsi_3_15m > 15.0) | (rsi_3_1d > 20.0) | (stochrsi_k_1h_lt_50))
+            & ((rsi_3_15m_gt_15) | (rsi_3_1d_gt_20) | (stochrsi_k_1h_lt_50))
             # 15m & 1d down move, 1d overbought
-            & ((rsi_3_15m > 15.0) | (rsi_3_1d > 30.0) | (roc_9_1d < 10.0))
+            & ((rsi_3_15m_gt_15) | (rsi_3_1d > 30.0) | (roc_9_1d < 10.0))
             # 15m down move, 15m still not low enough, 1h high
-            & ((rsi_3_15m > 15.0) | (aroonu_14_15m < 25.0) | (stochrsi_k_1h_lt_80))
+            & ((rsi_3_15m_gt_15) | (aroonu_14_15m < 25.0) | (stochrsi_k_1h_lt_80))
             # 15m down move, 15m still high, 4h high
-            & ((rsi_3_15m > 15.0) | (aroonu_14_15m < 40.0) | aroonu_14_4h_lt_70)
+            & ((rsi_3_15m_gt_15) | (aroonu_14_15m < 40.0) | aroonu_14_4h_lt_70)
             # 15m down move, 1h still high, 1d overbought
-            & ((rsi_3_15m > 15.0) | (aroonu_14_1h < 50.0) | (roc_9_1d < 80.0))
+            & ((rsi_3_15m_gt_15) | (aroonu_14_1h_lt_50) | (roc_9_1d_lt_80))
             # 15m down move, 1h & 4h high
-            & ((rsi_3_15m > 15.0) | (aroonu_14_1h < 60.0) | (aroonu_14_4h < 90.0))
+            & ((rsi_3_15m_gt_15) | (aroonu_14_1h < 60.0) | (aroonu_14_4h_lt_90))
             # 15m down move, 1h & 4h high
-            & ((rsi_3_15m > 15.0) | aroonu_14_1h_lt_80 | (aroonu_14_4h < 85.0))
+            & ((rsi_3_15m_gt_15) | aroonu_14_1h_lt_80 | (aroonu_14_4h < 85.0))
             # 15m down move, 1h & 1d high
-            & ((rsi_3_15m > 15.0) | aroonu_14_1h_lt_70 | (aroonu_14_1d < 70.0))
+            & ((rsi_3_15m_gt_15) | aroonu_14_1h_lt_70 | (aroonu_14_1d_lt_70))
             # 15m down move, 1h & 4h high
-            & ((rsi_3_15m > 15.0) | (aroonu_14_1h < 85.0) | (stochrsi_k_4h_lt_90))
+            & ((rsi_3_15m_gt_15) | (aroonu_14_1h < 85.0) | (stochrsi_k_4h_lt_90))
             # 15m down move, 4h high, 4h downtrend
-            & ((rsi_3_15m > 15.0) | (aroonu_14_4h < 60.0) | (roc_9_4h_gt_neg_20))
+            & ((rsi_3_15m_gt_15) | (aroonu_14_4h_lt_60) | (roc_9_4h_gt_neg_20))
             # 15m down move, 4h & 1d high
-            & ((rsi_3_15m > 15.0) | aroonu_14_4h_lt_70 | aroonu_14_1d_lt_100)
+            & ((rsi_3_15m_gt_15) | aroonu_14_4h_lt_70 | aroonu_14_1d_lt_100)
             # 15m down move, 4h high & overbought
-            & ((rsi_3_15m > 15.0) | aroonu_14_4h_lt_70 | (roc_9_4h < 30.0))
+            & ((rsi_3_15m_gt_15) | aroonu_14_4h_lt_70 | (roc_9_4h_lt_30))
             # 15m down move, 4h high, 1h overbought
-            & ((rsi_3_15m > 15.0) | (aroonu_14_4h < 90.0) | (roc_9_1h < 25.0))
+            & ((rsi_3_15m_gt_15) | (aroonu_14_4h_lt_90) | (roc_9_1h < 25.0))
             # 15m down move, 4h high, 1h overbought
-            & ((rsi_3_15m > 15.0) | aroonu_14_4h_lt_100 | (roc_9_1h < 10.0))
+            & ((rsi_3_15m_gt_15) | aroonu_14_4h_lt_100 | (roc_9_1h_lt_10))
             # 15m down move, 1h still high, 4h overbought
-            & ((rsi_3_15m > 15.0) | (stochrsi_k_1h_lt_50) | (roc_9_4h < 10.0))
+            & ((rsi_3_15m_gt_15) | (stochrsi_k_1h_lt_50) | (roc_9_4h_lt_10))
             # 15m down move, 1h high, 4h downtrend
-            & ((rsi_3_15m > 15.0) | (stochrsi_k_1h < 80.0) | (roc_9_4h_gt_neg_20))
+            & ((rsi_3_15m_gt_15) | (stochrsi_k_1h < 80.0) | (roc_9_4h_gt_neg_20))
             # 15m down move, 4h high & overbought
-            & ((rsi_3_15m > 15.0) | (stochrsi_k_4h < 90.0) | (roc_9_4h_lt_20))
+            & ((rsi_3_15m_gt_15) | (stochrsi_k_4h < 90.0) | (roc_9_4h_lt_20))
             # 15m & 1h down move, 1h still high
-            & ((rsi_3_15m > 20.0) | rsi_3_1h_gt_20 | (stochrsi_k_1h < 20.0))
+            & ((rsi_3_15m_gt_20) | rsi_3_1h_gt_20 | (stochrsi_k_1h < 20.0))
             # 15m & 1h down move, 1d downtrend
-            & ((rsi_3_15m > 20.0) | (rsi_3_1h > 30.0) | (roc_9_1d_gt_neg_30))
+            & ((rsi_3_15m_gt_20) | (rsi_3_1h_gt_30) | (roc_9_1d_gt_neg_30))
             # 15m & 1h down move, 1h overbought
-            & ((rsi_3_15m > 20.0) | (rsi_3_1h > 50.0) | (roc_9_1h < 10.0))
+            & ((rsi_3_15m_gt_20) | (rsi_3_1h_gt_50) | (roc_9_1h_lt_10))
             # 15m & 1h down move, 4h high
-            & ((rsi_3_15m > 20.0) | (rsi_3_1h > 25.0) | (stochrsi_k_4h_lt_80))
+            & ((rsi_3_15m_gt_20) | (rsi_3_1h_gt_25) | (stochrsi_k_4h_lt_80))
             # 15m & 1h down move, 1d high
-            & ((rsi_3_15m > 20.0) | (rsi_3_1h > 35.0) | aroonu_14_1d_lt_100)
+            & ((rsi_3_15m_gt_20) | (rsi_3_1h_gt_35) | aroonu_14_1d_lt_100)
             # 15m & 1h down move, 1h high
-            & ((rsi_3_15m > 20.0) | (rsi_3_1h > 45.0) | aroonu_14_1h_lt_70)
+            & ((rsi_3_15m_gt_20) | (rsi_3_1h_gt_45) | aroonu_14_1h_lt_70)
             # 15m & 1h down move, 1h high
-            & ((rsi_3_15m > 20.0) | (rsi_3_1h > 60.0) | (aroonu_14_1h < 90.0))
+            & ((rsi_3_15m_gt_20) | (rsi_3_1h > 60.0) | (aroonu_14_1h_lt_90))
             # 15m & 1h down move, 4h high
-            & ((rsi_3_15m > 20.0) | (rsi_3_1h > 60.0) | (stochrsi_k_4h_lt_90))
+            & ((rsi_3_15m_gt_20) | (rsi_3_1h > 60.0) | (stochrsi_k_4h_lt_90))
             # 15m & 4h & 1d down move
-            & ((rsi_3_15m > 20.0) | rsi_3_4h_gt_20 | (rsi_3_1d > 20.0))
+            & ((rsi_3_15m_gt_20) | rsi_3_4h_gt_20 | (rsi_3_1d_gt_20))
             # 15m & 4h down move, 1d high
-            & ((rsi_3_15m > 20.0) | rsi_3_4h_gt_20 | (stochrsi_k_1d < 90.0))
+            & ((rsi_3_15m_gt_20) | rsi_3_4h_gt_20 | (stochrsi_k_1d_lt_90))
             # 15m & 4h down move, 1d high
-            & ((rsi_3_15m > 20.0) | (rsi_3_4h > 45.0) | (stochrsi_k_1d < 90.0))
+            & ((rsi_3_15m_gt_20) | (rsi_3_4h > 45.0) | (stochrsi_k_1d_lt_90))
             # 15m & 1d down move, 1h high
-            & ((rsi_3_15m > 20.0) | (rsi_3_1d > 20.0) | aroonu_14_1h_lt_70)
+            & ((rsi_3_15m_gt_20) | (rsi_3_1d_gt_20) | aroonu_14_1h_lt_70)
             # 15m & 1d down move, 15m still high
-            & ((rsi_3_15m > 20.0) | (rsi_3_1d > 30.0) | (stochrsi_k_15m < 50.0))
+            & ((rsi_3_15m_gt_20) | (rsi_3_1d > 30.0) | (stochrsi_k_15m < 50.0))
             # 15m down move, 15m still not low enough, 1h high
-            & ((rsi_3_15m > 20.0) | (aroonu_14_15m < 25.0) | (stochrsi_k_1h < 90.0))
+            & ((rsi_3_15m_gt_20) | (aroonu_14_15m < 25.0) | (stochrsi_k_1h < 90.0))
             # 15m down move, 15m still high, 1h high
-            & ((rsi_3_15m > 20.0) | (aroonu_14_15m < 40.0) | aroonu_14_1h_lt_70)
+            & ((rsi_3_15m_gt_20) | (aroonu_14_15m < 40.0) | aroonu_14_1h_lt_70)
             # 15m down move, 15m still high, 4h high
-            & ((rsi_3_15m > 20.0) | (aroonu_14_15m < 40.0) | aroonu_14_4h_lt_70)
+            & ((rsi_3_15m_gt_20) | (aroonu_14_15m < 40.0) | aroonu_14_4h_lt_70)
             # 15m down move, 1h & 4h high
-            & ((rsi_3_15m > 20.0) | aroonu_14_1h_lt_80 | aroonu_14_4h_lt_80)
+            & ((rsi_3_15m_gt_20) | aroonu_14_1h_lt_80 | aroonu_14_4h_lt_80)
             # 15m down move, 1h high, 1d overbought
-            & ((rsi_3_15m > 20.0) | aroonu_14_1h_lt_80 | (roc_9_1d < 10.0))
+            & ((rsi_3_15m_gt_20) | aroonu_14_1h_lt_80 | (roc_9_1d < 10.0))
             # 15m down move, 4h high & overbought
-            & ((rsi_3_15m > 20.0) | aroonu_14_4h_lt_70 | (roc_9_4h < 30.0))
+            & ((rsi_3_15m_gt_20) | aroonu_14_4h_lt_70 | (roc_9_4h_lt_30))
             # 15m down move, 4h high, 1h overbought
-            & ((rsi_3_15m > 20.0) | aroonu_14_4h_lt_100 | (roc_9_1h < 30.0))
+            & ((rsi_3_15m_gt_20) | aroonu_14_4h_lt_100 | (roc_9_1h < 30.0))
             # 15m down move, 1d high, 4h downtrend
-            & ((rsi_3_15m > 20.0) | (aroonu_14_1d < 90.0) | (roc_9_4h_gt_neg_20))
+            & ((rsi_3_15m_gt_20) | (aroonu_14_1d_lt_90) | (roc_9_4h_gt_neg_20))
             # 15m down move, 1d high, 4h overbought
-            & ((rsi_3_15m > 20.0) | aroonu_14_1d_lt_100 | (roc_9_4h < 20.0))
+            & ((rsi_3_15m_gt_20) | aroonu_14_1d_lt_100 | (roc_9_4h < 20.0))
             # 15m down move, 1d high, 1d overbought
-            & ((rsi_3_15m > 20.0) | aroonu_14_1d_lt_100 | (roc_9_1d < 20.0))
+            & ((rsi_3_15m_gt_20) | aroonu_14_1d_lt_100 | (roc_9_1d_lt_20))
             # 15m down move, 15m high, 4h downtrend
-            & ((rsi_3_15m > 20.0) | (stochrsi_k_15m < 60.0) | (roc_9_4h > -50.0))
+            & ((rsi_3_15m_gt_20) | (stochrsi_k_15m < 60.0) | (roc_9_4h > -50.0))
             # 15 down move, 1h high, 1d overbought
-            & ((rsi_3_15m > 20.0) | (stochrsi_k_1h_lt_70) | (roc_9_1d < 10.0))
+            & ((rsi_3_15m_gt_20) | (stochrsi_k_1h_lt_70) | (roc_9_1d < 10.0))
             # 15m down move, 4h high, 15m downtrend
-            & ((rsi_3_15m > 20.0) | (stochrsi_k_4h < 70.0) | (cmf_20_15m > -0.40))
+            & ((rsi_3_15m_gt_20) | (stochrsi_k_4h_lt_70) | (cmf_20_15m > -0.40))
             # 15m & 1h down move, 15m high
-            & ((rsi_3_15m > 25.0) | (rsi_3_1h > 25.0) | (stochrsi_k_15m < 70.0))
+            & ((rsi_3_15m_gt_25) | (rsi_3_1h_gt_25) | (stochrsi_k_15m < 70.0))
             # 15m & 1h & 4h down move, 4h high
-            & ((rsi_3_15m > 25.0) | (rsi_3_1h > 30.0) | (rsi_3_4h > 50.0) | aroonu_14_4h_lt_70)
+            & ((rsi_3_15m_gt_25) | (rsi_3_1h_gt_30) | (rsi_3_4h_gt_50) | aroonu_14_4h_lt_70)
             # 15m & 1h down move, 1h still high
-            & ((rsi_3_15m > 25.0) | (rsi_3_1h > 35.0) | (stochrsi_k_1h_lt_50))
+            & ((rsi_3_15m_gt_25) | (rsi_3_1h_gt_35) | (stochrsi_k_1h_lt_50))
             # 15m & 1h down move, 1d high
-            & ((rsi_3_15m > 25.0) | (rsi_3_1h > 40.0) | (stochrsi_k_1d < 90.0))
+            & ((rsi_3_15m_gt_25) | (rsi_3_1h_gt_40) | (stochrsi_k_1d_lt_90))
             # 15m & 1h down move, 1d overbought
-            & ((rsi_3_15m > 25.0) | (rsi_3_1h > 40.0) | (roc_9_1d < 80.0))
+            & ((rsi_3_15m_gt_25) | (rsi_3_1h_gt_40) | (roc_9_1d_lt_80))
             # 15m & 1h down move, 1h high
-            & ((rsi_3_15m > 25.0) | (rsi_3_1h > 50.0) | (aroonu_14_1h < 85.0))
+            & ((rsi_3_15m_gt_25) | (rsi_3_1h_gt_50) | (aroonu_14_1h < 85.0))
             # 15m & 1h down move, 4h high
-            & ((rsi_3_15m > 25.0) | (rsi_3_1h > 60.0) | aroonu_14_4h_lt_100)
+            & ((rsi_3_15m_gt_25) | (rsi_3_1h > 60.0) | aroonu_14_4h_lt_100)
             # 15m & 1h down move, 4h high
-            & ((rsi_3_15m > 25.0) | (rsi_3_1h > 60.0) | (stochrsi_k_4h_lt_90))
+            & ((rsi_3_15m_gt_25) | (rsi_3_1h > 60.0) | (stochrsi_k_4h_lt_90))
             # 15m & 4h down move, 4h overbought
-            & ((rsi_3_15m > 25.0) | (rsi_3_4h > 55.0) | (roc_9_4h < 30.0))
+            & ((rsi_3_15m_gt_25) | (rsi_3_4h > 55.0) | (roc_9_4h_lt_30))
             # 15m & 1d down move, 1h high
-            & ((rsi_3_15m > 25.0) | (rsi_3_1d > 25.0) | aroonu_14_1h_lt_80)
+            & ((rsi_3_15m_gt_25) | (rsi_3_1d_gt_25) | aroonu_14_1h_lt_80)
             # 15m down move, 15m still not low enough, 1h high
-            & ((rsi_3_15m > 25.0) | (aroonu_14_15m < 25.0) | (stochrsi_k_1h < 90.0))
+            & ((rsi_3_15m_gt_25) | (aroonu_14_15m < 25.0) | (stochrsi_k_1h < 90.0))
             # 15m down move, 15m still high, 1h high
-            & ((rsi_3_15m > 25.0) | (aroonu_14_15m < 40.0) | (stochrsi_k_1h_lt_80))
+            & ((rsi_3_15m_gt_25) | (aroonu_14_15m < 40.0) | (stochrsi_k_1h_lt_80))
             # 15m down move, 1h high, 1d overbought
-            & ((rsi_3_15m > 25.0) | (aroonu_14_1h < 60.0) | (roc_9_1d < 60.0))
+            & ((rsi_3_15m_gt_25) | (aroonu_14_1h < 60.0) | (roc_9_1d < 60.0))
             # 15m down move, 1h high, 4h overbought
-            & ((rsi_3_15m > 25.0) | aroonu_14_1h_lt_70 | (roc_9_4h < 40.0))
+            & ((rsi_3_15m_gt_25) | aroonu_14_1h_lt_70 | (roc_9_4h_lt_40))
             # 15m down move, 1h & 4h high
-            & ((rsi_3_15m > 25.0) | (aroonu_14_1h < 85.0) | aroonu_14_4h_lt_100)
+            & ((rsi_3_15m_gt_25) | (aroonu_14_1h < 85.0) | aroonu_14_4h_lt_100)
             # 15m down move, 1h & 4h high
-            & ((rsi_3_15m > 25.0) | (aroonu_14_1h < 90.0) | (aroonu_14_4h < 90.0))
+            & ((rsi_3_15m_gt_25) | (aroonu_14_1h_lt_90) | (aroonu_14_4h_lt_90))
             # 15m down move, 4h high & overbought
-            & ((rsi_3_15m > 25.0) | aroonu_14_4h_lt_70 | (roc_9_4h < 50.0))
+            & ((rsi_3_15m_gt_25) | aroonu_14_4h_lt_70 | (roc_9_4h < 50.0))
             # 15m down move, 4h high, 1d overbought
-            & ((rsi_3_15m > 25.0) | aroonu_14_4h_lt_80 | (roc_9_1d < 100.0))
+            & ((rsi_3_15m_gt_25) | aroonu_14_4h_lt_80 | (roc_9_1d < 100.0))
             # 15m down move, 1h high, 1d downtrend
-            & ((rsi_3_15m > 25.0) | (stochrsi_k_1h < 70.0) | (roc_9_1d_gt_neg_20))
+            & ((rsi_3_15m_gt_25) | (stochrsi_k_1h < 70.0) | (roc_9_1d_gt_neg_20))
             # 15m down move, 1h high & overbought
-            & ((rsi_3_15m > 25.0) | (stochrsi_k_1h < 90.0) | (roc_9_1h < 20.0))
+            & ((rsi_3_15m_gt_25) | (stochrsi_k_1h < 90.0) | (roc_9_1h < 20.0))
             # 15m down move, 4h high & overbought
-            & ((rsi_3_15m > 25.0) | (stochrsi_k_4h_lt_90) | (roc_9_4h < 30.0))
+            & ((rsi_3_15m_gt_25) | (stochrsi_k_4h_lt_90) | (roc_9_4h_lt_30))
             # 15m & 1h down move, 1h high
-            & ((rsi_3_15m > 30.0) | (rsi_3_1h > 35.0) | aroonu_14_1h_lt_80)
+            & ((rsi_3_15m_gt_30) | (rsi_3_1h_gt_35) | aroonu_14_1h_lt_80)
             # 15m & 1h down move, 1h high
-            & ((rsi_3_15m > 30.0) | (rsi_3_1h > 55.0) | (stochrsi_k_1h_lt_80))
+            & ((rsi_3_15m_gt_30) | (rsi_3_1h > 55.0) | (stochrsi_k_1h_lt_80))
             # 15m & 4h down move, 15m high
-            & ((rsi_3_15m > 30.0) | (rsi_3_4h > 30.0) | (stochrsi_k_15m < 70.0))
+            & ((rsi_3_15m_gt_30) | (rsi_3_4h_gt_30) | (stochrsi_k_15m < 70.0))
             # 15m down move, 1h high & overbought
-            & ((rsi_3_15m > 30.0) | (aroonu_14_1h < 90.0) | (roc_9_1h < 10.0))
+            & ((rsi_3_15m_gt_30) | (aroonu_14_1h_lt_90) | (roc_9_1h_lt_10))
             # 15m down move, 15m still high, 4h high
             & ((rsi_3_15m > 35.0) | (aroonu_14_15m < 40.0) | (aroonu_14_4h < 85.0))
             # 15m down move, 4h high & overbought
-            & ((rsi_3_15m > 30.0) | aroonu_14_4h_lt_100 | (roc_9_4h < 40.0))
+            & ((rsi_3_15m_gt_30) | aroonu_14_4h_lt_100 | (roc_9_4h_lt_40))
             # 15m down move, 4h high & overbought
-            & ((rsi_3_15m > 30.0) | (stochrsi_k_4h_lt_90) | (roc_9_4h < 40.0))
+            & ((rsi_3_15m_gt_30) | (stochrsi_k_4h_lt_90) | (roc_9_4h_lt_40))
             # 15m & 1h down move, 1h high
-            & ((rsi_3_15m > 35.0) | (rsi_3_1h > 40.0) | (stochrsi_k_1h_lt_70))
+            & ((rsi_3_15m > 35.0) | (rsi_3_1h_gt_40) | (stochrsi_k_1h_lt_70))
             # 15m & 1h down move, 1h high
             & ((rsi_3_15m > 35.0) | (rsi_3_1h > 65.0) | aroonu_14_1h_lt_80)
             # 15m & 4h down move, 4h high
-            & ((rsi_3_15m > 35.0) | (rsi_3_4h > 35.0) | (stochrsi_k_4h_lt_80))
+            & ((rsi_3_15m > 35.0) | (rsi_3_4h_gt_35) | (stochrsi_k_4h_lt_80))
             # 15m down move, 15m still not low enough, 1h high
             & ((rsi_3_15m > 35.0) | (aroonu_14_15m < 25.0) | aroonu_14_1h_lt_80)
             # 15m down move, 15m still not low enough, 1h high
@@ -15548,41 +15600,41 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 1m still high, 4h overbought
             & ((rsi_3_15m > 35.0) | (aroonu_14_15m < 40.0) | (roc_9_4h < 50.0))
             # 15m down move, 1h high, 4h overbought
-            & ((rsi_3_15m > 35.0) | aroonu_14_1h_lt_80 | (roc_9_4h < 10.0))
+            & ((rsi_3_15m > 35.0) | aroonu_14_1h_lt_80 | (roc_9_4h_lt_10))
             # 15m down move, 4h high & overbought
             & ((rsi_3_15m > 35.0) | aroonu_14_4h_lt_100 | (roc_9_4h < 70.0))
             # 15m down move, 1h high & overbought
             & ((rsi_3_15m > 35.0) | (stochrsi_k_1h < 90.0) | (roc_9_1h < 40.0))
             # 15m & 1h down move, 4h high
-            & ((rsi_3_15m > 40.0) | (rsi_3_1h > 40.0) | aroonu_14_4h_lt_100)
+            & ((rsi_3_15m > 40.0) | (rsi_3_1h_gt_40) | aroonu_14_4h_lt_100)
             # 15m & 4h down move, 1h high
             & ((rsi_3_15m > 40.0) | (rsi_3_4h > 45.0) | (stochrsi_k_1h < 90.0))
             # 15m down move, 15m still high, 1d high
             & ((rsi_3_15m > 40.0) | (stochrsi_k_15m < 40.0) | (roc_9_1d_lt_100))
             # 15m down move, 4h high & overbought
-            & ((rsi_3_15m > 40.0) | aroonu_14_4h_lt_100 | (roc_9_4h < 40.0))
+            & ((rsi_3_15m > 40.0) | aroonu_14_4h_lt_100 | (roc_9_4h_lt_40))
             # 15m down move, 1h high, 4h overbought
-            & ((rsi_3_15m > 50.0) | (stochrsi_k_1h_lt_80) | (roc_9_4h < 40.0))
+            & ((rsi_3_15m > 50.0) | (stochrsi_k_1h_lt_80) | (roc_9_4h_lt_40))
             # 1h & 4h down move, 1d high
-            & ((rsi_3_1h > 3.0) | (rsi_3_4h_gt_15) | (stochrsi_k_1d < 70.0))
+            & ((rsi_3_1h_gt_3) | (rsi_3_4h_gt_15) | (stochrsi_k_1d < 70.0))
             # 1h & 4h down move, 4h high
-            & ((rsi_3_1h > 5.0) | (rsi_3_4h > 5.0) | (stochrsi_k_4h < 40.0))
+            & ((rsi_3_1h_gt_5) | (rsi_3_4h_gt_5) | (stochrsi_k_4h < 40.0))
             # 1h & 4h down move, 4h high
-            & ((rsi_3_1h > 5.0) | (rsi_3_4h > 30.0) | aroonu_14_4h_lt_70)
+            & ((rsi_3_1h_gt_5) | (rsi_3_4h_gt_30) | aroonu_14_4h_lt_70)
             # 1h & 4h down move, 4h still high
-            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_10) | (aroonu_14_4h < 50.0))
+            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_10) | (aroonu_14_4h_lt_50))
             # 1h & 4h down move, 4h high
             & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_15) | aroonu_14_4h_lt_70)
             # 1h & 4h down move, 1d downtrend
-            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_15) | (roc_9_1d > -40.0))
+            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_15) | (roc_9_1d_gt_neg_40))
             # 1h & 4h down move, 1h still high
-            & ((rsi_3_1h_gt_10) | (rsi_3_4h > 30.0) | (aroonu_14_1h < 50.0))
+            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_30) | (aroonu_14_1h_lt_50))
             # 1h & 4h down move, 15m still not low enough
-            & ((rsi_3_1h_gt_10) | (rsi_3_4h > 40.0) | (stochrsi_k_15m < 30.0))
+            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_40) | (stochrsi_k_15m < 30.0))
             # 1h down move, 1d high, 1d downtrend
-            & ((rsi_3_1h_gt_10) | (aroonu_14_1d < 70.0) | (roc_9_1d > -20.0))
+            & ((rsi_3_1h_gt_10) | (aroonu_14_1d_lt_70) | (roc_9_1d > -20.0))
             # 1h down move, 4h high, 1d downtrend
-            & ((rsi_3_1h_gt_10) | (stochrsi_k_4h < 50.0) | (roc_9_1d > -40.0))
+            & ((rsi_3_1h_gt_10) | (stochrsi_k_4h_lt_50) | (roc_9_1d_gt_neg_40))
             # 1h & 4h down move, 15m high
             & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_15) | (stochrsi_k_15m < 70.0))
             # 1h & 4h down move, 4h still not low enough
@@ -15590,117 +15642,117 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 1d downtrend
             & ((rsi_3_1h_gt_15) | rsi_3_4h_gt_20 | (roc_9_1d > -30.0))
             # 1h & 4h down move, 1h high
-            & ((rsi_3_1h_gt_15) | (rsi_3_4h > 35.0) | (aroonu_14_1h < 70.0))
+            & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_35) | (aroonu_14_1h < 70.0))
             # 1h & 4h down move, 4h still high
-            & ((rsi_3_1h_gt_15) | (rsi_3_4h > 35.0) | (stochrsi_k_4h < 50.0))
+            & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_35) | (stochrsi_k_4h_lt_50))
             # 1h down move, 1d high & overbought
-            & ((rsi_3_1h_gt_15) | (aroonu_14_1d < 80.0) | (roc_9_1d < 10.0))
+            & ((rsi_3_1h_gt_15) | (aroonu_14_1d_lt_80) | (roc_9_1d < 10.0))
             # 1h down move, 1d high, 4h downtrend
-            & ((rsi_3_1h_gt_15) | (aroonu_14_1d < 90.0) | (roc_9_4h > -20.0))
+            & ((rsi_3_1h_gt_15) | (aroonu_14_1d_lt_90) | (roc_9_4h > -20.0))
             # 1h & 4h down move, 4h high
-            & (rsi_3_1h_gt_20 | (rsi_3_4h > 35.0) | (stochrsi_k_4h < 70.0))
+            & (rsi_3_1h_gt_20 | (rsi_3_4h_gt_35) | (stochrsi_k_4h_lt_70))
             # 1h & 1d down move, 1d high
             & (rsi_3_1h_gt_20 | (rsi_3_1d > 50.0) | (stochrsi_k_1d < 60.0))
             # 1h down move, 1h high, 1d overbought
             & (rsi_3_1h_gt_20 | (aroonu_14_1h < 60.0) | roc_9_1d_lt_50)
             # 1h down move, 1h high, 1d overbought
-            & (rsi_3_1h_gt_20 | aroonu_14_1h_lt_70 | (roc_9_1d < 20.0))
+            & (rsi_3_1h_gt_20 | aroonu_14_1h_lt_70 | (roc_9_1d_lt_20))
             # 1h down move, 1d high, 4h downtrend
             & (rsi_3_1h_gt_20 | (stochrsi_k_1d < 80.0) | (roc_9_4h_gt_neg_20))
             # 1h down move, 4h downtrend, 1d overbought
-            & (rsi_3_1h_gt_20 | (roc_9_4h > -10.0) | (roc_9_1d < 20.0))
+            & (rsi_3_1h_gt_20 | (roc_9_4h > -10.0) | (roc_9_1d_lt_20))
             # 1h & 4h down move, 1h still high
-            & ((rsi_3_1h > 25.0) | (rsi_3_4h_gt_10) | (stochrsi_k_1h < 40.0))
+            & ((rsi_3_1h_gt_25) | (rsi_3_4h_gt_10) | (stochrsi_k_1h < 40.0))
             # 1h & 4h down move, 15m high
-            & ((rsi_3_1h > 25.0) | (rsi_3_4h > 30.0) | (stochrsi_k_15m < 70.0))
+            & ((rsi_3_1h_gt_25) | (rsi_3_4h_gt_30) | (stochrsi_k_15m < 70.0))
             # 1h down move, 4h downtrend, 4h high
-            & ((rsi_3_1h > 25.0) | (cmf_20_4h > -0.50) | aroonu_14_4h_lt_70)
+            & ((rsi_3_1h_gt_25) | (cmf_20_4h > -0.50) | aroonu_14_4h_lt_70)
             # 1h down move, 1h still high, 1d high
-            & ((rsi_3_1h > 25.0) | (aroonu_14_1h < 40.0) | (aroonu_14_1d < 90.0))
+            & ((rsi_3_1h_gt_25) | (aroonu_14_1h < 40.0) | (aroonu_14_1d_lt_90))
             # 1h down move, 1h still high, 4h overbought
-            & ((rsi_3_1h > 25.0) | (aroonu_14_1h < 50.0) | (roc_9_4h < 60.0))
+            & ((rsi_3_1h_gt_25) | (aroonu_14_1h_lt_50) | (roc_9_4h < 60.0))
             # 1h down move, 4h high, 1d overbought
-            & ((rsi_3_1h > 25.0) | (aroonu_14_4h < 40.0) | (roc_9_1d_lt_100))
+            & ((rsi_3_1h_gt_25) | (aroonu_14_4h_lt_40) | (roc_9_1d_lt_100))
             # 1h down move, 1d still high, 1d downtrend
-            & ((rsi_3_1h > 25.0) | (stochrsi_k_1d < 50.0) | (roc_9_1d_gt_neg_20))
+            & ((rsi_3_1h_gt_25) | (stochrsi_k_1d < 50.0) | (roc_9_1d_gt_neg_20))
             # 1h & 4h down move, 1d high
-            & ((rsi_3_1h > 30.0) | (rsi_3_4h > 35.0) | (rsi_14_1d < 80.0))
+            & ((rsi_3_1h_gt_30) | (rsi_3_4h_gt_35) | (rsi_14_1d < 80.0))
             # 1h & 4h down move, 4h high
-            & ((rsi_3_1h > 30.0) | (rsi_3_4h > 40.0) | (aroonu_14_4h < 60.0))
+            & ((rsi_3_1h_gt_30) | (rsi_3_4h_gt_40) | (aroonu_14_4h_lt_60))
             # 1h & 4h down move, 4h high
-            & ((rsi_3_1h > 30.0) | (rsi_3_4h > 60.0) | (stochrsi_k_4h_lt_80))
+            & ((rsi_3_1h_gt_30) | (rsi_3_4h > 60.0) | (stochrsi_k_4h_lt_80))
             # 1h & 1d down move, 1h high
-            & ((rsi_3_1h > 30.0) | (rsi_3_1d > 30.0) | (aroonu_14_1h < 60.0))
+            & ((rsi_3_1h_gt_30) | (rsi_3_1d > 30.0) | (aroonu_14_1h < 60.0))
             # 1h down move, 4h & 1d down move
-            & ((rsi_3_1h > 30.0) | aroonu_14_4h_lt_70 | aroonu_14_1d_lt_100)
+            & ((rsi_3_1h_gt_30) | aroonu_14_4h_lt_70 | aroonu_14_1d_lt_100)
             # 1h down move, 4h high & overbought
-            & ((rsi_3_1h > 30.0) | (aroonu_14_4h < 85.0) | (roc_9_4h < 80.0))
+            & ((rsi_3_1h_gt_30) | (aroonu_14_4h < 85.0) | (roc_9_4h < 80.0))
             # 1h down move, 1d still high, 1d downtrend
-            & ((rsi_3_1h > 30.0) | (aroonu_14_1d < 40.0) | (roc_9_1d_gt_neg_20))
+            & ((rsi_3_1h_gt_30) | (aroonu_14_1d < 40.0) | (roc_9_1d_gt_neg_20))
             # 1h down move, 1d high, 4h downtrend
-            & ((rsi_3_1h > 30.0) | aroonu_14_1d_lt_100 | (roc_9_4h > -30.0))
+            & ((rsi_3_1h_gt_30) | aroonu_14_1d_lt_100 | (roc_9_4h_gt_neg_30))
             # 1h down move, 1d high & overbought
-            & ((rsi_3_1h > 30.0) | (stochrsi_k_1d < 90.0) | (roc_9_1d < 20.0))
+            & ((rsi_3_1h_gt_30) | (stochrsi_k_1d_lt_90) | (roc_9_1d_lt_20))
             # 1h down move, 4h & 1d downtrend
-            & ((rsi_3_1h > 30.0) | (roc_9_4h > -25.0) | (roc_9_1d > -60.0))
+            & ((rsi_3_1h_gt_30) | (roc_9_4h > -25.0) | (roc_9_1d > -60.0))
             # 1h & 1d down move, 1h high
-            & ((rsi_3_1h > 35.0) | (rsi_3_1d > 35.0) | (aroonu_14_1h < 75.0))
+            & ((rsi_3_1h_gt_35) | (rsi_3_1d > 35.0) | (aroonu_14_1h < 75.0))
             # 1h down move, 1h & 4h high
-            & ((rsi_3_1h > 35.0) | (aroonu_14_1h < 60.0) | aroonu_14_4h_lt_70)
+            & ((rsi_3_1h_gt_35) | (aroonu_14_1h < 60.0) | aroonu_14_4h_lt_70)
             # 1h down move, 4h high, 1d downtrend
-            & ((rsi_3_1h > 35.0) | aroonu_14_4h_lt_70 | (roc_9_1d_gt_neg_30))
+            & ((rsi_3_1h_gt_35) | aroonu_14_4h_lt_70 | (roc_9_1d_gt_neg_30))
             # 1h down move, 1d high, 4h overbought
-            & ((rsi_3_1h > 35.0) | (aroonu_14_1d < 90.0) | (roc_9_4h < 40.0))
+            & ((rsi_3_1h_gt_35) | (aroonu_14_1d_lt_90) | (roc_9_4h_lt_40))
             # 1h down move, 4h & 1d overbought
-            & ((rsi_3_1h > 35.0) | (roc_9_4h < 10.0) | roc_9_1d_lt_50)
+            & ((rsi_3_1h_gt_35) | (roc_9_4h_lt_10) | roc_9_1d_lt_50)
             # 1h & 1d down move, 1d high
-            & ((rsi_3_1h > 35.0) | (rsi_3_1d > 45.0) | (aroonu_14_1d < 90.0))
+            & ((rsi_3_1h_gt_35) | (rsi_3_1d > 45.0) | (aroonu_14_1d_lt_90))
             # 1h & 4h down move, 1h high
-            & ((rsi_3_1h > 40.0) | (rsi_3_4h > 50.0) | (stochrsi_k_1h < 60.0))
+            & ((rsi_3_1h_gt_40) | (rsi_3_4h_gt_50) | (stochrsi_k_1h < 60.0))
             # 1h down move, 1h high, 1d overbought
-            & ((rsi_3_1h > 40.0) | (aroonu_14_1h < 60.0) | (roc_9_1d < 40.0))
+            & ((rsi_3_1h_gt_40) | (aroonu_14_1h < 60.0) | (roc_9_1d_lt_40))
             # 1h down move, 1h still high, 1d high
-            & ((rsi_3_1h > 40.0) | (aroonu_14_1h < 50.0) | (aroonu_14_1d < 85.0))
+            & ((rsi_3_1h_gt_40) | (aroonu_14_1h_lt_50) | (aroonu_14_1d < 85.0))
             # 1h down move, 1h still high, 1d overbought
-            & ((rsi_3_1h > 40.0) | (aroonu_14_1h < 50.0) | (roc_9_1d < 20.0))
+            & ((rsi_3_1h_gt_40) | (aroonu_14_1h_lt_50) | (roc_9_1d_lt_20))
             # 1h down move, 1h high, 4h overbought
-            & ((rsi_3_1h > 40.0) | aroonu_14_1h_lt_70 | (roc_9_4h < 30.0))
+            & ((rsi_3_1h_gt_40) | aroonu_14_1h_lt_70 | (roc_9_4h_lt_30))
             # 1h down move, 1h high, 15m downtrend
-            & ((rsi_3_1h > 40.0) | aroonu_14_1h_lt_80 | (roc_9_15m > -15.0))
+            & ((rsi_3_1h_gt_40) | aroonu_14_1h_lt_80 | (roc_9_15m > -15.0))
             # 1h down move, 1d high & overbought
-            & ((rsi_3_1h > 40.0) | (aroonu_14_1d < 80.0) | roc_9_1d_lt_50)
+            & ((rsi_3_1h_gt_40) | (aroonu_14_1d_lt_80) | roc_9_1d_lt_50)
             # 1h down move, 1d high, 4h overbought
-            & ((rsi_3_1h > 40.0) | (stochrsi_k_1d < 90.0) | (roc_9_4h_lt_20))
+            & ((rsi_3_1h_gt_40) | (stochrsi_k_1d_lt_90) | (roc_9_4h_lt_20))
             # 1h down move, 1h overbought
-            & ((rsi_3_1h > 40.0) | (roc_9_1h < 30.0))
+            & ((rsi_3_1h_gt_40) | (roc_9_1h < 30.0))
             # 1h & 4h down move, 1d overbought
-            & ((rsi_3_1h > 45.0) | (rsi_3_4h > 65.0) | (roc_9_1d < 200.0))
+            & ((rsi_3_1h_gt_45) | (rsi_3_4h > 65.0) | (roc_9_1d < 200.0))
             # 1h down move, 1h still not low enough, 1d downtrend
-            & ((rsi_3_1h > 45.0) | (aroonu_14_1h < 30.0) | (roc_9_1d > -25.0))
+            & ((rsi_3_1h_gt_45) | (aroonu_14_1h < 30.0) | (roc_9_1d > -25.0))
             # 1h down move, 1h still high, 1d overbought
-            & ((rsi_3_1h > 45.0) | (stochrsi_k_1h < 40.0) | (roc_9_1d_lt_100))
+            & ((rsi_3_1h_gt_45) | (stochrsi_k_1h < 40.0) | (roc_9_1d_lt_100))
             # 1h down move, 4h high, 1h overbought
-            & ((rsi_3_1h > 50.0) | (aroonu_14_4h < 85.0) | (roc_9_1h < 20.0))
+            & ((rsi_3_1h_gt_50) | (aroonu_14_4h < 85.0) | (roc_9_1h < 20.0))
             # 1h down move, 1d high, 4h overbought
-            & ((rsi_3_1h > 50.0) | (aroonu_14_1d < 90.0) | (roc_9_4h_lt_20))
+            & ((rsi_3_1h_gt_50) | (aroonu_14_1d_lt_90) | (roc_9_4h_lt_20))
             # 1h down move, 1h high & overbought
-            & ((rsi_3_1h > 50.0) | (stochrsi_k_1h_lt_80) | (roc_9_1h < 10.0))
+            & ((rsi_3_1h_gt_50) | (stochrsi_k_1h_lt_80) | (roc_9_1h_lt_10))
             # 1h down move, 1h & 4h overbought
-            & ((rsi_3_1h > 50.0) | (roc_9_1h < 10.0) | (roc_9_4h < 100.0))
+            & ((rsi_3_1h_gt_50) | (roc_9_1h_lt_10) | (roc_9_4h < 100.0))
             # 1h down move, 4h & 1d overbought
-            & ((rsi_3_1h > 50.0) | (roc_9_4h_lt_20) | (roc_9_1d < 20.0))
+            & ((rsi_3_1h_gt_50) | (roc_9_4h_lt_20) | (roc_9_1d_lt_20))
             # 1h & 4h down move, 1h high
             & ((rsi_3_1h > 55.0) | (rsi_3_4h > 55.0) | (stochrsi_k_1h_lt_70))
             # 1h down move, 1h high, 4h overbought
-            & ((rsi_3_1h > 55.0) | aroonu_14_1h_lt_80 | (roc_9_4h < 10.0))
+            & ((rsi_3_1h > 55.0) | aroonu_14_1h_lt_80 | (roc_9_4h_lt_10))
             # 1h down move, 4h high & overbought
-            & ((rsi_3_1h > 55.0) | aroonu_14_4h_lt_100 | (roc_9_4h < 10.0))
+            & ((rsi_3_1h > 55.0) | aroonu_14_4h_lt_100 | (roc_9_4h_lt_10))
             # 1h & 1d down move, 1h high
             & ((rsi_3_1h > 60.0) | (rsi_3_1d > 60.0) | aroonu_14_1h_lt_70)
             # 1h down move, 4 high, 1h overbought
-            & ((rsi_3_1h > 60.0) | aroonu_14_4h_lt_100 | (roc_9_1h < 10.0))
+            & ((rsi_3_1h > 60.0) | aroonu_14_4h_lt_100 | (roc_9_1h_lt_10))
             # 1h down move, 1d high, 1h overbought
-            & ((rsi_3_1h > 60.0) | (aroonu_14_1d < 90.0) | (roc_9_1h < 10.0))
+            & ((rsi_3_1h > 60.0) | (aroonu_14_1d_lt_90) | (roc_9_1h_lt_10))
             # 1h down move, 1h high, 1d downtrend
             & ((rsi_3_1h > 60.0) | (stochrsi_k_1h_lt_70) | (roc_9_1d > -10.0))
             # 1h down move, 1h high, 1d overbought
@@ -15708,19 +15760,19 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h high, 4h overbought
             & ((rsi_3_1h > 65.0) | aroonu_14_1h_lt_70 | (roc_9_4h < 25.0))
             # 1h down move, 1h high, 1d overbought
-            & ((rsi_3_1h > 65.0) | (stochrsi_k_1h < 90.0) | (roc_9_1d < 20.0))
+            & ((rsi_3_1h > 65.0) | (stochrsi_k_1h < 90.0) | (roc_9_1d_lt_20))
             # 4h down move, 1h still not low enough, 4h downtrend
             & ((rsi_3_4h > 3.0) | (aroonu_14_1h < 20.0) | (roc_9_4h > -10.0))
             # 4h down move, 4h & 1d downtrend
             & ((rsi_3_4h > 3.0) | (roc_9_4h > -10.0) | (roc_9_1d > -10.0))
             # 4h & 1d down move, 15m still high
-            & ((rsi_3_4h > 5.0) | (rsi_3_1d > 25.0) | (stochrsi_k_15m < 40.0))
+            & ((rsi_3_4h_gt_5) | (rsi_3_1d_gt_25) | (stochrsi_k_15m < 40.0))
             # 4h & 1d down move, 1h still not low enough
-            & ((rsi_3_4h_gt_10) | (rsi_3_1d > 10.0) | (stochrsi_k_1h < 20.0))
+            & ((rsi_3_4h_gt_10) | (rsi_3_1d_gt_10) | (stochrsi_k_1h < 20.0))
             # 4h & 1d down move, 1d downtrend
-            & ((rsi_3_4h_gt_10) | (rsi_3_1d > 15.0) | (roc_9_1d > -40.0))
+            & ((rsi_3_4h_gt_10) | (rsi_3_1d_gt_15) | (roc_9_1d_gt_neg_40))
             # 4h & 1d down move, 1d still high
-            & ((rsi_3_4h_gt_10) | (rsi_3_1d > 20.0) | (stochrsi_k_1d < 50.0))
+            & ((rsi_3_4h_gt_10) | (rsi_3_1d_gt_20) | (stochrsi_k_1d < 50.0))
             # 4h & 1d down move, 1d high
             & ((rsi_3_4h_gt_10) | (rsi_3_1d > 35.0) | (aroonu_14_1d < 100.0))
             # 4h & 1d down move, 1d overbought
@@ -15728,13 +15780,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 15m high
             & ((rsi_3_4h_gt_10) | (stochrsi_k_15m < 70.0))
             # 4h & 1d down move, 4h high
-            & ((rsi_3_4h_gt_15) | (rsi_3_1d > 25.0) | aroonu_14_4h_lt_70)
+            & ((rsi_3_4h_gt_15) | (rsi_3_1d_gt_25) | aroonu_14_4h_lt_70)
             # 4h & 1d down move, 1h still high
             & ((rsi_3_4h_gt_15) | (rsi_3_1d > 30.0) | (stochrsi_k_1h < 40.0))
             # 4h & 1d down move, 1d high
-            & ((rsi_3_4h_gt_15) | (rsi_3_1d > 25.0) | (aroonu_14_1d < 70.0))
+            & ((rsi_3_4h_gt_15) | (rsi_3_1d_gt_25) | (aroonu_14_1d_lt_70))
             # 4h & 1d down move, 1d downtrend
-            & ((rsi_3_4h_gt_15) | (rsi_3_1d > 25.0) | (roc_9_1d > -15.0))
+            & ((rsi_3_4h_gt_15) | (rsi_3_1d_gt_25) | (roc_9_1d > -15.0))
             # 4h & 1d down move, 4h still high
             & ((rsi_3_4h_gt_15) | (rsi_3_1d > 50.0) | (stochrsi_k_4h < 40.0))
             # 4h down move, 1d still high, 4h still not low enough
@@ -15742,65 +15794,65 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 4h still not low enough, 1d downtrend
             & ((rsi_3_4h_gt_15) | (stochrsi_k_4h < 20.0) | (roc_9_1d > -20.0))
             # 4h down move, 1h & 4h downtrend
-            & ((rsi_3_4h_gt_15) | (roc_9_1h > -30.0) | (roc_9_4h > -30.0))
+            & ((rsi_3_4h_gt_15) | (roc_9_1h > -30.0) | (roc_9_4h_gt_neg_30))
             # 4h & 1d down move, 1d high
-            & (rsi_3_4h_gt_20 | (rsi_3_1d > 20.0) | (aroonu_14_1d < 60.0))
+            & (rsi_3_4h_gt_20 | (rsi_3_1d_gt_20) | (aroonu_14_1d < 60.0))
             # 4h & 1d down move, 4h still high
-            & (rsi_3_4h_gt_20 | (rsi_3_1d > 20.0) | (stochrsi_k_4h < 40.0))
+            & (rsi_3_4h_gt_20 | (rsi_3_1d_gt_20) | (stochrsi_k_4h < 40.0))
             # 4h & 1d down move, 1d overbought
-            & (rsi_3_4h_gt_20 | (rsi_3_1d > 45.0) | (roc_9_1d < 40.0))
+            & (rsi_3_4h_gt_20 | (rsi_3_1d > 45.0) | (roc_9_1d_lt_40))
             # 4h down move, 15m high
             & (rsi_3_4h_gt_20 | (stochrsi_k_15m < 80.0))
             # 4h down move, 1h high, 4h downtrend
             & (rsi_3_4h_gt_20 | (stochrsi_k_1h < 70.0) | (roc_9_4h_gt_neg_20))
             # 4h down move, 4h still high, 4h downtrend
-            & ((rsi_3_4h > 25.0) | (aroonu_14_4h < 50.0) | (cmf_20_4h > -0.40))
+            & ((rsi_3_4h_gt_25) | (aroonu_14_4h_lt_50) | (cmf_20_4h > -0.40))
             # 4h down move, 4h high, 1d downtrend
-            & ((rsi_3_4h > 25.0) | (stochrsi_k_4h < 70.0) | (roc_9_1d_gt_neg_30))
+            & ((rsi_3_4h_gt_25) | (stochrsi_k_4h_lt_70) | (roc_9_1d_gt_neg_30))
             # 4h & 1d down move, 1d high
-            & ((rsi_3_4h > 30.0) | (rsi_3_1d > 50.0) | (aroonu_14_1d < 90.0))
+            & ((rsi_3_4h_gt_30) | (rsi_3_1d > 50.0) | (aroonu_14_1d_lt_90))
             # 4h down move, 1h high, 1h downtrend
-            & ((rsi_3_4h > 30.0) | aroonu_14_1h_lt_70 | (roc_9_1h > -10.0))
+            & ((rsi_3_4h_gt_30) | aroonu_14_1h_lt_70 | (roc_9_1h > -10.0))
             # 4h down move, 1h high, 4h downtrend
-            & ((rsi_3_4h > 30.0) | aroonu_14_1h_lt_70 | (roc_9_4h > -10.0))
+            & ((rsi_3_4h_gt_30) | aroonu_14_1h_lt_70 | (roc_9_4h > -10.0))
             # 4h down move, 1h still high, 1d overbought
-            & ((rsi_3_4h > 30.0) | (stochrsi_k_1h < 40.0) | (roc_9_1d < 30.0))
+            & ((rsi_3_4h_gt_30) | (stochrsi_k_1h < 40.0) | (roc_9_1d_lt_30))
             # 4h & 1d down move, 1d overbought
-            & ((rsi_3_4h > 35.0) | (rsi_3_1d > 50.0) | (roc_9_1d_lt_100))
+            & ((rsi_3_4h_gt_35) | (rsi_3_1d > 50.0) | (roc_9_1d_lt_100))
             # 4h down move, 4h & 1d high
-            & ((rsi_3_4h > 35.0) | aroonu_14_4h_lt_80 | aroonu_14_1d_lt_100)
+            & ((rsi_3_4h_gt_35) | aroonu_14_4h_lt_80 | aroonu_14_1d_lt_100)
             # 4h down move, 4h high, 1d downtrend
             & ((rsi_3_4h > 45.0) | aroonu_14_4h_lt_70 | (roc_9_1d_gt_neg_30))
             # 4h & 1d down move, 1d high
-            & ((rsi_3_4h > 40.0) | (rsi_3_1d > 60.0) | aroonu_14_1d_lt_100)
+            & ((rsi_3_4h_gt_40) | (rsi_3_1d > 60.0) | aroonu_14_1d_lt_100)
             # 4h down move, 4h high, 1d downtrend
-            & ((rsi_3_4h > 40.0) | (stochrsi_k_4h < 70.0) | (roc_9_1d > -60.0))
+            & ((rsi_3_4h_gt_40) | (stochrsi_k_4h_lt_70) | (roc_9_1d > -60.0))
             # 4h down move, 1d high & overbought
-            & ((rsi_3_4h > 45.0) | (aroonu_14_1d < 70.0) | (roc_9_1d < 20.0))
+            & ((rsi_3_4h > 45.0) | (aroonu_14_1d_lt_70) | (roc_9_1d_lt_20))
             # 4h down move, 4h high & overbought
             & ((rsi_3_4h > 45.0) | (stochrsi_k_4h < 60.0) | (roc_9_4h_lt_20))
             # 4h down move, 4h high, 1d overbought
             & ((rsi_3_4h > 45.0) | (stochrsi_k_4h_lt_80) | (roc_9_1d < 10.0))
             # 4h down move, 4h high & overbought
-            & ((rsi_3_4h > 50.0) | aroonu_14_4h_lt_80 | (roc_9_4h < 10.0))
+            & ((rsi_3_4h_gt_50) | aroonu_14_4h_lt_80 | (roc_9_4h_lt_10))
             # 4h down move, 1h high, 1d downtrend
-            & ((rsi_3_4h > 50.0) | (stochrsi_k_1h < 80.0) | (roc_9_1d_gt_neg_30))
+            & ((rsi_3_4h_gt_50) | (stochrsi_k_1h < 80.0) | (roc_9_1d_gt_neg_30))
             # 4h down move, 4h high & overbought
             & ((rsi_3_4h > 55.0) | aroonu_14_4h_lt_70 | (roc_9_4h_lt_20))
             # 4h down move, 4h high, 1d overbought
             & ((rsi_3_4h > 55.0) | aroonu_14_4h_lt_70 | (roc_9_1d_lt_100))
             # 4h down move, 1d high & overbought
-            & ((rsi_3_4h > 55.0) | (aroonu_14_1d < 90.0) | (roc_9_1d < 60.0))
+            & ((rsi_3_4h > 55.0) | (aroonu_14_1d_lt_90) | (roc_9_1d < 60.0))
             # 4h down move, 4h & 1d high
-            & ((rsi_3_4h > 60.0) | aroonu_14_4h_lt_70 | (aroonu_14_1d < 70.0))
+            & ((rsi_3_4h > 60.0) | aroonu_14_4h_lt_70 | (aroonu_14_1d_lt_70))
             # 4h down move, 1d high, 4h overbought
-            & ((rsi_3_4h > 60.0) | aroonu_14_1d_lt_100 | (roc_9_4h < 10.0))
+            & ((rsi_3_4h > 60.0) | aroonu_14_1d_lt_100 | (roc_9_4h_lt_10))
             # 4h down move, 1d high & overbought
             & ((rsi_3_4h > 60.0) | aroonu_14_1d_lt_100 | (roc_9_1d < 200.0))
             # 4h down move, 4h still high, 4h overbought
-            & ((rsi_3_4h > 60.0) | (stochrsi_k_4h < 50.0) | (roc_9_4h < 10.0))
+            & ((rsi_3_4h > 60.0) | (stochrsi_k_4h_lt_50) | (roc_9_4h_lt_10))
             # 4h down move, 4h high, 1d overbought
-            & ((rsi_3_4h > 65.0) | (aroonu_14_4h < 75.0) | (roc_9_1d < 30.0))
+            & ((rsi_3_4h > 65.0) | (aroonu_14_4h < 75.0) | (roc_9_1d_lt_30))
             # 4h down move, 4h high & overbought
             & ((rsi_3_4h > 65.0) | aroonu_14_4h_lt_80 | (roc_9_4h < 20.0))
             # 1d down move, 1d still not low enough, 1d downtrend
@@ -15808,19 +15860,19 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1d down move, 15m still high
             & ((rsi_3_1d > 5.0) | (stochrsi_k_15m < 40.0))
             # 1d down move, 1h high
-            & ((rsi_3_1d > 10.0) | aroonu_14_1h_lt_70)
+            & ((rsi_3_1d_gt_10) | aroonu_14_1h_lt_70)
             # 1d down move, 4h downtrend, 4h high
-            & ((rsi_3_1d > 20.0) | (cmf_20_4h > -0.25) | aroonu_14_4h_lt_70)
+            & ((rsi_3_1d_gt_20) | (cmf_20_4h > -0.25) | aroonu_14_4h_lt_70)
             # 1d down move, 1d still high, 1d downtrend
-            & ((rsi_3_1d > 25.0) | (stochrsi_k_1d < 50.0) | (roc_9_1d_gt_neg_20))
+            & ((rsi_3_1d_gt_25) | (stochrsi_k_1d < 50.0) | (roc_9_1d_gt_neg_20))
             # 1d down move, 4h & 1d high
             & ((rsi_3_1d > 40.0) | aroonu_14_4h_lt_70 | aroonu_14_1d_lt_100)
             # 1d down move, 1d high & overbought
-            & ((rsi_3_1d > 40.0) | (aroonu_14_1d < 80.0) | (roc_9_1d < 10.0))
+            & ((rsi_3_1d > 40.0) | (aroonu_14_1d_lt_80) | (roc_9_1d < 10.0))
             # 1d down move, 1h high, 1d overbought
             & ((rsi_3_1d > 60.0) | aroonu_14_1h_lt_70 | (roc_9_1d < 100.0))
             # 4h downtrend, 4h high & over
-            & ((cmf_20_4h > -0.10) | aroonu_14_4h_lt_100 | (roc_9_4h < 30.0))
+            & ((cmf_20_4h > -0.10) | aroonu_14_4h_lt_100 | (roc_9_4h_lt_30))
             # 15m still high, 4h high, 1h overbought
             & ((aroonu_14_15m < 40.0) | (aroonu_14_4h < 85.0) | (roc_9_1h < 20.0))
             # 15m still high, 4h high, 1h overbought
@@ -15828,73 +15880,73 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 1h still high, 1d downtrend
             & ((rsi_3_4h_gt_15) | (aroonu_14_1h < 40.0) | roc_9_1d_gt_neg_50)
             # 1h high, 4h high & overbought
-            & (aroonu_14_1h_lt_80 | aroonu_14_4h_lt_80 | (roc_9_4h < 30.0))
+            & (aroonu_14_1h_lt_80 | aroonu_14_4h_lt_80 | (roc_9_4h_lt_30))
             # 1h & 4h high, 1h overbought
-            & (aroonu_14_1h_lt_80 | (aroonu_14_4h < 90.0) | (roc_9_1h < 30.0))
+            & (aroonu_14_1h_lt_80 | (aroonu_14_4h_lt_90) | (roc_9_1h < 30.0))
             # 1h & 4h & 1d high
             & (aroonu_14_1h_lt_80 | aroonu_14_4h_lt_100 | aroonu_14_1d_lt_100)
             # 1h & 4h high, 1d overbought
-            & (aroonu_14_1h_lt_80 | aroonu_14_4h_lt_100 | (roc_9_1d < 30.0))
+            & (aroonu_14_1h_lt_80 | aroonu_14_4h_lt_100 | (roc_9_1d_lt_30))
             # 1h high, 1h overbought
-            & (aroonu_14_1h_lt_80 | (roc_9_1h < 10.0))
+            & (aroonu_14_1h_lt_80 | (roc_9_1h_lt_10))
             # 1h & 1d high, 4h overbought
-            & (aroonu_14_1h_lt_80 | aroonu_14_1d_lt_100 | (roc_9_4h < 10.0))
+            & (aroonu_14_1h_lt_80 | aroonu_14_1d_lt_100 | (roc_9_4h_lt_10))
             # 1h high, 1h & 4h overbought
-            & (aroonu_14_1h_lt_80 | (roc_9_1h < 10.0) | (roc_9_4h < 10.0))
+            & (aroonu_14_1h_lt_80 | (roc_9_1h_lt_10) | (roc_9_4h_lt_10))
             # 1h high, 1h overbought, 1d downtrend
             & (aroonu_14_1h_lt_80 | (roc_9_1h < 50.0) | roc_9_1d_gt_neg_50)
             # 1h high, 4h &1d overbought
-            & ((aroonu_14_1h < 85.0) | (roc_9_4h < 30.0) | (roc_9_1d < 30.0))
+            & ((aroonu_14_1h < 85.0) | (roc_9_4h_lt_30) | (roc_9_1d_lt_30))
             # 1h high, 4h & 1d overbought
-            & ((aroonu_14_1h < 90.0) | (roc_9_4h < 10.0) | (roc_9_1d < 15.0))
+            & ((aroonu_14_1h_lt_90) | (roc_9_4h_lt_10) | (roc_9_1d < 15.0))
             # 4h & 1d high, 4h overbought
             & (aroonu_14_4h_lt_70 | aroonu_14_1d_lt_100 | (roc_9_4h < 50.0))
             # 4h & 1d high, 1d overbought
-            & (aroonu_14_4h_lt_70 | aroonu_14_1d_lt_100 | (roc_9_1d < 20.0))
+            & (aroonu_14_4h_lt_70 | aroonu_14_1d_lt_100 | (roc_9_1d_lt_20))
             # 4h & 1d high, 4h overbought
-            & ((aroonu_14_4h < 90.0) | aroonu_14_1d_lt_100 | (roc_9_4h < 30.0))
+            & ((aroonu_14_4h_lt_90) | aroonu_14_1d_lt_100 | (roc_9_4h_lt_30))
             # 4h high, 4h overbought, 1d downtrend
-            & ((aroonu_14_4h < 90.0) | (roc_9_4h_lt_20) | (roc_9_1d > -40.0))
+            & ((aroonu_14_4h_lt_90) | (roc_9_4h_lt_20) | (roc_9_1d_gt_neg_40))
             # 1d high, 4h & 1d overbought
-            & ((aroonu_14_1d < 70.0) | (roc_9_4h < 30.0) | (roc_9_1d < 200.0))
+            & ((aroonu_14_1d_lt_70) | (roc_9_4h_lt_30) | (roc_9_1d < 200.0))
             # 1d high, 1h & 1d overbought
-            & ((aroonu_14_1d < 80.0) | (roc_9_1h < 20.0) | roc_9_1d_lt_50)
+            & ((aroonu_14_1d_lt_80) | (roc_9_1h < 20.0) | roc_9_1d_lt_50)
             # 1d high, 1d downtrend
-            & ((aroonu_14_1d < 80.0) | (roc_9_1d_gt_neg_30))
+            & ((aroonu_14_1d_lt_80) | (roc_9_1d_gt_neg_30))
             # 1d high, 1h & 4h downtrend
             & ((aroonu_14_1d < 85.0) | (roc_9_1h > -30.0) | (roc_9_4h > -50.0))
             # 1d high, 1h & 1d overbought
-            & ((aroonu_14_1d < 90.0) | (roc_9_1h < 10.0) | roc_9_1d_lt_50)
+            & ((aroonu_14_1d_lt_90) | (roc_9_1h_lt_10) | roc_9_1d_lt_50)
             # 1d high, 4h & 1d overbought
-            & (aroonu_14_1d_lt_100 | (roc_9_4h < 10.0) | (roc_9_1d < 20.0))
+            & (aroonu_14_1d_lt_100 | (roc_9_4h_lt_10) | (roc_9_1d_lt_20))
             # 15m still not low enough, 4h high, 1d overbought
-            & ((stochrsi_k_15m < 30.0) | aroonu_14_4h_lt_100 | (roc_9_1d < 30.0))
+            & ((stochrsi_k_15m < 30.0) | aroonu_14_4h_lt_100 | (roc_9_1d_lt_30))
             # 15m still high, 4h high & overbought
-            & ((stochrsi_k_15m < 40.0) | (stochrsi_k_4h_lt_80) | (roc_9_4h < 30.0))
+            & ((stochrsi_k_15m < 40.0) | (stochrsi_k_4h_lt_80) | (roc_9_4h_lt_30))
             # 1h high, 1d overbought
-            & ((stochrsi_k_1h_lt_70) | (roc_9_1d < 40.0))
+            & ((stochrsi_k_1h_lt_70) | (roc_9_1d_lt_40))
             # 1h high, 1h overbought, 4h downtrend
-            & ((stochrsi_k_1h_lt_80) | (roc_9_1h < 10.0) | (roc_9_4h > -10.0))
+            & ((stochrsi_k_1h_lt_80) | (roc_9_1h_lt_10) | (roc_9_4h > -10.0))
             # 1h high, 4h & 1d downtrend
             & ((stochrsi_k_1h < 80.0) | (roc_9_4h_gt_neg_20) | (roc_9_1d > -80.0))
             # 1h down move, 1h & 1d overbought
-            & ((stochrsi_k_1h < 90.0) | (roc_9_1h < 10.0) | roc_9_1d_lt_50)
+            & ((stochrsi_k_1h < 90.0) | (roc_9_1h_lt_10) | roc_9_1d_lt_50)
             # 1h high & overbought
             & ((stochrsi_k_1h < 90.0) | (roc_9_1h < 40.0))
             # 4h high, 1h & 4h overbought
-            & ((stochrsi_k_4h < 70.0) | (roc_9_1h < 10.0) | (roc_9_4h_lt_20))
+            & ((stochrsi_k_4h_lt_70) | (roc_9_1h_lt_10) | (roc_9_4h_lt_20))
             # 4h high, 1h & 1d overbought
-            & ((stochrsi_k_4h < 70.0) | (roc_9_1h < 20.0) | (roc_9_1d < 200.0))
+            & ((stochrsi_k_4h_lt_70) | (roc_9_1h < 20.0) | (roc_9_1d < 200.0))
             # 4h high, 4h & 1d overbought
-            & ((stochrsi_k_4h_lt_80) | (roc_9_4h < 30.0) | (roc_9_1d < 30.0))
+            & ((stochrsi_k_4h_lt_80) | (roc_9_4h_lt_30) | (roc_9_1d_lt_30))
             # 4h high, 1d downtrend
             & ((stochrsi_k_4h_lt_80) | roc_9_1d_gt_neg_50)
             # 4h high, 1h & 1d overbought
-            & ((stochrsi_k_4h_lt_90) | (roc_9_1h < 20.0) | (roc_9_1d < 20.0))
+            & ((stochrsi_k_4h_lt_90) | (roc_9_1h < 20.0) | (roc_9_1d_lt_20))
             # 4h high, 4h & 1d overbought
-            & ((stochrsi_k_4h_lt_90) | (roc_9_4h < 10.0) | (roc_9_1d < 10.0))
+            & ((stochrsi_k_4h_lt_90) | (roc_9_4h_lt_10) | (roc_9_1d < 10.0))
             # 1d hihg, 1h & 1d overbought
-            & ((stochrsi_k_1d < 90.0) | (roc_9_1h < 30.0) | (roc_9_1d_lt_100))
+            & ((stochrsi_k_1d_lt_90) | (roc_9_1h < 30.0) | (roc_9_1d_lt_100))
             # 1d P&D, dh downtrend
             & ((change_pct_1d > -50.0) | (change_pct_1d.shift(288) < 50.0) | (rsi_3_4h_gt_15))
             # big drop in the last 20 days, 1d high, 1d downtrend
@@ -15911,7 +15963,7 @@ class NostalgiaForInfinityX7(IStrategy):
             & (rsi_3 < 46.0)
             & (aroonu_14 < 25.0)
             & (stochrsi_k < 20.0)
-            & (aroonu_14_15m < 50.0)
+            & (aroonu_14_15m_lt_50)
             & (close < sma_16 * 0.960)
           )
 
@@ -15925,69 +15977,69 @@ class NostalgiaForInfinityX7(IStrategy):
             # 5m down move, 4h high, 1h overbought
             ((rsi_3 > 10.0) | aroonu_14_4h_lt_100 | (roc_9_1h < 30.0))
             # 15m down move, 1h & 4h overbought
-            & ((rsi_3_15m > 5.0) | (roc_9_1h < 25.0) | (roc_9_4h < 50.0))
+            & ((rsi_3_15m_gt_5) | (roc_9_1h < 25.0) | (roc_9_4h < 50.0))
             # 15m & 1h down move, 1d overbought
-            & ((rsi_3_15m > 10.0) | rsi_3_1h_gt_20 | (roc_9_1d < 80.0))
+            & ((rsi_3_15m_gt_10) | rsi_3_1h_gt_20 | (roc_9_1d_lt_80))
             # 15m & 1h down move, 1h high
-            & ((rsi_3_15m > 10.0) | (rsi_3_1h > 35.0) | aroonu_14_1h_lt_80)
+            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_35) | aroonu_14_1h_lt_80)
             # 15m & 1h down move, 1h high
-            & ((rsi_3_15m > 10.0) | (rsi_3_1h > 35.0) | (stochrsi_k_1h_lt_80))
+            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_35) | (stochrsi_k_1h_lt_80))
             # 15m & 1h down move, 4h overbought
-            & ((rsi_3_15m > 10.0) | (rsi_3_1h > 45.0) | (roc_9_4h < 50.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_45) | (roc_9_4h < 50.0))
             # 15m & 1h down move, 4h overbought
-            & ((rsi_3_15m > 10.0) | (rsi_3_1h > 60.0) | (roc_9_4h < 70.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_1h > 60.0) | (roc_9_4h < 70.0))
             # 15m & 4h down move, 4h high
-            & ((rsi_3_15m > 10.0) | (rsi_3_4h > 55.0) | (aroonu_14_4h < 90.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_4h > 55.0) | (aroonu_14_4h_lt_90))
             # 15m down move, 4h high & overbought
-            & ((rsi_3_15m > 10.0) | aroonu_14_4h_lt_100 | (roc_9_4h < 80.0))
+            & ((rsi_3_15m_gt_10) | aroonu_14_4h_lt_100 | (roc_9_4h < 80.0))
             # 15m down move, 1h high, 1d downtrend
-            & ((rsi_3_15m > 10.0) | (stochrsi_k_1h_lt_70) | roc_9_1d_gt_neg_50)
+            & ((rsi_3_15m_gt_10) | (stochrsi_k_1h_lt_70) | roc_9_1d_gt_neg_50)
             # 15m down move, 4h high & overbought
-            & ((rsi_3_15m > 10.0) | (stochrsi_k_4h_lt_80) | (roc_9_4h < 30.0))
+            & ((rsi_3_15m_gt_10) | (stochrsi_k_4h_lt_80) | (roc_9_4h_lt_30))
             # 15m down move, 1d high, 1d downtrend
-            & ((rsi_3_15m > 10.0) | (stochrsi_k_1d < 70.0) | (roc_9_1d > -15.0))
+            & ((rsi_3_15m_gt_10) | (stochrsi_k_1d < 70.0) | (roc_9_1d > -15.0))
             # 15m & 1h down move, 4h overbought
-            & ((rsi_3_15m > 15.0) | (rsi_3_1h > 35.0) | (roc_9_4h < 100.0))
+            & ((rsi_3_15m_gt_15) | (rsi_3_1h_gt_35) | (roc_9_4h < 100.0))
             # 15m & 1d down move, 1h high
-            & ((rsi_3_15m > 15.0) | (rsi_3_1d > 35.0) | (aroonu_14_1h < 90.0))
+            & ((rsi_3_15m_gt_15) | (rsi_3_1d > 35.0) | (aroonu_14_1h_lt_90))
             # 15m down move, 15m still high, 4h high
-            & ((rsi_3_15m > 15.0) | (aroonu_14_15m < 40.0) | aroonu_14_4h_lt_100)
+            & ((rsi_3_15m_gt_15) | (aroonu_14_15m < 40.0) | aroonu_14_4h_lt_100)
             # 15m down move, 1h & 4h high
-            & ((rsi_3_15m > 15.0) | (aroonu_14_1h < 40.0) | aroonu_14_4h_lt_100)
+            & ((rsi_3_15m_gt_15) | (aroonu_14_1h < 40.0) | aroonu_14_4h_lt_100)
             # 15m down move, 1h high, 4h overbought
-            & ((rsi_3_15m > 15.0) | (aroonu_14_1h < 60.0) | (roc_9_4h < 80.0))
+            & ((rsi_3_15m_gt_15) | (aroonu_14_1h < 60.0) | (roc_9_4h < 80.0))
             # 15m down move, 4h high, 4h downtrend
-            & ((rsi_3_15m > 15.0) | (aroonu_14_4h < 90.0) | (cmf_20_4h > -0.25))
+            & ((rsi_3_15m_gt_15) | (aroonu_14_4h_lt_90) | (cmf_20_4h > -0.25))
             # 15m down move, 1h & 4h high
-            & ((rsi_3_15m > 15.0) | (roc_9_1h < 30.0) | (roc_9_4h < 50.0))
+            & ((rsi_3_15m_gt_15) | (roc_9_1h < 30.0) | (roc_9_4h < 50.0))
             # 15m down move, 4h & 1d overbought
-            & ((rsi_3_15m > 15.0) | (roc_9_4h < 60.0) | (roc_9_1d < 80.0))
+            & ((rsi_3_15m_gt_15) | (roc_9_4h < 60.0) | (roc_9_1d_lt_80))
             # 15m down move, 1h & 4h high
-            & ((rsi_3_15m > 20.0) | (aroonu_14_1h < 60.0) | aroonu_14_4h_lt_100)
+            & ((rsi_3_15m_gt_20) | (aroonu_14_1h < 60.0) | aroonu_14_4h_lt_100)
             # 15m down move, 4h high, 1h overbought
-            & ((rsi_3_15m > 20.0) | (stochrsi_k_4h_lt_80) | (roc_9_1h < 10.0))
+            & ((rsi_3_15m_gt_20) | (stochrsi_k_4h_lt_80) | (roc_9_1h_lt_10))
             # 15m down move, 4h & 1d overbought
-            & ((rsi_3_15m > 20.0) | (roc_9_4h < 80.0) | (roc_9_1d < 200.0))
+            & ((rsi_3_15m_gt_20) | (roc_9_4h < 80.0) | (roc_9_1d < 200.0))
             # 15m & 1h down move, 1d overbought
-            & ((rsi_3_15m > 25.0) | (rsi_3_1h > 25.0) | (roc_9_1d < 80.0))
+            & ((rsi_3_15m_gt_25) | (rsi_3_1h_gt_25) | (roc_9_1d_lt_80))
             # 15m & 1h down move, 1h high
-            & ((rsi_3_15m > 25.0) | (rsi_3_1h > 55.0) | (aroonu_14_1h < 90.0))
+            & ((rsi_3_15m_gt_25) | (rsi_3_1h > 55.0) | (aroonu_14_1h_lt_90))
             # 15m down move, 15m still high, 1d downtrend
-            & ((rsi_3_15m > 25.0) | (aroonu_14_15m < 40.0) | (roc_9_1d > -25.0))
+            & ((rsi_3_15m_gt_25) | (aroonu_14_15m < 40.0) | (roc_9_1d > -25.0))
             # 15m down move, 1h & 4h high
-            & ((rsi_3_15m > 25.0) | (aroonu_14_1h < 90.0) | aroonu_14_4h_lt_100)
+            & ((rsi_3_15m_gt_25) | (aroonu_14_1h_lt_90) | aroonu_14_4h_lt_100)
             # 15m down move, 4h high, 1h overbought
-            & ((rsi_3_15m > 25.0) | aroonu_14_4h_lt_100 | (roc_9_1h < 20.0))
+            & ((rsi_3_15m_gt_25) | aroonu_14_4h_lt_100 | (roc_9_1h < 20.0))
             # 15m down move, 4h high, 1d overbought
-            & ((rsi_3_15m > 25.0) | aroonu_14_4h_lt_100 | (roc_9_1d < 100.0))
+            & ((rsi_3_15m_gt_25) | aroonu_14_4h_lt_100 | (roc_9_1d < 100.0))
             # 15m down move, 1h high & overbought
-            & ((rsi_3_15m > 25.0) | (stochrsi_k_1h < 90.0) | (roc_9_1h < 20.0))
+            & ((rsi_3_15m_gt_25) | (stochrsi_k_1h < 90.0) | (roc_9_1h < 20.0))
             # 15m down move, 1h & 4h overbought
-            & ((rsi_3_15m > 25.0) | (roc_9_1h < 40.0) | (roc_9_4h < 40.0))
+            & ((rsi_3_15m_gt_25) | (roc_9_1h < 40.0) | (roc_9_4h_lt_40))
             # 15m down move, 4h high & overbought
-            & ((rsi_3_15m > 30.0) | (stochrsi_k_4h_lt_90) | (roc_9_4h < 200.0))
+            & ((rsi_3_15m_gt_30) | (stochrsi_k_4h_lt_90) | (roc_9_4h < 200.0))
             # 15m down move, 1h & 4h overbought
-            & ((rsi_3_15m > 30.0) | (roc_9_1h < 60.0) | (roc_9_4h < 80.0))
+            & ((rsi_3_15m_gt_30) | (roc_9_1h < 60.0) | (roc_9_4h < 80.0))
             # 15m down move, 4h & 1d overbought
             & ((rsi_3_15m > 40.0) | (roc_9_4h < 100.0) | (roc_9_1d_lt_100))
             # 1h down move, 4h overbought, 1d downtrend
@@ -15997,63 +16049,63 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 1h still high
             & (rsi_3_1h_gt_20 | (roc_9_4h < 50.0) | (stochrsi_k_1h < 40.0))
             # 1h & 4h down move, 4h overbought
-            & (rsi_3_1h_gt_20 | (roc_9_4h < 50.0) | (roc_9_4h < 10.0))
+            & (rsi_3_1h_gt_20 | (roc_9_4h < 50.0) | (roc_9_4h_lt_10))
             # 1h down move, 1h & 4h high
             & (rsi_3_1h_gt_20 | aroonu_14_1h_lt_80 | aroonu_14_4h_lt_100)
             # 1h down move, 4h high & overbought
-            & (rsi_3_1h_gt_20 | aroonu_14_4h_lt_80 | (roc_9_4h < 10.0))
+            & (rsi_3_1h_gt_20 | aroonu_14_4h_lt_80 | (roc_9_4h_lt_10))
             # 1h down move, 4h high & overbought
             & (rsi_3_1h_gt_20 | aroonu_14_4h_lt_100 | (roc_9_4h < 50.0))
             # 1h down move, 1h still high, 1d overbought
-            & (rsi_3_1h_gt_20 | (stochrsi_k_1h < 40.0) | (roc_9_4h < 10.0))
+            & (rsi_3_1h_gt_20 | (stochrsi_k_1h < 40.0) | (roc_9_4h_lt_10))
             # 1h down move, 4h & 1d overbought
-            & (rsi_3_1h_gt_20 | (roc_9_4h < 40.0) | (roc_9_1d_lt_100))
+            & (rsi_3_1h_gt_20 | (roc_9_4h_lt_40) | (roc_9_1d_lt_100))
             # 1h down move, 1d high, 4h overbought
-            & ((rsi_3_1h > 25.0) | aroonu_14_1d_lt_100 | (roc_9_4h < 60.0))
+            & ((rsi_3_1h_gt_25) | aroonu_14_1d_lt_100 | (roc_9_4h < 60.0))
             # 1h down move, 4h high & overbought
-            & ((rsi_3_1h > 30.0) | aroonu_14_4h_lt_80 | (roc_9_4h < 30.0))
+            & ((rsi_3_1h_gt_30) | aroonu_14_4h_lt_80 | (roc_9_4h_lt_30))
             # 1h down move, 1h high, 1d downtrend
-            & ((rsi_3_1h > 35.0) | aroonu_14_1h_lt_80 | (roc_9_1d > -40.0))
+            & ((rsi_3_1h_gt_35) | aroonu_14_1h_lt_80 | (roc_9_1d_gt_neg_40))
             # 1h down move, 4h high, 1d downtrend
-            & ((rsi_3_1h > 35.0) | (stochrsi_k_4h_lt_80) | roc_9_1d_gt_neg_50)
+            & ((rsi_3_1h_gt_35) | (stochrsi_k_4h_lt_80) | roc_9_1d_gt_neg_50)
             # 1h down move, 1h & 1d overbought
-            & ((rsi_3_1h > 40.0) | (roc_9_1h < 30.0) | (roc_9_1d < 60.0))
+            & ((rsi_3_1h_gt_40) | (roc_9_1h < 30.0) | (roc_9_1d < 60.0))
             # 1h down move, 1h high, 4h overbought
-            & ((rsi_3_1h > 45.0) | aroonu_14_1h_lt_80 | (roc_9_4h < 25.0))
+            & ((rsi_3_1h_gt_45) | aroonu_14_1h_lt_80 | (roc_9_4h < 25.0))
             # 1h down move, 4h high, 1h overbought
-            & ((rsi_3_1h > 45.0) | (aroonu_14_4h < 90.0) | (roc_9_1h < 20.0))
+            & ((rsi_3_1h_gt_45) | (aroonu_14_4h_lt_90) | (roc_9_1h < 20.0))
             # 1h down move, 4h high, 1h overbought
-            & ((rsi_3_1h > 45.0) | aroonu_14_4h_lt_100 | (roc_9_1h < 10.0))
+            & ((rsi_3_1h_gt_45) | aroonu_14_4h_lt_100 | (roc_9_1h_lt_10))
             # 1h down move, 1d high, 1d downtrend
-            & ((rsi_3_1h > 45.0) | aroonu_14_1d_lt_100 | (roc_9_1d > -25.0))
+            & ((rsi_3_1h_gt_45) | aroonu_14_1d_lt_100 | (roc_9_1d > -25.0))
             # 1h down move, 1h high & overbought
-            & ((rsi_3_1h > 50.0) | (aroonu_14_1h < 90.0) | (roc_9_1h < 10.0))
+            & ((rsi_3_1h_gt_50) | (aroonu_14_1h_lt_90) | (roc_9_1h_lt_10))
             # 1h down move, 1h high, 1d downtrend
-            & ((rsi_3_1h > 50.0) | (stochrsi_k_1h < 70.0) | (roc_9_1d_gt_neg_20))
+            & ((rsi_3_1h_gt_50) | (stochrsi_k_1h < 70.0) | (roc_9_1d_gt_neg_20))
             # 1h down move, 1h & 1d overbought
-            & ((rsi_3_1h > 50.0) | (roc_9_1h < 25.0) | (roc_9_1d < 200.0))
+            & ((rsi_3_1h_gt_50) | (roc_9_1h < 25.0) | (roc_9_1d < 200.0))
             # 1h down move, 1h high, 4h overbought
-            & ((rsi_3_1h > 55.0) | aroonu_14_1h_lt_70 | (roc_9_4h < 40.0))
+            & ((rsi_3_1h > 55.0) | aroonu_14_1h_lt_70 | (roc_9_4h_lt_40))
             # 1h down move, 4h high & overbought
             & ((rsi_3_1h > 55.0) | (aroonu_14_4h < 85.0) | (roc_9_4h < 80.0))
             # 1h down move, 4h high & overbought
             & ((rsi_3_1h > 60.0) | aroonu_14_4h_lt_80 | (roc_9_4h < 100.0))
             # 1h down move, 1h & 1d overbought
-            & ((rsi_3_1h > 60.0) | (roc_9_1h < 10.0) | (roc_9_1d < 250.0))
+            & ((rsi_3_1h > 60.0) | (roc_9_1h_lt_10) | (roc_9_1d < 250.0))
             # 1h down move, 1h high, 4h overbought
-            & ((rsi_3_1h > 65.0) | aroonu_14_1h_lt_80 | (roc_9_4h < 30.0))
+            & ((rsi_3_1h > 65.0) | aroonu_14_1h_lt_80 | (roc_9_4h_lt_30))
             # 1h down move, 1h overbought
             & ((rsi_3_1h > 65.0) | (roc_9_1h < 40.0))
             # 4h down move, 1h high & overbought
             & ((rsi_3_4h > 3.0) | (aroonu_14_1h < 85.0) | (roc_9_1h < 60.0))
             # 1d down move, 4h high & overbought
-            & ((rsi_3_1d > 5.0) | (aroonu_14_4h < 90.0) | (roc_9_4h < 50.0))
+            & ((rsi_3_1d > 5.0) | (aroonu_14_4h_lt_90) | (roc_9_4h < 50.0))
             # 1d down move, 1h high
-            & ((rsi_3_1d > 10.0) | aroonu_14_1h_lt_70)
+            & ((rsi_3_1d_gt_10) | aroonu_14_1h_lt_70)
             # 1d down move, 4h high, 1h overbought
-            & ((rsi_3_1d > 20.0) | aroonu_14_4h_lt_100 | (roc_9_1h < 25.0))
+            & ((rsi_3_1d_gt_20) | aroonu_14_4h_lt_100 | (roc_9_1h < 25.0))
             # 1d down move, 4h high, 4h overbought
-            & ((rsi_3_1d > 20.0) | aroonu_14_4h_lt_100 | (roc_9_4h < 40.0))
+            & ((rsi_3_1d_gt_20) | aroonu_14_4h_lt_100 | (roc_9_4h_lt_40))
             # 1d down move, 1h & 4h overbought
             & ((rsi_3_1d > 30.0) | (roc_9_1h < 30.0) | (roc_9_4h < 60.0))
             # 1d down move, 4h high & overbought
@@ -16063,82 +16115,82 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1d down move, 4h & 1d high
             & ((rsi_3_1d > 40.0) | aroonu_14_4h_lt_70 | aroonu_14_1d_lt_100)
             # 1d down move, 4h high & overbought
-            & ((rsi_3_1d > 45.0) | aroonu_14_4h_lt_80 | (roc_9_4h < 30.0))
+            & ((rsi_3_1d > 45.0) | aroonu_14_4h_lt_80 | (roc_9_4h_lt_30))
             # 1d down move, 1h high, 1d overbought
-            & ((rsi_3_1d > 60.0) | (aroonu_14_1h < 75.0) | (roc_9_1d < 20.0))
+            & ((rsi_3_1d > 60.0) | (aroonu_14_1h < 75.0) | (roc_9_1d_lt_20))
             # 1d down move, 1h & 4h high
-            & ((rsi_3_1d > 65.0) | (aroonu_14_1h < 90.0) | aroonu_14_4h_lt_100)
+            & ((rsi_3_1d > 65.0) | (aroonu_14_1h_lt_90) | aroonu_14_4h_lt_100)
             # 1d downtrend, 1d high & overbought
-            & ((cmf_20_1d > -0.40) | (aroonu_14_1d < 85.0) | (roc_9_1d < 20.0))
+            & ((cmf_20_1d > -0.40) | (aroonu_14_1d < 85.0) | (roc_9_1d_lt_20))
             # 15m not low enough, 1h high, 1d overbought
             & ((aroonu_14_15m < 25.0) | (stochrsi_k_1h < 90.0) | (roc_9_1d < 200.0))
             # 1h still high, 1h & 4h overbought
-            & ((aroonu_14_1h < 50.0) | (roc_9_1h < 40.0) | (roc_9_4h < 40.0))
+            & ((aroonu_14_1h_lt_50) | (roc_9_1h < 40.0) | (roc_9_4h_lt_40))
             # 1h & 4h high, 4h overbought
             & (aroonu_14_1h_lt_70 | aroonu_14_4h_lt_100 | (roc_9_4h < 20.0))
             # 1h & 4h high, 4h overbought
-            & (aroonu_14_1h_lt_80 | aroonu_14_4h_lt_80 | (roc_9_4h < 30.0))
+            & (aroonu_14_1h_lt_80 | aroonu_14_4h_lt_80 | (roc_9_4h_lt_30))
             # 1h & 4h high, 1h overbought
-            & (aroonu_14_1h_lt_80 | (aroonu_14_4h < 90.0) | (roc_9_1h < 30.0))
+            & (aroonu_14_1h_lt_80 | (aroonu_14_4h_lt_90) | (roc_9_1h < 30.0))
             # 1h & 4h high, 1d overbought
-            & (aroonu_14_1h_lt_80 | (aroonu_14_4h < 90.0) | (roc_9_1d < 100.0))
+            & (aroonu_14_1h_lt_80 | (aroonu_14_4h_lt_90) | (roc_9_1d < 100.0))
             # 1h & 1d high, 4h overbought
-            & ((aroonu_14_1h < 90.0) | (aroonu_14_1d < 90.0) | (roc_9_4h < 30.0))
+            & ((aroonu_14_1h_lt_90) | (aroonu_14_1d_lt_90) | (roc_9_4h_lt_30))
             # 1h & 4h high, 1h overbought
-            & (aroonu_14_1h_lt_80 | (stochrsi_k_4h < 90.0) | (roc_9_1h < 10.0))
+            & (aroonu_14_1h_lt_80 | (stochrsi_k_4h < 90.0) | (roc_9_1h_lt_10))
             # 1h high & overbought
             & (aroonu_14_1h_lt_80 | (roc_9_1h < 80.0))
             # 1h high, 1h & 4h overbought
-            & (aroonu_14_1h_lt_80 | (roc_9_1h < 10.0) | (roc_9_4h < 10.0))
+            & (aroonu_14_1h_lt_80 | (roc_9_1h_lt_10) | (roc_9_4h_lt_10))
             # 1h high, 4h overbought, 1d downtrend
-            & (aroonu_14_1h_lt_80 | (roc_9_4h < 10.0) | roc_9_1d_gt_neg_50)
+            & (aroonu_14_1h_lt_80 | (roc_9_4h_lt_10) | roc_9_1d_gt_neg_50)
             # 1h & 4h high, 15m downtrend
             & ((aroonu_14_1h < 85.0) | (aroonu_14_4h < 85.0) | (roc_9_15m > -40.0))
             # 1h & 4h high, 1h overbought
-            & ((aroonu_14_1h < 90.0) | (aroonu_14_4h < 90.0) | (roc_9_1h < 10.0))
+            & ((aroonu_14_1h_lt_90) | (aroonu_14_4h_lt_90) | (roc_9_1h_lt_10))
             # 4h high, 1h overbought, 1d downtrend
             & (aroonu_14_4h_lt_80 | (roc_9_1h < 30.0) | (roc_9_1d > -30.0))
             # 4h & 1d high, 4h downtrend
             & ((aroonu_14_4h < 85.0) | aroonu_14_1d_lt_100 | (cmf_20_4h > -0.30))
             # 4h & 1d high, 1h overbought
-            & ((aroonu_14_4h < 85.0) | (aroonu_14_1d < 90.0) | (roc_9_1h < 20.0))
+            & ((aroonu_14_4h < 85.0) | (aroonu_14_1d_lt_90) | (roc_9_1h < 20.0))
             # 4h & 1d high, 4h overbought
-            & ((aroonu_14_4h < 85.0) | (aroonu_14_1d < 90.0) | (roc_9_4h < 60.0))
+            & ((aroonu_14_4h < 85.0) | (aroonu_14_1d_lt_90) | (roc_9_4h < 60.0))
             # 4h high, 1h & 4h overbought
-            & ((aroonu_14_4h < 85.0) | (roc_9_1h < 10.0) | (roc_9_4h_lt_20))
+            & ((aroonu_14_4h < 85.0) | (roc_9_1h_lt_10) | (roc_9_4h_lt_20))
             # 4h high, 1d high & overbought
-            & ((aroonu_14_4h < 90.0) | aroonu_14_1d_lt_100 | (roc_9_1d < 30.0))
+            & ((aroonu_14_4h_lt_90) | aroonu_14_1d_lt_100 | (roc_9_1d_lt_30))
             # 4h high, 1h & 4h overbought
-            & ((aroonu_14_4h < 90.0) | (roc_9_1h < 40.0) | (roc_9_4h < 40.0))
+            & ((aroonu_14_4h_lt_90) | (roc_9_1h < 40.0) | (roc_9_4h_lt_40))
             # 4h high, 4h & 1d overbought
-            & ((aroonu_14_4h < 90.0) | (roc_9_4h < 30.0) | (roc_9_1d_lt_100))
+            & ((aroonu_14_4h_lt_90) | (roc_9_4h_lt_30) | (roc_9_1d_lt_100))
             # 4h high, 1h & 4h overbought
             & (aroonu_14_4h_lt_100 | (roc_9_1h < 40.0) | (roc_9_4h < 80.0))
             # 1d high, 1h & 4h overbought
-            & (aroonu_14_1d_lt_100 | (roc_9_1h < 10.0) | (roc_9_4h < 20.0))
+            & (aroonu_14_1d_lt_100 | (roc_9_1h_lt_10) | (roc_9_4h < 20.0))
             # 1h high, 1h & 4h overbought
-            & ((stochrsi_k_1h < 60.0) | (roc_9_1h < 40.0) | (roc_9_4h < 40.0))
+            & ((stochrsi_k_1h < 60.0) | (roc_9_1h < 40.0) | (roc_9_4h_lt_40))
             # 1h high, 1h overbought
-            & ((stochrsi_k_1h_lt_80) | (roc_9_1h < 10.0))
+            & ((stochrsi_k_1h_lt_80) | (roc_9_1h_lt_10))
             # 1h high, 4h overbought. 1d downtrend
-            & ((stochrsi_k_1h_lt_80) | (roc_9_4h < 40.0) | (cmf_20_1d > -0.25))
+            & ((stochrsi_k_1h_lt_80) | (roc_9_4h_lt_40) | (cmf_20_1d > -0.25))
             # 4h high, 1h & 4h overbought
-            & ((stochrsi_k_4h < 90.0) | (roc_9_1h < 10.0) | (roc_9_4h_lt_20))
+            & ((stochrsi_k_4h < 90.0) | (roc_9_1h_lt_10) | (roc_9_4h_lt_20))
             # 4h high & 4h & 1d overbought
-            & ((stochrsi_k_4h < 90.0) | (roc_9_4h_lt_20) | (roc_9_1d < 20.0))
+            & ((stochrsi_k_4h < 90.0) | (roc_9_4h_lt_20) | (roc_9_1d_lt_20))
             # 1d high, 1h & 4h overbought
-            & ((stochrsi_k_1d < 80.0) | (roc_9_1h < 10.0) | (roc_9_4h_lt_20))
+            & ((stochrsi_k_1d < 80.0) | (roc_9_1h_lt_10) | (roc_9_4h_lt_20))
             # 1d hihg, 1h & 1d overbought
-            & ((stochrsi_k_1d < 90.0) | (roc_9_1h < 30.0) | (roc_9_1d_lt_100))
+            & ((stochrsi_k_1d_lt_90) | (roc_9_1h < 30.0) | (roc_9_1d_lt_100))
             # 1d high, 4h & 1d overbought
-            & ((stochrsi_k_1d < 90.0) | (roc_9_4h < 40.0) | (roc_9_1d_lt_100))
+            & ((stochrsi_k_1d_lt_90) | (roc_9_4h_lt_40) | (roc_9_1d_lt_100))
           )
 
           # Logic
           long_entry_logic.append(
             (aroonu_14 < 25.0)
             & (stochrsi_k < 20.0)
-            & (aroonu_14_15m < 50.0)
+            & (aroonu_14_15m_lt_50)
             & (close < df["EMA_16"] * 0.960)
             & (((df["EMA_50"] - df["EMA_200"]) / close * 100.0) > 6.0)
           )
@@ -16151,11 +16203,11 @@ class NostalgiaForInfinityX7(IStrategy):
 
           long_entry_logic.append(
             # 5m & 1d down move, 4h still high
-            ((rsi_3 > 15.0) | (rsi_3_1d > 30.0) | (aroonu_14_4h < 40.0))
+            ((rsi_3 > 15.0) | (rsi_3_1d > 30.0) | (aroonu_14_4h_lt_40))
             # 15m & 1h down move, 1d still high
-            & (rsi_3_15m_gt_3 | (rsi_3_1h > 3.0) | (stochrsi_k_1d < 50.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_3) | (stochrsi_k_1d < 50.0))
             # 15m & 1h down move, 1h still not low enough
-            & (rsi_3_15m_gt_3 | (rsi_3_1h > 5.0) | (stochrsi_k_1h < 30.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_5) | (stochrsi_k_1h < 30.0))
             # 15m & 1h down move, 15m downtrend
             & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_10) | (cmf_20_15m > -0.40))
             # 15m & 1h down move, 4h high
@@ -16167,31 +16219,31 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 1d downtrend
             & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_15) | (roc_9_1d > -20.0))
             # 15m & 1h down move, 1h still high
-            & (rsi_3_15m_gt_3 | rsi_3_1h_gt_20 | (aroonu_14_1h < 50.0))
+            & (rsi_3_15m_gt_3 | rsi_3_1h_gt_20 | (aroonu_14_1h_lt_50))
             # 15m & 1h down move, 1h high
-            & (rsi_3_15m_gt_3 | (rsi_3_1h > 25.0) | (aroonu_14_1h < 60.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_25) | (aroonu_14_1h < 60.0))
             # 15m & 1h down move, 1d still high
-            & (rsi_3_15m_gt_3 | (rsi_3_1h > 30.0) | (aroonu_14_1d < 50.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_30) | (aroonu_14_1d < 50.0))
             # 15m & 1h down move, 1h high
-            & (rsi_3_15m_gt_3 | (rsi_3_1h > 30.0) | (stochrsi_k_1h_lt_70))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_30) | (stochrsi_k_1h_lt_70))
             # 15m & 1h down move, 1h still high
-            & (rsi_3_15m_gt_3 | (rsi_3_1h > 30.0) | (stochrsi_k_1h_lt_50))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_30) | (stochrsi_k_1h_lt_50))
             # 15m & 1h down move, 1d high
-            & (rsi_3_15m_gt_3 | (rsi_3_1h > 30.0) | (stochrsi_k_1d < 90.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_30) | (stochrsi_k_1d_lt_90))
             # 15m & 1h down move, 1h high
-            & (rsi_3_15m_gt_3 | (rsi_3_1h > 45.0) | (aroonu_14_1h < 85.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_45) | (aroonu_14_1h < 85.0))
             # 15m & 1h down move, 1h high
-            & (rsi_3_15m_gt_3 | (rsi_3_1h > 45.0) | (stochrsi_k_1h < 75.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_45) | (stochrsi_k_1h < 75.0))
             # 15m & 4h down move, 4h high
-            & (rsi_3_15m_gt_3 | (rsi_3_4h > 5.0) | aroonu_14_4h_lt_80)
+            & (rsi_3_15m_gt_3 | (rsi_3_4h_gt_5) | aroonu_14_4h_lt_80)
             # 15m & 4h down move, 4h still high
-            & (rsi_3_15m_gt_3 | (rsi_3_4h > 40.0) | (stochrsi_k_4h < 50.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_4h_gt_40) | (stochrsi_k_4h_lt_50))
             # 15m down move, 15m still high, 1d high
-            & (rsi_3_15m_gt_3 | (aroonu_14_15m < 40.0) | (aroonu_14_1d < 80.0))
+            & (rsi_3_15m_gt_3 | (aroonu_14_15m < 40.0) | (aroonu_14_1d_lt_80))
             # 15m down move, 15m still high, 1d downtrend
-            & (rsi_3_15m_gt_3 | (aroonu_14_15m < 50.0) | (roc_9_1d_gt_neg_20))
+            & (rsi_3_15m_gt_3 | (aroonu_14_15m_lt_50) | (roc_9_1d_gt_neg_20))
             # 15m down move, 1h still high, 1d high
-            & (rsi_3_15m_gt_3 | (aroonu_14_1h < 50.0) | (aroonu_14_1d < 70.0))
+            & (rsi_3_15m_gt_3 | (aroonu_14_1h_lt_50) | (aroonu_14_1d_lt_70))
             # 15m down move, 1h & 4h high
             & (rsi_3_15m_gt_3 | aroonu_14_1h_lt_80 | aroonu_14_4h_lt_80)
             # 15m down move, 4h & 1d high
@@ -16199,221 +16251,221 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 1h & 4h high
             & (rsi_3_15m_gt_3 | (stochrsi_k_1h_lt_80) | (stochrsi_k_4h_lt_80))
             # 15m down move, 1h high, 4h overbought
-            & (rsi_3_15m_gt_3 | (stochrsi_k_1h < 90.0) | (roc_9_4h < 10.0))
+            & (rsi_3_15m_gt_3 | (stochrsi_k_1h < 90.0) | (roc_9_4h_lt_10))
             # 15m down move, 4h high & overbought
-            & (rsi_3_15m_gt_3 | (stochrsi_k_4h_lt_80) | (roc_9_4h < 10.0))
+            & (rsi_3_15m_gt_3 | (stochrsi_k_4h_lt_80) | (roc_9_4h_lt_10))
             # 15m down move, 4h & 1d downtrend
             & (rsi_3_15m_gt_3 | (roc_9_4h_gt_neg_20) | (roc_9_1d_gt_neg_20))
             # 15m & 1h down move, 1d downtrend
-            & ((rsi_3_15m > 5.0) | (rsi_3_1h > 5.0) | (roc_9_1d > -10.0))
+            & ((rsi_3_15m_gt_5) | (rsi_3_1h_gt_5) | (roc_9_1d > -10.0))
             # 15m & 1h down move, 1d high
-            & ((rsi_3_15m > 5.0) | (rsi_3_1h_gt_10) | (aroonu_14_1d < 80.0))
+            & ((rsi_3_15m_gt_5) | (rsi_3_1h_gt_10) | (aroonu_14_1d_lt_80))
             # 15m & 1h down move, 4h high
-            & ((rsi_3_15m > 5.0) | (rsi_3_1h_gt_10) | (stochrsi_k_4h < 80.0))
+            & ((rsi_3_15m_gt_5) | (rsi_3_1h_gt_10) | (stochrsi_k_4h < 80.0))
             # 15m & 1h down move, 1h high
-            & ((rsi_3_15m > 5.0) | (rsi_3_1h > 30.0) | aroonu_14_1h_lt_70)
+            & ((rsi_3_15m_gt_5) | (rsi_3_1h_gt_30) | aroonu_14_1h_lt_70)
             # 15m & 1h down move, 4h high
-            & ((rsi_3_15m > 5.0) | (rsi_3_1h > 30.0) | aroonu_14_4h_lt_70)
+            & ((rsi_3_15m_gt_5) | (rsi_3_1h_gt_30) | aroonu_14_4h_lt_70)
             # 15m & 4h down move, 1h still high
-            & ((rsi_3_15m > 5.0) | (rsi_3_4h > 5.0) | (stochrsi_k_1h_lt_50))
+            & ((rsi_3_15m_gt_5) | (rsi_3_4h_gt_5) | (stochrsi_k_1h_lt_50))
             # 15m & 4h down move, 1d downtrend
-            & ((rsi_3_15m > 5.0) | (rsi_3_4h_gt_10) | (roc_9_1d > -20.0))
+            & ((rsi_3_15m_gt_5) | (rsi_3_4h_gt_10) | (roc_9_1d > -20.0))
             # 15m & 4h down move, 1h high
-            & ((rsi_3_15m > 5.0) | rsi_3_4h_gt_20 | (stochrsi_k_1h_lt_80))
+            & ((rsi_3_15m_gt_5) | rsi_3_4h_gt_20 | (stochrsi_k_1h_lt_80))
             # 15m & 4h down move, 1d downtrend
-            & ((rsi_3_15m > 5.0) | (rsi_3_4h > 25.0) | (roc_9_1d > -70.0))
+            & ((rsi_3_15m_gt_5) | (rsi_3_4h_gt_25) | (roc_9_1d > -70.0))
             # 15m down move, 1h & 4h high
-            & ((rsi_3_15m > 5.0) | (aroonu_14_1h < 100.0) | aroonu_14_4h_lt_100)
+            & ((rsi_3_15m_gt_5) | (aroonu_14_1h_lt_100) | aroonu_14_4h_lt_100)
             # 15m down move, 1h still high, 1d downtrend
-            & ((rsi_3_15m > 5.0) | (stochrsi_k_1h_lt_50) | (roc_9_1d > -40.0))
+            & ((rsi_3_15m_gt_5) | (stochrsi_k_1h_lt_50) | (roc_9_1d_gt_neg_40))
             # 5m down move, 4h high, 1d downtrend
-            & ((rsi_3_15m > 5.0) | (stochrsi_k_4h_lt_80) | (roc_9_1d > -40.0))
+            & ((rsi_3_15m_gt_5) | (stochrsi_k_4h_lt_80) | (roc_9_1d_gt_neg_40))
             # 15m down move, 1h & 4h overbought
-            & ((rsi_3_15m > 5.0) | (roc_9_1h < 25.0) | (roc_9_4h < 25.0))
+            & ((rsi_3_15m_gt_5) | (roc_9_1h < 25.0) | (roc_9_4h < 25.0))
             # 15m down move, 4h & 1d overbought
-            & ((rsi_3_15m > 5.0) | (roc_9_4h < 30.0) | (roc_9_1d_lt_100))
+            & ((rsi_3_15m_gt_5) | (roc_9_4h_lt_30) | (roc_9_1d_lt_100))
             # 15m & 1h down move, 1h high
-            & ((rsi_3_15m > 10.0) | (rsi_3_1h_gt_10) | (aroonu_14_1h < 70.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_10) | (aroonu_14_1h < 70.0))
             # 15m & 1h down move, 1d high
-            & ((rsi_3_15m > 10.0) | (rsi_3_1h_gt_10) | (stochrsi_k_1d < 70.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_10) | (stochrsi_k_1d < 70.0))
             # 15m & 1h down move, 1d downtrend
-            & ((rsi_3_15m > 10.0) | (rsi_3_1h_gt_10) | (roc_9_1d > -30.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_10) | (roc_9_1d > -30.0))
             # 15m & 1h down move, 1h high
-            & ((rsi_3_15m > 10.0) | (rsi_3_1h_gt_15) | (aroonu_14_1h < 80.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_15) | (aroonu_14_1h < 80.0))
             # 15m & 1h down move, 4h high
-            & ((rsi_3_15m > 10.0) | (rsi_3_1h_gt_15) | (aroonu_14_4h < 100.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_15) | (aroonu_14_4h < 100.0))
             # 15m & 1h down move, 4h high
-            & ((rsi_3_15m > 10.0) | (rsi_3_1h_gt_15) | (stochrsi_k_4h < 70.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_15) | (stochrsi_k_4h_lt_70))
             # 15m & 1h down move, 1h still high
-            & ((rsi_3_15m > 10.0) | rsi_3_1h_gt_20 | (stochrsi_k_1h_lt_50))
+            & ((rsi_3_15m_gt_10) | rsi_3_1h_gt_20 | (stochrsi_k_1h_lt_50))
             # 15m & 1h down move, 1d overbought
-            & ((rsi_3_15m > 10.0) | (rsi_3_1h > 25.0) | (roc_9_1d < 20.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_25) | (roc_9_1d_lt_20))
             # 15m & 1h down move, 1d overbought
-            & ((rsi_3_15m > 10.0) | (rsi_3_1h > 30.0) | (roc_9_1d < 30.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_30) | (roc_9_1d_lt_30))
             # 15m & 1h down move, 1h high
-            & ((rsi_3_15m > 10.0) | (rsi_3_1h > 40.0) | (aroonu_14_1h < 90.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_40) | (aroonu_14_1h_lt_90))
             # 15m & 1d down move, 4h high
-            & ((rsi_3_15m > 10.0) | (rsi_3_1d > 25.0) | aroonu_14_4h_lt_100)
+            & ((rsi_3_15m_gt_10) | (rsi_3_1d_gt_25) | aroonu_14_4h_lt_100)
             # 15m & 1d down move, 4h high
-            & ((rsi_3_15m > 10.0) | (rsi_3_1d > 25.0) | (stochrsi_k_4h_lt_80))
+            & ((rsi_3_15m_gt_10) | (rsi_3_1d_gt_25) | (stochrsi_k_4h_lt_80))
             # 15m down move, 15m still high, 1d overbought
-            & ((rsi_3_15m > 10.0) | (aroonu_14_15m < 50.0) | (roc_9_1d < 30.0))
+            & ((rsi_3_15m_gt_10) | (aroonu_14_15m_lt_50) | (roc_9_1d_lt_30))
             # 15m down move, 15m high
-            & ((rsi_3_15m > 10.0) | (aroonu_14_15m < 70.0))
+            & ((rsi_3_15m_gt_10) | (aroonu_14_15m_lt_70))
             # 15m down move, 1h high, 15m downtrend
-            & ((rsi_3_15m > 10.0) | aroonu_14_1h_lt_80 | (roc_9_15m > -10.0))
+            & ((rsi_3_15m_gt_10) | aroonu_14_1h_lt_80 | (roc_9_15m > -10.0))
             # 15m down move, 1h high, 1d downtrend
-            & ((rsi_3_15m > 10.0) | aroonu_14_1h_lt_80 | (roc_9_1d > -30.0))
+            & ((rsi_3_15m_gt_10) | aroonu_14_1h_lt_80 | (roc_9_1d > -30.0))
             # 15m down move, 1h high, 1d overbought
-            & ((rsi_3_15m > 10.0) | (aroonu_14_1h < 85.0) | (roc_9_1d < 40.0))
+            & ((rsi_3_15m_gt_10) | (aroonu_14_1h < 85.0) | (roc_9_1d_lt_40))
             # 15m down move, 1h & 1d high
-            & ((rsi_3_15m > 10.0) | (aroonu_14_1h < 90.0) | aroonu_14_1d_lt_100)
+            & ((rsi_3_15m_gt_10) | (aroonu_14_1h_lt_90) | aroonu_14_1d_lt_100)
             # 15m down move, 1h & 4h high
-            & ((rsi_3_15m > 10.0) | (aroonu_14_1h < 100.0) | aroonu_14_4h_lt_100)
+            & ((rsi_3_15m_gt_10) | (aroonu_14_1h_lt_100) | aroonu_14_4h_lt_100)
             # 15m down move, 4h high, 1h downtrend
-            & ((rsi_3_15m > 10.0) | (aroonu_14_4h < 85.0) | (roc_9_1h > -25.0))
+            & ((rsi_3_15m_gt_10) | (aroonu_14_4h < 85.0) | (roc_9_1h > -25.0))
             # 15m down move, 4h & 1d high
-            & ((rsi_3_15m > 10.0) | (aroonu_14_4h < 90.0) | aroonu_14_1d_lt_100)
+            & ((rsi_3_15m_gt_10) | (aroonu_14_4h_lt_90) | aroonu_14_1d_lt_100)
             # 15m down move, 4h high, 15m downtrend
-            & ((rsi_3_15m > 10.0) | (aroonu_14_4h < 100.00) | (roc_9_15m > -30.0))
+            & ((rsi_3_15m_gt_10) | (aroonu_14_4h < 100.00) | (roc_9_15m > -30.0))
             # 15m down move, 1h high & overbought
-            & ((rsi_3_15m > 10.0) | aroonu_14_1d_lt_100 | (roc_9_1d < 60.0))
+            & ((rsi_3_15m_gt_10) | aroonu_14_1d_lt_100 | (roc_9_1d < 60.0))
             # 15m down move, 1d high, 1d downtrend
-            & ((rsi_3_15m > 10.0) | (aroonu_14_1d < 85.0) | (cmf_20_1d > -0.40))
+            & ((rsi_3_15m_gt_10) | (aroonu_14_1d < 85.0) | (cmf_20_1d > -0.40))
             # 15m down move, 1h high, 15m downtrend
-            & ((rsi_3_15m > 10.0) | (stochrsi_k_1h_lt_80) | (roc_9_15m > -10.0))
+            & ((rsi_3_15m_gt_10) | (stochrsi_k_1h_lt_80) | (roc_9_15m > -10.0))
             # 15m down move, 1h high, 1d downtrend
-            & ((rsi_3_15m > 10.0) | (stochrsi_k_1h < 90.0) | (roc_9_1d_gt_neg_30))
+            & ((rsi_3_15m_gt_10) | (stochrsi_k_1h < 90.0) | (roc_9_1d_gt_neg_30))
             # 15m down move, 1h high, 1d overbought
-            & ((rsi_3_15m > 10.0) | (stochrsi_k_1h < 90.0) | (roc_9_1d < 30.0))
+            & ((rsi_3_15m_gt_10) | (stochrsi_k_1h < 90.0) | (roc_9_1d_lt_30))
             # 15m down move, 4h high & overbought
-            & ((rsi_3_15m > 10.0) | (stochrsi_k_4h < 90.0) | (roc_9_4h_lt_20))
+            & ((rsi_3_15m_gt_10) | (stochrsi_k_4h < 90.0) | (roc_9_4h_lt_20))
             # 15m & 1h down move, 1d overbought
-            & ((rsi_3_15m > 15.0) | (rsi_3_1h_gt_15) | (roc_9_1d < 30.0))
+            & ((rsi_3_15m_gt_15) | (rsi_3_1h_gt_15) | (roc_9_1d_lt_30))
             # 15m & 1h down move, 1d high
-            & ((rsi_3_15m > 15.0) | rsi_3_1h_gt_20 | (aroonu_14_1d < 90.0))
+            & ((rsi_3_15m_gt_15) | rsi_3_1h_gt_20 | (aroonu_14_1d_lt_90))
             # 15m & 1h down move, 1h high
-            & ((rsi_3_15m > 15.0) | (rsi_3_1h > 35.0) | aroonu_14_1h_lt_80)
+            & ((rsi_3_15m_gt_15) | (rsi_3_1h_gt_35) | aroonu_14_1h_lt_80)
             # 15m & 1d down move, 4h high
-            & ((rsi_3_15m > 15.0) | (rsi_3_1d > 20.0) | (stochrsi_k_4h_lt_90))
+            & ((rsi_3_15m_gt_15) | (rsi_3_1d_gt_20) | (stochrsi_k_4h_lt_90))
             # 15m & 1d down move, 4h high
-            & ((rsi_3_15m > 15.0) | (rsi_3_1d > 25.0) | aroonu_14_4h_lt_100)
+            & ((rsi_3_15m_gt_15) | (rsi_3_1d_gt_25) | aroonu_14_4h_lt_100)
             # 15m & 1d down move, 1d high
-            & ((rsi_3_15m > 15.0) | (rsi_3_1d > 50.0) | (aroonu_14_1d < 80.0))
+            & ((rsi_3_15m_gt_15) | (rsi_3_1d > 50.0) | (aroonu_14_1d_lt_80))
             # 15m down move, 15m still high, 1h high
-            & ((rsi_3_15m > 15.0) | (aroonu_14_15m < 50.0) | (aroonu_14_1h < 90.0))
+            & ((rsi_3_15m_gt_15) | (aroonu_14_15m_lt_50) | (aroonu_14_1h_lt_90))
             # 15m down move, 15m still high, 1h high
-            & ((rsi_3_15m > 15.0) | (aroonu_14_15m < 50.0) | (stochrsi_k_1h_lt_80))
+            & ((rsi_3_15m_gt_15) | (aroonu_14_15m_lt_50) | (stochrsi_k_1h_lt_80))
             # 15m down move, 1h & 4h high
-            & ((rsi_3_15m > 15.0) | aroonu_14_1h_lt_80 | aroonu_14_4h_lt_100)
+            & ((rsi_3_15m_gt_15) | aroonu_14_1h_lt_80 | aroonu_14_4h_lt_100)
             # 15m down move, 4h high, 4h downtrend
-            & ((rsi_3_15m > 15.0) | (aroonu_14_4h < 60.0) | (roc_9_4h_gt_neg_20))
+            & ((rsi_3_15m_gt_15) | (aroonu_14_4h_lt_60) | (roc_9_4h_gt_neg_20))
             # 15m down move, 4h & 1d high
-            & ((rsi_3_15m > 15.0) | aroonu_14_4h_lt_80 | aroonu_14_1d_lt_100)
+            & ((rsi_3_15m_gt_15) | aroonu_14_4h_lt_80 | aroonu_14_1d_lt_100)
             # 15m down move, 1h high, 4h downtrend
-            & ((rsi_3_15m > 15.0) | (stochrsi_k_1h_lt_70) | (roc_9_4h > -30.0))
+            & ((rsi_3_15m_gt_15) | (stochrsi_k_1h_lt_70) | (roc_9_4h_gt_neg_30))
             # 15m down move, 4h high & overbought
-            & ((rsi_3_15m > 15.0) | (stochrsi_k_4h_lt_80) | (roc_9_4h < 10.0))
+            & ((rsi_3_15m_gt_15) | (stochrsi_k_4h_lt_80) | (roc_9_4h_lt_10))
             # 15m down move, 4h high, 1d downtrend
-            & ((rsi_3_15m > 15.0) | (stochrsi_k_4h_lt_80) | roc_9_1d_gt_neg_50)
+            & ((rsi_3_15m_gt_15) | (stochrsi_k_4h_lt_80) | roc_9_1d_gt_neg_50)
             # 15m down move, 1d high, 4h overbought
-            & ((rsi_3_15m > 15.0) | (stochrsi_k_1d < 90.0) | (roc_9_4h < 40.0))
+            & ((rsi_3_15m_gt_15) | (stochrsi_k_1d_lt_90) | (roc_9_4h_lt_40))
             # 15m down move, 1h downtrend, 4h overbought
-            & ((rsi_3_15m > 15.0) | (roc_9_1h > -20.0) | (roc_9_4h < 80.0))
+            & ((rsi_3_15m_gt_15) | (roc_9_1h > -20.0) | (roc_9_4h < 80.0))
             # 15m down move, 4h & 1d downtrend
-            & ((rsi_3_15m > 15.0) | (roc_9_4h > -10.0) | (roc_9_1d > -40.0))
+            & ((rsi_3_15m_gt_15) | (roc_9_4h > -10.0) | (roc_9_1d_gt_neg_40))
             # 15m & 1h down move, 1h high
-            & ((rsi_3_15m > 20.0) | rsi_3_1h_gt_20 | aroonu_14_1h_lt_70)
+            & ((rsi_3_15m_gt_20) | rsi_3_1h_gt_20 | aroonu_14_1h_lt_70)
             # 15m & 1h down move, 1d overbought
-            & ((rsi_3_15m > 20.0) | rsi_3_1h_gt_20 | roc_9_1d_lt_50)
+            & ((rsi_3_15m_gt_20) | rsi_3_1h_gt_20 | roc_9_1d_lt_50)
             # 15m & 1h down move, 1d high
-            & ((rsi_3_15m > 20.0) | (rsi_3_1h > 25.0) | aroonu_14_1d_lt_100)
+            & ((rsi_3_15m_gt_20) | (rsi_3_1h_gt_25) | aroonu_14_1d_lt_100)
             # 15m &4h down move, 4h still high
-            & ((rsi_3_15m > 20.0) | rsi_3_4h_gt_20 | (aroonu_14_4h < 50.0))
+            & ((rsi_3_15m_gt_20) | rsi_3_4h_gt_20 | (aroonu_14_4h_lt_50))
             # 15m & 4h down move, 1d overbought
-            & ((rsi_3_15m > 20.0) | (rsi_3_4h > 30.0) | roc_9_1d_lt_50)
+            & ((rsi_3_15m_gt_20) | (rsi_3_4h_gt_30) | roc_9_1d_lt_50)
             # 15m down move, 15m high, 1d overbought
-            & ((rsi_3_15m > 20.0) | (aroonu_14_15m < 70.0) | (roc_9_1d < 40.0))
+            & ((rsi_3_15m_gt_20) | (aroonu_14_15m_lt_70) | (roc_9_1d_lt_40))
             # 15m down move, 1h high, 4h downtrend
-            & ((rsi_3_15m > 20.0) | aroonu_14_1h_lt_80 | (roc_9_4h > -15.0))
+            & ((rsi_3_15m_gt_20) | aroonu_14_1h_lt_80 | (roc_9_4h > -15.0))
             # 15m down move, 1h high & overbought
-            & ((rsi_3_15m > 20.0) | (aroonu_14_1h < 100.0) | (roc_9_1h < 50.0))
+            & ((rsi_3_15m_gt_20) | (aroonu_14_1h_lt_100) | (roc_9_1h < 50.0))
             # 15m down move, 4h high & overbought
-            & ((rsi_3_15m > 20.0) | aroonu_14_4h_lt_70 | (roc_9_4h_lt_20))
+            & ((rsi_3_15m_gt_20) | aroonu_14_4h_lt_70 | (roc_9_4h_lt_20))
             # 15m down move, 4h high, 1d overbought
-            & ((rsi_3_15m > 20.0) | aroonu_14_4h_lt_80 | (roc_9_1d < 60.0))
+            & ((rsi_3_15m_gt_20) | aroonu_14_4h_lt_80 | (roc_9_1d < 60.0))
             # 15m & 4h down move, 4h high
-            & ((rsi_3_15m > 25.0) | (rsi_3_4h > 25.0) | (stochrsi_k_4h < 60.0))
+            & ((rsi_3_15m_gt_25) | (rsi_3_4h_gt_25) | (stochrsi_k_4h < 60.0))
             # 15m & 1d down move, 1h high
-            & ((rsi_3_15m > 25.0) | (rsi_3_1d > 25.0) | (aroonu_14_1h < 90.0))
+            & ((rsi_3_15m_gt_25) | (rsi_3_1d_gt_25) | (aroonu_14_1h_lt_90))
             # 15m down move, 15m high, 1h high
-            & ((rsi_3_15m > 30.0) | (aroonu_14_15m < 60.0) | (aroonu_14_1h < 90.0))
+            & ((rsi_3_15m_gt_30) | (aroonu_14_15m < 60.0) | (aroonu_14_1h_lt_90))
             # 15m down move, 15m high, 4h downtrend
-            & ((rsi_3_15m > 25.0) | (aroonu_14_15m < 60.0) | (roc_9_4h_gt_neg_20))
+            & ((rsi_3_15m_gt_25) | (aroonu_14_15m < 60.0) | (roc_9_4h_gt_neg_20))
             # 15m down move, 1h high, 4h overbought
-            & ((rsi_3_15m > 25.0) | (aroonu_14_1h < 90.0) | (roc_9_4h < 30.0))
+            & ((rsi_3_15m_gt_25) | (aroonu_14_1h_lt_90) | (roc_9_4h_lt_30))
             # 15m down move, 1h high, 4h overbought
-            & ((rsi_3_15m > 25.0) | (aroonu_14_1h < 100.0) | (roc_9_4h < 15.0))
+            & ((rsi_3_15m_gt_25) | (aroonu_14_1h_lt_100) | (roc_9_4h < 15.0))
             # 15m down move, 1h high, 1d overbought
-            & ((rsi_3_15m > 25.0) | (aroonu_14_1h < 100.0) | (roc_9_1d < 20.0))
+            & ((rsi_3_15m_gt_25) | (aroonu_14_1h_lt_100) | (roc_9_1d_lt_20))
             # 15m down move, 4h high & overbought
-            & ((rsi_3_15m > 25.0) | aroonu_14_4h_lt_100 | (roc_9_4h < 10.0))
+            & ((rsi_3_15m_gt_25) | aroonu_14_4h_lt_100 | (roc_9_4h_lt_10))
             # 15m down move, 1h & 4h high
-            & ((rsi_3_15m > 30.0) | (aroonu_14_1h < 90.0) | (aroonu_14_4h < 90.0))
+            & ((rsi_3_15m_gt_30) | (aroonu_14_1h_lt_90) | (aroonu_14_4h_lt_90))
             # 1h & 4h down move, 1d still high
-            & ((rsi_3_1h > 3.0) | (rsi_3_4h > 3.0) | (stochrsi_k_1d < 50.0))
+            & ((rsi_3_1h_gt_3) | (rsi_3_4h > 3.0) | (stochrsi_k_1d < 50.0))
             # 1h & 4h down move, 1h still high
-            & ((rsi_3_1h > 3.0) | (rsi_3_4h > 25.0) | (aroonu_14_1h < 40.0))
+            & ((rsi_3_1h_gt_3) | (rsi_3_4h_gt_25) | (aroonu_14_1h < 40.0))
             # 1h & 4h down move, 4h high
-            & ((rsi_3_1h > 3.0) | (rsi_3_4h > 45.0) | (stochrsi_k_4h < 70.0))
+            & ((rsi_3_1h_gt_3) | (rsi_3_4h > 45.0) | (stochrsi_k_4h_lt_70))
             # 1h down move, 15m & 1h downtrend
-            & ((rsi_3_1h > 3.0) | (cmf_20_15m > -0.30) | (cmf_20_1h > -0.30))
+            & ((rsi_3_1h_gt_3) | (cmf_20_15m > -0.30) | (cmf_20_1h > -0.30))
             # 1h down move, 1h still high, 1h downtrend
-            & ((rsi_3_1h > 3.0) | (aroonu_14_1h < 50.0) | (roc_9_1h > -20.0))
+            & ((rsi_3_1h_gt_3) | (aroonu_14_1h_lt_50) | (roc_9_1h > -20.0))
             # 1h down move, 1h high
-            & ((rsi_3_1h > 3.0) | aroonu_14_1h_lt_70)
+            & ((rsi_3_1h_gt_3) | aroonu_14_1h_lt_70)
             # 1h down move, 4h high
-            & ((rsi_3_1h > 3.0) | aroonu_14_4h_lt_70)
+            & ((rsi_3_1h_gt_3) | aroonu_14_4h_lt_70)
             # 1h down move, 1d high
-            & ((rsi_3_1h > 3.0) | (aroonu_14_1d < 70.0))
+            & ((rsi_3_1h_gt_3) | (aroonu_14_1d_lt_70))
             # 1h down move, 4h still high, 1d downtrend
-            & ((rsi_3_1h > 3.0) | (stochrsi_k_4h < 50.0) | (roc_9_1h > -20.0))
+            & ((rsi_3_1h_gt_3) | (stochrsi_k_4h_lt_50) | (roc_9_1h > -20.0))
             # 1h down move, 1d high & overbought
-            & ((rsi_3_1h > 3.0) | (stochrsi_k_1d < 60.0) | (roc_9_1d < 20.0))
+            & ((rsi_3_1h_gt_3) | (stochrsi_k_1d < 60.0) | (roc_9_1d_lt_20))
             # 1h & 4h & 1d down move
-            & ((rsi_3_1h > 5.0) | (rsi_3_4h_gt_10) | (rsi_3_1d > 20.0))
+            & ((rsi_3_1h_gt_5) | (rsi_3_4h_gt_10) | (rsi_3_1d_gt_20))
             # 1h & 4h down move, 1d overbought
-            & ((rsi_3_1h > 5.0) | (rsi_3_4h_gt_10) | (roc_9_1d < 100.0))
+            & ((rsi_3_1h_gt_5) | (rsi_3_4h_gt_10) | (roc_9_1d < 100.0))
             # 1h & 4h down move, 4h still not low enough
-            & ((rsi_3_1h > 5.0) | (rsi_3_4h_gt_15) | (aroonu_14_4h < 20.0))
+            & ((rsi_3_1h_gt_5) | (rsi_3_4h_gt_15) | (aroonu_14_4h < 20.0))
             # 1h & 4h down move, 4h still high
-            & ((rsi_3_1h > 5.0) | (rsi_3_4h > 30.0) | (rsi_14_4h < 40.0))
+            & ((rsi_3_1h_gt_5) | (rsi_3_4h_gt_30) | (rsi_14_4h < 40.0))
             # 1h & 4h down move, 1h downtrend
-            & ((rsi_3_1h > 5.0) | (rsi_3_4h > 30.0) | (cmf_20_1h > -0.30))
+            & ((rsi_3_1h_gt_5) | (rsi_3_4h_gt_30) | (cmf_20_1h > -0.30))
             # 1h & 4h down move, 4h high
-            & ((rsi_3_1h > 5.0) | (rsi_3_4h > 50.0) | aroonu_14_4h_lt_70)
+            & ((rsi_3_1h_gt_5) | (rsi_3_4h_gt_50) | aroonu_14_4h_lt_70)
             # 1h & 1d down move, 1h still high
-            & ((rsi_3_1h > 5.0) | (rsi_3_1d > 10.0) | (stochrsi_k_1h_lt_50))
+            & ((rsi_3_1h_gt_5) | (rsi_3_1d_gt_10) | (stochrsi_k_1h_lt_50))
             # 1h down move, 1d high, 1h downtrend
-            & ((rsi_3_1h > 5.0) | (aroonu_14_1d < 85.0) | (roc_9_1h > -50.0))
+            & ((rsi_3_1h_gt_5) | (aroonu_14_1d < 85.0) | (roc_9_1h > -50.0))
             # 1h down move, 1d high, 4h downtrend
-            & ((rsi_3_1h > 5.0) | (aroonu_14_1d < 90.0) | (roc_9_4h > -30.0))
+            & ((rsi_3_1h_gt_5) | (aroonu_14_1d_lt_90) | (roc_9_4h_gt_neg_30))
             # 1h down move, 1d high, 1d downtrend
-            & ((rsi_3_1h > 5.0) | aroonu_14_1d_lt_100 | (roc_9_1d > -20.0))
+            & ((rsi_3_1h_gt_5) | aroonu_14_1d_lt_100 | (roc_9_1d > -20.0))
             # 1h down move, 1d high & overbought
-            & ((rsi_3_1h > 5.0) | aroonu_14_1d_lt_100 | (roc_9_1d < 20.0))
+            & ((rsi_3_1h_gt_5) | aroonu_14_1d_lt_100 | (roc_9_1d_lt_20))
             # 1h down move, 4h still high, 1d downtrend
-            & ((rsi_3_1h > 5.0) | (stochrsi_k_4h < 50.0) | roc_9_1d_gt_neg_50)
+            & ((rsi_3_1h_gt_5) | (stochrsi_k_4h_lt_50) | roc_9_1d_gt_neg_50)
             # 1h down move, 4h & 1d downtrend
-            & ((rsi_3_1h > 5.0) | (roc_9_4h > -25.0) | roc_9_1d_gt_neg_50)
+            & ((rsi_3_1h_gt_5) | (roc_9_4h > -25.0) | roc_9_1d_gt_neg_50)
             # 1h & 4h & 1d down move
-            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_10) | (rsi_3_1d > 15.0))
+            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_10) | (rsi_3_1d_gt_15))
             # 1h & 4h down move, 1h high
             & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_10) | (aroonu_14_1h < 80.0))
             # 1h & 4h down move, 1d high
-            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_10) | (aroonu_14_1d < 80.0))
+            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_10) | (aroonu_14_1d_lt_80))
             # 1h & 4h down move, 4h still high
-            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_10) | (stochrsi_k_4h < 50.0))
+            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_10) | (stochrsi_k_4h_lt_50))
             # 1h & 4h down move, 1d still not low enough
             & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_10) | (stochrsi_k_1d < 20.0))
             # 1h & 4h down move, 4h downtrend
@@ -16423,33 +16475,33 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 15m downtrend
             & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_15) | (roc_9_15m > -20.0))
             # 1h & 4h down move, 4h still high
-            & ((rsi_3_1h_gt_10) | rsi_3_4h_gt_20 | (stochrsi_k_4h < 50.0))
+            & ((rsi_3_1h_gt_10) | rsi_3_4h_gt_20 | (stochrsi_k_4h_lt_50))
             # 1h & 4h down move, 1d downtrend
             & ((rsi_3_1h_gt_10) | rsi_3_4h_gt_20 | (roc_9_1d > -30.0))
             # 1h & 4h down move, 4h high
-            & ((rsi_3_1h_gt_10) | (rsi_3_4h > 25.0) | (aroonu_14_4h < 90.0))
+            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_25) | (aroonu_14_4h_lt_90))
             # 1h & 4h down move, 1d high
-            & ((rsi_3_1h_gt_10) | (rsi_3_4h > 25.0) | (aroonu_14_1d < 80.0))
+            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_25) | (aroonu_14_1d_lt_80))
             # 1h & 1d down move, 1d downtrend
-            & ((rsi_3_1h_gt_10) | (rsi_3_1d > 10.0) | (roc_9_1d > -30.0))
+            & ((rsi_3_1h_gt_10) | (rsi_3_1d_gt_10) | (roc_9_1d > -30.0))
             # 1h & 1d down move, 4h still high
-            & ((rsi_3_1h_gt_10) | (rsi_3_1d > 10.0) | (aroonu_14_4h < 40.0))
+            & ((rsi_3_1h_gt_10) | (rsi_3_1d_gt_10) | (aroonu_14_4h_lt_40))
             # 1h & 1d down move, 4h high
-            & ((rsi_3_1h_gt_10) | (rsi_3_1d > 15.0) | (stochrsi_k_4h < 70.0))
+            & ((rsi_3_1h_gt_10) | (rsi_3_1d_gt_15) | (stochrsi_k_4h_lt_70))
             # 1h & 1d down move, 1h still not low enough
-            & ((rsi_3_1h_gt_10) | (rsi_3_1d > 20.0) | (stochrsi_k_1h < 20.0))
+            & ((rsi_3_1h_gt_10) | (rsi_3_1d_gt_20) | (stochrsi_k_1h < 20.0))
             # 1h & 1d down move, 1h high
-            & ((rsi_3_1h_gt_10) | (rsi_3_1d > 25.0) | (aroonu_14_1h < 70.0))
+            & ((rsi_3_1h_gt_10) | (rsi_3_1d_gt_25) | (aroonu_14_1h < 70.0))
             # 1h & 1d down move, 1h downtrend
             & ((rsi_3_1h_gt_10) | (rsi_3_1d > 30.0) | (cmf_20_1h > -0.40))
             # 1h down move, 1d downtrend, 4h high
             & ((rsi_3_1h_gt_10) | (cmf_20_1d > -0.30) | (stochrsi_k_4h < 90.0))
             # 1h down move, 1h still high, 4h overbought
-            & ((rsi_3_1h_gt_10) | (aroonu_14_1h < 50.0) | (roc_9_4h < 20.0))
+            & ((rsi_3_1h_gt_10) | (aroonu_14_1h_lt_50) | (roc_9_4h < 20.0))
             # 1h down move, 1h & 4h high
-            & ((rsi_3_1h_gt_10) | (aroonu_14_1h < 60.0) | (aroonu_14_4h < 60.0))
+            & ((rsi_3_1h_gt_10) | (aroonu_14_1h < 60.0) | (aroonu_14_4h_lt_60))
             # 1h down move, 1h high, 1d high
-            & ((rsi_3_1h_gt_10) | (aroonu_14_1h < 60.0) | (stochrsi_k_1d < 90.0))
+            & ((rsi_3_1h_gt_10) | (aroonu_14_1h < 60.0) | (stochrsi_k_1d_lt_90))
             # 1h down move, 1d overbought
             & ((rsi_3_1h_gt_10) | roc_9_1d_lt_50)
             # 1h & 4h down move, 1h downtrend
@@ -16473,21 +16525,21 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1d downtrend, 1d high
             & ((rsi_3_1h_gt_15) | (cmf_20_1d > -0.30) | (stochrsi_k_1d < 80.0))
             # 1h down move, 1h & 1d high
-            & ((rsi_3_1h_gt_15) | (aroonu_14_1h < 70.0) | (aroonu_14_1d < 90.0))
+            & ((rsi_3_1h_gt_15) | (aroonu_14_1h < 70.0) | (aroonu_14_1d_lt_90))
             # 1h down move, 1h high, 1d overbought
-            & ((rsi_3_1h_gt_15) | (aroonu_14_1h < 70.0) | (roc_9_1d < 40.0))
+            & ((rsi_3_1h_gt_15) | (aroonu_14_1h < 70.0) | (roc_9_1d_lt_40))
             # 1h down move, 1h high, 1h downtrend
             & ((rsi_3_1h_gt_15) | (aroonu_14_1h < 80.0) | (cmf_20_1h > -0.25))
             # 1h down move, 1h high, 4h downtrend
-            & ((rsi_3_1h_gt_15) | (aroonu_14_1h < 80.0) | (roc_9_4h > -30.0))
+            & ((rsi_3_1h_gt_15) | (aroonu_14_1h < 80.0) | (roc_9_4h_gt_neg_30))
             # 1h down move, 4h still high, 1d overbought
-            & ((rsi_3_1h_gt_15) | (aroonu_14_4h < 50.0) | (roc_9_1d < 60.0))
+            & ((rsi_3_1h_gt_15) | (aroonu_14_4h_lt_50) | (roc_9_1d < 60.0))
             # 1h down move, 4h high, 15m downtrend
             & ((rsi_3_1h_gt_15) | (aroonu_14_4h < 85.0) | (roc_9_15m > -15.0))
             # 1h down move, 4h high, 1h downtrend
             & ((rsi_3_1h_gt_15) | (aroonu_14_4h < 85.0) | (roc_9_1h > -30.0))
             # 1h down move, 1d high, 4h overbought
-            & ((rsi_3_1h_gt_15) | (aroonu_14_1d < 100.0) | (roc_9_4h < 10.0))
+            & ((rsi_3_1h_gt_15) | (aroonu_14_1d < 100.0) | (roc_9_4h_lt_10))
             # 1h down move, 4h still not low enough, 1d downtrend
             & ((rsi_3_1h_gt_15) | (stochrsi_k_4h < 30.0) | (roc_9_1d > -30.0))
             # 1h down move, 4h high & overbought
@@ -16497,213 +16549,213 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 4h downtrend, 1d overbought
             & ((rsi_3_1h_gt_15) | (roc_9_4h > -25.0) | (roc_9_1d < 100.0))
             # 1h & 4h down move, 1d high
-            & (rsi_3_1h_gt_20 | rsi_3_4h_gt_20 | (aroonu_14_1d < 80.0))
+            & (rsi_3_1h_gt_20 | rsi_3_4h_gt_20 | (aroonu_14_1d_lt_80))
             # 1h & 4h down move, 4h high
-            & (rsi_3_1h_gt_20 | (rsi_3_4h > 50.0) | (stochrsi_k_4h < 70.0))
+            & (rsi_3_1h_gt_20 | (rsi_3_4h_gt_50) | (stochrsi_k_4h_lt_70))
             # 1h & 1d down move, 4h high
-            & (rsi_3_1h_gt_20 | (rsi_3_1d > 20.0) | (aroonu_14_4h < 90.0))
+            & (rsi_3_1h_gt_20 | (rsi_3_1d_gt_20) | (aroonu_14_4h_lt_90))
             # 1h & 1d down move, 1h high
-            & (rsi_3_1h_gt_20 | (rsi_3_1d > 25.0) | aroonu_14_1h_lt_70)
+            & (rsi_3_1h_gt_20 | (rsi_3_1d_gt_25) | aroonu_14_1h_lt_70)
             # 1h & 1d down move, 4h overbought
-            & (rsi_3_1h_gt_20 | (rsi_3_1d > 30.0) | (roc_9_4h < 30.0))
+            & (rsi_3_1h_gt_20 | (rsi_3_1d > 30.0) | (roc_9_4h_lt_30))
             # 1h down move, 1h still high, 4h high
-            & (rsi_3_1h_gt_20 | (aroonu_14_1h < 50.0) | (aroonu_14_4h < 90.0))
+            & (rsi_3_1h_gt_20 | (aroonu_14_1h_lt_50) | (aroonu_14_4h_lt_90))
             # 1h down move, 1h high, 1d overbought
             & (rsi_3_1h_gt_20 | aroonu_14_1h_lt_70 | (roc_9_1d < 100.0))
             # 1h down move, 1d high & overbought
             & (rsi_3_1h_gt_20 | aroonu_14_1d_lt_100 | (roc_9_1d < 60.0))
             # 1h down move, 1h high, 4h overbought
-            & (rsi_3_1h_gt_20 | (stochrsi_k_1h_lt_70) | (roc_9_4h < 10.0))
+            & (rsi_3_1h_gt_20 | (stochrsi_k_1h_lt_70) | (roc_9_4h_lt_10))
             # 1h down move, 1d high, 1d downtrend
             & (rsi_3_1h_gt_20 | (stochrsi_k_1d < 80.0) | roc_9_1d_gt_neg_50)
             # 1h down move, 1d high & overbought
-            & (rsi_3_1h_gt_20 | (stochrsi_k_1d < 90.0) | (roc_9_1d < 40.0))
+            & (rsi_3_1h_gt_20 | (stochrsi_k_1d_lt_90) | (roc_9_1d_lt_40))
             # 1h down move, 1h & 4h overbought
-            & (rsi_3_1h_gt_20 | (roc_9_1h < 20.0) | (roc_9_4h < 40.0))
+            & (rsi_3_1h_gt_20 | (roc_9_1h < 20.0) | (roc_9_4h_lt_40))
             # 1h down move, 4h & 1d downtrend
-            & (rsi_3_1h_gt_20 | (roc_9_4h > -30.0) | (roc_9_1d > -40.0))
+            & (rsi_3_1h_gt_20 | (roc_9_4h_gt_neg_30) | (roc_9_1d_gt_neg_40))
             # 1h & 4h down move, 1d overbought
-            & ((rsi_3_1h > 25.0) | (rsi_3_4h > 40.0) | (roc_9_1d_lt_100))
+            & ((rsi_3_1h_gt_25) | (rsi_3_4h_gt_40) | (roc_9_1d_lt_100))
             # 1h down move, 15m still high, 1h high
-            & ((rsi_3_1h > 25.0) | (aroonu_14_15m < 50.0) | (aroonu_14_1h < 90.0))
+            & ((rsi_3_1h_gt_25) | (aroonu_14_15m_lt_50) | (aroonu_14_1h_lt_90))
             # 1h down move, 1h high, 1d overbought
-            & ((rsi_3_1h > 25.0) | aroonu_14_1h_lt_70 | (roc_9_1d < 200.0))
+            & ((rsi_3_1h_gt_25) | aroonu_14_1h_lt_70 | (roc_9_1d < 200.0))
             # 1h down move, 1h & 1d high
-            & ((rsi_3_1h > 25.0) | aroonu_14_1h_lt_70 | (aroonu_14_1d < 90.0))
+            & ((rsi_3_1h_gt_25) | aroonu_14_1h_lt_70 | (aroonu_14_1d_lt_90))
             # 1h down move, 1h high, 4h overbought
-            & ((rsi_3_1h > 25.0) | aroonu_14_1h_lt_80 | (roc_9_4h < 20.0))
+            & ((rsi_3_1h_gt_25) | aroonu_14_1h_lt_80 | (roc_9_4h < 20.0))
             # 1h down move, 1h high, 1d overbought
-            & ((rsi_3_1h > 25.0) | (aroonu_14_1h < 85.0) | roc_9_1d_lt_50)
+            & ((rsi_3_1h_gt_25) | (aroonu_14_1h < 85.0) | roc_9_1d_lt_50)
             # 1h down move, 4h high
-            & ((rsi_3_1h > 25.0) | (aroonu_14_4h < 90.0))
+            & ((rsi_3_1h_gt_25) | (aroonu_14_4h_lt_90))
             # 1h down move, 1h still high, 1d overbought
-            & ((rsi_3_1h > 25.0) | (stochrsi_k_1h_lt_50) | (roc_9_1d < 40.0))
+            & ((rsi_3_1h_gt_25) | (stochrsi_k_1h_lt_50) | (roc_9_1d_lt_40))
             # 1h down move, 4h high, 1d downtrend
-            & ((rsi_3_1h > 25.0) | (stochrsi_k_4h_lt_80) | (roc_9_1d > -40.0))
+            & ((rsi_3_1h_gt_25) | (stochrsi_k_4h_lt_80) | (roc_9_1d_gt_neg_40))
             # 1h down move, 15m downtrend, 4h overbought
-            & ((rsi_3_1h > 25.0) | (roc_9_15m > -25.0) | (roc_9_4h < 30.0))
+            & ((rsi_3_1h_gt_25) | (roc_9_15m > -25.0) | (roc_9_4h_lt_30))
             # 1h down move, 1h & 1d downtrend
-            & ((rsi_3_1h > 25.0) | (roc_9_1h > -50.0) | roc_9_1d_gt_neg_50)
+            & ((rsi_3_1h_gt_25) | (roc_9_1h > -50.0) | roc_9_1d_gt_neg_50)
             # 1h down move, 1h downtrend, 4h overbought
-            & ((rsi_3_1h > 25.0) | (roc_9_1h > -25.0) | (roc_9_4h < 50.0))
+            & ((rsi_3_1h_gt_25) | (roc_9_1h > -25.0) | (roc_9_4h < 50.0))
             # 1h down move, 1h & 4h overbought
-            & ((rsi_3_1h > 25.0) | (roc_9_1h < 30.0) | (roc_9_4h < 100.0))
+            & ((rsi_3_1h_gt_25) | (roc_9_1h < 30.0) | (roc_9_4h < 100.0))
             # 1h & 4h down move, 1h high
-            & ((rsi_3_1h > 30.0) | (rsi_3_4h > 30.0) | (aroonu_14_1h < 90.0))
+            & ((rsi_3_1h_gt_30) | (rsi_3_4h_gt_30) | (aroonu_14_1h_lt_90))
             # 1h & 4h down move, 4h downtrend
-            & ((rsi_3_1h > 30.0) | (rsi_3_4h > 30.0) | (roc_9_4h_gt_neg_20))
+            & ((rsi_3_1h_gt_30) | (rsi_3_4h_gt_30) | (roc_9_4h_gt_neg_20))
             # 1h down move, 1h downtrend, 1h high
-            & ((rsi_3_1h > 30.0) | (cmf_20_1h > -0.25) | (stochrsi_k_1h_lt_70))
+            & ((rsi_3_1h_gt_30) | (cmf_20_1h > -0.25) | (stochrsi_k_1h_lt_70))
             # 1h down move, 4h downtrend, 4h high
-            & ((rsi_3_1h > 30.0) | (cmf_20_4h > -0.50) | aroonu_14_4h_lt_100)
+            & ((rsi_3_1h_gt_30) | (cmf_20_4h > -0.50) | aroonu_14_4h_lt_100)
             # 1h down move, 1h high & overbought
-            & ((rsi_3_1h > 30.0) | aroonu_14_1h_lt_70 | (roc_9_1h < 10.0))
+            & ((rsi_3_1h_gt_30) | aroonu_14_1h_lt_70 | (roc_9_1h_lt_10))
             # 1h down move, 1h high, 1d downtrend
-            & ((rsi_3_1h > 30.0) | aroonu_14_1h_lt_70 | (roc_9_1d > -60.0))
+            & ((rsi_3_1h_gt_30) | aroonu_14_1h_lt_70 | (roc_9_1d > -60.0))
             # 1h down move, 4h high, 1h overbought
-            & ((rsi_3_1h > 30.0) | aroonu_14_4h_lt_80 | (roc_9_1h < 50.0))
+            & ((rsi_3_1h_gt_30) | aroonu_14_4h_lt_80 | (roc_9_1h < 50.0))
             # 1h down move, 4h high, 1d downtrend
-            & ((rsi_3_1h > 30.0) | (aroonu_14_4h < 90.0) | (roc_9_1d_gt_neg_30))
+            & ((rsi_3_1h_gt_30) | (aroonu_14_4h_lt_90) | (roc_9_1d_gt_neg_30))
             # 1h down move, 4h high, 1d overbought
-            & ((rsi_3_1h > 30.0) | aroonu_14_4h_lt_100 | (roc_9_1d < 20.0))
+            & ((rsi_3_1h_gt_30) | aroonu_14_4h_lt_100 | (roc_9_1d_lt_20))
             # 1h down move, 4h & 1d overbought
-            & ((rsi_3_1h > 30.0) | (roc_9_4h < 10.0) | roc_9_1d_lt_50)
+            & ((rsi_3_1h_gt_30) | (roc_9_4h_lt_10) | roc_9_1d_lt_50)
             # 1h down move, 15m & 1h high
-            & ((rsi_3_1h > 35.0) | (aroonu_14_15m < 70.0) | (aroonu_14_1h < 100.0))
+            & ((rsi_3_1h_gt_35) | (aroonu_14_15m_lt_70) | (aroonu_14_1h_lt_100))
             # 1h down move, 1h high, 4h downtrend
-            & ((rsi_3_1h > 35.0) | aroonu_14_1h_lt_70 | (roc_9_4h > -40.0))
+            & ((rsi_3_1h_gt_35) | aroonu_14_1h_lt_70 | (roc_9_4h > -40.0))
             # 1h down move, 1h & 4h high
-            & ((rsi_3_1h > 35.0) | aroonu_14_1h_lt_80 | aroonu_14_4h_lt_100)
+            & ((rsi_3_1h_gt_35) | aroonu_14_1h_lt_80 | aroonu_14_4h_lt_100)
             # 1h down move, 1h high, 1d downtrend
-            & ((rsi_3_1h > 35.0) | aroonu_14_1h_lt_80 | (roc_9_1d > -40.0))
+            & ((rsi_3_1h_gt_35) | aroonu_14_1h_lt_80 | (roc_9_1d_gt_neg_40))
             # 1h down move, 1h high, 4h overbought
-            & ((rsi_3_1h > 35.0) | (aroonu_14_1h < 90.0) | (roc_9_4h < 10.0))
+            & ((rsi_3_1h_gt_35) | (aroonu_14_1h_lt_90) | (roc_9_4h_lt_10))
             # 1h down move, 4h high, 1d overbought
-            & ((rsi_3_1h > 35.0) | aroonu_14_4h_lt_70 | (roc_9_1d < 200.0))
+            & ((rsi_3_1h_gt_35) | aroonu_14_4h_lt_70 | (roc_9_1d < 200.0))
             # 1h down move, 4h high & overbought
-            & ((rsi_3_1h > 35.0) | aroonu_14_4h_lt_100 | (roc_9_4h < 20.0))
+            & ((rsi_3_1h_gt_35) | aroonu_14_4h_lt_100 | (roc_9_4h < 20.0))
             # 1h down move, 4h high & overbought
-            & ((rsi_3_1h > 35.0) | (stochrsi_k_4h_lt_80) | (roc_9_4h < 30.0))
+            & ((rsi_3_1h_gt_35) | (stochrsi_k_4h_lt_80) | (roc_9_4h_lt_30))
             # 1h down move, 1h downtrend, 4h overbought
-            & ((rsi_3_1h > 35.0) | (roc_9_1h > -30.0) | (roc_9_4h < 100.0))
+            & ((rsi_3_1h_gt_35) | (roc_9_1h > -30.0) | (roc_9_4h < 100.0))
             # 1h down move, 4h & 1d overbought
-            & ((rsi_3_1h > 35.0) | (roc_9_4h_lt_20) | (roc_9_1d < 70.0))
+            & ((rsi_3_1h_gt_35) | (roc_9_4h_lt_20) | (roc_9_1d < 70.0))
             # 1h down move, 1h & 4h high
-            & ((rsi_3_1h > 40.0) | aroonu_14_1h_lt_70 | aroonu_14_4h_lt_100)
+            & ((rsi_3_1h_gt_40) | aroonu_14_1h_lt_70 | aroonu_14_4h_lt_100)
             # 1h down move, 1h high & overbought
-            & ((rsi_3_1h > 40.0) | aroonu_14_1h_lt_80 | (roc_9_1h < 10.0))
+            & ((rsi_3_1h_gt_40) | aroonu_14_1h_lt_80 | (roc_9_1h_lt_10))
             # 1h down move, 1h high, 1d high
-            & ((rsi_3_1h > 40.0) | (aroonu_14_1h < 85.0) | (roc_9_1d < 80.0))
+            & ((rsi_3_1h_gt_40) | (aroonu_14_1h < 85.0) | (roc_9_1d_lt_80))
             # 1h down move, 1h high, 15m downtrend
-            & ((rsi_3_1h > 40.0) | (aroonu_14_1h < 90.0) | (roc_9_15m > -10.0))
+            & ((rsi_3_1h_gt_40) | (aroonu_14_1h_lt_90) | (roc_9_15m > -10.0))
             # 1h down move, 1h  high & overbought
-            & ((rsi_3_1h > 40.0) | (stochrsi_k_1h_lt_80) | (roc_9_1h < 10.0))
+            & ((rsi_3_1h_gt_40) | (stochrsi_k_1h_lt_80) | (roc_9_1h_lt_10))
             # 1h down move, 4h & 1d overbought
-            & ((rsi_3_1h > 40.0) | (roc_9_4h_lt_20) | (roc_9_1d_lt_100))
+            & ((rsi_3_1h_gt_40) | (roc_9_4h_lt_20) | (roc_9_1d_lt_100))
             # 1h down move, 4h & 1d overbought
-            & ((rsi_3_1h > 40.0) | (roc_9_4h < 30.0) | (roc_9_1d < 40.0))
+            & ((rsi_3_1h_gt_40) | (roc_9_4h_lt_30) | (roc_9_1d_lt_40))
             # 1h down move, 1h high, 1d overbought
-            & ((rsi_3_1h > 45.0) | (aroonu_14_1h < 100.0) | (roc_9_1d < 200.0))
+            & ((rsi_3_1h_gt_45) | (aroonu_14_1h_lt_100) | (roc_9_1d < 200.0))
             # 1h down move, 4h high & overbought
-            & ((rsi_3_1h > 45.0) | (stochrsi_k_4h_lt_80) | (roc_9_4h < 100.0))
+            & ((rsi_3_1h_gt_45) | (stochrsi_k_4h_lt_80) | (roc_9_4h < 100.0))
             # 1h down move, 1h high, 1d downtrend
-            & ((rsi_3_1h > 50.0) | (aroonu_14_1h < 60.0) | (roc_9_1d > -70.0))
+            & ((rsi_3_1h_gt_50) | (aroonu_14_1h < 60.0) | (roc_9_1d > -70.0))
             # 1h down move, 1h high, 1d overbought
-            & ((rsi_3_1h > 50.0) | (stochrsi_k_1h < 70.0) | (roc_9_1d_lt_100))
+            & ((rsi_3_1h_gt_50) | (stochrsi_k_1h < 70.0) | (roc_9_1d_lt_100))
             # 1h down move, 4h high, 1d downtrend
-            & ((rsi_3_1h > 50.0) | (stochrsi_k_4h < 60.0) | (roc_9_1d > -60.0))
+            & ((rsi_3_1h_gt_50) | (stochrsi_k_4h < 60.0) | (roc_9_1d > -60.0))
             # 1h down move, 1h high
             & ((rsi_3_1h > 60.0) | (stochrsi_k_1h_lt_80))
             # 1h down move, 1h overbought
             & ((rsi_3_1h > 60.0) | (roc_9_1h < 30.0))
             # 1h down move, 4h & 1d overbought
-            & ((rsi_3_1h > 60.0) | (roc_9_4h < 30.0) | (roc_9_1d < 60.0))
+            & ((rsi_3_1h > 60.0) | (roc_9_4h_lt_30) | (roc_9_1d < 60.0))
             # 4h & 1d down move, 1d still not low enough
             & ((rsi_3_4h > 3.0) | (rsi_3_1d > 30.0) | (aroonu_14_1d < 30.0))
             # 4h down move, 4h high, 1h downtrend
             & ((rsi_3_4h > 3.0) | aroonu_14_4h_lt_70 | (roc_9_1h > -40.0))
             # 4h down move, 1h still high, 4h downtrend
-            & ((rsi_3_4h > 3.0) | (stochrsi_k_1h_lt_50) | (roc_9_4h > -30.0))
+            & ((rsi_3_4h > 3.0) | (stochrsi_k_1h_lt_50) | (roc_9_4h_gt_neg_30))
             # 4h & 1d down move, 1d still high
-            & ((rsi_3_4h > 5.0) | (rsi_3_1d > 20.0) | (aroonu_14_1d < 50.0))
+            & ((rsi_3_4h_gt_5) | (rsi_3_1d_gt_20) | (aroonu_14_1d < 50.0))
             # 4h down move, 15m still high, 1d downtrend
-            & ((rsi_3_4h > 5.0) | (aroonu_14_15m < 50.0) | (roc_9_1d_gt_neg_30))
+            & ((rsi_3_4h_gt_5) | (aroonu_14_15m_lt_50) | (roc_9_1d_gt_neg_30))
             # 4h & 1d down move, 1d downtrend
-            & ((rsi_3_4h_gt_10) | (rsi_3_1d > 25.0) | roc_9_1d_gt_neg_50)
+            & ((rsi_3_4h_gt_10) | (rsi_3_1d_gt_25) | roc_9_1d_gt_neg_50)
             # 4h down move, 1d high & overbought
-            & ((rsi_3_4h_gt_10) | (aroonu_14_1d < 80.0) | (roc_9_1d < 80.0))
+            & ((rsi_3_4h_gt_10) | (aroonu_14_1d_lt_80) | (roc_9_1d_lt_80))
             # 4h down move, 1h & 4h downtrend
-            & ((rsi_3_4h_gt_10) | (roc_9_1h > -30.0) | (roc_9_4h > -30.0))
+            & ((rsi_3_4h_gt_10) | (roc_9_1h > -30.0) | (roc_9_4h_gt_neg_30))
             # 4h down move, 1d high & overbought
             & ((rsi_3_4h_gt_10) | (stochrsi_k_1d < 70.0) | (roc_9_1d < 35.0))
             # 4h down move, 4h & 1d downtrend
             & ((rsi_3_4h_gt_10) | (roc_9_4h > -15.0) | (roc_9_1d > -35.0))
             # 4h down move, 4h still high, 1d overbought
-            & ((rsi_3_4h_gt_15) | (aroonu_14_4h < 40.0) | (roc_9_1d < 40.0))
+            & ((rsi_3_4h_gt_15) | (aroonu_14_4h_lt_40) | (roc_9_1d_lt_40))
             # 4h down move, 1h still not low enough, 1d downtrend
             & ((rsi_3_4h_gt_15) | (stochrsi_k_1h < 20.0) | (roc_9_1d > -20.0))
             # 4h & 1d down move, 1d high
-            & (rsi_3_4h_gt_20 | (rsi_3_1d > 20.0) | (stochrsi_k_1d < 70.0))
+            & (rsi_3_4h_gt_20 | (rsi_3_1d_gt_20) | (stochrsi_k_1d < 70.0))
             # 4h down move, 1d high & overbought
-            & (rsi_3_4h_gt_20 | (aroonu_14_1d < 80.0) | (roc_9_1d < 200.0))
+            & (rsi_3_4h_gt_20 | (aroonu_14_1d_lt_80) | (roc_9_1d < 200.0))
             # 4h down move, 4h & 1d downtrend
             & (rsi_3_4h_gt_20 | (roc_9_4h_gt_neg_20) | (roc_9_1d_gt_neg_30))
             # 4h down move, 15m high, 1d overbought
-            & ((rsi_3_4h > 25.0) | (aroonu_14_15m < 70.0) | (roc_9_1d_lt_100))
+            & ((rsi_3_4h_gt_25) | (aroonu_14_15m_lt_70) | (roc_9_1d_lt_100))
             # 4h down move, 4h high
-            & ((rsi_3_4h > 25.0) | aroonu_14_4h_lt_80)
+            & ((rsi_3_4h_gt_25) | aroonu_14_4h_lt_80)
             # 4h down move, 1d high, 1h downtrend
-            & ((rsi_3_4h > 25.0) | aroonu_14_1d_lt_100 | (roc_9_1h > -40.0))
+            & ((rsi_3_4h_gt_25) | aroonu_14_1d_lt_100 | (roc_9_1h > -40.0))
             # 4h down move, 4h still high, 1d downtrend
-            & ((rsi_3_4h > 30.0) | (aroonu_14_4h < 50.0) | (roc_9_1d > -40.0))
+            & ((rsi_3_4h_gt_30) | (aroonu_14_4h_lt_50) | (roc_9_1d_gt_neg_40))
             # 4h down move, 4h still high, 1d overbought
-            & ((rsi_3_4h > 30.0) | (aroonu_14_4h < 50.0) | (roc_9_1d < 200.0))
+            & ((rsi_3_4h_gt_30) | (aroonu_14_4h_lt_50) | (roc_9_1d < 200.0))
             # 4h down move, 4h still not low enough, 1d overbought
-            & ((rsi_3_4h > 30.0) | (stochrsi_k_4h < 20.0) | (roc_9_1d < 60.0))
+            & ((rsi_3_4h_gt_30) | (stochrsi_k_4h < 20.0) | (roc_9_1d < 60.0))
             # 4h down move, 1d high, 1d downtrend
-            & ((rsi_3_4h > 35.0) | (stochrsi_k_1d < 60.0) | (roc_9_1d_gt_neg_30))
+            & ((rsi_3_4h_gt_35) | (stochrsi_k_1d < 60.0) | (roc_9_1d_gt_neg_30))
             # 4h down move, 1h high, 1d overbought
             & ((rsi_3_4h > 45.0) | (aroonu_14_1h < 85.0) | roc_9_1d_lt_50)
             # 4h down move, 1d high, 1d downtrend
-            & ((rsi_3_4h > 45.0) | (aroonu_14_1d < 80.0) | (roc_9_1d > -15.0))
+            & ((rsi_3_4h > 45.0) | (aroonu_14_1d_lt_80) | (roc_9_1d > -15.0))
             # 4h down move, 1d high & overbought
-            & ((rsi_3_4h > 45.0) | (stochrsi_k_1d < 90.0) | (roc_9_1d < 25.0))
+            & ((rsi_3_4h > 45.0) | (stochrsi_k_1d_lt_90) | (roc_9_1d < 25.0))
             # 4h down move, 4h still high, 1d downtrend
-            & ((rsi_3_4h > 50.0) | (rsi_14_4h < 40.0) | (roc_9_1d_gt_neg_30))
+            & ((rsi_3_4h_gt_50) | (rsi_14_4h < 40.0) | (roc_9_1d_gt_neg_30))
             # 4h down move, 4h high & overbought
-            & ((rsi_3_4h > 50.0) | aroonu_14_4h_lt_80 | (roc_9_4h < 10.0))
+            & ((rsi_3_4h_gt_50) | aroonu_14_4h_lt_80 | (roc_9_4h_lt_10))
             # 4h down move, 4h still high, 1d downtrend
-            & ((rsi_3_4h > 50.0) | (stochrsi_k_4h < 50.0) | (roc_9_1d_gt_neg_30))
+            & ((rsi_3_4h_gt_50) | (stochrsi_k_4h_lt_50) | (roc_9_1d_gt_neg_30))
             # 4h down move, 4h & 1d overbought
-            & ((rsi_3_4h > 50.0) | (roc_9_4h < 10.0) | (roc_9_1d < 40.0))
+            & ((rsi_3_4h_gt_50) | (roc_9_4h_lt_10) | (roc_9_1d_lt_40))
             # 1d down move, 4h still high, 1d downtrend
             & ((rsi_3_1d > 3.0) | (stochrsi_k_4h < 40.0) | (roc_9_1d > -25.0))
             # 1d down move, 1h & 4h high
-            & ((rsi_3_1d > 10.0) | (aroonu_14_1h < 50.0) | (aroonu_14_4h < 90.0))
+            & ((rsi_3_1d_gt_10) | (aroonu_14_1h_lt_50) | (aroonu_14_4h_lt_90))
             # 1d down move, 1d high, 1d downtrend
-            & ((rsi_3_1d > 10.0) | (aroonu_14_1d < 70.0) | (roc_9_1d > -40.0))
+            & ((rsi_3_1d_gt_10) | (aroonu_14_1d_lt_70) | (roc_9_1d_gt_neg_40))
             # 1d down move, 4h high, 1d downtrend
-            & ((rsi_3_1d > 10.0) | (stochrsi_k_4h_lt_90) | (roc_9_1d > -80.0))
+            & ((rsi_3_1d_gt_10) | (stochrsi_k_4h_lt_90) | (roc_9_1d > -80.0))
             # 1d down move, 1h & 4h high
-            & ((rsi_3_1d > 15.0) | (aroonu_14_1h < 90.0) | aroonu_14_4h_lt_100)
+            & ((rsi_3_1d_gt_15) | (aroonu_14_1h_lt_90) | aroonu_14_4h_lt_100)
             # 1d down move, 1h high, 1d downtrend
-            & ((rsi_3_1d > 20.0) | (aroonu_14_1h < 100.0) | (roc_9_1d_gt_neg_30))
+            & ((rsi_3_1d_gt_20) | (aroonu_14_1h_lt_100) | (roc_9_1d_gt_neg_30))
             # 1d down move, 1h still high, 4h downtrend
-            & ((rsi_3_1d > 25.0) | (stochrsi_k_1h_lt_50) | (roc_9_4h > -30.0))
+            & ((rsi_3_1d_gt_25) | (stochrsi_k_1h_lt_50) | (roc_9_4h_gt_neg_30))
             # 1d down move, 1h high & overbought
-            & ((rsi_3_1d > 35.0) | (stochrsi_k_1h < 90.0) | (roc_9_1h < 10.0))
+            & ((rsi_3_1d > 35.0) | (stochrsi_k_1h < 90.0) | (roc_9_1h_lt_10))
             # 15m downtrend, 4h & 1d high
             & ((cmf_20_15m > -0.30) | aroonu_14_4h_lt_80 | aroonu_14_1d_lt_100)
             # 15m & 1h high, 1h overbought
-            & ((aroonu_14_15m < 70.0) | (aroonu_14_1h < 100.0) | (roc_9_1h < 50.0))
+            & ((aroonu_14_15m_lt_70) | (aroonu_14_1h_lt_100) | (roc_9_1h < 50.0))
             # 15m & 1d high, 1d overbought
-            & ((aroonu_14_15m < 70.0) | (aroonu_14_1d < 90.0) | (roc_9_1d < 30.0))
+            & ((aroonu_14_15m_lt_70) | (aroonu_14_1d_lt_90) | (roc_9_1d_lt_30))
             # 1h & 4h high, 1h downtrend
             & (aroonu_14_1h_lt_70 | aroonu_14_4h_lt_100 | (cmf_20_1h > -0.30))
             # 1h high, 4h high, 1h overbought
             & (aroonu_14_1h_lt_70 | aroonu_14_4h_lt_100 | (roc_9_1h < 20.0))
             # 1h & 1d high, 1h overbought
-            & (aroonu_14_1h_lt_70 | (aroonu_14_1d < 70.0) | (roc_9_1h < 20.0))
+            & (aroonu_14_1h_lt_70 | (aroonu_14_1d_lt_70) | (roc_9_1h < 20.0))
             # 1h high, 1d high & overbought
             & (aroonu_14_1h_lt_70 | aroonu_14_1d_lt_100 | (roc_9_1d < 200.0))
             # 1h high, 1h & 1d overbought
@@ -16711,23 +16763,23 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h high, 4h downtrend, 1d overbought
             & (aroonu_14_1h_lt_70 | (roc_9_4h > -40.0) | (roc_9_1d < 100.0))
             # 1h high, 1h & 1d overbought
-            & (aroonu_14_1h_lt_80 | (roc_9_1h < 20.0) | (roc_9_1d < 20.0))
+            & (aroonu_14_1h_lt_80 | (roc_9_1h < 20.0) | (roc_9_1d_lt_20))
             # 1h high, 1h overbought, 1d downtrend
-            & (aroonu_14_1h_lt_80 | (roc_9_1h < 30.0) | (roc_9_1d > -40.0))
+            & (aroonu_14_1h_lt_80 | (roc_9_1h < 30.0) | (roc_9_1d_gt_neg_40))
             # 1h high, 4h & 1d overbought
-            & (aroonu_14_1h_lt_80 | (roc_9_4h < 10.0) | (roc_9_1d < 40.0))
+            & (aroonu_14_1h_lt_80 | (roc_9_4h_lt_10) | (roc_9_1d_lt_40))
             # 1h high, 4h & 1d downtrend
             & ((aroonu_14_1h < 85.0) | (roc_9_4h_gt_neg_20) | roc_9_1d_gt_neg_50)
             # 1h & 4h high, 1h overbought
-            & ((aroonu_14_1h < 100.0) | aroonu_14_4h_lt_100 | (roc_9_1h < 10.0))
+            & ((aroonu_14_1h_lt_100) | aroonu_14_4h_lt_100 | (roc_9_1h_lt_10))
             # 4h high, 4h & 1d overbought
-            & ((aroonu_14_4h < 60.0) | (roc_9_4h < 30.0) | (roc_9_1d < 60.0))
+            & ((aroonu_14_4h_lt_60) | (roc_9_4h_lt_30) | (roc_9_1d < 60.0))
             # 4h & 1d high, 4h overbought
-            & (aroonu_14_4h_lt_80 | aroonu_14_1d_lt_100 | (roc_9_4h < 30.0))
+            & (aroonu_14_4h_lt_80 | aroonu_14_1d_lt_100 | (roc_9_4h_lt_30))
             # 4h high, 4h & 1d overbought
-            & (aroonu_14_4h_lt_80 | (roc_9_4h < 20.0) | (roc_9_1d < 20.0))
+            & (aroonu_14_4h_lt_80 | (roc_9_4h < 20.0) | (roc_9_1d_lt_20))
             # 4h high, 15m downtrend, 4h overbought
-            & (aroonu_14_4h_lt_100 | (roc_9_15m > -30.0) | (roc_9_4h < 30.0))
+            & (aroonu_14_4h_lt_100 | (roc_9_15m > -30.0) | (roc_9_4h_lt_30))
             # 4h high, 1h & 4h overbought
             & (aroonu_14_4h_lt_100 | (roc_9_1h < 30.0) | (roc_9_4h < 70.0))
             # 4h & 1d high, 1h overbought
@@ -16739,19 +16791,19 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1d high, 4h downtrend, 1d overbought
             & ((aroonu_14_1d < 85.0) | (roc_9_4h > -25.0) | roc_9_1d_lt_50)
             # 1d high, 4h & 1d overbought
-            & ((aroonu_14_1d < 90.0) | (roc_9_4h < 10.0) | roc_9_1d_lt_50)
+            & ((aroonu_14_1d_lt_90) | (roc_9_4h_lt_10) | roc_9_1d_lt_50)
             # 1h high, 1d overbought
-            & ((stochrsi_k_1h_lt_70) | (roc_9_1d < 40.0))
+            & ((stochrsi_k_1h_lt_70) | (roc_9_1d_lt_40))
             # 1h high, 4h overbought
             & ((stochrsi_k_1h_lt_80) | (roc_9_4h < 80.0))
             # 1h high, 1h overbought, 4h downtrend
-            & ((stochrsi_k_1h < 90.0) | (roc_9_1h < 10.0) | (roc_9_4h > -15.0))
+            & ((stochrsi_k_1h < 90.0) | (roc_9_1h_lt_10) | (roc_9_4h > -15.0))
             # 4h high, 1h & 4h overbought
             & ((stochrsi_k_4h_lt_90) | (roc_9_1h < 20.0) | (roc_9_4h < 50.0))
             # 1d high, 4h & 1d overbought
-            & ((stochrsi_k_1d < 90.0) | (roc_9_4h < 100.0) | (roc_9_1d_lt_100))
+            & ((stochrsi_k_1d_lt_90) | (roc_9_4h < 100.0) | (roc_9_1d_lt_100))
             # 1d P&D, 4h overbought
-            & ((change_pct_1d > -10.0) | (change_pct_1d.shift(288) < 30.0) | (roc_9_4h < 10.0))
+            & ((change_pct_1d > -10.0) | (change_pct_1d.shift(288) < 30.0) | (roc_9_4h_lt_10))
             # big drop in the last 20 days, 1d high, 1d downtrend
             & ((close > (high_max_20_1d * 0.20)) | (stochrsi_k_1d < 70.0) | (roc_9_1d > -15.0))
           )
@@ -16769,131 +16821,131 @@ class NostalgiaForInfinityX7(IStrategy):
 
           long_entry_logic.append(
             # 5m & 1h down move, 1d still high
-            ((rsi_3 > 3.0) | (rsi_3_1h > 3.0) | (stochrsi_k_1d < 40.0))
+            ((rsi_3_gt_3) | (rsi_3_1h_gt_3) | (stochrsi_k_1d < 40.0))
             # 5m & 1h down move, 1d high
-            & ((rsi_3 > 3.0) | (rsi_3_1h > 25.0) | (stochrsi_k_1d < 70.0))
+            & ((rsi_3_gt_3) | (rsi_3_1h_gt_25) | (stochrsi_k_1d < 70.0))
             # 15m & 1h down move, 4h high
-            & (rsi_3_15m_gt_3 | (rsi_3_1h > 3.0) | (stochrsi_k_4h < 70.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_3) | (stochrsi_k_4h_lt_70))
             # 15m & 1h down move, 1h downtrend
-            & (rsi_3_15m_gt_3 | (rsi_3_1h > 3.0) | (roc_9_1h > -50.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_3) | (roc_9_1h > -50.0))
             # 15m & 1h down move, 1d still not low enough
-            & (rsi_3_15m_gt_3 | (rsi_3_1h > 5.0) | (stochrsi_k_1d < 30.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_5) | (stochrsi_k_1d < 30.0))
             # 15m & 1h down move, 4h still high
-            & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_10) | (aroonu_14_4h < 50.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_10) | (aroonu_14_4h_lt_50))
             # 15m & 1h down move, 1d high
             & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_10) | (aroonu_14_1d < 60.0))
             # 15m & 1h down move, 1h high
             & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_15) | (aroonu_14_1h < 60.0))
             # 15m & 4h down move, 4h still high
-            & (rsi_3_15m_gt_3 | (rsi_3_4h > 30.0) | (stochrsi_k_4h < 40.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_4h_gt_30) | (stochrsi_k_4h < 40.0))
             # 15m & 4h down move, 1d still high
             & (rsi_3_15m_gt_3 | (rsi_3_4h_gt_15) | (aroonu_14_1d < 40.0))
             # 15m & 1h down move, 1d downtrend
             & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_15) | (roc_9_1d > -30.0))
             # 15m down move, 4h still high, 1d downtrend
-            & (rsi_3_15m_gt_3 | (stochrsi_k_4h < 40.0) | (roc_9_1d > -40.0))
+            & (rsi_3_15m_gt_3 | (stochrsi_k_4h < 40.0) | (roc_9_1d_gt_neg_40))
             # 15m & 1h & 4h down move
-            & ((rsi_3_15m > 5.0) | (rsi_3_1h > 5.0) | rsi_3_4h_gt_20)
+            & ((rsi_3_15m_gt_5) | (rsi_3_1h_gt_5) | rsi_3_4h_gt_20)
             # 15m & 1h down move, 1h still high
-            & ((rsi_3_15m > 5.0) | (rsi_3_1h > 5.0) | (aroonu_14_1h < 40.0))
+            & ((rsi_3_15m_gt_5) | (rsi_3_1h_gt_5) | (aroonu_14_1h < 40.0))
             # 15m & 1h down move, 1d high
-            & ((rsi_3_15m > 5.0) | (rsi_3_1h > 5.0) | (aroonu_14_1d < 70.0))
+            & ((rsi_3_15m_gt_5) | (rsi_3_1h_gt_5) | (aroonu_14_1d_lt_70))
             # 15m & 1h & 4h down move
-            & ((rsi_3_15m > 5.0) | (rsi_3_1h_gt_10) | (rsi_3_4h_gt_15))
+            & ((rsi_3_15m_gt_5) | (rsi_3_1h_gt_10) | (rsi_3_4h_gt_15))
             # 15m & 4h down move, 1h downtrend
-            & ((rsi_3_15m > 5.0) | (rsi_3_4h_gt_10) | (roc_9_1h > -20.0))
+            & ((rsi_3_15m_gt_5) | (rsi_3_4h_gt_10) | (roc_9_1h > -20.0))
             # 15m & 4h down move, 1d downtrend
-            & ((rsi_3_15m > 5.0) | (rsi_3_4h_gt_10) | (roc_9_1d > -30.0))
+            & ((rsi_3_15m_gt_5) | (rsi_3_4h_gt_10) | (roc_9_1d > -30.0))
             # 15m & 4h down move, 4h still high
-            & ((rsi_3_15m > 5.0) | (rsi_3_4h > 30.0) | (aroonu_14_4h < 40.0))
+            & ((rsi_3_15m_gt_5) | (rsi_3_4h_gt_30) | (aroonu_14_4h_lt_40))
             # 15m & 1h down move, 4h high
-            & ((rsi_3_15m > 10.0) | (rsi_3_1h_gt_10) | aroonu_14_4h_lt_70)
+            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_10) | aroonu_14_4h_lt_70)
             # 15m & 1h down move, 1d high
-            & ((rsi_3_15m > 10.0) | (rsi_3_1h_gt_10) | (aroonu_14_1d < 100.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_10) | (aroonu_14_1d < 100.0))
             # 15m & 1h down move, 4h still high
-            & ((rsi_3_15m > 10.0) | (rsi_3_1h_gt_10) | (stochrsi_k_4h < 40.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_10) | (stochrsi_k_4h < 40.0))
             # 15m & 1h down move, 1d high
-            & ((rsi_3_15m > 10.0) | (rsi_3_1h_gt_10) | (stochrsi_k_1d < 90.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_10) | (stochrsi_k_1d_lt_90))
             # 15m & 1h down move, 4h high
-            & ((rsi_3_15m > 10.0) | (rsi_3_1h_gt_15) | (stochrsi_k_4h < 60.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_15) | (stochrsi_k_4h < 60.0))
             # 15m & 1h down move, 1d downtrend
-            & ((rsi_3_15m > 10.0) | (rsi_3_1h_gt_15) | (roc_9_1d > -30.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_15) | (roc_9_1d > -30.0))
             # 15m & 1h down move, 4h high
-            & ((rsi_3_15m > 10.0) | rsi_3_1h_gt_20 | aroonu_14_4h_lt_100)
+            & ((rsi_3_15m_gt_10) | rsi_3_1h_gt_20 | aroonu_14_4h_lt_100)
             # 15m & 1h down move, 1d overbought
-            & ((rsi_3_15m > 10.0) | rsi_3_1h_gt_20 | (roc_9_1d < 10.0))
+            & ((rsi_3_15m_gt_10) | rsi_3_1h_gt_20 | (roc_9_1d < 10.0))
             # 15m & 4h down move, 1d high
-            & ((rsi_3_15m > 10.0) | (rsi_3_4h > 30.0) | (stochrsi_k_1d < 90.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_4h_gt_30) | (stochrsi_k_1d_lt_90))
             # 15m & 1d down move, 4h still high
-            & ((rsi_3_15m > 10.0) | (rsi_3_1d > 10.0) | (stochrsi_k_4h < 40.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_1d_gt_10) | (stochrsi_k_4h < 40.0))
             # 15m & 4h down move, 4h still high
-            & ((rsi_3_15m > 10.0) | (rsi_3_4h_gt_10) | (stochrsi_k_4h < 40.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_4h_gt_10) | (stochrsi_k_4h < 40.0))
             # 15m & 4h down move, 1d high
-            & ((rsi_3_15m > 10.0) | rsi_3_4h_gt_20 | (stochrsi_k_1d < 70.0))
+            & ((rsi_3_15m_gt_10) | rsi_3_4h_gt_20 | (stochrsi_k_1d < 70.0))
             # 15m & 4h down move, 4h still not low enough
-            & ((rsi_3_15m > 10.0) | rsi_3_4h_gt_20 | (stochrsi_k_4h < 30.0))
+            & ((rsi_3_15m_gt_10) | rsi_3_4h_gt_20 | (stochrsi_k_4h < 30.0))
             # 15m & 4h down move, 1d high
-            & ((rsi_3_15m > 10.0) | rsi_3_4h_gt_20 | (stochrsi_k_1d < 80.0))
+            & ((rsi_3_15m_gt_10) | rsi_3_4h_gt_20 | (stochrsi_k_1d < 80.0))
             # 15m & 1h down move, 1h high
-            & ((rsi_3_15m > 15.0) | (rsi_3_1h_gt_15) | (aroonu_14_1h < 70.0))
+            & ((rsi_3_15m_gt_15) | (rsi_3_1h_gt_15) | (aroonu_14_1h < 70.0))
             # 15m & 1h down move, 15m still high
-            & ((rsi_3_15m > 15.0) | rsi_3_1h_gt_20 | (stochrsi_k_15m < 50.0))
+            & ((rsi_3_15m_gt_15) | rsi_3_1h_gt_20 | (stochrsi_k_15m < 50.0))
             # 15m & 4h down move, 15m still high
-            & ((rsi_3_15m > 15.0) | (rsi_3_4h_gt_15) | (stochrsi_k_15m < 50.0))
+            & ((rsi_3_15m_gt_15) | (rsi_3_4h_gt_15) | (stochrsi_k_15m < 50.0))
             # 15m & 4h down move, 4h high
-            & ((rsi_3_15m > 15.0) | rsi_3_4h_gt_20 | (aroonu_14_4h < 60.0))
+            & ((rsi_3_15m_gt_15) | rsi_3_4h_gt_20 | (aroonu_14_4h_lt_60))
             # 15m & 1d down move, 1d high
-            & ((rsi_3_15m > 15.0) | (rsi_3_1d > 40.0) | (stochrsi_k_1d < 70.0))
+            & ((rsi_3_15m_gt_15) | (rsi_3_1d > 40.0) | (stochrsi_k_1d < 70.0))
             # 15m down move, 15m high
-            & ((rsi_3_15m > 15.0) | (aroonu_14_15m < 70.0))
+            & ((rsi_3_15m_gt_15) | (aroonu_14_15m_lt_70))
             # 15m & 4h down move, 4h high
-            & ((rsi_3_15m > 20.0) | (rsi_3_4h > 25.0) | aroonu_14_4h_lt_70)
+            & ((rsi_3_15m_gt_20) | (rsi_3_4h_gt_25) | aroonu_14_4h_lt_70)
             # 15m down move, 1h & 4h high
-            & ((rsi_3_15m > 20.0) | aroonu_14_1h_lt_70 | aroonu_14_4h_lt_100)
+            & ((rsi_3_15m_gt_20) | aroonu_14_1h_lt_70 | aroonu_14_4h_lt_100)
             # 15m down move, 15m still not low enough, 1d downtrend
-            & ((rsi_3_15m > 25.0) | (aroonu_14_15m < 25.0) | roc_9_1d_gt_neg_50)
+            & ((rsi_3_15m_gt_25) | (aroonu_14_15m < 25.0) | roc_9_1d_gt_neg_50)
             # 15m down move, 15m still high, 4h high
-            & ((rsi_3_15m > 25.0) | (aroonu_14_15m < 50.0) | aroonu_14_4h_lt_80)
+            & ((rsi_3_15m_gt_25) | (aroonu_14_15m_lt_50) | aroonu_14_4h_lt_80)
             # 15m down move, 4h high, 1d downtrend
-            & ((rsi_3_15m > 25.0) | (stochrsi_k_4h_lt_80) | (roc_9_1d > -40.0))
+            & ((rsi_3_15m_gt_25) | (stochrsi_k_4h_lt_80) | (roc_9_1d_gt_neg_40))
             # 15m down move, 4h high, 1d downtrend
-            & ((rsi_3_15m > 25.0) | (stochrsi_k_4h_lt_90) | (roc_9_1d > -10.0))
+            & ((rsi_3_15m_gt_25) | (stochrsi_k_4h_lt_90) | (roc_9_1d > -10.0))
             # 15m down move, 15m still high, 4h high
-            & ((rsi_3_15m > 35.0) | (aroonu_14_15m < 50.0) | aroonu_14_4h_lt_80)
+            & ((rsi_3_15m > 35.0) | (aroonu_14_15m_lt_50) | aroonu_14_4h_lt_80)
             # 1h & 4h down move
-            & ((rsi_3_1h > 3.0) | (rsi_3_4h > 3.0))
+            & ((rsi_3_1h_gt_3) | (rsi_3_4h > 3.0))
             # 1h & 4h down move, 1d still high
-            & ((rsi_3_1h > 3.0) | (rsi_3_4h_gt_15) | (aroonu_14_1d < 50.0))
+            & ((rsi_3_1h_gt_3) | (rsi_3_4h_gt_15) | (aroonu_14_1d < 50.0))
             # 1h & 4h down move, 1d still high
-            & ((rsi_3_1h > 3.0) | (rsi_3_4h_gt_15) | (stochrsi_k_1d < 50.0))
+            & ((rsi_3_1h_gt_3) | (rsi_3_4h_gt_15) | (stochrsi_k_1d < 50.0))
             # 1h & 4h down move, 1h still high
-            & ((rsi_3_1h > 3.0) | rsi_3_4h_gt_20 | (aroonu_14_1h < 40.0))
+            & ((rsi_3_1h_gt_3) | rsi_3_4h_gt_20 | (aroonu_14_1h < 40.0))
             # 1h & 4h down move, 4h still not low enough
-            & ((rsi_3_1h > 3.0) | rsi_3_4h_gt_20 | (stochrsi_k_4h < 30.0))
+            & ((rsi_3_1h_gt_3) | rsi_3_4h_gt_20 | (stochrsi_k_4h < 30.0))
             # 1h & 4h down move, 4h high
-            & ((rsi_3_1h > 3.0) | (rsi_3_4h > 25.0) | aroonu_14_4h_lt_70)
+            & ((rsi_3_1h_gt_3) | (rsi_3_4h_gt_25) | aroonu_14_4h_lt_70)
             # 1h & 4h down move, 1d high
-            & ((rsi_3_1h > 3.0) | (rsi_3_4h > 25.0) | (aroonu_14_1d < 70.0))
+            & ((rsi_3_1h_gt_3) | (rsi_3_4h_gt_25) | (aroonu_14_1d_lt_70))
             # 1h & 4h down move, 4h high
-            & ((rsi_3_1h > 3.0) | (rsi_3_4h > 25.0) | (stochrsi_k_4h < 60.0))
+            & ((rsi_3_1h_gt_3) | (rsi_3_4h_gt_25) | (stochrsi_k_4h < 60.0))
             # 1h down move, 1d high, 1d downtrend
-            & ((rsi_3_1h > 3.0) | (aroonu_14_1d < 70.0) | (roc_9_1h > -50.0))
+            & ((rsi_3_1h_gt_3) | (aroonu_14_1d_lt_70) | (roc_9_1h > -50.0))
             # 1h & 4h down move, 15m still not low enough
-            & ((rsi_3_1h > 5.0) | (rsi_3_4h > 5.0) | (stochrsi_k_15m < 20.0))
+            & ((rsi_3_1h_gt_5) | (rsi_3_4h_gt_5) | (stochrsi_k_15m < 20.0))
             # 1h & 4h down move, 1d downtrend
-            & ((rsi_3_1h > 5.0) | (rsi_3_4h > 5.0) | (roc_9_1d_gt_neg_30))
+            & ((rsi_3_1h_gt_5) | (rsi_3_4h_gt_5) | (roc_9_1d_gt_neg_30))
             # 1h & 4h down move, 1d still high
-            & ((rsi_3_1h > 5.0) | (rsi_3_4h_gt_15) | (aroonu_14_1d < 40.0))
+            & ((rsi_3_1h_gt_5) | (rsi_3_4h_gt_15) | (aroonu_14_1d < 40.0))
             # 1h & 4h down move, 1h high
-            & ((rsi_3_1h > 5.0) | (rsi_3_4h > 25.0) | aroonu_14_1h_lt_70)
+            & ((rsi_3_1h_gt_5) | (rsi_3_4h_gt_25) | aroonu_14_1h_lt_70)
             # 1h & 4h down move, 1d high
-            & ((rsi_3_1h > 5.0) | (rsi_3_4h > 25.0) | (stochrsi_k_1d < 80.0))
+            & ((rsi_3_1h_gt_5) | (rsi_3_4h_gt_25) | (stochrsi_k_1d < 80.0))
             # 1h & 4h down move, 1d overbought
-            & ((rsi_3_1h > 5.0) | (rsi_3_4h > 35.0) | (roc_9_1d < 40.0))
+            & ((rsi_3_1h_gt_5) | (rsi_3_4h_gt_35) | (roc_9_1d_lt_40))
             # 1h & 1d down move, 1h still high
-            & ((rsi_3_1h > 5.0) | (rsi_3_1d > 5.0) | (aroonu_14_1h < 50.0))
+            & ((rsi_3_1h_gt_5) | (rsi_3_1d > 5.0) | (aroonu_14_1h_lt_50))
             # 1h down move, 4h high
-            & ((rsi_3_1h > 5.0) | (aroonu_14_4h < 90.0))
+            & ((rsi_3_1h_gt_5) | (aroonu_14_4h_lt_90))
             # 1h & 4h down move, 1d high
             & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_10) | (aroonu_14_1d < 75.0))
             # 1h & 4h down move, 1d high
@@ -16905,31 +16957,31 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 1d overbought
             & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_10) | (roc_9_1d < 10.0))
             # 1h & 4h down move, 1d high
-            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_15) | (aroonu_14_1d < 80.0))
+            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_15) | (aroonu_14_1d_lt_80))
             # 1h & 4h down move, 4h still not low enough
             & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_15) | (stochrsi_k_4h < 20.0))
             # 1h & 4h down move, 1d downtrend
-            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_15) | (roc_9_1d > -40.0))
+            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_15) | (roc_9_1d_gt_neg_40))
             # 1h & 4h down move, 1h still high
             & ((rsi_3_1h_gt_10) | rsi_3_4h_gt_20 | (aroonu_14_1h < 40.0))
             # 1h & 4h down move, 4h high
             & ((rsi_3_1h_gt_10) | rsi_3_4h_gt_20 | aroonu_14_4h_lt_70)
             # 1h & 4h down move, 1d high
-            & ((rsi_3_1h_gt_10) | rsi_3_4h_gt_20 | (aroonu_14_1d < 90.0))
+            & ((rsi_3_1h_gt_10) | rsi_3_4h_gt_20 | (aroonu_14_1d_lt_90))
             # 1h & 4h down move, 1d overbought
-            & ((rsi_3_1h_gt_10) | (rsi_3_4h > 25.0) | (roc_9_1d < 40.0))
+            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_25) | (roc_9_1d_lt_40))
             # 1h & 4h down move, 1d high
-            & ((rsi_3_1h_gt_10) | (rsi_3_4h > 35.0) | (aroonu_14_1d < 100.0))
+            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_35) | (aroonu_14_1d < 100.0))
             # 1h & 4h down move, 4h high
-            & ((rsi_3_1h_gt_10) | (rsi_3_4h > 35.0) | (stochrsi_k_4h < 70.0))
+            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_35) | (stochrsi_k_4h_lt_70))
             # 1h & 1d down move, 1d still high
-            & ((rsi_3_1h_gt_10) | (rsi_3_1d > 10.0) | (stochrsi_k_1d < 50.0))
+            & ((rsi_3_1h_gt_10) | (rsi_3_1d_gt_10) | (stochrsi_k_1d < 50.0))
             # 1h & 1d down move, 1d still high
-            & ((rsi_3_1h_gt_10) | (rsi_3_1d > 25.0) | (rsi_14_1d < 50.0))
+            & ((rsi_3_1h_gt_10) | (rsi_3_1d_gt_25) | (rsi_14_1d < 50.0))
             # 1h & 1d down move, 1h high
-            & ((rsi_3_1h_gt_10) | (rsi_3_1d > 25.0) | (aroonu_14_1h < 70.0))
+            & ((rsi_3_1h_gt_10) | (rsi_3_1d_gt_25) | (aroonu_14_1h < 70.0))
             # 1h & 1d down move, 1d high
-            & ((rsi_3_1h_gt_10) | (rsi_3_1d > 45.0) | (aroonu_14_1d < 70.0))
+            & ((rsi_3_1h_gt_10) | (rsi_3_1d > 45.0) | (aroonu_14_1d_lt_70))
             # 1h down move, 1h downtrend, 1h high
             & ((rsi_3_1h_gt_10) | (cmf_20_1h > -0.30) | (aroonu_14_1h < 70.0))
             # 1h down move, 1h high, 1d downtrend
@@ -16937,23 +16989,23 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h & 4h high
             & ((rsi_3_1h_gt_10) | (aroonu_14_1h < 60.0) | aroonu_14_4h_lt_70)
             # 1h down move, 1h high, 1d overbought
-            & ((rsi_3_1h_gt_10) | (aroonu_14_1h < 60.0) | (roc_9_1d < 20.0))
+            & ((rsi_3_1h_gt_10) | (aroonu_14_1h < 60.0) | (roc_9_1d_lt_20))
             # 1h down move, 4h still high, 1d downtrend
-            & ((rsi_3_1h_gt_10) | (aroonu_14_4h < 40.0) | (roc_9_1d > -40.0))
+            & ((rsi_3_1h_gt_10) | (aroonu_14_4h_lt_40) | (roc_9_1d_gt_neg_40))
             # 1h down move, 4h high, 1d downtrend
             & ((rsi_3_1h_gt_10) | aroonu_14_4h_lt_70 | (roc_9_1d > -20.0))
             # 1h down move, 1d still high, 1d downtrend
             & ((rsi_3_1h_gt_10) | (aroonu_14_1d < 40.0) | (roc_9_1d > -20.0))
             # 1h down move, 1d high & overbought
-            & ((rsi_3_1h_gt_10) | (aroonu_14_1d < 90.0) | (roc_9_1d < 30.0))
+            & ((rsi_3_1h_gt_10) | (aroonu_14_1d_lt_90) | (roc_9_1d_lt_30))
             # 1h down move, 15m high
             & ((rsi_3_1h_gt_10) | (stochrsi_k_15m < 80.0))
             # 1h down move, 4h & 1d downtrend
-            & ((rsi_3_1h_gt_10) | (roc_9_4h > -20.0) | (roc_9_1d > -40.0))
+            & ((rsi_3_1h_gt_10) | (roc_9_4h > -20.0) | (roc_9_1d_gt_neg_40))
             # 1h & 4h down move, 1d still high, 1d downtrend
             & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_15) | (rsi_14_1d < 40.0) | (roc_9_1d > -15.0))
             # 1h & 4h down move, 4h still high
-            & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_15) | (aroonu_14_4h < 50.0))
+            & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_15) | (aroonu_14_4h_lt_50))
             # 1h & 4h down move, 15m still high
             & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_15) | (stochrsi_k_15m < 40.0))
             # 1h & 4h down move, 4h still not low enough
@@ -16961,31 +17013,31 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 1d high
             & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_15) | (stochrsi_k_1d < 70.0))
             # 1h & 4h down move, 1d downtrend
-            & ((rsi_3_1h_gt_15) | (rsi_3_4h > 25.0) | (roc_9_1d > -40.0))
+            & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_25) | (roc_9_1d_gt_neg_40))
             # 1h & 4h down move, 4h high
-            & ((rsi_3_1h_gt_15) | (rsi_3_4h > 30.0) | (aroonu_14_4h < 60.0))
+            & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_30) | (aroonu_14_4h_lt_60))
             # 1h & 4h down move, 1d high
-            & ((rsi_3_1h_gt_15) | (rsi_3_4h > 30.0) | (stochrsi_k_1d < 80.0))
+            & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_30) | (stochrsi_k_1d < 80.0))
             # 1h & 4h down move, 4h overbought
-            & ((rsi_3_1h_gt_15) | (rsi_3_4h > 35.0) | (roc_9_4h < 10.0))
+            & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_35) | (roc_9_4h_lt_10))
             # 1h & 1d down move, 4h high
-            & ((rsi_3_1h_gt_15) | (rsi_3_1d > 20.0) | (stochrsi_k_4h < 60.0))
+            & ((rsi_3_1h_gt_15) | (rsi_3_1d_gt_20) | (stochrsi_k_4h < 60.0))
             # 1h & 1d down move, 1d overbought
             & ((rsi_3_1h_gt_15) | (rsi_3_1d > 35.0) | (roc_9_1d < 10.0))
             # 1h down move, 1h downtrend, 1h high
             & ((rsi_3_1h_gt_15) | (cmf_20_1h > -0.30) | (aroonu_14_1h < 70.0))
             # 1h down move, 1h still high, 4h downtrend
-            & ((rsi_3_1h_gt_15) | (aroonu_14_1h < 40.0) | (roc_9_4h > -30.0))
+            & ((rsi_3_1h_gt_15) | (aroonu_14_1h < 40.0) | (roc_9_4h_gt_neg_30))
             # 1h down move, 1h still high, 1d downtrend
-            & ((rsi_3_1h_gt_15) | (aroonu_14_1h < 50.0) | (roc_9_1d > -40.0))
+            & ((rsi_3_1h_gt_15) | (aroonu_14_1h_lt_50) | (roc_9_1d_gt_neg_40))
             # 1h down move, 1d still high, 4h downtrend
             & ((rsi_3_1h_gt_15) | (aroonu_14_1d < 50.0) | (roc_9_4h > -20.0))
             # 1h down move, 1d high, 1d downtrend
-            & ((rsi_3_1h_gt_15) | (aroonu_14_1d < 80.0) | (roc_9_1d > -20.0))
+            & ((rsi_3_1h_gt_15) | (aroonu_14_1d_lt_80) | (roc_9_1d > -20.0))
             # 1h down move, 1d high & overbought
-            & ((rsi_3_1h_gt_15) | (aroonu_14_1d < 80.0) | (roc_9_1d < 30.0))
+            & ((rsi_3_1h_gt_15) | (aroonu_14_1d_lt_80) | (roc_9_1d_lt_30))
             # 1h down move, 4h still high, 1d downtrend
-            & ((rsi_3_1h_gt_15) | (stochrsi_k_4h < 50.0) | (roc_9_1d > -30.0))
+            & ((rsi_3_1h_gt_15) | (stochrsi_k_4h_lt_50) | (roc_9_1d > -30.0))
             # 1h down move, 4h & 1d downtrend
             & ((rsi_3_1h_gt_15) | (roc_9_4h > -20.0) | (roc_9_1d > -20.0))
             # 1h & 4h down move, 1h high
@@ -16995,131 +17047,131 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 15m high
             & (rsi_3_1h_gt_20 | rsi_3_4h_gt_20 | (stochrsi_k_15m < 60.0))
             # 1h & 4h down move, 1d overbought
-            & (rsi_3_1h_gt_20 | rsi_3_4h_gt_20 | (roc_9_1d < 30.0))
+            & (rsi_3_1h_gt_20 | rsi_3_4h_gt_20 | (roc_9_1d_lt_30))
             # 1h & 4h down move, 4h high
-            & (rsi_3_1h_gt_20 | (rsi_3_4h > 50.0) | (stochrsi_k_4h_lt_80))
+            & (rsi_3_1h_gt_20 | (rsi_3_4h_gt_50) | (stochrsi_k_4h_lt_80))
             # 1h & 1d down move, 1d high
-            & (rsi_3_1h_gt_20 | (rsi_3_1d > 20.0) | (stochrsi_k_1d < 60.0))
+            & (rsi_3_1h_gt_20 | (rsi_3_1d_gt_20) | (stochrsi_k_1d < 60.0))
             # 1h & 1d down move, 1d high
             & (rsi_3_1h_gt_20 | (rsi_3_1d > 30.0) | aroonu_14_1d_lt_100)
             # 1h & 1d down move, 1d overbought
-            & (rsi_3_1h_gt_20 | (rsi_3_1d > 45.0) | (roc_9_1d < 20.0))
+            & (rsi_3_1h_gt_20 | (rsi_3_1d > 45.0) | (roc_9_1d_lt_20))
             # 1h down move, 1h high, 1d overbought
-            & (rsi_3_1h_gt_20 | (aroonu_14_1h < 60.0) | (roc_9_1d < 30.0))
+            & (rsi_3_1h_gt_20 | (aroonu_14_1h < 60.0) | (roc_9_1d_lt_30))
             # 1h down move, 1h high, 4h downtrend
             & (rsi_3_1h_gt_20 | aroonu_14_1h_lt_70 | (roc_9_4h > -20.0))
             # 1h down move, 1d high & overbought
-            & (rsi_3_1h_gt_20 | aroonu_14_1d_lt_100 | (roc_9_1d < 30.0))
+            & (rsi_3_1h_gt_20 | aroonu_14_1d_lt_100 | (roc_9_1d_lt_30))
             # 1h down move, 1d high, 4h downtrend
             & (rsi_3_1h_gt_20 | (stochrsi_k_1d < 80.0) | (roc_9_4h_gt_neg_20))
             # 1h & 4h down move, 15m high
-            & ((rsi_3_1h > 25.0) | (rsi_3_4h > 25.0) | (stochrsi_k_15m < 70.0))
+            & ((rsi_3_1h_gt_25) | (rsi_3_4h_gt_25) | (stochrsi_k_15m < 70.0))
             # 1h & 4h down move, 4h high
-            & ((rsi_3_1h > 25.0) | (rsi_3_4h > 40.0) | aroonu_14_4h_lt_70)
+            & ((rsi_3_1h_gt_25) | (rsi_3_4h_gt_40) | aroonu_14_4h_lt_70)
             # 1h & 1d down move, 1h high
-            & ((rsi_3_1h > 25.0) | (rsi_3_1d > 25.0) | aroonu_14_1h_lt_80)
+            & ((rsi_3_1h_gt_25) | (rsi_3_1d_gt_25) | aroonu_14_1h_lt_80)
             # 1h & 1d down move, 1d high
-            & ((rsi_3_1h > 25.0) | (rsi_3_1d > 45.0) | (stochrsi_k_1d < 80.0))
+            & ((rsi_3_1h_gt_25) | (rsi_3_1d > 45.0) | (stochrsi_k_1d < 80.0))
             # 1h down move, 4h downtrend, 4h high
-            & ((rsi_3_1h > 25.0) | (cmf_20_4h > -0.50) | aroonu_14_4h_lt_70)
+            & ((rsi_3_1h_gt_25) | (cmf_20_4h > -0.50) | aroonu_14_4h_lt_70)
             # 1h down move, 1h high, 1d overbought
-            & ((rsi_3_1h > 25.0) | (aroonu_14_1h < 60.0) | roc_9_1d_lt_50)
+            & ((rsi_3_1h_gt_25) | (aroonu_14_1h < 60.0) | roc_9_1d_lt_50)
             # 1h down move, 1h high, 1d downtrend
-            & ((rsi_3_1h > 25.0) | (aroonu_14_1h < 60.0) | (roc_9_1d > -40.0))
+            & ((rsi_3_1h_gt_25) | (aroonu_14_1h < 60.0) | (roc_9_1d_gt_neg_40))
             # 1h down move, 4h high & overbought
-            & ((rsi_3_1h > 25.0) | aroonu_14_4h_lt_70 | (roc_9_4h < 10.0))
+            & ((rsi_3_1h_gt_25) | aroonu_14_4h_lt_70 | (roc_9_4h_lt_10))
             # 1h down move, 1d high & overbought
-            & ((rsi_3_1h > 25.0) | (aroonu_14_1d < 80.0) | (roc_9_1d < 200.0))
+            & ((rsi_3_1h_gt_25) | (aroonu_14_1d_lt_80) | (roc_9_1d < 200.0))
             # 1h down move, 1d high, 4h overbought
-            & ((rsi_3_1h > 25.0) | aroonu_14_1d_lt_100 | (roc_9_4h < 10.0))
+            & ((rsi_3_1h_gt_25) | aroonu_14_1d_lt_100 | (roc_9_4h_lt_10))
             # 1h down move, 1h high & overbought
-            & ((rsi_3_1h > 25.0) | aroonu_14_1d_lt_100 | (roc_9_1d < 20.0))
+            & ((rsi_3_1h_gt_25) | aroonu_14_1d_lt_100 | (roc_9_1d_lt_20))
             # 1h down move, 4h high & overbought
-            & ((rsi_3_1h > 25.0) | (stochrsi_k_4h < 80.0) | (roc_9_4h_lt_20))
+            & ((rsi_3_1h_gt_25) | (stochrsi_k_4h < 80.0) | (roc_9_4h_lt_20))
             # 1h & 4h down move, 1d downtrend
-            & ((rsi_3_1h > 30.0) | (rsi_3_4h > 30.0) | roc_9_1d_gt_neg_50)
+            & ((rsi_3_1h_gt_30) | (rsi_3_4h_gt_30) | roc_9_1d_gt_neg_50)
             # 1h & 4h down move, 15m high
-            & ((rsi_3_1h > 30.0) | (rsi_3_4h > 35.0) | (aroonu_14_15m < 80.0))
+            & ((rsi_3_1h_gt_30) | (rsi_3_4h_gt_35) | (aroonu_14_15m < 80.0))
             # 1h & 4h down move, 4h high
-            & ((rsi_3_1h > 30.0) | (rsi_3_4h > 40.0) | (aroonu_14_4h < 75.0))
+            & ((rsi_3_1h_gt_30) | (rsi_3_4h_gt_40) | (aroonu_14_4h < 75.0))
             # 1h & 4h down move, 15m high
-            & ((rsi_3_1h > 30.0) | (rsi_3_4h > 40.0) | (stochrsi_k_15m < 80.0))
+            & ((rsi_3_1h_gt_30) | (rsi_3_4h_gt_40) | (stochrsi_k_15m < 80.0))
             # 1h & 4h down move, 4h high
-            & ((rsi_3_1h > 30.0) | (rsi_3_4h > 50.0) | aroonu_14_4h_lt_80)
+            & ((rsi_3_1h_gt_30) | (rsi_3_4h_gt_50) | aroonu_14_4h_lt_80)
             # 1h & 1d down move, 1d high
-            & ((rsi_3_1h > 30.0) | (rsi_3_1d > 30.0) | (aroonu_14_1d < 80.0))
+            & ((rsi_3_1h_gt_30) | (rsi_3_1d > 30.0) | (aroonu_14_1d_lt_80))
             # 1h & 1d down move, 1d overbought
-            & ((rsi_3_1h > 30.0) | (rsi_3_1d > 40.0) | roc_9_1d_lt_50)
+            & ((rsi_3_1h_gt_30) | (rsi_3_1d > 40.0) | roc_9_1d_lt_50)
             # 1h down move, 4h high, 4h downtrend
-            & ((rsi_3_1h > 30.0) | aroonu_14_4h_lt_70 | (cmf_20_4h > -0.40))
+            & ((rsi_3_1h_gt_30) | aroonu_14_4h_lt_70 | (cmf_20_4h > -0.40))
             # 1h down move, 4h high & overbought
-            & ((rsi_3_1h > 30.0) | aroonu_14_4h_lt_80 | (roc_9_4h < 30.0))
+            & ((rsi_3_1h_gt_30) | aroonu_14_4h_lt_80 | (roc_9_4h_lt_30))
             # 1h down move, 1d high, 4h overbought
-            & ((rsi_3_1h > 30.0) | aroonu_14_1d_lt_100 | (roc_9_4h < 10.0))
+            & ((rsi_3_1h_gt_30) | aroonu_14_1d_lt_100 | (roc_9_4h_lt_10))
             # 1h down move, 4h still high, 1d downtrend
-            & ((rsi_3_1h > 30.0) | (stochrsi_k_4h < 40.0) | (roc_9_1d > -80.0))
+            & ((rsi_3_1h_gt_30) | (stochrsi_k_4h < 40.0) | (roc_9_1d > -80.0))
             # 1h down move, 4h & 1d overbought
-            & ((rsi_3_1h > 30.0) | (roc_9_4h < 10.0) | (roc_9_1d < 30.0))
+            & ((rsi_3_1h_gt_30) | (roc_9_4h_lt_10) | (roc_9_1d_lt_30))
             # 1h & 4h down move, 15m high
-            & ((rsi_3_1h > 35.0) | (rsi_3_4h > 45.0) | (aroonu_14_15m < 90.0))
+            & ((rsi_3_1h_gt_35) | (rsi_3_4h > 45.0) | (aroonu_14_15m < 90.0))
             # 1h & 4h down move, 4h high
-            & ((rsi_3_1h > 35.0) | (rsi_3_4h > 45.0) | (aroonu_14_4h < 90.0))
+            & ((rsi_3_1h_gt_35) | (rsi_3_4h > 45.0) | (aroonu_14_4h_lt_90))
             # 1h down move, 15m high, 1d downtrend
-            & ((rsi_3_1h > 35.0) | (aroonu_14_15m < 60.0) | (roc_9_1d > -40.0))
+            & ((rsi_3_1h_gt_35) | (aroonu_14_15m < 60.0) | (roc_9_1d_gt_neg_40))
             # 1h down move, 1h still high, 1d high
-            & ((rsi_3_1h > 35.0) | (aroonu_14_1h < 50.0) | (aroonu_14_1d < 90.0))
+            & ((rsi_3_1h_gt_35) | (aroonu_14_1h_lt_50) | (aroonu_14_1d_lt_90))
             # 1h down move, 1h & 4h high
-            & ((rsi_3_1h > 35.0) | aroonu_14_1h_lt_70 | aroonu_14_4h_lt_100)
+            & ((rsi_3_1h_gt_35) | aroonu_14_1h_lt_70 | aroonu_14_4h_lt_100)
             # 1h down move, 1h & 1d high
-            & ((rsi_3_1h > 35.0) | aroonu_14_1h_lt_70 | aroonu_14_1d_lt_100)
+            & ((rsi_3_1h_gt_35) | aroonu_14_1h_lt_70 | aroonu_14_1d_lt_100)
             # 1h down move, 4h high, 1d downtrend
-            & ((rsi_3_1h > 35.0) | (aroonu_14_4h < 90.0) | (roc_9_1d_gt_neg_20))
+            & ((rsi_3_1h_gt_35) | (aroonu_14_4h_lt_90) | (roc_9_1d_gt_neg_20))
             # 1h down move, 4h high & overbought
-            & ((rsi_3_1h > 35.0) | (stochrsi_k_4h_lt_90) | (roc_9_4h < 10.0))
+            & ((rsi_3_1h_gt_35) | (stochrsi_k_4h_lt_90) | (roc_9_4h_lt_10))
             # 1h down move, 4h & 1d downtrend
-            & ((rsi_3_1h > 35.0) | (roc_9_4h > -10.0) | (roc_9_1d > -60.0))
+            & ((rsi_3_1h_gt_35) | (roc_9_4h > -10.0) | (roc_9_1d > -60.0))
             # 1h down move, 4h high & overbought
-            & ((rsi_3_1h > 40.0) | (aroonu_14_4h < 90.0) | (roc_9_4h_lt_20))
+            & ((rsi_3_1h_gt_40) | (aroonu_14_4h_lt_90) | (roc_9_4h_lt_20))
             # 1h down move, 4h high, 1d downtrend
-            & ((rsi_3_1h > 40.0) | (stochrsi_k_4h < 60.0) | roc_9_1d_gt_neg_50)
+            & ((rsi_3_1h_gt_40) | (stochrsi_k_4h < 60.0) | roc_9_1d_gt_neg_50)
             # 1h down move, 4h high & overbought
-            & ((rsi_3_1h > 40.0) | (stochrsi_k_4h < 70.0) | (roc_9_4h < 40.0))
+            & ((rsi_3_1h_gt_40) | (stochrsi_k_4h_lt_70) | (roc_9_4h_lt_40))
             # 1h down move, 4h high & overbought
-            & ((rsi_3_1h > 45.0) | aroonu_14_4h_lt_80 | (roc_9_4h < 100.0))
+            & ((rsi_3_1h_gt_45) | aroonu_14_4h_lt_80 | (roc_9_4h < 100.0))
             # 1h down move, 4h high & overbought
-            & ((rsi_3_1h > 50.0) | aroonu_14_4h_lt_100 | (roc_9_4h < 40.0))
+            & ((rsi_3_1h_gt_50) | aroonu_14_4h_lt_100 | (roc_9_4h_lt_40))
             # 1h down move, 1d high & overbought
-            & ((rsi_3_1h > 50.0) | (stochrsi_k_1d < 90.0) | (roc_9_1d < 20.0))
+            & ((rsi_3_1h_gt_50) | (stochrsi_k_1d_lt_90) | (roc_9_1d_lt_20))
             # 1h down move, 4h & 1d overbought
-            & ((rsi_3_1h > 60.0) | (roc_9_4h < 30.0) | (roc_9_1d_lt_100))
+            & ((rsi_3_1h > 60.0) | (roc_9_4h_lt_30) | (roc_9_1d_lt_100))
             # 4h & 1d down move
-            & ((rsi_3_4h > 3.0) | (rsi_3_1d > 15.0))
+            & ((rsi_3_4h > 3.0) | (rsi_3_1d_gt_15))
             # 4h & 1d down move, 1d high
-            & ((rsi_3_4h > 3.0) | (rsi_3_1d > 25.0) | (stochrsi_k_1d < 60.0))
+            & ((rsi_3_4h > 3.0) | (rsi_3_1d_gt_25) | (stochrsi_k_1d < 60.0))
             # 4h down move, 1h downtrend, 4h still high
-            & ((rsi_3_4h > 3.0) | (cmf_20_1h > -0.30) | (aroonu_14_4h < 40.0))
+            & ((rsi_3_4h > 3.0) | (cmf_20_1h > -0.30) | (aroonu_14_4h_lt_40))
             # 4h & 1d down move, 4h downtrend
-            & ((rsi_3_4h > 5.0) | (rsi_3_1d > 15.0) | (roc_9_4h > -10.0))
+            & ((rsi_3_4h_gt_5) | (rsi_3_1d_gt_15) | (roc_9_4h > -10.0))
             # 4h & 1d down move, 1d downtrend
-            & ((rsi_3_4h > 5.0) | (rsi_3_1d > 15.0) | (roc_9_1d_gt_neg_20))
+            & ((rsi_3_4h_gt_5) | (rsi_3_1d_gt_15) | (roc_9_1d_gt_neg_20))
             # 4h & 1d down move, 1d still high
-            & ((rsi_3_4h > 5.0) | (rsi_3_1d > 20.0) | (aroonu_14_1d < 40.0))
+            & ((rsi_3_4h_gt_5) | (rsi_3_1d_gt_20) | (aroonu_14_1d < 40.0))
             # 4h & 1d down move, 1d still high
-            & ((rsi_3_4h > 5.0) | (rsi_3_1d > 20.0) | (stochrsi_k_1d < 50.0))
+            & ((rsi_3_4h_gt_5) | (rsi_3_1d_gt_20) | (stochrsi_k_1d < 50.0))
             # 4h & 1d down move, 4h still not low enough
-            & ((rsi_3_4h > 5.0) | (rsi_3_1d > 30.0) | (aroonu_14_4h < 20.0))
+            & ((rsi_3_4h_gt_5) | (rsi_3_1d > 30.0) | (aroonu_14_4h < 20.0))
             # 4h & 1d down move, 1d high
-            & ((rsi_3_4h > 5.0) | (rsi_3_1d > 30.0) | (aroonu_14_1d < 70.0))
+            & ((rsi_3_4h_gt_5) | (rsi_3_1d > 30.0) | (aroonu_14_1d_lt_70))
             # 4h down move, 1h & 4h downtrend
-            & ((rsi_3_4h > 5.0) | (roc_9_1h > -15.0) | (roc_9_4h_gt_neg_20))
+            & ((rsi_3_4h_gt_5) | (roc_9_1h > -15.0) | (roc_9_4h_gt_neg_20))
             # 4h down move, 4h & 1d downtrend
-            & ((rsi_3_4h > 5.0) | (roc_9_4h_gt_neg_20) | (roc_9_1d_gt_neg_20))
+            & ((rsi_3_4h_gt_5) | (roc_9_4h_gt_neg_20) | (roc_9_1d_gt_neg_20))
             # 4h & 1d down move, 15m still not low enough
-            & ((rsi_3_4h_gt_10) | (rsi_3_1d > 10.0) | (aroonu_14_15m < 30.0))
+            & ((rsi_3_4h_gt_10) | (rsi_3_1d_gt_10) | (aroonu_14_15m < 30.0))
             # 4h & 1d down move, 1d downtrend
-            & ((rsi_3_4h_gt_10) | (rsi_3_1d > 10.0) | (roc_9_1d > -20.0))
+            & ((rsi_3_4h_gt_10) | (rsi_3_1d_gt_10) | (roc_9_1d > -20.0))
             # 15m & 1d down move, 15m still high
-            & ((rsi_3_4h_gt_10) | (rsi_3_1d > 15.0) | (stochrsi_k_15m < 50.0))
+            & ((rsi_3_4h_gt_10) | (rsi_3_1d_gt_15) | (stochrsi_k_15m < 50.0))
             # 4h & 1d down move, 4h downtrend
             & ((rsi_3_4h_gt_10) | (rsi_3_1d > 30.0) | (roc_9_4h > -20.0))
             # 4h & 1d down move, 1d overbought
@@ -17133,45 +17185,45 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 4h still not low e nough, 1d downtrend
             & ((rsi_3_4h_gt_10) | (stochrsi_k_4h < 30.0) | (roc_9_1d > -20.0))
             # 4h down move, 4h & 1d downtrend
-            & ((rsi_3_4h_gt_10) | (roc_9_4h > -20.0) | (roc_9_1d > -40.0))
+            & ((rsi_3_4h_gt_10) | (roc_9_4h > -20.0) | (roc_9_1d_gt_neg_40))
             # 4h & 1d down move, 1d downtrend
-            & ((rsi_3_4h_gt_15) | (rsi_3_1d > 15.0) | (roc_9_1d > -30.0))
+            & ((rsi_3_4h_gt_15) | (rsi_3_1d_gt_15) | (roc_9_1d > -30.0))
             # 4h & 1d down move, 1d still high
-            & ((rsi_3_4h_gt_15) | (rsi_3_1d > 25.0) | (aroonu_14_1d < 40.0))
+            & ((rsi_3_4h_gt_15) | (rsi_3_1d_gt_25) | (aroonu_14_1d < 40.0))
             # 15m & 1d down move, 15m high
             & ((rsi_3_4h_gt_15) | (rsi_3_1d > 30.0) | (stochrsi_k_15m < 70.0))
             # 4h & 1d down move, 4h still high
-            & ((rsi_3_4h_gt_15) | (rsi_3_1d > 30.0) | (stochrsi_k_4h < 50.0))
+            & ((rsi_3_4h_gt_15) | (rsi_3_1d > 30.0) | (stochrsi_k_4h_lt_50))
             # 4h & 1d down move, 1d still high
             & ((rsi_3_4h_gt_15) | (rsi_3_1d > 35.0) | (rsi_14_1d < 50.0))
             # 4h down move, 1h still high, 1d downtrend
             & ((rsi_3_4h_gt_15) | (aroonu_14_1h < 40.0) | roc_9_1d_gt_neg_50)
             # 4h down move, 1h high, 1d downtrend
-            & ((rsi_3_4h_gt_15) | (aroonu_14_1h < 90.0) | (roc_9_1d > -30.0))
+            & ((rsi_3_4h_gt_15) | (aroonu_14_1h_lt_90) | (roc_9_1d > -30.0))
             # 4h down move, 4h still high, 4h downtrend
-            & ((rsi_3_4h_gt_15) | (aroonu_14_4h < 40.0) | (roc_9_4h > -20.0))
+            & ((rsi_3_4h_gt_15) | (aroonu_14_4h_lt_40) | (roc_9_4h > -20.0))
             # 4h down move, 4h still high, 1d high
-            & ((rsi_3_4h_gt_15) | (aroonu_14_4h < 50.0) | (aroonu_14_1d < 70.0))
+            & ((rsi_3_4h_gt_15) | (aroonu_14_4h_lt_50) | (aroonu_14_1d_lt_70))
             # 4h down move, 4h still high, 1d downtrend
-            & ((rsi_3_4h_gt_15) | (aroonu_14_4h < 50.0) | (roc_9_1d > -20.0))
+            & ((rsi_3_4h_gt_15) | (aroonu_14_4h_lt_50) | (roc_9_1d > -20.0))
             # 4h down move, 1h & 4h downtrend
             & ((rsi_3_4h_gt_15) | (roc_9_1h > -40.0) | (roc_9_4h > -40.0))
             # 4h & 1d down move, 1d high
-            & (rsi_3_4h_gt_20 | (rsi_3_1d > 20.0) | (stochrsi_k_1d < 80.0))
+            & (rsi_3_4h_gt_20 | (rsi_3_1d_gt_20) | (stochrsi_k_1d < 80.0))
             # 4h & 1d down move, 15m high
             & (rsi_3_4h_gt_20 | (rsi_3_1d > 30.0) | (stochrsi_k_15m < 80.0))
             # 4h & 1d down move, 1d high
-            & (rsi_3_4h_gt_20 | (rsi_3_1d > 50.0) | (stochrsi_k_1d < 90.0))
+            & (rsi_3_4h_gt_20 | (rsi_3_1d > 50.0) | (stochrsi_k_1d_lt_90))
             # 4h down move, 15m high, 4h downtrend
-            & (rsi_3_4h_gt_20 | (aroonu_14_15m < 70.0) | (roc_9_4h > -30.0))
+            & (rsi_3_4h_gt_20 | (aroonu_14_15m_lt_70) | (roc_9_4h_gt_neg_30))
             # 4h down move, 4h high
             & (rsi_3_4h_gt_20 | aroonu_14_4h_lt_100)
             # 4h down move, 1d high & overbought
-            & (rsi_3_4h_gt_20 | (aroonu_14_1d < 70.0) | (roc_9_1d < 70.0))
+            & (rsi_3_4h_gt_20 | (aroonu_14_1d_lt_70) | (roc_9_1d < 70.0))
             # 4h down move, 1d high, 4h downtrend
-            & (rsi_3_4h_gt_20 | (aroonu_14_1d < 90.0) | (roc_9_4h > -50.0))
+            & (rsi_3_4h_gt_20 | (aroonu_14_1d_lt_90) | (roc_9_4h > -50.0))
             # 4h down move, 1d high & overbought
-            & (rsi_3_4h_gt_20 | (aroonu_14_1d < 90.0) | (roc_9_1d < 40.0))
+            & (rsi_3_4h_gt_20 | (aroonu_14_1d_lt_90) | (roc_9_1d_lt_40))
             # 4h down move, 15m high
             & (rsi_3_4h_gt_20 | (stochrsi_k_15m < 70.0))
             # 4h down move, 4h still not low enough, 1d downtrend
@@ -17181,115 +17233,115 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 1d high, 4h downtrend
             & (rsi_3_4h_gt_20 | (stochrsi_k_1d < 80.0) | (roc_9_4h_gt_neg_20))
             # 4h & 1d down move, 1h high
-            & ((rsi_3_4h > 25.0) | (rsi_3_1d > 25.0) | (aroonu_14_1h < 90.0))
+            & ((rsi_3_4h_gt_25) | (rsi_3_1d_gt_25) | (aroonu_14_1h_lt_90))
             # 4h & 1d down move, 1d high
-            & ((rsi_3_4h > 25.0) | (rsi_3_1d > 25.0) | (aroonu_14_1d < 90.0))
+            & ((rsi_3_4h_gt_25) | (rsi_3_1d_gt_25) | (aroonu_14_1d_lt_90))
             # 4h down move, 4h still high, 1d downtrend
-            & ((rsi_3_4h > 25.0) | (aroonu_14_4h < 40.0) | (roc_9_1d_gt_neg_20))
+            & ((rsi_3_4h_gt_25) | (aroonu_14_4h_lt_40) | (roc_9_1d_gt_neg_20))
             # 4h down move, 4h high, 1h downtrend
-            & ((rsi_3_4h > 25.0) | (aroonu_14_4h < 60.0) | (roc_9_1h > -10.0))
+            & ((rsi_3_4h_gt_25) | (aroonu_14_4h_lt_60) | (roc_9_1h > -10.0))
             # 4h down move, 1d high & overbought
-            & ((rsi_3_4h > 25.0) | (aroonu_14_1d < 80.0) | (roc_9_1d < 30.0))
+            & ((rsi_3_4h_gt_25) | (aroonu_14_1d_lt_80) | (roc_9_1d_lt_30))
             # 4h down move, 1d high, 4h downtrend
-            & ((rsi_3_4h > 25.0) | aroonu_14_1d_lt_100 | (roc_9_4h > -20.0))
+            & ((rsi_3_4h_gt_25) | aroonu_14_1d_lt_100 | (roc_9_4h > -20.0))
             # 4h down move, 4h still high, 1d downtrend
-            & ((rsi_3_4h > 25.0) | (stochrsi_k_4h < 40.0) | (roc_9_1d_gt_neg_30))
+            & ((rsi_3_4h_gt_25) | (stochrsi_k_4h < 40.0) | (roc_9_1d_gt_neg_30))
             # 4h down move, 4h high, 1d downtrend
-            & ((rsi_3_4h > 25.0) | (stochrsi_k_4h < 70.0) | (roc_9_1d_gt_neg_20))
+            & ((rsi_3_4h_gt_25) | (stochrsi_k_4h_lt_70) | (roc_9_1d_gt_neg_20))
             # 4h down move, 1d overbought
-            & ((rsi_3_4h > 25.0) | (roc_9_1d_lt_100))
+            & ((rsi_3_4h_gt_25) | (roc_9_1d_lt_100))
             # 4h down move, 1h high, 4h downtrend
-            & ((rsi_3_4h > 30.0) | (aroonu_14_1h < 60.0) | (roc_9_4h > -10.0))
+            & ((rsi_3_4h_gt_30) | (aroonu_14_1h < 60.0) | (roc_9_4h > -10.0))
             # 4h down move, 4h still high, 1d high
-            & ((rsi_3_4h > 30.0) | (aroonu_14_4h < 50.0) | aroonu_14_1d_lt_100)
+            & ((rsi_3_4h_gt_30) | (aroonu_14_4h_lt_50) | aroonu_14_1d_lt_100)
             # 4h down move, 4h high, 1h downtrend
-            & ((rsi_3_4h > 30.0) | aroonu_14_4h_lt_80 | (roc_9_1h > -40.0))
+            & ((rsi_3_4h_gt_30) | aroonu_14_4h_lt_80 | (roc_9_1h > -40.0))
             # 4h down move, 4h high
-            & ((rsi_3_4h > 30.0) | aroonu_14_4h_lt_100)
+            & ((rsi_3_4h_gt_30) | aroonu_14_4h_lt_100)
             # 4h down move, 1d high & overbought
-            & ((rsi_3_4h > 30.0) | (aroonu_14_1d < 70.0) | (roc_9_1d < 60.0))
+            & ((rsi_3_4h_gt_30) | (aroonu_14_1d_lt_70) | (roc_9_1d < 60.0))
             # 4h down move, 15m still high, 4h high
-            & ((rsi_3_4h > 35.0) | (aroonu_14_15m < 50.0) | aroonu_14_4h_lt_80)
+            & ((rsi_3_4h_gt_35) | (aroonu_14_15m_lt_50) | aroonu_14_4h_lt_80)
             # 4h down move, 1h high
-            & ((rsi_3_4h > 35.0) | aroonu_14_1h_lt_70)
+            & ((rsi_3_4h_gt_35) | aroonu_14_1h_lt_70)
             # 4h down move, 4h high, 1d downtrend
-            & ((rsi_3_4h > 35.0) | aroonu_14_4h_lt_80 | (roc_9_1d > -20.0))
+            & ((rsi_3_4h_gt_35) | aroonu_14_4h_lt_80 | (roc_9_1d > -20.0))
             # 4h down move, 4h high, 1d overbought
-            & ((rsi_3_4h > 35.0) | aroonu_14_4h_lt_80 | (roc_9_1d < 30.0))
+            & ((rsi_3_4h_gt_35) | aroonu_14_4h_lt_80 | (roc_9_1d_lt_30))
             # 4h down move, 1d high & overbought
-            & ((rsi_3_4h > 35.0) | aroonu_14_1d_lt_100 | (roc_9_1d < 20.0))
+            & ((rsi_3_4h_gt_35) | aroonu_14_1d_lt_100 | (roc_9_1d_lt_20))
             # 4h down move, 4h still high, 1d overbought
-            & ((rsi_3_4h > 35.0) | (stochrsi_k_4h < 50.0) | (roc_9_1d < 200.0))
+            & ((rsi_3_4h_gt_35) | (stochrsi_k_4h_lt_50) | (roc_9_1d < 200.0))
             # 4h down move, 4h & 1d high
-            & ((rsi_3_4h > 40.0) | aroonu_14_4h_lt_70 | aroonu_14_1d_lt_100)
+            & ((rsi_3_4h_gt_40) | aroonu_14_4h_lt_70 | aroonu_14_1d_lt_100)
             # 4h down move, 4h high, 1d overbought
-            & ((rsi_3_4h > 40.0) | aroonu_14_4h_lt_70 | (roc_9_1d < 20.0))
+            & ((rsi_3_4h_gt_40) | aroonu_14_4h_lt_70 | (roc_9_1d_lt_20))
             # 4h down move, 4h still high, 1d downtrend
-            & ((rsi_3_4h > 40.0) | (stochrsi_k_4h < 50.0) | (roc_9_1d > -40.0))
+            & ((rsi_3_4h_gt_40) | (stochrsi_k_4h_lt_50) | (roc_9_1d_gt_neg_40))
             # 4h down move, 4h overbought, 1d downtrend
-            & ((rsi_3_4h > 40.0) | (roc_9_4h < 10.0) | (roc_9_1d > -40.0))
+            & ((rsi_3_4h_gt_40) | (roc_9_4h_lt_10) | (roc_9_1d_gt_neg_40))
             # 4h down move, 4h & 1d overbought
-            & ((rsi_3_4h > 40.0) | (roc_9_4h < 60.0) | (roc_9_1d < 80.0))
+            & ((rsi_3_4h_gt_40) | (roc_9_4h < 60.0) | (roc_9_1d_lt_80))
             # 4h down move, 4h & 1d high
             & ((rsi_3_4h > 45.0) | aroonu_14_4h_lt_80 | aroonu_14_1d_lt_100)
             # 4h down move, 4h overbought
-            & ((rsi_3_4h > 55.0) | (roc_9_4h < 30.0))
+            & ((rsi_3_4h > 55.0) | (roc_9_4h_lt_30))
             # 4h down move, 4h high & overbought
-            & ((rsi_3_4h > 60.0) | (stochrsi_k_4h_lt_80) | (roc_9_4h < 10.0))
+            & ((rsi_3_4h > 60.0) | (stochrsi_k_4h_lt_80) | (roc_9_4h_lt_10))
             # 1d down move, 1d high, 1d downtrend
-            & ((rsi_3_1d > 15.0) | (aroonu_14_1d < 70.0) | (roc_9_1d_gt_neg_20))
+            & ((rsi_3_1d_gt_15) | (aroonu_14_1d_lt_70) | (roc_9_1d_gt_neg_20))
             # 1d down move, 1d still high
-            & ((rsi_3_1d > 15.0) | (stochrsi_k_1d < 40.0))
+            & ((rsi_3_1d_gt_15) | (stochrsi_k_1d < 40.0))
             # 1d down move, 4h & 1d downtrend
-            & ((rsi_3_1d > 15.0) | (roc_9_4h > -10.0) | (roc_9_1d > -40.0))
+            & ((rsi_3_1d_gt_15) | (roc_9_4h > -10.0) | (roc_9_1d_gt_neg_40))
             # 1d down move, 15m high
-            & ((rsi_3_1d > 20.0) | (aroonu_14_15m < 80.0))
+            & ((rsi_3_1d_gt_20) | (aroonu_14_15m < 80.0))
             # 1d down move, 4h high, 4h downtrend
-            & ((rsi_3_1d > 20.0) | (aroonu_14_4h < 50.0) | (roc_9_4h > -40.0))
+            & ((rsi_3_1d_gt_20) | (aroonu_14_4h_lt_50) | (roc_9_4h > -40.0))
             # 1d down move, 1d high, 1d downtrend
-            & ((rsi_3_1d > 25.0) | (aroonu_14_1d < 80.0) | (roc_9_1d_gt_neg_30))
+            & ((rsi_3_1d_gt_25) | (aroonu_14_1d_lt_80) | (roc_9_1d_gt_neg_30))
             # 1d down move, 1d still high, 1d downtrend
-            & ((rsi_3_1d > 25.0) | (stochrsi_k_1d < 50.0) | (roc_9_1d_gt_neg_20))
+            & ((rsi_3_1d_gt_25) | (stochrsi_k_1d < 50.0) | (roc_9_1d_gt_neg_20))
             # 1d down move, 4h & 1d high
-            & ((rsi_3_1d > 30.0) | (aroonu_14_4h < 90.0) | (aroonu_14_1d < 90.0))
+            & ((rsi_3_1d > 30.0) | (aroonu_14_4h_lt_90) | (aroonu_14_1d_lt_90))
             # 1h & 4h downtrend, 4h high
             & ((cmf_20_1h > -0.40) | (cmf_20_4h > -0.40) | aroonu_14_4h_lt_80)
             # 4h & 1d downtrend, 1d high
             & ((cmf_20_4h > -0.50) | (cmf_20_1d > -0.50) | (aroonu_14_1d < 85.0))
             # 15m & 1d high, 4h overbought
-            & ((aroonu_14_15m < 70.0) | aroonu_14_1d_lt_100 | (roc_9_4h < 20.0))
+            & ((aroonu_14_15m_lt_70) | aroonu_14_1d_lt_100 | (roc_9_4h < 20.0))
             # 15m & 4h high, 1d downtrend
             & ((aroonu_14_15m < 85.0) | (aroonu_14_4h < 85.0) | (roc_9_1d_gt_neg_20))
             # 1h still high, 1h & 4h downtrend
-            & ((aroonu_14_1h < 50.0) | (roc_9_1h > -20.0) | (roc_9_4h > -30.0))
+            & ((aroonu_14_1h_lt_50) | (roc_9_1h > -20.0) | (roc_9_4h_gt_neg_30))
             # 1h & 4h high, 4h overbought
-            & (aroonu_14_1h_lt_80 | aroonu_14_4h_lt_100 | (roc_9_4h < 10.0))
+            & (aroonu_14_1h_lt_80 | aroonu_14_4h_lt_100 | (roc_9_4h_lt_10))
             # 4h high, 4h & 1d downtrend
-            & ((aroonu_14_4h < 60.0) | (roc_9_4h > -30.0) | (roc_9_1d_gt_neg_30))
+            & ((aroonu_14_4h_lt_60) | (roc_9_4h_gt_neg_30) | (roc_9_1d_gt_neg_30))
             # 4h & 1d high, 4h overbought
-            & (aroonu_14_4h_lt_70 | aroonu_14_1d_lt_100 | (roc_9_4h < 30.0))
+            & (aroonu_14_4h_lt_70 | aroonu_14_1d_lt_100 | (roc_9_4h_lt_30))
             # 4h & 1d high, 1d overbought
-            & (aroonu_14_4h_lt_70 | aroonu_14_1d_lt_100 | (roc_9_1d < 80.0))
+            & (aroonu_14_4h_lt_70 | aroonu_14_1d_lt_100 | (roc_9_1d_lt_80))
             # 4h high, 4h & 1d overbought
-            & ((aroonu_14_4h < 90.0) | (roc_9_4h < 10.0) | (roc_9_1d < 10.0))
+            & ((aroonu_14_4h_lt_90) | (roc_9_4h_lt_10) | (roc_9_1d < 10.0))
             # 1d high, 4h & 1d overbought
-            & ((aroonu_14_1d < 70.0) | (roc_9_4h < 30.0) | (roc_9_1d < 200.0))
+            & ((aroonu_14_1d_lt_70) | (roc_9_4h_lt_30) | (roc_9_1d < 200.0))
             # 1d high, 4h downtrend, 1d overbought
             & ((aroonu_14_1d < 85.0) | (roc_9_4h_gt_neg_20) | (roc_9_1d < 200.0))
             # 1d high, 1h & 4h downtrend
-            & (aroonu_14_1d_lt_100 | (roc_9_1h > -30.0) | (roc_9_4h > -30.0))
+            & (aroonu_14_1d_lt_100 | (roc_9_1h > -30.0) | (roc_9_4h_gt_neg_30))
             # 1d high, 1h & 1d overbought
-            & (aroonu_14_1d_lt_100 | (roc_9_1h < 10.0) | (roc_9_1d < 30.0))
+            & (aroonu_14_1d_lt_100 | (roc_9_1h_lt_10) | (roc_9_1d_lt_30))
             # 1d high, 4h & 1d overbought
-            & (aroonu_14_1d_lt_100 | (roc_9_4h < 30.0) | (roc_9_1d < 60.0))
+            & (aroonu_14_1d_lt_100 | (roc_9_4h_lt_30) | (roc_9_1d < 60.0))
             # 15m still high, 1h & 4h downtrend
             & ((stochrsi_k_15m < 50.0) | (roc_9_1h > -20.0) | (roc_9_4h_gt_neg_20))
             # 4h high, 1h & 4h overbought
-            & ((stochrsi_k_4h_lt_90) | (roc_9_1h < 20.0) | (roc_9_4h < 30.0))
+            & ((stochrsi_k_4h_lt_90) | (roc_9_1h < 20.0) | (roc_9_4h_lt_30))
             # 4h high, 4h & 1d overbought
-            & ((stochrsi_k_4h < 90.0) | (roc_9_4h_lt_20) | (roc_9_1d < 80.0))
+            & ((stochrsi_k_4h < 90.0) | (roc_9_4h_lt_20) | (roc_9_1d_lt_80))
             # 1d still high, 4h & 1d downtrend
-            & ((stochrsi_k_1d < 50.0) | (roc_9_4h > -30.0) | (roc_9_1d_gt_neg_30))
+            & ((stochrsi_k_1d < 50.0) | (roc_9_4h_gt_neg_30) | (roc_9_1d_gt_neg_30))
             # big drop in the last 20 days, 1d high, 1d downtrend
             & ((close > (high_max_20_1d * 0.20)) | (stochrsi_k_1d < 70.0) | (roc_9_1d > -15.0))
           )
@@ -17312,83 +17364,83 @@ class NostalgiaForInfinityX7(IStrategy):
 
           long_entry_logic.append(
             # 5m & 15m down move, 15m still high
-            ((rsi_3 > 3.0) | (rsi_3_15m > 5.0) | (aroonu_14_15m < 40.0))
+            ((rsi_3_gt_3) | (rsi_3_15m_gt_5) | (aroonu_14_15m < 40.0))
             # 5m & 1h down move, 1h still not low enough
-            & ((rsi_3 > 3.0) | (rsi_3_1h_gt_10) | (aroonu_14_1h < 30.0))
+            & ((rsi_3_gt_3) | (rsi_3_1h_gt_10) | (aroonu_14_1h < 30.0))
             # 5m & 1h down move, 1h still not low enough
-            & ((rsi_3 > 3.0) | (rsi_3_1h_gt_15) | (stochrsi_k_1h < 30.0))
+            & ((rsi_3_gt_3) | (rsi_3_1h_gt_15) | (stochrsi_k_1h < 30.0))
             # 5m & 1h down move, 4h high
-            & ((rsi_3 > 3.0) | (rsi_3_1h > 50.0) | (stochrsi_k_4h < 60.0))
+            & ((rsi_3_gt_3) | (rsi_3_1h_gt_50) | (stochrsi_k_4h < 60.0))
             # 5m & 1d down move, 1d still not low enough
-            & ((rsi_3 > 3.0) | (rsi_3_1d > 15.0) | (aroonu_14_1d < 30.0))
+            & ((rsi_3_gt_3) | (rsi_3_1d_gt_15) | (aroonu_14_1d < 30.0))
             # 5m down move, 1h & 4h high
-            & ((rsi_3 > 3.0) | aroonu_14_1h_lt_80 | aroonu_14_4h_lt_100)
+            & ((rsi_3_gt_3) | aroonu_14_1h_lt_80 | aroonu_14_4h_lt_100)
             # 5m down move, 4h high & overbought
-            & ((rsi_3 > 3.0) | aroonu_14_4h_lt_100 | (roc_9_4h < 20.0))
+            & ((rsi_3_gt_3) | aroonu_14_4h_lt_100 | (roc_9_4h < 20.0))
             # 5m down move, 1h high, 4h overbought
-            & ((rsi_3 > 3.0) | (stochrsi_k_1h < 80.0) | (roc_9_4h_lt_20))
+            & ((rsi_3_gt_3) | (stochrsi_k_1h < 80.0) | (roc_9_4h_lt_20))
             # 5m down move, 1d high & overbought
-            & ((rsi_3 > 3.0) | (stochrsi_k_1d < 90.0) | (roc_9_1d < 20.0))
+            & ((rsi_3_gt_3) | (stochrsi_k_1d_lt_90) | (roc_9_1d_lt_20))
             # 5m & 1h down move, 1d overbought
-            & ((rsi_3 > 5.0) | (rsi_3_1h > 25.0) | (roc_9_1d_lt_100))
+            & ((rsi_3 > 5.0) | (rsi_3_1h_gt_25) | (roc_9_1d_lt_100))
             # 5m & 1d down move, 1h high
-            & ((rsi_3 > 5.0) | (rsi_3_1d > 20.0) | (aroonu_14_1h < 90.0))
+            & ((rsi_3 > 5.0) | (rsi_3_1d_gt_20) | (aroonu_14_1h_lt_90))
             # 5m & 1h down move, 1h high
             & ((rsi_3 > 10.0) | (rsi_3_1h_gt_15) | (aroonu_14_1h < 85.0))
             # 15m & 1h down move
-            & (rsi_3_15m_gt_3 | (rsi_3_1h > 3.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_3))
             # 15m & 1h & 4h down move
-            & (rsi_3_15m_gt_3 | (rsi_3_1h > 5.0) | (rsi_3_4h_gt_10))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_5) | (rsi_3_4h_gt_10))
             # 15m & 1h & 1d down move
-            & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_10) | (rsi_3_1d > 25.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_10) | (rsi_3_1d_gt_25))
             # 15m & 1h down move, 1d still high
             & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_10) | (rsi_14_1d < 50.0))
             # 15m & 1h down move, 15m still high
-            & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_10) | (aroonu_14_15m < 50.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_10) | (aroonu_14_15m_lt_50))
             # 15m & 1h down move, 1d high
-            & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_10) | (aroonu_14_1d < 70.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_10) | (aroonu_14_1d_lt_70))
             # 15m & 1d down move, 1d overbought
             & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_10) | (roc_9_1d < 10.0))
             # 15m & 1h down move, 1h still high
             & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_15) | (aroonu_14_1h < 40.0))
             # 15m & 1h down move, 1d high
-            & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_15) | (aroonu_14_1d < 90.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_15) | (aroonu_14_1d_lt_90))
             # 15m & 1h down move, 4h high
             & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_15) | aroonu_14_4h_lt_70)
             # 15m & 1h down move, 1d downtrend
             & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_15) | (roc_9_1d > -30.0))
             # 15m & 1h down move, 15m high
-            & (rsi_3_15m_gt_3 | rsi_3_1h_gt_20 | (aroonu_14_15m < 70.0))
+            & (rsi_3_15m_gt_3 | rsi_3_1h_gt_20 | (aroonu_14_15m_lt_70))
             # 15m & 1h down move, 1h high
-            & (rsi_3_15m_gt_3 | (rsi_3_1h > 30.0) | (aroonu_14_1h < 100.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_30) | (aroonu_14_1h_lt_100))
             # 15m & 1h down move, 1d high
-            & (rsi_3_15m_gt_3 | (rsi_3_1h > 30.0) | (stochrsi_k_1d < 90.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_30) | (stochrsi_k_1d_lt_90))
             # 15m & 1h down move, 1d overbought
-            & (rsi_3_15m_gt_3 | (rsi_3_1h > 30.0) | (roc_9_1d < 200.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_30) | (roc_9_1d < 200.0))
             # 15m & 1h down move, 1h still high
-            & (rsi_3_15m_gt_3 | (rsi_3_1h > 35.0) | (stochrsi_k_1h < 40.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_35) | (stochrsi_k_1h < 40.0))
             # 15m & 1h down move, 4h high
-            & (rsi_3_15m_gt_3 | (rsi_3_1h > 45.0) | (aroonu_14_4h < 90.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_45) | (aroonu_14_4h_lt_90))
             # 15m & 4h down move, 1d high
             & (rsi_3_15m_gt_3 | (rsi_3_4h_gt_15) | (aroonu_14_1d < 50.0))
             # 15m & 4h down move, 15m high
-            & (rsi_3_15m_gt_3 | rsi_3_4h_gt_20 | (aroonu_14_15m < 70.0))
+            & (rsi_3_15m_gt_3 | rsi_3_4h_gt_20 | (aroonu_14_15m_lt_70))
             # 15m & 4h down move, 1d overbought
-            & (rsi_3_15m_gt_3 | (rsi_3_4h > 35.0) | (roc_9_1d < 60.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_4h_gt_35) | (roc_9_1d < 60.0))
             # 15m & 1d down move, 1d still high
-            & (rsi_3_15m_gt_3 | (rsi_3_1d > 10.0) | (aroonu_14_1d < 40.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1d_gt_10) | (aroonu_14_1d < 40.0))
             # 15m & 1d down move, 4h still high
-            & (rsi_3_15m_gt_3 | (rsi_3_1d > 20.0) | (stochrsi_k_4h < 50.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1d_gt_20) | (stochrsi_k_4h_lt_50))
             # 15m & 1d down move, 1d high
-            & (rsi_3_15m_gt_3 | (rsi_3_1d > 45.0) | (aroonu_14_1d < 70.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1d > 45.0) | (aroonu_14_1d_lt_70))
             # 15m down move, 4h high & overbought
-            & (rsi_3_15m_gt_3 | (aroonu_14_4h < 90.0) | (roc_9_4h < 100.0))
+            & (rsi_3_15m_gt_3 | (aroonu_14_4h_lt_90) | (roc_9_4h < 100.0))
             # 15m down move, 1d high & overbought
-            & (rsi_3_15m_gt_3 | aroonu_14_1d_lt_100 | (roc_9_1d < 40.0))
+            & (rsi_3_15m_gt_3 | aroonu_14_1d_lt_100 | (roc_9_1d_lt_40))
             # 15m down move, 1h high, 1d downtrend
             & (rsi_3_15m_gt_3 | (stochrsi_k_1h < 80.0) | (roc_9_1d_gt_neg_20))
             # 15m down move, 4h high & overbought
-            & (rsi_3_15m_gt_3 | (stochrsi_k_4h_lt_80) | (roc_9_4h < 40.0))
+            & (rsi_3_15m_gt_3 | (stochrsi_k_4h_lt_80) | (roc_9_4h_lt_40))
             # 15m down move, 4h high, 1d overbought
             & (rsi_3_15m_gt_3 | (stochrsi_k_4h_lt_80) | (roc_9_1d < 10.0))
             # 15m down move, 1h downtrend, 4h overbought
@@ -17396,219 +17448,219 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 4h & 1d downtrend
             & (rsi_3_15m_gt_3 | (roc_9_4h > -70.0) | (roc_9_1d > -70.0))
             # 15m & 1h down move, 4h still high
-            & ((rsi_3_15m > 5.0) | (rsi_3_1h > 5.0) | (rsi_14_4h < 40.0))
+            & ((rsi_3_15m_gt_5) | (rsi_3_1h_gt_5) | (rsi_14_4h < 40.0))
             # 15m & 1h down move, 1h still not low enough
-            & ((rsi_3_15m > 5.0) | (rsi_3_1h_gt_15) | (stochrsi_k_1h < 20.0))
+            & ((rsi_3_15m_gt_5) | (rsi_3_1h_gt_15) | (stochrsi_k_1h < 20.0))
             # 15m & 1h down move, 1d still high
-            & ((rsi_3_15m > 5.0) | rsi_3_1h_gt_20 | (stochrsi_k_1d < 50.0))
+            & ((rsi_3_15m_gt_5) | rsi_3_1h_gt_20 | (stochrsi_k_1d < 50.0))
             # 15m & 1h down move, 1d overbought
-            & ((rsi_3_15m > 5.0) | (rsi_3_1h > 25.0) | (roc_9_1d < 70.0))
+            & ((rsi_3_15m_gt_5) | (rsi_3_1h_gt_25) | (roc_9_1d < 70.0))
             # 15m & 1h down move, 4h high
-            & ((rsi_3_15m > 5.0) | (rsi_3_1h > 30.0) | aroonu_14_4h_lt_70)
+            & ((rsi_3_15m_gt_5) | (rsi_3_1h_gt_30) | aroonu_14_4h_lt_70)
             # 15m & 1h down move, 1h high
-            & ((rsi_3_15m > 5.0) | (rsi_3_1h > 45.0) | aroonu_14_1h_lt_80)
+            & ((rsi_3_15m_gt_5) | (rsi_3_1h_gt_45) | aroonu_14_1h_lt_80)
             # 15m & 4h down move, 1h still high
-            & ((rsi_3_15m > 5.0) | (rsi_3_4h_gt_10) | (stochrsi_k_1h < 50.0))
+            & ((rsi_3_15m_gt_5) | (rsi_3_4h_gt_10) | (stochrsi_k_1h < 50.0))
             # 15m & 4h down move, 1h downtrend
-            & ((rsi_3_15m > 5.0) | (rsi_3_4h_gt_10) | (roc_9_1h > -20.0))
+            & ((rsi_3_15m_gt_5) | (rsi_3_4h_gt_10) | (roc_9_1h > -20.0))
             # 15m & 4h down move, 15m still high
-            & ((rsi_3_15m > 5.0) | (rsi_3_4h_gt_15) | (stochrsi_k_15m < 50.0))
+            & ((rsi_3_15m_gt_5) | (rsi_3_4h_gt_15) | (stochrsi_k_15m < 50.0))
             # 15m & 4h down move, 4h still high
-            & ((rsi_3_15m > 5.0) | rsi_3_4h_gt_20 | (aroonu_14_4h < 50.0))
+            & ((rsi_3_15m_gt_5) | rsi_3_4h_gt_20 | (aroonu_14_4h_lt_50))
             # 15m & 4h down move, 1d high
-            & ((rsi_3_15m > 5.0) | rsi_3_4h_gt_20 | (aroonu_14_1d < 70.0))
+            & ((rsi_3_15m_gt_5) | rsi_3_4h_gt_20 | (aroonu_14_1d_lt_70))
             # 15m & 1d down move, 1h still high
-            & ((rsi_3_15m > 5.0) | (rsi_3_1d > 20.0) | (stochrsi_k_1h_lt_50))
+            & ((rsi_3_15m_gt_5) | (rsi_3_1d_gt_20) | (stochrsi_k_1h_lt_50))
             # 15m down move, 15m & 1h still high
-            & ((rsi_3_15m > 5.0) | (aroonu_14_15m < 40.0) | (aroonu_14_1h < 50.0))
+            & ((rsi_3_15m_gt_5) | (aroonu_14_15m < 40.0) | (aroonu_14_1h_lt_50))
             # 15m down move, 1h high & overbought
-            & ((rsi_3_15m > 5.0) | aroonu_14_1h_lt_70 | (roc_9_1h < 10.0))
+            & ((rsi_3_15m_gt_5) | aroonu_14_1h_lt_70 | (roc_9_1h_lt_10))
             # 15m down move, 1h & 4h high
-            & ((rsi_3_15m > 5.0) | aroonu_14_1h_lt_80 | aroonu_14_4h_lt_100)
+            & ((rsi_3_15m_gt_5) | aroonu_14_1h_lt_80 | aroonu_14_4h_lt_100)
             # 15m down move, 1h high, 4h overbought
-            & ((rsi_3_15m > 5.0) | aroonu_14_1h_lt_80 | (roc_9_4h < 10.0))
+            & ((rsi_3_15m_gt_5) | aroonu_14_1h_lt_80 | (roc_9_4h_lt_10))
             # 15m down move, 4h high & overbought
-            & ((rsi_3_15m > 5.0) | aroonu_14_4h_lt_80 | (roc_9_4h < 50.0))
+            & ((rsi_3_15m_gt_5) | aroonu_14_4h_lt_80 | (roc_9_4h < 50.0))
             # 15m down move, 1d still high, 1d downtrend
-            & ((rsi_3_15m > 5.0) | (stochrsi_k_1d < 50.0) | (roc_9_1d_gt_neg_20))
+            & ((rsi_3_15m_gt_5) | (stochrsi_k_1d < 50.0) | (roc_9_1d_gt_neg_20))
             # 15m down move, 1d downtrend
-            & ((rsi_3_15m > 5.0) | (roc_9_1d > -60.0))
+            & ((rsi_3_15m_gt_5) | (roc_9_1d > -60.0))
             # 15m down move, 1h & 1d high
-            & ((rsi_3_15m > 5.0) | (roc_9_1h < 10.0) | (roc_9_1d < 40.0))
+            & ((rsi_3_15m_gt_5) | (roc_9_1h_lt_10) | (roc_9_1d_lt_40))
             # 15m & 1h down move, 15m high
-            & ((rsi_3_15m > 10.0) | (rsi_3_1h_gt_10) | (aroonu_14_15m < 70.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_10) | (aroonu_14_15m_lt_70))
             # 15m & 1h down move, 1h still high
-            & ((rsi_3_15m > 10.0) | (rsi_3_1h_gt_15) | (stochrsi_k_1h < 40.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_15) | (stochrsi_k_1h < 40.0))
             # 15m & 1h down move, 1d high
-            & ((rsi_3_15m > 10.0) | (rsi_3_1h_gt_15) | (stochrsi_k_1d < 90.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_15) | (stochrsi_k_1d_lt_90))
             # 15m & 1h down move, 4h downtrend
-            & ((rsi_3_15m > 10.0) | (rsi_3_1h_gt_15) | (roc_9_4h > -20.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_15) | (roc_9_4h > -20.0))
             # 15m & 1h down move, 1d downtrend
-            & ((rsi_3_15m > 10.0) | (rsi_3_1h_gt_15) | (roc_9_1d > -40.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_15) | (roc_9_1d_gt_neg_40))
             # 15m & 1h down move, 15m still high
-            & ((rsi_3_15m > 10.0) | rsi_3_1h_gt_20 | (aroonu_14_15m < 50.0))
+            & ((rsi_3_15m_gt_10) | rsi_3_1h_gt_20 | (aroonu_14_15m_lt_50))
             # 15m & 1h down move, 1h high
-            & ((rsi_3_15m > 10.0) | rsi_3_1h_gt_20 | aroonu_14_1h_lt_70)
+            & ((rsi_3_15m_gt_10) | rsi_3_1h_gt_20 | aroonu_14_1h_lt_70)
             # 15m & 1h down move, 1d high
-            & ((rsi_3_15m > 10.0) | rsi_3_1h_gt_20 | (aroonu_14_1d < 80.0))
+            & ((rsi_3_15m_gt_10) | rsi_3_1h_gt_20 | (aroonu_14_1d_lt_80))
             # 15m & 1h down move, 1d overbought
-            & ((rsi_3_15m > 10.0) | rsi_3_1h_gt_20 | (roc_9_1d < 80.0))
+            & ((rsi_3_15m_gt_10) | rsi_3_1h_gt_20 | (roc_9_1d_lt_80))
             # 15m & 1h down move, 4h high
-            & ((rsi_3_15m > 10.0) | (rsi_3_1h > 25.0) | (aroonu_14_4h < 90.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_25) | (aroonu_14_4h_lt_90))
             # 15m & 1h down move, 4h high
-            & ((rsi_3_15m > 10.0) | (rsi_3_1h > 25.0) | (stochrsi_k_4h_lt_80))
+            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_25) | (stochrsi_k_4h_lt_80))
             # 15m & 1h down move, 4h overbought
-            & ((rsi_3_15m > 10.0) | (rsi_3_1h > 25.0) | (roc_9_4h_lt_20))
+            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_25) | (roc_9_4h_lt_20))
             # 15m & 1h down move, 1h high
-            & ((rsi_3_15m > 10.0) | (rsi_3_1h > 30.0) | (stochrsi_k_1h < 60.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_30) | (stochrsi_k_1h < 60.0))
             # 15m & 1h down move, 1d high
-            & ((rsi_3_15m > 10.0) | (rsi_3_1h > 40.0) | (aroonu_14_1d < 90.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_40) | (aroonu_14_1d_lt_90))
             # 15m & 1h down move, 1h high
-            & ((rsi_3_15m > 10.0) | (rsi_3_1h > 40.0) | (stochrsi_k_1h < 90.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_40) | (stochrsi_k_1h < 90.0))
             # 15m & 1h down move, 4h high
-            & ((rsi_3_15m > 10.0) | (rsi_3_1h > 50.0) | (stochrsi_k_4h_lt_90))
+            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_50) | (stochrsi_k_4h_lt_90))
             # 15m & 4h down move, 15m still high
-            & ((rsi_3_15m > 10.0) | (rsi_3_4h_gt_10) | (stochrsi_k_15m < 40.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_4h_gt_10) | (stochrsi_k_15m < 40.0))
             # 15m & 4h down move, 4h still high
-            & ((rsi_3_15m > 10.0) | (rsi_3_4h_gt_10) | (stochrsi_k_4h < 40.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_4h_gt_10) | (stochrsi_k_4h < 40.0))
             # 15m & 4h down move, 1h high
-            & ((rsi_3_15m > 10.0) | (rsi_3_4h_gt_15) | (stochrsi_k_1h < 90.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_4h_gt_15) | (stochrsi_k_1h < 90.0))
             # 15m & 4h down move, 1d downtrend
-            & ((rsi_3_15m > 10.0) | (rsi_3_4h_gt_15) | (roc_9_1d > -20.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_4h_gt_15) | (roc_9_1d > -20.0))
             # 15m & 4h down move, 4h still high
-            & ((rsi_3_15m > 10.0) | (rsi_3_4h > 40.0) | (aroonu_14_4h < 50.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_4h_gt_40) | (aroonu_14_4h_lt_50))
             # 15m & 4h down move, 4h high
-            & ((rsi_3_15m > 10.0) | (rsi_3_4h > 50.0) | aroonu_14_4h_lt_70)
+            & ((rsi_3_15m_gt_10) | (rsi_3_4h_gt_50) | aroonu_14_4h_lt_70)
             # 15m & 1d down move, 4h high
-            & ((rsi_3_15m > 10.0) | (rsi_3_1d > 20.0) | (stochrsi_k_4h < 70.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_1d_gt_20) | (stochrsi_k_4h_lt_70))
             # 15m down move, 15m still high, 1d downtrend
-            & ((rsi_3_15m > 10.0) | (aroonu_14_15m < 40.0) | (roc_9_1d_gt_neg_30))
+            & ((rsi_3_15m_gt_10) | (aroonu_14_15m < 40.0) | (roc_9_1d_gt_neg_30))
             # 15m down move, 15m still high, 1d overbought
-            & ((rsi_3_15m > 10.0) | (aroonu_14_15m < 50.0) | (roc_9_1d < 30.0))
+            & ((rsi_3_15m_gt_10) | (aroonu_14_15m_lt_50) | (roc_9_1d_lt_30))
             # 15m down move, 15m high, 1h high
-            & ((rsi_3_15m > 10.0) | (aroonu_14_15m < 60.0) | aroonu_14_1h_lt_80)
+            & ((rsi_3_15m_gt_10) | (aroonu_14_15m < 60.0) | aroonu_14_1h_lt_80)
             # 15m down move, 15m high, 4h downtrend
-            & ((rsi_3_15m > 10.0) | (aroonu_14_15m < 60.0) | (roc_9_4h > -10.0))
+            & ((rsi_3_15m_gt_10) | (aroonu_14_15m < 60.0) | (roc_9_4h > -10.0))
             # 15m down move, 1h & 4h high
-            & ((rsi_3_15m > 10.0) | (aroonu_14_1h < 90.0) | aroonu_14_4h_lt_100)
+            & ((rsi_3_15m_gt_10) | (aroonu_14_1h_lt_90) | aroonu_14_4h_lt_100)
             # 15m down move, 1h high, 1d downtrend
-            & ((rsi_3_15m > 10.0) | (aroonu_14_1h < 90.0) | (roc_9_1d > -40.0))
+            & ((rsi_3_15m_gt_10) | (aroonu_14_1h_lt_90) | (roc_9_1d_gt_neg_40))
             # 15m down move, 4h & 1d high
-            & ((rsi_3_15m > 10.0) | (aroonu_14_4h < 90.0) | aroonu_14_1d_lt_100)
+            & ((rsi_3_15m_gt_10) | (aroonu_14_4h_lt_90) | aroonu_14_1d_lt_100)
             # 15m down move, 1d high & overbought
-            & ((rsi_3_15m > 10.0) | aroonu_14_1d_lt_100 | (roc_9_1d < 100.0))
+            & ((rsi_3_15m_gt_10) | aroonu_14_1d_lt_100 | (roc_9_1d < 100.0))
             # 15m down move, 4h still high, 1d overbought
-            & ((rsi_3_15m > 10.0) | (stochrsi_k_4h < 50.0) | (roc_9_1d < 30.0))
+            & ((rsi_3_15m_gt_10) | (stochrsi_k_4h_lt_50) | (roc_9_1d_lt_30))
             # 15m down move, 4h & 1d overbought
-            & ((rsi_3_15m > 10.0) | (roc_9_4h < 10.0) | (roc_9_1d < 200.0))
+            & ((rsi_3_15m_gt_10) | (roc_9_4h_lt_10) | (roc_9_1d < 200.0))
             # 15m & 1h down move, 1h high
-            & ((rsi_3_15m > 15.0) | (rsi_3_1h_gt_15) | (aroonu_14_1h < 90.0))
+            & ((rsi_3_15m_gt_15) | (rsi_3_1h_gt_15) | (aroonu_14_1h_lt_90))
             # 15m & 1h down move, 1d high
-            & ((rsi_3_15m > 15.0) | (rsi_3_1h_gt_15) | (stochrsi_k_1d < 90.0))
+            & ((rsi_3_15m_gt_15) | (rsi_3_1h_gt_15) | (stochrsi_k_1d_lt_90))
             # 15m & 1h down move, 1h high
-            & ((rsi_3_15m > 15.0) | rsi_3_1h_gt_20 | (aroonu_14_1h < 100.0))
+            & ((rsi_3_15m_gt_15) | rsi_3_1h_gt_20 | (aroonu_14_1h_lt_100))
             # 15m & 1h down move, 4h high
-            & ((rsi_3_15m > 15.0) | rsi_3_1h_gt_20 | aroonu_14_4h_lt_100)
+            & ((rsi_3_15m_gt_15) | rsi_3_1h_gt_20 | aroonu_14_4h_lt_100)
             # 15m & 4h down move, 4h high
-            & ((rsi_3_15m > 15.0) | (rsi_3_4h > 40.0) | aroonu_14_4h_lt_70)
+            & ((rsi_3_15m_gt_15) | (rsi_3_4h_gt_40) | aroonu_14_4h_lt_70)
             # 15m down move. 15m still high, 1h high
-            & ((rsi_3_15m > 15.0) | (aroonu_14_15m < 50.0) | (stochrsi_k_1h_lt_80))
+            & ((rsi_3_15m_gt_15) | (aroonu_14_15m_lt_50) | (stochrsi_k_1h_lt_80))
             # 15m down move, 15m & 4h high
-            & ((rsi_3_15m > 15.0) | (aroonu_14_15m < 70.0) | aroonu_14_4h_lt_100)
+            & ((rsi_3_15m_gt_15) | (aroonu_14_15m_lt_70) | aroonu_14_4h_lt_100)
             # 15m down move, 1h high, 1d overbought
-            & ((rsi_3_15m > 15.0) | aroonu_14_1h_lt_80 | (roc_9_1d < 40.0))
+            & ((rsi_3_15m_gt_15) | aroonu_14_1h_lt_80 | (roc_9_1d_lt_40))
             # 15m down move, 4h high & overbought
-            & ((rsi_3_15m > 15.0) | (aroonu_14_4h < 60.0) | (roc_9_4h < 30.0))
+            & ((rsi_3_15m_gt_15) | (aroonu_14_4h_lt_60) | (roc_9_4h_lt_30))
             # 15m down move, 4h high, 1d overbought
-            & ((rsi_3_15m > 15.0) | aroonu_14_4h_lt_70 | (roc_9_1d < 200.0))
+            & ((rsi_3_15m_gt_15) | aroonu_14_4h_lt_70 | (roc_9_1d < 200.0))
             # 15m down move, 4h high, 1d overbought
-            & ((rsi_3_15m > 15.0) | aroonu_14_4h_lt_100 | (roc_9_1d < 100.0))
+            & ((rsi_3_15m_gt_15) | aroonu_14_4h_lt_100 | (roc_9_1d < 100.0))
             # 15m down move, 1h high, 4h downtrend
-            & ((rsi_3_15m > 15.0) | (stochrsi_k_1h_lt_70) | (roc_9_4h > -30.0))
+            & ((rsi_3_15m_gt_15) | (stochrsi_k_1h_lt_70) | (roc_9_4h_gt_neg_30))
             # 15m down move, 4h high & overbought
-            & ((rsi_3_15m > 15.0) | (stochrsi_k_4h_lt_90) | (roc_9_4h < 25.0))
+            & ((rsi_3_15m_gt_15) | (stochrsi_k_4h_lt_90) | (roc_9_4h < 25.0))
             # 15m down move, 4h high, 1d downtrend
-            & ((rsi_3_15m > 15.0) | (stochrsi_k_4h_lt_90) | (roc_9_1d > -40.0))
+            & ((rsi_3_15m_gt_15) | (stochrsi_k_4h_lt_90) | (roc_9_1d_gt_neg_40))
             # 15m down move, 4h high, 1d overbought
-            & ((rsi_3_15m > 15.0) | (stochrsi_k_4h_lt_90) | (roc_9_1d < 30.0))
+            & ((rsi_3_15m_gt_15) | (stochrsi_k_4h_lt_90) | (roc_9_1d_lt_30))
             # 15m down move, 1d high & overbought
-            & ((rsi_3_15m > 15.0) | (stochrsi_k_1d < 90.0) | (roc_9_1d_lt_100))
+            & ((rsi_3_15m_gt_15) | (stochrsi_k_1d_lt_90) | (roc_9_1d_lt_100))
             # 15m down move, 4h & 1d downtrend
-            & ((rsi_3_15m > 15.0) | (roc_9_4h > -10.0) | (roc_9_1d > -40.0))
+            & ((rsi_3_15m_gt_15) | (roc_9_4h > -10.0) | (roc_9_1d_gt_neg_40))
             # 15m & 1h down move, 4h high
-            & ((rsi_3_15m > 20.0) | rsi_3_1h_gt_20 | (stochrsi_k_4h_lt_80))
+            & ((rsi_3_15m_gt_20) | rsi_3_1h_gt_20 | (stochrsi_k_4h_lt_80))
             # 15m & 1h down move, 1d overbought
-            & ((rsi_3_15m > 20.0) | (rsi_3_1h > 25.0) | (roc_9_1d_lt_100))
+            & ((rsi_3_15m_gt_20) | (rsi_3_1h_gt_25) | (roc_9_1d_lt_100))
             # 15m & 1d down move, 4h high
-            & ((rsi_3_15m > 20.0) | (rsi_3_1d > 20.0) | (aroonu_14_4h < 90.0))
+            & ((rsi_3_15m_gt_20) | (rsi_3_1d_gt_20) | (aroonu_14_4h_lt_90))
             # 15m down move, 15m & 1h high
-            & ((rsi_3_15m > 20.0) | (aroonu_14_15m < 70.0) | (aroonu_14_1h < 100.0))
+            & ((rsi_3_15m_gt_20) | (aroonu_14_15m_lt_70) | (aroonu_14_1h_lt_100))
             # 15m down move, 1h high, 4h overbought
-            & ((rsi_3_15m > 20.0) | aroonu_14_1h_lt_80 | (roc_9_4h < 10.0))
+            & ((rsi_3_15m_gt_20) | aroonu_14_1h_lt_80 | (roc_9_4h_lt_10))
             # 15m down move, 1h high, 1d overbought
-            & ((rsi_3_15m > 20.0) | aroonu_14_1h_lt_80 | (roc_9_1d < 10.0))
+            & ((rsi_3_15m_gt_20) | aroonu_14_1h_lt_80 | (roc_9_1d < 10.0))
             # 15m down move, 4h high & overbought
-            & ((rsi_3_15m > 20.0) | aroonu_14_4h_lt_80 | (roc_9_4h < 10.0))
+            & ((rsi_3_15m_gt_20) | aroonu_14_4h_lt_80 | (roc_9_4h_lt_10))
             # 15m & 1h down move, 15m high
-            & ((rsi_3_15m > 25.0) | (rsi_3_1h > 25.0) | (stochrsi_k_15m < 70.0))
+            & ((rsi_3_15m_gt_25) | (rsi_3_1h_gt_25) | (stochrsi_k_15m < 70.0))
             # 15m & 1h down move, 1h downtrend
-            & ((rsi_3_15m > 25.0) | (rsi_3_1h > 25.0) | (roc_9_1h > -30.0))
+            & ((rsi_3_15m_gt_25) | (rsi_3_1h_gt_25) | (roc_9_1h > -30.0))
             # 15m down move, 1d high & overbought
-            & ((rsi_3_15m > 30.0) | aroonu_14_1d_lt_100 | roc_9_1d_lt_50)
+            & ((rsi_3_15m_gt_30) | aroonu_14_1d_lt_100 | roc_9_1d_lt_50)
             # 1h & 4h down move, 1d still high
-            & ((rsi_3_1h > 3.0) | (rsi_3_4h_gt_10) | (stochrsi_k_1d < 40.0))
+            & ((rsi_3_1h_gt_3) | (rsi_3_4h_gt_10) | (stochrsi_k_1d < 40.0))
             # 1h & 4h down move, 4h still high
-            & ((rsi_3_1h > 3.0) | (rsi_3_4h_gt_15) | (aroonu_14_4h < 40.0))
+            & ((rsi_3_1h_gt_3) | (rsi_3_4h_gt_15) | (aroonu_14_4h_lt_40))
             # 1h & 4h down move, 1d still high
-            & ((rsi_3_1h > 3.0) | (rsi_3_4h_gt_15) | (aroonu_14_1d < 40.0))
+            & ((rsi_3_1h_gt_3) | (rsi_3_4h_gt_15) | (aroonu_14_1d < 40.0))
             # 1h & 4h down move, 1d high
-            & ((rsi_3_1h > 3.0) | rsi_3_4h_gt_20 | (aroonu_14_1d < 60.0))
+            & ((rsi_3_1h_gt_3) | rsi_3_4h_gt_20 | (aroonu_14_1d < 60.0))
             # 1h & 4h down move, 1d high
-            & ((rsi_3_1h > 3.0) | (rsi_3_4h > 25.0) | (aroonu_14_1d < 70.0))
+            & ((rsi_3_1h_gt_3) | (rsi_3_4h_gt_25) | (aroonu_14_1d_lt_70))
             # 1h & 4h down move, 1d overbought
-            & ((rsi_3_1h > 3.0) | (rsi_3_4h > 25.0) | (roc_9_1d < 20.0))
+            & ((rsi_3_1h_gt_3) | (rsi_3_4h_gt_25) | (roc_9_1d_lt_20))
             # 1h down move, 4h still high, 1d downtrend
-            & ((rsi_3_1h > 3.0) | (stochrsi_k_4h < 50.0) | (roc_9_1d_gt_neg_20))
+            & ((rsi_3_1h_gt_3) | (stochrsi_k_4h_lt_50) | (roc_9_1d_gt_neg_20))
             # 1h & 4h down move, 1h still high
-            & ((rsi_3_1h > 5.0) | (rsi_3_4h_gt_10) | (aroonu_14_1h < 50.0))
+            & ((rsi_3_1h_gt_5) | (rsi_3_4h_gt_10) | (aroonu_14_1h_lt_50))
             # 1h & 4h down move, 1d high
-            & ((rsi_3_1h > 5.0) | (rsi_3_4h_gt_15) | (stochrsi_k_1d < 90.0))
+            & ((rsi_3_1h_gt_5) | (rsi_3_4h_gt_15) | (stochrsi_k_1d_lt_90))
             # 1h & 4h down move, 1d high
-            & ((rsi_3_1h > 5.0) | rsi_3_4h_gt_20 | aroonu_14_1d_lt_100)
+            & ((rsi_3_1h_gt_5) | rsi_3_4h_gt_20 | aroonu_14_1d_lt_100)
             # 1h & 4h down move, 4h still high
-            & ((rsi_3_1h > 5.0) | (rsi_3_4h > 35.0) | (rsi_14_4h < 40.0))
+            & ((rsi_3_1h_gt_5) | (rsi_3_4h_gt_35) | (rsi_14_4h < 40.0))
             # 1h down move, 4h high, 1d downtrend
-            & ((rsi_3_1h > 5.0) | aroonu_14_4h_lt_70 | (roc_9_1d_gt_neg_30))
+            & ((rsi_3_1h_gt_5) | aroonu_14_4h_lt_70 | (roc_9_1d_gt_neg_30))
             # 1h down move, 1d high, 1h downtrend
-            & ((rsi_3_1h > 5.0) | (aroonu_14_1d < 90.0) | (roc_9_1h > -40.0))
+            & ((rsi_3_1h_gt_5) | (aroonu_14_1d_lt_90) | (roc_9_1h > -40.0))
             # 1h down move, 4h & 1d downtrend
-            & ((rsi_3_1h > 5.0) | (roc_9_4h_gt_neg_20) | (roc_9_1d_gt_neg_20))
+            & ((rsi_3_1h_gt_5) | (roc_9_4h_gt_neg_20) | (roc_9_1d_gt_neg_20))
             # 1h & 4h & 1d down move
-            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_10) | (rsi_3_1d > 15.0))
+            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_10) | (rsi_3_1d_gt_15))
             # 1h & 4h down move, 1d downtrend
             & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_10) | (roc_9_1d > -20.0))
             # 1h & 4h down move, 1h high
             & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_15) | (aroonu_14_1h < 60.0))
             # 1h & 4h down move, 1d high
-            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_15) | (aroonu_14_1d < 90.0))
+            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_15) | (aroonu_14_1d_lt_90))
             # 1h & 4h down move, 1d downtrend
             & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_15) | (roc_9_1d > -30.0))
             # 1h & 1d down move, 4h high
-            & ((rsi_3_1h_gt_10) | (rsi_3_1d > 15.0) | (stochrsi_k_4h < 70.0))
+            & ((rsi_3_1h_gt_10) | (rsi_3_1d_gt_15) | (stochrsi_k_4h_lt_70))
             # 1h & 1d down move, 1d still high
             & ((rsi_3_1h_gt_10) | (rsi_3_1d > 30.0) | (stochrsi_k_1d < 50.0))
             # 1h down move, 15m downtrend, 1d high
-            & ((rsi_3_1h_gt_10) | (cmf_20_15m > -0.40) | (aroonu_14_1d < 70.0))
+            & ((rsi_3_1h_gt_10) | (cmf_20_15m > -0.40) | (aroonu_14_1d_lt_70))
             # 1h down move, 1h high, 4h overbought
-            & ((rsi_3_1h_gt_10) | (aroonu_14_1h < 80.0) | (roc_9_4h < 10.0))
+            & ((rsi_3_1h_gt_10) | (aroonu_14_1h < 80.0) | (roc_9_4h_lt_10))
             # 1h down move, 1d high, 1d downtrend
-            & ((rsi_3_1h_gt_10) | (aroonu_14_1d < 70.0) | (roc_9_1d > -20.0))
+            & ((rsi_3_1h_gt_10) | (aroonu_14_1d_lt_70) | (roc_9_1d > -20.0))
             # 1h down move, 4h high, 1d downtrend
             & ((rsi_3_1h_gt_10) | (stochrsi_k_4h < 60.0) | (roc_9_1d > -30.0))
             # 1h & 4h down move, 1h still not low enough
             & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_15) | (aroonu_14_1h < 20.0))
             # 1h & 4h down move, 4h high
-            & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_15) | (aroonu_14_4h < 60.0))
+            & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_15) | (aroonu_14_4h_lt_60))
             # 1h & 4h down move, 1h downtrend
             & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_15) | (roc_9_1h > -15.0))
             # 1h & 4h down move, 1d overbought
@@ -17616,109 +17668,109 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 4h still high
             & ((rsi_3_1h_gt_15) | rsi_3_4h_gt_20 | (rsi_14_4h < 40.0))
             # 1h & 4h down move, 1h high
-            & ((rsi_3_1h_gt_15) | (rsi_3_4h > 30.0) | (aroonu_14_1h < 70.0))
+            & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_30) | (aroonu_14_1h < 70.0))
             # 1h & 4h down move, 1d high
-            & ((rsi_3_1h_gt_15) | (rsi_3_4h > 40.0) | (aroonu_14_1d < 70.0))
+            & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_40) | (aroonu_14_1d_lt_70))
             # 1h & 1d down move, 1d still high
-            & ((rsi_3_1h_gt_15) | (rsi_3_1d > 25.0) | (aroonu_14_1d < 50.0))
+            & ((rsi_3_1h_gt_15) | (rsi_3_1d_gt_25) | (aroonu_14_1d < 50.0))
             # 1h down move, 1h still high, 1d downtrend
             & ((rsi_3_1h_gt_15) | (aroonu_14_1h < 30.0) | (roc_9_1d > -30.0))
             # 1h down move, 1h still high, 4h downtrend
-            & ((rsi_3_1h_gt_15) | (aroonu_14_1h < 40.0) | (roc_9_4h > -30.0))
+            & ((rsi_3_1h_gt_15) | (aroonu_14_1h < 40.0) | (roc_9_4h_gt_neg_30))
             # 1h down move, 4h high & overbought
-            & ((rsi_3_1h_gt_15) | (aroonu_14_4h < 80.0) | (roc_9_4h < 10.0))
+            & ((rsi_3_1h_gt_15) | (aroonu_14_4h < 80.0) | (roc_9_4h_lt_10))
             # 1h & 4h down move, 1h still high
-            & (rsi_3_1h_gt_20 | (rsi_3_4h > 30.0) | (stochrsi_k_1h_lt_50))
+            & (rsi_3_1h_gt_20 | (rsi_3_4h_gt_30) | (stochrsi_k_1h_lt_50))
             # 1h & 4h down move, 4h high
-            & (rsi_3_1h_gt_20 | (rsi_3_4h > 50.0) | (aroonu_14_4h < 75.0))
+            & (rsi_3_1h_gt_20 | (rsi_3_4h_gt_50) | (aroonu_14_4h < 75.0))
             # 1h down move, 1h high, 4h overbought
-            & (rsi_3_1h_gt_20 | aroonu_14_1h_lt_70 | (roc_9_4h < 10.0))
+            & (rsi_3_1h_gt_20 | aroonu_14_1h_lt_70 | (roc_9_4h_lt_10))
             # 1h down move, 1h high & overbought
             & (rsi_3_1h_gt_20 | aroonu_14_1d_lt_100 | (roc_9_1d < 100.0))
             # 1h down move, 4h downtrend, 1d overbought
             & (rsi_3_1h_gt_20 | (roc_9_4h > -40.0) | roc_9_1d_lt_50)
             # 1h & 4h down move, 1d high
-            & ((rsi_3_1h > 25.0) | (rsi_3_4h > 30.0) | (aroonu_14_1d < 80.0))
+            & ((rsi_3_1h_gt_25) | (rsi_3_4h_gt_30) | (aroonu_14_1d_lt_80))
             # 1h & 4h down move, 1d overbought
-            & ((rsi_3_1h > 25.0) | (rsi_3_4h > 30.0) | (roc_9_1d < 20.0))
+            & ((rsi_3_1h_gt_25) | (rsi_3_4h_gt_30) | (roc_9_1d_lt_20))
             # 1h & 1d down move, 1h high
-            & ((rsi_3_1h > 25.0) | (rsi_3_1d > 25.0) | aroonu_14_1h_lt_80)
+            & ((rsi_3_1h_gt_25) | (rsi_3_1d_gt_25) | aroonu_14_1h_lt_80)
             # 1h down move, 1h high, 1d downtrend
-            & ((rsi_3_1h > 25.0) | (aroonu_14_1h < 60.0) | (roc_9_1d > -40.0))
+            & ((rsi_3_1h_gt_25) | (aroonu_14_1h < 60.0) | (roc_9_1d_gt_neg_40))
             # 1h down move, 1h & 1d high
-            & ((rsi_3_1h > 25.0) | aroonu_14_1h_lt_70 | (aroonu_14_1d < 90.0))
+            & ((rsi_3_1h_gt_25) | aroonu_14_1h_lt_70 | (aroonu_14_1d_lt_90))
             # 1h down move, 1h high & overbought
-            & ((rsi_3_1h > 25.0) | aroonu_14_1h_lt_80 | (roc_9_1h < 10.0))
+            & ((rsi_3_1h_gt_25) | aroonu_14_1h_lt_80 | (roc_9_1h_lt_10))
             # 1h down move, 1h high, 4h overbought
-            & ((rsi_3_1h > 25.0) | aroonu_14_1h_lt_80 | (roc_9_4h < 50.0))
+            & ((rsi_3_1h_gt_25) | aroonu_14_1h_lt_80 | (roc_9_4h < 50.0))
             # 1h down move, 4h & 1d high
-            & ((rsi_3_1h > 25.0) | (aroonu_14_4h < 90.0) | aroonu_14_1d_lt_100)
+            & ((rsi_3_1h_gt_25) | (aroonu_14_4h_lt_90) | aroonu_14_1d_lt_100)
             # 1h down move, 1d high, 4h downtrend
-            & ((rsi_3_1h > 25.0) | (aroonu_14_1d < 80.0) | (roc_9_4h > -70.0))
+            & ((rsi_3_1h_gt_25) | (aroonu_14_1d_lt_80) | (roc_9_4h > -70.0))
             # 1h down move, 4h high, 1d downtrend
-            & ((rsi_3_1h > 25.0) | (stochrsi_k_4h < 80.0) | (roc_9_1d_gt_neg_30))
+            & ((rsi_3_1h_gt_25) | (stochrsi_k_4h < 80.0) | (roc_9_1d_gt_neg_30))
             # 1h down move, 4h & 1d downtrend
-            & ((rsi_3_1h > 25.0) | (roc_9_4h > -30.0) | (roc_9_1d > -60.0))
+            & ((rsi_3_1h_gt_25) | (roc_9_4h_gt_neg_30) | (roc_9_1d > -60.0))
             # 1h & 4h down move, 1h high
-            & ((rsi_3_1h > 30.0) | (rsi_3_4h > 40.0) | aroonu_14_1h_lt_70)
+            & ((rsi_3_1h_gt_30) | (rsi_3_4h_gt_40) | aroonu_14_1h_lt_70)
             # 1h down move, 1h high, 1d overbought
-            & ((rsi_3_1h > 30.0) | aroonu_14_1h_lt_80 | (roc_9_1d < 10.0))
+            & ((rsi_3_1h_gt_30) | aroonu_14_1h_lt_80 | (roc_9_1d < 10.0))
             # 1h down move, 4h high, 1d overbought
-            & ((rsi_3_1h > 30.0) | aroonu_14_4h_lt_70 | (roc_9_1d < 40.0))
+            & ((rsi_3_1h_gt_30) | aroonu_14_4h_lt_70 | (roc_9_1d_lt_40))
             # 1h down move, 4h high & overbought
-            & ((rsi_3_1h > 30.0) | aroonu_14_4h_lt_80 | (roc_9_4h < 30.0))
+            & ((rsi_3_1h_gt_30) | aroonu_14_4h_lt_80 | (roc_9_4h_lt_30))
             # 1h down move, 1d high, 4h downtrend
-            & ((rsi_3_1h > 30.0) | (aroonu_14_1d < 90.0) | (roc_9_4h > -40.0))
+            & ((rsi_3_1h_gt_30) | (aroonu_14_1d_lt_90) | (roc_9_4h > -40.0))
             # 1h down move, 1d high, 4h overbought
-            & ((rsi_3_1h > 30.0) | aroonu_14_1d_lt_100 | (roc_9_4h < 30.0))
+            & ((rsi_3_1h_gt_30) | aroonu_14_1d_lt_100 | (roc_9_4h_lt_30))
             # 1h down move, 4h & 1d overbought
-            & ((rsi_3_1h > 30.0) | (roc_9_4h < 30.0) | (roc_9_1d < 200.0))
+            & ((rsi_3_1h_gt_30) | (roc_9_4h_lt_30) | (roc_9_1d < 200.0))
             # 1h & 4h down move, 1d high
-            & ((rsi_3_1h > 35.0) | (rsi_3_4h > 35.0) | (aroonu_14_1d < 90.0))
+            & ((rsi_3_1h_gt_35) | (rsi_3_4h_gt_35) | (aroonu_14_1d_lt_90))
             # 1h down move, 1h high, 1d overbought
-            & ((rsi_3_1h > 35.0) | (aroonu_14_1h < 90.0) | (roc_9_1d < 80.0))
+            & ((rsi_3_1h_gt_35) | (aroonu_14_1h_lt_90) | (roc_9_1d_lt_80))
             # 1h down move, 1h & 4h high
-            & ((rsi_3_1h > 35.0) | (aroonu_14_1h < 100.0) | aroonu_14_4h_lt_100)
+            & ((rsi_3_1h_gt_35) | (aroonu_14_1h_lt_100) | aroonu_14_4h_lt_100)
             # 1h down move, 1d high & overbought
-            & ((rsi_3_1h > 35.0) | aroonu_14_1d_lt_100 | (roc_9_1d < 200.0))
+            & ((rsi_3_1h_gt_35) | aroonu_14_1d_lt_100 | (roc_9_1d < 200.0))
             # 1h down move, 1h high, 4h downtrend
-            & ((rsi_3_1h > 35.0) | (stochrsi_k_1h < 70.0) | (roc_9_4h_gt_neg_20))
+            & ((rsi_3_1h_gt_35) | (stochrsi_k_1h < 70.0) | (roc_9_4h_gt_neg_20))
             # 1h & 1d down move, 1h high
-            & ((rsi_3_1h > 40.0) | (rsi_3_1d > 40.0) | (aroonu_14_1h < 90.0))
+            & ((rsi_3_1h_gt_40) | (rsi_3_1d > 40.0) | (aroonu_14_1h_lt_90))
             # 1h down move, 1h high, 1d downtrend
-            & ((rsi_3_1h > 40.0) | aroonu_14_1h_lt_80 | (roc_9_1d > -30.0))
+            & ((rsi_3_1h_gt_40) | aroonu_14_1h_lt_80 | (roc_9_1d > -30.0))
             # 1h down move, 4h high, 1d overbought
-            & ((rsi_3_1h > 40.0) | aroonu_14_4h_lt_80 | (roc_9_1d < 40.0))
+            & ((rsi_3_1h_gt_40) | aroonu_14_4h_lt_80 | (roc_9_1d_lt_40))
             # 1h down move, 4h high & overbought
-            & ((rsi_3_1h > 40.0) | (aroonu_14_4h < 90.0) | (roc_9_4h_lt_20))
+            & ((rsi_3_1h_gt_40) | (aroonu_14_4h_lt_90) | (roc_9_4h_lt_20))
             # 1h down move, 1h high, 4h overbought
-            & ((rsi_3_1h > 40.0) | (stochrsi_k_1h < 80.0) | (roc_9_4h_lt_20))
+            & ((rsi_3_1h_gt_40) | (stochrsi_k_1h < 80.0) | (roc_9_4h_lt_20))
             # 1h down move, 4h high & overbought
-            & ((rsi_3_1h > 40.0) | (stochrsi_k_4h < 80.0) | (roc_9_4h_lt_20))
+            & ((rsi_3_1h_gt_40) | (stochrsi_k_4h < 80.0) | (roc_9_4h_lt_20))
             # 1h down move, 1d high, 4h overbought
-            & ((rsi_3_1h > 45.0) | aroonu_14_1d_lt_100 | (roc_9_4h < 40.0))
+            & ((rsi_3_1h_gt_45) | aroonu_14_1d_lt_100 | (roc_9_4h_lt_40))
             # 1h down move, 1h high, 1d downtrend
-            & ((rsi_3_1h > 50.0) | (aroonu_14_1h < 60.0) | (roc_9_1d > -70.0))
+            & ((rsi_3_1h_gt_50) | (aroonu_14_1h < 60.0) | (roc_9_1d > -70.0))
             # 1h down move, 1h & 1d high
-            & ((rsi_3_1h > 50.0) | aroonu_14_1h_lt_80 | aroonu_14_1d_lt_100)
+            & ((rsi_3_1h_gt_50) | aroonu_14_1h_lt_80 | aroonu_14_1d_lt_100)
             # 4h & 1d down move, 15m still high
-            & ((rsi_3_4h > 3.0) | (rsi_3_1d > 15.0) | (stochrsi_k_15m < 40.0))
+            & ((rsi_3_4h > 3.0) | (rsi_3_1d_gt_15) | (stochrsi_k_15m < 40.0))
             # 4h & 1d down move, 1h still not low enough
-            & ((rsi_3_4h > 3.0) | (rsi_3_1d > 15.0) | (stochrsi_k_1h < 30.0))
+            & ((rsi_3_4h > 3.0) | (rsi_3_1d_gt_15) | (stochrsi_k_1h < 30.0))
             # 4h down move, 4h still high
-            & ((rsi_3_4h > 3.0) | (aroonu_14_4h < 50.0))
+            & ((rsi_3_4h > 3.0) | (aroonu_14_4h_lt_50))
             # 4h down move, 1h still high, 4h downtrend
-            & ((rsi_3_4h > 3.0) | (stochrsi_k_1h_lt_50) | (roc_9_4h > -30.0))
+            & ((rsi_3_4h > 3.0) | (stochrsi_k_1h_lt_50) | (roc_9_4h_gt_neg_30))
             # 4h & 1d down move, 1d still high
-            & ((rsi_3_4h > 5.0) | (rsi_3_1d > 30.0) | (stochrsi_k_1d < 40.0))
+            & ((rsi_3_4h_gt_5) | (rsi_3_1d > 30.0) | (stochrsi_k_1d < 40.0))
             # 4h down move, 1h & 4h downtrend
-            & ((rsi_3_4h > 5.0) | (roc_9_1h > -10.0) | (roc_9_4h > -10.0))
+            & ((rsi_3_4h_gt_5) | (roc_9_1h > -10.0) | (roc_9_4h > -10.0))
             # 4h & 1d down move, 4h downtrend
-            & ((rsi_3_4h_gt_10) | (rsi_3_1d > 10.0) | (roc_9_4h > -20.0))
+            & ((rsi_3_4h_gt_10) | (rsi_3_1d_gt_10) | (roc_9_4h > -20.0))
             # 4h & 1d down move, 1d downtrend
-            & ((rsi_3_4h_gt_10) | (rsi_3_1d > 10.0) | (roc_9_1d > -30.0))
+            & ((rsi_3_4h_gt_10) | (rsi_3_1d_gt_10) | (roc_9_1d > -30.0))
             # 4h down move, 4h still high
-            & ((rsi_3_4h_gt_10) | (aroonu_14_4h < 50.0))
+            & ((rsi_3_4h_gt_10) | (aroonu_14_4h_lt_50))
             # 4h down move, 1d still high, 1d downtrend
             & ((rsi_3_4h_gt_10) | (aroonu_14_1d < 50.0) | (roc_9_1d > -30.0))
             # 4h down move, 4h still not low enough, 1d downtrend
@@ -17726,73 +17778,73 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 4h & 1d  downtrend
             & ((rsi_3_4h_gt_10) | (roc_9_4h > -20.0) | (roc_9_1d > -30.0))
             # 4h down move, 1h still high
-            & ((rsi_3_4h_gt_15) | (aroonu_14_1h < 50.0))
+            & ((rsi_3_4h_gt_15) | (aroonu_14_1h_lt_50))
             # 4h down move, 1h still high, 1d downtrend
             & ((rsi_3_4h_gt_15) | (stochrsi_k_1h < 50.0) | (roc_9_1d > -30.0))
             # 4h down move, 4h still high, 1d downtrend
-            & ((rsi_3_4h_gt_15) | (stochrsi_k_4h < 50.0) | (roc_9_1d > -20.0))
+            & ((rsi_3_4h_gt_15) | (stochrsi_k_4h_lt_50) | (roc_9_1d > -20.0))
             # 4h down move, 4h still high, 1d downtrend
-            & (rsi_3_4h_gt_20 | (aroonu_14_4h < 50.0) | (roc_9_1d > -40.0))
+            & (rsi_3_4h_gt_20 | (aroonu_14_4h_lt_50) | (roc_9_1d_gt_neg_40))
             # 4h down move, 1d high & overbought
-            & (rsi_3_4h_gt_20 | (aroonu_14_1d < 70.0) | roc_9_1d_lt_50)
+            & (rsi_3_4h_gt_20 | (aroonu_14_1d_lt_70) | roc_9_1d_lt_50)
             # 4h & 1d down move, 1h high
-            & ((rsi_3_4h > 25.0) | (rsi_3_1d > 25.0) | (aroonu_14_1h < 90.0))
+            & ((rsi_3_4h_gt_25) | (rsi_3_1d_gt_25) | (aroonu_14_1h_lt_90))
             # 4h down move, 4h still high, 1d downtrend
-            & ((rsi_3_4h > 30.0) | (aroonu_14_4h < 50.0) | (roc_9_1d > -40.0))
+            & ((rsi_3_4h_gt_30) | (aroonu_14_4h_lt_50) | (roc_9_1d_gt_neg_40))
             # 4h down move, 1d high, 1d downtrend
-            & ((rsi_3_4h > 35.0) | (stochrsi_k_1d < 60.0) | (roc_9_1d_gt_neg_30))
+            & ((rsi_3_4h_gt_35) | (stochrsi_k_1d < 60.0) | (roc_9_1d_gt_neg_30))
             # 4h down move, 1d high, 1d downtrend
-            & ((rsi_3_4h > 45.0) | (aroonu_14_1d < 80.0) | (roc_9_1d > -15.0))
+            & ((rsi_3_4h > 45.0) | (aroonu_14_1d_lt_80) | (roc_9_1d > -15.0))
             # 4h down move, 4h still high, 1d downtrend
-            & ((rsi_3_4h > 50.0) | (rsi_14_4h < 40.0) | (roc_9_1d_gt_neg_30))
+            & ((rsi_3_4h_gt_50) | (rsi_14_4h < 40.0) | (roc_9_1d_gt_neg_30))
             # 1d down move, 4h high, 1d downtrend
-            & ((rsi_3_1d > 15.0) | (stochrsi_k_4h < 70.0) | (roc_9_1d > -70.0))
+            & ((rsi_3_1d_gt_15) | (stochrsi_k_4h_lt_70) | (roc_9_1d > -70.0))
             # 1d down move, 1h high & overbought
-            & ((rsi_3_1d > 35.0) | (stochrsi_k_1h < 90.0) | (roc_9_1h < 10.0))
+            & ((rsi_3_1d > 35.0) | (stochrsi_k_1h < 90.0) | (roc_9_1h_lt_10))
             # 1d down move, 1h high & overbought
-            & ((rsi_3_1d > 40.0) | (aroonu_14_1d < 70.0) | (roc_9_1d < 80.0))
+            & ((rsi_3_1d > 40.0) | (aroonu_14_1d_lt_70) | (roc_9_1d_lt_80))
             # 4h downtrend, 1h & 4h high
             & ((cmf_20_4h > -0.30) | aroonu_14_1h_lt_70 | aroonu_14_4h_lt_100)
             # 15m still high, 1h & 4h overbought
-            & ((aroonu_14_15m < 50.0) | (roc_9_1h < 100.0) | (roc_9_4h < 100.0))
+            & ((aroonu_14_15m_lt_50) | (roc_9_1h < 100.0) | (roc_9_4h < 100.0))
             # 15m & 1d high, 1d overbought
-            & ((aroonu_14_15m < 70.0) | (aroonu_14_1d < 90.0) | (roc_9_1d < 30.0))
+            & ((aroonu_14_15m_lt_70) | (aroonu_14_1d_lt_90) | (roc_9_1d_lt_30))
             # 1h still high, 4h & 1d downtrend
-            & ((aroonu_14_1h < 40.0) | (roc_9_4h_gt_neg_20) | (roc_9_1d > -40.0))
+            & ((aroonu_14_1h < 40.0) | (roc_9_4h_gt_neg_20) | (roc_9_1d_gt_neg_40))
             # 1h & 4h high, 1d downtrend
             & (aroonu_14_1h_lt_70 | aroonu_14_4h_lt_100 | (roc_9_1d > -20.0))
             # 1h & 4h high, 1d overbought
-            & (aroonu_14_1h_lt_70 | aroonu_14_4h_lt_100 | (roc_9_1d < 20.0))
+            & (aroonu_14_1h_lt_70 | aroonu_14_4h_lt_100 | (roc_9_1d_lt_20))
             # 1h & 1d high, 1d overbought
-            & (aroonu_14_1h_lt_70 | (aroonu_14_1d < 90.0) | (roc_9_1d < 200.0))
+            & (aroonu_14_1h_lt_70 | (aroonu_14_1d_lt_90) | (roc_9_1d < 200.0))
             # 1h high, 4h downtrend, 1d overbought
             & (aroonu_14_1h_lt_70 | (roc_9_4h > -40.0) | (roc_9_1d < 100.0))
             # 1h & 4h high, 4h overbought
-            & (aroonu_14_1h_lt_80 | aroonu_14_4h_lt_100 | (roc_9_4h < 30.0))
+            & (aroonu_14_1h_lt_80 | aroonu_14_4h_lt_100 | (roc_9_4h_lt_30))
             # 1h high, 1d downtrend
             & (aroonu_14_1h_lt_80 | (roc_9_1d > -60.0))
             # 1h high, 1h & 4h overbought
-            & ((aroonu_14_1h < 100.0) | (roc_9_1h < 100.0) | (roc_9_4h < 100.0))
+            & ((aroonu_14_1h_lt_100) | (roc_9_1h < 100.0) | (roc_9_4h < 100.0))
             # 4h & 1d high, 1d overbought
-            & ((aroonu_14_4h < 60.0) | aroonu_14_1d_lt_100 | (roc_9_1d < 70.0))
+            & ((aroonu_14_4h_lt_60) | aroonu_14_1d_lt_100 | (roc_9_1d < 70.0))
             # 4h high, 1h & 4h overbought
             & ((aroonu_14_4h < 85.0) | (roc_9_1h < 80.0) | (roc_9_4h < 80.0))
             # 4h high, 1h downtrend, 4h overbought
-            & ((aroonu_14_4h < 90.0) | (roc_9_1h > -40.0) | (roc_9_4h < 100.0))
+            & ((aroonu_14_4h_lt_90) | (roc_9_1h > -40.0) | (roc_9_4h < 100.0))
             # 4h & 1d high, 4h overbought
-            & ((aroonu_14_4h < 90.0) | aroonu_14_1d_lt_100 | (roc_9_4h < 100.0))
+            & ((aroonu_14_4h_lt_90) | aroonu_14_1d_lt_100 | (roc_9_4h < 100.0))
             # 4h high, 1h & 4h overbought
-            & ((aroonu_14_4h < 90.0) | (roc_9_1h < 10.0) | (roc_9_4h_lt_20))
+            & ((aroonu_14_4h_lt_90) | (roc_9_1h_lt_10) | (roc_9_4h_lt_20))
             # 4h & 1d high, 4h overbought
-            & (aroonu_14_4h_lt_100 | aroonu_14_1d_lt_100 | (roc_9_4h < 30.0))
+            & (aroonu_14_4h_lt_100 | aroonu_14_1d_lt_100 | (roc_9_4h_lt_30))
             # 4h & 1d high, 1d overbought
-            & (aroonu_14_4h_lt_100 | aroonu_14_1d_lt_100 | (roc_9_1d < 40.0))
+            & (aroonu_14_4h_lt_100 | aroonu_14_1d_lt_100 | (roc_9_1d_lt_40))
             # 1d high, 1h & 4h downtrend
-            & (aroonu_14_1d_lt_100 | (roc_9_1h > -30.0) | (roc_9_4h > -30.0))
+            & (aroonu_14_1d_lt_100 | (roc_9_1h > -30.0) | (roc_9_4h_gt_neg_30))
             # 1d high, 4h & 1d overbought
             & (aroonu_14_1d_lt_100 | (roc_9_4h < 20.0) | (roc_9_1d < 100.0))
             # 1h high, 1d overbought
-            & ((stochrsi_k_1h_lt_70) | (roc_9_1d < 40.0))
+            & ((stochrsi_k_1h_lt_70) | (roc_9_1d_lt_40))
             # 1h high, 4h overbought
             & ((stochrsi_k_1h_lt_80) | (roc_9_4h < 80.0))
             # 1h high, 4h & 1d downtrend
@@ -17800,7 +17852,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h high, 1h & 4h overbought
             & ((stochrsi_k_4h_lt_80) | (roc_9_1h < 40.0) | (roc_9_4h < 100.0))
             # 1d high, 4h & 1d overbought
-            & ((stochrsi_k_1d < 90.0) | (roc_9_4h_lt_20) | (roc_9_1d_lt_100))
+            & ((stochrsi_k_1d_lt_90) | (roc_9_4h_lt_20) | (roc_9_1d_lt_100))
             # 1h & 4h overbought, 1d downtrend
             & ((roc_9_1h < 40.0) | (roc_9_4h < 50.0) | (roc_9_1d_gt_neg_30))
             # big drop in the last 20 days, 1d high, 1d downtrend
@@ -17827,29 +17879,29 @@ class NostalgiaForInfinityX7(IStrategy):
 
           long_entry_logic.append(
             # 5m & 1h & 4h down move
-            ((rsi_3 > 3.0) | (rsi_3_1h_gt_15) | (rsi_3_4h_gt_15))
+            ((rsi_3_gt_3) | (rsi_3_1h_gt_15) | (rsi_3_4h_gt_15))
             # 15m & 1h & 4h down move
-            & (rsi_3_15m_gt_3 | (rsi_3_1h > 3.0) | (rsi_3_4h_gt_10))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_3) | (rsi_3_4h_gt_10))
             # 15m & 1h down move, 1h high
-            & (rsi_3_15m_gt_3 | (rsi_3_1h > 3.0) | (aroonu_14_1h < 60.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_3) | (aroonu_14_1h < 60.0))
             # 15m & 1h & 4h down move
-            & (rsi_3_15m_gt_3 | (rsi_3_1h > 5.0) | (rsi_3_4h_gt_10))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_5) | (rsi_3_4h_gt_10))
             # 15m & 1h down move, 1d downtrend
-            & (rsi_3_15m_gt_3 | (rsi_3_1h > 5.0) | (roc_9_1d_gt_neg_30))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_5) | (roc_9_1d_gt_neg_30))
             # 15m & 1h down move, 1d high
             & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_10) | (aroonu_14_1d < 100.0))
             # 15m & 1h down move, 1h high
             & (rsi_3_15m_gt_3 | rsi_3_1h_gt_20 | aroonu_14_1h_lt_80)
             # 15m & 4h down move, 4h still high
-            & (rsi_3_15m_gt_3 | (rsi_3_4h_gt_10) | (aroonu_14_4h < 40.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_4h_gt_10) | (aroonu_14_4h_lt_40))
             # 15m & 4h down move, 15m downtrend
             & (rsi_3_15m_gt_3 | (rsi_3_4h_gt_10) | (roc_9_15m > -30.0))
             # 15m & 4h down move, 1h downtrend
             & (rsi_3_15m_gt_3 | (rsi_3_4h_gt_10) | (roc_9_1h > -20.0))
             # 15m & 4h down move, 1h still high
-            & (rsi_3_15m_gt_3 | (rsi_3_4h_gt_15) | (aroonu_14_1h < 50.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_4h_gt_15) | (aroonu_14_1h_lt_50))
             # 15m & 4h down move, 1h still high
-            & (rsi_3_15m_gt_3 | (rsi_3_4h > 40.0) | (stochrsi_k_1h < 40.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_4h_gt_40) | (stochrsi_k_1h < 40.0))
             # 15m down move, 1h still high, 1d overbought
             & (rsi_3_15m_gt_3 | (aroonu_14_1h < 40.0) | (roc_9_1d < 70.0))
             # 15m down move, 4h high & overbought
@@ -17857,91 +17909,91 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 1h high
             & (rsi_3_15m_gt_3 | (stochrsi_k_1h_lt_70))
             # 15m down move, 4h high, 15m downtrend
-            & (rsi_3_15m_gt_3 | (stochrsi_k_4h < 70.0) | (roc_9_15m > -30.0))
+            & (rsi_3_15m_gt_3 | (stochrsi_k_4h_lt_70) | (roc_9_15m > -30.0))
             # 15m & 1h down move, 1h high
-            & ((rsi_3_15m > 5.0) | (rsi_3_1h_gt_15) | (aroonu_14_1h < 70.0))
+            & ((rsi_3_15m_gt_5) | (rsi_3_1h_gt_15) | (aroonu_14_1h < 70.0))
             # 15m & 1h down move, 1h downtrend
-            & ((rsi_3_15m > 10.0) | (rsi_3_1h_gt_10) | (roc_9_1h > -20.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_10) | (roc_9_1h > -20.0))
             # 15m & 4h down move, 1h still not low enough
-            & ((rsi_3_15m > 10.0) | (rsi_3_4h_gt_10) | (stochrsi_k_1h < 30.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_4h_gt_10) | (stochrsi_k_1h < 30.0))
             # 15m down move, 4h overbought
-            & ((rsi_3_15m > 10.0) | (roc_9_4h < 30.0))
+            & ((rsi_3_15m_gt_10) | (roc_9_4h_lt_30))
             # 15m & 4h down move, 4h high
-            & ((rsi_3_15m > 15.0) | (rsi_3_4h > 25.0) | aroonu_14_4h_lt_70)
+            & ((rsi_3_15m_gt_15) | (rsi_3_4h_gt_25) | aroonu_14_4h_lt_70)
             # 15m & 4h down move, 4h high
-            & ((rsi_3_15m > 15.0) | (rsi_3_4h > 40.0) | (aroonu_14_4h < 75.0))
+            & ((rsi_3_15m_gt_15) | (rsi_3_4h_gt_40) | (aroonu_14_4h < 75.0))
             # 15m & 4h down move, 4h high
-            & ((rsi_3_15m > 15.0) | (rsi_3_4h > 45.0) | (aroonu_14_4h < 90.0))
+            & ((rsi_3_15m_gt_15) | (rsi_3_4h > 45.0) | (aroonu_14_4h_lt_90))
             # 15m down move, 4h & 1d downtrend
-            & ((rsi_3_15m > 15.0) | (roc_9_4h > -10.0) | (roc_9_1d > -40.0))
+            & ((rsi_3_15m_gt_15) | (roc_9_4h > -10.0) | (roc_9_1d_gt_neg_40))
             # 15m down move, 1h high & overbought
-            & ((rsi_3_15m > 25.0) | (aroonu_14_1d < 90.0) | (roc_9_1d_lt_100))
+            & ((rsi_3_15m_gt_25) | (aroonu_14_1d_lt_90) | (roc_9_1d_lt_100))
             # 1h & 4h down move, 1h still not low enough
-            & ((rsi_3_1h > 3.0) | (rsi_3_4h > 3.0) | (aroonu_14_1h < 20.0))
+            & ((rsi_3_1h_gt_3) | (rsi_3_4h > 3.0) | (aroonu_14_1h < 20.0))
             # 1h & 4h down move
-            & ((rsi_3_1h > 3.0) | (rsi_3_4h > 5.0))
+            & ((rsi_3_1h_gt_3) | (rsi_3_4h_gt_5))
             # 1h & 4h down move, 1d still high
-            & ((rsi_3_1h > 3.0) | (rsi_3_4h_gt_10) | (aroonu_14_1d < 50.0))
+            & ((rsi_3_1h_gt_3) | (rsi_3_4h_gt_10) | (aroonu_14_1d < 50.0))
             # 1h & 4h down move, 1d high
-            & ((rsi_3_1h > 3.0) | (rsi_3_4h_gt_10) | (stochrsi_k_1d < 60.0))
+            & ((rsi_3_1h_gt_3) | (rsi_3_4h_gt_10) | (stochrsi_k_1d < 60.0))
             # 1h & 4h down move, 1d high
-            & ((rsi_3_1h > 3.0) | rsi_3_4h_gt_20 | (aroonu_14_1d < 60.0))
+            & ((rsi_3_1h_gt_3) | rsi_3_4h_gt_20 | (aroonu_14_1d < 60.0))
             # 1h & 4h down move, 4h high
-            & ((rsi_3_1h > 3.0) | rsi_3_4h_gt_20 | (stochrsi_k_4h < 60.0))
+            & ((rsi_3_1h_gt_3) | rsi_3_4h_gt_20 | (stochrsi_k_4h < 60.0))
             # 1h down move, 1h & 4h still high
-            & ((rsi_3_1h > 3.0) | (aroonu_14_1h < 50.0) | (aroonu_14_4h < 50.0))
+            & ((rsi_3_1h_gt_3) | (aroonu_14_1h_lt_50) | (aroonu_14_4h_lt_50))
             # 1h down move, 1h still high, 1h downtrend
-            & ((rsi_3_1h > 3.0) | (aroonu_14_1h < 50.0) | (roc_9_1h > -20.0))
+            & ((rsi_3_1h_gt_3) | (aroonu_14_1h_lt_50) | (roc_9_1h > -20.0))
             # 1h down move, 4h still high, 1d downtrend
-            & ((rsi_3_1h > 3.0) | (stochrsi_k_4h < 50.0) | (roc_9_1h > -15.0))
+            & ((rsi_3_1h_gt_3) | (stochrsi_k_4h_lt_50) | (roc_9_1h > -15.0))
             # 1h downtrend, 4h high
-            & ((rsi_3_1h > 3.0) | (stochrsi_k_4h < 70.0))
+            & ((rsi_3_1h_gt_3) | (stochrsi_k_4h_lt_70))
             # 1h down move, 1h & 4h downtrend
-            & ((rsi_3_1h > 3.0) | (roc_9_1h > -20.0) | (roc_9_4h_gt_neg_20))
+            & ((rsi_3_1h_gt_3) | (roc_9_1h > -20.0) | (roc_9_4h_gt_neg_20))
             # 1h & 4h down move, 4h still high
-            & ((rsi_3_1h > 5.0) | (rsi_3_4h_gt_10) | (aroonu_14_4h < 50.0))
+            & ((rsi_3_1h_gt_5) | (rsi_3_4h_gt_10) | (aroonu_14_4h_lt_50))
             # 1h & 4h down move, 1d high
-            & ((rsi_3_1h > 5.0) | (rsi_3_4h_gt_10) | (stochrsi_k_1d < 90.0))
+            & ((rsi_3_1h_gt_5) | (rsi_3_4h_gt_10) | (stochrsi_k_1d_lt_90))
             # 1h & 4h down move, 4h still high
-            & ((rsi_3_1h > 5.0) | (rsi_3_4h > 30.0) | (rsi_14_4h < 40.0))
+            & ((rsi_3_1h_gt_5) | (rsi_3_4h_gt_30) | (rsi_14_4h < 40.0))
             # 1h & 1d down move, 1d downtrend
-            & ((rsi_3_1h > 5.0) | (rsi_3_1d > 5.0) | (roc_9_1d_gt_neg_20))
+            & ((rsi_3_1h_gt_5) | (rsi_3_1d > 5.0) | (roc_9_1d_gt_neg_20))
             # 1h down move, 1h high
-            & ((rsi_3_1h > 5.0) | (aroonu_14_1h < 60.0))
+            & ((rsi_3_1h_gt_5) | (aroonu_14_1h < 60.0))
             # 1h down move, 4h high
-            & ((rsi_3_1h > 5.0) | aroonu_14_4h_lt_70)
+            & ((rsi_3_1h_gt_5) | aroonu_14_4h_lt_70)
             # 1h down move, 1d high & overbought
-            & ((rsi_3_1h > 5.0) | (aroonu_14_1d < 90.0) | (roc_9_1d < 30.0))
+            & ((rsi_3_1h_gt_5) | (aroonu_14_1d_lt_90) | (roc_9_1d_lt_30))
             # 1h down move, 4h & 1d downtrend
-            & ((rsi_3_1h > 5.0) | (roc_9_4h_gt_neg_20) | (roc_9_1d > -25.0))
+            & ((rsi_3_1h_gt_5) | (roc_9_4h_gt_neg_20) | (roc_9_1d > -25.0))
             # 1h down move, 1d overbought
-            & ((rsi_3_1h > 5.0) | (roc_9_1d_lt_100))
+            & ((rsi_3_1h_gt_5) | (roc_9_1d_lt_100))
             # 1h & 4h down move, 1d downtrend
             & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_10) | (roc_9_1d > -20.0))
             # 1h & 4h down move, 4h still high
             & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_15) | (rsi_14_4h < 40.0))
             # 1h & 4h down move, 1h still high
-            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_15) | (aroonu_14_1h < 50.0))
+            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_15) | (aroonu_14_1h_lt_50))
             # 1h & 4h down move, 4h still high
-            & ((rsi_3_1h_gt_10) | rsi_3_4h_gt_20 | (stochrsi_k_4h < 50.0))
+            & ((rsi_3_1h_gt_10) | rsi_3_4h_gt_20 | (stochrsi_k_4h_lt_50))
             # 1h & 4h down move, 1d downtrend
-            & ((rsi_3_1h_gt_10) | rsi_3_4h_gt_20 | (roc_9_1d > -40.0))
+            & ((rsi_3_1h_gt_10) | rsi_3_4h_gt_20 | (roc_9_1d_gt_neg_40))
             # 1h & 4h down move, 1h downtrend
             & ((rsi_3_1h_gt_10) | rsi_3_4h_gt_20 | (roc_9_1h > -25.0))
             # 1h & 4h down move, 4h high
-            & ((rsi_3_1h_gt_10) | (rsi_3_4h > 25.0) | aroonu_14_4h_lt_70)
+            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_25) | aroonu_14_4h_lt_70)
             # 1h & 4h down move, 1h high
             & ((rsi_3_1h_gt_10) | (rsi_3_4h > 60.0) | (aroonu_14_1h < 70.0))
             # 1h & 1d down move, 4h still high
-            & ((rsi_3_1h_gt_10) | (rsi_3_1d > 10.0) | (aroonu_14_4h < 40.0))
+            & ((rsi_3_1h_gt_10) | (rsi_3_1d_gt_10) | (aroonu_14_4h_lt_40))
             # 1h & 1d down move, 1h still high
-            & ((rsi_3_1h_gt_10) | (rsi_3_1d > 15.0) | (aroonu_14_1h < 50.0))
+            & ((rsi_3_1h_gt_10) | (rsi_3_1d_gt_15) | (aroonu_14_1h_lt_50))
             # 1h & 1d down move, 1h high
             & ((rsi_3_1h_gt_10) | (rsi_3_1d > 40.0) | (aroonu_14_1h < 70.0))
             # 1h down move, 1h still high, 4h downtrend
-            & ((rsi_3_1h_gt_10) | (aroonu_14_1h < 40.0) | (roc_9_4h > -30.0))
+            & ((rsi_3_1h_gt_10) | (aroonu_14_1h < 40.0) | (roc_9_4h_gt_neg_30))
             # 1h down move, 1h still high, 1d high
-            & ((rsi_3_1h_gt_10) | (aroonu_14_1h < 50.0) | (aroonu_14_1d < 90.0))
+            & ((rsi_3_1h_gt_10) | (aroonu_14_1h_lt_50) | (aroonu_14_1d_lt_90))
             # 1h down move, 1h high, 1h downtrend
             & ((rsi_3_1h_gt_10) | (aroonu_14_1h < 60.0) | (roc_9_1h > -10.0))
             # 1h down move, 1h high, 1d downtrend
@@ -17949,29 +18001,29 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h high
             & ((rsi_3_1h_gt_10) | (aroonu_14_1h < 80.0))
             # 1h down move, 4h still high, 15m downtrend
-            & ((rsi_3_1h_gt_10) | (aroonu_14_4h < 50.0) | (cmf_20_15m > -0.40))
+            & ((rsi_3_1h_gt_10) | (aroonu_14_4h_lt_50) | (cmf_20_15m > -0.40))
             # 1h down move, 4h still high, 4h downtrend
-            & ((rsi_3_1h_gt_10) | (aroonu_14_4h < 50.0) | (roc_9_4h > -30.0))
+            & ((rsi_3_1h_gt_10) | (aroonu_14_4h_lt_50) | (roc_9_4h_gt_neg_30))
             # 1h down move, 4h still high, 1d downtrend
-            & ((rsi_3_1h_gt_10) | (aroonu_14_4h < 50.0) | (roc_9_1d > -30.0))
+            & ((rsi_3_1h_gt_10) | (aroonu_14_4h_lt_50) | (roc_9_1d > -30.0))
             # 1h down move, 4h & 1d high
-            & ((rsi_3_1h_gt_10) | (aroonu_14_4h < 60.0) | (aroonu_14_1d < 100.0))
+            & ((rsi_3_1h_gt_10) | (aroonu_14_4h_lt_60) | (aroonu_14_1d < 100.0))
             # 1h down move, 4h high, 1d overbought
-            & ((rsi_3_1h_gt_10) | (aroonu_14_4h < 90.0) | (roc_9_1d < 100.0))
+            & ((rsi_3_1h_gt_10) | (aroonu_14_4h_lt_90) | (roc_9_1d < 100.0))
             # 1h down move, 4h high
             & ((rsi_3_1h_gt_10) | (aroonu_14_4h < 100.0))
             # 1h down move, 1d high & overbought
             & ((rsi_3_1h_gt_10) | (aroonu_14_1d < 100.0) | (roc_9_1d < 60.0))
             # 1h down move, 4h overbought
-            & ((rsi_3_1h_gt_10) | (roc_9_4h < 10.0))
+            & ((rsi_3_1h_gt_10) | (roc_9_4h_lt_10))
             # 1h down move, 4h high & overbought
             & ((rsi_3_1h_gt_10) | (stochrsi_k_4h < 80.0) | (roc_9_4h < 20.0))
             # 1h down move, 4h & 1d downtrend
-            & ((rsi_3_1h_gt_10) | (roc_9_4h > -30.0) | roc_9_1d_gt_neg_50)
+            & ((rsi_3_1h_gt_10) | (roc_9_4h_gt_neg_30) | roc_9_1d_gt_neg_50)
             # 1h & 4h down move, 4h high
             & ((rsi_3_1h_gt_15) | (rsi_3_4h > 45.0) | (aroonu_14_4h < 80.0))
             # 1h down move, 1h high, 1d downtrend
-            & ((rsi_3_1h_gt_15) | (aroonu_14_1h < 50.0) | (roc_9_1d > -40.0))
+            & ((rsi_3_1h_gt_15) | (aroonu_14_1h_lt_50) | (roc_9_1d_gt_neg_40))
             # 1h down move, 1h & 1d high
             & ((rsi_3_1h_gt_15) | (aroonu_14_1h < 60.0) | (aroonu_14_1d < 85.0))
             # 1h down move, 1h high, 1d downtrend
@@ -17983,103 +18035,103 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 4h high & overbought
             & ((rsi_3_1h_gt_15) | (aroonu_14_4h < 80.0) | (roc_9_4h < 100.0))
             # 1h down move, 1d high & overbought
-            & ((rsi_3_1h_gt_15) | (aroonu_14_1d < 80.0) | (roc_9_1d < 100.0))
+            & ((rsi_3_1h_gt_15) | (aroonu_14_1d_lt_80) | (roc_9_1d < 100.0))
             # 1h down move, 1h & 4h downtrend
-            & ((rsi_3_1h_gt_15) | (roc_9_1h > -30.0) | (roc_9_4h > -30.0))
+            & ((rsi_3_1h_gt_15) | (roc_9_1h > -30.0) | (roc_9_4h_gt_neg_30))
             # 1h down move, 1h & 4h overbought
-            & ((rsi_3_1h_gt_15) | (roc_9_4h < 10.0) | roc_9_1d_lt_50)
+            & ((rsi_3_1h_gt_15) | (roc_9_4h_lt_10) | roc_9_1d_lt_50)
             # 1h down move, 1h & 4h overbought
-            & ((rsi_3_1h_gt_15) | (roc_9_4h < 20.0) | (roc_9_1d < 20.0))
+            & ((rsi_3_1h_gt_15) | (roc_9_4h < 20.0) | (roc_9_1d_lt_20))
             # 1h & 4h down move, 4h high
-            & (rsi_3_1h_gt_20 | (rsi_3_4h > 50.0) | (aroonu_14_4h < 90.0))
+            & (rsi_3_1h_gt_20 | (rsi_3_4h_gt_50) | (aroonu_14_4h_lt_90))
             # 1h down move, 1h still high, 4h downtrend
-            & (rsi_3_1h_gt_20 | (aroonu_14_1h < 40.0) | (roc_9_4h > -30.0))
+            & (rsi_3_1h_gt_20 | (aroonu_14_1h < 40.0) | (roc_9_4h_gt_neg_30))
             # 1h down move, 4h high, 1d downtrend
-            & (rsi_3_1h_gt_20 | (stochrsi_k_4h_lt_80) | (roc_9_1d > -40.0))
+            & (rsi_3_1h_gt_20 | (stochrsi_k_4h_lt_80) | (roc_9_1d_gt_neg_40))
             # 1h down move, 4h & 1d downtrend
-            & (rsi_3_1h_gt_20 | (roc_9_4h > -30.0) | (roc_9_1d > -40.0))
+            & (rsi_3_1h_gt_20 | (roc_9_4h_gt_neg_30) | (roc_9_1d_gt_neg_40))
             # 1h & 4h down ove, 4h high
-            & ((rsi_3_1h > 25.0) | (rsi_3_4h > 45.0) | (aroonu_14_4h < 90.0))
+            & ((rsi_3_1h_gt_25) | (rsi_3_4h > 45.0) | (aroonu_14_4h_lt_90))
             # 1h down move, 1h & 1d high
-            & ((rsi_3_1h > 25.0) | aroonu_14_1h_lt_70 | (aroonu_14_1d < 80.0))
+            & ((rsi_3_1h_gt_25) | aroonu_14_1h_lt_70 | (aroonu_14_1d_lt_80))
             # 1h down move, 4h high, 1d downtrend
-            & ((rsi_3_1h > 25.0) | aroonu_14_4h_lt_80 | (roc_9_1d > -20.0))
+            & ((rsi_3_1h_gt_25) | aroonu_14_4h_lt_80 | (roc_9_1d > -20.0))
             # 1h down move, 1d high & overbought
-            & ((rsi_3_1h > 25.0) | (aroonu_14_1d < 90.0) | (roc_9_1d_lt_100))
+            & ((rsi_3_1h_gt_25) | (aroonu_14_1d_lt_90) | (roc_9_1d_lt_100))
             # 1h down move, 1h still high, 1d overbought
-            & ((rsi_3_1h > 25.0) | (stochrsi_k_1h_lt_50) | (roc_9_1d < 40.0))
+            & ((rsi_3_1h_gt_25) | (stochrsi_k_1h_lt_50) | (roc_9_1d_lt_40))
             # 1h down move, 1h downtrend, 4h overbought
-            & ((rsi_3_1h > 25.0) | (roc_9_1h > -20.0) | (roc_9_4h_lt_20))
+            & ((rsi_3_1h_gt_25) | (roc_9_1h > -20.0) | (roc_9_4h_lt_20))
             # 1h down move, 1d overbought
-            & ((rsi_3_1h > 25.0) | (roc_9_1d < 200.0))
+            & ((rsi_3_1h_gt_25) | (roc_9_1d < 200.0))
             # 1h down move, 4h high
-            & ((rsi_3_1h > 30.0) | aroonu_14_4h_lt_100)
+            & ((rsi_3_1h_gt_30) | aroonu_14_4h_lt_100)
             # 1h down move, 4h high & overbought
-            & ((rsi_3_1h > 30.0) | (stochrsi_k_4h_lt_80) | (roc_9_4h < 10.0))
+            & ((rsi_3_1h_gt_30) | (stochrsi_k_4h_lt_80) | (roc_9_4h_lt_10))
             # 4h down move, 4h still high, 1d high
-            & ((rsi_3_4h > 3.0) | (aroonu_14_4h < 50.0) | aroonu_14_1d_lt_100)
+            & ((rsi_3_4h > 3.0) | (aroonu_14_4h_lt_50) | aroonu_14_1d_lt_100)
             # 4h down move, 1d still high, 4h downtrend
-            & ((rsi_3_4h > 3.0) | (stochrsi_k_1d < 50.0) | (roc_9_4h > -30.0))
+            & ((rsi_3_4h > 3.0) | (stochrsi_k_1d < 50.0) | (roc_9_4h_gt_neg_30))
             # 4h down move, 1d overbought
             & ((rsi_3_4h > 3.0) | (roc_9_1d < 200.0))
             # 4h down move, 1h still high
-            & ((rsi_3_4h > 5.0) | (stochrsi_k_1h < 40.0))
+            & ((rsi_3_4h_gt_5) | (stochrsi_k_1h < 40.0))
             # 4h down move, 1h & 4h downtrend
-            & ((rsi_3_4h > 5.0) | (roc_9_1h > -15.0) | (roc_9_4h_gt_neg_20))
+            & ((rsi_3_4h_gt_5) | (roc_9_1h > -15.0) | (roc_9_4h_gt_neg_20))
             # 4h down move, 4h downtrend
-            & ((rsi_3_4h > 5.0) | (roc_9_4h > -40.0))
+            & ((rsi_3_4h_gt_5) | (roc_9_4h > -40.0))
             # 4h & 1d down move, 1d high
-            & ((rsi_3_4h_gt_10) | (rsi_3_1d > 20.0) | (aroonu_14_1d < 80.0))
+            & ((rsi_3_4h_gt_10) | (rsi_3_1d_gt_20) | (aroonu_14_1d_lt_80))
             # 4h down move, 1d high, 4h downtrend
-            & ((rsi_3_4h_gt_10) | (aroonu_14_1d < 90.0) | (roc_9_4h > -20.0))
+            & ((rsi_3_4h_gt_10) | (aroonu_14_1d_lt_90) | (roc_9_4h > -20.0))
             # 4h down move, 1h & 4h downtrend
-            & ((rsi_3_4h_gt_10) | (roc_9_1h > -30.0) | (roc_9_4h > -30.0))
+            & ((rsi_3_4h_gt_10) | (roc_9_1h > -30.0) | (roc_9_4h_gt_neg_30))
             # 4h down move, 4h still not low enough, 1d overbought
             & ((rsi_3_4h_gt_15) | (aroonu_14_4h < 30.0) | roc_9_1d_lt_50)
             # 4h down move, 4h high
-            & ((rsi_3_4h_gt_15) | (aroonu_14_4h < 60.0))
+            & ((rsi_3_4h_gt_15) | (aroonu_14_4h_lt_60))
             # 4h down move, 4h still high, 1d overbought
-            & ((rsi_3_4h_gt_15) | (aroonu_14_4h < 40.0) | (roc_9_1d < 40.0))
+            & ((rsi_3_4h_gt_15) | (aroonu_14_4h_lt_40) | (roc_9_1d_lt_40))
             # 15m down move, 4h still high, 1d downtrend
-            & ((rsi_3_4h_gt_15) | (aroonu_14_4h < 50.0) | (roc_9_1d > -40.0))
+            & ((rsi_3_4h_gt_15) | (aroonu_14_4h_lt_50) | (roc_9_1d_gt_neg_40))
             # 4h down move, 1d high & overbought
-            & ((rsi_3_4h_gt_15) | (aroonu_14_1d < 80.0) | (roc_9_1d < 80.0))
+            & ((rsi_3_4h_gt_15) | (aroonu_14_1d_lt_80) | (roc_9_1d_lt_80))
             # 4h down move, 4h still high, 1d downtrend
-            & ((rsi_3_4h > 30.0) | (aroonu_14_4h < 50.0) | (roc_9_1d > -40.0))
+            & ((rsi_3_4h_gt_30) | (aroonu_14_4h_lt_50) | (roc_9_1d_gt_neg_40))
             # 4h down move, 4h & 1d high
-            & ((rsi_3_4h > 30.0) | aroonu_14_4h_lt_80 | aroonu_14_1d_lt_100)
+            & ((rsi_3_4h_gt_30) | aroonu_14_4h_lt_80 | aroonu_14_1d_lt_100)
             # 4h down move, 1d high & overbought
-            & ((rsi_3_4h > 30.0) | aroonu_14_1d_lt_100 | (roc_9_1d < 30.0))
+            & ((rsi_3_4h_gt_30) | aroonu_14_1d_lt_100 | (roc_9_1d_lt_30))
             # 4h down move, 1h high & overbought
-            & ((rsi_3_4h > 35.0) | (aroonu_14_1d < 90.0) | (roc_9_1d_lt_100))
+            & ((rsi_3_4h_gt_35) | (aroonu_14_1d_lt_90) | (roc_9_1d_lt_100))
             # 4h down move, 4h still high, 1d downtrend
-            & ((rsi_3_4h > 50.0) | (rsi_14_4h < 40.0) | (roc_9_1d_gt_neg_30))
+            & ((rsi_3_4h_gt_50) | (rsi_14_4h < 40.0) | (roc_9_1d_gt_neg_30))
             # 4h down move, 4h high, 1d overbought
-            & ((rsi_3_4h > 50.0) | aroonu_14_4h_lt_70 | (roc_9_1d < 40.0))
+            & ((rsi_3_4h_gt_50) | aroonu_14_4h_lt_70 | (roc_9_1d_lt_40))
             # 4h down move, 4h high
-            & ((rsi_3_4h > 50.0) | (stochrsi_k_4h < 70.0))
+            & ((rsi_3_4h_gt_50) | (stochrsi_k_4h_lt_70))
             # 4h down move, 4h overbought
-            & ((rsi_3_4h > 50.0) | (roc_9_4h < 60.0))
+            & ((rsi_3_4h_gt_50) | (roc_9_4h < 60.0))
             # 4h downtrend, 4h high
             & ((cmf_20_4h > -0.50) | aroonu_14_4h_lt_70)
             # 1h & 1d high, 4h downtrend
-            & ((aroonu_14_1h < 40.0) | (aroonu_14_1d < 70.0) | (roc_9_4h_gt_neg_20))
+            & ((aroonu_14_1h < 40.0) | (aroonu_14_1d_lt_70) | (roc_9_4h_gt_neg_20))
             # 1h still high, 1h & 4h downtrend
-            & ((aroonu_14_1h < 40.0) | (roc_9_1h > -20.0) | (roc_9_4h > -30.0))
+            & ((aroonu_14_1h < 40.0) | (roc_9_1h > -20.0) | (roc_9_4h_gt_neg_30))
             # 1h & 4h high, 1d overbought
-            & (aroonu_14_1h_lt_70 | aroonu_14_4h_lt_100 | (roc_9_1d < 20.0))
+            & (aroonu_14_1h_lt_70 | aroonu_14_4h_lt_100 | (roc_9_1d_lt_20))
             # 1h high, 4h & 1d downtrend
             & (aroonu_14_1h_lt_70 | (roc_9_4h > -20.0) | roc_9_1d_gt_neg_50)
             # 1h high, 4h downtrend
             & (aroonu_14_1h_lt_70 | (roc_9_4h > -40.0))
             # 1h & 1d high, 1d overbought
-            & (aroonu_14_1h_lt_80 | (aroonu_14_1d < 90.0) | (roc_9_1d < 80.0))
+            & (aroonu_14_1h_lt_80 | (aroonu_14_1d_lt_90) | (roc_9_1d_lt_80))
             # 1h & 1d high, 1h downtrend
             & (aroonu_14_1h_lt_80 | aroonu_14_1d_lt_100 | (roc_9_1h > -20.0))
             # 4h & 1d high, 1h downtrend
             & (aroonu_14_4h_lt_80 | aroonu_14_1d_lt_100 | (roc_9_1h > -30.0))
             # 4h & 1d high, 4h overbought
-            & (aroonu_14_4h_lt_80 | aroonu_14_1d_lt_100 | (roc_9_4h < 40.0))
+            & (aroonu_14_4h_lt_80 | aroonu_14_1d_lt_100 | (roc_9_4h_lt_40))
             # 4h high, 1h downtrend
             & (aroonu_14_4h_lt_80 | (roc_9_1h > -40.0))
             # 4h high & overbought
@@ -18089,25 +18141,25 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1d still high, 1d downtrend
             & ((aroonu_14_1d < 50.0) | (roc_9_1d_gt_neg_30))
             # 1d high, 15m downtrend
-            & ((aroonu_14_1d < 70.0) | (roc_9_15m > -50.0))
+            & ((aroonu_14_1d_lt_70) | (roc_9_15m > -50.0))
             # 1d high, 1h downtrend
-            & ((aroonu_14_1d < 70.0) | (roc_9_1h > -70.0))
+            & ((aroonu_14_1d_lt_70) | (roc_9_1h > -70.0))
             # 1d high, 4h downtrend
-            & ((aroonu_14_1d < 80.0) | (roc_9_4h > -70.0))
+            & ((aroonu_14_1d_lt_80) | (roc_9_4h > -70.0))
             # 1d high, 4h downtrend
-            & ((aroonu_14_1d < 90.0) | (roc_9_4h > -40.0))
+            & ((aroonu_14_1d_lt_90) | (roc_9_4h > -40.0))
             # 1d high & overbought
-            & ((aroonu_14_1d < 90.0) | (roc_9_1d < 200.0))
+            & ((aroonu_14_1d_lt_90) | (roc_9_1d < 200.0))
             # 1d high, 4h & 1d overbought
-            & (aroonu_14_1d_lt_100 | (roc_9_4h < 20.0) | (roc_9_1d < 80.0))
+            & (aroonu_14_1d_lt_100 | (roc_9_4h < 20.0) | (roc_9_1d_lt_80))
             # 1h still high, 4h & 1d downtrend
             & ((stochrsi_k_1h < 50.0) | (roc_9_4h_gt_neg_20) | roc_9_1d_gt_neg_50)
             # 1h high, 15m downtrend
             & ((stochrsi_k_1h_lt_70) | (roc_9_15m > -30.0))
             # 4h high, 1d downtrend
-            & ((stochrsi_k_4h < 70.0) | (roc_9_1d > -70.0))
+            & ((stochrsi_k_4h_lt_70) | (roc_9_1d > -70.0))
             # 1d high, 1h downtrend
-            & ((stochrsi_k_1d < 90.0) | (roc_9_1h > -20.0))
+            & ((stochrsi_k_1d_lt_90) | (roc_9_1h > -20.0))
             # 1d high, 1d downtrend
             & ((stochrsi_k_1d < 60.0) | (roc_9_1d_gt_neg_30))
             # 15m downtrend, 1d overbought
@@ -18136,91 +18188,91 @@ class NostalgiaForInfinityX7(IStrategy):
           long_entry_logic.append(protections_long_global == True)
 
           # 5m & 15m down move, 4h still high
-          long_entry_logic.append((rsi_3 > 3.0) | (rsi_3_15m > 15.0) | (stochrsi_k_4h < 50.0))
+          long_entry_logic.append((rsi_3_gt_3) | (rsi_3_15m_gt_15) | (stochrsi_k_4h_lt_50))
           # 15m & 1h down move, 1h still high
-          long_entry_logic.append(rsi_3_15m_gt_3 | (rsi_3_1h > 25.0) | (stochrsi_k_1h < 40.0))
+          long_entry_logic.append(rsi_3_15m_gt_3 | (rsi_3_1h_gt_25) | (stochrsi_k_1h < 40.0))
           # 5m & 4h & 1d down move
-          long_entry_logic.append((rsi_3 > 3.0) | rsi_3_4h_gt_20 | (rsi_3_1d > 20.0))
+          long_entry_logic.append((rsi_3_gt_3) | rsi_3_4h_gt_20 | (rsi_3_1d_gt_20))
           # 15m & 1h down move, 4h high
-          long_entry_logic.append(rsi_3_15m_gt_3 | (rsi_3_1h > 30.0) | (stochrsi_k_4h < 60.0))
+          long_entry_logic.append(rsi_3_15m_gt_3 | (rsi_3_1h_gt_30) | (stochrsi_k_4h < 60.0))
           # 15m & 4h down move
           long_entry_logic.append(rsi_3_15m_gt_3 | (rsi_3_4h_gt_10))
           # 15m & 4h down move, 4h still not low enough
-          long_entry_logic.append(rsi_3_15m_gt_3 | (rsi_3_4h > 30.0) | (rsi_14_4h < 35.0))
+          long_entry_logic.append(rsi_3_15m_gt_3 | (rsi_3_4h_gt_30) | (rsi_14_4h < 35.0))
           # 15m down move, 4h still high, 15m downtrend
-          long_entry_logic.append(rsi_3_15m_gt_3 | (aroonu_14_4h < 40.0) | (cmf_20_15m > -0.35))
+          long_entry_logic.append(rsi_3_15m_gt_3 | (aroonu_14_4h_lt_40) | (cmf_20_15m > -0.35))
           # 15m & 1h down move
-          long_entry_logic.append((rsi_3_15m > 5.0) | (rsi_3_1h_gt_15))
+          long_entry_logic.append((rsi_3_15m_gt_5) | (rsi_3_1h_gt_15))
           # 15m & 1h down move, 4h high
-          long_entry_logic.append((rsi_3_15m > 5.0) | (rsi_3_1h > 40.0) | (stochrsi_k_4h_lt_80))
+          long_entry_logic.append((rsi_3_15m_gt_5) | (rsi_3_1h_gt_40) | (stochrsi_k_4h_lt_80))
           # 15m down move, 1h still not low enough
-          long_entry_logic.append((rsi_3_15m > 5.0) | (aroonu_14_1h < 30.0))
+          long_entry_logic.append((rsi_3_15m_gt_5) | (aroonu_14_1h < 30.0))
           # 15m down move, 4h high
-          long_entry_logic.append((rsi_3_15m > 5.0) | (aroonu_14_4h < 90.0))
+          long_entry_logic.append((rsi_3_15m_gt_5) | (aroonu_14_4h_lt_90))
           # 15m & 1h & 1d down move
-          long_entry_logic.append((rsi_3_15m > 10.0) | (rsi_3_1h_gt_10) | (rsi_3_1d > 10.0))
+          long_entry_logic.append((rsi_3_15m_gt_10) | (rsi_3_1h_gt_10) | (rsi_3_1d_gt_10))
           # 15m & 1h down move, 1d overbought
-          long_entry_logic.append((rsi_3_15m > 10.0) | rsi_3_1h_gt_20 | (roc_9_1d < 30.0))
+          long_entry_logic.append((rsi_3_15m_gt_10) | rsi_3_1h_gt_20 | (roc_9_1d_lt_30))
           # 15m & 1h down move, 1h high
-          long_entry_logic.append((rsi_3_15m > 10.0) | (rsi_3_1h > 45.0) | aroonu_14_1h_lt_80)
+          long_entry_logic.append((rsi_3_15m_gt_10) | (rsi_3_1h_gt_45) | aroonu_14_1h_lt_80)
           # 15m & 1h down move, 1h high
-          long_entry_logic.append((rsi_3_15m > 10.0) | (rsi_3_1h > 65.0) | (stochrsi_k_1h_lt_80))
+          long_entry_logic.append((rsi_3_15m_gt_10) | (rsi_3_1h > 65.0) | (stochrsi_k_1h_lt_80))
           # 15m & 4h down move, 4h still not low enough
-          long_entry_logic.append((rsi_3_15m > 10.0) | (rsi_3_4h_gt_10) | (stochrsi_k_4h < 30.0))
+          long_entry_logic.append((rsi_3_15m_gt_10) | (rsi_3_4h_gt_10) | (stochrsi_k_4h < 30.0))
           # 15m & 4h down move, 1d high
-          long_entry_logic.append((rsi_3_15m > 10.0) | (rsi_3_4h_gt_10) | (stochrsi_k_1d < 80.0))
+          long_entry_logic.append((rsi_3_15m_gt_10) | (rsi_3_4h_gt_10) | (stochrsi_k_1d < 80.0))
           # 15m & 4h down move, 4h still high
-          long_entry_logic.append((rsi_3_15m > 10.0) | (rsi_3_4h > 30.0) | (stochrsi_k_4h < 40.0))
+          long_entry_logic.append((rsi_3_15m_gt_10) | (rsi_3_4h_gt_30) | (stochrsi_k_4h < 40.0))
           # 15m down move, 1h & 4h high
-          long_entry_logic.append((rsi_3_15m > 10.0) | aroonu_14_1h_lt_70 | aroonu_14_4h_lt_100)
+          long_entry_logic.append((rsi_3_15m_gt_10) | aroonu_14_1h_lt_70 | aroonu_14_4h_lt_100)
           # 15m down move, 1h high & overbought
-          long_entry_logic.append((rsi_3_15m > 10.0) | aroonu_14_1h_lt_70 | (roc_9_1h < 10.0))
+          long_entry_logic.append((rsi_3_15m_gt_10) | aroonu_14_1h_lt_70 | (roc_9_1h_lt_10))
           # 15m down move, 1h high, 4h overbought
-          long_entry_logic.append((rsi_3_15m > 10.0) | aroonu_14_1h_lt_70 | (roc_9_4h < 20.0))
+          long_entry_logic.append((rsi_3_15m_gt_10) | aroonu_14_1h_lt_70 | (roc_9_4h < 20.0))
           # 15m down move, 4h & 1d high
-          long_entry_logic.append((rsi_3_15m > 10.0) | (aroonu_14_4h < 75.0) | aroonu_14_1d_lt_100)
+          long_entry_logic.append((rsi_3_15m_gt_10) | (aroonu_14_4h < 75.0) | aroonu_14_1d_lt_100)
           # 15m down move, 4h high, 1h overbought
-          long_entry_logic.append((rsi_3_15m > 10.0) | aroonu_14_4h_lt_100 | (roc_9_1h < 10.0))
+          long_entry_logic.append((rsi_3_15m_gt_10) | aroonu_14_4h_lt_100 | (roc_9_1h_lt_10))
           # 15m & 1h down move, 4h high
-          long_entry_logic.append((rsi_3_15m > 15.0) | (rsi_3_1h_gt_15) | aroonu_14_4h_lt_70)
+          long_entry_logic.append((rsi_3_15m_gt_15) | (rsi_3_1h_gt_15) | aroonu_14_4h_lt_70)
           # 15m down move, 1h & 4h high
-          long_entry_logic.append((rsi_3_15m > 15.0) | aroonu_14_1h_lt_70 | (stochrsi_k_4h < 90.0))
+          long_entry_logic.append((rsi_3_15m_gt_15) | aroonu_14_1h_lt_70 | (stochrsi_k_4h < 90.0))
           # 15m down move, 4h high, 1d overbought
-          long_entry_logic.append((rsi_3_15m > 15.0) | aroonu_14_4h_lt_70 | roc_9_1d_lt_50)
+          long_entry_logic.append((rsi_3_15m_gt_15) | aroonu_14_4h_lt_70 | roc_9_1d_lt_50)
           # 15m & 1h down move, 1d overbought
-          long_entry_logic.append((rsi_3_15m > 25.0) | (rsi_3_1h > 40.0) | (roc_9_1d < 80.0))
+          long_entry_logic.append((rsi_3_15m_gt_25) | (rsi_3_1h_gt_40) | (roc_9_1d_lt_80))
           # 15m down move, 4h high & overbought
-          long_entry_logic.append((rsi_3_15m > 25.0) | aroonu_14_4h_lt_100 | (roc_9_4h < 10.0))
+          long_entry_logic.append((rsi_3_15m_gt_25) | aroonu_14_4h_lt_100 | (roc_9_4h_lt_10))
           # 15m & 1h down move, 1h high
-          long_entry_logic.append((rsi_3_15m > 30.0) | (rsi_3_1h > 30.0) | aroonu_14_1h_lt_70)
+          long_entry_logic.append((rsi_3_15m_gt_30) | (rsi_3_1h_gt_30) | aroonu_14_1h_lt_70)
           # 1h down move, 4h still not low enough
-          long_entry_logic.append((rsi_3_1h > 3.0) | (aroonu_14_4h < 30.0))
+          long_entry_logic.append((rsi_3_1h_gt_3) | (aroonu_14_4h < 30.0))
           # 1h & 4h down move, 1h still not low enough
-          long_entry_logic.append((rsi_3_1h > 5.0) | (rsi_3_4h > 30.0) | (aroonu_14_1h < 20.0))
+          long_entry_logic.append((rsi_3_1h_gt_5) | (rsi_3_4h_gt_30) | (aroonu_14_1h < 20.0))
           # 1h down move, 1h still not low enough
-          long_entry_logic.append((rsi_3_1h > 5.0) | (aroonu_14_1h < 30.0))
+          long_entry_logic.append((rsi_3_1h_gt_5) | (aroonu_14_1h < 30.0))
           # 1h down move, 1h still not low enough
-          long_entry_logic.append((rsi_3_1h > 5.0) | (stochrsi_k_1h < 25.0))
+          long_entry_logic.append((rsi_3_1h_gt_5) | (stochrsi_k_1h < 25.0))
           # 1h & 4h down move
           long_entry_logic.append((rsi_3_1h_gt_10) | (rsi_3_4h_gt_15))
           # 1h & 4h down move, 4h still not low enough
           long_entry_logic.append((rsi_3_1h_gt_10) | rsi_3_4h_gt_20 | (stochrsi_k_4h < 30.0))
           # 1h & 4h down move, 4h still high
-          long_entry_logic.append((rsi_3_1h_gt_10) | (rsi_3_4h > 25.0) | (aroonu_14_4h < 50.0))
+          long_entry_logic.append((rsi_3_1h_gt_10) | (rsi_3_4h_gt_25) | (aroonu_14_4h_lt_50))
           # 1h & 4h down move, 4h still not low enough
-          long_entry_logic.append((rsi_3_1h_gt_10) | (rsi_3_4h > 30.0) | (rsi_14_4h < 40.0))
+          long_entry_logic.append((rsi_3_1h_gt_10) | (rsi_3_4h_gt_30) | (rsi_14_4h < 40.0))
           # 1h & 4h down move, 4h high
-          long_entry_logic.append((rsi_3_1h_gt_10) | (rsi_3_4h > 40.0) | (aroonu_14_4h < 60.0))
+          long_entry_logic.append((rsi_3_1h_gt_10) | (rsi_3_4h_gt_40) | (aroonu_14_4h_lt_60))
           # 1h & 1d down move, 4h still high
-          long_entry_logic.append((rsi_3_1h_gt_10) | (rsi_3_1d > 10.0) | (aroonu_14_4h < 40.0))
+          long_entry_logic.append((rsi_3_1h_gt_10) | (rsi_3_1d_gt_10) | (aroonu_14_4h_lt_40))
           # 1h & 1d down move, 5m moving down
-          long_entry_logic.append((rsi_3_1h_gt_10) | (rsi_3_1d > 15.0) | (roc_2 > -0.0))
+          long_entry_logic.append((rsi_3_1h_gt_10) | (rsi_3_1d_gt_15) | (roc_2 > -0.0))
           # 1h & 1d down move, 4h still high
-          long_entry_logic.append((rsi_3_1h_gt_10) | (rsi_3_1d > 30.0) | (aroonu_14_4h < 50.0))
+          long_entry_logic.append((rsi_3_1h_gt_10) | (rsi_3_1d > 30.0) | (aroonu_14_4h_lt_50))
           # 15m & 1d down move, 1d high
-          long_entry_logic.append((rsi_3_15m > 10.0) | (rsi_3_1d > 30.0) | (stochrsi_k_1d < 70.0))
+          long_entry_logic.append((rsi_3_15m_gt_10) | (rsi_3_1d > 30.0) | (stochrsi_k_1d < 70.0))
           # 1h & 4h down move, 4h still not low enough
-          long_entry_logic.append((rsi_3_1h > 3.0) | (rsi_3_4h > 25.0) | (stochrsi_k_4h < 30.0))
+          long_entry_logic.append((rsi_3_1h_gt_3) | (rsi_3_4h_gt_25) | (stochrsi_k_4h < 30.0))
           # 1h down move, 1h still not low enough, 1d high
           long_entry_logic.append((rsi_3_1h_gt_10) | (stochrsi_k_1h < 20.0) | (aroonu_14_1d < 85.0))
           # 1h down move, 1h still not low enough
@@ -18228,61 +18280,61 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1h down move, 4h high
           long_entry_logic.append((rsi_3_1h_gt_10) | (aroonu_14_4h < 85.0))
           # 1h down move, 1d high & overbought
-          long_entry_logic.append((rsi_3_1h_gt_10) | (aroonu_14_1d < 70.0) | roc_9_1d_lt_50)
+          long_entry_logic.append((rsi_3_1h_gt_10) | (aroonu_14_1d_lt_70) | roc_9_1d_lt_50)
           # 1h down move, 1d overbought
           long_entry_logic.append((rsi_3_1h_gt_10) | (roc_9_1d < 100.0))
           # 1h & 4h down move, 4h still high
-          long_entry_logic.append((rsi_3_1h_gt_15) | (rsi_3_4h_gt_15) | (aroonu_14_4h < 40.0))
+          long_entry_logic.append((rsi_3_1h_gt_15) | (rsi_3_4h_gt_15) | (aroonu_14_4h_lt_40))
           # 1h & 4h down move, 1d high
           long_entry_logic.append((rsi_3_1h_gt_15) | rsi_3_4h_gt_20 | (stochrsi_k_1d < 70.0))
           # 1h & 4h & 1d down move
           long_entry_logic.append((rsi_3_1h_gt_15) | rsi_3_4h_gt_20 | (rsi_3_1d > 30.0))
           # 1h & 4h down move, 1d high
-          long_entry_logic.append((rsi_3_1h_gt_15) | (rsi_3_4h > 30.0) | (aroonu_14_1d < 100.0))
+          long_entry_logic.append((rsi_3_1h_gt_15) | (rsi_3_4h_gt_30) | (aroonu_14_1d < 100.0))
           # 1h down move, 1h still high
-          long_entry_logic.append((rsi_3_1h_gt_15) | (aroonu_14_1h < 50.0))
+          long_entry_logic.append((rsi_3_1h_gt_15) | (aroonu_14_1h_lt_50))
           # 1h down move, 1d high, 4h downtrend
-          long_entry_logic.append((rsi_3_1h_gt_15) | (aroonu_14_1d < 70.0) | (roc_9_4h > -20.0))
+          long_entry_logic.append((rsi_3_1h_gt_15) | (aroonu_14_1d_lt_70) | (roc_9_4h > -20.0))
           # 1h down move, 1h still high
           long_entry_logic.append((rsi_3_1h_gt_15) | (stochrsi_k_1h < 30.0))
           # 1h & 4h down move, 1d overbought
-          long_entry_logic.append(rsi_3_1h_gt_20 | rsi_3_4h_gt_20 | (roc_9_1d < 20.0))
+          long_entry_logic.append(rsi_3_1h_gt_20 | rsi_3_4h_gt_20 | (roc_9_1d_lt_20))
           # 1h down move, 4h high
-          long_entry_logic.append(rsi_3_1h_gt_20 | (aroonu_14_4h < 90.0))
+          long_entry_logic.append(rsi_3_1h_gt_20 | (aroonu_14_4h_lt_90))
           # 1h down move, 4h still high
-          long_entry_logic.append(rsi_3_1h_gt_20 | (stochrsi_k_4h < 50.0))
+          long_entry_logic.append(rsi_3_1h_gt_20 | (stochrsi_k_4h_lt_50))
           # 1h & 4h down move, 1h high
-          long_entry_logic.append((rsi_3_1h > 25.0) | (rsi_3_4h > 30.0) | (stochrsi_k_1h < 60.0))
+          long_entry_logic.append((rsi_3_1h_gt_25) | (rsi_3_4h_gt_30) | (stochrsi_k_1h < 60.0))
           # 1h & 4h down move, 4h high
-          long_entry_logic.append((rsi_3_1h > 25.0) | (rsi_3_4h > 40.0) | aroonu_14_4h_lt_70)
+          long_entry_logic.append((rsi_3_1h_gt_25) | (rsi_3_4h_gt_40) | aroonu_14_4h_lt_70)
           # 1h down move, 1h high
-          long_entry_logic.append((rsi_3_1h > 25.0) | aroonu_14_1h_lt_70)
+          long_entry_logic.append((rsi_3_1h_gt_25) | aroonu_14_1h_lt_70)
           # 1h down move, 4h high
-          long_entry_logic.append((rsi_3_1h > 25.0) | (stochrsi_k_4h_lt_80))
+          long_entry_logic.append((rsi_3_1h_gt_25) | (stochrsi_k_4h_lt_80))
           # 1h & 1d down move, 1h still high
-          long_entry_logic.append((rsi_3_1h > 30.0) | (rsi_3_1d > 50.0) | (stochrsi_k_1h_lt_50))
+          long_entry_logic.append((rsi_3_1h_gt_30) | (rsi_3_1d > 50.0) | (stochrsi_k_1h_lt_50))
           # 1h down move, 4h high
-          long_entry_logic.append((rsi_3_1h > 30.0) | (rsi_14_4h < 80.0))
+          long_entry_logic.append((rsi_3_1h_gt_30) | (rsi_14_4h < 80.0))
           # 14 down move, 1h high
-          long_entry_logic.append((rsi_3_1h > 30.0) | aroonu_14_1h_lt_80)
+          long_entry_logic.append((rsi_3_1h_gt_30) | aroonu_14_1h_lt_80)
           # 1h down move, 4h high
-          long_entry_logic.append((rsi_3_1h > 30.0) | aroonu_14_4h_lt_80)
+          long_entry_logic.append((rsi_3_1h_gt_30) | aroonu_14_4h_lt_80)
           # 1h down move, 4h high
-          long_entry_logic.append((rsi_3_1h > 30.0) | (stochrsi_k_4h_lt_80))
+          long_entry_logic.append((rsi_3_1h_gt_30) | (stochrsi_k_4h_lt_80))
           # 1h down move, 4h & 1d high
-          long_entry_logic.append((rsi_3_1h > 35.0) | (stochrsi_k_4h_lt_80) | (stochrsi_k_1d < 80.0))
+          long_entry_logic.append((rsi_3_1h_gt_35) | (stochrsi_k_4h_lt_80) | (stochrsi_k_1d < 80.0))
           # 1h down move, 1h still high, 1d overbought
-          long_entry_logic.append((rsi_3_1h > 40.0) | (aroonu_14_1h < 50.0) | roc_9_1d_lt_50)
+          long_entry_logic.append((rsi_3_1h_gt_40) | (aroonu_14_1h_lt_50) | roc_9_1d_lt_50)
           # 1h down move, 1h & 4h high
-          long_entry_logic.append((rsi_3_1h > 45.0) | aroonu_14_1h_lt_70 | (aroonu_14_4h < 90.0))
+          long_entry_logic.append((rsi_3_1h_gt_45) | aroonu_14_1h_lt_70 | (aroonu_14_4h_lt_90))
           # 1h down move, 1h & 4h high
-          long_entry_logic.append((rsi_3_1h > 60.0) | (stochrsi_k_1h_lt_70) | (aroonu_14_4h < 90.0))
+          long_entry_logic.append((rsi_3_1h > 60.0) | (stochrsi_k_1h_lt_70) | (aroonu_14_4h_lt_90))
           # 4h down move, 1d high
-          long_entry_logic.append((rsi_3_4h > 5.0) | aroonu_14_1d_lt_100)
+          long_entry_logic.append((rsi_3_4h_gt_5) | aroonu_14_1d_lt_100)
           # 4h & 1d down move, 1d still high
-          long_entry_logic.append((rsi_3_4h_gt_10) | (rsi_3_1d > 25.0) | (stochrsi_k_1d < 50.0))
+          long_entry_logic.append((rsi_3_4h_gt_10) | (rsi_3_1d_gt_25) | (stochrsi_k_1d < 50.0))
           # 4h downmove, 4h still high
-          long_entry_logic.append((rsi_3_4h_gt_10) | (aroonu_14_4h < 40.0))
+          long_entry_logic.append((rsi_3_4h_gt_10) | (aroonu_14_4h_lt_40))
           # 4h down move, 1h still high, 1d downtrend
           long_entry_logic.append((rsi_3_4h_gt_10) | (stochrsi_k_1h < 40.0) | (roc_9_1d > -20.0))
           # 4h down move, 1h & 1d downtrend
@@ -18292,19 +18344,19 @@ class NostalgiaForInfinityX7(IStrategy):
           # 4h down move, 1h still not low enough
           long_entry_logic.append((rsi_3_4h_gt_15) | (aroonu_14_1h < 30.0))
           # 4h & 1d down move, 1d high
-          long_entry_logic.append(rsi_3_4h_gt_20 | (rsi_3_1d > 20.0) | (aroonu_14_1d < 80.0))
+          long_entry_logic.append(rsi_3_4h_gt_20 | (rsi_3_1d_gt_20) | (aroonu_14_1d_lt_80))
           # 4h down move, 4h still high, 1d high
-          long_entry_logic.append(rsi_3_4h_gt_20 | (aroonu_14_4h < 50.0) | aroonu_14_1d_lt_100)
+          long_entry_logic.append(rsi_3_4h_gt_20 | (aroonu_14_4h_lt_50) | aroonu_14_1d_lt_100)
           # 4h down move, 1d high
-          long_entry_logic.append((rsi_3_4h > 25.0) | (stochrsi_k_1d < 90.0))
+          long_entry_logic.append((rsi_3_4h_gt_25) | (stochrsi_k_1d_lt_90))
           # 4h down move, 4h & 1d downtrend
-          long_entry_logic.append((rsi_3_4h > 25.0) | (roc_9_4h_gt_neg_20) | (roc_9_1d_gt_neg_20))
+          long_entry_logic.append((rsi_3_4h_gt_25) | (roc_9_4h_gt_neg_20) | (roc_9_1d_gt_neg_20))
           # 4h down move, 4h & 1d high
-          long_entry_logic.append((rsi_3_4h > 30.0) | aroonu_14_4h_lt_80 | aroonu_14_1d_lt_100)
+          long_entry_logic.append((rsi_3_4h_gt_30) | aroonu_14_4h_lt_80 | aroonu_14_1d_lt_100)
           # 4h down move, 1h high
-          long_entry_logic.append((rsi_3_4h > 40.0) | (stochrsi_k_1h_lt_70))
+          long_entry_logic.append((rsi_3_4h_gt_40) | (stochrsi_k_1h_lt_70))
           # 4h down move, 4h still high
-          long_entry_logic.append((rsi_3_4h > 50.0) | (stochrsi_k_4h < 50.0))
+          long_entry_logic.append((rsi_3_4h_gt_50) | (stochrsi_k_4h_lt_50))
           # 4h down move, 1h high
           long_entry_logic.append((rsi_3_4h > 60.0) | (stochrsi_k_1h_lt_80))
           # 4h down move, 4h high
@@ -18312,37 +18364,37 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1d down move, 1h still not low enough
           long_entry_logic.append((rsi_3_1d > 5.0) | (stochrsi_k_1h < 30.0))
           # 1d down move, 1h still not low enough
-          long_entry_logic.append((rsi_3_1d > 15.0) | (stochrsi_k_1h < 30.0))
+          long_entry_logic.append((rsi_3_1d_gt_15) | (stochrsi_k_1h < 30.0))
           # 1d down move, 4h still high
-          long_entry_logic.append((rsi_3_1d > 15.0) | (stochrsi_k_4h < 50.0))
+          long_entry_logic.append((rsi_3_1d_gt_15) | (stochrsi_k_4h_lt_50))
           # 1d down move, 1h high & overbought
-          long_entry_logic.append((rsi_3_1d > 35.0) | (stochrsi_k_1h < 90.0) | (roc_9_1h < 10.0))
+          long_entry_logic.append((rsi_3_1d > 35.0) | (stochrsi_k_1h < 90.0) | (roc_9_1h_lt_10))
           # 15m still high, 1h & 4h high
-          long_entry_logic.append((rsi_14_15m < 40.0) | aroonu_14_1h_lt_80 | (aroonu_14_4h < 90.0))
+          long_entry_logic.append((rsi_14_15m < 40.0) | aroonu_14_1h_lt_80 | (aroonu_14_4h_lt_90))
           # 1h & 4h high, 4h overbought
           long_entry_logic.append(aroonu_14_1h_lt_70 | aroonu_14_4h_lt_100 | (roc_9_4h < 20.0))
           # 4h high, 1d overbought
-          long_entry_logic.append(aroonu_14_4h_lt_70 | (roc_9_1d < 80.0))
+          long_entry_logic.append(aroonu_14_4h_lt_70 | (roc_9_1d_lt_80))
           # 4h high, 1h & 1d downtrend
           long_entry_logic.append(aroonu_14_4h_lt_70 | (roc_9_1h > -20.0) | (roc_9_1d_gt_neg_20))
           # 4h high, 1h & 4h overbought
-          long_entry_logic.append(aroonu_14_4h_lt_80 | (roc_9_1h < 10.0) | (roc_9_4h < 10.0))
+          long_entry_logic.append(aroonu_14_4h_lt_80 | (roc_9_1h_lt_10) | (roc_9_4h_lt_10))
           # 4h high & overbought
-          long_entry_logic.append((aroonu_14_4h < 90.0) | (roc_9_4h < 80.0))
+          long_entry_logic.append((aroonu_14_4h_lt_90) | (roc_9_4h < 80.0))
           # 1d high, 4h & 1d downtrend
-          long_entry_logic.append((aroonu_14_1d < 80.0) | (roc_9_4h_gt_neg_20) | (roc_9_1d_gt_neg_20))
+          long_entry_logic.append((aroonu_14_1d_lt_80) | (roc_9_4h_gt_neg_20) | (roc_9_1d_gt_neg_20))
           # 1h high, 4h overbought
           long_entry_logic.append((stochrsi_k_1h_lt_80) | (roc_9_4h < 80.0))
           # 4h high, 1h & 1d downtrend
-          long_entry_logic.append((stochrsi_k_4h < 70.0) | (roc_9_1h > -20.0) | (roc_9_1d_gt_neg_20))
+          long_entry_logic.append((stochrsi_k_4h_lt_70) | (roc_9_1h > -20.0) | (roc_9_1d_gt_neg_20))
           # 4h high, 1h & 4h overbought
-          long_entry_logic.append((stochrsi_k_4h_lt_80) | (roc_9_1h < 10.0) | (roc_9_4h < 10.0))
+          long_entry_logic.append((stochrsi_k_4h_lt_80) | (roc_9_1h_lt_10) | (roc_9_4h_lt_10))
           # 4h high, 4h & 1d overbought
-          long_entry_logic.append((stochrsi_k_4h_lt_80) | (roc_9_4h < 30.0) | (roc_9_1d < 30.0))
+          long_entry_logic.append((stochrsi_k_4h_lt_80) | (roc_9_4h_lt_30) | (roc_9_1d_lt_30))
           # 1d top wick, 4h still high
-          long_entry_logic.append((top_wick_pct_1d < 40.0) | (aroonu_14_4h < 50.0))
+          long_entry_logic.append((top_wick_pct_1d < 40.0) | (aroonu_14_4h_lt_50))
           # pump, 4h still high
-          long_entry_logic.append((((high_max_24_4h - low_min_24_4h) / low_min_24_4h) < 2.0) | (stochrsi_k_4h < 50.0))
+          long_entry_logic.append((((high_max_24_4h - low_min_24_4h) / low_min_24_4h) < 2.0) | (stochrsi_k_4h_lt_50))
           # pump, drop but not yet near the previous lows
           long_entry_logic.append(
             (((high_max_24_4h - low_min_24_4h) / low_min_24_4h) < 2.0)
@@ -18358,13 +18410,13 @@ class NostalgiaForInfinityX7(IStrategy):
           # big drop in last hour
           long_entry_logic.append(close > (close_max_12 * 0.50))
           # big drop in last hour, 1d down move
-          long_entry_logic.append((close > (close_max_12 * 0.80)) | (rsi_3_1d > 15.0))
+          long_entry_logic.append((close > (close_max_12 * 0.80)) | (rsi_3_1d_gt_15))
           # big drop in the last 12 hours, 4h still high
-          long_entry_logic.append((close > (df["high_max_12_1h"] * 0.50)) | (aroonu_14_4h < 50.0))
+          long_entry_logic.append((close > (df["high_max_12_1h"] * 0.50)) | (aroonu_14_4h_lt_50))
           # big drop in the last 6 days, 1h still high
-          long_entry_logic.append((close > (high_max_6_1d * 0.25)) | (aroonu_14_1h < 50.0))
+          long_entry_logic.append((close > (high_max_6_1d * 0.25)) | (aroonu_14_1h_lt_50))
           # big drop in the last 12 days, 1h down move
-          long_entry_logic.append((close > (high_max_12_1d * 0.45)) | (rsi_3_1h > 5.0))
+          long_entry_logic.append((close > (high_max_12_1d * 0.45)) | (rsi_3_1h_gt_5))
           # big drop in the last 12 days, 4h down move
           long_entry_logic.append((close > (high_max_12_1d * 0.40)) | (rsi_3_4h_gt_15))
           # big drop in the last 12 days, 1h still high
@@ -18393,97 +18445,97 @@ class NostalgiaForInfinityX7(IStrategy):
           long_entry_logic.append(protections_long_global == True)
 
           # 5m & 1h down move
-          long_entry_logic.append(rsi_3_15m_gt_3 | (rsi_3_1h > 5.0))
+          long_entry_logic.append(rsi_3_15m_gt_3 | (rsi_3_1h_gt_5))
           # 15m & 4h down move, 4h still high
-          long_entry_logic.append(rsi_3_15m_gt_3 | rsi_3_4h_gt_20 | (aroonu_14_4h < 40.0))
+          long_entry_logic.append(rsi_3_15m_gt_3 | rsi_3_4h_gt_20 | (aroonu_14_4h_lt_40))
           # 15m & 4h down move
-          long_entry_logic.append((rsi_3_15m > 5.0) | (rsi_3_4h_gt_10))
+          long_entry_logic.append((rsi_3_15m_gt_5) | (rsi_3_4h_gt_10))
           # 15m & 4h down move, 4h still high
-          long_entry_logic.append((rsi_3_15m > 5.0) | rsi_3_4h_gt_20 | (aroonu_14_4h < 40.0))
+          long_entry_logic.append((rsi_3_15m_gt_5) | rsi_3_4h_gt_20 | (aroonu_14_4h_lt_40))
           # 15m & 4h down move, 4h still high
-          long_entry_logic.append((rsi_3_15m > 5.0) | (rsi_3_4h > 30.0) | (aroonu_14_4h < 50.0))
+          long_entry_logic.append((rsi_3_15m_gt_5) | (rsi_3_4h_gt_30) | (aroonu_14_4h_lt_50))
           # 15m & 1h & 4h down move
-          long_entry_logic.append((rsi_3_15m > 10.0) | (rsi_3_1h_gt_10) | (rsi_3_4h > 30.0))
+          long_entry_logic.append((rsi_3_15m_gt_10) | (rsi_3_1h_gt_10) | (rsi_3_4h_gt_30))
           # 15m & 1h down move, 4h still not low enough
-          long_entry_logic.append((rsi_3_15m > 10.0) | (rsi_3_1h_gt_10) | (rsi_14_4h < 30.0))
+          long_entry_logic.append((rsi_3_15m_gt_10) | (rsi_3_1h_gt_10) | (rsi_14_4h < 30.0))
           # 15m & 1h & 4h down move
-          long_entry_logic.append((rsi_3_15m > 10.0) | rsi_3_1h_gt_20 | rsi_3_4h_gt_20)
+          long_entry_logic.append((rsi_3_15m_gt_10) | rsi_3_1h_gt_20 | rsi_3_4h_gt_20)
           # 15m & 1h down move, 1h still high
-          long_entry_logic.append((rsi_3_15m > 10.0) | rsi_3_1h_gt_20 | (aroonu_14_1h < 40.0))
+          long_entry_logic.append((rsi_3_15m_gt_10) | rsi_3_1h_gt_20 | (aroonu_14_1h < 40.0))
           # 15m & 1h down move, 4h still high
-          long_entry_logic.append((rsi_3_15m > 10.0) | (rsi_3_1h > 25.0) | (stochrsi_k_4h < 40.0))
+          long_entry_logic.append((rsi_3_15m_gt_10) | (rsi_3_1h_gt_25) | (stochrsi_k_4h < 40.0))
           # 15m & 4h down move, 1d high
-          long_entry_logic.append((rsi_3_15m > 10.0) | (rsi_3_4h_gt_15) | (stochrsi_k_1d < 90.0))
+          long_entry_logic.append((rsi_3_15m_gt_10) | (rsi_3_4h_gt_15) | (stochrsi_k_1d_lt_90))
           # 15m & 4h down move, 4h downtrend
-          long_entry_logic.append((rsi_3_15m > 10.0) | (rsi_3_4h_gt_15) | (roc_9_4h > -20.0))
+          long_entry_logic.append((rsi_3_15m_gt_10) | (rsi_3_4h_gt_15) | (roc_9_4h > -20.0))
           # 15m & 4h down move, 4h still high
-          long_entry_logic.append((rsi_3_15m > 10.0) | rsi_3_4h_gt_20 | (aroonu_14_4h < 50.0))
+          long_entry_logic.append((rsi_3_15m_gt_10) | rsi_3_4h_gt_20 | (aroonu_14_4h_lt_50))
           # 15m & 4h down move, 4h still not low enough
-          long_entry_logic.append((rsi_3_15m > 10.0) | rsi_3_4h_gt_20 | (stochrsi_k_4h < 30.0))
+          long_entry_logic.append((rsi_3_15m_gt_10) | rsi_3_4h_gt_20 | (stochrsi_k_4h < 30.0))
           # 15m & 4h down move, 1d high
-          long_entry_logic.append((rsi_3_15m > 10.0) | (rsi_3_4h > 30.0) | (stochrsi_k_1d < 90.0))
+          long_entry_logic.append((rsi_3_15m_gt_10) | (rsi_3_4h_gt_30) | (stochrsi_k_1d_lt_90))
           # 15m down move, 4h still high, 1d high
-          long_entry_logic.append((rsi_3_15m > 10.0) | (aroonu_14_4h < 50.0) | (aroonu_14_1d < 90.0))
+          long_entry_logic.append((rsi_3_15m_gt_10) | (aroonu_14_4h_lt_50) | (aroonu_14_1d_lt_90))
           # 15m & 1h down move, 4h high
-          long_entry_logic.append((rsi_3_15m > 15.0) | rsi_3_1h_gt_20 | (aroonu_14_4h < 60.0))
+          long_entry_logic.append((rsi_3_15m_gt_15) | rsi_3_1h_gt_20 | (aroonu_14_4h_lt_60))
           # 15m & 4h down move, 1h still high
-          long_entry_logic.append((rsi_3_15m > 15.0) | (rsi_3_4h_gt_15) | (aroonu_14_1h < 40.0))
+          long_entry_logic.append((rsi_3_15m_gt_15) | (rsi_3_4h_gt_15) | (aroonu_14_1h < 40.0))
           # 15m & 1h & 1d down move, 1h still not low enough, 1d high
           long_entry_logic.append(
-            (rsi_3_15m > 20.0) | rsi_3_1h_gt_20 | (rsi_3_1d > 30.0) | (rsi_14_1h < 30.0) | (aroonu_14_1d < 80.0)
+            (rsi_3_15m_gt_20) | rsi_3_1h_gt_20 | (rsi_3_1d > 30.0) | (rsi_14_1h < 30.0) | (aroonu_14_1d_lt_80)
           )
           # 15m & 1h down move, 4h still high, 4h overbought
-          long_entry_logic.append((rsi_3_15m > 20.0) | rsi_3_1h_gt_20 | (aroonu_14_4h < 50.0) | (roc_9_4h < 10.0))
+          long_entry_logic.append((rsi_3_15m_gt_20) | rsi_3_1h_gt_20 | (aroonu_14_4h_lt_50) | (roc_9_4h_lt_10))
           # 15m & 1h down move, 4h high
-          long_entry_logic.append((rsi_3_15m > 20.0) | rsi_3_1h_gt_20 | aroonu_14_4h_lt_70)
+          long_entry_logic.append((rsi_3_15m_gt_20) | rsi_3_1h_gt_20 | aroonu_14_4h_lt_70)
           # 15m down move, 1h & 4h still high
-          long_entry_logic.append((rsi_3_15m > 20.0) | (aroonu_14_1h < 40.0) | (stochrsi_k_4h < 50.0))
+          long_entry_logic.append((rsi_3_15m_gt_20) | (aroonu_14_1h < 40.0) | (stochrsi_k_4h_lt_50))
           # 15m & 1h & 4h down move, 1d high
-          long_entry_logic.append((rsi_3_15m > 25.0) | (rsi_3_1h > 25.0) | (rsi_3_4h > 25.0) | (roc_9_1d < 70.0))
+          long_entry_logic.append((rsi_3_15m_gt_25) | (rsi_3_1h_gt_25) | (rsi_3_4h_gt_25) | (roc_9_1d < 70.0))
           # 15m & 4h down move, 4h high
-          long_entry_logic.append((rsi_3_15m > 25.0) | (rsi_3_4h > 45.0) | (aroonu_14_4h < 85.0))
+          long_entry_logic.append((rsi_3_15m_gt_25) | (rsi_3_4h > 45.0) | (aroonu_14_4h < 85.0))
           # 15m & 1h down move, 15m still not low enough
-          long_entry_logic.append((rsi_3_15m > 30.0) | (rsi_3_1h > 30.0) | (aroonu_14_15m < 15.0))
+          long_entry_logic.append((rsi_3_15m_gt_30) | (rsi_3_1h_gt_30) | (aroonu_14_15m < 15.0))
           # 15m & 1h down move, 1h high
-          long_entry_logic.append((rsi_3_15m > 30.0) | (rsi_3_1h > 35.0) | aroonu_14_1h_lt_80)
+          long_entry_logic.append((rsi_3_15m_gt_30) | (rsi_3_1h_gt_35) | aroonu_14_1h_lt_80)
           # 1h down move, 1h still not low enough, 1d high
-          long_entry_logic.append((rsi_3_1h > 3.0) | (aroonu_14_1h < 20.0) | (aroonu_14_1d < 90.0))
+          long_entry_logic.append((rsi_3_1h_gt_3) | (aroonu_14_1h < 20.0) | (aroonu_14_1d_lt_90))
           # 1h & 4h down move
-          long_entry_logic.append((rsi_3_1h > 5.0) | (rsi_3_4h_gt_10))
+          long_entry_logic.append((rsi_3_1h_gt_5) | (rsi_3_4h_gt_10))
           # 1h & 4h down move, 4h downtrend
-          long_entry_logic.append((rsi_3_1h > 5.0) | (rsi_3_4h_gt_15) | (roc_9_4h > -30.0))
+          long_entry_logic.append((rsi_3_1h_gt_5) | (rsi_3_4h_gt_15) | (roc_9_4h_gt_neg_30))
           # 1h & 4h down move, 4h still not low enough
-          long_entry_logic.append((rsi_3_1h > 5.0) | (rsi_3_4h > 30.0) | (stochrsi_k_4h < 30.0))
+          long_entry_logic.append((rsi_3_1h_gt_5) | (rsi_3_4h_gt_30) | (stochrsi_k_4h < 30.0))
           # 1h & 1d down move, 1d high
-          long_entry_logic.append((rsi_3_1h > 5.0) | (rsi_3_1d > 45.0) | (aroonu_14_1d < 80.0))
+          long_entry_logic.append((rsi_3_1h_gt_5) | (rsi_3_1d > 45.0) | (aroonu_14_1d_lt_80))
           # 1h down move, 4h high
-          long_entry_logic.append((rsi_3_1h > 5.0) | aroonu_14_4h_lt_70)
+          long_entry_logic.append((rsi_3_1h_gt_5) | aroonu_14_4h_lt_70)
           # 1h down move, 1d still high
-          long_entry_logic.append((rsi_3_1h > 5.0) | (stochrsi_k_1d < 50.0))
+          long_entry_logic.append((rsi_3_1h_gt_5) | (stochrsi_k_1d < 50.0))
           # 1h & 4h down move, 4h still not low enough
           long_entry_logic.append((rsi_3_1h_gt_10) | rsi_3_4h_gt_20 | (rsi_14_4h < 30.0))
           # 1h & 4h down move, 4h still not low enough
-          long_entry_logic.append((rsi_3_1h_gt_10) | (rsi_3_4h > 30.0) | (rsi_14_4h < 40.0))
+          long_entry_logic.append((rsi_3_1h_gt_10) | (rsi_3_4h_gt_30) | (rsi_14_4h < 40.0))
           # 1h & 4h down move, 4h still not low enough
-          long_entry_logic.append((rsi_3_1h_gt_10) | (rsi_3_4h > 30.0) | (aroonu_14_4h < 30.0))
+          long_entry_logic.append((rsi_3_1h_gt_10) | (rsi_3_4h_gt_30) | (aroonu_14_4h < 30.0))
           # 1h & 4h & 1d down move
-          long_entry_logic.append((rsi_3_1h_gt_10) | (rsi_3_4h > 30.0) | (rsi_3_1d > 30.0))
+          long_entry_logic.append((rsi_3_1h_gt_10) | (rsi_3_4h_gt_30) | (rsi_3_1d > 30.0))
           # 1h & 4h down move, 1d overbought
-          long_entry_logic.append((rsi_3_1h_gt_10) | (rsi_3_4h > 35.0) | roc_9_1d_lt_50)
+          long_entry_logic.append((rsi_3_1h_gt_10) | (rsi_3_4h_gt_35) | roc_9_1d_lt_50)
           # 1h & 4h down move, 4h high
           long_entry_logic.append((rsi_3_1h_gt_10) | (rsi_3_4h > 45.0) | aroonu_14_4h_lt_70)
           # 1h & 4h down move, 4h still high
-          long_entry_logic.append((rsi_3_1h_gt_10) | (rsi_3_4h > 50.0) | (stochrsi_k_4h < 40.0))
+          long_entry_logic.append((rsi_3_1h_gt_10) | (rsi_3_4h_gt_50) | (stochrsi_k_4h < 40.0))
           # 1h & 1d down move, 4h still not low enough
-          long_entry_logic.append((rsi_3_1h_gt_10) | (rsi_3_1d > 25.0) | (stochrsi_k_4h < 30.0))
+          long_entry_logic.append((rsi_3_1h_gt_10) | (rsi_3_1d_gt_25) | (stochrsi_k_4h < 30.0))
           # 1h & 1d down move, 4h still high
-          long_entry_logic.append((rsi_3_1h_gt_10) | (rsi_3_1d > 30.0) | (aroonu_14_4h < 50.0))
+          long_entry_logic.append((rsi_3_1h_gt_10) | (rsi_3_1d > 30.0) | (aroonu_14_4h_lt_50))
           # 1h down move, 1h still high
-          long_entry_logic.append((rsi_3_1h_gt_10) | (aroonu_14_1h < 50.0))
+          long_entry_logic.append((rsi_3_1h_gt_10) | (aroonu_14_1h_lt_50))
           # 1h down move, 4h still high, 1d high
-          long_entry_logic.append((rsi_3_1h_gt_10) | (aroonu_14_4h < 60.0) | (aroonu_14_1d < 90.0))
+          long_entry_logic.append((rsi_3_1h_gt_10) | (aroonu_14_4h_lt_60) | (aroonu_14_1d_lt_90))
           # 1h down move, 1d high & overbought
-          long_entry_logic.append((rsi_3_1h_gt_10) | (aroonu_14_1d < 80.0) | (roc_9_1d < 30.0))
+          long_entry_logic.append((rsi_3_1h_gt_10) | (aroonu_14_1d_lt_80) | (roc_9_1d_lt_30))
           # 1h & 4h down move, 1d stll high
           long_entry_logic.append((rsi_3_1h_gt_15) | (rsi_3_4h_gt_15) | (rsi_14_1d < 40.0))
           # 1h & 4h & 1d down move
@@ -18493,131 +18545,131 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1h & 4h down move, 1d overbought
           long_entry_logic.append((rsi_3_1h_gt_15) | rsi_3_4h_gt_20 | roc_9_1d_lt_50)
           # 1h & 4h & 1d down move
-          long_entry_logic.append((rsi_3_1h_gt_15) | (rsi_3_4h > 25.0) | (rsi_3_1d > 25.0))
+          long_entry_logic.append((rsi_3_1h_gt_15) | (rsi_3_4h_gt_25) | (rsi_3_1d_gt_25))
           # 1h & 4h down move, 1d high
-          long_entry_logic.append((rsi_3_1h_gt_15) | (rsi_3_4h > 30.0) | (stochrsi_k_1d < 80.0))
+          long_entry_logic.append((rsi_3_1h_gt_15) | (rsi_3_4h_gt_30) | (stochrsi_k_1d < 80.0))
           # 1h & 4h down move, 1h & 4h still high
-          long_entry_logic.append((rsi_3_1h_gt_15) | (rsi_3_4h > 40.0) | (rsi_14_1h < 40.0) | (rsi_14_4h < 50.0))
+          long_entry_logic.append((rsi_3_1h_gt_15) | (rsi_3_4h_gt_40) | (rsi_14_1h < 40.0) | (rsi_14_4h < 50.0))
           # 1h & 4h down move, 4h still high
-          long_entry_logic.append((rsi_3_1h_gt_15) | (rsi_3_4h > 45.0) | (stochrsi_k_4h < 50.0))
+          long_entry_logic.append((rsi_3_1h_gt_15) | (rsi_3_4h > 45.0) | (stochrsi_k_4h_lt_50))
           # 1h & 4h down move, 4h still high
-          long_entry_logic.append((rsi_3_1h_gt_15) | (rsi_3_4h > 50.0) | (aroonu_14_4h < 40.0))
+          long_entry_logic.append((rsi_3_1h_gt_15) | (rsi_3_4h_gt_50) | (aroonu_14_4h_lt_40))
           # 1h & 1d down move, 1d still high
-          long_entry_logic.append((rsi_3_1h_gt_15) | (rsi_3_1d > 15.0) | (aroonu_14_1d < 50.0))
+          long_entry_logic.append((rsi_3_1h_gt_15) | (rsi_3_1d_gt_15) | (aroonu_14_1d < 50.0))
           # 1h down move, 1h still high, 1d overbought
           long_entry_logic.append((rsi_3_1h_gt_15) | (aroonu_14_1h < 40.0) | roc_9_1d_lt_50)
           # 1h down move, 1d high, 4h downtrend
-          long_entry_logic.append((rsi_3_1h_gt_15) | (aroonu_14_1d < 70.0) | (roc_9_4h > -20.0))
+          long_entry_logic.append((rsi_3_1h_gt_15) | (aroonu_14_1d_lt_70) | (roc_9_4h > -20.0))
           # 1h down move, 1d high & overbought
-          long_entry_logic.append((rsi_3_1h_gt_15) | (aroonu_14_1d < 80.0) | (roc_9_1d < 30.0))
+          long_entry_logic.append((rsi_3_1h_gt_15) | (aroonu_14_1d_lt_80) | (roc_9_1d_lt_30))
           # 1h down move, 4h high
-          long_entry_logic.append((rsi_3_1h_gt_15) | (stochrsi_k_4h < 70.0))
+          long_entry_logic.append((rsi_3_1h_gt_15) | (stochrsi_k_4h_lt_70))
           # 1h & 4h down move, 1h still not low enough
           long_entry_logic.append(rsi_3_1h_gt_20 | rsi_3_4h_gt_20 | (aroonu_14_1h < 30.0))
           # 1h & 4h down move, 4h still high
           long_entry_logic.append(rsi_3_1h_gt_20 | rsi_3_4h_gt_20 | (rsi_14_4h < 40.0))
           # 1h & 4h down move, 4h still high
-          long_entry_logic.append(rsi_3_1h_gt_20 | rsi_3_4h_gt_20 | (aroonu_14_4h < 50.0))
+          long_entry_logic.append(rsi_3_1h_gt_20 | rsi_3_4h_gt_20 | (aroonu_14_4h_lt_50))
           # 1h & 4h down move, 1d downtrend
           long_entry_logic.append(rsi_3_1h_gt_20 | rsi_3_4h_gt_20 | (roc_9_1d_gt_neg_30))
           # 1h & 4h down move, 1d high
-          long_entry_logic.append(rsi_3_1h_gt_20 | (rsi_3_4h > 35.0) | (aroonu_14_1d < 80.0))
+          long_entry_logic.append(rsi_3_1h_gt_20 | (rsi_3_4h_gt_35) | (aroonu_14_1d_lt_80))
           # 1h & 4h down move, 4h high
           long_entry_logic.append(rsi_3_1h_gt_20 | (rsi_3_4h > 45.0) | (aroonu_14_4h < 65.0))
           # 1h & 1d down move, 1d high
-          long_entry_logic.append(rsi_3_1h_gt_20 | (rsi_3_1d > 20.0) | (aroonu_14_1d < 70.0))
+          long_entry_logic.append(rsi_3_1h_gt_20 | (rsi_3_1d_gt_20) | (aroonu_14_1d_lt_70))
           # 1h down move, 1h still high, 1d high
-          long_entry_logic.append(rsi_3_1h_gt_20 | (aroonu_14_1h < 40.0) | (aroonu_14_1d < 90.0))
+          long_entry_logic.append(rsi_3_1h_gt_20 | (aroonu_14_1h < 40.0) | (aroonu_14_1d_lt_90))
           # 4h down move, 4h still high, 1d high
-          long_entry_logic.append(rsi_3_4h_gt_20 | (aroonu_14_4h < 50.0) | aroonu_14_1d_lt_100)
+          long_entry_logic.append(rsi_3_4h_gt_20 | (aroonu_14_4h_lt_50) | aroonu_14_1d_lt_100)
           # 1h down move, 4h still high, 1d downtrend
           long_entry_logic.append(rsi_3_1h_gt_20 | (stochrsi_k_4h < 40.0) | (roc_9_1d > -25.0))
           # 1h down move, 4h & 1d high
-          long_entry_logic.append(rsi_3_1h_gt_20 | (stochrsi_k_4h < 50.0) | (stochrsi_k_1d < 80.0))
+          long_entry_logic.append(rsi_3_1h_gt_20 | (stochrsi_k_4h_lt_50) | (stochrsi_k_1d < 80.0))
           # 1h & 4h down move, 1h still high
-          long_entry_logic.append((rsi_3_1h > 25.0) | (rsi_3_4h > 35.0) | (aroonu_14_1h < 40.0))
+          long_entry_logic.append((rsi_3_1h_gt_25) | (rsi_3_4h_gt_35) | (aroonu_14_1h < 40.0))
           # 1h & 4h down move, 4h high
-          long_entry_logic.append((rsi_3_1h > 25.0) | (rsi_3_4h > 40.0) | aroonu_14_4h_lt_70)
+          long_entry_logic.append((rsi_3_1h_gt_25) | (rsi_3_4h_gt_40) | aroonu_14_4h_lt_70)
           # 1h down move, 15m still not low enough, 4h high
-          long_entry_logic.append((rsi_3_1h > 25.0) | (rsi_14_15m < 30.0) | (stochrsi_k_4h < 60.0))
+          long_entry_logic.append((rsi_3_1h_gt_25) | (rsi_14_15m < 30.0) | (stochrsi_k_4h < 60.0))
           # 1h & 4h down move, 4h still high
-          long_entry_logic.append((rsi_3_1h > 25.0) | (rsi_3_4h > 35.0) | (stochrsi_k_4h < 50.0))
+          long_entry_logic.append((rsi_3_1h_gt_25) | (rsi_3_4h_gt_35) | (stochrsi_k_4h_lt_50))
           # 1h down move, 1h high
-          long_entry_logic.append((rsi_3_1h > 25.0) | (aroonu_14_1h < 60.0))
+          long_entry_logic.append((rsi_3_1h_gt_25) | (aroonu_14_1h < 60.0))
           # 1h down move, 4h high
-          long_entry_logic.append((rsi_3_1h > 25.0) | aroonu_14_4h_lt_80)
+          long_entry_logic.append((rsi_3_1h_gt_25) | aroonu_14_4h_lt_80)
           # 1h & 1d down move, 1d high
-          long_entry_logic.append((rsi_3_1h > 30.0) | (rsi_3_1d > 45.0) | (aroonu_14_1d < 80.0))
+          long_entry_logic.append((rsi_3_1h_gt_30) | (rsi_3_1d > 45.0) | (aroonu_14_1d_lt_80))
           # 1h down move, 4h & 1d high
-          long_entry_logic.append((rsi_3_1h > 30.0) | aroonu_14_4h_lt_70 | aroonu_14_1d_lt_100)
+          long_entry_logic.append((rsi_3_1h_gt_30) | aroonu_14_4h_lt_70 | aroonu_14_1d_lt_100)
           # 1h down move, 4h high, 1d downtrend
-          long_entry_logic.append((rsi_3_1h > 30.0) | aroonu_14_4h_lt_100 | (roc_9_1d > -30.0))
+          long_entry_logic.append((rsi_3_1h_gt_30) | aroonu_14_4h_lt_100 | (roc_9_1d > -30.0))
           # 1h down move, 4h high
-          long_entry_logic.append((rsi_3_1h > 30.0) | (stochrsi_k_4h_lt_90))
+          long_entry_logic.append((rsi_3_1h_gt_30) | (stochrsi_k_4h_lt_90))
           # 1h & 4h down move, 4h high
-          long_entry_logic.append((rsi_3_1h > 35.0) | (rsi_3_4h > 55.0) | aroonu_14_4h_lt_80)
+          long_entry_logic.append((rsi_3_1h_gt_35) | (rsi_3_4h > 55.0) | aroonu_14_4h_lt_80)
           # 1h down move, 1h & 4h high
-          long_entry_logic.append((rsi_3_1h > 35.0) | aroonu_14_1h_lt_70 | (aroonu_14_4h < 90.0))
+          long_entry_logic.append((rsi_3_1h_gt_35) | aroonu_14_1h_lt_70 | (aroonu_14_4h_lt_90))
           # 1h down move, 4h high, 4h downtrend
-          long_entry_logic.append((rsi_3_1h > 35.0) | aroonu_14_4h_lt_70 | (cmf_20_4h > -0.30))
+          long_entry_logic.append((rsi_3_1h_gt_35) | aroonu_14_4h_lt_70 | (cmf_20_4h > -0.30))
           # 1h down move, 1d high, 4h overbought
-          long_entry_logic.append((rsi_3_1h > 35.0) | (aroonu_14_1d < 90.0) | (roc_9_4h < 40.0))
+          long_entry_logic.append((rsi_3_1h_gt_35) | (aroonu_14_1d_lt_90) | (roc_9_4h_lt_40))
           # 1h down move, 1h high, 1d overbought
-          long_entry_logic.append((rsi_3_1h > 40.0) | aroonu_14_1h_lt_70 | (roc_9_1d < 20.0))
+          long_entry_logic.append((rsi_3_1h_gt_40) | aroonu_14_1h_lt_70 | (roc_9_1d_lt_20))
           # 1h down move, 1h & 4h high
-          long_entry_logic.append((rsi_3_1h > 50.0) | aroonu_14_1h_lt_70 | aroonu_14_4h_lt_100)
+          long_entry_logic.append((rsi_3_1h_gt_50) | aroonu_14_1h_lt_70 | aroonu_14_4h_lt_100)
           # 1h down move, 1h overbought
-          long_entry_logic.append((rsi_3_1h > 50.0) | (roc_9_1h < 40.0))
+          long_entry_logic.append((rsi_3_1h_gt_50) | (roc_9_1h < 40.0))
           # 4h & 1d down move, 1d high
-          long_entry_logic.append((rsi_3_4h > 5.0) | (rsi_3_1d > 30.0) | (aroonu_14_1d < 70.0))
+          long_entry_logic.append((rsi_3_4h_gt_5) | (rsi_3_1d > 30.0) | (aroonu_14_1d_lt_70))
           # 4h down move, 1h & 4h downtrend
-          long_entry_logic.append((rsi_3_4h > 5.0) | (roc_9_1h > -15.0) | (roc_9_4h_gt_neg_20))
+          long_entry_logic.append((rsi_3_4h_gt_5) | (roc_9_1h > -15.0) | (roc_9_4h_gt_neg_20))
           # 4h & 1d down move
-          long_entry_logic.append((rsi_3_4h_gt_10) | (rsi_3_1d > 20.0))
+          long_entry_logic.append((rsi_3_4h_gt_10) | (rsi_3_1d_gt_20))
           # 4h & 1d down move, 1d high
-          long_entry_logic.append((rsi_3_4h_gt_10) | (rsi_3_1d > 50.0) | (aroonu_14_1d < 90.0))
+          long_entry_logic.append((rsi_3_4h_gt_10) | (rsi_3_1d > 50.0) | (aroonu_14_1d_lt_90))
           # 4h down move, 4h & 1d still high
-          long_entry_logic.append((rsi_3_4h_gt_10) | (aroonu_14_4h < 50.0) | (aroonu_14_1d < 50.0))
+          long_entry_logic.append((rsi_3_4h_gt_10) | (aroonu_14_4h_lt_50) | (aroonu_14_1d < 50.0))
           # 4h & 1d down move, 1d low
-          long_entry_logic.append((rsi_3_4h_gt_15) | (rsi_3_1d > 25.0) | (cmf_20_1d > -0.2))
+          long_entry_logic.append((rsi_3_4h_gt_15) | (rsi_3_1d_gt_25) | (cmf_20_1d > -0.2))
           # 4h & 1d down move, 1d still high
           long_entry_logic.append((rsi_3_4h_gt_15) | (rsi_3_1d > 30.0) | (aroonu_14_1d < 50.0))
           # 4h & 1d down move, 1d overbought
-          long_entry_logic.append(rsi_3_4h_gt_20 | (rsi_3_1d > 45.0) | (roc_9_1d < 40.0))
+          long_entry_logic.append(rsi_3_4h_gt_20 | (rsi_3_1d > 45.0) | (roc_9_1d_lt_40))
           # 4h down move, 4h still not low enough, 1d downtrend
           long_entry_logic.append(rsi_3_4h_gt_20 | (stochrsi_k_4h < 30.0) | (roc_9_1d_gt_neg_20))
           # 4h down move, 4h & 1d downtrend
           long_entry_logic.append(rsi_3_4h_gt_20 | (roc_9_4h_gt_neg_20) | (roc_9_1d_gt_neg_20))
           # 4h down move, 4h high
-          long_entry_logic.append((rsi_3_4h > 30.0) | (aroonu_14_4h < 90.0))
+          long_entry_logic.append((rsi_3_4h_gt_30) | (aroonu_14_4h_lt_90))
           # 4h down move, 4h & 1d high
-          long_entry_logic.append((rsi_3_4h > 35.0) | (aroonu_14_4h < 60.0) | (stochrsi_k_1d < 90.0))
+          long_entry_logic.append((rsi_3_4h_gt_35) | (aroonu_14_4h_lt_60) | (stochrsi_k_1d_lt_90))
           # 4h down move, 1d high, 4h overbought
-          long_entry_logic.append((rsi_3_4h > 45.0) | aroonu_14_1d_lt_100 | (roc_9_4h < 10.0))
+          long_entry_logic.append((rsi_3_4h > 45.0) | aroonu_14_1d_lt_100 | (roc_9_4h_lt_10))
           # 4h down move, 4h overbought
-          long_entry_logic.append((rsi_3_4h > 60.0) | (roc_9_4h < 40.0))
+          long_entry_logic.append((rsi_3_4h > 60.0) | (roc_9_4h_lt_40))
           # 1d down move, 4h & 1d downtrend
-          long_entry_logic.append((rsi_3_1d > 10.0) | (roc_9_4h_gt_neg_20) | (roc_9_1d_gt_neg_20))
+          long_entry_logic.append((rsi_3_1d_gt_10) | (roc_9_4h_gt_neg_20) | (roc_9_1d_gt_neg_20))
           # 15m down move, 1d high, 1d downtrend
-          long_entry_logic.append((rsi_3_1d > 15.0) | (aroonu_14_1d < 70.0) | (roc_9_1d > -40.0))
+          long_entry_logic.append((rsi_3_1d_gt_15) | (aroonu_14_1d_lt_70) | (roc_9_1d_gt_neg_40))
           # 1d down move, 1d high, 1d downtrend
-          long_entry_logic.append((rsi_3_1d > 25.0) | (aroonu_14_1d < 80.0) | (roc_9_1d_gt_neg_30))
+          long_entry_logic.append((rsi_3_1d_gt_25) | (aroonu_14_1d_lt_80) | (roc_9_1d_gt_neg_30))
           # 4h & 1d high, 4h overbought
           long_entry_logic.append(aroonu_14_4h_lt_80 | aroonu_14_1d_lt_100 | (roc_9_4h < 20.0))
           # 4h high, 1h overbought
           long_entry_logic.append(aroonu_14_4h_lt_80 | (roc_9_1h < 40.0))
           # 4h high, 4h overbought
-          long_entry_logic.append(aroonu_14_4h_lt_80 | (roc_9_4h < 40.0))
+          long_entry_logic.append(aroonu_14_4h_lt_80 | (roc_9_4h_lt_40))
           # 4h high, 1h overbought
-          long_entry_logic.append((stochrsi_k_4h < 70.0) | (roc_9_1h < 40.0))
+          long_entry_logic.append((stochrsi_k_4h_lt_70) | (roc_9_1h < 40.0))
           # 4h high, 4h overbought
-          long_entry_logic.append((stochrsi_k_4h < 70.0) | (roc_9_4h < 40.0))
+          long_entry_logic.append((stochrsi_k_4h_lt_70) | (roc_9_4h_lt_40))
           # 4h high, 4h overbought, 1d downtrend
           long_entry_logic.append((stochrsi_k_4h < 90.0) | (roc_9_4h_lt_20) | (roc_9_1d_gt_neg_20))
           # 1d green, 4h down move, 4h still high
-          long_entry_logic.append((change_pct_1d < 40.0) | (rsi_3_4h > 35.0) | (aroonu_14_4h < 40.0))
+          long_entry_logic.append((change_pct_1d < 40.0) | (rsi_3_4h_gt_35) | (aroonu_14_4h_lt_40))
           # 4h top wick, 1h down move, 1h still high
-          long_entry_logic.append((df["top_wick_pct_4h"] < 20.0) | (rsi_3_1h > 45.0) | (aroonu_14_1h < 50.0))
+          long_entry_logic.append((df["top_wick_pct_4h"] < 20.0) | (rsi_3_1h_gt_45) | (aroonu_14_1h_lt_50))
           # pump, drop but not yet near the previous lows
           long_entry_logic.append(
             (((high_max_6_1d - df["low_min_6_1d"]) / df["low_min_6_1d"]) < 2.0)
@@ -18637,11 +18689,11 @@ class NostalgiaForInfinityX7(IStrategy):
           # big drop in the last 12 days, 1h down move
           long_entry_logic.append((close > (high_max_12_1d * 0.30)) | rsi_3_1h_gt_20)
           # big drop in the last 12 days, 4h still high
-          long_entry_logic.append((close > (high_max_12_1d * 0.40)) | (stochrsi_k_4h < 50.0))
+          long_entry_logic.append((close > (high_max_12_1d * 0.40)) | (stochrsi_k_4h_lt_50))
           # big drop in the last 20 days, 1h down move
           long_entry_logic.append((close > (high_max_20_1d * 0.40)) | (rsi_3_1h_gt_10))
           # big drop in the last 20 days, 4h down move
-          long_entry_logic.append((close > (high_max_20_1d * 0.10)) | (rsi_3_4h > 25.0))
+          long_entry_logic.append((close > (high_max_20_1d * 0.10)) | (rsi_3_4h_gt_25))
           # big drop in the last 30 days, 4h down move
           long_entry_logic.append((close > (high_max_30_1d * 0.40)) | (rsi_3_4h_gt_15))
           # big drop in the last 30 days, 4h still not low enough
@@ -18666,21 +18718,21 @@ class NostalgiaForInfinityX7(IStrategy):
 
           long_entry_logic.append(
             # 5m & 1h down move, 1h still not low enough
-            ((rsi_3 > 3.0) | (rsi_3_1h_gt_10) | (aroonu_14_1h < 30.0))
+            ((rsi_3_gt_3) | (rsi_3_1h_gt_10) | (aroonu_14_1h < 30.0))
             # 5m & 1h down move, 1d high
-            & ((rsi_3 > 3.0) | rsi_3_1h_gt_20 | aroonu_14_1d_lt_100)
+            & ((rsi_3_gt_3) | rsi_3_1h_gt_20 | aroonu_14_1d_lt_100)
             # 5m & 4h down move, 4h high
-            & ((rsi_3 > 3.0) | (rsi_3_4h > 25.0) | aroonu_14_4h_lt_70)
+            & ((rsi_3_gt_3) | (rsi_3_4h_gt_25) | aroonu_14_4h_lt_70)
             # 5m down move, 1d high & overbought
-            & ((rsi_3 > 3.0) | (stochrsi_k_1d < 90.0) | (roc_9_1d < 20.0))
+            & ((rsi_3_gt_3) | (stochrsi_k_1d_lt_90) | (roc_9_1d_lt_20))
             # 15m & 1h & 4h down move
-            & (rsi_3_15m_gt_3 | (rsi_3_1h > 3.0) | (rsi_3_4h_gt_10))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_3) | (rsi_3_4h_gt_10))
             # 15m & 1h down move, 4h still high
-            & (rsi_3_15m_gt_3 | (rsi_3_1h > 3.0) | (rsi_14_4h < 40.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_3) | (rsi_14_4h < 40.0))
             # 15m & 1h down move, 4h still high
-            & (rsi_3_15m_gt_3 | (rsi_3_1h > 3.0) | (aroonu_14_4h < 40.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_3) | (aroonu_14_4h_lt_40))
             # 15m & 1h down move, 4h still not low enough
-            & (rsi_3_15m_gt_3 | (rsi_3_1h > 5.0) | (stochrsi_k_4h < 20.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_5) | (stochrsi_k_4h < 20.0))
             # 15m & 1h & 4h down move
             & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_10) | (rsi_3_4h > 3.0))
             # 15m & 1h down move, 1d still high
@@ -18690,21 +18742,21 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 1d still high
             & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_10) | (stochrsi_k_1d < 50.0))
             # 15m & 1h down move, 1d overbought
-            & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_10) | (roc_9_1d < 40.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_10) | (roc_9_1d_lt_40))
             # 15m & 1h down move, 1d overbought
             & (rsi_3_15m_gt_3 | rsi_3_1h_gt_20 | roc_9_1d_lt_50)
             # 15m & 1h down move, 1d high
-            & (rsi_3_15m_gt_3 | (rsi_3_1h > 30.0) | (aroonu_14_1d < 80.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_30) | (aroonu_14_1d_lt_80))
             # 15m & 1h down move, 1h still high
-            & (rsi_3_15m_gt_3 | (rsi_3_1h > 30.0) | (stochrsi_k_1h < 40.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_30) | (stochrsi_k_1h < 40.0))
             # 15m & 1h down move, 1h high
-            & (rsi_3_15m_gt_3 | (rsi_3_1h > 45.0) | aroonu_14_1h_lt_80)
+            & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_45) | aroonu_14_1h_lt_80)
             # 15m & 1h down move, 1h high
             & (rsi_3_15m_gt_3 | (rsi_3_1h > 60.0) | (stochrsi_k_1h_lt_80))
             # 15m & 4h down move, 4h still high
-            & (rsi_3_15m_gt_3 | (rsi_3_4h > 40.0) | (rsi_14_4h < 40.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_4h_gt_40) | (rsi_14_4h < 40.0))
             # 15m down move, 15m downtrend. 4h high
-            & (rsi_3_15m_gt_3 | (cmf_20_15m > -0.50) | (aroonu_14_4h < 60.0))
+            & (rsi_3_15m_gt_3 | (cmf_20_15m > -0.50) | (aroonu_14_4h_lt_60))
             # 15m down move, 15m still not low enough
             & (rsi_3_15m_gt_3 | (aroonu_14_15m < 30.0))
             # 15m down move, 4h high
@@ -18712,119 +18764,119 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 4h & 1d downtrend
             & (rsi_3_15m_gt_3 | (roc_9_4h_gt_neg_20) | (roc_9_1d_gt_neg_20))
             # 15m & 1h down move, 1h still high
-            & ((rsi_3_15m > 5.0) | rsi_3_1h_gt_20 | (stochrsi_k_1h < 40.0))
+            & ((rsi_3_15m_gt_5) | rsi_3_1h_gt_20 | (stochrsi_k_1h < 40.0))
             # 15m & 1h down move, 1h high
-            & ((rsi_3_15m > 5.0) | (rsi_3_1h > 30.0) | (stochrsi_k_1h_lt_80))
+            & ((rsi_3_15m_gt_5) | (rsi_3_1h_gt_30) | (stochrsi_k_1h_lt_80))
             # 15m & 4h down move, 1h downtrend
-            & ((rsi_3_15m > 5.0) | (rsi_3_4h_gt_10) | (roc_9_1h > -20.0))
+            & ((rsi_3_15m_gt_5) | (rsi_3_4h_gt_10) | (roc_9_1h > -20.0))
             # 15m & 4h down move, 1d overbought
-            & ((rsi_3_15m > 5.0) | (rsi_3_4h_gt_15) | (roc_9_1d < 70.0))
+            & ((rsi_3_15m_gt_5) | (rsi_3_4h_gt_15) | (roc_9_1d < 70.0))
             # 15m & 4h down move, 1h high
-            & ((rsi_3_15m > 5.0) | rsi_3_4h_gt_20 | (stochrsi_k_1h_lt_80))
+            & ((rsi_3_15m_gt_5) | rsi_3_4h_gt_20 | (stochrsi_k_1h_lt_80))
             # 15m down move, 15m still low, 4h still high
-            & ((rsi_3_15m > 5.0) | (aroonu_14_15m < 20.0) | (aroonu_14_4h < 50.0))
+            & ((rsi_3_15m_gt_5) | (aroonu_14_15m < 20.0) | (aroonu_14_4h_lt_50))
             # 15m down move, 15m still high
-            & ((rsi_3_15m > 5.0) | (aroonu_14_15m < 50.0))
+            & ((rsi_3_15m_gt_5) | (aroonu_14_15m_lt_50))
             # 15m down move, 1h high & overbought
-            & ((rsi_3_15m > 5.0) | aroonu_14_1h_lt_70 | (roc_9_1h < 10.0))
+            & ((rsi_3_15m_gt_5) | aroonu_14_1h_lt_70 | (roc_9_1h_lt_10))
             # 15m down move, 1h & 1d high
-            & ((rsi_3_15m > 5.0) | (roc_9_1h < 10.0) | (roc_9_1d < 40.0))
+            & ((rsi_3_15m_gt_5) | (roc_9_1h_lt_10) | (roc_9_1d_lt_40))
             # 15m & 1h down move, 1d high
-            & ((rsi_3_15m > 10.0) | (rsi_3_1h_gt_10) | (stochrsi_k_1d < 70.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_10) | (stochrsi_k_1d < 70.0))
             # 15m & 1h down move, 4h downtrend
-            & ((rsi_3_15m > 10.0) | (rsi_3_1h_gt_10) | (roc_9_4h > -50.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_10) | (roc_9_4h > -50.0))
             # 15m & 1h down move, 1d overbought
-            & ((rsi_3_15m > 10.0) | rsi_3_1h_gt_20 | (roc_9_1d < 80.0))
+            & ((rsi_3_15m_gt_10) | rsi_3_1h_gt_20 | (roc_9_1d_lt_80))
             # 15m & 1h down move, 15m still high
-            & ((rsi_3_15m > 10.0) | (rsi_3_1h > 30.0) | (aroonu_14_15m < 50.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_30) | (aroonu_14_15m_lt_50))
             # 15m & 1h down move, 4h overbought
-            & ((rsi_3_15m > 10.0) | (rsi_3_1h > 30.0) | (roc_9_4h < 50.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_30) | (roc_9_4h < 50.0))
             # 15m & 4h down move, 4h still not low enough
-            & ((rsi_3_15m > 10.0) | (rsi_3_4h_gt_10) | (stochrsi_k_4h < 30.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_4h_gt_10) | (stochrsi_k_4h < 30.0))
             # 15m & 4h down move, 4h high
-            & ((rsi_3_15m > 10.0) | (rsi_3_4h > 25.0) | aroonu_14_4h_lt_70)
+            & ((rsi_3_15m_gt_10) | (rsi_3_4h_gt_25) | aroonu_14_4h_lt_70)
             # 15m & 4h down move, 4h overbought
-            & ((rsi_3_15m > 10.0) | (rsi_3_4h > 55.0) | (roc_9_4h < 50.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_4h > 55.0) | (roc_9_4h < 50.0))
             # 15m down move, 15m still not low enough, 1d downtrend
-            & ((rsi_3_15m > 10.0) | (aroonu_14_15m < 30.0) | (roc_9_1d_gt_neg_30))
+            & ((rsi_3_15m_gt_10) | (aroonu_14_15m < 30.0) | (roc_9_1d_gt_neg_30))
             # 15m down move, 15m still high, 1d overbought
-            & ((rsi_3_15m > 10.0) | (aroonu_14_15m < 50.0) | (roc_9_1d < 30.0))
+            & ((rsi_3_15m_gt_10) | (aroonu_14_15m_lt_50) | (roc_9_1d_lt_30))
             # 15m down move, 4h & 1d high
-            & ((rsi_3_15m > 10.0) | (aroonu_14_4h < 60.0) | aroonu_14_1d_lt_100)
+            & ((rsi_3_15m_gt_10) | (aroonu_14_4h_lt_60) | aroonu_14_1d_lt_100)
             # 15m down move, 1d high, 1d downtrend
-            & ((rsi_3_15m > 10.0) | (aroonu_14_1d < 85.0) | (cmf_20_1d > -0.40))
+            & ((rsi_3_15m_gt_10) | (aroonu_14_1d < 85.0) | (cmf_20_1d > -0.40))
             # 15m down move, 1h high & overbought
-            & ((rsi_3_15m > 10.0) | (stochrsi_k_1h < 90.0) | (roc_9_1h < 20.0))
+            & ((rsi_3_15m_gt_10) | (stochrsi_k_1h < 90.0) | (roc_9_1h < 20.0))
             # 15m down move, 4h high
-            & ((rsi_3_15m > 10.0) | (stochrsi_k_4h < 70.0))
+            & ((rsi_3_15m_gt_10) | (stochrsi_k_4h_lt_70))
             # 15m down move, 4h & 1d overbought
-            & ((rsi_3_15m > 10.0) | (roc_9_4h < 10.0) | (roc_9_1d < 40.0))
+            & ((rsi_3_15m_gt_10) | (roc_9_4h_lt_10) | (roc_9_1d_lt_40))
             # 15m & 1h down move, 15m high
-            & ((rsi_3_15m > 15.0) | (rsi_3_1h_gt_15) | (aroonu_14_15m < 60.0))
+            & ((rsi_3_15m_gt_15) | (rsi_3_1h_gt_15) | (aroonu_14_15m < 60.0))
             # 15m & 1h down move, 1h still high
-            & ((rsi_3_15m > 15.0) | (rsi_3_1h_gt_15) | (stochrsi_k_1h < 50.0))
+            & ((rsi_3_15m_gt_15) | (rsi_3_1h_gt_15) | (stochrsi_k_1h < 50.0))
             # 15m & 1h down move, 1h high
-            & ((rsi_3_15m > 15.0) | (rsi_3_1h > 25.0) | aroonu_14_1h_lt_80)
+            & ((rsi_3_15m_gt_15) | (rsi_3_1h_gt_25) | aroonu_14_1h_lt_80)
             # 15m & 1h down move, 1h high
-            & ((rsi_3_15m > 15.0) | (rsi_3_1h > 35.0) | aroonu_14_1h_lt_80)
+            & ((rsi_3_15m_gt_15) | (rsi_3_1h_gt_35) | aroonu_14_1h_lt_80)
             # 15m down move, 15m still high, 1h high
-            & ((rsi_3_15m > 15.0) | (aroonu_14_15m < 50.0) | aroonu_14_1h_lt_80)
+            & ((rsi_3_15m_gt_15) | (aroonu_14_15m_lt_50) | aroonu_14_1h_lt_80)
             # 15m down move, 4h high, 4h downtrend
-            & ((rsi_3_15m > 15.0) | (aroonu_14_4h < 60.0) | (roc_9_4h_gt_neg_20))
+            & ((rsi_3_15m_gt_15) | (aroonu_14_4h_lt_60) | (roc_9_4h_gt_neg_20))
             # 15m down move, 1d high, 4h overbought
-            & ((rsi_3_15m > 15.0) | (stochrsi_k_1d < 90.0) | (roc_9_4h < 40.0))
+            & ((rsi_3_15m_gt_15) | (stochrsi_k_1d_lt_90) | (roc_9_4h_lt_40))
             # 15m down move, 1h & 4h overbought
-            & ((rsi_3_15m > 15.0) | (roc_9_1h < 20.0) | (roc_9_4h < 40.0))
+            & ((rsi_3_15m_gt_15) | (roc_9_1h < 20.0) | (roc_9_4h_lt_40))
             # 15m down move, 4h & 1d downtrend
-            & ((rsi_3_15m > 15.0) | (roc_9_4h > -10.0) | (roc_9_1d > -40.0))
+            & ((rsi_3_15m_gt_15) | (roc_9_4h > -10.0) | (roc_9_1d_gt_neg_40))
             # 15m down move, 4h & 1d overbought
-            & ((rsi_3_15m > 15.0) | (roc_9_4h_lt_20) | (roc_9_1d < 60.0))
+            & ((rsi_3_15m_gt_15) | (roc_9_4h_lt_20) | (roc_9_1d < 60.0))
             # 15m & 1h down move, 15m high
-            & ((rsi_3_15m > 20.0) | rsi_3_1h_gt_20 | (aroonu_14_15m < 60.0))
+            & ((rsi_3_15m_gt_20) | rsi_3_1h_gt_20 | (aroonu_14_15m < 60.0))
             # 15m & 1h down move, 1h high
-            & ((rsi_3_15m > 20.0) | rsi_3_1h_gt_20 | aroonu_14_1h_lt_70)
+            & ((rsi_3_15m_gt_20) | rsi_3_1h_gt_20 | aroonu_14_1h_lt_70)
             # 15m & 1h down move, 4h high
-            & ((rsi_3_15m > 20.0) | (rsi_3_1h > 25.0) | (aroonu_14_4h < 90.0))
+            & ((rsi_3_15m_gt_20) | (rsi_3_1h_gt_25) | (aroonu_14_4h_lt_90))
             # 15m down move, 1h high
-            & ((rsi_3_15m > 20.0) | (aroonu_14_1h < 90.0))
+            & ((rsi_3_15m_gt_20) | (aroonu_14_1h_lt_90))
             # 15m down move, 4h high & overbought
-            & ((rsi_3_15m > 20.0) | aroonu_14_4h_lt_70 | (roc_9_4h_lt_20))
+            & ((rsi_3_15m_gt_20) | aroonu_14_4h_lt_70 | (roc_9_4h_lt_20))
             # 15m down move, 1h high
-            & ((rsi_3_15m > 20.0) | (stochrsi_k_1h_lt_80))
+            & ((rsi_3_15m_gt_20) | (stochrsi_k_1h_lt_80))
             # 15m down move, 4h high
-            & ((rsi_3_15m > 20.0) | (stochrsi_k_4h_lt_90))
+            & ((rsi_3_15m_gt_20) | (stochrsi_k_4h_lt_90))
             # 15m down move, 1h high, 1d overbought
-            & ((rsi_3_15m > 25.0) | (aroonu_14_1h < 100.0) | (roc_9_1d < 20.0))
+            & ((rsi_3_15m_gt_25) | (aroonu_14_1h_lt_100) | (roc_9_1d_lt_20))
             # 15m & 1h down move, 1h high
-            & ((rsi_3_15m > 30.0) | (rsi_3_1h > 50.0) | (aroonu_14_1h < 100.0))
+            & ((rsi_3_15m_gt_30) | (rsi_3_1h_gt_50) | (aroonu_14_1h_lt_100))
             # 15m & 1h down move, 4h high
-            & ((rsi_3_15m > 30.0) | (rsi_3_1h > 50.0) | aroonu_14_4h_lt_100)
+            & ((rsi_3_15m_gt_30) | (rsi_3_1h_gt_50) | aroonu_14_4h_lt_100)
             # 15m down move, 15m high, 4h high
-            & ((rsi_3_15m > 30.0) | (aroonu_14_15m < 60.0) | (stochrsi_k_4h < 70.0))
+            & ((rsi_3_15m_gt_30) | (aroonu_14_15m < 60.0) | (stochrsi_k_4h_lt_70))
             # 15m down move, 1h & 4h high
-            & ((rsi_3_15m > 30.0) | (stochrsi_k_1h_lt_70) | (stochrsi_k_4h_lt_80))
+            & ((rsi_3_15m_gt_30) | (stochrsi_k_1h_lt_70) | (stochrsi_k_4h_lt_80))
             # 1h & 4h down move, 4h still not low enough
-            & ((rsi_3_1h > 3.0) | (rsi_3_4h > 5.0) | (stochrsi_k_4h < 20.0))
+            & ((rsi_3_1h_gt_3) | (rsi_3_4h_gt_5) | (stochrsi_k_4h < 20.0))
             # 1h & 4h down move, 15m stil high
-            & ((rsi_3_1h > 3.0) | (rsi_3_4h_gt_10) | (stochrsi_k_15m < 50.0))
+            & ((rsi_3_1h_gt_3) | (rsi_3_4h_gt_10) | (stochrsi_k_15m < 50.0))
             # 1h & 4h down move, 1d still high
-            & ((rsi_3_1h > 3.0) | (rsi_3_4h_gt_10) | (stochrsi_k_1d < 40.0))
+            & ((rsi_3_1h_gt_3) | (rsi_3_4h_gt_10) | (stochrsi_k_1d < 40.0))
             # 1h down move, 1h still not low enough
-            & ((rsi_3_1h > 3.0) | (aroonu_14_1h < 20.0))
+            & ((rsi_3_1h_gt_3) | (aroonu_14_1h < 20.0))
             # 1h & 4h down move, 1d downtrend
-            & ((rsi_3_1h > 5.0) | (rsi_3_4h_gt_10) | (roc_9_1d > -40.0))
+            & ((rsi_3_1h_gt_5) | (rsi_3_4h_gt_10) | (roc_9_1d_gt_neg_40))
             # 1h & 4h down move, 4h still not low enough
-            & ((rsi_3_1h > 5.0) | (rsi_3_4h_gt_15) | (aroonu_14_4h < 30.0))
+            & ((rsi_3_1h_gt_5) | (rsi_3_4h_gt_15) | (aroonu_14_4h < 30.0))
             # 1h & 4h down move, 1d high
-            & ((rsi_3_1h > 5.0) | (rsi_3_4h_gt_15) | (roc_9_1d < 40.0))
+            & ((rsi_3_1h_gt_5) | (rsi_3_4h_gt_15) | (roc_9_1d_lt_40))
             # 1h & 4h down move, 4h still not low enough
-            & ((rsi_3_1h > 5.0) | rsi_3_4h_gt_20 | (stochrsi_k_4h < 30.0))
+            & ((rsi_3_1h_gt_5) | rsi_3_4h_gt_20 | (stochrsi_k_4h < 30.0))
             # 1h down move, 4h high, 1d overbought
-            & ((rsi_3_1h > 5.0) | (aroonu_14_4h < 60.0) | (roc_9_1d < 10.0))
+            & ((rsi_3_1h_gt_5) | (aroonu_14_4h_lt_60) | (roc_9_1d < 10.0))
             # 1h down move, 1d high, 4h downtrend
-            & ((rsi_3_1h > 5.0) | (aroonu_14_1d < 90.0) | (roc_9_4h > -30.0))
+            & ((rsi_3_1h_gt_5) | (aroonu_14_1d_lt_90) | (roc_9_4h_gt_neg_30))
             # 1h down move, 1d high, 1d downtrend
-            & ((rsi_3_1h > 5.0) | aroonu_14_1d_lt_100 | (roc_9_1d > -20.0))
+            & ((rsi_3_1h_gt_5) | aroonu_14_1d_lt_100 | (roc_9_1d > -20.0))
             # 1h & 4h down move, 1h still not low enough
             & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_10) | (stochrsi_k_1h < 20.0))
             # 1h & 4h down move, 15m downtrend
@@ -18834,151 +18886,151 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 4h still high
             & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_15) | (rsi_14_4h < 40.0))
             # 1h & 4h down move, 1d overbought
-            & ((rsi_3_1h_gt_10) | (rsi_3_4h > 30.0) | (roc_9_1d < 80.0))
+            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_30) | (roc_9_1d_lt_80))
             # 1h down move, 15m still high, 4h high
             & ((rsi_3_1h_gt_10) | (aroonu_14_15m < 40.0) | (stochrsi_k_4h < 90.0))
             # 1h down move, 1d high & overbought
             & ((rsi_3_1h_gt_10) | (aroonu_14_1d < 100.0) | (roc_9_1d < 10.0))
             # 1h down move, 4h still high, 4d downtrend
-            & ((rsi_3_1h_gt_10) | (stochrsi_k_4h < 50.0) | roc_9_1d_gt_neg_50)
+            & ((rsi_3_1h_gt_10) | (stochrsi_k_4h_lt_50) | roc_9_1d_gt_neg_50)
             # 1h down move, 4h downtrend, 1d overbought
-            & ((rsi_3_1h_gt_10) | (roc_9_4h > -10.0) | (roc_9_1d < 40.0))
+            & ((rsi_3_1h_gt_10) | (roc_9_4h > -10.0) | (roc_9_1d_lt_40))
             # 1h down move, 1d overbought
             & ((rsi_3_1h_gt_10) | (roc_9_1d < 100.0))
             # 1h & 4h down move, 4h high
-            & ((rsi_3_1h_gt_15) | (rsi_3_4h > 40.0) | (aroonu_14_4h < 80.0))
+            & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_40) | (aroonu_14_4h < 80.0))
             # 1h down move, 1d downtrend, 1d high
             & ((rsi_3_1h_gt_15) | (cmf_20_1d > -0.30) | (stochrsi_k_1d < 80.0))
             # 1h down move, 1h still high
-            & ((rsi_3_1h_gt_15) | (aroonu_14_1h < 50.0))
+            & ((rsi_3_1h_gt_15) | (aroonu_14_1h_lt_50))
             # 1h down move, 4h high, 1d overbought
-            & ((rsi_3_1h_gt_15) | (aroonu_14_4h < 60.0) | roc_9_1d_lt_50)
+            & ((rsi_3_1h_gt_15) | (aroonu_14_4h_lt_60) | roc_9_1d_lt_50)
             # 1h down move, 4h & 1d high
-            & ((rsi_3_1h_gt_15) | aroonu_14_4h_lt_70 | (aroonu_14_1d < 90.0))
+            & ((rsi_3_1h_gt_15) | aroonu_14_4h_lt_70 | (aroonu_14_1d_lt_90))
             # 1h & 4h down move, 1d overbought
-            & (rsi_3_1h_gt_20 | rsi_3_4h_gt_20 | (roc_9_1d < 20.0))
+            & (rsi_3_1h_gt_20 | rsi_3_4h_gt_20 | (roc_9_1d_lt_20))
             # 1h & 4h down move, 4h high
-            & (rsi_3_1h_gt_20 | (rsi_3_4h > 30.0) | aroonu_14_4h_lt_80)
+            & (rsi_3_1h_gt_20 | (rsi_3_4h_gt_30) | aroonu_14_4h_lt_80)
             # 1h down move, 1h high, 4h overbought
-            & (rsi_3_1h_gt_20 | aroonu_14_1h_lt_70 | (roc_9_4h < 10.0))
+            & (rsi_3_1h_gt_20 | aroonu_14_1h_lt_70 | (roc_9_4h_lt_10))
             # 1h & 4h down move, 1d overbought
-            & ((rsi_3_1h > 25.0) | (rsi_3_4h > 40.0) | (roc_9_1d_lt_100))
+            & ((rsi_3_1h_gt_25) | (rsi_3_4h_gt_40) | (roc_9_1d_lt_100))
             # 1h down move, 1h & 1d high
-            & ((rsi_3_1h > 25.0) | aroonu_14_1h_lt_70 | (aroonu_14_1d < 90.0))
+            & ((rsi_3_1h_gt_25) | aroonu_14_1h_lt_70 | (aroonu_14_1d_lt_90))
             # 1h down move, 1h still high, 1d overbought
-            & ((rsi_3_1h > 25.0) | (stochrsi_k_1h_lt_50) | (roc_9_1d < 40.0))
+            & ((rsi_3_1h_gt_25) | (stochrsi_k_1h_lt_50) | (roc_9_1d_lt_40))
             # 1h down move, 4h high, 1d downtrend
-            & ((rsi_3_1h > 25.0) | (stochrsi_k_4h_lt_80) | (roc_9_1d > -40.0))
+            & ((rsi_3_1h_gt_25) | (stochrsi_k_4h_lt_80) | (roc_9_1d_gt_neg_40))
             # 1h & 4h down move, 1h high
-            & ((rsi_3_1h > 30.0) | (rsi_3_4h > 35.0) | (aroonu_14_1h < 75.0))
+            & ((rsi_3_1h_gt_30) | (rsi_3_4h_gt_35) | (aroonu_14_1h < 75.0))
             # 1h down move, 1h high, 4h downtrend
-            & ((rsi_3_1h > 35.0) | aroonu_14_1h_lt_80 | (roc_9_4h > -40.0))
+            & ((rsi_3_1h_gt_35) | aroonu_14_1h_lt_80 | (roc_9_4h > -40.0))
             # 1h down move, 1h still high, 1d overbought
-            & ((rsi_3_1h > 35.0) | (stochrsi_k_1h_lt_50) | (roc_9_1d < 200.0))
+            & ((rsi_3_1h_gt_35) | (stochrsi_k_1h_lt_50) | (roc_9_1d < 200.0))
             # 1h down move, 1h high, 4h downtrend
-            & ((rsi_3_1h > 35.0) | (stochrsi_k_1h < 70.0) | (roc_9_4h_gt_neg_20))
+            & ((rsi_3_1h_gt_35) | (stochrsi_k_1h < 70.0) | (roc_9_4h_gt_neg_20))
             # 1h down move, 4h & 1d overbought
-            & ((rsi_3_1h > 35.0) | (roc_9_4h_lt_20) | (roc_9_1d < 80.0))
+            & ((rsi_3_1h_gt_35) | (roc_9_4h_lt_20) | (roc_9_1d_lt_80))
             # 1h down move, 1h & 4h high
-            & ((rsi_3_1h > 40.0) | aroonu_14_1h_lt_70 | (aroonu_14_4h < 90.0))
+            & ((rsi_3_1h_gt_40) | aroonu_14_1h_lt_70 | (aroonu_14_4h_lt_90))
             # 1h down move, 1h high, 1d overbought
-            & ((rsi_3_1h > 40.0) | (aroonu_14_1h < 85.0) | (roc_9_1d < 80.0))
+            & ((rsi_3_1h_gt_40) | (aroonu_14_1h < 85.0) | (roc_9_1d_lt_80))
             # 1h down move, 1h high, 4h downtrend
-            & ((rsi_3_1h > 40.0) | (stochrsi_k_1h < 80.0) | (roc_9_4h_gt_neg_20))
+            & ((rsi_3_1h_gt_40) | (stochrsi_k_1h < 80.0) | (roc_9_4h_gt_neg_20))
             # 1h down move, 1h high, 1h overbought
-            & ((rsi_3_1h > 50.0) | aroonu_14_1h_lt_70 | (roc_9_1h < 25.0))
+            & ((rsi_3_1h_gt_50) | aroonu_14_1h_lt_70 | (roc_9_1h < 25.0))
             # 1h down move, 4h high, 1d downtrend
-            & ((rsi_3_1h > 50.0) | (stochrsi_k_4h < 60.0) | (roc_9_1d > -60.0))
+            & ((rsi_3_1h_gt_50) | (stochrsi_k_4h < 60.0) | (roc_9_1d > -60.0))
             # 1h down move, 4h & 1d overbought
-            & ((rsi_3_1h > 60.0) | (roc_9_4h < 30.0) | (roc_9_1d < 60.0))
+            & ((rsi_3_1h > 60.0) | (roc_9_4h_lt_30) | (roc_9_1d < 60.0))
             # 4h & 1d down move, 15m still high
-            & ((rsi_3_4h > 3.0) | (rsi_3_1d > 15.0) | (stochrsi_k_15m < 40.0))
+            & ((rsi_3_4h > 3.0) | (rsi_3_1d_gt_15) | (stochrsi_k_15m < 40.0))
             # 4h & 1d down move, 1h still not low enough
-            & ((rsi_3_4h > 3.0) | (rsi_3_1d > 15.0) | (stochrsi_k_1h < 30.0))
+            & ((rsi_3_4h > 3.0) | (rsi_3_1d_gt_15) | (stochrsi_k_1h < 30.0))
             # 4h & 1d down move, 1d still not low enough
             & ((rsi_3_4h > 3.0) | (rsi_3_1d > 30.0) | (aroonu_14_1d < 30.0))
             # 4h down move, 1d high
-            & ((rsi_3_4h > 3.0) | (aroonu_14_1d < 90.0))
+            & ((rsi_3_4h > 3.0) | (aroonu_14_1d_lt_90))
             # 4h down move, 1h still high, 4h downtrend
-            & ((rsi_3_4h > 3.0) | (stochrsi_k_1h_lt_50) | (roc_9_4h > -30.0))
+            & ((rsi_3_4h > 3.0) | (stochrsi_k_1h_lt_50) | (roc_9_4h_gt_neg_30))
             # 4h down move, 1d high
-            & ((rsi_3_4h > 3.0) | (stochrsi_k_1d < 90.0))
+            & ((rsi_3_4h > 3.0) | (stochrsi_k_1d_lt_90))
             # 4h down move, 1h & 4h downtrend
-            & ((rsi_3_4h > 3.0) | (roc_9_1h > -30.0) | (roc_9_4h > -30.0))
+            & ((rsi_3_4h > 3.0) | (roc_9_1h > -30.0) | (roc_9_4h_gt_neg_30))
             # 4h down move, 1d overbought
-            & ((rsi_3_4h > 3.0) | (roc_9_1d < 40.0))
+            & ((rsi_3_4h > 3.0) | (roc_9_1d_lt_40))
             # 4h & 1d down move, 1d still high
-            & ((rsi_3_4h > 5.0) | (rsi_3_1d > 30.0) | (stochrsi_k_1d < 40.0))
+            & ((rsi_3_4h_gt_5) | (rsi_3_1d > 30.0) | (stochrsi_k_1d < 40.0))
             # 4h down move, 4h downtrend, 4h still high
-            & ((rsi_3_4h > 5.0) | (cmf_20_4h > -0.20) | (aroonu_14_4h < 40.0))
+            & ((rsi_3_4h_gt_5) | (cmf_20_4h > -0.20) | (aroonu_14_4h_lt_40))
             # 4h & 1d down move, 1d downtrend
-            & ((rsi_3_4h_gt_10) | (rsi_3_1d > 10.0) | (roc_9_1d > -40.0))
+            & ((rsi_3_4h_gt_10) | (rsi_3_1d_gt_10) | (roc_9_1d_gt_neg_40))
             # 4h down move, 1h high, 1d downtrend
-            & ((rsi_3_4h_gt_10) | (stochrsi_k_1h < 60.0) | (roc_9_1d > -40.0))
+            & ((rsi_3_4h_gt_10) | (stochrsi_k_1h < 60.0) | (roc_9_1d_gt_neg_40))
             # 4h & 1d down move, 1d high
-            & ((rsi_3_4h_gt_15) | (rsi_3_1d > 20.0) | (aroonu_14_1d < 60.0))
+            & ((rsi_3_4h_gt_15) | (rsi_3_1d_gt_20) | (aroonu_14_1d < 60.0))
             # 4h down move, 4h high, 1h downtrend
-            & ((rsi_3_4h_gt_15) | (aroonu_14_4h < 60.0) | (roc_9_1h > -20.0))
+            & ((rsi_3_4h_gt_15) | (aroonu_14_4h_lt_60) | (roc_9_1h > -20.0))
             # 4h down move, 4h & 1d high
-            & ((rsi_3_4h_gt_15) | aroonu_14_4h_lt_70 | (aroonu_14_1d < 70.0))
+            & ((rsi_3_4h_gt_15) | aroonu_14_4h_lt_70 | (aroonu_14_1d_lt_70))
             # 4h down move, 1d high & overbought
-            & (rsi_3_4h_gt_20 | (aroonu_14_1d < 80.0) | roc_9_1d_lt_50)
+            & (rsi_3_4h_gt_20 | (aroonu_14_1d_lt_80) | roc_9_1d_lt_50)
             # 4h down move, 1h still not low enough, 1d downtrend
             & ((rsi_3_4h_gt_15) | (stochrsi_k_1h < 20.0) | (roc_9_1d > -20.0))
             # 4h down move, 4h still high, 1d downtrend
             & (rsi_3_4h_gt_20 | (stochrsi_k_4h < 40.0) | (roc_9_1d_gt_neg_20))
             # 4h down move, 4h still high, 1d downtrend
-            & ((rsi_3_4h > 25.0) | (aroonu_14_4h < 50.0) | (roc_9_1d > -40.0))
+            & ((rsi_3_4h_gt_25) | (aroonu_14_4h_lt_50) | (roc_9_1d_gt_neg_40))
             # 4h down move, 4h still high, 1d downtrend
-            & ((rsi_3_4h > 30.0) | (aroonu_14_4h < 50.0) | (roc_9_1d > -40.0))
+            & ((rsi_3_4h_gt_30) | (aroonu_14_4h_lt_50) | (roc_9_1d_gt_neg_40))
             # 4h down move, 4h high, 1d overbought
-            & ((rsi_3_4h > 30.0) | aroonu_14_4h_lt_80 | roc_9_1d_lt_50)
+            & ((rsi_3_4h_gt_30) | aroonu_14_4h_lt_80 | roc_9_1d_lt_50)
             # 4h down move, 4h & 1d overbought
-            & ((rsi_3_4h > 40.0) | (roc_9_4h < 10.0) | roc_9_1d_lt_50)
+            & ((rsi_3_4h_gt_40) | (roc_9_4h_lt_10) | roc_9_1d_lt_50)
             # 4h down move, 1h high, 1d overbought
             & ((rsi_3_4h > 45.0) | (aroonu_14_1h < 85.0) | roc_9_1d_lt_50)
             # 4h down move, 4h still high, 1d downtrend
-            & ((rsi_3_4h > 50.0) | (rsi_14_4h < 40.0) | (roc_9_1d_gt_neg_30))
+            & ((rsi_3_4h_gt_50) | (rsi_14_4h < 40.0) | (roc_9_1d_gt_neg_30))
             # 4h down move, 4h high & overbought
-            & ((rsi_3_4h > 50.0) | aroonu_14_4h_lt_80 | (roc_9_4h < 10.0))
+            & ((rsi_3_4h_gt_50) | aroonu_14_4h_lt_80 | (roc_9_4h_lt_10))
             # 4h down move, 4h still high, 1d downtrend
-            & ((rsi_3_4h > 50.0) | (stochrsi_k_4h < 50.0) | (roc_9_1d_gt_neg_30))
+            & ((rsi_3_4h_gt_50) | (stochrsi_k_4h_lt_50) | (roc_9_1d_gt_neg_30))
             # 1d down move, 1h still high, 1d downtrend
             & ((rsi_3_1d > 5.0) | (stochrsi_k_1h < 50.0) | (roc_9_1d_gt_neg_30))
             # 1d down move, 1h high, 1d downtrend
-            & ((rsi_3_1d > 10.0) | aroonu_14_1h_lt_80 | (roc_9_1d > -10.0))
+            & ((rsi_3_1d_gt_10) | aroonu_14_1h_lt_80 | (roc_9_1d > -10.0))
             # 1d down move, 1d high, 1d downtrend
-            & ((rsi_3_1d > 10.0) | (aroonu_14_1d < 70.0) | (roc_9_1d > -40.0))
+            & ((rsi_3_1d_gt_10) | (aroonu_14_1d_lt_70) | (roc_9_1d_gt_neg_40))
             # 1d down move, 1h high & overbought
-            & ((rsi_3_1d > 35.0) | (stochrsi_k_1h < 90.0) | (roc_9_1h < 10.0))
+            & ((rsi_3_1d > 35.0) | (stochrsi_k_1h < 90.0) | (roc_9_1h_lt_10))
             # 1d downtrend, 1d high & overbought
             & ((cmf_20_1d > -0.30) | (aroonu_14_1d < 85.0) | (roc_9_1d_lt_100))
             # 15m high, 1h high & overbought
-            & ((aroonu_14_15m < 60.0) | (aroonu_14_1h < 85.0) | (roc_9_1h < 10.0))
+            & ((aroonu_14_15m < 60.0) | (aroonu_14_1h < 85.0) | (roc_9_1h_lt_10))
             # 1h high, 4h high, 1h overbought
             & (aroonu_14_1h_lt_70 | aroonu_14_4h_lt_100 | (roc_9_1h < 20.0))
             # 1h & 1d high, 1h overbought
-            & (aroonu_14_1h_lt_70 | (aroonu_14_1d < 70.0) | (roc_9_1h < 20.0))
+            & (aroonu_14_1h_lt_70 | (aroonu_14_1d_lt_70) | (roc_9_1h < 20.0))
             # 1h & 4h high, 1d downtrend
             & ((aroonu_14_1h < 85.0) | aroonu_14_4h_lt_100 | (roc_9_1d > -80.0))
             # 4h still high, 5m downtrend
-            & ((aroonu_14_4h < 40.0) | (roc_9 > -40.0))
+            & ((aroonu_14_4h_lt_40) | (roc_9 > -40.0))
             # 4h high, 4h & 1d overbought
-            & ((aroonu_14_4h < 60.0) | (roc_9_4h < 30.0) | (roc_9_1d < 60.0))
+            & ((aroonu_14_4h_lt_60) | (roc_9_4h_lt_30) | (roc_9_1d < 60.0))
             # 4h & 1d high, 4h overbought
-            & (aroonu_14_4h_lt_80 | aroonu_14_1d_lt_100 | (roc_9_4h < 30.0))
+            & (aroonu_14_4h_lt_80 | aroonu_14_1d_lt_100 | (roc_9_4h_lt_30))
             # 4h & 1d high, 1d overbought
             & (aroonu_14_4h_lt_80 | aroonu_14_1d_lt_100 | roc_9_1d_lt_50)
             # 4h high, 4h & 1d overbought
-            & (aroonu_14_4h_lt_80 | (roc_9_4h < 20.0) | (roc_9_1d < 20.0))
+            & (aroonu_14_4h_lt_80 | (roc_9_4h < 20.0) | (roc_9_1d_lt_20))
             # 1d high, 1h & 4h downtrend
             & ((aroonu_14_1d < 85.0) | (roc_9_1h > -30.0) | (roc_9_4h > -50.0))
             # 1d high, 1h & 1d overbought
             & ((aroonu_14_1d < 85.0) | (roc_9_1h < 20.0) | (roc_9_1d_lt_100))
             # 1d high, 4h & 1d overbought
-            & ((aroonu_14_1d < 90.0) | (roc_9_4h < 30.0) | (roc_9_1d < 60.0))
+            & ((aroonu_14_1d_lt_90) | (roc_9_4h_lt_30) | (roc_9_1d < 60.0))
             # 1h high, 1d overbought
-            & ((stochrsi_k_1h_lt_70) | (roc_9_1d < 40.0))
+            & ((stochrsi_k_1h_lt_70) | (roc_9_1d_lt_40))
             # 4h high, 1h overbought, 1d downtrend
             & ((stochrsi_k_4h_lt_80) | (roc_9_1h < 40.0) | (roc_9_1d > -70.0))
             # 4h high, 1h & 4h overbought
@@ -19007,11 +19059,11 @@ class NostalgiaForInfinityX7(IStrategy):
 
           long_entry_logic.append(
             # 5m & 4h down move, 1d high
-            ((rsi_3 > 3.0) | (rsi_3_4h_gt_10) | (aroonu_14_1d < 90.0))
+            ((rsi_3_gt_3) | (rsi_3_4h_gt_10) | (aroonu_14_1d_lt_90))
             # 5m & 1d down move, 15m still high
-            & ((rsi_3 > 3.0) | (rsi_3_1d > 20.0) | (stochrsi_k_15m < 40.0))
+            & ((rsi_3_gt_3) | (rsi_3_1d_gt_20) | (stochrsi_k_15m < 40.0))
             # 5m & 4h down move, 15m still high
-            & ((rsi_3 > 5.0) | (rsi_3_4h > 25.0) | (stochrsi_k_15m < 50.0))
+            & ((rsi_3 > 5.0) | (rsi_3_4h_gt_25) | (stochrsi_k_15m < 50.0))
             # 5m & 4h down move, 4h still not low enough
             & ((rsi_3 > 5.0) | (rsi_3_4h_gt_15) | (stochrsi_k_4h < 20.0))
             # 15m & 1h down move, 1h still not low enough
@@ -19023,111 +19075,111 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 4h still high
             & (rsi_3_15m_gt_3 | rsi_3_1h_gt_20 | (stochrsi_k_4h < 40.0))
             # 15m & 1h down move, 4h still high
-            & (rsi_3_15m_gt_3 | (rsi_3_1h > 25.0) | (aroonu_14_4h < 50.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_25) | (aroonu_14_4h_lt_50))
             # 15m & 4h down move, 4h still not low enough
             & (rsi_3_15m_gt_3 | (rsi_3_4h > 3.0) | (aroonu_14_4h < 20.0))
             # 15m & 4h down move, 4h still high
-            & (rsi_3_15m_gt_3 | rsi_3_4h_gt_20 | (aroonu_14_4h < 40.0))
+            & (rsi_3_15m_gt_3 | rsi_3_4h_gt_20 | (aroonu_14_4h_lt_40))
             # 15m & 1h down move, 1h still not low enough
-            & ((rsi_3_15m > 5.0) | (rsi_3_1h_gt_10) | (stochrsi_k_1h < 20.0))
+            & ((rsi_3_15m_gt_5) | (rsi_3_1h_gt_10) | (stochrsi_k_1h < 20.0))
             # 15m & 1h down move, 15m still not low enough
-            & ((rsi_3_15m > 5.0) | (rsi_3_1h_gt_10) | (stochrsi_k_15m < 20.0))
+            & ((rsi_3_15m_gt_5) | (rsi_3_1h_gt_10) | (stochrsi_k_15m < 20.0))
             # 15m & 1h down move, 4h still high
-            & ((rsi_3_15m > 5.0) | (rsi_3_1h_gt_10) | (aroonu_14_4h < 40.0))
+            & ((rsi_3_15m_gt_5) | (rsi_3_1h_gt_10) | (aroonu_14_4h_lt_40))
             # 15m & 4h down move, 15m still not low enough
-            & ((rsi_3_15m > 5.0) | (rsi_3_4h_gt_10) | (stochrsi_k_15m < 30.0))
+            & ((rsi_3_15m_gt_5) | (rsi_3_4h_gt_10) | (stochrsi_k_15m < 30.0))
             # 15m & 4h down move, 1h downtrend
-            & ((rsi_3_15m > 5.0) | (rsi_3_4h_gt_10) | (roc_9_1h > -20.0))
+            & ((rsi_3_15m_gt_5) | (rsi_3_4h_gt_10) | (roc_9_1h > -20.0))
             # 15m & 4h down move, 1d overbought
-            & ((rsi_3_15m > 5.0) | (rsi_3_4h_gt_10) | (roc_9_1d < 20.0))
+            & ((rsi_3_15m_gt_5) | (rsi_3_4h_gt_10) | (roc_9_1d_lt_20))
             # 15m & 4h down move, 4h still high
-            & ((rsi_3_15m > 5.0) | (rsi_3_4h_gt_15) | (rsi_14_4h < 40.0))
+            & ((rsi_3_15m_gt_5) | (rsi_3_4h_gt_15) | (rsi_14_4h < 40.0))
             # 15m & 1h down move, 4h still high
-            & ((rsi_3_15m > 10.0) | (rsi_3_1h_gt_10) | (stochrsi_k_4h < 40.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_10) | (stochrsi_k_4h < 40.0))
             # 15m & 1h down move, 1d downtrend
-            & ((rsi_3_15m > 10.0) | (rsi_3_1h_gt_10) | (roc_9_1d > -20.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_10) | (roc_9_1d > -20.0))
             # 15m & 1h down move, 15m high
-            & ((rsi_3_15m > 10.0) | (rsi_3_1h_gt_10) | (aroonu_14_15m < 70.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_10) | (aroonu_14_15m_lt_70))
             # 15m & 1h down move, 1h still not low enough
-            & ((rsi_3_15m > 10.0) | (rsi_3_1h_gt_10) | (aroonu_14_1h < 30.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_10) | (aroonu_14_1h < 30.0))
             # 15m & 1h down move, 1h still high
-            & ((rsi_3_15m > 10.0) | (rsi_3_1h_gt_15) | (aroonu_14_1h < 40.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_15) | (aroonu_14_1h < 40.0))
             # 15m & 1h down move, 1d high
-            & ((rsi_3_15m > 10.0) | (rsi_3_1h_gt_10) | (aroonu_14_1d < 100.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_10) | (aroonu_14_1d < 100.0))
             # 15m & 1h down move, 4h high
-            & ((rsi_3_15m > 10.0) | (rsi_3_1h_gt_15) | (aroonu_14_4h < 60.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_15) | (aroonu_14_4h_lt_60))
             # 15m & 1h down move, 4h high
-            & ((rsi_3_15m > 10.0) | (rsi_3_1h > 35.0) | (aroonu_14_4h < 90.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_35) | (aroonu_14_4h_lt_90))
             # 15m & 4h down move, 15m still not low enough
-            & ((rsi_3_15m > 10.0) | (rsi_3_4h_gt_15) | (aroonu_14_15m < 20.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_4h_gt_15) | (aroonu_14_15m < 20.0))
             # 15m & 4h down move, 1d high
-            & ((rsi_3_15m > 10.0) | rsi_3_4h_gt_20 | (stochrsi_k_1d < 90.0))
+            & ((rsi_3_15m_gt_10) | rsi_3_4h_gt_20 | (stochrsi_k_1d_lt_90))
             # 15m & 4h down move, 4h still not low enough
-            & ((rsi_3_15m > 10.0) | rsi_3_4h_gt_20 | (stochrsi_k_4h < 30.0))
+            & ((rsi_3_15m_gt_10) | rsi_3_4h_gt_20 | (stochrsi_k_4h < 30.0))
             # 15m & 4h down move, 1d high
-            & ((rsi_3_15m > 10.0) | rsi_3_4h_gt_20 | (stochrsi_k_1d < 70.0))
+            & ((rsi_3_15m_gt_10) | rsi_3_4h_gt_20 | (stochrsi_k_1d < 70.0))
             # 15m & 4h down move, 4h downtrend
-            & ((rsi_3_15m > 10.0) | (rsi_3_4h > 25.0) | (cmf_20_4h > -0.30))
+            & ((rsi_3_15m_gt_10) | (rsi_3_4h_gt_25) | (cmf_20_4h > -0.30))
             # 15m & 4h down move, 1d high
-            & ((rsi_3_15m > 10.0) | (rsi_3_4h > 30.0) | (stochrsi_k_1d < 90.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_4h_gt_30) | (stochrsi_k_1d_lt_90))
             # 15m & 4h down move, 1d overbought
-            & ((rsi_3_15m > 10.0) | (rsi_3_4h > 40.0) | (roc_9_1d < 200.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_4h_gt_40) | (roc_9_1d < 200.0))
             # 15m & 1d down move, 1d high
-            & ((rsi_3_15m > 10.0) | (rsi_3_1d > 20.0) | (aroonu_14_1d < 75.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_1d_gt_20) | (aroonu_14_1d < 75.0))
             # 15m down move, 4h high, 1d downtrend
-            & ((rsi_3_15m > 10.0) | aroonu_14_4h_lt_70 | (roc_9_1d > -25.0))
+            & ((rsi_3_15m_gt_10) | aroonu_14_4h_lt_70 | (roc_9_1d > -25.0))
             # 15m & 1h down move, 4h high
-            & ((rsi_3_15m > 15.0) | (rsi_3_1h_gt_15) | (aroonu_14_4h < 75.0))
+            & ((rsi_3_15m_gt_15) | (rsi_3_1h_gt_15) | (aroonu_14_4h < 75.0))
             # 15m & 4h down move, 4h high
-            & ((rsi_3_15m > 15.0) | rsi_3_4h_gt_20 | (aroonu_14_4h < 60.0))
+            & ((rsi_3_15m_gt_15) | rsi_3_4h_gt_20 | (aroonu_14_4h_lt_60))
             # 15m & 4h down move, 4h still high
-            & ((rsi_3_15m > 15.0) | (rsi_3_4h > 25.0) | (stochrsi_k_4h < 40.0))
+            & ((rsi_3_15m_gt_15) | (rsi_3_4h_gt_25) | (stochrsi_k_4h < 40.0))
             # 15m down move, 15m downtrend, 4h high
-            & ((rsi_3_15m > 15.0) | (cmf_20_15m > -0.30) | (aroonu_14_4h < 50.0))
+            & ((rsi_3_15m_gt_15) | (cmf_20_15m > -0.30) | (aroonu_14_4h_lt_50))
             # 15m down move, 15m still high, 4h overbought
-            & ((rsi_3_15m > 15.0) | (aroonu_14_15m < 40.0) | (roc_9_4h < 40.0))
+            & ((rsi_3_15m_gt_15) | (aroonu_14_15m < 40.0) | (roc_9_4h_lt_40))
             # 15m down move, 4h & 1d high
-            & ((rsi_3_15m > 15.0) | aroonu_14_4h_lt_80 | aroonu_14_1d_lt_100)
+            & ((rsi_3_15m_gt_15) | aroonu_14_4h_lt_80 | aroonu_14_1d_lt_100)
             # 15m down move, 1h & 4h high
-            & ((rsi_3_15m > 20.0) | aroonu_14_1h_lt_70 | aroonu_14_4h_lt_100)
+            & ((rsi_3_15m_gt_20) | aroonu_14_1h_lt_70 | aroonu_14_4h_lt_100)
             # 15m down move, 15m still not low enough, 1d overbought
-            & ((rsi_3_15m > 20.0) | (stochrsi_k_15m < 30.0) | (roc_9_1d < 80.0))
+            & ((rsi_3_15m_gt_20) | (stochrsi_k_15m < 30.0) | (roc_9_1d_lt_80))
             # 15m & 4h down move, 15m stil high
-            & ((rsi_3_15m > 25.0) | (rsi_3_4h > 30.0) | (stochrsi_k_15m < 40.0))
+            & ((rsi_3_15m_gt_25) | (rsi_3_4h_gt_30) | (stochrsi_k_15m < 40.0))
             # 15m down move, 15m still not low enough, 1d downtrend
-            & ((rsi_3_15m > 25.0) | (aroonu_14_15m < 25.0) | roc_9_1d_gt_neg_50)
+            & ((rsi_3_15m_gt_25) | (aroonu_14_15m < 25.0) | roc_9_1d_gt_neg_50)
             # 15m down move, 15m still high, 4h high
-            & ((rsi_3_15m > 25.0) | (aroonu_14_15m < 50.0) | aroonu_14_4h_lt_80)
+            & ((rsi_3_15m_gt_25) | (aroonu_14_15m_lt_50) | aroonu_14_4h_lt_80)
             # 15m & 1h down move, 1h high
-            & ((rsi_3_15m > 30.0) | (rsi_3_1h > 40.0) | (aroonu_14_1h < 50.0))
+            & ((rsi_3_15m_gt_30) | (rsi_3_1h_gt_40) | (aroonu_14_1h_lt_50))
             # 15m & 4h down move, 4h high
-            & ((rsi_3_15m > 30.0) | (rsi_3_4h > 35.0) | aroonu_14_4h_lt_70)
+            & ((rsi_3_15m_gt_30) | (rsi_3_4h_gt_35) | aroonu_14_4h_lt_70)
             # 15m down move, 15m still high, 4h high
-            & ((rsi_3_15m > 35.0) | (aroonu_14_15m < 50.0) | aroonu_14_4h_lt_80)
+            & ((rsi_3_15m > 35.0) | (aroonu_14_15m_lt_50) | aroonu_14_4h_lt_80)
             # 1h & 4h down move, 1d still high
-            & ((rsi_3_1h > 3.0) | (rsi_3_4h_gt_10) | (stochrsi_k_1d < 40.0))
+            & ((rsi_3_1h_gt_3) | (rsi_3_4h_gt_10) | (stochrsi_k_1d < 40.0))
             # 1h & 4h down move, 4h still high
-            & ((rsi_3_1h > 3.0) | (rsi_3_4h > 40.0) | (stochrsi_k_4h < 50.0))
+            & ((rsi_3_1h_gt_3) | (rsi_3_4h_gt_40) | (stochrsi_k_4h_lt_50))
             # 1h & 4h down move, 4h high
-            & ((rsi_3_1h > 3.0) | (rsi_3_4h > 50.0) | aroonu_14_4h_lt_70)
+            & ((rsi_3_1h_gt_3) | (rsi_3_4h_gt_50) | aroonu_14_4h_lt_70)
             # 1h down move, 15m still not low enough
-            & ((rsi_3_1h > 3.0) | (stochrsi_k_15m < 20.0))
+            & ((rsi_3_1h_gt_3) | (stochrsi_k_15m < 20.0))
             # 1h down move, 4h still high, 1d downtrend
-            & ((rsi_3_1h > 3.0) | (stochrsi_k_4h < 50.0) | (roc_9_1d_gt_neg_20))
+            & ((rsi_3_1h_gt_3) | (stochrsi_k_4h_lt_50) | (roc_9_1d_gt_neg_20))
             # 1h & 4h down move, 15m still not low enough
-            & ((rsi_3_1h > 5.0) | (rsi_3_4h > 5.0) | (stochrsi_k_15m < 30.0))
+            & ((rsi_3_1h_gt_5) | (rsi_3_4h_gt_5) | (stochrsi_k_15m < 30.0))
             # 1h & 4h down move, 4h still not low enough
-            & ((rsi_3_1h > 5.0) | (rsi_3_4h > 5.0) | (stochrsi_k_4h < 30.0))
+            & ((rsi_3_1h_gt_5) | (rsi_3_4h_gt_5) | (stochrsi_k_4h < 30.0))
             # 1h & 4h down move, 4h still not low enough
-            & ((rsi_3_1h > 5.0) | (rsi_3_4h_gt_10) | (aroonu_14_4h < 20.0))
+            & ((rsi_3_1h_gt_5) | (rsi_3_4h_gt_10) | (aroonu_14_4h < 20.0))
             # 1h & 4h down move, 4h downtrend
-            & ((rsi_3_1h > 5.0) | (rsi_3_4h_gt_15) | (roc_9_4h > -30.0))
+            & ((rsi_3_1h_gt_5) | (rsi_3_4h_gt_15) | (roc_9_4h_gt_neg_30))
             # 1h & 4h down move, 4h still not low enough
-            & ((rsi_3_1h > 5.0) | rsi_3_4h_gt_20 | (rsi_14_4h < 30.0))
+            & ((rsi_3_1h_gt_5) | rsi_3_4h_gt_20 | (rsi_14_4h < 30.0))
             # 1h & 4h down move, 4h still high
-            & ((rsi_3_1h > 5.0) | (rsi_3_4h > 30.0) | (aroonu_14_4h < 40.0))
+            & ((rsi_3_1h_gt_5) | (rsi_3_4h_gt_30) | (aroonu_14_4h_lt_40))
             # 1h & 4h & 1d down move
-            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_10) | (rsi_3_1d > 15.0))
+            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_10) | (rsi_3_1d_gt_15))
             # 1h & 4h down move, 15m high
             & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_10) | (stochrsi_k_15m < 60.0))
             # 1h & 4h down move, 4h still not low enough
@@ -19139,125 +19191,125 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 1d overbought
             & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_10) | (roc_9_1d < 10.0))
             # 1h & 4h down move, 4h still high
-            & ((rsi_3_1h_gt_10) | rsi_3_4h_gt_20 | (aroonu_14_4h < 40.0))
+            & ((rsi_3_1h_gt_10) | rsi_3_4h_gt_20 | (aroonu_14_4h_lt_40))
             # 1h & 4h down move, 4h high
-            & ((rsi_3_1h_gt_10) | (rsi_3_4h > 25.0) | (aroonu_14_4h < 60.0))
+            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_25) | (aroonu_14_4h_lt_60))
             # 1h & 4h down move, 4h still high
-            & ((rsi_3_1h_gt_10) | (rsi_3_4h > 25.0) | (stochrsi_k_4h < 40.0))
+            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_25) | (stochrsi_k_4h < 40.0))
             # 1h & 4h down move, 1h still not low enough
-            & ((rsi_3_1h_gt_10) | (rsi_3_4h > 35.0) | (aroonu_14_1h < 30.0))
+            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_35) | (aroonu_14_1h < 30.0))
             # 1h& 1d down move, 1h still high
-            & ((rsi_3_1h_gt_10) | (rsi_3_1d > 25.0) | (aroonu_14_1h < 40.0))
+            & ((rsi_3_1h_gt_10) | (rsi_3_1d_gt_25) | (aroonu_14_1h < 40.0))
             # 1h & 1d down move, 1d high
-            & ((rsi_3_1h_gt_10) | (rsi_3_1d > 60.0) | (aroonu_14_1d < 80.0))
+            & ((rsi_3_1h_gt_10) | (rsi_3_1d > 60.0) | (aroonu_14_1d_lt_80))
             # 1h & 4h down move, 1d high
             & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_15) | (rsi_14_1d < 60.0))
             # 1h & 4h down move, 4h still high
-            & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_15) | (aroonu_14_4h < 40.0))
+            & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_15) | (aroonu_14_4h_lt_40))
             # 1h & 4h down move, 1d high
             & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_15) | (stochrsi_k_1d < 70.0))
             # 1h & 4h down move, 4h still high
             & ((rsi_3_1h_gt_15) | rsi_3_4h_gt_20 | (stochrsi_k_4h < 40.0))
             # 1h & 4h down move, 1d high
-            & ((rsi_3_1h_gt_15) | rsi_3_4h_gt_20 | (stochrsi_k_1d < 90.0))
+            & ((rsi_3_1h_gt_15) | rsi_3_4h_gt_20 | (stochrsi_k_1d_lt_90))
             # 1h & 4h down move, 1d high
-            & ((rsi_3_1h_gt_15) | (rsi_3_4h > 30.0) | (stochrsi_k_1d < 80.0))
+            & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_30) | (stochrsi_k_1d < 80.0))
             # 1h & 4h down move, 1d downtrend
-            & ((rsi_3_1h_gt_15) | (rsi_3_4h > 45.0) | (roc_9_1d > -40.0))
+            & ((rsi_3_1h_gt_15) | (rsi_3_4h > 45.0) | (roc_9_1d_gt_neg_40))
             # 1h & 1d down move, 4h high
-            & ((rsi_3_1h_gt_15) | (rsi_3_1d > 15.0) | (stochrsi_k_4h < 80.0))
+            & ((rsi_3_1h_gt_15) | (rsi_3_1d_gt_15) | (stochrsi_k_4h < 80.0))
             # 1h down move, 4h high, 1d overbought
             & ((rsi_3_1h_gt_15) | aroonu_14_4h_lt_70 | (roc_9_1d < 100.0))
             # 1h down move, 1d high, 4h downtrend
-            & ((rsi_3_1h_gt_15) | (aroonu_14_1d < 90.0) | (roc_9_4h > -20.0))
+            & ((rsi_3_1h_gt_15) | (aroonu_14_1d_lt_90) | (roc_9_4h > -20.0))
             # 1h & 4h down move, 1d high
-            & (rsi_3_1h_gt_20 | (rsi_3_4h > 25.0) | (stochrsi_k_1d < 70.0))
+            & (rsi_3_1h_gt_20 | (rsi_3_4h_gt_25) | (stochrsi_k_1d < 70.0))
             # 1h & 4h down move, 4h high
-            & (rsi_3_1h_gt_20 | (rsi_3_4h > 40.0) | (stochrsi_k_4h < 70.0))
+            & (rsi_3_1h_gt_20 | (rsi_3_4h_gt_40) | (stochrsi_k_4h_lt_70))
             # 1h & 4h down move, 4h overbought
-            & (rsi_3_1h_gt_20 | (rsi_3_4h > 40.0) | (roc_9_4h < 10.0))
+            & (rsi_3_1h_gt_20 | (rsi_3_4h_gt_40) | (roc_9_4h_lt_10))
             # 1h & 4h down move, 1d high
             & (rsi_3_1h_gt_20 | (rsi_3_4h > 45.0) | aroonu_14_1d_lt_100)
             # 1h & 4h down move, 4h high
-            & (rsi_3_1h_gt_20 | (rsi_3_4h > 50.0) | (stochrsi_k_4h_lt_80))
+            & (rsi_3_1h_gt_20 | (rsi_3_4h_gt_50) | (stochrsi_k_4h_lt_80))
             # 1h down move, 1h high
             & (rsi_3_1h_gt_20 | aroonu_14_1h_lt_70)
             # 1h down move, 4h still high, 1d downtrend
-            & (rsi_3_1h_gt_20 | (aroonu_14_4h < 40.0) | (roc_9_1d_gt_neg_20))
+            & (rsi_3_1h_gt_20 | (aroonu_14_4h_lt_40) | (roc_9_1d_gt_neg_20))
             # 1h down move, 4h high
             & (rsi_3_1h_gt_20 | (aroonu_14_4h < 85.0))
             # 1h down move, 1h still not low enough, 4h stil high
-            & (rsi_3_1h_gt_20 | (stochrsi_k_1h < 20.0) | (aroonu_14_4h < 40.0))
+            & (rsi_3_1h_gt_20 | (stochrsi_k_1h < 20.0) | (aroonu_14_4h_lt_40))
             # 1h down move, 4h still high, 1d downtrend
-            & (rsi_3_1h_gt_20 | (stochrsi_k_4h < 40.0) | (roc_9_1d > -40.0))
+            & (rsi_3_1h_gt_20 | (stochrsi_k_4h < 40.0) | (roc_9_1d_gt_neg_40))
             # 1h down move, 1d high, 4h downtrend
             & (rsi_3_1h_gt_20 | (stochrsi_k_1d < 80.0) | (roc_9_4h_gt_neg_20))
             # 1h down move, 4h high
             & (rsi_3_1h_gt_20 | (stochrsi_k_4h_lt_80))
             # 1h & 4h down move, 1h still not low enough
-            & ((rsi_3_1h > 25.0) | (rsi_3_4h > 25.0) | (stochrsi_k_1h < 20.0))
+            & ((rsi_3_1h_gt_25) | (rsi_3_4h_gt_25) | (stochrsi_k_1h < 20.0))
             # 1h & 4h down move, 1d overbought
-            & ((rsi_3_1h > 25.0) | (rsi_3_4h > 25.0) | roc_9_1d_lt_50)
+            & ((rsi_3_1h_gt_25) | (rsi_3_4h_gt_25) | roc_9_1d_lt_50)
             # 1h & 4h down move, 4h high
-            & ((rsi_3_1h > 25.0) | (rsi_3_4h > 30.0) | (aroonu_14_4h < 60.0))
+            & ((rsi_3_1h_gt_25) | (rsi_3_4h_gt_30) | (aroonu_14_4h_lt_60))
             # 1h down move, 4h & 1d high
-            & ((rsi_3_1h > 25.0) | (aroonu_14_4h < 60.0) | aroonu_14_1d_lt_100)
+            & ((rsi_3_1h_gt_25) | (aroonu_14_4h_lt_60) | aroonu_14_1d_lt_100)
             # 1h down move, 4h high, 4h downtrend
-            & ((rsi_3_1h > 25.0) | aroonu_14_4h_lt_70 | (cmf_20_4h > -0.50))
+            & ((rsi_3_1h_gt_25) | aroonu_14_4h_lt_70 | (cmf_20_4h > -0.50))
             # 1h down move, 4h high & overbought
-            & ((rsi_3_1h > 25.0) | aroonu_14_4h_lt_70 | (roc_9_4h < 10.0))
+            & ((rsi_3_1h_gt_25) | aroonu_14_4h_lt_70 | (roc_9_4h_lt_10))
             # 1h down move, 15m still high, 1d overbought
-            & ((rsi_3_1h > 25.0) | (stochrsi_k_15m < 50.0) | (roc_9_1d < 30.0))
+            & ((rsi_3_1h_gt_25) | (stochrsi_k_15m < 50.0) | (roc_9_1d_lt_30))
             # 1h & 4h down move, 4h still high
-            & ((rsi_3_1h > 30.0) | (rsi_3_4h > 30.0) | (stochrsi_k_4h < 50.0))
+            & ((rsi_3_1h_gt_30) | (rsi_3_4h_gt_30) | (stochrsi_k_4h_lt_50))
             # 1h & 4h down move, 1d overbought
-            & ((rsi_3_1h > 30.0) | (rsi_3_4h > 30.0) | (roc_9_1d_lt_100))
+            & ((rsi_3_1h_gt_30) | (rsi_3_4h_gt_30) | (roc_9_1d_lt_100))
             # 1h & dh down move, 4h high
-            & ((rsi_3_1h > 30.0) | (rsi_3_4h > 50.0) | (aroonu_14_4h < 85.0))
+            & ((rsi_3_1h_gt_30) | (rsi_3_4h_gt_50) | (aroonu_14_4h < 85.0))
             # 1h down move, 4h & 1d downtrend
-            & ((rsi_3_1h > 30.0) | (roc_9_4h > -25.0) | (roc_9_1d > -60.0))
+            & ((rsi_3_1h_gt_30) | (roc_9_4h > -25.0) | (roc_9_1d > -60.0))
             # 1h down move, 4h & 1h overbought
-            & ((rsi_3_1h > 30.0) | (roc_9_4h < 30.0) | (roc_9_1d < 40.0))
+            & ((rsi_3_1h_gt_30) | (roc_9_4h_lt_30) | (roc_9_1d_lt_40))
             # 1h down move, 4h high, 4h downtrend
-            & ((rsi_3_1h > 30.0) | aroonu_14_4h_lt_70 | (cmf_20_4h > -0.40))
+            & ((rsi_3_1h_gt_30) | aroonu_14_4h_lt_70 | (cmf_20_4h > -0.40))
             # 1h down move, 1d high, 4h downtrend
-            & ((rsi_3_1h > 30.0) | (aroonu_14_1d < 80.0) | (roc_9_4h > -30.0))
+            & ((rsi_3_1h_gt_30) | (aroonu_14_1d_lt_80) | (roc_9_4h_gt_neg_30))
             # 1h down move, 1d high, 4h overbought
-            & ((rsi_3_1h > 30.0) | aroonu_14_1d_lt_100 | (roc_9_4h < 20.0))
+            & ((rsi_3_1h_gt_30) | aroonu_14_1d_lt_100 | (roc_9_4h < 20.0))
             # 1h down move, 4h still high, 1d downtrend
-            & ((rsi_3_1h > 30.0) | (stochrsi_k_4h < 40.0) | (roc_9_1d > -80.0))
+            & ((rsi_3_1h_gt_30) | (stochrsi_k_4h < 40.0) | (roc_9_1d > -80.0))
             # 1h down move, 4h high & overbought
-            & ((rsi_3_1h > 30.0) | (stochrsi_k_4h < 90.0) | (roc_9_4h_lt_20))
+            & ((rsi_3_1h_gt_30) | (stochrsi_k_4h < 90.0) | (roc_9_4h_lt_20))
             # 1h down move, 4h & 1d overbought
-            & ((rsi_3_1h > 30.0) | (roc_9_4h < 10.0) | (roc_9_1d < 30.0))
+            & ((rsi_3_1h_gt_30) | (roc_9_4h_lt_10) | (roc_9_1d_lt_30))
             # 1h & 4h down move, 1h still high
-            & ((rsi_3_1h > 35.0) | (rsi_3_4h > 35.0) | (aroonu_14_1h < 50.0))
+            & ((rsi_3_1h_gt_35) | (rsi_3_4h_gt_35) | (aroonu_14_1h_lt_50))
             # 1h & 4h down move, 4h high
-            & ((rsi_3_1h > 35.0) | (rsi_3_4h > 40.0) | aroonu_14_4h_lt_80)
+            & ((rsi_3_1h_gt_35) | (rsi_3_4h_gt_40) | aroonu_14_4h_lt_80)
             # 1h down move, 1h & 4h high
-            & ((rsi_3_1h > 35.0) | aroonu_14_1h_lt_70 | aroonu_14_4h_lt_100)
+            & ((rsi_3_1h_gt_35) | aroonu_14_1h_lt_70 | aroonu_14_4h_lt_100)
             # 1h down move, 1d high, 4h overbought
-            & ((rsi_3_1h > 35.0) | (aroonu_14_1d < 90.0) | (roc_9_4h < 40.0))
+            & ((rsi_3_1h_gt_35) | (aroonu_14_1d_lt_90) | (roc_9_4h_lt_40))
             # 1h down move, 4h high & overbought
-            & ((rsi_3_1h > 40.0) | (stochrsi_k_4h < 70.0) | (roc_9_4h < 30.0))
+            & ((rsi_3_1h_gt_40) | (stochrsi_k_4h_lt_70) | (roc_9_4h_lt_30))
             # 1h down move, 4h high & overbought
-            & ((rsi_3_1h > 45.0) | aroonu_14_4h_lt_80 | (roc_9_4h < 100.0))
+            & ((rsi_3_1h_gt_45) | aroonu_14_4h_lt_80 | (roc_9_4h < 100.0))
             # 1h down move, 1h overbought
-            & ((rsi_3_1h > 50.0) | (roc_9_1h < 40.0))
+            & ((rsi_3_1h_gt_50) | (roc_9_1h < 40.0))
             # 1h down move, 4h & 1d overbought
-            & ((rsi_3_1h > 60.0) | (roc_9_4h < 30.0) | (roc_9_1d_lt_100))
+            & ((rsi_3_1h > 60.0) | (roc_9_4h_lt_30) | (roc_9_1d_lt_100))
             # 4h & 1d down move, 1d still high
-            & ((rsi_3_4h > 5.0) | (rsi_3_1d > 20.0) | (aroonu_14_1d < 40.0))
+            & ((rsi_3_4h_gt_5) | (rsi_3_1d_gt_20) | (aroonu_14_1d < 40.0))
             # 4h & 1d down move, 4h still not low enough
-            & ((rsi_3_4h > 5.0) | (rsi_3_1d > 30.0) | (aroonu_14_4h < 20.0))
+            & ((rsi_3_4h_gt_5) | (rsi_3_1d > 30.0) | (aroonu_14_4h < 20.0))
             # 4h & 1d down move, 1d high
-            & ((rsi_3_4h > 5.0) | (rsi_3_1d > 30.0) | (aroonu_14_1d < 70.0))
+            & ((rsi_3_4h_gt_5) | (rsi_3_1d > 30.0) | (aroonu_14_1d_lt_70))
             # 4h down move, 1h high, 4h downtrend
-            & ((rsi_3_4h > 5.0) | aroonu_14_1h_lt_70 | (roc_9_4h > -20.0))
+            & ((rsi_3_4h_gt_5) | aroonu_14_1h_lt_70 | (roc_9_4h > -20.0))
             # 4h down move, 4h high
-            & ((rsi_3_4h > 5.0) | (aroonu_14_4h < 60.0))
+            & ((rsi_3_4h_gt_5) | (aroonu_14_4h_lt_60))
             # 4h & 1d down move, 1d still not low enough
-            & ((rsi_3_4h_gt_10) | (rsi_3_1d > 15.0) | (aroonu_14_1d < 30.0))
+            & ((rsi_3_4h_gt_10) | (rsi_3_1d_gt_15) | (aroonu_14_1d < 30.0))
             # 4h down move, 15m still high
             & ((rsi_3_4h_gt_10) | (stochrsi_k_15m < 40.0))
             # 4h down move, 1d still high, 1d downtrend
@@ -19265,77 +19317,77 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 1h downtrend, 1d downtrend
             & ((rsi_3_4h_gt_15) | (cmf_20_1h > -0.40) | (roc_9_1d > -20.0))
             # 4h down move, 15m high, 1d overbought
-            & ((rsi_3_4h_gt_15) | (aroonu_14_15m < 70.0) | (roc_9_1d < 100.0))
+            & ((rsi_3_4h_gt_15) | (aroonu_14_15m_lt_70) | (roc_9_1d < 100.0))
             # 4h down move, 4h still high, 4h downtrend
-            & ((rsi_3_4h_gt_15) | (aroonu_14_4h < 40.0) | (roc_9_4h > -20.0))
+            & ((rsi_3_4h_gt_15) | (aroonu_14_4h_lt_40) | (roc_9_4h > -20.0))
             # 4h down move, 15m still not low enough, 1d downtrend
             & ((rsi_3_4h_gt_15) | (stochrsi_k_15m < 30.0) | (roc_9_1d > -20.0))
             # 4h down move, 1d high & overbought
-            & ((rsi_3_4h_gt_15) | (stochrsi_k_1d < 90.0) | (roc_9_1d < 20.0))
+            & ((rsi_3_4h_gt_15) | (stochrsi_k_1d_lt_90) | (roc_9_1d_lt_20))
             # 4h & 1d down move, 1d overbought
-            & (rsi_3_4h_gt_20 | (rsi_3_1d > 45.0) | (roc_9_1d < 40.0))
+            & (rsi_3_4h_gt_20 | (rsi_3_1d > 45.0) | (roc_9_1d_lt_40))
             # 4h down move, 15m high, 4h downtrend
-            & (rsi_3_4h_gt_20 | (aroonu_14_15m < 70.0) | (roc_9_4h > -30.0))
+            & (rsi_3_4h_gt_20 | (aroonu_14_15m_lt_70) | (roc_9_4h_gt_neg_30))
             # 4h down move, 1d high & overbought
-            & (rsi_3_4h_gt_20 | (aroonu_14_1d < 80.0) | (roc_9_1d < 30.0))
+            & (rsi_3_4h_gt_20 | (aroonu_14_1d_lt_80) | (roc_9_1d_lt_30))
             # 4h & 1d down move, 1d overbought
-            & ((rsi_3_4h > 25.0) | (rsi_3_1d > 45.0) | (roc_9_1d < 10.0))
+            & ((rsi_3_4h_gt_25) | (rsi_3_1d > 45.0) | (roc_9_1d < 10.0))
             # 4h down move, 15m high, 4h high
-            & ((rsi_3_4h > 25.0) | (aroonu_14_15m < 70.0) | aroonu_14_4h_lt_80)
+            & ((rsi_3_4h_gt_25) | (aroonu_14_15m_lt_70) | aroonu_14_4h_lt_80)
             # 4h down move, 4h still high, 1d downtrend
-            & ((rsi_3_4h > 25.0) | (aroonu_14_4h < 40.0) | (roc_9_1d_gt_neg_20))
+            & ((rsi_3_4h_gt_25) | (aroonu_14_4h_lt_40) | (roc_9_1d_gt_neg_20))
             # 4h down move, 4h still high, 4h downtrend
-            & ((rsi_3_4h > 25.0) | (aroonu_14_4h < 50.0) | (cmf_20_4h > -0.40))
+            & ((rsi_3_4h_gt_25) | (aroonu_14_4h_lt_50) | (cmf_20_4h > -0.40))
             # 4h down move, 4h high, 1d high
-            & ((rsi_3_4h > 30.0) | aroonu_14_4h_lt_70 | (stochrsi_k_1d < 80.0))
+            & ((rsi_3_4h_gt_30) | aroonu_14_4h_lt_70 | (stochrsi_k_1d < 80.0))
             # 4h down move, 1d still high, 1d downtrend
-            & ((rsi_3_4h > 30.0) | (aroonu_14_1d < 40.0) | (roc_9_1d_gt_neg_20))
+            & ((rsi_3_4h_gt_30) | (aroonu_14_1d < 40.0) | (roc_9_1d_gt_neg_20))
             # 4h down move, 1d high & overbought
-            & ((rsi_3_4h > 30.0) | aroonu_14_1d_lt_100 | (roc_9_1d < 20.0))
+            & ((rsi_3_4h_gt_30) | aroonu_14_1d_lt_100 | (roc_9_1d_lt_20))
             # 4h down move, 4h still not low enough, 1d overbought
-            & ((rsi_3_4h > 30.0) | (stochrsi_k_4h < 20.0) | (roc_9_1d < 40.0))
+            & ((rsi_3_4h_gt_30) | (stochrsi_k_4h < 20.0) | (roc_9_1d_lt_40))
             # 4h down move, 1h high
-            & ((rsi_3_4h > 35.0) | aroonu_14_1h_lt_70)
+            & ((rsi_3_4h_gt_35) | aroonu_14_1h_lt_70)
             # 4h down move, 15m & 4h still high
-            & ((rsi_3_4h > 40.0) | (stochrsi_k_15m < 50.0) | (stochrsi_k_4h < 50.0))
+            & ((rsi_3_4h_gt_40) | (stochrsi_k_15m < 50.0) | (stochrsi_k_4h_lt_50))
             # 4h down move, 1d high & overbought
-            & ((rsi_3_4h > 40.0) | (stochrsi_k_1d < 90.0) | (roc_9_1d < 200.0))
+            & ((rsi_3_4h_gt_40) | (stochrsi_k_1d_lt_90) | (roc_9_1d < 200.0))
             # 4h down move, 4h high
-            & ((rsi_3_4h > 40.0) | aroonu_14_4h_lt_100)
+            & ((rsi_3_4h_gt_40) | aroonu_14_4h_lt_100)
             # 4h down move, 4h still high, 1d downtrend
-            & ((rsi_3_4h > 50.0) | (rsi_14_4h < 40.0) | (roc_9_1d_gt_neg_30))
+            & ((rsi_3_4h_gt_50) | (rsi_14_4h < 40.0) | (roc_9_1d_gt_neg_30))
             # 4h down move, 4h still high, 1d downtrend
-            & ((rsi_3_4h > 50.0) | (stochrsi_k_4h < 50.0) | (roc_9_1d_gt_neg_30))
+            & ((rsi_3_4h_gt_50) | (stochrsi_k_4h_lt_50) | (roc_9_1d_gt_neg_30))
             # 4h down move, 4h overbought
-            & ((rsi_3_4h > 55.0) | (roc_9_4h < 30.0))
+            & ((rsi_3_4h > 55.0) | (roc_9_4h_lt_30))
             # 4h down move, 4h overbought
-            & ((rsi_3_4h > 60.0) | (roc_9_4h < 40.0))
+            & ((rsi_3_4h > 60.0) | (roc_9_4h_lt_40))
             # 1d down move, 4h & 1d downtrend
-            & ((rsi_3_1d > 10.0) | (roc_9_4h_gt_neg_20) | (roc_9_1d_gt_neg_30))
+            & ((rsi_3_1d_gt_10) | (roc_9_4h_gt_neg_20) | (roc_9_1d_gt_neg_30))
             # 1d down move, 1d high, 1d downtrend
-            & ((rsi_3_1d > 15.0) | (aroonu_14_1d < 70.0) | (roc_9_1d_gt_neg_20))
+            & ((rsi_3_1d_gt_15) | (aroonu_14_1d_lt_70) | (roc_9_1d_gt_neg_20))
             # 1d down move, 4h & 1d downtrend
-            & ((rsi_3_1d > 15.0) | (roc_9_4h > -10.0) | (roc_9_1d > -40.0))
+            & ((rsi_3_1d_gt_15) | (roc_9_4h > -10.0) | (roc_9_1d_gt_neg_40))
             # 4h & 1d downtrend, 1d high
             & ((cmf_20_4h > -0.50) | (cmf_20_1d > -0.50) | (aroonu_14_1d < 85.0))
             # 4h still not low enough, 4h & 1d downtrend
             & ((aroonu_14_4h < 30.0) | (roc_9_4h_gt_neg_20) | (roc_9_1d > -25.0))
             # 4h & 1d high, 4h overbought
-            & (aroonu_14_4h_lt_70 | aroonu_14_1d_lt_100 | (roc_9_4h < 30.0))
+            & (aroonu_14_4h_lt_70 | aroonu_14_1d_lt_100 | (roc_9_4h_lt_30))
             # 4h & 1d high, 1d overbought
-            & (aroonu_14_4h_lt_70 | aroonu_14_1d_lt_100 | (roc_9_1d < 80.0))
+            & (aroonu_14_4h_lt_70 | aroonu_14_1d_lt_100 | (roc_9_1d_lt_80))
             # 4h high, 1h & 4h overbought
-            & (aroonu_14_4h_lt_80 | (roc_9_1h < 40.0) | (roc_9_4h < 40.0))
+            & (aroonu_14_4h_lt_80 | (roc_9_1h < 40.0) | (roc_9_4h_lt_40))
             # 1d high, 4h downtrend, 1d overbought
             & ((aroonu_14_1d < 85.0) | (roc_9_4h_gt_neg_20) | (roc_9_1d < 200.0))
             # 1d high, 4h & 1d overbought
-            & ((aroonu_14_1d < 90.0) | (roc_9_4h < 30.0) | (roc_9_1d < 60.0))
+            & ((aroonu_14_1d_lt_90) | (roc_9_4h_lt_30) | (roc_9_1d < 60.0))
             # 4h high, 1h & 4h overbought
-            & ((stochrsi_k_4h < 70.0) | (roc_9_1h < 40.0) | (roc_9_4h < 40.0))
+            & ((stochrsi_k_4h_lt_70) | (roc_9_1h < 40.0) | (roc_9_4h_lt_40))
             # 4h high, 4h & 1d overbought
-            & ((stochrsi_k_4h < 80.0) | (roc_9_4h_lt_20) | (roc_9_1d < 20.0))
+            & ((stochrsi_k_4h < 80.0) | (roc_9_4h_lt_20) | (roc_9_1d_lt_20))
             # 1d green, 4h down move, 4h still high
-            & ((change_pct_1d < 40.0) | (rsi_3_4h > 35.0) | (aroonu_14_4h < 40.0))
+            & ((change_pct_1d < 40.0) | (rsi_3_4h_gt_35) | (aroonu_14_4h_lt_40))
           )
 
           # Logic
@@ -19357,173 +19409,173 @@ class NostalgiaForInfinityX7(IStrategy):
           long_entry_logic.append(protections_long_global == True)
 
           long_entry_logic.append(
-            (rsi_3_15m > 5.0)
+            (rsi_3_15m_gt_5)
             # 5m & 1h down move, 1h still not low enough
-            & ((rsi_3 > 3.0) | (rsi_3_1h_gt_10) | (aroonu_14_1h < 30.0))
+            & ((rsi_3_gt_3) | (rsi_3_1h_gt_10) | (aroonu_14_1h < 30.0))
             # 5m & 1d down move, 1d downtrend
-            & ((rsi_3 > 3.0) | (rsi_3_1d > 15.0) | (cmf_20_1d > -0.25))
+            & ((rsi_3_gt_3) | (rsi_3_1d_gt_15) | (cmf_20_1d > -0.25))
             # 5m down move, 1h high, 4h overbought
-            & ((rsi_3 > 3.0) | (stochrsi_k_1h < 80.0) | (roc_9_4h_lt_20))
+            & ((rsi_3_gt_3) | (stochrsi_k_1h < 80.0) | (roc_9_4h_lt_20))
             # 5m down move, 1d high & overbought
-            & ((rsi_3 > 3.0) | (stochrsi_k_1d < 90.0) | (roc_9_1d < 20.0))
+            & ((rsi_3_gt_3) | (stochrsi_k_1d_lt_90) | (roc_9_1d_lt_20))
             # 15m & 1h down move, 1h still not low enough
-            & ((rsi_3_15m > 10.0) | (rsi_3_1h_gt_15) | (stochrsi_k_1h < 30.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_15) | (stochrsi_k_1h < 30.0))
             # 15m & 1h down move, 4h still high
-            & ((rsi_3_15m > 10.0) | rsi_3_1h_gt_20 | (stochrsi_k_4h < 50.0))
+            & ((rsi_3_15m_gt_10) | rsi_3_1h_gt_20 | (stochrsi_k_4h_lt_50))
             # 15m & 1h down move 1h still high
-            & ((rsi_3_15m > 10.0) | (rsi_3_1h > 25.0) | (stochrsi_k_1h < 40.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_25) | (stochrsi_k_1h < 40.0))
             # 15m & 1h down move, 15m still high
-            & ((rsi_3_15m > 10.0) | (rsi_3_1h > 30.0) | (aroonu_14_15m < 50.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_30) | (aroonu_14_15m_lt_50))
             # 15m & 1h down move 1h still high
-            & ((rsi_3_15m > 10.0) | (rsi_3_1h > 30.0) | (stochrsi_k_1h_lt_50))
+            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_30) | (stochrsi_k_1h_lt_50))
             # 15m & 1h down move, 4h overbought
-            & ((rsi_3_15m > 10.0) | (rsi_3_1h > 30.0) | (roc_9_4h < 10.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_30) | (roc_9_4h_lt_10))
             # 15m & 1h down move, 1h high
-            & ((rsi_3_15m > 10.0) | (rsi_3_1h > 50.0) | (stochrsi_k_1h < 90.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_50) | (stochrsi_k_1h < 90.0))
             # 15m & 4h down move, 4h still not low enough
-            & ((rsi_3_15m > 10.0) | (rsi_3_4h_gt_10) | (stochrsi_k_4h < 30.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_4h_gt_10) | (stochrsi_k_4h < 30.0))
             # 15m & 4h down move, 1d high
-            & ((rsi_3_15m > 10.0) | (rsi_3_4h_gt_10) | (stochrsi_k_1d < 80.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_4h_gt_10) | (stochrsi_k_1d < 80.0))
             # 15m & 4h down move, 4h still not low enough
-            & ((rsi_3_15m > 10.0) | (rsi_3_4h_gt_15) | (stochrsi_k_4h < 30.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_4h_gt_15) | (stochrsi_k_4h < 30.0))
             # 15m & 4h down move, 1d downtrend
-            & ((rsi_3_15m > 10.0) | (rsi_3_4h_gt_15) | (roc_9_1d > -20.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_4h_gt_15) | (roc_9_1d > -20.0))
             # 1h & 4h down move, 15m still high
-            & ((rsi_3_15m > 10.0) | (rsi_3_4h > 30.0) | (aroonu_14_15m < 50.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_4h_gt_30) | (aroonu_14_15m_lt_50))
             # 15m & 4h down move, 4h high
-            & ((rsi_3_15m > 10.0) | (rsi_3_4h > 40.0) | (stochrsi_k_4h_lt_80))
+            & ((rsi_3_15m_gt_10) | (rsi_3_4h_gt_40) | (stochrsi_k_4h_lt_80))
             # 15m & 1d down move, 1d high
-            & ((rsi_3_15m > 10.0) | (rsi_3_1d > 10.0) | (aroonu_14_1d < 70.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_1d_gt_10) | (aroonu_14_1d_lt_70))
             # 15m & 1d down move, 1d high
-            & ((rsi_3_15m > 10.0) | (rsi_3_1d > 20.0) | (aroonu_14_1d < 75.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_1d_gt_20) | (aroonu_14_1d < 75.0))
             # 15m down move, 15m still high, 4h high
-            & ((rsi_3_15m > 10.0) | (aroonu_14_15m < 50.0) | aroonu_14_4h_lt_80)
+            & ((rsi_3_15m_gt_10) | (aroonu_14_15m_lt_50) | aroonu_14_4h_lt_80)
             # 15m down move, 1h still high, 1d overbought
-            & ((rsi_3_15m > 10.0) | (aroonu_14_1h < 50.0) | (roc_9_1d < 60.0))
+            & ((rsi_3_15m_gt_10) | (aroonu_14_1h_lt_50) | (roc_9_1d < 60.0))
             # 15m down move, 4h high, 1d overbought
-            & ((rsi_3_15m > 10.0) | (aroonu_14_4h < 60.0) | (roc_9_1d < 60.0))
+            & ((rsi_3_15m_gt_10) | (aroonu_14_4h_lt_60) | (roc_9_1d < 60.0))
             # 15m down move, 1d high & overbought
-            & ((rsi_3_15m > 10.0) | (aroonu_14_1d < 90.0) | (roc_9_1d < 20.0))
+            & ((rsi_3_15m_gt_10) | (aroonu_14_1d_lt_90) | (roc_9_1d_lt_20))
             # 15m down move, 1d high, 4h overbought
-            & ((rsi_3_15m > 10.0) | (stochrsi_k_1d < 90.0) | (roc_9_4h < 10.0))
+            & ((rsi_3_15m_gt_10) | (stochrsi_k_1d_lt_90) | (roc_9_4h_lt_10))
             # 15m & 1h & 4h down move
-            & ((rsi_3_15m > 15.0) | (rsi_3_1h_gt_15) | (rsi_3_4h_gt_15))
+            & ((rsi_3_15m_gt_15) | (rsi_3_1h_gt_15) | (rsi_3_4h_gt_15))
             # 15m & 1h down move, 1h high
-            & ((rsi_3_15m > 15.0) | (rsi_3_1h > 25.0) | aroonu_14_1h_lt_70)
+            & ((rsi_3_15m_gt_15) | (rsi_3_1h_gt_25) | aroonu_14_1h_lt_70)
             # 15m & 4h down move, 15m still high
-            & ((rsi_3_15m > 15.0) | (rsi_3_4h > 25.0) | (aroonu_14_15m < 40.0))
+            & ((rsi_3_15m_gt_15) | (rsi_3_4h_gt_25) | (aroonu_14_15m < 40.0))
             # 15m & 4h down move, 1d high
-            & ((rsi_3_15m > 15.0) | (rsi_3_4h > 35.0) | (stochrsi_k_1d < 90.0))
+            & ((rsi_3_15m_gt_15) | (rsi_3_4h_gt_35) | (stochrsi_k_1d_lt_90))
             # 15m & 4h down move, 15m high
-            & ((rsi_3_15m > 15.0) | (rsi_3_4h > 35.0) | (aroonu_14_15m < 60.0))
+            & ((rsi_3_15m_gt_15) | (rsi_3_4h_gt_35) | (aroonu_14_15m < 60.0))
             # 15m & 4h down move, 4h high
-            & ((rsi_3_15m > 15.0) | (rsi_3_4h > 35.0) | (aroonu_14_4h < 60.0))
+            & ((rsi_3_15m_gt_15) | (rsi_3_4h_gt_35) | (aroonu_14_4h_lt_60))
             # 15m & 1d down move, 4h high
-            & ((rsi_3_15m > 15.0) | (rsi_3_1d > 25.0) | aroonu_14_4h_lt_100)
+            & ((rsi_3_15m_gt_15) | (rsi_3_1d_gt_25) | aroonu_14_4h_lt_100)
             # 15m down move, 15m still high, 4h high
-            & ((rsi_3_15m > 15.0) | (aroonu_14_15m < 50.0) | (stochrsi_k_4h_lt_80))
+            & ((rsi_3_15m_gt_15) | (aroonu_14_15m_lt_50) | (stochrsi_k_4h_lt_80))
             # 15m down move, 4h high, 4h downtrend
-            & ((rsi_3_15m > 15.0) | (aroonu_14_4h < 60.0) | (roc_9_4h_gt_neg_20))
+            & ((rsi_3_15m_gt_15) | (aroonu_14_4h_lt_60) | (roc_9_4h_gt_neg_20))
             # 15m down move, 4h & 1d high
-            & ((rsi_3_15m > 15.0) | (aroonu_14_4h < 75.0) | aroonu_14_1d_lt_100)
+            & ((rsi_3_15m_gt_15) | (aroonu_14_4h < 75.0) | aroonu_14_1d_lt_100)
             # 15m down move, 15m still not low enough, 1h still high
-            & ((rsi_3_15m > 15.0) | (stochrsi_k_15m < 30.0) | (stochrsi_k_1h_lt_50))
+            & ((rsi_3_15m_gt_15) | (stochrsi_k_15m < 30.0) | (stochrsi_k_1h_lt_50))
             # 15m down move, 4h & 1d overbought
-            & ((rsi_3_15m > 15.0) | (roc_9_4h_lt_20) | (roc_9_1d < 60.0))
+            & ((rsi_3_15m_gt_15) | (roc_9_4h_lt_20) | (roc_9_1d < 60.0))
             # 15m & 1h down move, 1h high
-            & ((rsi_3_15m > 20.0) | rsi_3_1h_gt_20 | (stochrsi_k_1h_lt_70))
+            & ((rsi_3_15m_gt_20) | rsi_3_1h_gt_20 | (stochrsi_k_1h_lt_70))
             # 15m & 4h down move, 4h high
-            & ((rsi_3_15m > 20.0) | (rsi_3_4h > 50.0) | (aroonu_14_4h < 85.0))
+            & ((rsi_3_15m_gt_20) | (rsi_3_4h_gt_50) | (aroonu_14_4h < 85.0))
             # 15m down move, 1h high
-            & ((rsi_3_15m > 20.0) | (aroonu_14_1h < 75.0))
+            & ((rsi_3_15m_gt_20) | (aroonu_14_1h < 75.0))
             # 15m down move, 1d high & overbought
-            & ((rsi_3_15m > 20.0) | (aroonu_14_1d < 90.0) | (roc_9_1d < 80.0))
+            & ((rsi_3_15m_gt_20) | (aroonu_14_1d_lt_90) | (roc_9_1d_lt_80))
             # 15m down move, 15m high, 4h downtrend
-            & ((rsi_3_15m > 20.0) | (stochrsi_k_15m < 60.0) | (roc_9_4h > -50.0))
+            & ((rsi_3_15m_gt_20) | (stochrsi_k_15m < 60.0) | (roc_9_4h > -50.0))
             # 15m down move, 4h overbought
-            & ((rsi_3_15m > 20.0) | (roc_9_4h < 40.0))
+            & ((rsi_3_15m_gt_20) | (roc_9_4h_lt_40))
             # 15m & 1h down move, 1h high
-            & ((rsi_3_15m > 25.0) | (rsi_3_1h > 25.0) | aroonu_14_1h_lt_70)
+            & ((rsi_3_15m_gt_25) | (rsi_3_1h_gt_25) | aroonu_14_1h_lt_70)
             # 15m & 1h down move, 1d overbought
-            & ((rsi_3_15m > 25.0) | (rsi_3_1h > 40.0) | (roc_9_1d < 80.0))
+            & ((rsi_3_15m_gt_25) | (rsi_3_1h_gt_40) | (roc_9_1d_lt_80))
             # 15m & 4h down move, 4h high
-            & ((rsi_3_15m > 25.0) | (rsi_3_4h > 25.0) | (stochrsi_k_4h < 60.0))
+            & ((rsi_3_15m_gt_25) | (rsi_3_4h_gt_25) | (stochrsi_k_4h < 60.0))
             # 15m down move, 1d high, 4h overbought
-            & ((rsi_3_15m > 25.0) | (aroonu_14_1d < 80.0) | (roc_9_4h < 10.0))
+            & ((rsi_3_15m_gt_25) | (aroonu_14_1d_lt_80) | (roc_9_4h_lt_10))
             # 15m down move, 4h & 1d overbought
-            & ((rsi_3_15m > 25.0) | (roc_9_4h < 10.0) | roc_9_1d_lt_50)
+            & ((rsi_3_15m_gt_25) | (roc_9_4h_lt_10) | roc_9_1d_lt_50)
             # 15m & 1h down move, 1h high
-            & ((rsi_3_15m > 30.0) | (rsi_3_1h > 40.0) | aroonu_14_1h_lt_80)
+            & ((rsi_3_15m_gt_30) | (rsi_3_1h_gt_40) | aroonu_14_1h_lt_80)
             # 15m & 1h down move, 1h high
-            & ((rsi_3_15m > 30.0) | (rsi_3_1h > 45.0) | (stochrsi_k_1h_lt_80))
+            & ((rsi_3_15m_gt_30) | (rsi_3_1h_gt_45) | (stochrsi_k_1h_lt_80))
             # 15m down move, 15m downtrend, 4h high
-            & ((rsi_3_15m > 30.0) | (cmf_20_15m > -0.30) | aroonu_14_4h_lt_100)
+            & ((rsi_3_15m_gt_30) | (cmf_20_15m > -0.30) | aroonu_14_4h_lt_100)
             # 15m down move, 15m still high, 1d high
-            & ((rsi_3_15m > 30.0) | (aroonu_14_15m < 50.0) | (stochrsi_k_1d < 70.0))
+            & ((rsi_3_15m_gt_30) | (aroonu_14_15m_lt_50) | (stochrsi_k_1d < 70.0))
             # 15m down move, 15m high, 4h high
-            & ((rsi_3_15m > 30.0) | (aroonu_14_15m < 60.0) | (stochrsi_k_4h < 70.0))
+            & ((rsi_3_15m_gt_30) | (aroonu_14_15m < 60.0) | (stochrsi_k_4h_lt_70))
             # 15m down move, 4h high, 1h downtrend
             & ((rsi_3_15m < 30.0) | (aroonu_14_4h < 85.0) | (roc_9_1h > -40.0))
             # 15m down move, 4h high
-            & ((rsi_3_15m > 30.0) | (stochrsi_k_4h_lt_90))
+            & ((rsi_3_15m_gt_30) | (stochrsi_k_4h_lt_90))
             # 15m & 1h down move, 15m high
-            & ((rsi_3_15m > 35.0) | (rsi_3_1h > 45.0) | (aroonu_14_15m < 70.0))
+            & ((rsi_3_15m > 35.0) | (rsi_3_1h_gt_45) | (aroonu_14_15m_lt_70))
             # 15m & 4h down move, 4h high
-            & ((rsi_3_15m > 35.0) | (rsi_3_4h > 35.0) | (stochrsi_k_4h_lt_80))
+            & ((rsi_3_15m > 35.0) | (rsi_3_4h_gt_35) | (stochrsi_k_4h_lt_80))
             # 15m down move, 15m still high, 4h overbought
             & ((rsi_3_15m > 35.0) | (aroonu_14_15m < 40.0) | (roc_9_4h_lt_20))
             # 15m down move, 15m still high, 1d overbought
-            & ((rsi_3_15m > 35.0) | (aroonu_14_15m < 40.0) | (roc_9_1d < 30.0))
+            & ((rsi_3_15m > 35.0) | (aroonu_14_15m < 40.0) | (roc_9_1d_lt_30))
             # 15m down move, 4h high & overbought
-            & ((rsi_3_15m > 35.0) | (aroonu_14_4h < 60.0) | (roc_9_4h_lt_20))
+            & ((rsi_3_15m > 35.0) | (aroonu_14_4h_lt_60) | (roc_9_4h_lt_20))
             # 15m down move, 4h high & overbought
-            & ((rsi_3_15m > 35.0) | (stochrsi_k_4h < 70.0) | (roc_9_4h_lt_20))
+            & ((rsi_3_15m > 35.0) | (stochrsi_k_4h_lt_70) | (roc_9_4h_lt_20))
             # 15m still high, 4h high
             & ((rsi_3_15m < 40.0) | (aroonu_14_4h < 85.0))
             # 1h & 4h down move, 4h still not low enough
             & ((rsi_3_1h > 2.0) | (rsi_3_4h_gt_15) | (rsi_14_4h < 30.0))
             # 1h & 4h down move, 15m still not low enough
-            & ((rsi_3_1h > 3.0) | (rsi_3_4h > 3.0) | (stochrsi_k_15m < 30.0))
+            & ((rsi_3_1h_gt_3) | (rsi_3_4h > 3.0) | (stochrsi_k_15m < 30.0))
             # 1h & 4h down move, 15m downtrend
-            & ((rsi_3_1h > 3.0) | (rsi_3_4h > 3.0) | (roc_9_15m > -30.0))
+            & ((rsi_3_1h_gt_3) | (rsi_3_4h > 3.0) | (roc_9_15m > -30.0))
             # 1h & 4h down move, 4h still high
-            & ((rsi_3_1h > 3.0) | (rsi_3_4h_gt_10) | (stochrsi_k_4h < 40.0))
+            & ((rsi_3_1h_gt_3) | (rsi_3_4h_gt_10) | (stochrsi_k_4h < 40.0))
             # 1h & 4h down move, 1d still high
-            & ((rsi_3_1h > 3.0) | (rsi_3_4h_gt_10) | (stochrsi_k_1d < 40.0))
+            & ((rsi_3_1h_gt_3) | (rsi_3_4h_gt_10) | (stochrsi_k_1d < 40.0))
             # 1h & 4h down move, 4h stil high
-            & ((rsi_3_1h > 3.0) | rsi_3_4h_gt_20 | (rsi_14_4h < 40.0))
+            & ((rsi_3_1h_gt_3) | rsi_3_4h_gt_20 | (rsi_14_4h < 40.0))
             # 1h ^ 4h down move, 1d downtrend
-            & ((rsi_3_1h > 3.0) | (rsi_3_4h > 25.0) | roc_9_1d_gt_neg_50)
+            & ((rsi_3_1h_gt_3) | (rsi_3_4h_gt_25) | roc_9_1d_gt_neg_50)
             # 1h & 1d down move, 4h still high
-            & ((rsi_3_1h > 3.0) | (rsi_3_1d > 10.0) | (stochrsi_k_4h < 40.0))
+            & ((rsi_3_1h_gt_3) | (rsi_3_1d_gt_10) | (stochrsi_k_4h < 40.0))
             # 1h & 1d down move, 1h downtrend
-            & ((rsi_3_1h > 3.0) | (rsi_3_1d > 15.0) | (roc_9_1h > -40.0))
+            & ((rsi_3_1h_gt_3) | (rsi_3_1d_gt_15) | (roc_9_1h > -40.0))
             # 1h down move, 15m downtrend, 1h still high
-            & ((rsi_3_1h > 3.0) | (cmf_20_15m > -0.40) | (aroonu_14_1h < 40.0))
+            & ((rsi_3_1h_gt_3) | (cmf_20_15m > -0.40) | (aroonu_14_1h < 40.0))
             # 1h down move, 15m still not low enough, 4h still high
-            & ((rsi_3_1h > 3.0) | (aroonu_14_15m < 30.0) | (stochrsi_k_4h < 40.0))
+            & ((rsi_3_1h_gt_3) | (aroonu_14_15m < 30.0) | (stochrsi_k_4h < 40.0))
             # 1h down move, 1h still not low enough
-            & ((rsi_3_1h > 3.0) | (stochrsi_k_1h < 30.0))
+            & ((rsi_3_1h_gt_3) | (stochrsi_k_1h < 30.0))
             # 1h down move, 4h still high, 1d downtrend
-            & ((rsi_3_1h > 3.0) | (stochrsi_k_4h < 50.0) | (roc_9_1d_gt_neg_20))
+            & ((rsi_3_1h_gt_3) | (stochrsi_k_4h_lt_50) | (roc_9_1d_gt_neg_20))
             # 1h down move, 4h high
-            & ((rsi_3_1h > 3.0) | (stochrsi_k_4h < 70.0))
+            & ((rsi_3_1h_gt_3) | (stochrsi_k_4h_lt_70))
             # 1h & 4h down move, 1d high
-            & ((rsi_3_1h > 5.0) | (rsi_3_4h > 5.0) | (stochrsi_k_1d < 60.0))
+            & ((rsi_3_1h_gt_5) | (rsi_3_4h_gt_5) | (stochrsi_k_1d < 60.0))
             # 1h & 4h down move, 4h still not low enough
-            & ((rsi_3_1h > 5.0) | (rsi_3_4h_gt_10) | (aroonu_14_4h < 20.0))
+            & ((rsi_3_1h_gt_5) | (rsi_3_4h_gt_10) | (aroonu_14_4h < 20.0))
             # 1h & 4h down move, 4h downtrend
-            & ((rsi_3_1h > 5.0) | (rsi_3_4h_gt_10) | (roc_9_4h > -20.0))
+            & ((rsi_3_1h_gt_5) | (rsi_3_4h_gt_10) | (roc_9_4h > -20.0))
             # 1h & 4h down move, 4h still not low enough
-            & ((rsi_3_1h > 5.0) | (rsi_3_4h_gt_15) | (aroonu_14_4h < 30.0))
+            & ((rsi_3_1h_gt_5) | (rsi_3_4h_gt_15) | (aroonu_14_4h < 30.0))
             # 1h & 4h down move, 4h still high
-            & ((rsi_3_1h > 5.0) | (rsi_3_4h > 35.0) | (rsi_14_4h < 40.0))
+            & ((rsi_3_1h_gt_5) | (rsi_3_4h_gt_35) | (rsi_14_4h < 40.0))
             # 1h down move, 1d high, 4h downtrend
-            & ((rsi_3_1h > 5.0) | (aroonu_14_1d < 90.0) | (roc_9_4h > -30.0))
+            & ((rsi_3_1h_gt_5) | (aroonu_14_1d_lt_90) | (roc_9_4h_gt_neg_30))
             # 1h down move, 4h downtrend
-            & ((rsi_3_1h > 5.0) | (roc_9_4h_gt_neg_20))
+            & ((rsi_3_1h_gt_5) | (roc_9_4h_gt_neg_20))
             # 1h, 1d downtrend
-            & ((rsi_3_1h > 5.0) | roc_9_1d_gt_neg_50)
+            & ((rsi_3_1h_gt_5) | roc_9_1d_gt_neg_50)
             # 1h & 4h down move, 4h still not low enough
             & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_10) | (rsi_14_4h < 30.0))
             # 1h & 4h down move, 4h still not low enough
@@ -19535,17 +19587,17 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 1h still not low enough
             & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_15) | (stochrsi_k_1h < 20.0))
             # 1h & 4h down move, 1d high
-            & ((rsi_3_1h_gt_10) | (rsi_3_4h > 25.0) | (aroonu_14_1d < 80.0))
+            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_25) | (aroonu_14_1d_lt_80))
             # 1h & 4h down move, 1d downtrend
-            & ((rsi_3_1h_gt_10) | (rsi_3_4h > 25.0) | (roc_9_1d > -40.0))
+            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_25) | (roc_9_1d_gt_neg_40))
             # 1h & 4h down move, 4h still high
-            & ((rsi_3_1h_gt_10) | (rsi_3_4h > 30.0) | (stochrsi_k_4h < 50.0))
+            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_30) | (stochrsi_k_4h_lt_50))
             # 1h & 4h down move, 1d overbought
-            & ((rsi_3_1h_gt_10) | (rsi_3_4h > 35.0) | (roc_9_1d < 70.0))
+            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_35) | (roc_9_1d < 70.0))
             # 1h & 1d down move, 1h still high
-            & ((rsi_3_1h_gt_10) | (rsi_3_1d > 10.0) | (stochrsi_k_1h < 40.0))
+            & ((rsi_3_1h_gt_10) | (rsi_3_1d_gt_10) | (stochrsi_k_1h < 40.0))
             # 1h & 1d down move, 4h high
-            & ((rsi_3_1h_gt_10) | (rsi_3_1d > 15.0) | (stochrsi_k_4h < 70.0))
+            & ((rsi_3_1h_gt_10) | (rsi_3_1d_gt_15) | (stochrsi_k_4h_lt_70))
             # 1h & 1d downtrend, 1d overbought
             & ((rsi_3_1h_gt_10) | (rsi_3_1d > 45.0) | (roc_9_1d < 10.0))
             # 1h down move, 1h downtrend, 1h still not low enough
@@ -19555,7 +19607,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h downtrend
             & ((rsi_3_1h_gt_10) | (cmf_20_1h > -0.30))
             # 1h down move, 1d high & overbought
-            & ((rsi_3_1h_gt_10) | (aroonu_14_1d < 70.0) | roc_9_1d_lt_50)
+            & ((rsi_3_1h_gt_10) | (aroonu_14_1d_lt_70) | roc_9_1d_lt_50)
             # 1h & 4h down move, 4h still not low enough
             & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_10) | (stochrsi_k_4h < 20.0))
             # 1h down move, 1d overbought
@@ -19565,131 +19617,131 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 15m high
             & ((rsi_3_1h_gt_15) | rsi_3_4h_gt_20 | (stochrsi_k_15m < 90.0))
             # 1h & 4h down move, 1d downtrend
-            & ((rsi_3_1h_gt_15) | rsi_3_4h_gt_20 | (roc_9_1d > -40.0))
+            & ((rsi_3_1h_gt_15) | rsi_3_4h_gt_20 | (roc_9_1d_gt_neg_40))
             # 1h & 4h down mov, 1d overbought
-            & ((rsi_3_1h_gt_15) | (rsi_3_4h > 30.0) | (roc_9_1d < 100.0))
+            & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_30) | (roc_9_1d < 100.0))
             # 1h down move, 1d downtrend, 1d high
             & ((rsi_3_1h_gt_15) | (cmf_20_1d > -0.30) | (stochrsi_k_1d < 80.0))
             # 1h down move, 1h still high
-            & ((rsi_3_1h_gt_15) | (aroonu_14_1h < 50.0))
+            & ((rsi_3_1h_gt_15) | (aroonu_14_1h_lt_50))
             # 1h down move, 1d high, 4h downtrend
-            & ((rsi_3_1h_gt_15) | (aroonu_14_1d < 70.0) | (roc_9_4h > -20.0))
+            & ((rsi_3_1h_gt_15) | (aroonu_14_1d_lt_70) | (roc_9_4h > -20.0))
             # 1h down move, 1d high, 1d downtrend
-            & ((rsi_3_1h_gt_15) | (aroonu_14_1d < 70.0) | (roc_9_1d > -20.0))
+            & ((rsi_3_1h_gt_15) | (aroonu_14_1d_lt_70) | (roc_9_1d > -20.0))
             # 1h down move, 1d high & overbought
-            & ((rsi_3_1h_gt_15) | (aroonu_14_1d < 90.0) | (roc_9_1d < 30.0))
+            & ((rsi_3_1h_gt_15) | (aroonu_14_1d_lt_90) | (roc_9_1d_lt_30))
             # 1h down move, 1h still high
             & ((rsi_3_1h_gt_15) | (stochrsi_k_1h < 40.0))
             # 1h & 4h down move, 1d high
-            & (rsi_3_1h_gt_20 | (rsi_3_4h > 25.0) | (aroonu_14_1d < 80.0))
+            & (rsi_3_1h_gt_20 | (rsi_3_4h_gt_25) | (aroonu_14_1d_lt_80))
             # 1h & 4h down move, 1h high
             & (rsi_3_1h_gt_20 | (rsi_3_4h > 45.0) | (aroonu_14_1h < 60.0))
             # 1h down move, 1h high, 1d overbought
             & (rsi_3_1h_gt_20 | aroonu_14_1h_lt_70 | (roc_9_1d < 100.0))
             # 1h down move, 4h still high
-            & (rsi_3_1h_gt_20 | (aroonu_14_4h < 40.0))
+            & (rsi_3_1h_gt_20 | (aroonu_14_4h_lt_40))
             # 1h down move, 4h still high, 1d downtrend
             & (rsi_3_1h_gt_20 | (stochrsi_k_4h < 40.0) | (roc_9_1d > -25.0))
             # 1h down move, 4h high & overbought
-            & (rsi_3_1h_gt_20 | (stochrsi_k_4h < 70.0) | (roc_9_4h < 10.0))
+            & (rsi_3_1h_gt_20 | (stochrsi_k_4h_lt_70) | (roc_9_4h_lt_10))
             # 1h down move, 1h & 1d high
-            & ((rsi_3_1h > 25.0) | aroonu_14_1h_lt_70 | (aroonu_14_1d < 90.0))
+            & ((rsi_3_1h_gt_25) | aroonu_14_1h_lt_70 | (aroonu_14_1d_lt_90))
             # 1h & 4h down move, 4h high
-            & ((rsi_3_1h > 25.0) | (rsi_3_4h > 50.0) | (aroonu_14_4h < 85.0))
+            & ((rsi_3_1h_gt_25) | (rsi_3_4h_gt_50) | (aroonu_14_4h < 85.0))
             # 1h & 4h down move, 1d overbought
-            & ((rsi_3_1h > 25.0) | (rsi_3_4h > 50.0) | (roc_9_1d_lt_100))
+            & ((rsi_3_1h_gt_25) | (rsi_3_4h_gt_50) | (roc_9_1d_lt_100))
             # 1h down move, 1h still not low enough, 4h still high
-            & ((rsi_3_1h > 25.0) | (stochrsi_k_1h < 30.0) | (stochrsi_k_4h < 50.0))
+            & ((rsi_3_1h_gt_25) | (stochrsi_k_1h < 30.0) | (stochrsi_k_4h_lt_50))
             # 1h down move, 4h high, 1d downtrend
-            & ((rsi_3_1h > 25.0) | (stochrsi_k_4h_lt_80) | (roc_9_1d > -40.0))
+            & ((rsi_3_1h_gt_25) | (stochrsi_k_4h_lt_80) | (roc_9_1d_gt_neg_40))
             # 1h down move, 1h still high, 1h downtrend
-            & ((rsi_3_1h > 25.0) | (aroonu_14_1h < 40.0) | (roc_9_1h > -50.0))
+            & ((rsi_3_1h_gt_25) | (aroonu_14_1h < 40.0) | (roc_9_1h > -50.0))
             # 1h down move, 4h high & overbought
-            & ((rsi_3_1h > 25.0) | (aroonu_14_4h < 90.0) | (roc_9_4h_lt_20))
+            & ((rsi_3_1h_gt_25) | (aroonu_14_4h_lt_90) | (roc_9_4h_lt_20))
             # 1h down move, 1h still high, 1d overbought
-            & ((rsi_3_1h > 25.0) | (stochrsi_k_1h_lt_50) | (roc_9_1d < 40.0))
+            & ((rsi_3_1h_gt_25) | (stochrsi_k_1h_lt_50) | (roc_9_1d_lt_40))
             # 1h down move, 4h high & overbought
-            & ((rsi_3_1h > 25.0) | (stochrsi_k_4h < 80.0) | (roc_9_4h_lt_20))
+            & ((rsi_3_1h_gt_25) | (stochrsi_k_4h < 80.0) | (roc_9_4h_lt_20))
             # 1h down move, 4h high, 1d overbought
-            & ((rsi_3_1h > 25.0) | (stochrsi_k_4h_lt_80) | (roc_9_1d < 70.0))
+            & ((rsi_3_1h_gt_25) | (stochrsi_k_4h_lt_80) | (roc_9_1d < 70.0))
             # 1h & 4h down move, 1h high
-            & ((rsi_3_1h > 30.0) | (rsi_3_4h > 30.0) | (stochrsi_k_1h < 60.0))
+            & ((rsi_3_1h_gt_30) | (rsi_3_4h_gt_30) | (stochrsi_k_1h < 60.0))
             # 1h & 4h down move, 4h still high
-            & ((rsi_3_1h > 30.0) | (rsi_3_4h > 30.0) | (aroonu_14_4h < 50.0))
+            & ((rsi_3_1h_gt_30) | (rsi_3_4h_gt_30) | (aroonu_14_4h_lt_50))
             # 1h & 4h down move, 1h high
-            & ((rsi_3_1h > 30.0) | (rsi_3_4h > 50.0) | aroonu_14_1h_lt_70)
+            & ((rsi_3_1h_gt_30) | (rsi_3_4h_gt_50) | aroonu_14_1h_lt_70)
             # 1h & 4h down move, 4h high
-            & ((rsi_3_1h > 30.0) | (rsi_3_4h > 50.0) | (aroonu_14_4h < 90.0))
+            & ((rsi_3_1h_gt_30) | (rsi_3_4h_gt_50) | (aroonu_14_4h_lt_90))
             # 1h down move, 1h high, 4h overbought
-            & ((rsi_3_1h > 30.0) | aroonu_14_1h_lt_70 | (roc_9_4h < 30.0))
+            & ((rsi_3_1h_gt_30) | aroonu_14_1h_lt_70 | (roc_9_4h_lt_30))
             # 1h down move, 1h high
-            & ((rsi_3_1h > 30.0) | aroonu_14_1h_lt_80)
+            & ((rsi_3_1h_gt_30) | aroonu_14_1h_lt_80)
             # 1h down move, 4h high & overbought
-            & ((rsi_3_1h > 30.0) | (aroonu_14_4h < 90.0) | (roc_9_4h_lt_20))
+            & ((rsi_3_1h_gt_30) | (aroonu_14_4h_lt_90) | (roc_9_4h_lt_20))
             # 1h down move, 1d high & overbought
-            & ((rsi_3_1h > 30.0) | (aroonu_14_1d < 80.0) | (roc_9_1d < 200.0))
+            & ((rsi_3_1h_gt_30) | (aroonu_14_1d_lt_80) | (roc_9_1d < 200.0))
             # 1h down move, 1d high, 4h downtrend
-            & ((rsi_3_1h > 30.0) | (aroonu_14_1d < 90.0) | (roc_9_4h > -40.0))
+            & ((rsi_3_1h_gt_30) | (aroonu_14_1d_lt_90) | (roc_9_4h > -40.0))
             # 1h down move, 1d high, 4h overbought
-            & ((rsi_3_1h > 30.0) | aroonu_14_1d_lt_100 | (roc_9_4h < 80.0))
+            & ((rsi_3_1h_gt_30) | aroonu_14_1d_lt_100 | (roc_9_4h < 80.0))
             # 1h down move, 1h & 4h still high
-            & ((rsi_3_1h > 30.0) | (stochrsi_k_1h < 40.0) | (stochrsi_k_4h < 50.0))
+            & ((rsi_3_1h_gt_30) | (stochrsi_k_1h < 40.0) | (stochrsi_k_4h_lt_50))
             # 1h down move, 1h highm 1d overbought
-            & ((rsi_3_1h > 30.0) | (stochrsi_k_1h < 60.0) | (roc_9_1d < 30.0))
+            & ((rsi_3_1h_gt_30) | (stochrsi_k_1h < 60.0) | (roc_9_1d_lt_30))
             # 1h down move, 4h overbought
-            & ((rsi_3_1h > 30.0) | (roc_9_4h < 50.0))
+            & ((rsi_3_1h_gt_30) | (roc_9_4h < 50.0))
             # 4h down move, 1d downtrend
-            & ((rsi_3_4h > 30.0) | roc_9_1d_gt_neg_50)
+            & ((rsi_3_4h_gt_30) | roc_9_1d_gt_neg_50)
             # 1h down move, 1h high, 4h overbought
-            & ((rsi_3_1h > 35.0) | aroonu_14_1h_lt_70 | (roc_9_4h < 40.0))
+            & ((rsi_3_1h_gt_35) | aroonu_14_1h_lt_70 | (roc_9_4h_lt_40))
             # 1h down move, 1h high, 1d downtrend
-            & ((rsi_3_1h > 35.0) | aroonu_14_1h_lt_70 | (roc_9_1d > -25.0))
+            & ((rsi_3_1h_gt_35) | aroonu_14_1h_lt_70 | (roc_9_1d > -25.0))
             # 1h down move, 4h high & overbought
-            & ((rsi_3_1h > 35.0) | (aroonu_14_4h < 85.0) | (roc_9_4h < 100.0))
+            & ((rsi_3_1h_gt_35) | (aroonu_14_4h < 85.0) | (roc_9_4h < 100.0))
             # 1h down move, 4h high & overbought
-            & ((rsi_3_1h > 35.0) | aroonu_14_4h_lt_100 | (roc_9_4h < 20.0))
+            & ((rsi_3_1h_gt_35) | aroonu_14_4h_lt_100 | (roc_9_4h < 20.0))
             # 1h down move, 4h high & overbought
-            & ((rsi_3_1h > 35.0) | (stochrsi_k_4h < 70.0) | (roc_9_4h < 10.0))
+            & ((rsi_3_1h_gt_35) | (stochrsi_k_4h_lt_70) | (roc_9_4h_lt_10))
             # 1h down move, 1d high & overbought
-            & ((rsi_3_1h > 35.0) | aroonu_14_1d_lt_100 | (roc_9_1d < 100.0))
+            & ((rsi_3_1h_gt_35) | aroonu_14_1d_lt_100 | (roc_9_1d < 100.0))
             # 1h down move, 1h still high, 1d overbought
-            & ((rsi_3_1h > 35.0) | (stochrsi_k_1h_lt_50) | (roc_9_1d < 200.0))
+            & ((rsi_3_1h_gt_35) | (stochrsi_k_1h_lt_50) | (roc_9_1d < 200.0))
             # 1h down move, 1d high & overbought
-            & ((rsi_3_1h > 40.0) | (rsi_14_1d < 80.0) | (roc_9_1d < 150.0))
+            & ((rsi_3_1h_gt_40) | (rsi_14_1d < 80.0) | (roc_9_1d < 150.0))
             # 1h down move, 15m high, 1h high
-            & ((rsi_3_1h > 40.0) | (aroonu_14_15m < 60.0) | aroonu_14_1h_lt_70)
+            & ((rsi_3_1h_gt_40) | (aroonu_14_15m < 60.0) | aroonu_14_1h_lt_70)
             # 1h down move, 1h high, 1d overbought
-            & ((rsi_3_1h > 40.0) | aroonu_14_1h_lt_80 | (roc_9_1d < 80.0))
+            & ((rsi_3_1h_gt_40) | aroonu_14_1h_lt_80 | (roc_9_1d_lt_80))
             # 1h down move, 1h high, 4h overbought
-            & ((rsi_3_1h > 40.0) | (stochrsi_k_1h < 80.0) | (roc_9_4h_lt_20))
+            & ((rsi_3_1h_gt_40) | (stochrsi_k_1h < 80.0) | (roc_9_4h_lt_20))
             # 1h down move, 1h & 4h overbought
-            & ((rsi_3_1h > 40.0) | (roc_9_1h < 10.0) | (roc_9_4h < 10.0))
+            & ((rsi_3_1h_gt_40) | (roc_9_1h_lt_10) | (roc_9_4h_lt_10))
             # 1h & 4h down move, 1d overbought
-            & ((rsi_3_1h > 45.0) | (rsi_3_4h > 65.0) | (roc_9_1d < 200.0))
+            & ((rsi_3_1h_gt_45) | (rsi_3_4h > 65.0) | (roc_9_1d < 200.0))
             # 1h down move, 1h high & overbought
-            & ((rsi_3_1h > 45.0) | aroonu_14_1h_lt_70 | (roc_9_1h < 10.0))
+            & ((rsi_3_1h_gt_45) | aroonu_14_1h_lt_70 | (roc_9_1h_lt_10))
             # 1h down move, 4h high & overbought
-            & ((rsi_3_1h > 45.0) | aroonu_14_4h_lt_100 | (roc_9_4h < 40.0))
+            & ((rsi_3_1h_gt_45) | aroonu_14_4h_lt_100 | (roc_9_4h_lt_40))
             # 1h down move, 1h high, 1d downtrend
-            & ((rsi_3_1h > 50.0) | (aroonu_14_1h < 90.0) | (roc_9_1d_gt_neg_30))
+            & ((rsi_3_1h_gt_50) | (aroonu_14_1h_lt_90) | (roc_9_1d_gt_neg_30))
             # 1h down move, 4h high & overbought
-            & ((rsi_3_1h > 50.0) | aroonu_14_4h_lt_100 | (roc_9_4h < 100.0))
+            & ((rsi_3_1h_gt_50) | aroonu_14_4h_lt_100 | (roc_9_4h < 100.0))
             # 1h down move, 4h high, 1d downtrend
-            & ((rsi_3_1h > 50.0) | (stochrsi_k_4h < 60.0) | (roc_9_1d > -60.0))
+            & ((rsi_3_1h_gt_50) | (stochrsi_k_4h < 60.0) | (roc_9_1d > -60.0))
             # 1h down move, 15m high, 1h high
             & ((rsi_3_1h > 55.0) | (aroonu_14_15m < 60.0) | (stochrsi_k_1h_lt_80))
             # 1h down move, 1h high & overbought
-            & ((rsi_3_1h > 55.0) | (aroonu_14_1h < 90.0) | (roc_9_1h < 10.0))
+            & ((rsi_3_1h > 55.0) | (aroonu_14_1h_lt_90) | (roc_9_1h_lt_10))
             # 4h down move, 1h still not low enough, 4h downtrend
-            & ((rsi_3_4h > 3.0) | (stochrsi_k_1h < 20.0) | (roc_9_4h > -30.0))
+            & ((rsi_3_4h > 3.0) | (stochrsi_k_1h < 20.0) | (roc_9_4h_gt_neg_30))
             # 4h down move, 1h & 4h downtrend
-            & ((rsi_3_4h > 3.0) | (roc_9_1h > -30.0) | (roc_9_4h > -30.0))
+            & ((rsi_3_4h > 3.0) | (roc_9_1h > -30.0) | (roc_9_4h_gt_neg_30))
             # 4h down move, 1d high, 4h downtrend
-            & ((rsi_3_4h > 5.0) | (aroonu_14_1d < 80.0) | (roc_9_4h > -10.0))
+            & ((rsi_3_4h_gt_5) | (aroonu_14_1d_lt_80) | (roc_9_4h > -10.0))
             # 4h down move, 1h still high
-            & ((rsi_3_4h > 5.0) | (stochrsi_k_1h_lt_50))
+            & ((rsi_3_4h_gt_5) | (stochrsi_k_1h_lt_50))
             # 4h down move, 4h & 1d downtrend
-            & ((rsi_3_4h > 5.0) | (roc_9_4h > -15.0) | (roc_9_1d_gt_neg_20))
+            & ((rsi_3_4h_gt_5) | (roc_9_4h > -15.0) | (roc_9_1d_gt_neg_20))
             # 4h & 1d down move, 1d overbought
             & ((rsi_3_4h_gt_10) | (rsi_3_1d > 45.0) | (roc_9_1d < 10.0))
             # 4h down move, 1d still high, 1d downtrend
@@ -19705,59 +19757,59 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 4h still high, 1d downtrend
             & ((rsi_3_4h_gt_10) | (stochrsi_k_4h < 40.0) | (roc_9_1d > -20.0))
             # 4h down move, 4h downtrend, 1d overbought
-            & ((rsi_3_4h_gt_10) | (roc_9_4h > -30.0) | (roc_9_1d < 40.0))
+            & ((rsi_3_4h_gt_10) | (roc_9_4h_gt_neg_30) | (roc_9_1d_lt_40))
             # 4h & 1d down move, 1d high
-            & ((rsi_3_4h_gt_15) | (rsi_3_1d > 20.0) | (aroonu_14_1d < 60.0))
+            & ((rsi_3_4h_gt_15) | (rsi_3_1d_gt_20) | (aroonu_14_1d < 60.0))
             # 4h & 1d down move, 1d high
-            & ((rsi_3_4h_gt_15) | (rsi_3_1d > 40.0) | (aroonu_14_1d < 80.0))
+            & ((rsi_3_4h_gt_15) | (rsi_3_1d > 40.0) | (aroonu_14_1d_lt_80))
             # 4h down move, 1h high
-            & ((rsi_3_4h_gt_15) | (aroonu_14_1h < 50.0))
+            & ((rsi_3_4h_gt_15) | (aroonu_14_1h_lt_50))
             # 4h down move, 1h still high, 1d downtrend
             & ((rsi_3_4h_gt_15) | (stochrsi_k_1h < 50.0) | (roc_9_1d > -30.0))
             # 4h down move, 1d high & overbought
-            & ((rsi_3_4h_gt_15) | (stochrsi_k_1d < 90.0) | (roc_9_1d < 20.0))
+            & ((rsi_3_4h_gt_15) | (stochrsi_k_1d_lt_90) | (roc_9_1d_lt_20))
             # 4h down move, 15m still high
             & (rsi_3_4h_gt_20 | (aroonu_14_15m < 45.0))
             # 4h down move, 1h still not low enough, 1d downtrend
             & (rsi_3_4h_gt_20 | (aroonu_14_1h < 30.0) | (roc_9_1d_gt_neg_20))
             # 4h down move, 4h still high, 1d high
-            & (rsi_3_4h_gt_20 | (aroonu_14_4h < 50.0) | aroonu_14_1d_lt_100)
+            & (rsi_3_4h_gt_20 | (aroonu_14_4h_lt_50) | aroonu_14_1d_lt_100)
             # 4h down move, 1d high & overbought
-            & (rsi_3_4h_gt_20 | (aroonu_14_1d < 80.0) | (roc_9_1d < 80.0))
+            & (rsi_3_4h_gt_20 | (aroonu_14_1d_lt_80) | (roc_9_1d_lt_80))
             # 4h down move, 15m still high, 4h high
-            & ((rsi_3_4h > 25.0) | (aroonu_14_15m < 40.0) | aroonu_14_4h_lt_70)
+            & ((rsi_3_4h_gt_25) | (aroonu_14_15m < 40.0) | aroonu_14_4h_lt_70)
             # 4h down move, 1h & 4h still high
-            & ((rsi_3_4h > 25.0) | (stochrsi_k_1h < 40.0) | (stochrsi_k_4h < 40.0))
+            & ((rsi_3_4h_gt_25) | (stochrsi_k_1h < 40.0) | (stochrsi_k_4h < 40.0))
             # 4h dowqn move, 4h still high, 1d downtrend
-            & ((rsi_3_4h > 25.0) | (stochrsi_k_4h < 30.0) | (roc_9_1d_gt_neg_30))
+            & ((rsi_3_4h_gt_25) | (stochrsi_k_4h < 30.0) | (roc_9_1d_gt_neg_30))
             # 4h down move, 4h high, 1d overbought
-            & ((rsi_3_4h > 30.0) | aroonu_14_4h_lt_80 | roc_9_1d_lt_50)
+            & ((rsi_3_4h_gt_30) | aroonu_14_4h_lt_80 | roc_9_1d_lt_50)
             # 4h down move, 1h high, 4h downtrend
-            & ((rsi_3_4h > 30.0) | aroonu_14_1h_lt_70 | (roc_9_4h > -10.0))
+            & ((rsi_3_4h_gt_30) | aroonu_14_1h_lt_70 | (roc_9_4h > -10.0))
             # 4h down move, 4h & 1d downtrend
-            & ((rsi_3_4h > 40.0) | aroonu_14_4h_lt_70 | aroonu_14_1d_lt_100)
+            & ((rsi_3_4h_gt_40) | aroonu_14_4h_lt_70 | aroonu_14_1d_lt_100)
             # 4h down move, 1d high & overbought
-            & ((rsi_3_4h > 40.0) | (aroonu_14_1d < 90.0) | (roc_9_1d < 80.0))
+            & ((rsi_3_4h_gt_40) | (aroonu_14_1d_lt_90) | (roc_9_1d_lt_80))
             # 4h down move, 1h high, 1d downtrend
-            & ((rsi_3_4h > 40.0) | (stochrsi_k_1h < 80.0) | (roc_9_1d_gt_neg_20))
+            & ((rsi_3_4h_gt_40) | (stochrsi_k_1h < 80.0) | (roc_9_1d_gt_neg_20))
             # 4h down move, 4h & 1d overbought
-            & ((rsi_3_4h > 40.0) | (roc_9_4h < 10.0) | roc_9_1d_lt_50)
+            & ((rsi_3_4h_gt_40) | (roc_9_4h_lt_10) | roc_9_1d_lt_50)
             # 4h down move, 4h still high, 1d downtrend
-            & ((rsi_3_4h > 50.0) | (rsi_14_4h < 40.0) | (roc_9_1d_gt_neg_30))
+            & ((rsi_3_4h_gt_50) | (rsi_14_4h < 40.0) | (roc_9_1d_gt_neg_30))
             # 4h down move, 4h high, 1d overbought
-            & ((rsi_3_4h > 50.0) | aroonu_14_4h_lt_70 | (roc_9_1d < 40.0))
+            & ((rsi_3_4h_gt_50) | aroonu_14_4h_lt_70 | (roc_9_1d_lt_40))
             # 4h down move, 4h still high, 1d downtrend
-            & ((rsi_3_4h > 50.0) | (stochrsi_k_4h < 50.0) | (roc_9_1d_gt_neg_30))
+            & ((rsi_3_4h_gt_50) | (stochrsi_k_4h_lt_50) | (roc_9_1d_gt_neg_30))
             # 4h down move, 1h high, 1d overbought
-            & ((rsi_3_4h > 60.0) | (stochrsi_k_1h < 90.0) | (roc_9_1d < 30.0))
+            & ((rsi_3_4h > 60.0) | (stochrsi_k_1h < 90.0) | (roc_9_1d_lt_30))
             # 4h down move, 4h high & overbought
-            & ((rsi_3_4h > 60.0) | (stochrsi_k_4h < 70.0) | (roc_9_4h_lt_20))
+            & ((rsi_3_4h > 60.0) | (stochrsi_k_4h_lt_70) | (roc_9_4h_lt_20))
             # 1d down move, 1h high & overbought
-            & ((rsi_3_1d > 35.0) | (stochrsi_k_1h < 90.0) | (roc_9_1h < 10.0))
+            & ((rsi_3_1d > 35.0) | (stochrsi_k_1h < 90.0) | (roc_9_1h_lt_10))
             # 1d down move, 1h high & overbought
-            & ((rsi_3_1d > 40.0) | (aroonu_14_1d < 70.0) | (roc_9_1d < 80.0))
+            & ((rsi_3_1d > 40.0) | (aroonu_14_1d_lt_70) | (roc_9_1d_lt_80))
             # 1d down move, 4h high & overbought
-            & ((rsi_3_1d > 45.0) | aroonu_14_4h_lt_80 | (roc_9_4h < 30.0))
+            & ((rsi_3_1d > 45.0) | aroonu_14_4h_lt_80 | (roc_9_4h_lt_30))
             # 1h downtrend, 1h high
             & ((cmf_20_1h > -0.20) | aroonu_14_1h_lt_80)
             # 4h & 1d downtrend, 1d high
@@ -19765,43 +19817,43 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1d downtrend, 1d high & overbought
             & ((cmf_20_1d > -0.30) | (aroonu_14_1d < 85.0) | (roc_9_1d_lt_100))
             # 1d downtrend, 1d high & overbought
-            & ((cmf_20_1d > -0.40) | (aroonu_14_1d < 85.0) | (roc_9_1d < 20.0))
+            & ((cmf_20_1d > -0.40) | (aroonu_14_1d < 85.0) | (roc_9_1d_lt_20))
             # 15m still high, 1h overbought
             & ((aroonu_14_15m < 40.0) | (roc_9_1h < 40.0))
             # 15m still high, 4h overbought
             & ((aroonu_14_15m < 40.0) | (roc_9_4h < 80.0))
             # 15m still high, 1h high
-            & ((aroonu_14_15m < 50.0) | (aroonu_14_1h < 85.0))
+            & ((aroonu_14_15m_lt_50) | (aroonu_14_1h < 85.0))
             # 15m still high, 4h high & overbought
-            & ((aroonu_14_15m < 50.0) | aroonu_14_4h_lt_70 | (roc_9_4h < 30.0))
+            & ((aroonu_14_15m_lt_50) | aroonu_14_4h_lt_70 | (roc_9_4h_lt_30))
             # 15m still high, 4h downtrend, 1d overbought
-            & ((aroonu_14_15m < 50.0) | (roc_9_4h_gt_neg_20) | (roc_9_1d < 40.0))
+            & ((aroonu_14_15m_lt_50) | (roc_9_4h_gt_neg_20) | (roc_9_1d_lt_40))
             # 1h still high, 4h & 1d downtrend
-            & ((aroonu_14_1h < 40.0) | (roc_9_4h_gt_neg_20) | (roc_9_1d > -40.0))
+            & ((aroonu_14_1h < 40.0) | (roc_9_4h_gt_neg_20) | (roc_9_1d_gt_neg_40))
             # 1h high, 4h high, 1h overbought
             & (aroonu_14_1h_lt_70 | aroonu_14_4h_lt_100 | (roc_9_1h < 20.0))
             # 1h & 4h high, 4h overbought
-            & (aroonu_14_1h_lt_70 | aroonu_14_4h_lt_100 | (roc_9_4h < 40.0))
+            & (aroonu_14_1h_lt_70 | aroonu_14_4h_lt_100 | (roc_9_4h_lt_40))
             # 1h & 1d high, 1h overbought
-            & (aroonu_14_1h_lt_70 | (aroonu_14_1d < 70.0) | (roc_9_1h < 20.0))
+            & (aroonu_14_1h_lt_70 | (aroonu_14_1d_lt_70) | (roc_9_1h < 20.0))
             # 1h high, 1h & 4h overbought
-            & (aroonu_14_1h_lt_70 | (roc_9_1h < 10.0) | (roc_9_4h < 40.0))
+            & (aroonu_14_1h_lt_70 | (roc_9_1h_lt_10) | (roc_9_4h_lt_40))
             # 1h high, 1d downtrend
-            & (aroonu_14_1h_lt_80 | (roc_9_1d > -40.0))
+            & (aroonu_14_1h_lt_80 | (roc_9_1d_gt_neg_40))
             # 4h still not low enough, 4h & 1d downtrend
             & ((aroonu_14_4h < 30.0) | (roc_9_4h_gt_neg_20) | (roc_9_1d > -25.0))
             # 4h still high, 1d high, 4h downtrend
-            & ((aroonu_14_4h < 50.0) | aroonu_14_1d_lt_100 | (roc_9_4h > -30.0))
+            & ((aroonu_14_4h_lt_50) | aroonu_14_1d_lt_100 | (roc_9_4h_gt_neg_30))
             # 4h high, 1h & 1d downtrend
             & (aroonu_14_4h_lt_70 | (roc_9_1h > -20.0) | (roc_9_1d_gt_neg_20))
             # 4h & 1d high, 1d overbought
             & (aroonu_14_4h_lt_80 | aroonu_14_1d_lt_100 | roc_9_1d_lt_50)
             # 4h & 1d high, 4h overbought
-            & (aroonu_14_4h_lt_100 | aroonu_14_1d_lt_100 | (roc_9_4h < 10.0))
+            & (aroonu_14_4h_lt_100 | aroonu_14_1d_lt_100 | (roc_9_4h_lt_10))
             # 4h high, 1h & 4h overbought
-            & (aroonu_14_4h_lt_100 | (roc_9_1h < 10.0) | (roc_9_4h < 40.0))
+            & (aroonu_14_4h_lt_100 | (roc_9_1h_lt_10) | (roc_9_4h_lt_40))
             # 1d high, 4h & 1d downtrend
-            & ((aroonu_14_1d < 80.0) | (roc_9_4h_gt_neg_20) | (roc_9_1d_gt_neg_20))
+            & ((aroonu_14_1d_lt_80) | (roc_9_4h_gt_neg_20) | (roc_9_1d_gt_neg_20))
             # 1d high, 1h & 4h downtrend
             & ((aroonu_14_1d < 85.0) | (roc_9_1h > -30.0) | (roc_9_4h > -50.0))
             # 1d high, 1h & 1d overbought
@@ -19809,29 +19861,29 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1d high, 1h & 4h down move
             & (aroonu_14_1d_lt_100 | (roc_9_1h < 25.0) | (roc_9_4h < 60.0))
             # 1d high, 4h & 1d overbought
-            & (aroonu_14_1d_lt_100 | (roc_9_4h < 20.0) | (roc_9_1d < 30.0))
+            & (aroonu_14_1d_lt_100 | (roc_9_4h < 20.0) | (roc_9_1d_lt_30))
             # 1h high, 4h & 1d overbought
             & ((stochrsi_k_1h < 90.0) | (roc_9_4h_lt_20) | (roc_9_1d_lt_100))
             # 4h still high, 4h & 1d downtrend
-            & ((stochrsi_k_4h < 40.0) | (roc_9_4h_gt_neg_20) | (roc_9_1d > -40.0))
+            & ((stochrsi_k_4h < 40.0) | (roc_9_4h_gt_neg_20) | (roc_9_1d_gt_neg_40))
             # 4h high, 1h & 1d downtrend
-            & ((stochrsi_k_4h < 70.0) | (roc_9_1h > -20.0) | (roc_9_1d_gt_neg_20))
+            & ((stochrsi_k_4h_lt_70) | (roc_9_1h > -20.0) | (roc_9_1d_gt_neg_20))
             # 4h high, 4h & 1d overbought
-            & ((stochrsi_k_4h < 70.0) | (roc_9_4h_lt_20) | (roc_9_1d < 30.0))
+            & ((stochrsi_k_4h_lt_70) | (roc_9_4h_lt_20) | (roc_9_1d_lt_30))
             # 4h high, 1h overbought, 1d downtrend
             & ((stochrsi_k_4h_lt_80) | (roc_9_1h < 40.0) | (roc_9_1d > -70.0))
             # 4h high, 4h overbought
-            & ((stochrsi_k_4h_lt_80) | (roc_9_4h < 10.0))
+            & ((stochrsi_k_4h_lt_80) | (roc_9_4h_lt_10))
             # 4h high, 1h & 4h overbought
             & ((stochrsi_k_4h_lt_90) | (roc_9_1h < 20.0) | (roc_9_4h < 50.0))
             # 1d high, 4h & 1d overbought
-            & ((stochrsi_k_1d < 90.0) | (roc_9_4h < 40.0) | (roc_9_1d_lt_100))
+            & ((stochrsi_k_1d_lt_90) | (roc_9_4h_lt_40) | (roc_9_1d_lt_100))
             # 1h & 4h overbought
             & ((roc_9_1h < 30.0) | (roc_9_4h < 80.0))
             # 1d green with top wick, 4h high
             & ((change_pct_1d < 30.0) | (top_wick_pct_1d < 20.0) | aroonu_14_4h_lt_80)
             # 1d top wick, 4h down move, 1d overbought
-            & ((top_wick_pct_1d < 50.0) | (rsi_3_4h > 35.0) | (roc_9_1d < 60.0))
+            & ((top_wick_pct_1d < 50.0) | (rsi_3_4h_gt_35) | (roc_9_1d < 60.0))
             # drop in last 20 days, 4h high
             & ((close > (high_max_20_1d * 0.10)) | (stochrsi_k_4h_lt_90))
             # drop in last 20 days, 1h high, 1d downtrend
@@ -19864,253 +19916,253 @@ class NostalgiaForInfinityX7(IStrategy):
           # 5m & 4h down move, 1d downtrend
           long_entry_logic.append((rsi_3 > 5.0) | (rsi_3_4h_gt_10) | (roc_9_1d > -20.0))
           # 5m & 4h down move, 15m still high
-          long_entry_logic.append((rsi_3 > 5.0) | (rsi_3_4h > 25.0) | (stochrsi_k_15m < 50.0))
+          long_entry_logic.append((rsi_3 > 5.0) | (rsi_3_4h_gt_25) | (stochrsi_k_15m < 50.0))
           # 5 & 15m down move, 1h high
           long_entry_logic.append((rsi_3 > 10.0) | (rsi_3_15m > 40.0) | (stochrsi_k_1h < 90.0))
           # 5m down move, 1h & 4h high
-          long_entry_logic.append((rsi_3 > 10.0) | (aroonu_14_1h < 85.0) | (aroonu_14_4h < 90.0))
+          long_entry_logic.append((rsi_3 > 10.0) | (aroonu_14_1h < 85.0) | (aroonu_14_4h_lt_90))
           # 15m & 1h down move, 4h still not low enough
-          long_entry_logic.append(rsi_3_15m_gt_3 | (rsi_3_1h > 5.0) | (stochrsi_k_4h < 30.0))
+          long_entry_logic.append(rsi_3_15m_gt_3 | (rsi_3_1h_gt_5) | (stochrsi_k_4h < 30.0))
           # 15m & 1h down move, 1d still high
-          long_entry_logic.append(rsi_3_15m_gt_3 | (rsi_3_1h > 5.0) | (aroonu_14_1d < 40.0))
+          long_entry_logic.append(rsi_3_15m_gt_3 | (rsi_3_1h_gt_5) | (aroonu_14_1d < 40.0))
           # 15m & 1h down move, 4h still high
           long_entry_logic.append(rsi_3_15m_gt_3 | (rsi_3_1h_gt_15) | (rsi_14_4h < 40.0))
           # 15m & 4h down move, 4h high
-          long_entry_logic.append(rsi_3_15m_gt_3 | (rsi_3_1h > 30.0) | (aroonu_14_4h < 75.0))
+          long_entry_logic.append(rsi_3_15m_gt_3 | (rsi_3_1h_gt_30) | (aroonu_14_4h < 75.0))
           # 15m & 1h down move, 1h still not low enough
-          long_entry_logic.append(rsi_3_15m_gt_3 | (rsi_3_1h > 35.0) | (stochrsi_k_1h < 30.0))
+          long_entry_logic.append(rsi_3_15m_gt_3 | (rsi_3_1h_gt_35) | (stochrsi_k_1h < 30.0))
           # 15m & 4h down move, 4h still not low enough
           long_entry_logic.append(rsi_3_15m_gt_3 | (rsi_3_4h_gt_10) | (stochrsi_k_4h < 20.0))
           # 15m & 4h down move, 1d downtrend
           long_entry_logic.append(rsi_3_15m_gt_3 | (rsi_3_4h_gt_10) | (roc_9_1d > -20.0))
           # 15m & 4h down move, 4h still not low enough
-          long_entry_logic.append(rsi_3_15m_gt_3 | (rsi_3_4h > 25.0) | (aroonu_14_4h < 30.0))
+          long_entry_logic.append(rsi_3_15m_gt_3 | (rsi_3_4h_gt_25) | (aroonu_14_4h < 30.0))
           # 15m & 4h down move, 4h still not low enough
-          long_entry_logic.append(rsi_3_15m_gt_3 | (rsi_3_4h > 25.0) | (stochrsi_k_4h < 30.0))
+          long_entry_logic.append(rsi_3_15m_gt_3 | (rsi_3_4h_gt_25) | (stochrsi_k_4h < 30.0))
           # 15m down move, 15m still not low enough, 1h high
           long_entry_logic.append(rsi_3_15m_gt_3 | (aroonu_14_15m < 20.0) | (stochrsi_k_1h < 60.0))
           # 15m down move, 15m still not low enough, 4h high
-          long_entry_logic.append(rsi_3_15m_gt_3 | (aroonu_14_15m < 30.0) | (stochrsi_k_4h < 70.0))
+          long_entry_logic.append(rsi_3_15m_gt_3 | (aroonu_14_15m < 30.0) | (stochrsi_k_4h_lt_70))
           # 15m down move, 4h high, 1d overbought
-          long_entry_logic.append(rsi_3_15m_gt_3 | aroonu_14_4h_lt_70 | (roc_9_1d < 30.0))
+          long_entry_logic.append(rsi_3_15m_gt_3 | aroonu_14_4h_lt_70 | (roc_9_1d_lt_30))
           # 15m & 1h & 1d down move
-          long_entry_logic.append((rsi_3_15m > 5.0) | (rsi_3_1h_gt_10) | (rsi_3_1d > 20.0))
+          long_entry_logic.append((rsi_3_15m_gt_5) | (rsi_3_1h_gt_10) | (rsi_3_1d_gt_20))
           # 15m down move, 1h still not low enough, 1d high
-          long_entry_logic.append((rsi_3_15m > 5.0) | (stochrsi_k_1h < 30.0) | (aroonu_14_1d < 90.0))
+          long_entry_logic.append((rsi_3_15m_gt_5) | (stochrsi_k_1h < 30.0) | (aroonu_14_1d_lt_90))
           # 15m & 1h down move, 1h still not low enough
-          long_entry_logic.append((rsi_3_15m > 5.0) | (rsi_3_1h > 30.0) | (stochrsi_k_1h < 30.0))
+          long_entry_logic.append((rsi_3_15m_gt_5) | (rsi_3_1h_gt_30) | (stochrsi_k_1h < 30.0))
           # 15m & 1h down move, 4h high
-          long_entry_logic.append((rsi_3_15m > 5.0) | (rsi_3_1h > 30.0) | (stochrsi_k_4h_lt_80))
+          long_entry_logic.append((rsi_3_15m_gt_5) | (rsi_3_1h_gt_30) | (stochrsi_k_4h_lt_80))
           # 15m & 1h down move, 4h high
-          long_entry_logic.append((rsi_3_15m > 5.0) | (rsi_3_1h > 40.0) | (stochrsi_k_4h_lt_80))
+          long_entry_logic.append((rsi_3_15m_gt_5) | (rsi_3_1h_gt_40) | (stochrsi_k_4h_lt_80))
           # 15m & 1h down move, 1h high
-          long_entry_logic.append((rsi_3_15m > 5.0) | (rsi_3_1h > 50.0) | (stochrsi_k_1h_lt_70))
+          long_entry_logic.append((rsi_3_15m_gt_5) | (rsi_3_1h_gt_50) | (stochrsi_k_1h_lt_70))
           # 15m & 1h down move, 4h high
-          long_entry_logic.append((rsi_3_15m > 5.0) | (rsi_3_1h > 50.0) | (stochrsi_k_4h_lt_90))
+          long_entry_logic.append((rsi_3_15m_gt_5) | (rsi_3_1h_gt_50) | (stochrsi_k_4h_lt_90))
           # 15m & 4h down move, 1d still high
-          long_entry_logic.append((rsi_3_15m > 5.0) | (rsi_3_4h > 5.0) | (stochrsi_k_1d < 40.0))
+          long_entry_logic.append((rsi_3_15m_gt_5) | (rsi_3_4h_gt_5) | (stochrsi_k_1d < 40.0))
           # 15m & 4h down move, 4h still high
-          long_entry_logic.append((rsi_3_15m > 5.0) | (rsi_3_4h > 40.0) | (stochrsi_k_4h < 50.0))
+          long_entry_logic.append((rsi_3_15m_gt_5) | (rsi_3_4h_gt_40) | (stochrsi_k_4h_lt_50))
           # 15m & 1d down move
-          long_entry_logic.append((rsi_3_15m > 5.0) | (rsi_3_1d > 5.0))
+          long_entry_logic.append((rsi_3_15m_gt_5) | (rsi_3_1d > 5.0))
           # 15m & 1d down move, 4h still not low enough
-          long_entry_logic.append((rsi_3_15m > 5.0) | (rsi_3_1d > 30.0) | (stochrsi_k_4h < 30.0))
+          long_entry_logic.append((rsi_3_15m_gt_5) | (rsi_3_1d > 30.0) | (stochrsi_k_4h < 30.0))
           # 15m down move, 1h still high, 4h high
-          long_entry_logic.append((rsi_3_15m > 5.0) | (aroonu_14_1h < 50.0) | (stochrsi_k_4h_lt_90))
+          long_entry_logic.append((rsi_3_15m_gt_5) | (aroonu_14_1h_lt_50) | (stochrsi_k_4h_lt_90))
           # 15m down move, 1h high & overbought
-          long_entry_logic.append((rsi_3_15m > 5.0) | aroonu_14_1h_lt_80 | (roc_9_1h < 10.0))
+          long_entry_logic.append((rsi_3_15m_gt_5) | aroonu_14_1h_lt_80 | (roc_9_1h_lt_10))
           # 15m down move, 1h high & overbought
-          long_entry_logic.append((rsi_3_15m > 5.0) | (stochrsi_k_1h_lt_80) | (roc_9_1h < 10.0))
+          long_entry_logic.append((rsi_3_15m_gt_5) | (stochrsi_k_1h_lt_80) | (roc_9_1h_lt_10))
           # 15m & 1h down move, 4h still high
-          long_entry_logic.append((rsi_3_15m > 10.0) | rsi_3_1h_gt_20 | (stochrsi_k_4h < 50.0))
+          long_entry_logic.append((rsi_3_15m_gt_10) | rsi_3_1h_gt_20 | (stochrsi_k_4h_lt_50))
           # 15m & 1h down move, 1h still not low enough
-          long_entry_logic.append((rsi_3_15m > 10.0) | (rsi_3_1h > 25.0) | (aroonu_14_1h < 25.0))
+          long_entry_logic.append((rsi_3_15m_gt_10) | (rsi_3_1h_gt_25) | (aroonu_14_1h < 25.0))
           # 15m & 1h down move, 1h still high
-          long_entry_logic.append((rsi_3_15m > 10.0) | (rsi_3_1h > 30.0) | (stochrsi_k_1h < 40.0))
+          long_entry_logic.append((rsi_3_15m_gt_10) | (rsi_3_1h_gt_30) | (stochrsi_k_1h < 40.0))
           # 15m & 1h down move, 4h still high
-          long_entry_logic.append((rsi_3_15m > 10.0) | (rsi_3_1h > 30.0) | (stochrsi_k_4h < 50.0))
+          long_entry_logic.append((rsi_3_15m_gt_10) | (rsi_3_1h_gt_30) | (stochrsi_k_4h_lt_50))
           # 15m & 1h down move, 1h still high
-          long_entry_logic.append((rsi_3_15m > 10.0) | (rsi_3_1h > 35.0) | (stochrsi_k_1h_lt_50))
+          long_entry_logic.append((rsi_3_15m_gt_10) | (rsi_3_1h_gt_35) | (stochrsi_k_1h_lt_50))
           # 15m & 1h down move, 1h high
-          long_entry_logic.append((rsi_3_15m > 10.0) | (rsi_3_1h > 50.0) | aroonu_14_1h_lt_80)
+          long_entry_logic.append((rsi_3_15m_gt_10) | (rsi_3_1h_gt_50) | aroonu_14_1h_lt_80)
           # 15m & 1h down move, 1h high
-          long_entry_logic.append((rsi_3_15m > 10.0) | (rsi_3_1h > 50.0) | (stochrsi_k_1h_lt_80))
+          long_entry_logic.append((rsi_3_15m_gt_10) | (rsi_3_1h_gt_50) | (stochrsi_k_1h_lt_80))
           # 15m & 4h down move, 15m still not low enough
-          long_entry_logic.append((rsi_3_15m > 10.0) | (rsi_3_4h_gt_10) | (stochrsi_k_15m < 10.0))
+          long_entry_logic.append((rsi_3_15m_gt_10) | (rsi_3_4h_gt_10) | (stochrsi_k_15m < 10.0))
           # 15m & 4h down move, 1d downtrend
-          long_entry_logic.append((rsi_3_15m > 10.0) | rsi_3_4h_gt_20 | (roc_9_1d > -25.0))
+          long_entry_logic.append((rsi_3_15m_gt_10) | rsi_3_4h_gt_20 | (roc_9_1d > -25.0))
           # 15m & 4h down move, 1d high
-          long_entry_logic.append((rsi_3_15m > 10.0) | (rsi_3_4h > 25.0) | (aroonu_14_1d < 85.0))
+          long_entry_logic.append((rsi_3_15m_gt_10) | (rsi_3_4h_gt_25) | (aroonu_14_1d < 85.0))
           # 15m & 4h down move, 1h still high
-          long_entry_logic.append((rsi_3_15m > 10.0) | (rsi_3_4h > 30.0) | (stochrsi_k_1h_lt_50))
+          long_entry_logic.append((rsi_3_15m_gt_10) | (rsi_3_4h_gt_30) | (stochrsi_k_1h_lt_50))
           # 15m & 4h down move, 4h high
-          long_entry_logic.append((rsi_3_15m > 10.0) | (rsi_3_4h > 30.0) | (stochrsi_k_4h < 70.0))
+          long_entry_logic.append((rsi_3_15m_gt_10) | (rsi_3_4h_gt_30) | (stochrsi_k_4h_lt_70))
           # 15m & 1d down move, 1h still high
-          long_entry_logic.append((rsi_3_15m > 10.0) | (rsi_3_1d > 25.0) | (stochrsi_k_1h_lt_50))
+          long_entry_logic.append((rsi_3_15m_gt_10) | (rsi_3_1d_gt_25) | (stochrsi_k_1h_lt_50))
           # 15m down move, 15m still not low enough, 1h still high
-          long_entry_logic.append((rsi_3_15m > 10.0) | (aroonu_14_15m < 30.0) | (stochrsi_k_1h_lt_50))
+          long_entry_logic.append((rsi_3_15m_gt_10) | (aroonu_14_15m < 30.0) | (stochrsi_k_1h_lt_50))
           # 15m down move, 1h still high, 4h high
-          long_entry_logic.append((rsi_3_15m > 10.0) | (stochrsi_k_1h_lt_50) | (aroonu_14_4h < 85.0))
+          long_entry_logic.append((rsi_3_15m_gt_10) | (stochrsi_k_1h_lt_50) | (aroonu_14_4h < 85.0))
           # 15m down move, 1h & 4h high
-          long_entry_logic.append((rsi_3_15m > 10.0) | (stochrsi_k_1h_lt_70) | (stochrsi_k_4h < 75.0))
+          long_entry_logic.append((rsi_3_15m_gt_10) | (stochrsi_k_1h_lt_70) | (stochrsi_k_4h < 75.0))
           # 15m & 1h down move, 15m still not low enough
-          long_entry_logic.append((rsi_3_15m > 15.0) | (rsi_3_1h_gt_15) | (stochrsi_k_15m < 30.0))
+          long_entry_logic.append((rsi_3_15m_gt_15) | (rsi_3_1h_gt_15) | (stochrsi_k_15m < 30.0))
           # 15m & 1h down move, 4h high
-          long_entry_logic.append((rsi_3_15m > 15.0) | rsi_3_1h_gt_20 | (stochrsi_k_4h_lt_90))
+          long_entry_logic.append((rsi_3_15m_gt_15) | rsi_3_1h_gt_20 | (stochrsi_k_4h_lt_90))
           # 15m & 1h down move, 1h still high
-          long_entry_logic.append((rsi_3_15m > 15.0) | (rsi_3_1h > 25.0) | (stochrsi_k_1h < 40.0))
+          long_entry_logic.append((rsi_3_15m_gt_15) | (rsi_3_1h_gt_25) | (stochrsi_k_1h < 40.0))
           # 15m & 1h down move, 1h still high
-          long_entry_logic.append((rsi_3_15m > 15.0) | (rsi_3_1h > 40.0) | (aroonu_14_1h < 50.0))
+          long_entry_logic.append((rsi_3_15m_gt_15) | (rsi_3_1h_gt_40) | (aroonu_14_1h_lt_50))
           # 15m & 4h & 1d down move
-          long_entry_logic.append((rsi_3_15m > 15.0) | (rsi_3_4h_gt_15) | (rsi_3_1d > 15.0))
+          long_entry_logic.append((rsi_3_15m_gt_15) | (rsi_3_4h_gt_15) | (rsi_3_1d_gt_15))
           # 15m & 4h down move, 1h high
-          long_entry_logic.append((rsi_3_15m > 15.0) | (rsi_3_4h_gt_15) | (stochrsi_k_1h < 80.0))
+          long_entry_logic.append((rsi_3_15m_gt_15) | (rsi_3_4h_gt_15) | (stochrsi_k_1h < 80.0))
           # 15m & 4h down move, 1h still high
-          long_entry_logic.append((rsi_3_15m > 15.0) | rsi_3_4h_gt_20 | (stochrsi_k_1h_lt_50))
+          long_entry_logic.append((rsi_3_15m_gt_15) | rsi_3_4h_gt_20 | (stochrsi_k_1h_lt_50))
           # 15m & 4h down move, 15m still not low enough
-          long_entry_logic.append((rsi_3_15m > 15.0) | (rsi_3_4h > 25.0) | (aroonu_14_15m < 30.0))
+          long_entry_logic.append((rsi_3_15m_gt_15) | (rsi_3_4h_gt_25) | (aroonu_14_15m < 30.0))
           # 15m & 4h down move, 4h still high
-          long_entry_logic.append((rsi_3_15m > 15.0) | (rsi_3_4h > 50.0) | (aroonu_14_4h < 50.0))
+          long_entry_logic.append((rsi_3_15m_gt_15) | (rsi_3_4h_gt_50) | (aroonu_14_4h_lt_50))
           # 1h & 1d down move, 1d overbought
           long_entry_logic.append((rsi_3_1h_gt_15) | (rsi_3_1d > 35.0) | (roc_9_1d < 10.0))
           # 15m down move, 15m still not low enough, 1h high
-          long_entry_logic.append((rsi_3_15m > 15.0) | (aroonu_14_15m < 25.0) | (stochrsi_k_1h_lt_80))
+          long_entry_logic.append((rsi_3_15m_gt_15) | (aroonu_14_15m < 25.0) | (stochrsi_k_1h_lt_80))
           # 15m down move, 4h high & overbought
-          long_entry_logic.append((rsi_3_15m > 15.0) | aroonu_14_4h_lt_80 | (roc_9_4h < 40.0))
+          long_entry_logic.append((rsi_3_15m_gt_15) | aroonu_14_4h_lt_80 | (roc_9_4h_lt_40))
           # 15m down move, 1h & 4h high
-          long_entry_logic.append((rsi_3_15m > 15.0) | (stochrsi_k_1h_lt_70) | (aroonu_14_4h < 85.0))
+          long_entry_logic.append((rsi_3_15m_gt_15) | (stochrsi_k_1h_lt_70) | (aroonu_14_4h < 85.0))
           # 15m & 1h down move, 4h high
-          long_entry_logic.append((rsi_3_15m > 20.0) | (rsi_3_1h > 30.0) | (stochrsi_k_4h_lt_90))
+          long_entry_logic.append((rsi_3_15m_gt_20) | (rsi_3_1h_gt_30) | (stochrsi_k_4h_lt_90))
           # 15m & 1d down move, 1h high
-          long_entry_logic.append((rsi_3_15m > 20.0) | (rsi_3_1d > 20.0) | (stochrsi_k_1h_lt_70))
+          long_entry_logic.append((rsi_3_15m_gt_20) | (rsi_3_1d_gt_20) | (stochrsi_k_1h_lt_70))
           # 15m down move, 1d high & overbought
-          long_entry_logic.append((rsi_3_15m > 20.0) | aroonu_14_1d_lt_100 | (roc_9_1d < 20.0))
+          long_entry_logic.append((rsi_3_15m_gt_20) | aroonu_14_1d_lt_100 | (roc_9_1d_lt_20))
           # 15m down move, 1h high, 1d downtrend
-          long_entry_logic.append((rsi_3_15m > 20.0) | (stochrsi_k_1h < 80.0) | (roc_9_1d_gt_neg_20))
+          long_entry_logic.append((rsi_3_15m_gt_20) | (stochrsi_k_1h < 80.0) | (roc_9_1d_gt_neg_20))
           # 15m down move, 1d high & overbought
-          long_entry_logic.append((rsi_3_15m > 20.0) | (stochrsi_k_1h_lt_80) | (roc_9_1d < 20.0))
+          long_entry_logic.append((rsi_3_15m_gt_20) | (stochrsi_k_1h_lt_80) | (roc_9_1d_lt_20))
           # 15m & 1h down move, 1h high
-          long_entry_logic.append((rsi_3_15m > 25.0) | (rsi_3_1h > 25.0) | (stochrsi_k_1h < 60.0))
+          long_entry_logic.append((rsi_3_15m_gt_25) | (rsi_3_1h_gt_25) | (stochrsi_k_1h < 60.0))
           # 15m & 1h down move, 1h high
-          long_entry_logic.append((rsi_3_15m > 25.0) | (rsi_3_1h > 60.0) | (aroonu_14_1h < 85.0))
+          long_entry_logic.append((rsi_3_15m_gt_25) | (rsi_3_1h > 60.0) | (aroonu_14_1h < 85.0))
           # 15m down move, 15m still not low enough, 4h high
-          long_entry_logic.append((rsi_3_15m > 25.0) | (aroonu_14_15m < 25.0) | (aroonu_14_4h < 60.0))
+          long_entry_logic.append((rsi_3_15m_gt_25) | (aroonu_14_15m < 25.0) | (aroonu_14_4h_lt_60))
           # 15m down move, 15m still not low enough, 1h high
-          long_entry_logic.append((rsi_3_15m > 25.0) | (stochrsi_k_15m < 30.0) | aroonu_14_1h_lt_80)
+          long_entry_logic.append((rsi_3_15m_gt_25) | (stochrsi_k_15m < 30.0) | aroonu_14_1h_lt_80)
           # 15m & 1h down move, 1h high
-          long_entry_logic.append((rsi_3_15m > 30.0) | (rsi_3_1h > 45.0) | aroonu_14_1h_lt_70)
+          long_entry_logic.append((rsi_3_15m_gt_30) | (rsi_3_1h_gt_45) | aroonu_14_1h_lt_70)
           # 1h & 4h down move, 15m downtrend
-          long_entry_logic.append((rsi_3_1h > 3.0) | (rsi_3_4h > 3.0) | (roc_9_15m > -30.0))
+          long_entry_logic.append((rsi_3_1h_gt_3) | (rsi_3_4h > 3.0) | (roc_9_15m > -30.0))
           # 1h & 4h & 1d down move
-          long_entry_logic.append((rsi_3_1h > 3.0) | (rsi_3_4h_gt_15) | (rsi_3_1d > 25.0))
+          long_entry_logic.append((rsi_3_1h_gt_3) | (rsi_3_4h_gt_15) | (rsi_3_1d_gt_25))
           # 1h & 4h down move, 4h high
-          long_entry_logic.append((rsi_3_1h > 3.0) | (rsi_3_4h > 50.0) | aroonu_14_4h_lt_70)
+          long_entry_logic.append((rsi_3_1h_gt_3) | (rsi_3_4h_gt_50) | aroonu_14_4h_lt_70)
           # 1h & 4h down move, 4h downtrend
-          long_entry_logic.append((rsi_3_1h > 5.0) | (rsi_3_4h > 5.0) | (roc_9_4h_gt_neg_20))
+          long_entry_logic.append((rsi_3_1h_gt_5) | (rsi_3_4h_gt_5) | (roc_9_4h_gt_neg_20))
           # 1h & 4h down move, 4h downtrend
-          long_entry_logic.append((rsi_3_1h > 5.0) | (rsi_3_4h_gt_15) | (roc_9_4h > -30.0))
+          long_entry_logic.append((rsi_3_1h_gt_5) | (rsi_3_4h_gt_15) | (roc_9_4h_gt_neg_30))
           # 1h & 4h down move, 4h still not low enough
-          long_entry_logic.append((rsi_3_1h > 5.0) | rsi_3_4h_gt_20 | (stochrsi_k_4h < 20.0))
+          long_entry_logic.append((rsi_3_1h_gt_5) | rsi_3_4h_gt_20 | (stochrsi_k_4h < 20.0))
           # 1h & 4h down move, 1d low
           long_entry_logic.append((rsi_3_1h_gt_10) | (rsi_3_4h_gt_10) | (cmf_20_1d > -0.2))
           # 1h & 4h down move, 4h still not low enough
           long_entry_logic.append((rsi_3_1h_gt_10) | (rsi_3_4h_gt_15) | (aroonu_14_4h < 20.0))
           # 1h & 4h down move, 4h still not low enough
-          long_entry_logic.append((rsi_3_1h_gt_10) | (rsi_3_4h > 25.0) | (stochrsi_k_4h < 30.0))
+          long_entry_logic.append((rsi_3_1h_gt_10) | (rsi_3_4h_gt_25) | (stochrsi_k_4h < 30.0))
           # 1h & 1d down move, 5m moving down
-          long_entry_logic.append((rsi_3_1h_gt_10) | (rsi_3_1d > 15.0) | (roc_2 > -0.0))
+          long_entry_logic.append((rsi_3_1h_gt_10) | (rsi_3_1d_gt_15) | (roc_2 > -0.0))
           # 1h down move, 4h downtrend
-          long_entry_logic.append((rsi_3_1h_gt_10) | (roc_9_4h > -30.0))
+          long_entry_logic.append((rsi_3_1h_gt_10) | (roc_9_4h_gt_neg_30))
           # 1h down move, 1d downtrend
           long_entry_logic.append((rsi_3_1h_gt_10) | (roc_9_1d > -30.0))
           # 1h & 4h & 1d down move
           long_entry_logic.append((rsi_3_1h_gt_15) | rsi_3_4h_gt_20 | (rsi_3_1d > 30.0))
           # 1h & 4h down move, 1h still high
-          long_entry_logic.append((rsi_3_1h_gt_15) | (rsi_3_4h > 30.0) | (stochrsi_k_1h < 40.0))
+          long_entry_logic.append((rsi_3_1h_gt_15) | (rsi_3_4h_gt_30) | (stochrsi_k_1h < 40.0))
           # 1h & 4h down move, 1h still not low enough
-          long_entry_logic.append((rsi_3_1h_gt_15) | (rsi_3_4h > 40.0) | (stochrsi_k_1h < 30.0))
+          long_entry_logic.append((rsi_3_1h_gt_15) | (rsi_3_4h_gt_40) | (stochrsi_k_1h < 30.0))
           # 1h & 4h down move, 1h still high
-          long_entry_logic.append((rsi_3_1h_gt_15) | (rsi_3_1d > 10.0) | (aroonu_14_1h < 40.0))
+          long_entry_logic.append((rsi_3_1h_gt_15) | (rsi_3_1d_gt_10) | (aroonu_14_1h < 40.0))
           # 1h down move, 1d high & overbought
-          long_entry_logic.append(rsi_3_1h_gt_20 | (aroonu_14_1d < 90.0) | (roc_9_1d < 30.0))
+          long_entry_logic.append(rsi_3_1h_gt_20 | (aroonu_14_1d_lt_90) | (roc_9_1d_lt_30))
           # 1h down move, 1h still not low enough, 4h high
           long_entry_logic.append(rsi_3_1h_gt_20 | (stochrsi_k_1h < 20.0) | aroonu_14_4h_lt_80)
           # 1h & 4h down move, 1h still high
-          long_entry_logic.append((rsi_3_1h > 25.0) | (rsi_3_4h > 25.0) | (stochrsi_k_1h_lt_50))
+          long_entry_logic.append((rsi_3_1h_gt_25) | (rsi_3_4h_gt_25) | (stochrsi_k_1h_lt_50))
           # 1h & 4h down move, 1d high
-          long_entry_logic.append((rsi_3_1h > 25.0) | (rsi_3_4h > 30.0) | (stochrsi_k_1d < 80.0))
+          long_entry_logic.append((rsi_3_1h_gt_25) | (rsi_3_4h_gt_30) | (stochrsi_k_1d < 80.0))
           # 1h & 4h down move, 1h high
-          long_entry_logic.append((rsi_3_1h > 25.0) | (rsi_3_4h > 60.0) | (stochrsi_k_4h_lt_80))
+          long_entry_logic.append((rsi_3_1h_gt_25) | (rsi_3_4h > 60.0) | (stochrsi_k_4h_lt_80))
           # 1h & 4h down move, 1h still high
-          long_entry_logic.append((rsi_3_1h > 30.0) | (rsi_3_4h > 40.0) | (stochrsi_k_1h_lt_50))
+          long_entry_logic.append((rsi_3_1h_gt_30) | (rsi_3_4h_gt_40) | (stochrsi_k_1h_lt_50))
           # 1h down move, 4h high, 1d overbought
-          long_entry_logic.append((rsi_3_1h > 30.0) | (aroonu_14_4h < 90.0) | (roc_9_1d < 40.0))
+          long_entry_logic.append((rsi_3_1h_gt_30) | (aroonu_14_4h_lt_90) | (roc_9_1d_lt_40))
           # 1h down move, 4h & 1d high
-          long_entry_logic.append((rsi_3_1h > 30.0) | aroonu_14_4h_lt_80 | aroonu_14_1d_lt_100)
+          long_entry_logic.append((rsi_3_1h_gt_30) | aroonu_14_4h_lt_80 | aroonu_14_1d_lt_100)
           # 1h down move, 15m high
-          long_entry_logic.append((rsi_3_1h > 35.0) | (stochrsi_k_15m < 80.0))
+          long_entry_logic.append((rsi_3_1h_gt_35) | (stochrsi_k_15m < 80.0))
           # 1h down move, 1h high, 1d overbought
-          long_entry_logic.append((rsi_3_1h > 35.0) | aroonu_14_1h_lt_70 | (roc_9_1d < 20.0))
+          long_entry_logic.append((rsi_3_1h_gt_35) | aroonu_14_1h_lt_70 | (roc_9_1d_lt_20))
           # 1h down move, 1h & 4h high
-          long_entry_logic.append((rsi_3_1h > 40.0) | aroonu_14_1h_lt_80 | aroonu_14_4h_lt_100)
+          long_entry_logic.append((rsi_3_1h_gt_40) | aroonu_14_1h_lt_80 | aroonu_14_4h_lt_100)
           # 1h down move, 1h high & overbought
-          long_entry_logic.append((rsi_3_1h > 55.0) | (stochrsi_k_1h_lt_80) | (roc_9_1h < 10.0))
+          long_entry_logic.append((rsi_3_1h > 55.0) | (stochrsi_k_1h_lt_80) | (roc_9_1h_lt_10))
           # 1h down move, 4h high
-          long_entry_logic.append((rsi_3_1h > 60.0) | (aroonu_14_4h < 90.0))
+          long_entry_logic.append((rsi_3_1h > 60.0) | (aroonu_14_4h_lt_90))
           # 4h down move, 15m still high
-          long_entry_logic.append((rsi_3_4h > 5.0) | (stochrsi_k_15m < 40.0))
+          long_entry_logic.append((rsi_3_4h_gt_5) | (stochrsi_k_15m < 40.0))
           # 4h down move, 1d still high, 1d downtrend
           long_entry_logic.append((rsi_3_4h_gt_10) | (aroonu_14_1d < 40.0) | (roc_9_1d > -20.0))
           # 4h down move, 15m 4h still high
-          long_entry_logic.append((rsi_3_4h_gt_10) | (stochrsi_k_15m < 40.0) | (aroonu_14_4h < 50.0))
+          long_entry_logic.append((rsi_3_4h_gt_10) | (stochrsi_k_15m < 40.0) | (aroonu_14_4h_lt_50))
           # 4h & 1d down move, 4h high
-          long_entry_logic.append((rsi_3_4h_gt_15) | (rsi_3_1d > 25.0) | aroonu_14_4h_lt_70)
+          long_entry_logic.append((rsi_3_4h_gt_15) | (rsi_3_1d_gt_25) | aroonu_14_4h_lt_70)
           # 4h down move, 1h still high
-          long_entry_logic.append((rsi_3_4h_gt_15) | (aroonu_14_1h < 50.0))
+          long_entry_logic.append((rsi_3_4h_gt_15) | (aroonu_14_1h_lt_50))
           # 4h down move, 4h still high
-          long_entry_logic.append((rsi_3_4h_gt_15) | (aroonu_14_4h < 50.0))
+          long_entry_logic.append((rsi_3_4h_gt_15) | (aroonu_14_4h_lt_50))
           # 4h down move, 1d high & overbought
-          long_entry_logic.append((rsi_3_4h_gt_15) | (stochrsi_k_1d < 90.0) | (roc_9_1d < 20.0))
+          long_entry_logic.append((rsi_3_4h_gt_15) | (stochrsi_k_1d_lt_90) | (roc_9_1d_lt_20))
           # 4h down move, 4h & 1d downtrend
           long_entry_logic.append((rsi_3_4h_gt_15) | (roc_9_4h > -10.0) | (roc_9_1d > -15.0))
           # 4h down move, 4h & 1d downtrend
           long_entry_logic.append(rsi_3_4h_gt_20 | (roc_9_4h_gt_neg_20) | (roc_9_1d_gt_neg_30))
           # 4h dowqn move, 4h still high, 1d downtrend
-          long_entry_logic.append((rsi_3_4h > 25.0) | (stochrsi_k_4h < 50.0) | (roc_9_1d_gt_neg_30))
+          long_entry_logic.append((rsi_3_4h_gt_25) | (stochrsi_k_4h_lt_50) | (roc_9_1d_gt_neg_30))
           # 4h down move, 4h & 1d high
-          long_entry_logic.append((rsi_3_4h > 35.0) | aroonu_14_4h_lt_80 | aroonu_14_1d_lt_100)
+          long_entry_logic.append((rsi_3_4h_gt_35) | aroonu_14_4h_lt_80 | aroonu_14_1d_lt_100)
           # 4h & 1d down move, 4h still high
-          long_entry_logic.append((rsi_3_4h > 40.0) | (rsi_3_1d > 10.0) | (stochrsi_k_4h < 50.0))
+          long_entry_logic.append((rsi_3_4h_gt_40) | (rsi_3_1d_gt_10) | (stochrsi_k_4h_lt_50))
           # 4h down move, 4h high, 1d downtrend
-          long_entry_logic.append((rsi_3_4h > 40.0) | (stochrsi_k_4h < 70.0) | (roc_9_1d > -60.0))
+          long_entry_logic.append((rsi_3_4h_gt_40) | (stochrsi_k_4h_lt_70) | (roc_9_1d > -60.0))
           # 4h down move, 4h still high
           long_entry_logic.append((rsi_3_4h > 60.0) | (stochrsi_k_4h < 40.0))
           # 4h down move, 4h overbought
           long_entry_logic.append((rsi_3_4h > 60.0) | (roc_9_4h_lt_20))
           # 1d down move, 1h still high, 4h high
-          long_entry_logic.append((rsi_3_1d > 20.0) | (aroonu_14_1h < 50.0) | (aroonu_14_4h < 85.0))
+          long_entry_logic.append((rsi_3_1d_gt_20) | (aroonu_14_1h_lt_50) | (aroonu_14_4h < 85.0))
           # 1d down move, 1h high & overbought
-          long_entry_logic.append((rsi_3_1d > 35.0) | (stochrsi_k_1h < 90.0) | (roc_9_1h < 10.0))
+          long_entry_logic.append((rsi_3_1d > 35.0) | (stochrsi_k_1h < 90.0) | (roc_9_1h_lt_10))
           # 1d down move, 4h high, 1d overbought
           long_entry_logic.append((rsi_3_1d > 45.0) | (stochrsi_k_4h_lt_90) | (roc_9_1d < 10.0))
           # 4h still high, 4h moving lower, 4h overbought
-          long_entry_logic.append((aroonu_14_4h < 50.0) | (aroonu_14_4h > aroonu_14_4h.shift(48)) | (roc_9_4h < 40.0))
+          long_entry_logic.append((aroonu_14_4h_lt_50) | (aroonu_14_4h > aroonu_14_4h.shift(48)) | (roc_9_4h_lt_40))
           # 1h high, 1d downtrend
-          long_entry_logic.append((aroonu_14_1d < 70.0) | (roc_9_1d_gt_neg_30))
+          long_entry_logic.append((aroonu_14_1d_lt_70) | (roc_9_1d_gt_neg_30))
           # 1d high, 4h & 1d overbought
           long_entry_logic.append((aroonu_14_1d < 85.0) | (roc_9_4h < 60.0) | (roc_9_1d < 60.0))
           # 1d high, 4h & 1d overbought
-          long_entry_logic.append(aroonu_14_1d_lt_100 | (roc_9_4h < 10.0) | (roc_9_1d < 20.0))
+          long_entry_logic.append(aroonu_14_1d_lt_100 | (roc_9_4h_lt_10) | (roc_9_1d_lt_20))
           # 1h high, 4h downtrend
           long_entry_logic.append((stochrsi_k_1h < 80.0) | (roc_9_4h_gt_neg_20))
           # 1h high, 4h overbought
           long_entry_logic.append((stochrsi_k_1h_lt_80) | (roc_9_4h < 80.0))
           # 4h high, 4h & 1d overbought
-          long_entry_logic.append((stochrsi_k_4h_lt_80) | (roc_9_4h < 30.0) | (roc_9_1d < 30.0))
+          long_entry_logic.append((stochrsi_k_4h_lt_80) | (roc_9_4h_lt_30) | (roc_9_1d_lt_30))
           # 1d high, 4h & 1d overbought
           long_entry_logic.append((stochrsi_k_1d < 80.0) | (roc_9_4h < 60.0) | (roc_9_1d < 60.0))
           # 1d red, 4h down move, 1h still high
-          long_entry_logic.append((change_pct_1d > -30.0) | (rsi_3_4h > 30.0) | (stochrsi_k_1h_lt_50))
+          long_entry_logic.append((change_pct_1d > -30.0) | (rsi_3_4h_gt_30) | (stochrsi_k_1h_lt_50))
           # pump, drop but not yet near the previous lows
           long_entry_logic.append(
             (((high_max_24_4h - low_min_24_4h) / low_min_24_4h) < 2.0)
@@ -20127,7 +20179,7 @@ class NostalgiaForInfinityX7(IStrategy):
           )
           # 1h down move, drop but not yet near the previous lows
           long_entry_logic.append(
-            (rsi_3_1h > 30.0) | (close > (high_max_12_4h * 0.50)) | (close < (low_min_24_4h * 1.25))
+            (rsi_3_1h_gt_30) | (close > (high_max_12_4h * 0.50)) | (close < (low_min_24_4h * 1.25))
           )
           # 1d overbought, drop but not yet near the previous lows
           long_entry_logic.append(roc_9_1d_lt_50 | (close > (high_max_6_1d * 0.70)) | (close < (low_min_12_1d * 1.25)))
@@ -20138,25 +20190,25 @@ class NostalgiaForInfinityX7(IStrategy):
           # big drop in the last 4 days, 4h down move
           long_entry_logic.append((close > (high_max_24_4h * 0.20)) | rsi_3_4h_gt_20)
           # big drop in the last 6 days, 1d down move
-          long_entry_logic.append((close > (high_max_6_1d * 0.30)) | (rsi_3_1d > 15.0))
+          long_entry_logic.append((close > (high_max_6_1d * 0.30)) | (rsi_3_1d_gt_15))
           # big drop in the last 12 days, 4h high
           long_entry_logic.append((close > (high_max_12_1d * 0.50)) | (stochrsi_k_4h_lt_90))
           # big drop in the last 30 days, 4h down move
-          long_entry_logic.append((close > (high_max_20_1d * 0.10)) | (rsi_3_4h > 30.0))
+          long_entry_logic.append((close > (high_max_20_1d * 0.10)) | (rsi_3_4h_gt_30))
           # big drop in the last 20 days, 1h still high
-          long_entry_logic.append((close > (high_max_20_1d * 0.05)) | (aroonu_14_1h < 50.0))
+          long_entry_logic.append((close > (high_max_20_1d * 0.05)) | (aroonu_14_1h_lt_50))
           # big drop in the last 20 days, 1d high, 1d downtrend
           long_entry_logic.append((close > (high_max_20_1d * 0.20)) | (stochrsi_k_1d < 70.0) | (roc_9_1d > -15.0))
           # big drop in the last 30 days, 1h down move
           long_entry_logic.append((close > (high_max_30_1d * 0.25)) | (rsi_3_1h_gt_15))
 
           # Logic
-          long_entry_logic.append(rsi_3 > 3.0)
+          long_entry_logic.append(rsi_3_gt_3)
           long_entry_logic.append(rsi_14 < 36.0)
           long_entry_logic.append(aroonu_14 < 25.0)
           long_entry_logic.append(stochrsi_k < 20.0)
           long_entry_logic.append(close < (sma_16 * 0.946))
-          long_entry_logic.append(aroonu_14_15m < 50.0)
+          long_entry_logic.append(aroonu_14_15m_lt_50)
 
         # Condition #102 - Rapid mode (Long).
         if long_entry_condition_index == 102:
@@ -20165,31 +20217,31 @@ class NostalgiaForInfinityX7(IStrategy):
           long_entry_logic.append(protections_long_global == True)
 
           long_entry_logic.append(rsi_3 < 46.0)
-          long_entry_logic.append(rsi_3_15m > 5.0)
+          long_entry_logic.append(rsi_3_15m_gt_5)
           long_entry_logic.append(rsi_3_1h_gt_10)
           long_entry_logic.append(rsi_3_4h_gt_10)
           # 5m & 15m down move, 4h still high
-          long_entry_logic.append((rsi_3 > 3.0) | (rsi_3_15m > 15.0) | (stochrsi_k_4h < 50.0))
+          long_entry_logic.append((rsi_3_gt_3) | (rsi_3_15m_gt_15) | (stochrsi_k_4h_lt_50))
           # 5m & 15m down move, 15m still high
-          long_entry_logic.append((rsi_3 > 3.0) | (rsi_3_15m > 20.0) | (aroonu_14_15m < 40.0))
+          long_entry_logic.append((rsi_3_gt_3) | (rsi_3_15m_gt_20) | (aroonu_14_15m < 40.0))
           # 5m & 15m down move, 1h still high
-          long_entry_logic.append((rsi_3 > 3.0) | (rsi_3_15m > 25.0) | (stochrsi_k_1h < 40.0))
+          long_entry_logic.append((rsi_3_gt_3) | (rsi_3_15m_gt_25) | (stochrsi_k_1h < 40.0))
           # 5m & 1h down move, 4h still high
-          long_entry_logic.append((rsi_3 > 3.0) | (rsi_3_1h > 25.0) | (aroonu_14_4h < 50.0))
+          long_entry_logic.append((rsi_3_gt_3) | (rsi_3_1h_gt_25) | (aroonu_14_4h_lt_50))
           # 5m & 4h & 1d down move
-          long_entry_logic.append((rsi_3 > 3.0) | rsi_3_4h_gt_20 | (rsi_3_1d > 20.0))
+          long_entry_logic.append((rsi_3_gt_3) | rsi_3_4h_gt_20 | (rsi_3_1d_gt_20))
           # 5m & 1d down move, 15m still high
-          long_entry_logic.append((rsi_3 > 3.0) | (rsi_3_1d > 10.0) | (stochrsi_k_15m < 40.0))
+          long_entry_logic.append((rsi_3_gt_3) | (rsi_3_1d_gt_10) | (stochrsi_k_15m < 40.0))
           # 5m down move, 15m high
-          long_entry_logic.append((rsi_3 > 3.0) | (aroonu_14_15m < 70.0))
+          long_entry_logic.append((rsi_3_gt_3) | (aroonu_14_15m_lt_70))
           # 5m down move, 15m & 1h still high
-          long_entry_logic.append((rsi_3 > 3.0) | (stochrsi_k_15m < 40.0) | (aroonu_14_1h < 40.0))
+          long_entry_logic.append((rsi_3_gt_3) | (stochrsi_k_15m < 40.0) | (aroonu_14_1h < 40.0))
           # 5m down move, 1h high
-          long_entry_logic.append((rsi_3 > 3.0) | aroonu_14_1h_lt_70 | (stochrsi_k_1h < 50.0))
+          long_entry_logic.append((rsi_3_gt_3) | aroonu_14_1h_lt_70 | (stochrsi_k_1h < 50.0))
           # 5m & 1h down move, 1h high
-          long_entry_logic.append((rsi_3 > 5.0) | (rsi_3_1h > 40.0) | (stochrsi_k_1h < 60.0))
+          long_entry_logic.append((rsi_3 > 5.0) | (rsi_3_1h_gt_40) | (stochrsi_k_1h < 60.0))
           # 5m & 4h down move, 4h high
-          long_entry_logic.append((rsi_3 > 5.0) | (rsi_3_4h > 50.0) | aroonu_14_4h_lt_70)
+          long_entry_logic.append((rsi_3 > 5.0) | (rsi_3_4h_gt_50) | aroonu_14_4h_lt_70)
           # 5m down move, 15m still high, 1h high
           long_entry_logic.append((rsi_3 > 5.0) | (rsi_14_15m < 40.0) | aroonu_14_1h_lt_80)
           # 5m down move, 15m still high, 1h high
@@ -20197,17 +20249,17 @@ class NostalgiaForInfinityX7(IStrategy):
           # 5m down move, 15m & 4h high
           long_entry_logic.append((rsi_3 > 5.0) | (stochrsi_k_15m < 70.0) | (stochrsi_k_4h_lt_90))
           # 5m & 15m down move, 4h high
-          long_entry_logic.append((rsi_3 > 10.0) | (rsi_3_15m > 20.0) | (aroonu_14_4h < 90.0))
+          long_entry_logic.append((rsi_3 > 10.0) | (rsi_3_15m_gt_20) | (aroonu_14_4h_lt_90))
           # 5m & 15m down move, 1d high
-          long_entry_logic.append((rsi_3 > 10.0) | (rsi_3_15m > 20.0) | (stochrsi_k_1d < 80.0))
+          long_entry_logic.append((rsi_3 > 10.0) | (rsi_3_15m_gt_20) | (stochrsi_k_1d < 80.0))
           # 5m & 15m down move, 1h high
-          long_entry_logic.append((rsi_3 > 10.0) | (rsi_3_15m > 25.0) | (stochrsi_k_1h < 90.0))
+          long_entry_logic.append((rsi_3 > 10.0) | (rsi_3_15m_gt_25) | (stochrsi_k_1h < 90.0))
           # 5m & 1h down move, 4h still high
-          long_entry_logic.append((rsi_3 > 10.0) | (rsi_3_1h > 30.0) | (stochrsi_k_4h < 50.0))
+          long_entry_logic.append((rsi_3 > 10.0) | (rsi_3_1h_gt_30) | (stochrsi_k_4h_lt_50))
           # 5m down move, 1h & 4h high
-          long_entry_logic.append((rsi_3 > 10.0) | (aroonu_14_1h < 85.0) | (aroonu_14_4h < 90.0))
+          long_entry_logic.append((rsi_3 > 10.0) | (aroonu_14_1h < 85.0) | (aroonu_14_4h_lt_90))
           # 5m down move, 4h high, 1d high
-          long_entry_logic.append((rsi_3 > 10.0) | (aroonu_14_4h < 60.0) | (stochrsi_k_1d < 90.0))
+          long_entry_logic.append((rsi_3 > 10.0) | (aroonu_14_4h_lt_60) | (stochrsi_k_1d_lt_90))
           # 5m down move, 15m still high, 1h high
           long_entry_logic.append((rsi_3 > 15.0) | (rsi_14_15m < 40.0) | (stochrsi_k_1h < 90.0))
           # 5m down move, 15m still high, 4h high
@@ -20215,265 +20267,265 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m down move, 15m still not low enough, 1h high
           long_entry_logic.append(rsi_3_15m_gt_3 | (aroonu_14_15m < 20.0) | (stochrsi_k_1h < 60.0))
           # 15m & 1h down move, 1d high
-          long_entry_logic.append((rsi_3_15m > 10.0) | rsi_3_1h_gt_20 | (aroonu_14_1d < 70.0))
+          long_entry_logic.append((rsi_3_15m_gt_10) | rsi_3_1h_gt_20 | (aroonu_14_1d_lt_70))
           # 15m & 1h down move, 1h still not low enough
-          long_entry_logic.append((rsi_3_15m > 10.0) | rsi_3_1h_gt_20 | (stochrsi_k_1h < 20.0))
+          long_entry_logic.append((rsi_3_15m_gt_10) | rsi_3_1h_gt_20 | (stochrsi_k_1h < 20.0))
           # 15m & 1h down move, 1h still not low enough
-          long_entry_logic.append((rsi_3_15m > 10.0) | (rsi_3_1h > 25.0) | (aroonu_14_1h < 30.0))
+          long_entry_logic.append((rsi_3_15m_gt_10) | (rsi_3_1h_gt_25) | (aroonu_14_1h < 30.0))
           # 15m & 1h down move, 1h still high
-          long_entry_logic.append((rsi_3_15m > 10.0) | (rsi_3_1h > 35.0) | (aroonu_14_1h < 50.0))
+          long_entry_logic.append((rsi_3_15m_gt_10) | (rsi_3_1h_gt_35) | (aroonu_14_1h_lt_50))
           # 15m & 1h down move, 1h still high
-          long_entry_logic.append((rsi_3_15m > 10.0) | (rsi_3_1h > 35.0) | (stochrsi_k_1h_lt_50))
+          long_entry_logic.append((rsi_3_15m_gt_10) | (rsi_3_1h_gt_35) | (stochrsi_k_1h_lt_50))
           # 15m & 1h down move, 4h still high
-          long_entry_logic.append((rsi_3_15m > 10.0) | (rsi_3_1h > 35.0) | aroonu_14_4h_lt_70)
+          long_entry_logic.append((rsi_3_15m_gt_10) | (rsi_3_1h_gt_35) | aroonu_14_4h_lt_70)
           # 15m & 4h down move, 4h still not low enough
-          long_entry_logic.append((rsi_3_15m > 10.0) | (rsi_3_4h_gt_15) | (aroonu_14_4h < 30.0))
+          long_entry_logic.append((rsi_3_15m_gt_10) | (rsi_3_4h_gt_15) | (aroonu_14_4h < 30.0))
           # 15m& 4h down move, 15m still high
-          long_entry_logic.append((rsi_3_15m > 10.0) | (rsi_3_4h_gt_15) | (stochrsi_k_15m < 40.0))
+          long_entry_logic.append((rsi_3_15m_gt_10) | (rsi_3_4h_gt_15) | (stochrsi_k_15m < 40.0))
           # 15m & 4h down move, 15m still high
-          long_entry_logic.append((rsi_3_15m > 10.0) | rsi_3_4h_gt_20 | (aroonu_14_15m < 50.0))
+          long_entry_logic.append((rsi_3_15m_gt_10) | rsi_3_4h_gt_20 | (aroonu_14_15m_lt_50))
           # 15m & 4h down move, 4h still not low enough
-          long_entry_logic.append((rsi_3_15m > 10.0) | rsi_3_4h_gt_20 | (stochrsi_k_4h < 30.0))
+          long_entry_logic.append((rsi_3_15m_gt_10) | rsi_3_4h_gt_20 | (stochrsi_k_4h < 30.0))
           # 15m & 4h down move, 4h still high
-          long_entry_logic.append((rsi_3_15m > 10.0) | (rsi_3_4h > 25.0) | (aroonu_14_4h < 50.0))
+          long_entry_logic.append((rsi_3_15m_gt_10) | (rsi_3_4h_gt_25) | (aroonu_14_4h_lt_50))
           # 15m & 4h down move, 4h still high
-          long_entry_logic.append((rsi_3_15m > 10.0) | (rsi_3_4h > 30.0) | (stochrsi_k_4h < 40.0))
+          long_entry_logic.append((rsi_3_15m_gt_10) | (rsi_3_4h_gt_30) | (stochrsi_k_4h < 40.0))
           # 15m & 4h down move, 1h still high
-          long_entry_logic.append((rsi_3_15m > 10.0) | rsi_3_4h_gt_20 | (stochrsi_k_1h < 40.0))
+          long_entry_logic.append((rsi_3_15m_gt_10) | rsi_3_4h_gt_20 | (stochrsi_k_1h < 40.0))
           # 15m & 4h down move, 1d high
-          long_entry_logic.append((rsi_3_15m > 10.0) | (rsi_3_4h > 25.0) | (aroonu_14_1d < 85.0))
+          long_entry_logic.append((rsi_3_15m_gt_10) | (rsi_3_4h_gt_25) | (aroonu_14_1d < 85.0))
           # 15m & 4h down move, 1h still high
-          long_entry_logic.append((rsi_3_15m > 10.0) | (rsi_3_4h > 30.0) | (stochrsi_k_1h_lt_50))
+          long_entry_logic.append((rsi_3_15m_gt_10) | (rsi_3_4h_gt_30) | (stochrsi_k_1h_lt_50))
           # 15m & 4h down move, 4h high
-          long_entry_logic.append((rsi_3_15m > 10.0) | (rsi_3_4h > 30.0) | aroonu_14_4h_lt_70)
+          long_entry_logic.append((rsi_3_15m_gt_10) | (rsi_3_4h_gt_30) | aroonu_14_4h_lt_70)
           # 15m & 1d down move, 1h still high
-          long_entry_logic.append((rsi_3_15m > 10.0) | (rsi_3_1d > 25.0) | (stochrsi_k_1h_lt_50))
+          long_entry_logic.append((rsi_3_15m_gt_10) | (rsi_3_1d_gt_25) | (stochrsi_k_1h_lt_50))
           # 15m down move, 15m still not low enough, 1h high
-          long_entry_logic.append((rsi_3_15m > 10.0) | (aroonu_14_15m < 30.0) | (stochrsi_k_1h_lt_80))
+          long_entry_logic.append((rsi_3_15m_gt_10) | (aroonu_14_15m < 30.0) | (stochrsi_k_1h_lt_80))
           # 15m down move, 1h high, 4h overbought
-          long_entry_logic.append((rsi_3_15m > 10.0) | aroonu_14_1h_lt_70 | (roc_9_4h < 50.0))
+          long_entry_logic.append((rsi_3_15m_gt_10) | aroonu_14_1h_lt_70 | (roc_9_4h < 50.0))
           # 15m down move, 1d high & overbought
-          long_entry_logic.append((rsi_3_15m > 10.0) | (aroonu_14_1d < 80.0) | (roc_9_1d < 20.0))
+          long_entry_logic.append((rsi_3_15m_gt_10) | (aroonu_14_1d_lt_80) | (roc_9_1d_lt_20))
           # 15m & 1h down move, 1h still high
-          long_entry_logic.append((rsi_3_15m > 10.0) | (rsi_3_1h > 30.0) | (aroonu_14_1h < 40.0))
+          long_entry_logic.append((rsi_3_15m_gt_10) | (rsi_3_1h_gt_30) | (aroonu_14_1h < 40.0))
           # 15m & 1h down move, 1h still high
-          long_entry_logic.append((rsi_3_15m > 15.0) | (rsi_3_1h > 40.0) | (aroonu_14_1h < 50.0))
+          long_entry_logic.append((rsi_3_15m_gt_15) | (rsi_3_1h_gt_40) | (aroonu_14_1h_lt_50))
           # 15m & 1h down move, 1h still high
-          long_entry_logic.append((rsi_3_15m > 15.0) | (rsi_3_1h > 45.0) | (stochrsi_k_1h_lt_50))
+          long_entry_logic.append((rsi_3_15m_gt_15) | (rsi_3_1h_gt_45) | (stochrsi_k_1h_lt_50))
           # 15m & 1h down move, 4h high
-          long_entry_logic.append((rsi_3_15m > 15.0) | (rsi_3_1h > 45.0) | aroonu_14_4h_lt_80)
+          long_entry_logic.append((rsi_3_15m_gt_15) | (rsi_3_1h_gt_45) | aroonu_14_4h_lt_80)
           # 15m & 1h down move, 15m still not low enough
-          long_entry_logic.append((rsi_3_15m > 15.0) | (rsi_3_1h > 45.0) | (stochrsi_k_15m < 50.0))
+          long_entry_logic.append((rsi_3_15m_gt_15) | (rsi_3_1h_gt_45) | (stochrsi_k_15m < 50.0))
           # 15m & 4h & 1d down move
-          long_entry_logic.append((rsi_3_15m > 15.0) | (rsi_3_4h_gt_15) | (rsi_3_1d > 15.0))
+          long_entry_logic.append((rsi_3_15m_gt_15) | (rsi_3_4h_gt_15) | (rsi_3_1d_gt_15))
           # 15m & 4h down move, 4h still high
-          long_entry_logic.append((rsi_3_15m > 15.0) | rsi_3_4h_gt_20 | (aroonu_14_4h < 50.0))
+          long_entry_logic.append((rsi_3_15m_gt_15) | rsi_3_4h_gt_20 | (aroonu_14_4h_lt_50))
           # 15m & 4h down move, 15m still not low enough
-          long_entry_logic.append((rsi_3_15m > 15.0) | (rsi_3_4h > 30.0) | (stochrsi_k_15m < 25.0))
+          long_entry_logic.append((rsi_3_15m_gt_15) | (rsi_3_4h_gt_30) | (stochrsi_k_15m < 25.0))
           # 15m & 4h down move, 4h high
-          long_entry_logic.append((rsi_3_15m > 15.0) | (rsi_3_4h > 35.0) | (aroonu_14_4h < 60.0))
+          long_entry_logic.append((rsi_3_15m_gt_15) | (rsi_3_4h_gt_35) | (aroonu_14_4h_lt_60))
           # 15m & 4h down move, 4h high
-          long_entry_logic.append((rsi_3_15m > 15.0) | (rsi_3_4h > 35.0) | (stochrsi_k_4h < 70.0))
+          long_entry_logic.append((rsi_3_15m_gt_15) | (rsi_3_4h_gt_35) | (stochrsi_k_4h_lt_70))
           # 15m & 4h down move, 4h still high
-          long_entry_logic.append((rsi_3_15m > 15.0) | (rsi_3_4h > 45.0) | (stochrsi_k_4h < 50.0))
+          long_entry_logic.append((rsi_3_15m_gt_15) | (rsi_3_4h > 45.0) | (stochrsi_k_4h_lt_50))
           # 15m down move, 15m still not low enough, 4h high
-          long_entry_logic.append((rsi_3_15m > 15.0) | (rsi_14_15m < 35.0) | (stochrsi_k_4h_lt_90))
+          long_entry_logic.append((rsi_3_15m_gt_15) | (rsi_14_15m < 35.0) | (stochrsi_k_4h_lt_90))
           # 15m down move, 15m still not low enough, 4h high
-          long_entry_logic.append((rsi_3_15m > 15.0) | (aroonu_14_15m < 30.0) | (stochrsi_k_4h_lt_90))
+          long_entry_logic.append((rsi_3_15m_gt_15) | (aroonu_14_15m < 30.0) | (stochrsi_k_4h_lt_90))
           # 15m down move, 15m & 4h still high
-          long_entry_logic.append((rsi_3_15m > 15.0) | (aroonu_14_15m < 50.0) | (aroonu_14_4h < 50.0))
+          long_entry_logic.append((rsi_3_15m_gt_15) | (aroonu_14_15m_lt_50) | (aroonu_14_4h_lt_50))
           # 15m down move, 15m still high, 1h high
-          long_entry_logic.append((rsi_3_15m > 15.0) | (stochrsi_k_15m < 40.0) | (stochrsi_k_1h_lt_70))
+          long_entry_logic.append((rsi_3_15m_gt_15) | (stochrsi_k_15m < 40.0) | (stochrsi_k_1h_lt_70))
           # 15m down move, 1h still high, 4h high
-          long_entry_logic.append((rsi_3_15m > 15.0) | (stochrsi_k_1h_lt_50) | (stochrsi_k_4h < 60.0))
+          long_entry_logic.append((rsi_3_15m_gt_15) | (stochrsi_k_1h_lt_50) | (stochrsi_k_4h < 60.0))
           # 15m down move, 4h still high 1d overbought
-          long_entry_logic.append((rsi_3_15m > 15.0) | (aroonu_14_4h < 50.0) | roc_9_1d_lt_50)
+          long_entry_logic.append((rsi_3_15m_gt_15) | (aroonu_14_4h_lt_50) | roc_9_1d_lt_50)
           # 15m & 1h down move, 15m still not low enough
-          long_entry_logic.append((rsi_3_15m > 20.0) | rsi_3_1h_gt_20 | (aroonu_14_15m < 30.0))
+          long_entry_logic.append((rsi_3_15m_gt_20) | rsi_3_1h_gt_20 | (aroonu_14_15m < 30.0))
           # 15m & 1h down move, 4h high
-          long_entry_logic.append((rsi_3_15m > 20.0) | (rsi_3_1h > 30.0) | (stochrsi_k_4h_lt_90))
+          long_entry_logic.append((rsi_3_15m_gt_20) | (rsi_3_1h_gt_30) | (stochrsi_k_4h_lt_90))
           # 15m & 1h down move, 15m high
-          long_entry_logic.append((rsi_3_15m > 20.0) | (rsi_3_1h > 40.0) | (aroonu_14_15m < 60.0))
+          long_entry_logic.append((rsi_3_15m_gt_20) | (rsi_3_1h_gt_40) | (aroonu_14_15m < 60.0))
           # 15m & 4h down move, 1h high
-          long_entry_logic.append((rsi_3_15m > 20.0) | rsi_3_4h_gt_20 | (stochrsi_k_1h < 60.0))
+          long_entry_logic.append((rsi_3_15m_gt_20) | rsi_3_4h_gt_20 | (stochrsi_k_1h < 60.0))
           # 15m & 4h down move, 4h high
-          long_entry_logic.append((rsi_3_15m > 20.0) | (rsi_3_4h > 60.0) | aroonu_14_4h_lt_80)
+          long_entry_logic.append((rsi_3_15m_gt_20) | (rsi_3_4h > 60.0) | aroonu_14_4h_lt_80)
           # 15m & 1d down move, 4h high
-          long_entry_logic.append((rsi_3_15m > 20.0) | (rsi_3_1d > 20.0) | (stochrsi_k_4h_lt_90))
+          long_entry_logic.append((rsi_3_15m_gt_20) | (rsi_3_1d_gt_20) | (stochrsi_k_4h_lt_90))
           # 15m down move, 15m still not low enough, 4h high
-          long_entry_logic.append((rsi_3_15m > 20.0) | (rsi_14_15m < 35.0) | (rsi_14_4h < 85.0))
+          long_entry_logic.append((rsi_3_15m_gt_20) | (rsi_14_15m < 35.0) | (rsi_14_4h < 85.0))
           # 15m down move, 15m still not low enough, 1h high
-          long_entry_logic.append((rsi_3_15m > 20.0) | (aroonu_14_15m < 30.0) | (stochrsi_k_1h_lt_80))
+          long_entry_logic.append((rsi_3_15m_gt_20) | (aroonu_14_15m < 30.0) | (stochrsi_k_1h_lt_80))
           # 15m down move, 15m still not low enough, 4h high
-          long_entry_logic.append((rsi_3_15m > 20.0) | (aroonu_14_15m < 30.0) | (stochrsi_k_4h < 70.0))
+          long_entry_logic.append((rsi_3_15m_gt_20) | (aroonu_14_15m < 30.0) | (stochrsi_k_4h_lt_70))
           # 15m down move, 15m still high, 4d downtrend
-          long_entry_logic.append((rsi_3_15m > 20.0) | (aroonu_14_15m < 40.0) | (roc_9_4h_gt_neg_20))
+          long_entry_logic.append((rsi_3_15m_gt_20) | (aroonu_14_15m < 40.0) | (roc_9_4h_gt_neg_20))
           # 15m down move, 15m still not low enough, 1h still high
-          long_entry_logic.append((rsi_3_15m > 20.0) | (stochrsi_k_15m < 30.0) | (aroonu_14_1h < 50.0))
+          long_entry_logic.append((rsi_3_15m_gt_20) | (stochrsi_k_15m < 30.0) | (aroonu_14_1h_lt_50))
           # 15m down move, 15m & 1h still high
-          long_entry_logic.append((rsi_3_15m > 20.0) | (aroonu_14_15m < 50.0) | (stochrsi_k_1h < 40.0))
+          long_entry_logic.append((rsi_3_15m_gt_20) | (aroonu_14_15m_lt_50) | (stochrsi_k_1h < 40.0))
           # 15m down move, 1h & 4h high
-          long_entry_logic.append((rsi_3_15m > 20.0) | aroonu_14_1h_lt_70 | (aroonu_14_4h < 90.0))
+          long_entry_logic.append((rsi_3_15m_gt_20) | aroonu_14_1h_lt_70 | (aroonu_14_4h_lt_90))
           # 15m & 1h down move, 1h high
-          long_entry_logic.append((rsi_3_15m > 25.0) | (rsi_3_1h > 25.0) | aroonu_14_1h_lt_80)
+          long_entry_logic.append((rsi_3_15m_gt_25) | (rsi_3_1h_gt_25) | aroonu_14_1h_lt_80)
           # 15m & 1h down move, 4h high
-          long_entry_logic.append((rsi_3_15m > 25.0) | (rsi_3_1h > 35.0) | (stochrsi_k_4h_lt_80))
+          long_entry_logic.append((rsi_3_15m_gt_25) | (rsi_3_1h_gt_35) | (stochrsi_k_4h_lt_80))
           # 15m & 1h down move, 1d high
-          long_entry_logic.append((rsi_3_15m > 25.0) | (rsi_3_1h > 40.0) | (stochrsi_k_1d < 90.0))
+          long_entry_logic.append((rsi_3_15m_gt_25) | (rsi_3_1h_gt_40) | (stochrsi_k_1d_lt_90))
           # 15m & 1h down move, 1h high
-          long_entry_logic.append((rsi_3_15m > 25.0) | (rsi_3_1h > 60.0) | (aroonu_14_1h < 85.0))
+          long_entry_logic.append((rsi_3_15m_gt_25) | (rsi_3_1h > 60.0) | (aroonu_14_1h < 85.0))
           # 15m & 4h down move, 15m still high
-          long_entry_logic.append((rsi_3_15m > 25.0) | (rsi_3_4h > 40.0) | (aroonu_14_15m < 50.0))
+          long_entry_logic.append((rsi_3_15m_gt_25) | (rsi_3_4h_gt_40) | (aroonu_14_15m_lt_50))
           # 15m & 1d down move, 4h high
-          long_entry_logic.append((rsi_3_15m > 25.0) | (rsi_3_1d > 25.0) | (stochrsi_k_4h < 70.0))
+          long_entry_logic.append((rsi_3_15m_gt_25) | (rsi_3_1d_gt_25) | (stochrsi_k_4h_lt_70))
           # 15m & 1d down move, 1h high
-          long_entry_logic.append((rsi_3_15m > 25.0) | (rsi_3_1d > 30.0) | (stochrsi_k_1h_lt_80))
+          long_entry_logic.append((rsi_3_15m_gt_25) | (rsi_3_1d > 30.0) | (stochrsi_k_1h_lt_80))
           # 15m down move, 15m & 1h still high
-          long_entry_logic.append((rsi_3_15m > 25.0) | (aroonu_14_15m < 50.0) | (stochrsi_k_1h_lt_50))
+          long_entry_logic.append((rsi_3_15m_gt_25) | (aroonu_14_15m_lt_50) | (stochrsi_k_1h_lt_50))
           # 15m down move, 15m still high, 4h high
-          long_entry_logic.append((rsi_3_15m > 25.0) | (aroonu_14_15m < 50.0) | (stochrsi_k_4h < 70.0))
+          long_entry_logic.append((rsi_3_15m_gt_25) | (aroonu_14_15m_lt_50) | (stochrsi_k_4h_lt_70))
           # 15m down move, 15m high, 1d overbought
-          long_entry_logic.append((rsi_3_15m > 25.0) | (aroonu_14_15m < 70.0) | (roc_9_1d_lt_100))
+          long_entry_logic.append((rsi_3_15m_gt_25) | (aroonu_14_15m_lt_70) | (roc_9_1d_lt_100))
           # 15m down move, 15m high
-          long_entry_logic.append((rsi_3_15m > 25.0) | (aroonu_14_15m < 85.0))
+          long_entry_logic.append((rsi_3_15m_gt_25) | (aroonu_14_15m < 85.0))
           # 15m down move, 1h & 4h high
-          long_entry_logic.append((rsi_3_15m > 25.0) | aroonu_14_1h_lt_80 | (aroonu_14_4h < 90.0))
+          long_entry_logic.append((rsi_3_15m_gt_25) | aroonu_14_1h_lt_80 | (aroonu_14_4h_lt_90))
           # 15m down move, 1h & 4h high
-          long_entry_logic.append((rsi_3_15m > 25.0) | (stochrsi_k_1h_lt_70) | (aroonu_14_4h < 90.0))
+          long_entry_logic.append((rsi_3_15m_gt_25) | (stochrsi_k_1h_lt_70) | (aroonu_14_4h_lt_90))
           # 15m down move, 4h high, 1d overbought
-          long_entry_logic.append((rsi_3_15m > 25.0) | aroonu_14_4h_lt_80 | roc_9_1d_lt_50)
+          long_entry_logic.append((rsi_3_15m_gt_25) | aroonu_14_4h_lt_80 | roc_9_1d_lt_50)
           # 15m & 1h down move, 1h high
-          long_entry_logic.append((rsi_3_15m > 30.0) | (rsi_3_1h > 45.0) | (aroonu_14_1h < 60.0))
+          long_entry_logic.append((rsi_3_15m_gt_30) | (rsi_3_1h_gt_45) | (aroonu_14_1h < 60.0))
           # 15m down move, 15m high, 4h still high
-          long_entry_logic.append((rsi_3_15m > 30.0) | (aroonu_14_15m < 70.0) | (aroonu_14_4h < 50.0))
+          long_entry_logic.append((rsi_3_15m_gt_30) | (aroonu_14_15m_lt_70) | (aroonu_14_4h_lt_50))
           # 15m down move, 15m still not low enough, 1h high
-          long_entry_logic.append((rsi_3_15m > 30.0) | (stochrsi_k_15m < 30.0) | (stochrsi_k_1h_lt_80))
+          long_entry_logic.append((rsi_3_15m_gt_30) | (stochrsi_k_15m < 30.0) | (stochrsi_k_1h_lt_80))
           # 15m down move, 1h still high, 4h high
-          long_entry_logic.append((rsi_3_15m > 30.0) | (aroonu_14_1h < 50.0) | (aroonu_14_4h < 90.0))
+          long_entry_logic.append((rsi_3_15m_gt_30) | (aroonu_14_1h_lt_50) | (aroonu_14_4h_lt_90))
           # 15m down move, 15m & 1h high
-          long_entry_logic.append((rsi_3_15m > 35.0) | (aroonu_14_15m < 70.0) | (stochrsi_k_1h_lt_70))
+          long_entry_logic.append((rsi_3_15m > 35.0) | (aroonu_14_15m_lt_70) | (stochrsi_k_1h_lt_70))
           # 15m down move, 15m & 4h high
-          long_entry_logic.append((rsi_3_15m > 35.0) | (aroonu_14_15m < 70.0) | (stochrsi_k_4h_lt_90))
+          long_entry_logic.append((rsi_3_15m > 35.0) | (aroonu_14_15m_lt_70) | (stochrsi_k_4h_lt_90))
           # 15m down move, 15m high
           long_entry_logic.append((rsi_3_15m > 35.0) | (aroonu_14_15m < 80.0))
           # 15m down move, 4h still high, 4h overbought
-          long_entry_logic.append((rsi_3_15m > 35.0) | (stochrsi_k_4h < 50.0) | (roc_9_4h_lt_20))
+          long_entry_logic.append((rsi_3_15m > 35.0) | (stochrsi_k_4h_lt_50) | (roc_9_4h_lt_20))
           # 15m down move, 15m still high, 1h high
           long_entry_logic.append((rsi_3_15m > 40.0) | (rsi_14_15m < 50.0) | aroonu_14_1h_lt_80)
           # 15m down move, 15m high, 1h high
-          long_entry_logic.append((rsi_3_15m > 40.0) | (aroonu_14_15m < 70.0) | (aroonu_14_1h < 90.0))
+          long_entry_logic.append((rsi_3_15m > 40.0) | (aroonu_14_15m_lt_70) | (aroonu_14_1h_lt_90))
           # 15m down move, 15m high
           long_entry_logic.append((rsi_3_15m > 45.0) | (aroonu_14_15m < 90.0))
           # 1h & 4h down move, 4h still high
           long_entry_logic.append((rsi_3_1h_gt_15) | rsi_3_4h_gt_20 | (rsi_14_4h < 40.0))
           # 1h & 4h down move, 1h still high
-          long_entry_logic.append((rsi_3_1h_gt_15) | (rsi_3_4h > 30.0) | (stochrsi_k_1h < 50.0))
+          long_entry_logic.append((rsi_3_1h_gt_15) | (rsi_3_4h_gt_30) | (stochrsi_k_1h < 50.0))
           # 1h & 4h down move, 4h still high
-          long_entry_logic.append((rsi_3_1h_gt_15) | (rsi_3_4h > 30.0) | (aroonu_14_4h < 40.0))
+          long_entry_logic.append((rsi_3_1h_gt_15) | (rsi_3_4h_gt_30) | (aroonu_14_4h_lt_40))
           # 1h & 1d down move, 4h downtrend
           long_entry_logic.append((rsi_3_1h_gt_15) | (rsi_3_1d > 35.0) | (cmf_20_4h > -0.40))
           # 1h down move, 1d high & overbought
-          long_entry_logic.append(rsi_3_1h_gt_20 | (stochrsi_k_1d < 90.0) | (roc_9_1d < 30.0))
+          long_entry_logic.append(rsi_3_1h_gt_20 | (stochrsi_k_1d_lt_90) | (roc_9_1d_lt_30))
           # 1h & 4h down move, 4h still high
-          long_entry_logic.append((rsi_3_1h > 25.0) | (rsi_3_4h > 25.0) | (stochrsi_k_4h < 50.0))
+          long_entry_logic.append((rsi_3_1h_gt_25) | (rsi_3_4h_gt_25) | (stochrsi_k_4h_lt_50))
           # 1h & 4h down move, 4h high
-          long_entry_logic.append((rsi_3_1h > 25.0) | (rsi_3_4h > 40.0) | aroonu_14_4h_lt_70)
+          long_entry_logic.append((rsi_3_1h_gt_25) | (rsi_3_4h_gt_40) | aroonu_14_4h_lt_70)
           # 1h down move, 1h still not low enough, 4h high
-          long_entry_logic.append((rsi_3_1h > 25.0) | (stochrsi_k_1h < 30.0) | (stochrsi_k_4h < 70.0))
+          long_entry_logic.append((rsi_3_1h_gt_25) | (stochrsi_k_1h < 30.0) | (stochrsi_k_4h_lt_70))
           # 1h down move, 1d still high, 1d downtrend
-          long_entry_logic.append((rsi_3_1h > 25.0) | (stochrsi_k_1d < 50.0) | (roc_9_1d_gt_neg_20))
+          long_entry_logic.append((rsi_3_1h_gt_25) | (stochrsi_k_1d < 50.0) | (roc_9_1d_gt_neg_20))
           # 1h down move, 4h high & overbought
-          long_entry_logic.append((rsi_3_1h > 30.0) | aroonu_14_4h_lt_70 | (roc_9_4h < 10.0))
+          long_entry_logic.append((rsi_3_1h_gt_30) | aroonu_14_4h_lt_70 | (roc_9_4h_lt_10))
           # 1h down move, 4h high, 1d downtrend
-          long_entry_logic.append((rsi_3_1h > 30.0) | aroonu_14_4h_lt_70 | roc_9_1d_gt_neg_50)
+          long_entry_logic.append((rsi_3_1h_gt_30) | aroonu_14_4h_lt_70 | roc_9_1d_gt_neg_50)
           # 1h down move, 4h high, 1d overbought
-          long_entry_logic.append((rsi_3_1h > 30.0) | aroonu_14_4h_lt_70 | (roc_9_1d < 40.0))
+          long_entry_logic.append((rsi_3_1h_gt_30) | aroonu_14_4h_lt_70 | (roc_9_1d_lt_40))
           # 1h down move, 4h & 1d overbought
-          long_entry_logic.append((rsi_3_1h > 30.0) | (roc_9_4h < 10.0) | (roc_9_1d < 40.0))
+          long_entry_logic.append((rsi_3_1h_gt_30) | (roc_9_4h_lt_10) | (roc_9_1d_lt_40))
           # 1h & 4h down move, 4h high
-          long_entry_logic.append((rsi_3_1h > 35.0) | (rsi_3_4h > 55.0) | (stochrsi_k_4h_lt_80))
+          long_entry_logic.append((rsi_3_1h_gt_35) | (rsi_3_4h > 55.0) | (stochrsi_k_4h_lt_80))
           # 1h down move, 1h high, 1d overbought
-          long_entry_logic.append((rsi_3_1h > 35.0) | aroonu_14_1h_lt_70 | (roc_9_1d < 20.0))
+          long_entry_logic.append((rsi_3_1h_gt_35) | aroonu_14_1h_lt_70 | (roc_9_1d_lt_20))
           # 1h down move, 4h high, 1d overbought
-          long_entry_logic.append((rsi_3_1h > 40.0) | (rsi_14_4h < 75.0) | (roc_9_1d_lt_100))
+          long_entry_logic.append((rsi_3_1h_gt_40) | (rsi_14_4h < 75.0) | (roc_9_1d_lt_100))
           # 1h down move, 1h still high, 1d high
-          long_entry_logic.append((rsi_3_1h > 40.0) | (aroonu_14_1h < 50.0) | (aroonu_14_1d < 85.0))
+          long_entry_logic.append((rsi_3_1h_gt_40) | (aroonu_14_1h_lt_50) | (aroonu_14_1d < 85.0))
           # 1h down move, 1h still high, 1d overbought
-          long_entry_logic.append((rsi_3_1h > 40.0) | (aroonu_14_1h < 50.0) | (roc_9_1d < 20.0))
+          long_entry_logic.append((rsi_3_1h_gt_40) | (aroonu_14_1h_lt_50) | (roc_9_1d_lt_20))
           # 1h down move 1h high & overbought
-          long_entry_logic.append((rsi_3_1h > 45.0) | (aroonu_14_1h < 90.0) | (roc_9_1h < 10.0))
+          long_entry_logic.append((rsi_3_1h_gt_45) | (aroonu_14_1h_lt_90) | (roc_9_1h_lt_10))
           # 1h down move, 1h high & overbought
-          long_entry_logic.append((rsi_3_1h > 55.0) | (stochrsi_k_1h_lt_80) | (roc_9_1h < 10.0))
+          long_entry_logic.append((rsi_3_1h > 55.0) | (stochrsi_k_1h_lt_80) | (roc_9_1h_lt_10))
           # 1h down move, 1d high, 1h overbought
-          long_entry_logic.append((rsi_3_1h > 60.0) | (aroonu_14_1d < 90.0) | (roc_9_1h < 10.0))
+          long_entry_logic.append((rsi_3_1h > 60.0) | (aroonu_14_1d_lt_90) | (roc_9_1h_lt_10))
           # 4h down move, 4h still not low enough, 1d overbought
           long_entry_logic.append((rsi_3_4h_gt_15) | (aroonu_14_4h < 30.0) | (roc_9_1d < 100.0))
           # 4h down move, 15m still high, 1d downtrend
           long_entry_logic.append((rsi_3_4h_gt_15) | (stochrsi_k_15m < 50.0) | (roc_9_1d > -20.0))
           # 4h & 1d down move, 15m still not low enough
-          long_entry_logic.append(rsi_3_4h_gt_20 | (rsi_3_1d > 20.0) | (stochrsi_k_15m < 30.0))
+          long_entry_logic.append(rsi_3_4h_gt_20 | (rsi_3_1d_gt_20) | (stochrsi_k_15m < 30.0))
           # 4h down move, 4h still not low enough, 1d downtrend
           long_entry_logic.append(rsi_3_4h_gt_20 | (stochrsi_k_4h < 30.0) | (roc_9_1d_gt_neg_20))
           # 4h down move, 1d high, 4h downtrend
-          long_entry_logic.append((rsi_3_4h > 30.0) | (stochrsi_k_1d < 90.0) | (roc_9_4h_gt_neg_20))
+          long_entry_logic.append((rsi_3_4h_gt_30) | (stochrsi_k_1d_lt_90) | (roc_9_4h_gt_neg_20))
           # 4h down move, 4h high, 1d downtrend
-          long_entry_logic.append((rsi_3_4h > 35.0) | (stochrsi_k_4h < 70.0) | (roc_9_1d_gt_neg_30))
+          long_entry_logic.append((rsi_3_4h_gt_35) | (stochrsi_k_4h_lt_70) | (roc_9_1d_gt_neg_30))
           # 4h & 1d down move, 1d high
-          long_entry_logic.append((rsi_3_4h > 40.0) | (rsi_3_1d > 60.0) | aroonu_14_1d_lt_100)
+          long_entry_logic.append((rsi_3_4h_gt_40) | (rsi_3_1d > 60.0) | aroonu_14_1d_lt_100)
           # 4h down move, 4h high, 1d downtrend
           long_entry_logic.append((rsi_3_4h > 60.0) | (stochrsi_k_4h < 80.0) | (roc_9_1d_gt_neg_20))
           # 4h down move, 15m high, 4h overbought
           long_entry_logic.append((rsi_3_4h > 60.0) | (stochrsi_k_15m < 80.0) | (roc_9_4h_lt_20))
           # 4h down move, 4h & 1d overbought
-          long_entry_logic.append((rsi_3_4h > 60.0) | (roc_9_4h_lt_20) | (roc_9_1d < 20.0))
+          long_entry_logic.append((rsi_3_4h > 60.0) | (roc_9_4h_lt_20) | (roc_9_1d_lt_20))
           # 1d down move, 1h high, 1d downtrend
-          long_entry_logic.append((rsi_3_1d > 10.0) | (aroonu_14_1h < 85.0) | (roc_9_1d_gt_neg_30))
+          long_entry_logic.append((rsi_3_1d_gt_10) | (aroonu_14_1h < 85.0) | (roc_9_1d_gt_neg_30))
           # 1d down move, 15m still not low enough, 1h still high
-          long_entry_logic.append((rsi_3_1d > 15.0) | (aroonu_14_15m < 30.0) | (stochrsi_k_1h_lt_50))
+          long_entry_logic.append((rsi_3_1d_gt_15) | (aroonu_14_15m < 30.0) | (stochrsi_k_1h_lt_50))
           # 15m still not low enough, 1h high, 1d overbought
           long_entry_logic.append((aroonu_14_15m < 30.0) | (stochrsi_k_1h < 80.0) | (roc_9_1d_lt_100))
           # 15m still high, 4h high & overbought
-          long_entry_logic.append((aroonu_14_15m < 40.0) | (stochrsi_k_4h_lt_80) | (roc_9_4h < 30.0))
+          long_entry_logic.append((aroonu_14_15m < 40.0) | (stochrsi_k_4h_lt_80) | (roc_9_4h_lt_30))
           # 15m & 1h & 4h high
-          long_entry_logic.append((aroonu_14_15m < 70.0) | aroonu_14_1h_lt_80 | (aroonu_14_4h < 90.0))
+          long_entry_logic.append((aroonu_14_15m_lt_70) | aroonu_14_1h_lt_80 | (aroonu_14_4h_lt_90))
           # 15m & 1h high, 4h overbought
-          long_entry_logic.append((aroonu_14_15m < 70.0) | (aroonu_14_1h < 90.0) | (roc_9_4h_lt_20))
+          long_entry_logic.append((aroonu_14_15m_lt_70) | (aroonu_14_1h_lt_90) | (roc_9_4h_lt_20))
           # 15m & 1d high, 1d overbought
-          long_entry_logic.append((aroonu_14_15m < 70.0) | (aroonu_14_1d < 90.0) | (roc_9_1d_lt_100))
+          long_entry_logic.append((aroonu_14_15m_lt_70) | (aroonu_14_1d_lt_90) | (roc_9_1d_lt_100))
           # 15m high
           long_entry_logic.append((aroonu_14_15m < 80.0) | (stochrsi_k_15m < 60.0))
           # 15m & 4h high
-          long_entry_logic.append((aroonu_14_15m < 80.0) | (stochrsi_k_4h < 70.0))
+          long_entry_logic.append((aroonu_14_15m < 80.0) | (stochrsi_k_4h_lt_70))
           # 15m high, 1d overbought
           long_entry_logic.append((aroonu_14_15m < 80.0) | roc_9_1d_lt_50)
           # 15m & 4h high
           long_entry_logic.append((aroonu_14_15m < 90.0) | aroonu_14_4h_lt_70)
           # 15m & 1h high
-          long_entry_logic.append((aroonu_14_15m < 90.0) | (aroonu_14_1h < 90.0))
+          long_entry_logic.append((aroonu_14_15m < 90.0) | (aroonu_14_1h_lt_90))
           # 1h still high, 4h high & overbought
-          long_entry_logic.append((aroonu_14_1h < 50.0) | (aroonu_14_4h < 90.0) | (roc_9_4h < 80.0))
+          long_entry_logic.append((aroonu_14_1h_lt_50) | (aroonu_14_4h_lt_90) | (roc_9_4h < 80.0))
           # 1h & 4h high, 1h overbought
           long_entry_logic.append(aroonu_14_1h_lt_80 | aroonu_14_4h_lt_100 | (roc_9_1h < 40.0))
           # 1h & 1d high, 1d overbought
-          long_entry_logic.append(aroonu_14_1h_lt_80 | aroonu_14_1d_lt_100 | (roc_9_1d < 30.0))
+          long_entry_logic.append(aroonu_14_1h_lt_80 | aroonu_14_1d_lt_100 | (roc_9_1d_lt_30))
           # 1h high, 4h & 1d overbought
-          long_entry_logic.append((aroonu_14_1h < 90.0) | (roc_9_4h_lt_20) | (roc_9_1d < 40.0))
+          long_entry_logic.append((aroonu_14_1h_lt_90) | (roc_9_4h_lt_20) | (roc_9_1d_lt_40))
           # 4h & 1d high, 4h overbought
-          long_entry_logic.append(aroonu_14_4h_lt_80 | aroonu_14_1d_lt_100 | (roc_9_4h < 30.0))
+          long_entry_logic.append(aroonu_14_4h_lt_80 | aroonu_14_1d_lt_100 | (roc_9_4h_lt_30))
           # 4h & 1d high, 1d overbought
           long_entry_logic.append(aroonu_14_4h_lt_70 | aroonu_14_1d_lt_100 | (roc_9_1d < 10.0))
           # 4h high & overbought
-          long_entry_logic.append((aroonu_14_4h < 90.0) | (stochrsi_k_4h < 85.0) | (roc_9_4h < 50.0))
+          long_entry_logic.append((aroonu_14_4h_lt_90) | (stochrsi_k_4h < 85.0) | (roc_9_4h < 50.0))
           # 1d high, 4h & 1d overbought
-          long_entry_logic.append(aroonu_14_1d_lt_100 | (roc_9_4h < 10.0) | roc_9_1d_lt_50)
+          long_entry_logic.append(aroonu_14_1d_lt_100 | (roc_9_4h_lt_10) | roc_9_1d_lt_50)
           # 1d high, 4h & 1d overbought
-          long_entry_logic.append(aroonu_14_1d_lt_100 | (roc_9_4h < 20.0) | (roc_9_1d < 40.0))
+          long_entry_logic.append(aroonu_14_1d_lt_100 | (roc_9_4h < 20.0) | (roc_9_1d_lt_40))
           # 4h high, 4h & 1d overbought
-          long_entry_logic.append((stochrsi_k_4h < 70.0) | (roc_9_4h < 30.0) | (roc_9_1d < 30.0))
+          long_entry_logic.append((stochrsi_k_4h_lt_70) | (roc_9_4h_lt_30) | (roc_9_1d_lt_30))
           # 5m red, 1h still high
           long_entry_logic.append((df["change_pct"] > -5.0) | (stochrsi_k_1h_lt_50))
           # 1d top wick, 4h down move, 4h still high
-          long_entry_logic.append((top_wick_pct_1d < 30.0) | (rsi_3_4h > 60.0) | (aroonu_14_4h < 50.0))
+          long_entry_logic.append((top_wick_pct_1d < 30.0) | (rsi_3_4h > 60.0) | (aroonu_14_4h_lt_50))
           # pump, drop but not yet near the previous lows
           long_entry_logic.append(
             (((high_max_24_4h - low_min_24_4h) / low_min_24_4h) < 2.0)
@@ -20515,53 +20567,53 @@ class NostalgiaForInfinityX7(IStrategy):
 
           long_entry_logic.append(roc_2 > -0.0)
           # 15m down move, 4h high, 1d overbought
-          long_entry_logic.append((rsi_3_15m > 10.0) | (stochrsi_k_4h < 70.0) | (roc_9_1d < 80.0))
+          long_entry_logic.append((rsi_3_15m_gt_10) | (stochrsi_k_4h_lt_70) | (roc_9_1d_lt_80))
           # 15m & 1h & 4h down move
-          long_entry_logic.append((rsi_3_15m > 20.0) | (rsi_3_1h_gt_10) | rsi_3_4h_gt_20)
+          long_entry_logic.append((rsi_3_15m_gt_20) | (rsi_3_1h_gt_10) | rsi_3_4h_gt_20)
           # 15m & 4h down move, 1h still high
-          long_entry_logic.append((rsi_3_15m > 10.0) | rsi_3_4h_gt_20 | (stochrsi_k_1h_lt_50))
+          long_entry_logic.append((rsi_3_15m_gt_10) | rsi_3_4h_gt_20 | (stochrsi_k_1h_lt_50))
           # 15m & 1h down move, 1h high
-          long_entry_logic.append((rsi_3_15m > 15.0) | (rsi_3_1h > 40.0) | aroonu_14_1h_lt_70)
+          long_entry_logic.append((rsi_3_15m_gt_15) | (rsi_3_1h_gt_40) | aroonu_14_1h_lt_70)
           # 15m down move, 4h high & overbought
-          long_entry_logic.append((rsi_3_15m > 15.0) | (stochrsi_k_4h < 70.0) | (roc_9_4h < 30.0))
+          long_entry_logic.append((rsi_3_15m_gt_15) | (stochrsi_k_4h_lt_70) | (roc_9_4h_lt_30))
           # 15m & 1h down move, 15m high
-          long_entry_logic.append((rsi_3_15m > 20.0) | (rsi_3_1h > 45.0) | (aroonu_14_15m < 70.0))
+          long_entry_logic.append((rsi_3_15m_gt_20) | (rsi_3_1h_gt_45) | (aroonu_14_15m_lt_70))
           # 15m & 4h down move, 15m still high
-          long_entry_logic.append((rsi_3_15m > 20.0) | rsi_3_4h_gt_20 | (stochrsi_k_15m < 50.0))
+          long_entry_logic.append((rsi_3_15m_gt_20) | rsi_3_4h_gt_20 | (stochrsi_k_15m < 50.0))
           # 15m down move, 15m still high, 1h high
-          long_entry_logic.append((rsi_3_15m > 20.0) | (rsi_14_15m < 40.0) | (stochrsi_k_1h_lt_70))
+          long_entry_logic.append((rsi_3_15m_gt_20) | (rsi_14_15m < 40.0) | (stochrsi_k_1h_lt_70))
           # 15m down move, 15m still high, 4h high
-          long_entry_logic.append((rsi_3_15m > 20.0) | (rsi_14_15m < 40.0) | (aroonu_14_4h < 90.0))
+          long_entry_logic.append((rsi_3_15m_gt_20) | (rsi_14_15m < 40.0) | (aroonu_14_4h_lt_90))
           # 15m down move, 15m still high, 4h high
-          long_entry_logic.append((rsi_3_15m > 20.0) | (aroonu_14_15m < 50.0) | (aroonu_14_4h < 90.0))
+          long_entry_logic.append((rsi_3_15m_gt_20) | (aroonu_14_15m_lt_50) | (aroonu_14_4h_lt_90))
           # 15m down move, 15m & 1h high
-          long_entry_logic.append((rsi_3_15m > 20.0) | (aroonu_14_15m < 60.0) | aroonu_14_1h_lt_70)
+          long_entry_logic.append((rsi_3_15m_gt_20) | (aroonu_14_15m < 60.0) | aroonu_14_1h_lt_70)
           # 15m down move, 15m high, 4h still high
-          long_entry_logic.append((rsi_3_15m > 20.0) | (aroonu_14_15m < 70.0) | (aroonu_14_4h < 50.0))
+          long_entry_logic.append((rsi_3_15m_gt_20) | (aroonu_14_15m_lt_70) | (aroonu_14_4h_lt_50))
           # 15m down move, 15m & 1h still high
-          long_entry_logic.append((rsi_3_15m > 20.0) | (stochrsi_k_15m < 50.0) | (stochrsi_k_1h_lt_50))
+          long_entry_logic.append((rsi_3_15m_gt_20) | (stochrsi_k_15m < 50.0) | (stochrsi_k_1h_lt_50))
           # 15m down move, 4h overbought
-          long_entry_logic.append((rsi_3_15m > 20.0) | (roc_9_4h < 70.0))
+          long_entry_logic.append((rsi_3_15m_gt_20) | (roc_9_4h < 70.0))
           # 15m down move, 15m still high, 1h high
-          long_entry_logic.append((rsi_3_15m > 25.0) | (aroonu_14_15m < 50.0) | aroonu_14_1h_lt_80)
+          long_entry_logic.append((rsi_3_15m_gt_25) | (aroonu_14_15m_lt_50) | aroonu_14_1h_lt_80)
           # 15m down move, 4h & 1d high
-          long_entry_logic.append((rsi_3_15m > 25.0) | (aroonu_14_4h < 90.0) | (stochrsi_k_1d < 90.0))
+          long_entry_logic.append((rsi_3_15m_gt_25) | (aroonu_14_4h_lt_90) | (stochrsi_k_1d_lt_90))
           # 15m down move, 1h & 1d high
-          long_entry_logic.append((rsi_3_15m > 25.0) | (stochrsi_k_1h_lt_80) | (stochrsi_k_1d < 90.0))
+          long_entry_logic.append((rsi_3_15m_gt_25) | (stochrsi_k_1h_lt_80) | (stochrsi_k_1d_lt_90))
           # 15m down move, 1h high & overbought
-          long_entry_logic.append((rsi_3_15m > 25.0) | (stochrsi_k_1h_lt_80) | (roc_9_1h < 20.0))
+          long_entry_logic.append((rsi_3_15m_gt_25) | (stochrsi_k_1h_lt_80) | (roc_9_1h < 20.0))
           # 15m & 1h down move, 15m high
-          long_entry_logic.append((rsi_3_15m > 30.0) | (rsi_3_1h > 30.0) | (aroonu_14_15m < 70.0))
+          long_entry_logic.append((rsi_3_15m_gt_30) | (rsi_3_1h_gt_30) | (aroonu_14_15m_lt_70))
           # 15m down move, 15m & 1h high
-          long_entry_logic.append((rsi_3_15m > 30.0) | (aroonu_14_15m < 70.0) | (aroonu_14_1h < 90.0))
+          long_entry_logic.append((rsi_3_15m_gt_30) | (aroonu_14_15m_lt_70) | (aroonu_14_1h_lt_90))
           # 15m down move, 1h & 4h high
-          long_entry_logic.append((rsi_3_15m > 30.0) | (stochrsi_k_1h_lt_70) | (aroonu_14_4h < 90.0))
+          long_entry_logic.append((rsi_3_15m_gt_30) | (stochrsi_k_1h_lt_70) | (aroonu_14_4h_lt_90))
           # 15m & 1h down move, 1h high
-          long_entry_logic.append((rsi_3_15m > 35.0) | (rsi_3_1h > 45.0) | (stochrsi_k_1h_lt_80))
+          long_entry_logic.append((rsi_3_15m > 35.0) | (rsi_3_1h_gt_45) | (stochrsi_k_1h_lt_80))
           # 15m down move, 15m still high, 4h high
-          long_entry_logic.append((rsi_3_15m > 35.0) | (aroonu_14_15m < 50.0) | aroonu_14_4h_lt_80)
+          long_entry_logic.append((rsi_3_15m > 35.0) | (aroonu_14_15m_lt_50) | aroonu_14_4h_lt_80)
           # 15m down move, 15m & 1h high
-          long_entry_logic.append((rsi_3_15m > 35.0) | (aroonu_14_15m < 70.0) | (stochrsi_k_1h_lt_80))
+          long_entry_logic.append((rsi_3_15m > 35.0) | (aroonu_14_15m_lt_70) | (stochrsi_k_1h_lt_80))
           # 15m down move, 1h high, 4h overbought
           long_entry_logic.append((rsi_3_15m > 35.0) | (aroonu_14_1h < 85.0) | (roc_9_4h < 80.0))
           # 1h & 4h down move, 1h still high
@@ -20569,107 +20621,107 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1h & 4h down move, 15m still not low enough
           long_entry_logic.append((rsi_3_1h_gt_10) | rsi_3_4h_gt_20 | (stochrsi_k_15m < 20.0))
           # 1h down move, 1d high & overbought
-          long_entry_logic.append((rsi_3_1h_gt_10) | (aroonu_14_1d < 90.0) | (roc_9_1d < 10.0))
+          long_entry_logic.append((rsi_3_1h_gt_10) | (aroonu_14_1d_lt_90) | (roc_9_1d < 10.0))
           # 1h & 4h down move, 4h still high
-          long_entry_logic.append((rsi_3_1h_gt_15) | rsi_3_4h_gt_20 | (aroonu_14_4h < 40.0))
+          long_entry_logic.append((rsi_3_1h_gt_15) | rsi_3_4h_gt_20 | (aroonu_14_4h_lt_40))
           # 1h down move, 4h still high, 4h downtrend
-          long_entry_logic.append((rsi_3_1h_gt_15) | (aroonu_14_4h < 50.0) | (roc_9_4h > -20.0))
+          long_entry_logic.append((rsi_3_1h_gt_15) | (aroonu_14_4h_lt_50) | (roc_9_4h > -20.0))
           # 1h down move, 15m still not low enough, 4h high
           long_entry_logic.append(rsi_3_1h_gt_20 | (aroonu_14_15m < 25.0) | aroonu_14_4h_lt_80)
           # 1h down move, 4h & 1d high
-          long_entry_logic.append((rsi_3_1h > 30.0) | aroonu_14_4h_lt_70 | (stochrsi_k_1d < 80.0))
+          long_entry_logic.append((rsi_3_1h_gt_30) | aroonu_14_4h_lt_70 | (stochrsi_k_1d < 80.0))
           # 1h down move, 4h high & overbought
-          long_entry_logic.append((rsi_3_1h > 30.0) | aroonu_14_4h_lt_70 | (roc_9_4h < 10.0))
+          long_entry_logic.append((rsi_3_1h_gt_30) | aroonu_14_4h_lt_70 | (roc_9_4h_lt_10))
           # 1h down move, 4h high, 1d overbought
-          long_entry_logic.append((rsi_3_1h > 30.0) | aroonu_14_4h_lt_70 | (roc_9_1d < 40.0))
+          long_entry_logic.append((rsi_3_1h_gt_30) | aroonu_14_4h_lt_70 | (roc_9_1d_lt_40))
           # 1h down move, 4h & 1d overbought
-          long_entry_logic.append((rsi_3_1h > 30.0) | (roc_9_4h < 10.0) | (roc_9_1d < 40.0))
+          long_entry_logic.append((rsi_3_1h_gt_30) | (roc_9_4h_lt_10) | (roc_9_1d_lt_40))
           # 1h down move, 4h & 1d overbought
-          long_entry_logic.append((rsi_3_1h > 30.0) | (roc_9_4h < 30.0) | (roc_9_1d < 40.0))
+          long_entry_logic.append((rsi_3_1h_gt_30) | (roc_9_4h_lt_30) | (roc_9_1d_lt_40))
           # 1h down move, 15m & 1h still high
-          long_entry_logic.append((rsi_3_1h > 40.0) | (aroonu_14_15m < 50.0) | (stochrsi_k_1h_lt_50))
+          long_entry_logic.append((rsi_3_1h_gt_40) | (aroonu_14_15m_lt_50) | (stochrsi_k_1h_lt_50))
           # 1h down move, 1h still high, 4h high
-          long_entry_logic.append((rsi_3_1h > 40.0) | (aroonu_14_1h < 50.0) | (aroonu_14_4h < 90.0))
+          long_entry_logic.append((rsi_3_1h_gt_40) | (aroonu_14_1h_lt_50) | (aroonu_14_4h_lt_90))
           # 1h down move, 1h high, 4h overbought
-          long_entry_logic.append((rsi_3_1h > 40.0) | aroonu_14_1h_lt_70 | (roc_9_4h < 30.0))
+          long_entry_logic.append((rsi_3_1h_gt_40) | aroonu_14_1h_lt_70 | (roc_9_4h_lt_30))
           # 1h down move, 1h overbought
-          long_entry_logic.append((rsi_3_1h > 40.0) | (roc_9_1h < 30.0))
+          long_entry_logic.append((rsi_3_1h_gt_40) | (roc_9_1h < 30.0))
           # 1h down move, 1d high & overbought
-          long_entry_logic.append((rsi_3_1h > 45.0) | aroonu_14_1d_lt_100 | (roc_9_1d < 30.0))
+          long_entry_logic.append((rsi_3_1h_gt_45) | aroonu_14_1d_lt_100 | (roc_9_1d_lt_30))
           # 1h down move, 15m & 1h still high
-          long_entry_logic.append((rsi_3_1h > 50.0) | (aroonu_14_15m < 50.0) | (aroonu_14_1h < 85.0))
+          long_entry_logic.append((rsi_3_1h_gt_50) | (aroonu_14_15m_lt_50) | (aroonu_14_1h < 85.0))
           # 1h & 4h down move, 4h high
           long_entry_logic.append((rsi_3_1h > 60.0) | (rsi_3_4h > 60.0) | aroonu_14_4h_lt_80)
           # 1h & 4h down move, 4h high
           long_entry_logic.append((rsi_3_1h > 60.0) | (rsi_3_4h > 60.0) | (stochrsi_k_4h_lt_80))
           # 4h down move, 1h & 4h downtrend
-          long_entry_logic.append((rsi_3_4h > 5.0) | (roc_9_1h > -30.0) | (roc_9_4h > -30.0))
+          long_entry_logic.append((rsi_3_4h_gt_5) | (roc_9_1h > -30.0) | (roc_9_4h_gt_neg_30))
           # 1h down move, 4h high & overbought
-          long_entry_logic.append((rsi_3_1h > 50.0) | (stochrsi_k_4h < 90.0) | (roc_9_4h_lt_20))
+          long_entry_logic.append((rsi_3_1h_gt_50) | (stochrsi_k_4h < 90.0) | (roc_9_4h_lt_20))
           # 4h down move, 4h still high, 1d downtrend
-          long_entry_logic.append(rsi_3_4h_gt_20 | (aroonu_14_4h < 50.0) | (roc_9_1d > -40.0))
+          long_entry_logic.append(rsi_3_4h_gt_20 | (aroonu_14_4h_lt_50) | (roc_9_1d_gt_neg_40))
           # 1h down move, 15m & 1h still high
           long_entry_logic.append(rsi_3_4h_gt_20 | (stochrsi_k_15m < 40.0) | (stochrsi_k_1h_lt_50))
           # 4h down move, 15m still high, 4h high
-          long_entry_logic.append((rsi_3_4h > 25.0) | (stochrsi_k_15m < 50.0) | aroonu_14_4h_lt_70)
+          long_entry_logic.append((rsi_3_4h_gt_25) | (stochrsi_k_15m < 50.0) | aroonu_14_4h_lt_70)
           # 4h down move, 15m still not low enough, 4h high
-          long_entry_logic.append((rsi_3_4h > 35.0) | (aroonu_14_15m < 30.0) | aroonu_14_4h_lt_70)
+          long_entry_logic.append((rsi_3_4h_gt_35) | (aroonu_14_15m < 30.0) | aroonu_14_4h_lt_70)
           # 4h down move, 1h high, 4h downtrend
-          long_entry_logic.append((rsi_3_4h > 30.0) | aroonu_14_1h_lt_70 | (roc_9_4h > -10.0))
+          long_entry_logic.append((rsi_3_4h_gt_30) | aroonu_14_1h_lt_70 | (roc_9_4h > -10.0))
           # 4h down move, 4h still high, 1d downtrend
-          long_entry_logic.append((rsi_3_4h > 50.0) | (rsi_14_4h < 40.0) | (roc_9_1d_gt_neg_30))
+          long_entry_logic.append((rsi_3_4h_gt_50) | (rsi_14_4h < 40.0) | (roc_9_1d_gt_neg_30))
           # 4h down move, 4h high & overbought
-          long_entry_logic.append((rsi_3_4h > 50.0) | aroonu_14_4h_lt_80 | (roc_9_4h < 20.0))
+          long_entry_logic.append((rsi_3_4h_gt_50) | aroonu_14_4h_lt_80 | (roc_9_4h < 20.0))
           # 4h down move, 4h still high, 1d downtrend
-          long_entry_logic.append((rsi_3_4h > 50.0) | (stochrsi_k_4h < 50.0) | (roc_9_1d_gt_neg_30))
+          long_entry_logic.append((rsi_3_4h_gt_50) | (stochrsi_k_4h_lt_50) | (roc_9_1d_gt_neg_30))
           # 4h down move, 15m still high, 1h high
-          long_entry_logic.append((rsi_3_4h > 60.0) | (aroonu_14_15m < 50.0) | (aroonu_14_1h < 90.0))
+          long_entry_logic.append((rsi_3_4h > 60.0) | (aroonu_14_15m_lt_50) | (aroonu_14_1h_lt_90))
           # 4h down move, 1h high, 1d overbought
-          long_entry_logic.append((rsi_3_4h > 60.0) | (stochrsi_k_1h < 90.0) | (roc_9_1d < 30.0))
+          long_entry_logic.append((rsi_3_4h > 60.0) | (stochrsi_k_1h < 90.0) | (roc_9_1d_lt_30))
           # 1d down move, 1h high, 1d downtrend
-          long_entry_logic.append((rsi_3_1d > 10.0) | aroonu_14_1h_lt_80 | (roc_9_1d > -10.0))
+          long_entry_logic.append((rsi_3_1d_gt_10) | aroonu_14_1h_lt_80 | (roc_9_1d > -10.0))
           # 1d down move, 4h high
-          long_entry_logic.append((rsi_3_1d > 10.0) | (stochrsi_k_4h_lt_80))
+          long_entry_logic.append((rsi_3_1d_gt_10) | (stochrsi_k_4h_lt_80))
           # 1d down move, 15m still high, 1h high
-          long_entry_logic.append((rsi_3_1d > 15.0) | (aroonu_14_15m < 50.0) | (aroonu_14_1h < 85.0))
+          long_entry_logic.append((rsi_3_1d_gt_15) | (aroonu_14_15m_lt_50) | (aroonu_14_1h < 85.0))
           # 1d down move, 1h & 1d overbought
-          long_entry_logic.append((rsi_3_1d > 45.0) | (roc_9_1h < 80.0) | (roc_9_1d < 80.0))
+          long_entry_logic.append((rsi_3_1d > 45.0) | (roc_9_1h < 80.0) | (roc_9_1d_lt_80))
           # 15m still high, 1h & 4h high
-          long_entry_logic.append((rsi_14_15m < 40.0) | aroonu_14_1h_lt_80 | (aroonu_14_4h < 90.0))
+          long_entry_logic.append((rsi_14_15m < 40.0) | aroonu_14_1h_lt_80 | (aroonu_14_4h_lt_90))
           # 15m & 1h still high, 4h high
-          long_entry_logic.append((rsi_14_15m < 45.0) | (aroonu_14_1h < 40.0) | (stochrsi_k_4h < 70.0))
+          long_entry_logic.append((rsi_14_15m < 45.0) | (aroonu_14_1h < 40.0) | (stochrsi_k_4h_lt_70))
           # 15m still high, 4h high & overbought
-          long_entry_logic.append((rsi_14_15m < 50.0) | (aroonu_14_4h < 90.0) | (roc_9_4h < 80.0))
+          long_entry_logic.append((rsi_14_15m < 50.0) | (aroonu_14_4h_lt_90) | (roc_9_4h < 80.0))
           # 15m still high, 1h high, 4h still high
-          long_entry_logic.append((aroonu_14_15m < 50.0) | (aroonu_14_1h < 90.0) | (stochrsi_k_4h < 50.0))
+          long_entry_logic.append((aroonu_14_15m_lt_50) | (aroonu_14_1h_lt_90) | (stochrsi_k_4h_lt_50))
           # 15m still high, 1d high
-          long_entry_logic.append((aroonu_14_15m < 50.0) | (stochrsi_k_1d < 90.0))
+          long_entry_logic.append((aroonu_14_15m_lt_50) | (stochrsi_k_1d_lt_90))
           # 15m & 1h
-          long_entry_logic.append((aroonu_14_15m < 70.0) | (aroonu_14_1h < 90.0))
+          long_entry_logic.append((aroonu_14_15m_lt_70) | (aroonu_14_1h_lt_90))
           # 15m & 1h & 4h high
-          long_entry_logic.append((aroonu_14_15m < 70.0) | (stochrsi_k_1h_lt_70) | (aroonu_14_4h < 90.0))
+          long_entry_logic.append((aroonu_14_15m_lt_70) | (stochrsi_k_1h_lt_70) | (aroonu_14_4h_lt_90))
           # 1h & 1d high, 4h downtrend
-          long_entry_logic.append((aroonu_14_1h < 40.0) | (aroonu_14_1d < 70.0) | (roc_9_4h_gt_neg_20))
+          long_entry_logic.append((aroonu_14_1h < 40.0) | (aroonu_14_1d_lt_70) | (roc_9_4h_gt_neg_20))
           # 1h & 4h high, 4h overbought
-          long_entry_logic.append(aroonu_14_1h_lt_70 | (aroonu_14_4h < 90.0) | (roc_9_4h < 10.0))
+          long_entry_logic.append(aroonu_14_1h_lt_70 | (aroonu_14_4h_lt_90) | (roc_9_4h_lt_10))
           # 1h high, 1h & 1d overbought
-          long_entry_logic.append((aroonu_14_1h < 90.0) | (roc_9_1h < 10.0) | (roc_9_1d < 30.0))
+          long_entry_logic.append((aroonu_14_1h_lt_90) | (roc_9_1h_lt_10) | (roc_9_1d_lt_30))
           # 4h & 1d high, 1d overbought
           long_entry_logic.append(aroonu_14_4h_lt_70 | aroonu_14_1d_lt_100 | (roc_9_1d < 10.0))
           # 4h high, 4h & 1d overbought
           long_entry_logic.append(aroonu_14_4h_lt_80 | (roc_9_4h < 80.0) | (roc_9_1d < 100.0))
           # 1d high, 4h & 1d overbought
-          long_entry_logic.append(aroonu_14_1d_lt_100 | (roc_9_4h < 10.0) | roc_9_1d_lt_50)
+          long_entry_logic.append(aroonu_14_1d_lt_100 | (roc_9_4h_lt_10) | roc_9_1d_lt_50)
           # 15m still high, 1h high
-          long_entry_logic.append((stochrsi_k_15m < 40.0) | (aroonu_14_1h < 90.0) | (stochrsi_k_1h < 90.0))
+          long_entry_logic.append((stochrsi_k_15m < 40.0) | (aroonu_14_1h_lt_90) | (stochrsi_k_1h < 90.0))
           # 15m still high, 1d high
-          long_entry_logic.append((stochrsi_k_15m < 50.0) | (stochrsi_k_1d < 90.0))
+          long_entry_logic.append((stochrsi_k_15m < 50.0) | (stochrsi_k_1d_lt_90))
           # 4h high, 4h & 1d overbought
-          long_entry_logic.append((stochrsi_k_4h < 80.0) | (roc_9_4h < 40.0) | (roc_9_1d_lt_100))
+          long_entry_logic.append((stochrsi_k_4h < 80.0) | (roc_9_4h_lt_40) | (roc_9_1d_lt_100))
           # 1d green, 4h down move, 4h still high
-          long_entry_logic.append((change_pct_1d < 40.0) | (rsi_3_4h > 35.0) | (aroonu_14_4h < 40.0))
+          long_entry_logic.append((change_pct_1d < 40.0) | (rsi_3_4h_gt_35) | (aroonu_14_4h_lt_40))
           # 1d top wick, 4h high
-          long_entry_logic.append((top_wick_pct_1d < 30.0) | (aroonu_14_4h < 90.0))
+          long_entry_logic.append((top_wick_pct_1d < 30.0) | (aroonu_14_4h_lt_90))
           # pump, 4h overbought
           long_entry_logic.append(
             (((df["high_max_6_1h"] - df["low_min_6_1h"]) / df["low_min_6_1h"]) < 0.5) | (roc_9_4h < 50.0)
@@ -20685,11 +20737,11 @@ class NostalgiaForInfinityX7(IStrategy):
           # big drop in the last 2 days, 1d down move
           long_entry_logic.append((close > (high_max_12_4h * 0.30)) | (rsi_3_1d > 30.0))
           # big drop in the last 12 days, 1h still high
-          long_entry_logic.append((close > (high_max_12_1d * 0.25)) | (aroonu_14_1h < 50.0))
+          long_entry_logic.append((close > (high_max_12_1d * 0.25)) | (aroonu_14_1h_lt_50))
           # big drop in the last 12 days, 1h still not low enough
           long_entry_logic.append((close > (high_max_12_1d * 0.10)) | (stochrsi_k_1h < 30.0))
           # big drop in the last 12 days, 15m still high
-          long_entry_logic.append((close > (high_max_12_1d * 0.20)) | (aroonu_14_15m < 50.0))
+          long_entry_logic.append((close > (high_max_12_1d * 0.20)) | (aroonu_14_15m_lt_50))
           # big drop in the last 20 days, 4h down move
           long_entry_logic.append((close > (high_max_20_1d * 0.10)) | rsi_3_4h_gt_20)
 
@@ -20707,95 +20759,95 @@ class NostalgiaForInfinityX7(IStrategy):
           long_entry_logic.append(protections_long_global == True)
 
           # 5m & 4h & 1d down move
-          long_entry_logic.append((rsi_3 > 3.0) | rsi_3_4h_gt_20 | (rsi_3_1d > 20.0))
+          long_entry_logic.append((rsi_3_gt_3) | rsi_3_4h_gt_20 | (rsi_3_1d_gt_20))
           # 5m & 4h down move, 1d downtrend
           long_entry_logic.append((rsi_3 > 5.0) | (rsi_3_4h_gt_10) | (roc_9_1d > -20.0))
           # 5m & 1h down move, 1h still high
-          long_entry_logic.append((rsi_3 > 5.0) | (rsi_3_1h > 30.0) | (stochrsi_k_1h_lt_50))
+          long_entry_logic.append((rsi_3 > 5.0) | (rsi_3_1h_gt_30) | (stochrsi_k_1h_lt_50))
           # 15m & 4h & 1d down move
-          long_entry_logic.append(rsi_3_15m_gt_3 | (rsi_3_4h_gt_10) | (rsi_3_1d > 15.0))
+          long_entry_logic.append(rsi_3_15m_gt_3 | (rsi_3_4h_gt_10) | (rsi_3_1d_gt_15))
           # 15m & 1h down move
-          long_entry_logic.append(rsi_3_15m_gt_3 | (rsi_3_1h > 3.0))
+          long_entry_logic.append(rsi_3_15m_gt_3 | (rsi_3_1h_gt_3))
           # 15m & 1h down move, 4h still not low enough
-          long_entry_logic.append(rsi_3_15m_gt_3 | (rsi_3_1h > 5.0) | (rsi_14_4h < 35.0))
+          long_entry_logic.append(rsi_3_15m_gt_3 | (rsi_3_1h_gt_5) | (rsi_14_4h < 35.0))
           # 15m & 1h down move, 1d still high
           long_entry_logic.append(rsi_3_15m_gt_3 | (rsi_3_1h_gt_10) | (aroonu_14_1d < 50.0))
           # 15m & 1h down move, 1h still not low enough
           long_entry_logic.append(rsi_3_15m_gt_3 | (rsi_3_1h_gt_15) | (stochrsi_k_1h < 30.0))
           # 15m & 4h down move, 4h still high
-          long_entry_logic.append(rsi_3_15m_gt_3 | (rsi_3_4h > 30.0) | (rsi_14_4h < 40.0))
+          long_entry_logic.append(rsi_3_15m_gt_3 | (rsi_3_4h_gt_30) | (rsi_14_4h < 40.0))
           # 15m & 1h & 4h down move
-          long_entry_logic.append((rsi_3_15m > 5.0) | (rsi_3_1h_gt_15) | (rsi_3_4h_gt_15))
+          long_entry_logic.append((rsi_3_15m_gt_5) | (rsi_3_1h_gt_15) | (rsi_3_4h_gt_15))
           # 15m & 1h & 4h down move, 15m downtrend
-          long_entry_logic.append((rsi_3_15m > 5.0) | rsi_3_1h_gt_20 | rsi_3_4h_gt_20 | (cmf_20_15m > -0.20))
+          long_entry_logic.append((rsi_3_15m_gt_5) | rsi_3_1h_gt_20 | rsi_3_4h_gt_20 | (cmf_20_15m > -0.20))
           # 15m & 1h down move, 4h still not low enough
-          long_entry_logic.append((rsi_3_15m > 5.0) | rsi_3_1h_gt_20 | (aroonu_14_4h < 20.0))
+          long_entry_logic.append((rsi_3_15m_gt_5) | rsi_3_1h_gt_20 | (aroonu_14_4h < 20.0))
           # 15m & 1h down move, 1h high
-          long_entry_logic.append((rsi_3_15m > 5.0) | (rsi_3_1h > 30.0) | (stochrsi_k_1h_lt_50))
+          long_entry_logic.append((rsi_3_15m_gt_5) | (rsi_3_1h_gt_30) | (stochrsi_k_1h_lt_50))
           # 15m & 4h down move, 4h still high
-          long_entry_logic.append((rsi_3_15m > 5.0) | (rsi_3_4h_gt_15) | (aroonu_14_4h < 50.0))
+          long_entry_logic.append((rsi_3_15m_gt_5) | (rsi_3_4h_gt_15) | (aroonu_14_4h_lt_50))
           # 15m & 1h down move, 15m & 1h downtrend
-          long_entry_logic.append((rsi_3_15m > 10.0) | (rsi_3_1h_gt_10) | (cmf_20_15m > -0.40) | (cmf_20_1h > -0.40))
+          long_entry_logic.append((rsi_3_15m_gt_10) | (rsi_3_1h_gt_10) | (cmf_20_15m > -0.40) | (cmf_20_1h > -0.40))
           # 15m & 1h down move, 1h still not low enough
-          long_entry_logic.append((rsi_3_15m > 10.0) | (rsi_3_1h_gt_10) | (stochrsi_k_1h < 20.0))
+          long_entry_logic.append((rsi_3_15m_gt_10) | (rsi_3_1h_gt_10) | (stochrsi_k_1h < 20.0))
           # 15m & 1h down move, 4h still high
-          long_entry_logic.append((rsi_3_15m > 10.0) | rsi_3_1h_gt_20 | (stochrsi_k_4h < 50.0))
+          long_entry_logic.append((rsi_3_15m_gt_10) | rsi_3_1h_gt_20 | (stochrsi_k_4h_lt_50))
           # 15m & 1h down move, 4h overbought
-          long_entry_logic.append((rsi_3_15m > 10.0) | (rsi_3_1h > 40.0) | (roc_9_4h < 50.0))
+          long_entry_logic.append((rsi_3_15m_gt_10) | (rsi_3_1h_gt_40) | (roc_9_4h < 50.0))
           # 15m & 1h down move, 1h high
-          long_entry_logic.append((rsi_3_15m > 10.0) | (rsi_3_1h > 25.0) | aroonu_14_1h_lt_80)
+          long_entry_logic.append((rsi_3_15m_gt_10) | (rsi_3_1h_gt_25) | aroonu_14_1h_lt_80)
           # 15m & 4h down move, 1h & 4h downtrend
-          long_entry_logic.append((rsi_3_15m > 10.0) | (rsi_3_4h_gt_10) | (cmf_20_1h > -0.20) | (cmf_20_4h > -0.20))
+          long_entry_logic.append((rsi_3_15m_gt_10) | (rsi_3_4h_gt_10) | (cmf_20_1h > -0.20) | (cmf_20_4h > -0.20))
           # 15m & 4h down move, 4h still not low enough
-          long_entry_logic.append((rsi_3_15m > 10.0) | (rsi_3_4h_gt_10) | (stochrsi_k_4h < 30.0))
+          long_entry_logic.append((rsi_3_15m_gt_10) | (rsi_3_4h_gt_10) | (stochrsi_k_4h < 30.0))
           # 15m & 4h down move, 4h still high
-          long_entry_logic.append((rsi_3_15m > 10.0) | (rsi_3_4h_gt_10) | (aroonu_14_4h < 40.0))
+          long_entry_logic.append((rsi_3_15m_gt_10) | (rsi_3_4h_gt_10) | (aroonu_14_4h_lt_40))
           # 15m & 4h down move, 1d high
-          long_entry_logic.append((rsi_3_15m > 10.0) | (rsi_3_4h_gt_15) | (stochrsi_k_1d < 90.0))
+          long_entry_logic.append((rsi_3_15m_gt_10) | (rsi_3_4h_gt_15) | (stochrsi_k_1d_lt_90))
           # 15m & 4h down move, 1h high
-          long_entry_logic.append((rsi_3_15m > 10.0) | rsi_3_4h_gt_20 | (stochrsi_k_1h_lt_70))
+          long_entry_logic.append((rsi_3_15m_gt_10) | rsi_3_4h_gt_20 | (stochrsi_k_1h_lt_70))
           # 15m & 4h down move, 4h still high
-          long_entry_logic.append((rsi_3_15m > 10.0) | rsi_3_4h_gt_20 | (stochrsi_k_4h < 40.0))
+          long_entry_logic.append((rsi_3_15m_gt_10) | rsi_3_4h_gt_20 | (stochrsi_k_4h < 40.0))
           # 15m & 4h down move, 1d downtrend
-          long_entry_logic.append((rsi_3_15m > 10.0) | rsi_3_4h_gt_20 | (roc_9_1d > -25.0))
+          long_entry_logic.append((rsi_3_15m_gt_10) | rsi_3_4h_gt_20 | (roc_9_1d > -25.0))
           # 15m & 4h down move, 15m still not low enough
-          long_entry_logic.append((rsi_3_15m > 10.0) | (rsi_3_4h > 25.0) | (stochrsi_k_15m < 20.0))
+          long_entry_logic.append((rsi_3_15m_gt_10) | (rsi_3_4h_gt_25) | (stochrsi_k_15m < 20.0))
           # 15m & 4h down move, 4h high
-          long_entry_logic.append((rsi_3_15m > 10.0) | (rsi_3_4h > 40.0) | aroonu_14_4h_lt_80)
+          long_entry_logic.append((rsi_3_15m_gt_10) | (rsi_3_4h_gt_40) | aroonu_14_4h_lt_80)
           # 15m & 1h down move, 4h still high
-          long_entry_logic.append((rsi_3_15m > 15.0) | rsi_3_1h_gt_20 | (aroonu_14_4h < 40.0))
+          long_entry_logic.append((rsi_3_15m_gt_15) | rsi_3_1h_gt_20 | (aroonu_14_4h_lt_40))
           # 15m & 1h down move, 4h high
-          long_entry_logic.append((rsi_3_15m > 15.0) | (rsi_3_1h > 25.0) | aroonu_14_4h_lt_70)
+          long_entry_logic.append((rsi_3_15m_gt_15) | (rsi_3_1h_gt_25) | aroonu_14_4h_lt_70)
           # 15m & 1h down move, 1h high
-          long_entry_logic.append((rsi_3_15m > 15.0) | (rsi_3_1h > 25.0) | (stochrsi_k_1h < 60.0))
+          long_entry_logic.append((rsi_3_15m_gt_15) | (rsi_3_1h_gt_25) | (stochrsi_k_1h < 60.0))
           # 15m & 1h down move, 1h still high
-          long_entry_logic.append((rsi_3_15m > 15.0) | (rsi_3_1h > 30.0) | (aroonu_14_1h < 40.0))
+          long_entry_logic.append((rsi_3_15m_gt_15) | (rsi_3_1h_gt_30) | (aroonu_14_1h < 40.0))
           # 15m down move, 4h still high, 4h downtrend
-          long_entry_logic.append((rsi_3_15m > 15.0) | (aroonu_14_4h < 40.0) | (roc_9_4h_gt_neg_20))
+          long_entry_logic.append((rsi_3_15m_gt_15) | (aroonu_14_4h_lt_40) | (roc_9_4h_gt_neg_20))
           # 15m down move, 1d high, 4h overbought
-          long_entry_logic.append((rsi_3_15m > 15.0) | aroonu_14_1d_lt_100 | (roc_9_4h < 50.0))
+          long_entry_logic.append((rsi_3_15m_gt_15) | aroonu_14_1d_lt_100 | (roc_9_4h < 50.0))
           # 15m & 3h down move, 15m still not low enough
-          long_entry_logic.append((rsi_3_15m > 20.0) | rsi_3_4h_gt_20 | (stochrsi_k_15m < 20.0))
+          long_entry_logic.append((rsi_3_15m_gt_20) | rsi_3_4h_gt_20 | (stochrsi_k_15m < 20.0))
           # 15m & 1h down move, 1h still high
-          long_entry_logic.append((rsi_3_15m > 25.0) | (rsi_3_1h > 25.0) | (rsi_14_1h < 40.0))
+          long_entry_logic.append((rsi_3_15m_gt_25) | (rsi_3_1h_gt_25) | (rsi_14_1h < 40.0))
           # 15m & 4h down move, 4h high
-          long_entry_logic.append((rsi_3_15m > 25.0) | (rsi_3_4h > 25.0) | aroonu_14_4h_lt_70)
+          long_entry_logic.append((rsi_3_15m_gt_25) | (rsi_3_4h_gt_25) | aroonu_14_4h_lt_70)
           # 15m down move, 15m still not low enough, 1d overbought
-          long_entry_logic.append((rsi_3_15m > 25.0) | (stochrsi_k_15m < 20.0) | (roc_9_1d < 80.0))
+          long_entry_logic.append((rsi_3_15m_gt_25) | (stochrsi_k_15m < 20.0) | (roc_9_1d_lt_80))
           # 1h & 4h down move
-          long_entry_logic.append((rsi_3_1h > 3.0) | (rsi_3_4h_gt_10))
+          long_entry_logic.append((rsi_3_1h_gt_3) | (rsi_3_4h_gt_10))
           # 1h & 4h down move, 4h still not low enough
-          long_entry_logic.append((rsi_3_1h > 3.0) | (rsi_3_4h > 25.0) | (stochrsi_k_4h < 30.0))
+          long_entry_logic.append((rsi_3_1h_gt_3) | (rsi_3_4h_gt_25) | (stochrsi_k_4h < 30.0))
           # 1h & 4h down move, 4h high
-          long_entry_logic.append((rsi_3_1h > 3.0) | (rsi_3_4h > 50.0) | aroonu_14_4h_lt_70)
+          long_entry_logic.append((rsi_3_1h_gt_3) | (rsi_3_4h_gt_50) | aroonu_14_4h_lt_70)
           # 1h & 4h down move
-          long_entry_logic.append((rsi_3_1h > 5.0) | (rsi_3_4h > 5.0))
+          long_entry_logic.append((rsi_3_1h_gt_5) | (rsi_3_4h_gt_5))
           # 1h & 4h down move, 4h still high
-          long_entry_logic.append((rsi_3_1h > 5.0) | (rsi_3_4h > 30.0) | (aroonu_14_4h < 50.0))
+          long_entry_logic.append((rsi_3_1h_gt_5) | (rsi_3_4h_gt_30) | (aroonu_14_4h_lt_50))
           # 1h down move, 1h still high
-          long_entry_logic.append((rsi_3_1h > 5.0) | (aroonu_14_1h < 50.0))
+          long_entry_logic.append((rsi_3_1h_gt_5) | (aroonu_14_1h_lt_50))
           # 1h down move, 4h high
-          long_entry_logic.append((rsi_3_1h > 5.0) | (aroonu_14_4h < 85.0))
+          long_entry_logic.append((rsi_3_1h_gt_5) | (aroonu_14_4h < 85.0))
           # 1h & 4h down move
           long_entry_logic.append((rsi_3_1h_gt_10) | (rsi_3_4h_gt_10))
           # 1h & 4h down move, 4h still not low enough
@@ -20803,11 +20855,11 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1h & 4h down move, 1d still high
           long_entry_logic.append((rsi_3_1h_gt_10) | (rsi_3_4h_gt_15) | (stochrsi_k_1d < 50.0))
           # 1h & 1d down move, 1h still moving lower
-          long_entry_logic.append((rsi_3_1h_gt_10) | (rsi_3_1d > 15.0) | (cci_20_change_pct_1h > -0.0))
+          long_entry_logic.append((rsi_3_1h_gt_10) | (rsi_3_1d_gt_15) | (cci_20_change_pct_1h > -0.0))
           # 1h down move, 1d high, 4h downtrend
           long_entry_logic.append((rsi_3_1h_gt_10) | (aroonu_14_1d < 85.0) | (roc_9_4h > -10.0))
           # 1h & 4h down move, 1h still high
-          long_entry_logic.append((rsi_3_1h_gt_15) | (rsi_3_4h_gt_15) | (aroonu_14_1h < 50.0))
+          long_entry_logic.append((rsi_3_1h_gt_15) | (rsi_3_4h_gt_15) | (aroonu_14_1h_lt_50))
           # 1h & 4h & 1d down move
           long_entry_logic.append((rsi_3_1h_gt_15) | rsi_3_4h_gt_20 | (rsi_3_1d > 30.0))
           # 1h & 4h down move, 1h still not low enough
@@ -20815,59 +20867,59 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1h & 4h down move, 4h still not low enough
           long_entry_logic.append((rsi_3_1h_gt_15) | rsi_3_4h_gt_20 | (stochrsi_k_4h < 30.0))
           # 1h & 4h & 1d down move
-          long_entry_logic.append((rsi_3_1h_gt_15) | (rsi_3_4h > 25.0) | (rsi_3_1d > 25.0))
+          long_entry_logic.append((rsi_3_1h_gt_15) | (rsi_3_4h_gt_25) | (rsi_3_1d_gt_25))
           # 1h & 4h down move, 1h high
-          long_entry_logic.append((rsi_3_1h_gt_15) | (rsi_3_4h > 40.0) | (aroonu_14_1h < 80.0))
+          long_entry_logic.append((rsi_3_1h_gt_15) | (rsi_3_4h_gt_40) | (aroonu_14_1h < 80.0))
           # 1h & 1d down move, 1d high
-          long_entry_logic.append((rsi_3_1h_gt_15) | (rsi_3_1d > 25.0) | (aroonu_14_1d < 70.0))
+          long_entry_logic.append((rsi_3_1h_gt_15) | (rsi_3_1d_gt_25) | (aroonu_14_1d_lt_70))
           # 1h & 1d down move, 1d high
-          long_entry_logic.append((rsi_3_1h_gt_15) | (rsi_3_1d > 25.0) | (stochrsi_k_1d < 70.0))
+          long_entry_logic.append((rsi_3_1h_gt_15) | (rsi_3_1d_gt_25) | (stochrsi_k_1d < 70.0))
           # 1h down move, 1h & 4h high
-          long_entry_logic.append((rsi_3_1h_gt_15) | (aroonu_14_1h < 60.0) | (aroonu_14_4h < 60.0))
+          long_entry_logic.append((rsi_3_1h_gt_15) | (aroonu_14_1h < 60.0) | (aroonu_14_4h_lt_60))
           # 1h & 4h down move, 1d overbought
           long_entry_logic.append(rsi_3_1h_gt_20 | rsi_3_4h_gt_20 | roc_9_1d_lt_50)
           # 1h & 4h down move, 1h still high
-          long_entry_logic.append(rsi_3_1h_gt_20 | (rsi_3_4h > 25.0) | (stochrsi_k_1h_lt_50))
+          long_entry_logic.append(rsi_3_1h_gt_20 | (rsi_3_4h_gt_25) | (stochrsi_k_1h_lt_50))
           # 1h & 1d down move, 1d high
-          long_entry_logic.append(rsi_3_1h_gt_20 | (rsi_3_1d > 20.0) | (aroonu_14_1d < 70.0))
+          long_entry_logic.append(rsi_3_1h_gt_20 | (rsi_3_1d_gt_20) | (aroonu_14_1d_lt_70))
           # 4h & 1d down move, 1d high
-          long_entry_logic.append(rsi_3_1h_gt_20 | (rsi_3_1d > 40.0) | (aroonu_14_1d < 80.0))
+          long_entry_logic.append(rsi_3_1h_gt_20 | (rsi_3_1d > 40.0) | (aroonu_14_1d_lt_80))
           # 1h down move, 1h still high, 4h high
-          long_entry_logic.append(rsi_3_1h_gt_20 | (aroonu_14_1h < 50.0) | aroonu_14_4h_lt_70)
+          long_entry_logic.append(rsi_3_1h_gt_20 | (aroonu_14_1h_lt_50) | aroonu_14_4h_lt_70)
           # 1h down move, 4h high
           long_entry_logic.append(rsi_3_1h_gt_20 | (stochrsi_k_4h_lt_90))
           # 1h down move, 1h & 1d high
-          long_entry_logic.append((rsi_3_1h > 25.0) | aroonu_14_1h_lt_70 | (aroonu_14_1d < 90.0))
+          long_entry_logic.append((rsi_3_1h_gt_25) | aroonu_14_1h_lt_70 | (aroonu_14_1d_lt_90))
           # 1h down move, 4h still high, 1d downtrend
-          long_entry_logic.append((rsi_3_1h > 25.0) | (aroonu_14_4h < 40.0) | (roc_9_1d_gt_neg_20))
+          long_entry_logic.append((rsi_3_1h_gt_25) | (aroonu_14_4h_lt_40) | (roc_9_1d_gt_neg_20))
           # 1h down move, 1h still high, 1d overbought
-          long_entry_logic.append((rsi_3_1h > 25.0) | (stochrsi_k_1h_lt_50) | (roc_9_1d < 40.0))
+          long_entry_logic.append((rsi_3_1h_gt_25) | (stochrsi_k_1h_lt_50) | (roc_9_1d_lt_40))
           # 1h & 4h down move, 4h high
-          long_entry_logic.append((rsi_3_1h > 30.0) | (rsi_3_4h > 45.0) | aroonu_14_4h_lt_80)
+          long_entry_logic.append((rsi_3_1h_gt_30) | (rsi_3_4h > 45.0) | aroonu_14_4h_lt_80)
           # 1h & dh down move, 4h high
-          long_entry_logic.append((rsi_3_1h > 30.0) | (rsi_3_4h > 50.0) | (aroonu_14_4h < 85.0))
+          long_entry_logic.append((rsi_3_1h_gt_30) | (rsi_3_4h_gt_50) | (aroonu_14_4h < 85.0))
           # 1h down move, 4h still not low enough, 1d overbought
-          long_entry_logic.append((rsi_3_1h > 30.0) | (aroonu_14_4h < 30.0) | roc_9_1d_lt_50)
+          long_entry_logic.append((rsi_3_1h_gt_30) | (aroonu_14_4h < 30.0) | roc_9_1d_lt_50)
           # 1h down move, 1h still not low enough, 4h downtrend
-          long_entry_logic.append((rsi_3_1h > 35.0) | (stochrsi_k_1h < 30.0) | (roc_9_4h_gt_neg_20))
+          long_entry_logic.append((rsi_3_1h_gt_35) | (stochrsi_k_1h < 30.0) | (roc_9_4h_gt_neg_20))
           # 1h down move, 4h still high, 1d downtrend
-          long_entry_logic.append((rsi_3_1h > 35.0) | (stochrsi_k_4h < 50.0) | (roc_9_1d_gt_neg_20))
+          long_entry_logic.append((rsi_3_1h_gt_35) | (stochrsi_k_4h_lt_50) | (roc_9_1d_gt_neg_20))
           # 1h down move, 4h & 1d overbought
-          long_entry_logic.append((rsi_3_1h > 40.0) | (roc_9_4h < 10.0) | roc_9_1d_lt_50)
+          long_entry_logic.append((rsi_3_1h_gt_40) | (roc_9_4h_lt_10) | roc_9_1d_lt_50)
           # 1h down move, 4h high & overbought
-          long_entry_logic.append((rsi_3_1h > 50.0) | (aroonu_14_4h < 90.0) | (roc_9_4h_lt_20))
+          long_entry_logic.append((rsi_3_1h_gt_50) | (aroonu_14_4h_lt_90) | (roc_9_4h_lt_20))
           # 1h down move, 4h high & overbought
-          long_entry_logic.append((rsi_3_1h > 50.0) | (stochrsi_k_4h < 80.0) | (roc_9_4h_lt_20))
+          long_entry_logic.append((rsi_3_1h_gt_50) | (stochrsi_k_4h < 80.0) | (roc_9_4h_lt_20))
           # 4h down move, 15m not low enough, 1h still high
           long_entry_logic.append((rsi_3_4h > 3.0) | (stochrsi_k_15m < 20.0) | (stochrsi_k_1h < 40.0))
           # 4h & 1d down move, 4h downtrend
-          long_entry_logic.append((rsi_3_4h > 5.0) | (rsi_3_1d > 20.0) | (roc_9_4h_gt_neg_20))
+          long_entry_logic.append((rsi_3_4h_gt_5) | (rsi_3_1d_gt_20) | (roc_9_4h_gt_neg_20))
           # 4h & 1d down move, 1d high
-          long_entry_logic.append((rsi_3_4h > 5.0) | (rsi_3_1d > 30.0) | (aroonu_14_1d < 70.0))
+          long_entry_logic.append((rsi_3_4h_gt_5) | (rsi_3_1d > 30.0) | (aroonu_14_1d_lt_70))
           # 4h down move, 4h still high, 1d downtrend
-          long_entry_logic.append((rsi_3_4h > 5.0) | (stochrsi_k_4h < 40.0) | (roc_9_1d_gt_neg_20))
+          long_entry_logic.append((rsi_3_4h_gt_5) | (stochrsi_k_4h < 40.0) | (roc_9_1d_gt_neg_20))
           # 4h down move, 1d still not low enough, 1d downtrend
-          long_entry_logic.append((rsi_3_4h > 5.0) | (stochrsi_k_1d < 30.0) | (roc_9_1d_gt_neg_20))
+          long_entry_logic.append((rsi_3_4h_gt_5) | (stochrsi_k_1d < 30.0) | (roc_9_1d_gt_neg_20))
           # 4h down move, 1h downtrend, 1h still not low enough
           long_entry_logic.append((rsi_3_4h_gt_10) | (cmf_20_1h > -0.25) | (aroonu_14_1h < 30.0))
           # 4h down move, 1h & 1d downtrend
@@ -20875,9 +20927,9 @@ class NostalgiaForInfinityX7(IStrategy):
           # 4h & 1d down move, 4h still high
           long_entry_logic.append((rsi_3_4h_gt_15) | (rsi_3_1d > 45.0) | (stochrsi_k_4h < 40.0))
           # 4h & 1d down move, 1d high
-          long_entry_logic.append(rsi_3_4h_gt_20 | (rsi_3_1d > 25.0) | (stochrsi_k_1d < 60.0))
+          long_entry_logic.append(rsi_3_4h_gt_20 | (rsi_3_1d_gt_25) | (stochrsi_k_1d < 60.0))
           # 4h down move, 1d high & overbought
-          long_entry_logic.append(rsi_3_4h_gt_20 | (aroonu_14_1d < 70.0) | roc_9_1d_lt_50)
+          long_entry_logic.append(rsi_3_4h_gt_20 | (aroonu_14_1d_lt_70) | roc_9_1d_lt_50)
           # 4h down move, 1h still high, 1d downtrend
           long_entry_logic.append(rsi_3_4h_gt_20 | (stochrsi_k_1h < 50.0) | (roc_9_1d_gt_neg_20))
           # 4h down move, 1h high
@@ -20885,25 +20937,25 @@ class NostalgiaForInfinityX7(IStrategy):
           # 4h down move, 1d high, 1h downtrend
           long_entry_logic.append(rsi_3_4h_gt_20 | (stochrsi_k_1d < 70.0) | (roc_9_1h > -10.0))
           # 4h down move, 4h still high, 1d overbought
-          long_entry_logic.append((rsi_3_4h > 30.0) | (aroonu_14_4h < 40.0) | (roc_9_1d_lt_100))
+          long_entry_logic.append((rsi_3_4h_gt_30) | (aroonu_14_4h_lt_40) | (roc_9_1d_lt_100))
           # 4h down move, 4h high, 1h downtrend
-          long_entry_logic.append((rsi_3_4h > 30.0) | aroonu_14_4h_lt_80 | (roc_9_1h > -30.0))
+          long_entry_logic.append((rsi_3_4h_gt_30) | aroonu_14_4h_lt_80 | (roc_9_1h > -30.0))
           # 4h down move, 4h still high, 1d overbought
-          long_entry_logic.append((rsi_3_4h > 35.0) | (aroonu_14_4h < 50.0) | (roc_9_1d < 40.0))
+          long_entry_logic.append((rsi_3_4h_gt_35) | (aroonu_14_4h_lt_50) | (roc_9_1d_lt_40))
           # 4h down move, 4h still high, 1d high
-          long_entry_logic.append((rsi_3_4h > 40.0) | (aroonu_14_4h < 50.0) | aroonu_14_1d_lt_100)
+          long_entry_logic.append((rsi_3_4h_gt_40) | (aroonu_14_4h_lt_50) | aroonu_14_1d_lt_100)
           # 4h down move, 4h & 1d overbought
-          long_entry_logic.append((rsi_3_4h > 40.0) | (roc_9_4h < 10.0) | roc_9_1d_lt_50)
+          long_entry_logic.append((rsi_3_4h_gt_40) | (roc_9_4h_lt_10) | roc_9_1d_lt_50)
           # 1d down move, 1h still not low enough
           long_entry_logic.append((rsi_3_1d > 5.0) | (stochrsi_k_1h < 20.0))
           # 1h & 4h high, 4h overbought
-          long_entry_logic.append((aroonu_14_1h < 60.0) | aroonu_14_4h_lt_100 | (roc_9_4h < 30.0))
+          long_entry_logic.append((aroonu_14_1h < 60.0) | aroonu_14_4h_lt_100 | (roc_9_4h_lt_30))
           # 4h & 1d high, 4h overbought
-          long_entry_logic.append((aroonu_14_4h < 60.0) | aroonu_14_1d_lt_100 | (roc_9_4h < 40.0))
+          long_entry_logic.append((aroonu_14_4h_lt_60) | aroonu_14_1d_lt_100 | (roc_9_4h_lt_40))
           # 4h & 1d high,1d overbought
           long_entry_logic.append(aroonu_14_4h_lt_70 | aroonu_14_1d_lt_100 | roc_9_1d_lt_50)
           # 1d red, 4h down move, 1h still high
-          long_entry_logic.append((change_pct_1d > -30.0) | (rsi_3_4h > 30.0) | (stochrsi_k_1h_lt_50))
+          long_entry_logic.append((change_pct_1d > -30.0) | (rsi_3_4h_gt_30) | (stochrsi_k_1h_lt_50))
           # pump, drop but not yet near the previous lows
           long_entry_logic.append(
             (((high_max_24_4h - low_min_24_4h) / low_min_24_4h) < 2.0)
@@ -20919,7 +20971,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # big drop in the last hour
           long_entry_logic.append(close > (close_max_12 * 0.50))
           # big drop in the last 12 days, 15m & 4h down move
-          long_entry_logic.append((close > (high_max_12_1d * 0.40)) | (rsi_3_15m > 10.0) | (rsi_3_4h_gt_10))
+          long_entry_logic.append((close > (high_max_12_1d * 0.40)) | (rsi_3_15m_gt_10) | (rsi_3_4h_gt_10))
           # big drop in the last 20 days, 15m & 1h down move
           long_entry_logic.append((close > (high_max_20_1d * 0.40)) | (rsi_14_15m < 10.0) | (rsi_14_1h < 10.0))
           # big drop in the last 20 days, 1d down move
@@ -20951,11 +21003,11 @@ class NostalgiaForInfinityX7(IStrategy):
           long_entry_logic.append(rsi_14_1h < 80.0)
           long_entry_logic.append(rsi_14_4h < 80.0)
           long_entry_logic.append(rsi_14_1d < 80.0)
-          long_entry_logic.append(aroonu_14_15m < 70.0)
-          long_entry_logic.append(aroonu_14_1h < 100.0)
+          long_entry_logic.append(aroonu_14_15m_lt_70)
+          long_entry_logic.append(aroonu_14_1h_lt_100)
           long_entry_logic.append(aroonu_14_4h_lt_100)
           long_entry_logic.append(aroonu_14_1d_lt_100)
-          long_entry_logic.append(stochrsi_k_1d < 90.0)
+          long_entry_logic.append(stochrsi_k_1d_lt_90)
 
           # Logic
           long_entry_logic.append(
@@ -20971,31 +21023,31 @@ class NostalgiaForInfinityX7(IStrategy):
 
           long_entry_logic.append(
             # 5m & 15m down move, 15m high
-            ((rsi_3 > 3.0) | (rsi_3_15m > 15.0) | (aroonu_14_15m < 70.0))
+            ((rsi_3_gt_3) | (rsi_3_15m_gt_15) | (aroonu_14_15m_lt_70))
             # 5m & 15m down move, 4h still high
-            & ((rsi_3 > 3.0) | (rsi_3_15m > 15.0) | (stochrsi_k_4h < 50.0))
+            & ((rsi_3_gt_3) | (rsi_3_15m_gt_15) | (stochrsi_k_4h_lt_50))
             # 5m & 15m down move, 15m high
-            & ((rsi_3 > 3.0) | (rsi_3_15m > 20.0) | (aroonu_14_15m < 70.0))
+            & ((rsi_3_gt_3) | (rsi_3_15m_gt_20) | (aroonu_14_15m_lt_70))
             # 5m & 1h down move, 15m still high
-            & ((rsi_3 > 3.0) | (rsi_3_1h_gt_15) | (aroonu_14_15m < 40.0))
+            & ((rsi_3_gt_3) | (rsi_3_1h_gt_15) | (aroonu_14_15m < 40.0))
             # 5m & 1h down move, 1h high
-            & ((rsi_3 > 3.0) | (rsi_3_1h > 45.0) | (stochrsi_k_1h_lt_80))
+            & ((rsi_3_gt_3) | (rsi_3_1h_gt_45) | (stochrsi_k_1h_lt_80))
             # 5m & 4h down move, 15m still high
-            & ((rsi_3 > 3.0) | (rsi_3_4h > 5.0) | (aroonu_14_15m < 40.0))
+            & ((rsi_3_gt_3) | (rsi_3_4h_gt_5) | (aroonu_14_15m < 40.0))
             # 5m & 4h down move, 15m still high
-            & ((rsi_3 > 3.0) | (rsi_3_4h > 5.0) | (stochrsi_k_15m < 40.0))
+            & ((rsi_3_gt_3) | (rsi_3_4h_gt_5) | (stochrsi_k_15m < 40.0))
             # 5m & 4h down move, 15m still high
-            & ((rsi_3 > 3.0) | rsi_3_4h_gt_20 | (stochrsi_k_15m < 50.0))
+            & ((rsi_3_gt_3) | rsi_3_4h_gt_20 | (stochrsi_k_15m < 50.0))
             # 5m & 4h down move, 1h high
-            & ((rsi_3 > 3.0) | (rsi_3_4h > 45.0) | (stochrsi_k_1h_lt_80))
+            & ((rsi_3_gt_3) | (rsi_3_4h > 45.0) | (stochrsi_k_1h_lt_80))
             # 5m & 1d down move, 15m high
-            & ((rsi_3 > 3.0) | (rsi_3_1d > 10.0) | (aroonu_14_15m < 70.0))
+            & ((rsi_3_gt_3) | (rsi_3_1d_gt_10) | (aroonu_14_15m_lt_70))
             # 5m & 1d down move, 15m stil high
-            & ((rsi_3 > 3.0) | (rsi_3_1d > 10.0) | (stochrsi_k_15m < 40.0))
+            & ((rsi_3_gt_3) | (rsi_3_1d_gt_10) | (stochrsi_k_15m < 40.0))
             # 5m & 1d down move, 4h still high
-            & ((rsi_3 > 3.0) | (rsi_3_1d > 10.0) | (stochrsi_k_4h < 40.0))
+            & ((rsi_3_gt_3) | (rsi_3_1d_gt_10) | (stochrsi_k_4h < 40.0))
             # 5m down move, 1h high
-            & ((rsi_3 > 3.0) | (stochrsi_k_1h < 90.0))
+            & ((rsi_3_gt_3) | (stochrsi_k_1h < 90.0))
             # 5m down move, 15m & 1d high
             & ((rsi_3 > 5.0) | (aroonu_14_15m < 60.0) | aroonu_14_1d_lt_100)
             # 5m down move, 1h & 1d high
@@ -21007,181 +21059,181 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 1d overbought
             & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_10) | (roc_9_1d < 60.0))
             # 15m & 1h down move, 4h still high
-            & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_15) | (aroonu_14_4h < 40.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_15) | (aroonu_14_4h_lt_40))
             # 15m & 1h down move, 4h high
             & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_15) | (stochrsi_k_4h < 90.0))
             # 15m & 1h down move, 1d still high
             & (rsi_3_15m_gt_3 | rsi_3_1h_gt_20 | (stochrsi_k_1d < 50.0))
             # 15m & 1h & 4h down move, 1d downtrend
-            & (rsi_3_15m_gt_3 | (rsi_3_1h > 25.0) | (rsi_14_4h < 40.0) | (roc_9_1d > -10.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_25) | (rsi_14_4h < 40.0) | (roc_9_1d > -10.0))
             # 15m & 1h down move, 15m still high
-            & (rsi_3_15m_gt_3 | (rsi_3_1h > 30.0) | (aroonu_14_15m < 50.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_30) | (aroonu_14_15m_lt_50))
             # 15m & 1h down move, 1d high
-            & (rsi_3_15m_gt_3 | (rsi_3_1h > 30.0) | (aroonu_14_1d < 80.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_30) | (aroonu_14_1d_lt_80))
             # 15m & 1h down move, 4h high
-            & (rsi_3_15m_gt_3 | (rsi_3_1h > 40.0) | (aroonu_14_1h < 85.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_40) | (aroonu_14_1h < 85.0))
             # 15m & 1h down move, 1h high
-            & (rsi_3_15m_gt_3 | (rsi_3_1h > 40.0) | (stochrsi_k_1h_lt_80))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_40) | (stochrsi_k_1h_lt_80))
             # 15m & 1h down move, 1h high
-            & (rsi_3_15m_gt_3 | (rsi_3_1h > 45.0) | (stochrsi_k_1h_lt_80))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_45) | (stochrsi_k_1h_lt_80))
             # 15m & 1h down move, 1d high
-            & (rsi_3_15m_gt_3 | (rsi_3_1h > 45.0) | (stochrsi_k_1d < 80.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_45) | (stochrsi_k_1d < 80.0))
             # 15m & 4h down move, 15m downtrend
             & (rsi_3_15m_gt_3 | (rsi_3_4h > 3.0) | (cmf_20_15m > -0.30))
             # 15m & 4h down move, 4h still high
-            & (rsi_3_15m_gt_3 | (rsi_3_4h > 25.0) | (aroonu_14_4h < 40.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_4h_gt_25) | (aroonu_14_4h_lt_40))
             # 15m down move, 1h high, 4h overbought
-            & (rsi_3_15m_gt_3 | aroonu_14_1h_lt_70 | (roc_9_4h < 10.0))
+            & (rsi_3_15m_gt_3 | aroonu_14_1h_lt_70 | (roc_9_4h_lt_10))
             # 15m down move, 1d high & overbought
-            & (rsi_3_15m_gt_3 | (aroonu_14_1d < 70.0) | (roc_9_1d < 10.0))
+            & (rsi_3_15m_gt_3 | (aroonu_14_1d_lt_70) | (roc_9_1d < 10.0))
             # 15m & 1h down move, 4h still high
-            & ((rsi_3_15m > 5.0) | (rsi_3_1h_gt_10) | (stochrsi_k_4h < 50.0))
+            & ((rsi_3_15m_gt_5) | (rsi_3_1h_gt_10) | (stochrsi_k_4h_lt_50))
             # 15m & 1h down move, 1h still high
-            & ((rsi_3_15m > 5.0) | (rsi_3_1h > 25.0) | (stochrsi_k_1h_lt_50))
+            & ((rsi_3_15m_gt_5) | (rsi_3_1h_gt_25) | (stochrsi_k_1h_lt_50))
             # 15m & 1h down move, 1h high
-            & ((rsi_3_15m > 5.0) | (rsi_3_1h > 30.0) | (stochrsi_k_1h_lt_80))
+            & ((rsi_3_15m_gt_5) | (rsi_3_1h_gt_30) | (stochrsi_k_1h_lt_80))
             # 15m & 4h down move, 1d high
-            & ((rsi_3_15m > 5.0) | (rsi_3_4h_gt_15) | (aroonu_14_1d < 70.0))
+            & ((rsi_3_15m_gt_5) | (rsi_3_4h_gt_15) | (aroonu_14_1d_lt_70))
             # 15m & 4h down move, 1d high
-            & ((rsi_3_15m > 5.0) | rsi_3_4h_gt_20 | (aroonu_14_1d < 80.0))
+            & ((rsi_3_15m_gt_5) | rsi_3_4h_gt_20 | (aroonu_14_1d_lt_80))
             # 15m & 1d down move, 1d still high
-            & ((rsi_3_15m > 5.0) | (rsi_3_1d > 10.0) | (aroonu_14_1d < 40.0))
+            & ((rsi_3_15m_gt_5) | (rsi_3_1d_gt_10) | (aroonu_14_1d < 40.0))
             # 15m down move, 15m downtrend, 1d high
-            & ((rsi_3_15m > 5.0) | (cmf_20_15m > -0.40) | aroonu_14_1d_lt_100)
+            & ((rsi_3_15m_gt_5) | (cmf_20_15m > -0.40) | aroonu_14_1d_lt_100)
             # 15m down move, 4h high, 1h overbought
-            & ((rsi_3_15m > 5.0) | aroonu_14_4h_lt_100 | (roc_9_1h < 10.0))
+            & ((rsi_3_15m_gt_5) | aroonu_14_4h_lt_100 | (roc_9_1h_lt_10))
             # 15m & 1h down move, 4h high
-            & ((rsi_3_15m > 10.0) | (rsi_3_1h_gt_10) | (aroonu_14_4h < 85.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_10) | (aroonu_14_4h < 85.0))
             # 15m & 1h down move, 1d high
-            & ((rsi_3_15m > 10.0) | (rsi_3_1h_gt_10) | (aroonu_14_1d < 85.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_10) | (aroonu_14_1d < 85.0))
             # 15m & 1h down move, 15m still high
-            & ((rsi_3_15m > 10.0) | (rsi_3_1h_gt_15) | (stochrsi_k_15m < 50.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_15) | (stochrsi_k_15m < 50.0))
             # 15m & 1h down move, 1h still high
-            & ((rsi_3_15m > 10.0) | (rsi_3_1h_gt_15) | (stochrsi_k_1h < 50.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_15) | (stochrsi_k_1h < 50.0))
             # 15m & 1h down move, 1d still high
-            & ((rsi_3_15m > 10.0) | (rsi_3_1h_gt_15) | (stochrsi_k_1d < 50.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_15) | (stochrsi_k_1d < 50.0))
             # 15m & 1h down move, 15m high
-            & ((rsi_3_15m > 10.0) | rsi_3_1h_gt_20 | (aroonu_14_15m < 60.0))
+            & ((rsi_3_15m_gt_10) | rsi_3_1h_gt_20 | (aroonu_14_15m < 60.0))
             # 15m & 1h down move, 1h high
-            & ((rsi_3_15m > 10.0) | rsi_3_1h_gt_20 | aroonu_14_1h_lt_80)
+            & ((rsi_3_15m_gt_10) | rsi_3_1h_gt_20 | aroonu_14_1h_lt_80)
             # 15m & 1h down move, 1h high
-            & ((rsi_3_15m > 10.0) | (rsi_3_1h > 30.0) | (stochrsi_k_1h_lt_70))
+            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_30) | (stochrsi_k_1h_lt_70))
             # 15m & 1h down move, 1d overbought
-            & ((rsi_3_15m > 10.0) | (rsi_3_1h > 30.0) | (roc_9_1d < 60.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_30) | (roc_9_1d < 60.0))
             # 15m & 4h down move, 15m still high
-            & ((rsi_3_15m > 10.0) | (rsi_3_4h_gt_10) | (aroonu_14_15m < 40.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_4h_gt_10) | (aroonu_14_15m < 40.0))
             # 15m & 4h down move, 1d high
-            & ((rsi_3_15m > 10.0) | (rsi_3_4h_gt_10) | (aroonu_14_1d < 80.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_4h_gt_10) | (aroonu_14_1d_lt_80))
             # 15m & 4h down move, 1d downtrend
-            & ((rsi_3_15m > 10.0) | (rsi_3_4h_gt_10) | (roc_9_1d > -20.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_4h_gt_10) | (roc_9_1d > -20.0))
             # 15m & 4h down move, 1d overbought
-            & ((rsi_3_15m > 10.0) | (rsi_3_4h_gt_15) | (roc_9_1d < 20.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_4h_gt_15) | (roc_9_1d_lt_20))
             # 15m & 4h down move, 1d high
-            & ((rsi_3_15m > 10.0) | rsi_3_4h_gt_20 | (rsi_14_1d < 70.0))
+            & ((rsi_3_15m_gt_10) | rsi_3_4h_gt_20 | (rsi_14_1d < 70.0))
             # 15m & 4h down move, 15m high
-            & ((rsi_3_15m > 10.0) | rsi_3_4h_gt_20 | (aroonu_14_15m < 60.0))
+            & ((rsi_3_15m_gt_10) | rsi_3_4h_gt_20 | (aroonu_14_15m < 60.0))
             # 15m & 4h down move, 4h still high
-            & ((rsi_3_15m > 10.0) | rsi_3_4h_gt_20 | (aroonu_14_4h < 50.0))
+            & ((rsi_3_15m_gt_10) | rsi_3_4h_gt_20 | (aroonu_14_4h_lt_50))
             # 15m & 4h down move, 1d high
-            & ((rsi_3_15m > 10.0) | rsi_3_4h_gt_20 | (aroonu_14_1d < 80.0))
+            & ((rsi_3_15m_gt_10) | rsi_3_4h_gt_20 | (aroonu_14_1d_lt_80))
             # 15m & 4h down move, 1h high
-            & ((rsi_3_15m > 10.0) | rsi_3_4h_gt_20 | (stochrsi_k_1h_lt_70))
+            & ((rsi_3_15m_gt_10) | rsi_3_4h_gt_20 | (stochrsi_k_1h_lt_70))
             # 15m & 4h down move, 1d high
-            & ((rsi_3_15m > 10.0) | rsi_3_4h_gt_20 | (stochrsi_k_1d < 80.0))
+            & ((rsi_3_15m_gt_10) | rsi_3_4h_gt_20 | (stochrsi_k_1d < 80.0))
             # 15m & 4h down move, 1d overbought
-            & ((rsi_3_15m > 10.0) | rsi_3_4h_gt_20 | roc_9_1d_lt_50)
+            & ((rsi_3_15m_gt_10) | rsi_3_4h_gt_20 | roc_9_1d_lt_50)
             # 15m & 4h down move, 1d high
-            & ((rsi_3_15m > 10.0) | (rsi_3_4h > 30.0) | (roc_9_1d < 30.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_4h_gt_30) | (roc_9_1d_lt_30))
             # 15m & 4h down move, 15m high
-            & ((rsi_3_15m > 10.0) | (rsi_3_4h > 40.0) | (aroonu_14_15m < 70.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_4h_gt_40) | (aroonu_14_15m_lt_70))
             # 15m & 4h down move, 4h high
-            & ((rsi_3_15m > 10.0) | (rsi_3_4h > 45.0) | aroonu_14_4h_lt_70)
+            & ((rsi_3_15m_gt_10) | (rsi_3_4h > 45.0) | aroonu_14_4h_lt_70)
             # 15m down move, 1h high
-            & ((rsi_3_15m > 10.0) | (stochrsi_k_1h < 90.0))
+            & ((rsi_3_15m_gt_10) | (stochrsi_k_1h < 90.0))
             # 15m & 1d down move, 1h still high
-            & ((rsi_3_15m > 10.0) | (rsi_3_1d > 10.0) | (stochrsi_k_1h_lt_50))
+            & ((rsi_3_15m_gt_10) | (rsi_3_1d_gt_10) | (stochrsi_k_1h_lt_50))
             # 15m & 1d down move, 1d high
-            & ((rsi_3_15m > 10.0) | (rsi_3_1d > 30.0) | (stochrsi_k_1d < 60.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_1d > 30.0) | (stochrsi_k_1d < 60.0))
             # 15m down move, 15m & 1h high
-            & ((rsi_3_15m > 10.0) | (aroonu_14_15m < 60.0) | (aroonu_14_1h < 100.0))
+            & ((rsi_3_15m_gt_10) | (aroonu_14_15m < 60.0) | (aroonu_14_1h_lt_100))
             # 15m down move, 15m & 4h high
-            & ((rsi_3_15m > 10.0) | (aroonu_14_15m < 60.0) | aroonu_14_4h_lt_70)
+            & ((rsi_3_15m_gt_10) | (aroonu_14_15m < 60.0) | aroonu_14_4h_lt_70)
             # 15m down move, 15m high, 1h high
-            & ((rsi_3_15m > 10.0) | (aroonu_14_15m < 70.0) | (stochrsi_k_1h_lt_80))
+            & ((rsi_3_15m_gt_10) | (aroonu_14_15m_lt_70) | (stochrsi_k_1h_lt_80))
             # 15m down move, 4h high, 1d overbought
-            & ((rsi_3_15m > 10.0) | aroonu_14_4h_lt_70 | (roc_9_1d_lt_100))
+            & ((rsi_3_15m_gt_10) | aroonu_14_4h_lt_70 | (roc_9_1d_lt_100))
             # 15m down move, 1d high & overbought
-            & ((rsi_3_15m > 10.0) | (aroonu_14_1d < 85.0) | (roc_9_1d < 20.0))
+            & ((rsi_3_15m_gt_10) | (aroonu_14_1d < 85.0) | (roc_9_1d_lt_20))
             # 15m down move, 1h high, 1d overbought
-            & ((rsi_3_15m > 10.0) | (stochrsi_k_1h_lt_50) | (roc_9_1d < 40.0))
+            & ((rsi_3_15m_gt_10) | (stochrsi_k_1h_lt_50) | (roc_9_1d_lt_40))
             # 15m & 1h down move, 1h high
-            & ((rsi_3_15m > 15.0) | (rsi_3_1h_gt_15) | (aroonu_14_1h < 70.0))
+            & ((rsi_3_15m_gt_15) | (rsi_3_1h_gt_15) | (aroonu_14_1h < 70.0))
             # 15m & 1h down move, 4h high
-            & ((rsi_3_15m > 15.0) | (rsi_3_1h_gt_15) | (aroonu_14_4h < 80.0))
+            & ((rsi_3_15m_gt_15) | (rsi_3_1h_gt_15) | (aroonu_14_4h < 80.0))
             # 15m & 1h down move, 1h high
-            & ((rsi_3_15m > 15.0) | (rsi_3_1h > 40.0) | (aroonu_14_1h < 90.0))
+            & ((rsi_3_15m_gt_15) | (rsi_3_1h_gt_40) | (aroonu_14_1h_lt_90))
             # 15m & 4h down move, 15m high
-            & ((rsi_3_15m > 15.0) | (rsi_3_4h_gt_15) | (aroonu_14_15m < 50.0))
+            & ((rsi_3_15m_gt_15) | (rsi_3_4h_gt_15) | (aroonu_14_15m_lt_50))
             # 15m & 4h down move, 1h high
-            & ((rsi_3_15m > 15.0) | (rsi_3_4h_gt_15) | (stochrsi_k_1h < 70.0))
+            & ((rsi_3_15m_gt_15) | (rsi_3_4h_gt_15) | (stochrsi_k_1h < 70.0))
             # 15m & 4h down move, 15m high
-            & ((rsi_3_15m > 15.0) | rsi_3_4h_gt_20 | (aroonu_14_15m < 70.0))
+            & ((rsi_3_15m_gt_15) | rsi_3_4h_gt_20 | (aroonu_14_15m_lt_70))
             # 15m & 4h down move, 4h high
-            & ((rsi_3_15m > 15.0) | (rsi_3_4h > 25.0) | (aroonu_14_4h < 60.0))
+            & ((rsi_3_15m_gt_15) | (rsi_3_4h_gt_25) | (aroonu_14_4h_lt_60))
             # 15m & 4h down move, 4h still high
-            & ((rsi_3_15m > 15.0) | (rsi_3_4h > 25.0) | (stochrsi_k_4h < 40.0))
+            & ((rsi_3_15m_gt_15) | (rsi_3_4h_gt_25) | (stochrsi_k_4h < 40.0))
             # 15m & 4h down move, 1h high
-            & ((rsi_3_15m > 15.0) | (rsi_3_4h > 35.0) | (aroonu_14_1h < 90.0))
+            & ((rsi_3_15m_gt_15) | (rsi_3_4h_gt_35) | (aroonu_14_1h_lt_90))
             # 15m & 1d down move, 1h still high
-            & ((rsi_3_15m > 15.0) | (rsi_3_1d > 15.0) | (stochrsi_k_1h < 30.0))
+            & ((rsi_3_15m_gt_15) | (rsi_3_1d_gt_15) | (stochrsi_k_1h < 30.0))
             # 15m down move, 15m downtrend, 1h high
-            & ((rsi_3_15m > 15.0) | (cmf_20_15m > -0.40) | (aroonu_14_1h < 60.0))
+            & ((rsi_3_15m_gt_15) | (cmf_20_15m > -0.40) | (aroonu_14_1h < 60.0))
             # 15m down move, 15m still high, 4h high
-            & ((rsi_3_15m > 15.0) | (aroonu_14_15m < 50.0) | (stochrsi_k_4h_lt_80))
+            & ((rsi_3_15m_gt_15) | (aroonu_14_15m_lt_50) | (stochrsi_k_4h_lt_80))
             # 15m down move, 15m high, 1d overbought
-            & ((rsi_3_15m > 15.0) | (aroonu_14_15m < 70.0) | (roc_9_1d < 20.0))
+            & ((rsi_3_15m_gt_15) | (aroonu_14_15m_lt_70) | (roc_9_1d_lt_20))
             # 15m down move, 1h & 4h high
-            & ((rsi_3_15m > 15.0) | (aroonu_14_1h < 100.0) | aroonu_14_4h_lt_100)
+            & ((rsi_3_15m_gt_15) | (aroonu_14_1h_lt_100) | aroonu_14_4h_lt_100)
             # 15m down move, 4h & 1d overbought
-            & ((rsi_3_15m > 15.0) | (roc_9_4h_lt_20) | (roc_9_1d < 80.0))
+            & ((rsi_3_15m_gt_15) | (roc_9_4h_lt_20) | (roc_9_1d_lt_80))
             # 15m down move, 1h high, 1d overbought
-            & ((rsi_3_15m > 20.0) | aroonu_14_1h_lt_80 | (roc_9_1d < 10.0))
+            & ((rsi_3_15m_gt_20) | aroonu_14_1h_lt_80 | (roc_9_1d < 10.0))
             # 15m down move, 1h high, 1d downtrend
-            & ((rsi_3_15m > 20.0) | (stochrsi_k_1h < 80.0) | (roc_9_1d_gt_neg_20))
+            & ((rsi_3_15m_gt_20) | (stochrsi_k_1h < 80.0) | (roc_9_1d_gt_neg_20))
             # 15m down move, 4h high, 1d downtrend
-            & ((rsi_3_15m > 20.0) | (stochrsi_k_4h < 80.0) | (roc_9_1d_gt_neg_30))
+            & ((rsi_3_15m_gt_20) | (stochrsi_k_4h < 80.0) | (roc_9_1d_gt_neg_30))
             # 15m & 1h & 4h down move, 4h high
-            & ((rsi_3_15m > 25.0) | (rsi_3_1h > 30.0) | (rsi_3_4h > 50.0) | aroonu_14_4h_lt_70)
+            & ((rsi_3_15m_gt_25) | (rsi_3_1h_gt_30) | (rsi_3_4h_gt_50) | aroonu_14_4h_lt_70)
             # 15m & 4h down move, 15m high
-            & ((rsi_3_15m > 25.0) | (rsi_3_4h > 30.0) | (stochrsi_k_15m < 70.0))
+            & ((rsi_3_15m_gt_25) | (rsi_3_4h_gt_30) | (stochrsi_k_15m < 70.0))
             # 15m down move, 15m & 1h high
-            & ((rsi_3_15m > 25.0) | (aroonu_14_15m < 70.0) | (aroonu_14_1h < 100.0))
+            & ((rsi_3_15m_gt_25) | (aroonu_14_15m_lt_70) | (aroonu_14_1h_lt_100))
             # 15m & 4h down mve, 1h high
-            & ((rsi_3_15m > 30.0) | (rsi_3_4h > 30.0) | (stochrsi_k_1h_lt_80))
+            & ((rsi_3_15m_gt_30) | (rsi_3_4h_gt_30) | (stochrsi_k_1h_lt_80))
             # 15m & 4h down move, 4h high
-            & ((rsi_3_15m > 30.0) | (rsi_3_4h > 45.0) | (stochrsi_k_4h_lt_80))
+            & ((rsi_3_15m_gt_30) | (rsi_3_4h > 45.0) | (stochrsi_k_4h_lt_80))
             # 15m down move, 15m & 1h high
-            & ((rsi_3_15m > 30.0) | (aroonu_14_15m < 70.0) | (aroonu_14_1h < 90.0))
+            & ((rsi_3_15m_gt_30) | (aroonu_14_15m_lt_70) | (aroonu_14_1h_lt_90))
             # 15m down move, 1h high, 1d downtrend
-            & ((rsi_3_15m > 30.0) | (aroonu_14_1h < 90.0) | (roc_9_1d > -10.0))
+            & ((rsi_3_15m_gt_30) | (aroonu_14_1h_lt_90) | (roc_9_1d > -10.0))
             # 15m down move, 15m high, 4h high
-            & ((rsi_3_15m > 35.0) | (aroonu_14_15m < 70.0) | (stochrsi_k_4h_lt_80))
+            & ((rsi_3_15m > 35.0) | (aroonu_14_15m_lt_70) | (stochrsi_k_4h_lt_80))
             # 15m down move, 15m & 4h high
-            & ((rsi_3_15m > 35.0) | (aroonu_14_15m < 70.0) | (aroonu_14_4h < 90.0))
+            & ((rsi_3_15m > 35.0) | (aroonu_14_15m_lt_70) | (aroonu_14_4h_lt_90))
             # 1h & 4h down move, 4h still not low enough
-            & ((rsi_3_1h > 3.0) | (rsi_3_4h_gt_10) | (stochrsi_k_4h < 10.0))
+            & ((rsi_3_1h_gt_3) | (rsi_3_4h_gt_10) | (stochrsi_k_4h < 10.0))
             # 1h & 4h down move, 1d still high
-            & ((rsi_3_1h > 3.0) | (rsi_3_4h_gt_10) | (stochrsi_k_1d < 40.0))
+            & ((rsi_3_1h_gt_3) | (rsi_3_4h_gt_10) | (stochrsi_k_1d < 40.0))
             # 1h & 4h down move, 1d overbought
-            & ((rsi_3_1h > 3.0) | (rsi_3_4h > 25.0) | (roc_9_1d < 10.0))
+            & ((rsi_3_1h_gt_3) | (rsi_3_4h_gt_25) | (roc_9_1d < 10.0))
             # 1h & 1d down move, 1d still high
-            & ((rsi_3_1h > 3.0) | (rsi_3_1d > 25.0) | (stochrsi_k_1d < 40.0))
+            & ((rsi_3_1h_gt_3) | (rsi_3_1d_gt_25) | (stochrsi_k_1d < 40.0))
             # 1h & 4h down move, 15m still not low enough
-            & ((rsi_3_1h > 5.0) | (rsi_3_4h > 5.0) | (stochrsi_k_15m < 20.0))
+            & ((rsi_3_1h_gt_5) | (rsi_3_4h_gt_5) | (stochrsi_k_15m < 20.0))
             # 1h & 4h down move, 4h downtrend
-            & ((rsi_3_1h > 5.0) | (rsi_3_4h_gt_10) | (roc_9_4h > -10.0))
+            & ((rsi_3_1h_gt_5) | (rsi_3_4h_gt_10) | (roc_9_4h > -10.0))
             # 1h & 4h down move, 15m high
-            & ((rsi_3_1h > 5.0) | (rsi_3_4h > 25.0) | (stochrsi_k_15m < 60.0))
+            & ((rsi_3_1h_gt_5) | (rsi_3_4h_gt_25) | (stochrsi_k_15m < 60.0))
             # 1h & 4h down move, 1d still high
             & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_10) | (aroonu_14_1d < 50.0))
             # 1h & 4h down move, 15m still high
@@ -21189,17 +21241,17 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 4h still not low enough
             & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_15) | (aroonu_14_4h < 30.0))
             # 1h & 4h down move, 4h still high
-            & ((rsi_3_1h_gt_10) | rsi_3_4h_gt_20 | (aroonu_14_4h < 40.0))
+            & ((rsi_3_1h_gt_10) | rsi_3_4h_gt_20 | (aroonu_14_4h_lt_40))
             # 1h & 4h down move, 4h high
-            & ((rsi_3_1h_gt_10) | (rsi_3_4h > 25.0) | (stochrsi_k_4h < 60.0))
+            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_25) | (stochrsi_k_4h < 60.0))
             # 1h & 4h down move, 4h high
-            & ((rsi_3_1h_gt_10) | (rsi_3_4h > 40.0) | aroonu_14_4h_lt_70)
+            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_40) | aroonu_14_4h_lt_70)
             # 1h & 1d down move, 1h still not low enough
-            & ((rsi_3_1h_gt_10) | (rsi_3_1d > 15.0) | (aroonu_14_1h < 20.0))
+            & ((rsi_3_1h_gt_10) | (rsi_3_1d_gt_15) | (aroonu_14_1h < 20.0))
             # 1h & 1d down move, 1h still not low enough
-            & ((rsi_3_1h_gt_10) | (rsi_3_1d > 20.0) | (aroonu_14_1h < 30.0))
+            & ((rsi_3_1h_gt_10) | (rsi_3_1d_gt_20) | (aroonu_14_1h < 30.0))
             # 1h down move, 15m downtrend, 1d high
-            & ((rsi_3_1h_gt_10) | (cmf_20_15m > -0.40) | (aroonu_14_1d < 70.0))
+            & ((rsi_3_1h_gt_10) | (cmf_20_15m > -0.40) | (aroonu_14_1d_lt_70))
             # 1h down move, 1h high, 4h high
             & ((rsi_3_1h_gt_10) | (aroonu_14_1h < 70.0) | (stochrsi_k_4h < 80.0))
             # 1h & 4h down move, 1h still high
@@ -21209,113 +21261,113 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 1d downtrend
             & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_15) | (roc_9_1d > -30.0))
             # 1h & 1d down move, 4h downtrend
-            & ((rsi_3_1h_gt_15) | (rsi_3_1d > 15.0) | (roc_9_4h > -30.0))
+            & ((rsi_3_1h_gt_15) | (rsi_3_1d_gt_15) | (roc_9_4h_gt_neg_30))
             # 1h & 1d down move, 1d still high
-            & ((rsi_3_1h_gt_15) | (rsi_3_1d > 25.0) | (aroonu_14_1d < 50.0))
+            & ((rsi_3_1h_gt_15) | (rsi_3_1d_gt_25) | (aroonu_14_1d < 50.0))
             # 1h & 1d down move, 1d high
-            & ((rsi_3_1h_gt_15) | (rsi_3_1d > 35.0) | (aroonu_14_1d < 70.0))
+            & ((rsi_3_1h_gt_15) | (rsi_3_1d > 35.0) | (aroonu_14_1d_lt_70))
             # 1h down move, 1h still high, 1d high
-            & ((rsi_3_1h_gt_15) | (aroonu_14_1h < 50.0) | (stochrsi_k_1d < 80.0))
+            & ((rsi_3_1h_gt_15) | (aroonu_14_1h_lt_50) | (stochrsi_k_1d < 80.0))
             # 1h down move, 1h still high, 4h overbought
-            & ((rsi_3_1h_gt_15) | (aroonu_14_1h < 50.0) | (roc_9_4h < 10.0))
+            & ((rsi_3_1h_gt_15) | (aroonu_14_1h_lt_50) | (roc_9_4h_lt_10))
             # 1h down move, 1h still high, 1d downtrend
-            & ((rsi_3_1h_gt_15) | (aroonu_14_1h < 50.0) | (roc_9_1d > -30.0))
+            & ((rsi_3_1h_gt_15) | (aroonu_14_1h_lt_50) | (roc_9_1d > -30.0))
             # 1h down move, 4h still high, 1d overbought
-            & ((rsi_3_1h_gt_15) | (aroonu_14_4h < 50.0) | (roc_9_1d < 40.0))
+            & ((rsi_3_1h_gt_15) | (aroonu_14_4h_lt_50) | (roc_9_1d_lt_40))
             # 1h down move, 1d high, 4h downtrend
-            & ((rsi_3_1h_gt_15) | (aroonu_14_1d < 70.0) | (roc_9_4h > -20.0))
+            & ((rsi_3_1h_gt_15) | (aroonu_14_1d_lt_70) | (roc_9_4h > -20.0))
             # 1h & 4h down move, 1d high
-            & (rsi_3_1h_gt_20 | (rsi_3_4h > 25.0) | (aroonu_14_1d < 80.0))
+            & (rsi_3_1h_gt_20 | (rsi_3_4h_gt_25) | (aroonu_14_1d_lt_80))
             # 1h & 4h down move, 1d overbought
-            & (rsi_3_1h_gt_20 | (rsi_3_4h > 30.0) | (roc_9_1d_lt_100))
+            & (rsi_3_1h_gt_20 | (rsi_3_4h_gt_30) | (roc_9_1d_lt_100))
             # 1h & 4h down move, 1h high
-            & (rsi_3_1h_gt_20 | (rsi_3_4h > 35.0) | aroonu_14_1h_lt_70)
+            & (rsi_3_1h_gt_20 | (rsi_3_4h_gt_35) | aroonu_14_1h_lt_70)
             # 1h & 4h down move, 4h high
-            & (rsi_3_1h_gt_20 | (rsi_3_4h > 50.0) | aroonu_14_4h_lt_100)
+            & (rsi_3_1h_gt_20 | (rsi_3_4h_gt_50) | aroonu_14_4h_lt_100)
             # 1h & 4h down move, 1d downtrend
-            & (rsi_3_1h_gt_20 | (rsi_3_1d > 25.0) | (roc_9_1d_gt_neg_30))
+            & (rsi_3_1h_gt_20 | (rsi_3_1d_gt_25) | (roc_9_1d_gt_neg_30))
             # 1h down move, 15m still high, 1d high
-            & (rsi_3_1h_gt_20 | (aroonu_14_15m < 40.0) | (aroonu_14_1d < 90.0))
+            & (rsi_3_1h_gt_20 | (aroonu_14_15m < 40.0) | (aroonu_14_1d_lt_90))
             # 1h down move, 1h high, 1d overbought
             & (rsi_3_1h_gt_20 | (aroonu_14_1h < 60.0) | (roc_9_1d < 10.0))
             # 1h & 4h down move, 15m high
-            & ((rsi_3_1h > 25.0) | (rsi_3_4h > 25.0) | (stochrsi_k_15m < 70.0))
+            & ((rsi_3_1h_gt_25) | (rsi_3_4h_gt_25) | (stochrsi_k_15m < 70.0))
             # 1h & 4h down move, 1h high
-            & ((rsi_3_1h > 25.0) | (rsi_3_4h > 30.0) | aroonu_14_1h_lt_80)
+            & ((rsi_3_1h_gt_25) | (rsi_3_4h_gt_30) | aroonu_14_1h_lt_80)
             # 1h & 4h down move, 4h high
-            & ((rsi_3_1h > 25.0) | (rsi_3_4h > 30.0) | (aroonu_14_4h < 60.0))
+            & ((rsi_3_1h_gt_25) | (rsi_3_4h_gt_30) | (aroonu_14_4h_lt_60))
             # 1h & 4h down move, 1d high
-            & ((rsi_3_1h > 30.0) | (rsi_3_4h > 35.0) | (rsi_14_1d < 80.0))
+            & ((rsi_3_1h_gt_30) | (rsi_3_4h_gt_35) | (rsi_14_1d < 80.0))
             # 1h down move, 1d high & overbought
-            & ((rsi_3_1h > 30.0) | (aroonu_14_1d < 85.0) | (roc_9_1d < 40.0))
+            & ((rsi_3_1h_gt_30) | (aroonu_14_1d < 85.0) | (roc_9_1d_lt_40))
             # 1h down move, 1d high & overbought
-            & ((rsi_3_1h > 30.0) | (stochrsi_k_1d < 80.0) | (roc_9_1d < 20.0))
+            & ((rsi_3_1h_gt_30) | (stochrsi_k_1d < 80.0) | (roc_9_1d_lt_20))
             # 1h down move, 15m still high, 1h high
-            & ((rsi_3_1h > 30.0) | (aroonu_14_15m < 50.0) | (aroonu_14_1h < 85.0))
+            & ((rsi_3_1h_gt_30) | (aroonu_14_15m_lt_50) | (aroonu_14_1h < 85.0))
             # 1h down move, 4h high, 1d overbought
-            & ((rsi_3_1h > 30.0) | (aroonu_14_4h < 90.0) | (roc_9_1d < 40.0))
+            & ((rsi_3_1h_gt_30) | (aroonu_14_4h_lt_90) | (roc_9_1d_lt_40))
             # 1h & 4h down move, 1h still high
-            & ((rsi_3_1h > 35.0) | (rsi_3_4h > 35.0) | (stochrsi_k_1h_lt_50))
+            & ((rsi_3_1h_gt_35) | (rsi_3_4h_gt_35) | (stochrsi_k_1h_lt_50))
             # 1h & 4h down move, 4h high
-            & ((rsi_3_1h > 35.0) | (rsi_3_4h > 50.0) | aroonu_14_4h_lt_80)
+            & ((rsi_3_1h_gt_35) | (rsi_3_4h_gt_50) | aroonu_14_4h_lt_80)
             # 1h down move, 1h high , 1d overbought
-            & ((rsi_3_1h > 35.0) | (stochrsi_k_1h_lt_80) | (roc_9_1d < 30.0))
+            & ((rsi_3_1h_gt_35) | (stochrsi_k_1h_lt_80) | (roc_9_1d_lt_30))
             # 1h down move, 4h high, 1d overbought
-            & ((rsi_3_1h > 35.0) | aroonu_14_4h_lt_70 | (roc_9_1d_lt_100))
+            & ((rsi_3_1h_gt_35) | aroonu_14_4h_lt_70 | (roc_9_1d_lt_100))
             # 1h & 1d down move, 1h high
-            & ((rsi_3_1h > 45.0) | (rsi_3_1d > 45.0) | aroonu_14_1h_lt_80)
+            & ((rsi_3_1h_gt_45) | (rsi_3_1d > 45.0) | aroonu_14_1h_lt_80)
             # 1h down move, 1h & 4h high
-            & ((rsi_3_1h > 45.0) | (aroonu_14_1h < 75.0) | aroonu_14_4h_lt_100)
+            & ((rsi_3_1h_gt_45) | (aroonu_14_1h < 75.0) | aroonu_14_4h_lt_100)
             # 1h down move, 4h high & overbought
-            & ((rsi_3_1h > 50.0) | (stochrsi_k_4h_lt_90) | (roc_9_4h < 25.0))
+            & ((rsi_3_1h_gt_50) | (stochrsi_k_4h_lt_90) | (roc_9_4h < 25.0))
             # 1h & 1d down move, 1h high
             & ((rsi_3_1h > 60.0) | (rsi_3_1d > 60.0) | aroonu_14_1h_lt_70)
             # 4h & 1d down move, 1d still high
-            & ((rsi_3_4h > 3.0) | (rsi_3_1d > 20.0) | (rsi_14_1d < 40.0))
+            & ((rsi_3_4h > 3.0) | (rsi_3_1d_gt_20) | (rsi_14_1d < 40.0))
             # 4h down move, 1h still not low enough, 4h downtrend
             & ((rsi_3_4h > 3.0) | (aroonu_14_1h < 20.0) | (roc_9_4h > -10.0))
             # 4h & 1d down move, 1d still high
-            & ((rsi_3_4h > 5.0) | (rsi_3_1d > 30.0) | (stochrsi_k_1d < 40.0))
+            & ((rsi_3_4h_gt_5) | (rsi_3_1d > 30.0) | (stochrsi_k_1d < 40.0))
             # 4h down move, 1h high
-            & ((rsi_3_4h > 5.0) | (stochrsi_k_1h < 90.0))
+            & ((rsi_3_4h_gt_5) | (stochrsi_k_1h < 90.0))
             # 4h down move, 4h & 1d downtrend
-            & ((rsi_3_4h > 5.0) | (roc_9_4h > -10.0) | (roc_9_1d > -10.0))
+            & ((rsi_3_4h_gt_5) | (roc_9_4h > -10.0) | (roc_9_1d > -10.0))
             # 4h & 1d down move, 1h high
-            & ((rsi_3_4h_gt_10) | (rsi_3_1d > 10.0) | (stochrsi_k_1h < 60.0))
+            & ((rsi_3_4h_gt_10) | (rsi_3_1d_gt_10) | (stochrsi_k_1h < 60.0))
             # 4h & 1d down move, 4h downtrend
-            & ((rsi_3_4h_gt_10) | (rsi_3_1d > 10.0) | (roc_9_4h > -20.0))
+            & ((rsi_3_4h_gt_10) | (rsi_3_1d_gt_10) | (roc_9_4h > -20.0))
             # 4h & 1d down move, 1d still high
-            & ((rsi_3_4h_gt_10) | (rsi_3_1d > 15.0) | (aroonu_14_1d < 40.0))
+            & ((rsi_3_4h_gt_10) | (rsi_3_1d_gt_15) | (aroonu_14_1d < 40.0))
             # 4h & 1d down move, 1d downtrend
-            & ((rsi_3_4h_gt_10) | (rsi_3_1d > 15.0) | (roc_9_1d > -30.0))
+            & ((rsi_3_4h_gt_10) | (rsi_3_1d_gt_15) | (roc_9_1d > -30.0))
             # 4h & 1d down move, 1h high
-            & ((rsi_3_4h_gt_10) | (rsi_3_1d > 30.0) | (aroonu_14_1h < 100.0))
+            & ((rsi_3_4h_gt_10) | (rsi_3_1d > 30.0) | (aroonu_14_1h_lt_100))
             # 4h down move, 15m still high, 1h still high
             & ((rsi_3_4h_gt_10) | (aroonu_14_15m < 40.0) | (stochrsi_k_1h < 50.0))
             # 4h down move, 4h still high, 4h downtrend
-            & ((rsi_3_4h_gt_10) | (aroonu_14_4h < 40.0) | (roc_9_4h > -20.0))
+            & ((rsi_3_4h_gt_10) | (aroonu_14_4h_lt_40) | (roc_9_4h > -20.0))
             # 4h down move, 15m high
             & ((rsi_3_4h_gt_10) | (stochrsi_k_15m < 80.0))
             # 4h down move, 1h still not low enough, 4h downtrend
             & ((rsi_3_4h_gt_10) | (stochrsi_k_1h < 20.0) | (roc_9_4h > -20.0))
             # 4h & 1d down move, 15m still high
-            & ((rsi_3_4h_gt_15) | (rsi_3_1d > 15.0) | (stochrsi_k_15m < 50.0))
+            & ((rsi_3_4h_gt_15) | (rsi_3_1d_gt_15) | (stochrsi_k_15m < 50.0))
             # 4h & 1d down move, 1h still high
-            & ((rsi_3_4h_gt_15) | (rsi_3_1d > 15.0) | (stochrsi_k_1h < 40.0))
+            & ((rsi_3_4h_gt_15) | (rsi_3_1d_gt_15) | (stochrsi_k_1h < 40.0))
             # 4h & 1d down move, 1d high
-            & ((rsi_3_4h_gt_15) | (rsi_3_1d > 20.0) | (aroonu_14_1d < 60.0))
+            & ((rsi_3_4h_gt_15) | (rsi_3_1d_gt_20) | (aroonu_14_1d < 60.0))
             # 4h & 1d down move, 4h high
-            & ((rsi_3_4h_gt_15) | (rsi_3_1d > 25.0) | aroonu_14_4h_lt_70)
+            & ((rsi_3_4h_gt_15) | (rsi_3_1d_gt_25) | aroonu_14_4h_lt_70)
             # 4h & 1d down move, 4h still high
-            & ((rsi_3_4h_gt_15) | (rsi_3_1d > 30.0) | (stochrsi_k_4h < 50.0))
+            & ((rsi_3_4h_gt_15) | (rsi_3_1d > 30.0) | (stochrsi_k_4h_lt_50))
             # 4h & 1d down move, 1d high
-            & ((rsi_3_4h_gt_15) | (rsi_3_1d > 40.0) | (aroonu_14_1d < 70.0))
+            & ((rsi_3_4h_gt_15) | (rsi_3_1d > 40.0) | (aroonu_14_1d_lt_70))
             # 4h & 1d down move, 4h still high
             & ((rsi_3_4h_gt_15) | (rsi_3_1d > 50.0) | (stochrsi_k_4h < 40.0))
             # 4h down move, 1d still high, 4h still not low enough
             & ((rsi_3_4h_gt_15) | (rsi_14_1d < 40.0) | (stochrsi_k_4h < 30.0))
             # 4h down move, 4h still high, 4h downtrend
-            & ((rsi_3_4h_gt_15) | (aroonu_14_4h < 50.0) | (roc_9_4h > -10.0))
+            & ((rsi_3_4h_gt_15) | (aroonu_14_4h_lt_50) | (roc_9_4h > -10.0))
             # 4h down move, 1d still high, 1d downtrend
             & ((rsi_3_4h_gt_15) | (aroonu_14_1d < 50.0) | (roc_9_1d > -20.0))
             # 4h down move, 4h still not low enough, 1d downtrend
@@ -21323,43 +21375,43 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 1h downtrend, 1d overbought
             & ((rsi_3_4h_gt_15) | (roc_9_1h > -10.0) | (roc_9_1d < 200.0))
             # 4h down move, 4h high, 4h downtrend
-            & (rsi_3_4h_gt_20 | (aroonu_14_4h < 60.0) | (roc_9_4h_gt_neg_20))
+            & (rsi_3_4h_gt_20 | (aroonu_14_4h_lt_60) | (roc_9_4h_gt_neg_20))
             # 4h down move, 1d high & overbought
-            & (rsi_3_4h_gt_20 | (aroonu_14_1d < 80.0) | (roc_9_1d < 70.0))
+            & (rsi_3_4h_gt_20 | (aroonu_14_1d_lt_80) | (roc_9_1d < 70.0))
             # 4h down move, 4h & 1d downtrend
-            & ((rsi_3_4h > 25.0) | (roc_9_4h > -10.0) | (roc_9_1d > -10.0))
+            & ((rsi_3_4h_gt_25) | (roc_9_4h > -10.0) | (roc_9_1d > -10.0))
             # 1h down move, 4h still not low enough, 1d downtrend
             & (rsi_3_4h_gt_20 | (stochrsi_k_4h < 30.0) | (roc_9_1d_gt_neg_20))
             # 4h & 1d down move, 1h high
-            & ((rsi_3_4h > 25.0) | (rsi_3_1d > 25.0) | (stochrsi_k_1h_lt_80))
+            & ((rsi_3_4h_gt_25) | (rsi_3_1d_gt_25) | (stochrsi_k_1h_lt_80))
             # 4h down move, 1h high
-            & ((rsi_3_4h > 25.0) | (stochrsi_k_1h_lt_70))
+            & ((rsi_3_4h_gt_25) | (stochrsi_k_1h_lt_70))
             # 4h & 1d down move, 1d overbought
-            & ((rsi_3_4h > 25.0) | (rsi_3_1d > 40.0) | (roc_9_1d < 30.0))
+            & ((rsi_3_4h_gt_25) | (rsi_3_1d > 40.0) | (roc_9_1d_lt_30))
             # 4h & 1d down move, 4h still high
-            & ((rsi_3_4h > 30.0) | (rsi_3_1d > 30.0) | (stochrsi_k_4h < 50.0))
+            & ((rsi_3_4h_gt_30) | (rsi_3_1d > 30.0) | (stochrsi_k_4h_lt_50))
             # 4h & 1d down move, 1d high
-            & ((rsi_3_4h > 30.0) | (rsi_3_1d > 60.0) | (aroonu_14_1d < 90.0))
+            & ((rsi_3_4h_gt_30) | (rsi_3_1d > 60.0) | (aroonu_14_1d_lt_90))
             # 4h down move, 15m & 4h high
-            & ((rsi_3_4h > 30.0) | (aroonu_14_15m < 70.0) | aroonu_14_4h_lt_70)
+            & ((rsi_3_4h_gt_30) | (aroonu_14_15m_lt_70) | aroonu_14_4h_lt_70)
             # 4h down move, 1h high, 1d downtrend
-            & ((rsi_3_4h > 30.0) | (stochrsi_k_1h_lt_80) | (roc_9_1d > -40.0))
+            & ((rsi_3_4h_gt_30) | (stochrsi_k_1h_lt_80) | (roc_9_1d_gt_neg_40))
             # 4h down move, 4h & 1d downtrend
-            & ((rsi_3_4h > 30.0) | (roc_9_4h_gt_neg_20) | (roc_9_1d > -40.0))
+            & ((rsi_3_4h_gt_30) | (roc_9_4h_gt_neg_20) | (roc_9_1d_gt_neg_40))
             # 4h down move, 4h still high, 1d downtrend
-            & ((rsi_3_4h > 35.0) | (stochrsi_k_4h < 40.0) | (roc_9_1d_gt_neg_30))
+            & ((rsi_3_4h_gt_35) | (stochrsi_k_4h < 40.0) | (roc_9_1d_gt_neg_30))
             # 4h down move, 1d high & overbought
-            & ((rsi_3_4h > 35.0) | (stochrsi_k_1d < 80.0) | (roc_9_1d < 20.0))
+            & ((rsi_3_4h_gt_35) | (stochrsi_k_1d < 80.0) | (roc_9_1d_lt_20))
             # 4h down move, 15m still high, 1h high
-            & ((rsi_3_4h > 35.0) | (aroonu_14_15m < 50.0) | (aroonu_14_1h < 100.0))
+            & ((rsi_3_4h_gt_35) | (aroonu_14_15m_lt_50) | (aroonu_14_1h_lt_100))
             # 4h down move, 1h high
-            & ((rsi_3_4h > 40.0) | aroonu_14_1h_lt_80)
+            & ((rsi_3_4h_gt_40) | aroonu_14_1h_lt_80)
             # 4h down move, 1d high & overbought
-            & ((rsi_3_4h > 45.0) | (aroonu_14_1d < 70.0) | (roc_9_1d < 20.0))
+            & ((rsi_3_4h > 45.0) | (aroonu_14_1d_lt_70) | (roc_9_1d_lt_20))
             # 4h down move, 1d high & overbought
-            & ((rsi_3_4h > 55.0) | (stochrsi_k_1d < 90.0) | (roc_9_1d < 80.0))
+            & ((rsi_3_4h > 55.0) | (stochrsi_k_1d_lt_90) | (roc_9_1d_lt_80))
             # 1d down move, 1d high, 4h downtrend
-            & ((rsi_3_1d > 15.0) | (aroonu_14_1d < 70.0) | (roc_9_4h > -40.0))
+            & ((rsi_3_1d_gt_15) | (aroonu_14_1d_lt_70) | (roc_9_4h > -40.0))
             # 1d down move, 1h & 4h high
             & ((rsi_3_1d > 30.0) | aroonu_14_1h_lt_70 | aroonu_14_4h_lt_100)
             # 1d down move, 4h high, 1d overbought
@@ -21369,27 +21421,27 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1d down move, 1d overbought
             & ((rsi_3_1d > 60.0) | (roc_9_1d < 200.0))
             # 15m & 1h high, 4h overbought
-            & ((aroonu_14_15m < 70.0) | (aroonu_14_1h < 100.0) | (roc_9_4h < 15.0))
+            & ((aroonu_14_15m_lt_70) | (aroonu_14_1h_lt_100) | (roc_9_4h < 15.0))
             # 15m & 1h high, 1d overbought
-            & ((aroonu_14_15m < 70.0) | (aroonu_14_1h < 100.0) | (roc_9_1d_lt_100))
+            & ((aroonu_14_15m_lt_70) | (aroonu_14_1h_lt_100) | (roc_9_1d_lt_100))
             # 15m & 1h high, 1d downtrend
-            & ((aroonu_14_15m < 70.0) | (aroonu_14_1h < 100.0) | (roc_9_1d > -10.0))
+            & ((aroonu_14_15m_lt_70) | (aroonu_14_1h_lt_100) | (roc_9_1d > -10.0))
             # 15m high, 1d high & overbought
-            & ((aroonu_14_15m < 70.0) | (aroonu_14_1d < 90.0) | (roc_9_1d < 30.0))
+            & ((aroonu_14_15m_lt_70) | (aroonu_14_1d_lt_90) | (roc_9_1d_lt_30))
             # 15m high, 1d high & overbought
-            & ((aroonu_14_15m < 70.0) | aroonu_14_1d_lt_100 | (roc_9_1d < 20.0))
+            & ((aroonu_14_15m_lt_70) | aroonu_14_1d_lt_100 | (roc_9_1d_lt_20))
             # 15m high, 1h high, 1d downtrend
-            & ((aroonu_14_15m < 70.0) | (stochrsi_k_1h < 80.0) | (roc_9_1d_gt_neg_20))
+            & ((aroonu_14_15m_lt_70) | (stochrsi_k_1h < 80.0) | (roc_9_1d_gt_neg_20))
             # 1h & 4h high, 4h overbought
-            & ((aroonu_14_1h < 90.0) | (aroonu_14_4h < 90.0) | (roc_9_4h < 10.0))
+            & ((aroonu_14_1h_lt_90) | (aroonu_14_4h_lt_90) | (roc_9_4h_lt_10))
             # 1h & 4h high, 1d overbought
-            & ((aroonu_14_1h < 90.0) | aroonu_14_4h_lt_100 | roc_9_1d_lt_50)
+            & ((aroonu_14_1h_lt_90) | aroonu_14_4h_lt_100 | roc_9_1d_lt_50)
             # 1h & 1d high, 1d overbought
-            & ((aroonu_14_1h < 100.0) | aroonu_14_1d_lt_100 | (roc_9_1d < 40.0))
+            & ((aroonu_14_1h_lt_100) | aroonu_14_1d_lt_100 | (roc_9_1d_lt_40))
             # 4h & 1d high, 4h overbought
             & (aroonu_14_4h_lt_100 | aroonu_14_1d_lt_100 | (roc_9_4h < 50.0))
             # 4h & 1d high, 1d overbought
-            & ((aroonu_14_4h < 90.0) | aroonu_14_1d_lt_100 | roc_9_1d_lt_50)
+            & ((aroonu_14_4h_lt_90) | aroonu_14_1d_lt_100 | roc_9_1d_lt_50)
             # 1h high, 1h & 4h overbought
             & ((stochrsi_k_1h < 80.0) | (roc_9_1h < 20.0) | (roc_9_4h_lt_20))
             # 4h & 1d overbought
@@ -21416,179 +21468,179 @@ class NostalgiaForInfinityX7(IStrategy):
             # 5m down move, 1h & 1d high
             & ((rsi_3 > 10.0) | aroonu_14_1h_lt_80 | aroonu_14_1d_lt_100)
             # 5m down move, 15m & 1h high
-            & ((rsi_3 > 10.0) | (aroonu_14_15m < 85.0) | (aroonu_14_1h < 100.0))
+            & ((rsi_3 > 10.0) | (aroonu_14_15m < 85.0) | (aroonu_14_1h_lt_100))
             # 15m & 1h & 4h down move
-            & (rsi_3_15m_gt_3 | (rsi_3_1h > 3.0) | (rsi_3_4h_gt_15))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_3) | (rsi_3_4h_gt_15))
             # 15m & 1h down move, 1d high
-            & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_10) | (aroonu_14_1d < 70.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_10) | (aroonu_14_1d_lt_70))
             # 15m & 1h down move, 1h still high
             & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_10) | (stochrsi_k_1h < 40.0))
             # 15m & 1h down move, 1d overbought
             & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_10) | (roc_9_1d < 60.0))
             # 15m & 1h down move, 1h still high
-            & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_15) | (aroonu_14_1h < 50.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_15) | (aroonu_14_1h_lt_50))
             # 15m & 1h down move, 4h still high
-            & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_15) | (aroonu_14_4h < 40.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_15) | (aroonu_14_4h_lt_40))
             # 15m & 1h down move, 4h high
             & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_15) | (stochrsi_k_4h < 90.0))
             # 15m & 1h down move, 15m high
-            & (rsi_3_15m_gt_3 | (rsi_3_1h > 30.0) | (aroonu_14_15m < 70.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_30) | (aroonu_14_15m_lt_70))
             # 15m & 1h down move, 1h high
-            & (rsi_3_15m_gt_3 | (rsi_3_1h > 40.0) | (aroonu_14_1h < 75.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_40) | (aroonu_14_1h < 75.0))
             # 15m & 4h down move, 1d downtrend
             & (rsi_3_15m_gt_3 | (rsi_3_4h_gt_10) | (roc_9_1d > -20.0))
             # 15m & 4h down move, 4h still high
-            & (rsi_3_15m_gt_3 | (rsi_3_4h > 25.0) | (aroonu_14_4h < 40.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_4h_gt_25) | (aroonu_14_4h_lt_40))
             # 15m down move, 1h high, 4h overbought
-            & (rsi_3_15m_gt_3 | aroonu_14_1h_lt_70 | (roc_9_4h < 10.0))
+            & (rsi_3_15m_gt_3 | aroonu_14_1h_lt_70 | (roc_9_4h_lt_10))
             # 15m down move, 4h high
-            & (rsi_3_15m_gt_3 | (aroonu_14_4h < 90.0))
+            & (rsi_3_15m_gt_3 | (aroonu_14_4h_lt_90))
             # 15m down move, 1h high, 1d overbought
-            & (rsi_3_15m_gt_3 | (stochrsi_k_1h < 60.0) | (roc_9_1d < 20.0))
+            & (rsi_3_15m_gt_3 | (stochrsi_k_1h < 60.0) | (roc_9_1d_lt_20))
             # 15m down move, 4h high
             & (rsi_3_15m_gt_3 | (stochrsi_k_4h_lt_80))
             # 15m & 1h down move, 15m still not low enough
-            & ((rsi_3_15m > 5.0) | (rsi_3_1h > 5.0) | (stochrsi_k_15m < 30.0))
+            & ((rsi_3_15m_gt_5) | (rsi_3_1h_gt_5) | (stochrsi_k_15m < 30.0))
             # 15m & 1h down move, 4h still high
-            & ((rsi_3_15m > 5.0) | (rsi_3_1h_gt_10) | (stochrsi_k_4h < 50.0))
+            & ((rsi_3_15m_gt_5) | (rsi_3_1h_gt_10) | (stochrsi_k_4h_lt_50))
             # 15m & 4h down move, 1d high
-            & ((rsi_3_15m > 5.0) | (rsi_3_4h_gt_15) | (aroonu_14_1d < 70.0))
+            & ((rsi_3_15m_gt_5) | (rsi_3_4h_gt_15) | (aroonu_14_1d_lt_70))
             # 15m & 4h down move, 15m high
-            & ((rsi_3_15m > 5.0) | rsi_3_4h_gt_20 | (aroonu_14_15m < 60.0))
+            & ((rsi_3_15m_gt_5) | rsi_3_4h_gt_20 | (aroonu_14_15m < 60.0))
             # 15m & 1h down move, 4h high
-            & ((rsi_3_15m > 5.0) | (rsi_3_1h_gt_15) | (aroonu_14_4h < 85.0))
+            & ((rsi_3_15m_gt_5) | (rsi_3_1h_gt_15) | (aroonu_14_4h < 85.0))
             # 15m & 1h down move, 4h high
-            & ((rsi_3_15m > 5.0) | (rsi_3_1h_gt_15) | (stochrsi_k_4h < 60.0))
+            & ((rsi_3_15m_gt_5) | (rsi_3_1h_gt_15) | (stochrsi_k_4h < 60.0))
             # 15m & 4h down move, 1d high
-            & ((rsi_3_15m > 5.0) | rsi_3_4h_gt_20 | (aroonu_14_1d < 80.0))
+            & ((rsi_3_15m_gt_5) | rsi_3_4h_gt_20 | (aroonu_14_1d_lt_80))
             # 15m down move, 4h high, 1h overbought
-            & ((rsi_3_15m > 5.0) | aroonu_14_4h_lt_100 | (roc_9_1h < 10.0))
+            & ((rsi_3_15m_gt_5) | aroonu_14_4h_lt_100 | (roc_9_1h_lt_10))
             # 15m & 1h down move, 4h high
-            & ((rsi_3_15m > 10.0) | (rsi_3_1h_gt_10) | (aroonu_14_4h < 85.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_10) | (aroonu_14_4h < 85.0))
             # 15m & 1h down move, 1h still high
-            & ((rsi_3_15m > 10.0) | (rsi_3_1h_gt_10) | (stochrsi_k_1h < 40.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_10) | (stochrsi_k_1h < 40.0))
             # 15m & 1h down move, 4h high
-            & ((rsi_3_15m > 10.0) | (rsi_3_1h_gt_10) | (stochrsi_k_4h < 60.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_10) | (stochrsi_k_4h < 60.0))
             # 15m & 1h down move, 1h still high
-            & ((rsi_3_15m > 10.0) | (rsi_3_1h_gt_15) | (stochrsi_k_1h < 50.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_15) | (stochrsi_k_1h < 50.0))
             # 15m & 1h down move, 15m high
-            & ((rsi_3_15m > 10.0) | rsi_3_1h_gt_20 | (aroonu_14_15m < 60.0))
+            & ((rsi_3_15m_gt_10) | rsi_3_1h_gt_20 | (aroonu_14_15m < 60.0))
             # 15m & 1h down move, 15m still high
-            & ((rsi_3_15m > 10.0) | (rsi_3_1h > 25.0) | (aroonu_14_15m < 40.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_25) | (aroonu_14_15m < 40.0))
             # 15m & 1h down move, 1h high
-            & ((rsi_3_15m > 10.0) | (rsi_3_1h > 30.0) | (stochrsi_k_1h_lt_70))
+            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_30) | (stochrsi_k_1h_lt_70))
             # 15m & 1h down move, 1d overbought
-            & ((rsi_3_15m > 10.0) | (rsi_3_1h > 30.0) | (roc_9_1d < 60.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_30) | (roc_9_1d < 60.0))
             # 15m & 4h down move, 1d still high
-            & ((rsi_3_15m > 10.0) | (rsi_3_4h_gt_10) | (aroonu_14_1d < 50.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_4h_gt_10) | (aroonu_14_1d < 50.0))
             # 15m & 4h down move, 15m still high
-            & ((rsi_3_15m > 10.0) | (rsi_3_4h_gt_15) | (aroonu_14_15m < 50.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_4h_gt_15) | (aroonu_14_15m_lt_50))
             # 15m & 4h down move, 1d high
-            & ((rsi_3_15m > 10.0) | (rsi_3_4h_gt_15) | (aroonu_14_1d < 80.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_4h_gt_15) | (aroonu_14_1d_lt_80))
             # 15m & 4h down move, 1d overbought
-            & ((rsi_3_15m > 10.0) | (rsi_3_4h_gt_15) | (roc_9_1d < 20.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_4h_gt_15) | (roc_9_1d_lt_20))
             # 15m & 4h down move, 1d high
-            & ((rsi_3_15m > 10.0) | rsi_3_4h_gt_20 | (rsi_14_1d < 70.0))
+            & ((rsi_3_15m_gt_10) | rsi_3_4h_gt_20 | (rsi_14_1d < 70.0))
             # 15m & 4h down move, 4h still high
-            & ((rsi_3_15m > 10.0) | rsi_3_4h_gt_20 | (aroonu_14_4h < 50.0))
+            & ((rsi_3_15m_gt_10) | rsi_3_4h_gt_20 | (aroonu_14_4h_lt_50))
             # 14m & 4h down move, 1d high
-            & ((rsi_3_15m > 10.0) | rsi_3_4h_gt_20 | (aroonu_14_1d < 80.0))
+            & ((rsi_3_15m_gt_10) | rsi_3_4h_gt_20 | (aroonu_14_1d_lt_80))
             # 15m & 4h down move, 1h high
-            & ((rsi_3_15m > 10.0) | rsi_3_4h_gt_20 | (stochrsi_k_1h_lt_70))
+            & ((rsi_3_15m_gt_10) | rsi_3_4h_gt_20 | (stochrsi_k_1h_lt_70))
             # 15m & 4h down move, 1d high
-            & ((rsi_3_15m > 10.0) | rsi_3_4h_gt_20 | (stochrsi_k_1d < 80.0))
+            & ((rsi_3_15m_gt_10) | rsi_3_4h_gt_20 | (stochrsi_k_1d < 80.0))
             # 15m & 4h down move, 1d overbought
-            & ((rsi_3_15m > 10.0) | rsi_3_4h_gt_20 | roc_9_1d_lt_50)
+            & ((rsi_3_15m_gt_10) | rsi_3_4h_gt_20 | roc_9_1d_lt_50)
             # 15m & 4h down move, 15m high
-            & ((rsi_3_15m > 10.0) | (rsi_3_4h > 30.0) | (aroonu_14_15m < 70.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_4h_gt_30) | (aroonu_14_15m_lt_70))
             # 15m & 4h down move, 1d high
-            & ((rsi_3_15m > 10.0) | (rsi_3_4h > 30.0) | (roc_9_1d < 30.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_4h_gt_30) | (roc_9_1d_lt_30))
             # 15m & 4h down move, 1h high
-            & ((rsi_3_15m > 10.0) | (rsi_3_4h > 35.0) | (aroonu_14_1h < 90.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_4h_gt_35) | (aroonu_14_1h_lt_90))
             # 15m & 4h down move, 4h overbought
-            & ((rsi_3_15m > 10.0) | (rsi_3_4h > 35.0) | (roc_9_4h < 10.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_4h_gt_35) | (roc_9_4h_lt_10))
             # 15m & 4h down move, 15m high
-            & ((rsi_3_15m > 10.0) | (rsi_3_4h > 40.0) | (aroonu_14_15m < 70.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_4h_gt_40) | (aroonu_14_15m_lt_70))
             # 15m & 1d down move, 1h still high
-            & ((rsi_3_15m > 10.0) | (rsi_3_1d > 10.0) | (stochrsi_k_1h_lt_50))
+            & ((rsi_3_15m_gt_10) | (rsi_3_1d_gt_10) | (stochrsi_k_1h_lt_50))
             # 15m down move, 15m high, 1h high
-            & ((rsi_3_15m > 10.0) | (aroonu_14_15m < 70.0) | (stochrsi_k_1h_lt_80))
+            & ((rsi_3_15m_gt_10) | (aroonu_14_15m_lt_70) | (stochrsi_k_1h_lt_80))
             # 15m down move, 4h high, 1d overbought
-            & ((rsi_3_15m > 10.0) | aroonu_14_4h_lt_70 | (roc_9_1d_lt_100))
+            & ((rsi_3_15m_gt_10) | aroonu_14_4h_lt_70 | (roc_9_1d_lt_100))
             # 15m down move, 1d high & overbought
-            & ((rsi_3_15m > 10.0) | (aroonu_14_1d < 85.0) | (roc_9_1d < 20.0))
+            & ((rsi_3_15m_gt_10) | (aroonu_14_1d < 85.0) | (roc_9_1d_lt_20))
             # 15m down move, 1h high, 1d overbought
-            & ((rsi_3_15m > 10.0) | (stochrsi_k_1h_lt_50) | (roc_9_1d < 40.0))
+            & ((rsi_3_15m_gt_10) | (stochrsi_k_1h_lt_50) | (roc_9_1d_lt_40))
             # 15m & 1h down move, 1h high
-            & ((rsi_3_15m > 15.0) | (rsi_3_1h_gt_15) | (aroonu_14_1h < 70.0))
+            & ((rsi_3_15m_gt_15) | (rsi_3_1h_gt_15) | (aroonu_14_1h < 70.0))
             # 15m & 1h down move, 4h high
-            & ((rsi_3_15m > 15.0) | (rsi_3_1h > 25.0) | aroonu_14_4h_lt_100)
+            & ((rsi_3_15m_gt_15) | (rsi_3_1h_gt_25) | aroonu_14_4h_lt_100)
             # 15m & 1h down move, 1h high
-            & ((rsi_3_15m > 15.0) | (rsi_3_1h > 40.0) | (aroonu_14_1h < 90.0))
+            & ((rsi_3_15m_gt_15) | (rsi_3_1h_gt_40) | (aroonu_14_1h_lt_90))
             # 15m & 4h down move, 15m high
-            & ((rsi_3_15m > 15.0) | (rsi_3_4h_gt_15) | (aroonu_14_15m < 70.0))
+            & ((rsi_3_15m_gt_15) | (rsi_3_4h_gt_15) | (aroonu_14_15m_lt_70))
             # 15m & 4h down move, 1d downtrend
-            & ((rsi_3_15m > 15.0) | (rsi_3_4h_gt_15) | (roc_9_1d > -20.0))
+            & ((rsi_3_15m_gt_15) | (rsi_3_4h_gt_15) | (roc_9_1d > -20.0))
             # 15m & 4h down move, 1d overbought
-            & ((rsi_3_15m > 15.0) | rsi_3_4h_gt_20 | roc_9_1d_lt_50)
+            & ((rsi_3_15m_gt_15) | rsi_3_4h_gt_20 | roc_9_1d_lt_50)
             # 15m & 4h down move, 1h high
-            & ((rsi_3_15m > 15.0) | (rsi_3_4h > 35.0) | (aroonu_14_1h < 90.0))
+            & ((rsi_3_15m_gt_15) | (rsi_3_4h_gt_35) | (aroonu_14_1h_lt_90))
             # 15m & 1d down move, 4h high
-            & ((rsi_3_15m > 15.0) | (rsi_3_1d > 20.0) | (stochrsi_k_4h_lt_80))
+            & ((rsi_3_15m_gt_15) | (rsi_3_1d_gt_20) | (stochrsi_k_4h_lt_80))
             # 15m down move, 15m downtrend, 1h high
-            & ((rsi_3_15m > 15.0) | (cmf_20_15m > -0.40) | (aroonu_14_1h < 60.0))
+            & ((rsi_3_15m_gt_15) | (cmf_20_15m > -0.40) | (aroonu_14_1h < 60.0))
             # 15m down move, 15m still high, 4h high
-            & ((rsi_3_15m > 15.0) | (aroonu_14_15m < 50.0) | (stochrsi_k_4h_lt_80))
+            & ((rsi_3_15m_gt_15) | (aroonu_14_15m_lt_50) | (stochrsi_k_4h_lt_80))
             # 15m down move, 15m high, 1d overbought
-            & ((rsi_3_15m > 15.0) | (aroonu_14_15m < 70.0) | (roc_9_1d < 10.0))
+            & ((rsi_3_15m_gt_15) | (aroonu_14_15m_lt_70) | (roc_9_1d < 10.0))
             # 15m down move, 1h & 4h high
-            & ((rsi_3_15m > 15.0) | (aroonu_14_1h < 100.0) | aroonu_14_4h_lt_100)
+            & ((rsi_3_15m_gt_15) | (aroonu_14_1h_lt_100) | aroonu_14_4h_lt_100)
             # 15m down move, 1d high & overbought
-            & ((rsi_3_15m > 15.0) | aroonu_14_1d_lt_100 | (roc_9_1d < 80.0))
+            & ((rsi_3_15m_gt_15) | aroonu_14_1d_lt_100 | (roc_9_1d_lt_80))
             # 15m & 1h down move, 1h high
-            & ((rsi_3_15m > 20.0) | rsi_3_1h_gt_20 | (stochrsi_k_1h < 60.0))
+            & ((rsi_3_15m_gt_20) | rsi_3_1h_gt_20 | (stochrsi_k_1h < 60.0))
             # 15m & 4h down move, 15m high
-            & ((rsi_3_15m > 20.0) | rsi_3_4h_gt_20 | (aroonu_14_15m < 70.0))
+            & ((rsi_3_15m_gt_20) | rsi_3_4h_gt_20 | (aroonu_14_15m_lt_70))
             # 15m & 4h down move, 15m still high
-            & ((rsi_3_15m > 20.0) | rsi_3_4h_gt_20 | (stochrsi_k_15m < 50.0))
+            & ((rsi_3_15m_gt_20) | rsi_3_4h_gt_20 | (stochrsi_k_15m < 50.0))
             # 15m down move, 15m & 1h high
-            & ((rsi_3_15m > 20.0) | (aroonu_14_15m < 70.0) | (aroonu_14_1h < 100.0))
+            & ((rsi_3_15m_gt_20) | (aroonu_14_15m_lt_70) | (aroonu_14_1h_lt_100))
             # 15m down move, 15m high, 1d high
-            & ((rsi_3_15m > 20.0) | (aroonu_14_15m < 90.0) | aroonu_14_1d_lt_100)
+            & ((rsi_3_15m_gt_20) | (aroonu_14_15m < 90.0) | aroonu_14_1d_lt_100)
             # 15m down move, 1h high, 1d downtrend
-            & ((rsi_3_15m > 20.0) | (stochrsi_k_1h < 80.0) | (roc_9_1d_gt_neg_20))
+            & ((rsi_3_15m_gt_20) | (stochrsi_k_1h < 80.0) | (roc_9_1d_gt_neg_20))
             # 15m down move, 1h high & overbought
-            & ((rsi_3_15m > 20.0) | (stochrsi_k_1h < 90.0) | (roc_9_1h < 10.0))
+            & ((rsi_3_15m_gt_20) | (stochrsi_k_1h < 90.0) | (roc_9_1h_lt_10))
             # 15m & 1h & 4h down move, 4h high
-            & ((rsi_3_15m > 25.0) | (rsi_3_1h > 30.0) | (rsi_3_4h > 50.0) | aroonu_14_4h_lt_70)
+            & ((rsi_3_15m_gt_25) | (rsi_3_1h_gt_30) | (rsi_3_4h_gt_50) | aroonu_14_4h_lt_70)
             # 15m down move, 15m still high, 4h high
-            & ((rsi_3_15m > 25.0) | (aroonu_14_15m < 50.0) | aroonu_14_4h_lt_80)
+            & ((rsi_3_15m_gt_25) | (aroonu_14_15m_lt_50) | aroonu_14_4h_lt_80)
             # 15m & 4h down mve, 1h high
-            & ((rsi_3_15m > 30.0) | (rsi_3_4h > 30.0) | (stochrsi_k_1h_lt_80))
+            & ((rsi_3_15m_gt_30) | (rsi_3_4h_gt_30) | (stochrsi_k_1h_lt_80))
             # 15m & 4h down move, 4h high
-            & ((rsi_3_15m > 30.0) | (rsi_3_4h > 45.0) | (stochrsi_k_4h_lt_80))
+            & ((rsi_3_15m_gt_30) | (rsi_3_4h > 45.0) | (stochrsi_k_4h_lt_80))
             # 15m down move, 1h high, 1d downtrend
-            & ((rsi_3_15m > 30.0) | (aroonu_14_1h < 90.0) | (roc_9_1d > -10.0))
+            & ((rsi_3_15m_gt_30) | (aroonu_14_1h_lt_90) | (roc_9_1d > -10.0))
             # 15m down move, 15m high, 4h high
-            & ((rsi_3_15m > 35.0) | (aroonu_14_15m < 70.0) | (stochrsi_k_4h_lt_80))
+            & ((rsi_3_15m > 35.0) | (aroonu_14_15m_lt_70) | (stochrsi_k_4h_lt_80))
             # 15m down move, 15m & 4h high
-            & ((rsi_3_15m > 35.0) | (aroonu_14_15m < 70.0) | (aroonu_14_4h < 90.0))
+            & ((rsi_3_15m > 35.0) | (aroonu_14_15m_lt_70) | (aroonu_14_4h_lt_90))
             # 15m down move, 15m high, 1d overbought
             & ((rsi_3_15m > 35.0) | (aroonu_14_15m < 80.0) | roc_9_1d_lt_50)
             # 15m down move, 1d high, 1h overbought
             & ((rsi_3_15m > 40.0) | (stochrsi_k_1d < 80.0) | (roc_9_1h < 20.0))
             # 1h & 4h down move, 1d still high
-            & ((rsi_3_1h > 3.0) | (rsi_3_4h_gt_10) | (aroonu_14_1d < 50.0))
+            & ((rsi_3_1h_gt_3) | (rsi_3_4h_gt_10) | (aroonu_14_1d < 50.0))
             # 1h & 4h down move, 1d overbought
-            & ((rsi_3_1h > 3.0) | (rsi_3_4h > 25.0) | (roc_9_1d < 10.0))
+            & ((rsi_3_1h_gt_3) | (rsi_3_4h_gt_25) | (roc_9_1d < 10.0))
             # 1h & 4h down move, 1d still high
-            & ((rsi_3_1h > 5.0) | (rsi_3_4h_gt_15) | (aroonu_14_1d < 40.0))
+            & ((rsi_3_1h_gt_5) | (rsi_3_4h_gt_15) | (aroonu_14_1d < 40.0))
             # 1h & 4h & 1d down move
-            & ((rsi_3_1h > 5.0) | rsi_3_4h_gt_20 | (rsi_3_1d > 25.0))
+            & ((rsi_3_1h_gt_5) | rsi_3_4h_gt_20 | (rsi_3_1d_gt_25))
             # 1h & 4h down move, 15m high
-            & ((rsi_3_1h > 5.0) | (rsi_3_4h > 25.0) | (stochrsi_k_15m < 60.0))
+            & ((rsi_3_1h_gt_5) | (rsi_3_4h_gt_25) | (stochrsi_k_15m < 60.0))
             # 1h & 4h & 1d down move
-            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_10) | (rsi_3_1d > 15.0))
+            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_10) | (rsi_3_1d_gt_15))
             # 1h & 4h down move, 1d still not low enough
             & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_10) | (stochrsi_k_1d < 20.0))
             # 1h & 4h down move, 15m still high
@@ -21598,11 +21650,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 1d overbought
             & ((rsi_3_1h_gt_10) | rsi_3_4h_gt_20 | (roc_9_1d < 100.0))
             # 1h & 1d downtrend, 1d high
-            & ((rsi_3_1h_gt_10) | (rsi_3_1d > 45.0) | (aroonu_14_1d < 70.0))
+            & ((rsi_3_1h_gt_10) | (rsi_3_1d > 45.0) | (aroonu_14_1d_lt_70))
             # 1h & 4h down move, 1h still not low enough
             & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_15) | (aroonu_14_1h < 20.0))
             # 1h & 4h down move. 4h high
-            & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_15) | (aroonu_14_4h < 60.0))
+            & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_15) | (aroonu_14_4h_lt_60))
             # 1h & 4h down move, 1d still high
             & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_15) | (aroonu_14_1d < 50.0))
             # 1h & 4h down move, 1h still not low enough
@@ -21612,67 +21664,67 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 4h still high
             & ((rsi_3_1h_gt_15) | rsi_3_4h_gt_20 | (stochrsi_k_4h < 40.0))
             # 1h & 1d down move, 1d still high
-            & ((rsi_3_1h_gt_15) | (rsi_3_1d > 20.0) | (stochrsi_k_1d < 40.0))
+            & ((rsi_3_1h_gt_15) | (rsi_3_1d_gt_20) | (stochrsi_k_1d < 40.0))
             # 1h & 1d down move, 1d high
-            & ((rsi_3_1h_gt_15) | (rsi_3_1d > 35.0) | (aroonu_14_1d < 70.0))
+            & ((rsi_3_1h_gt_15) | (rsi_3_1d > 35.0) | (aroonu_14_1d_lt_70))
             # 1h down move, 15m & 1d high
-            & ((rsi_3_1h_gt_15) | (aroonu_14_15m < 70.0) | (aroonu_14_1d < 100.0))
+            & ((rsi_3_1h_gt_15) | (aroonu_14_15m_lt_70) | (aroonu_14_1d < 100.0))
             # 1h down move, 1h still high, 4h overbought
-            & ((rsi_3_1h_gt_15) | (aroonu_14_1h < 50.0) | (roc_9_4h < 10.0))
+            & ((rsi_3_1h_gt_15) | (aroonu_14_1h_lt_50) | (roc_9_4h_lt_10))
             # 1h down move, 1h still high, 1d downtrend
-            & ((rsi_3_1h_gt_15) | (aroonu_14_1h < 50.0) | (roc_9_1d > -30.0))
+            & ((rsi_3_1h_gt_15) | (aroonu_14_1h_lt_50) | (roc_9_1d > -30.0))
             # 1h down move, 4h & 1d overbought
-            & ((rsi_3_1h_gt_15) | (roc_9_4h < 30.0) | roc_9_1d_lt_50)
+            & ((rsi_3_1h_gt_15) | (roc_9_4h_lt_30) | roc_9_1d_lt_50)
             # 1h & 4h down move, 1h still high
-            & (rsi_3_1h_gt_20 | rsi_3_4h_gt_20 | (aroonu_14_1h < 50.0))
+            & (rsi_3_1h_gt_20 | rsi_3_4h_gt_20 | (aroonu_14_1h_lt_50))
             # 1h & 4h down move, 1d high
-            & (rsi_3_1h_gt_20 | (rsi_3_4h > 25.0) | (aroonu_14_1d < 80.0))
+            & (rsi_3_1h_gt_20 | (rsi_3_4h_gt_25) | (aroonu_14_1d_lt_80))
             # 1h & 4h down move, 1d overbought
-            & (rsi_3_1h_gt_20 | (rsi_3_4h > 30.0) | (roc_9_1d_lt_100))
+            & (rsi_3_1h_gt_20 | (rsi_3_4h_gt_30) | (roc_9_1d_lt_100))
             # 1h & 4h down move, 1h high
-            & (rsi_3_1h_gt_20 | (rsi_3_4h > 35.0) | aroonu_14_1h_lt_70)
+            & (rsi_3_1h_gt_20 | (rsi_3_4h_gt_35) | aroonu_14_1h_lt_70)
             # 1h & 4h down move, 4h high
-            & (rsi_3_1h_gt_20 | (rsi_3_4h > 50.0) | aroonu_14_4h_lt_100)
+            & (rsi_3_1h_gt_20 | (rsi_3_4h_gt_50) | aroonu_14_4h_lt_100)
             # 1h & 4h down move, 15m high
-            & ((rsi_3_1h > 25.0) | (rsi_3_4h > 25.0) | (stochrsi_k_15m < 70.0))
+            & ((rsi_3_1h_gt_25) | (rsi_3_4h_gt_25) | (stochrsi_k_15m < 70.0))
             # 1h & 4h down move, 4h high
-            & ((rsi_3_1h > 25.0) | (rsi_3_4h > 30.0) | (aroonu_14_4h < 60.0))
+            & ((rsi_3_1h_gt_25) | (rsi_3_4h_gt_30) | (aroonu_14_4h_lt_60))
             # 1h down move, 4h & 1d overbought
-            & ((rsi_3_1h > 25.0) | (roc_9_4h < 30.0) | (roc_9_1d < 60.0))
+            & ((rsi_3_1h_gt_25) | (roc_9_4h_lt_30) | (roc_9_1d < 60.0))
             # 1h & 1d down move, 1d still high
-            & ((rsi_3_1h > 25.0) | (rsi_3_1d > 25.0) | (stochrsi_k_1d < 50.0))
+            & ((rsi_3_1h_gt_25) | (rsi_3_1d_gt_25) | (stochrsi_k_1d < 50.0))
             # 1h & 4h down move, 1h high
-            & ((rsi_3_1h > 30.0) | (rsi_3_4h > 30.0) | (stochrsi_k_1h < 60.0))
+            & ((rsi_3_1h_gt_30) | (rsi_3_4h_gt_30) | (stochrsi_k_1h < 60.0))
             # 1h & 4g down move, 4h still high
-            & ((rsi_3_1h > 30.0) | (rsi_3_4h > 30.0) | (stochrsi_k_4h < 50.0))
+            & ((rsi_3_1h_gt_30) | (rsi_3_4h_gt_30) | (stochrsi_k_4h_lt_50))
             # 1h down move, 15m still high, 1h high
-            & ((rsi_3_1h > 30.0) | (aroonu_14_15m < 50.0) | (aroonu_14_1h < 85.0))
+            & ((rsi_3_1h_gt_30) | (aroonu_14_15m_lt_50) | (aroonu_14_1h < 85.0))
             # 1h down move, 4h high, 1d overbought
-            & ((rsi_3_1h > 35.0) | aroonu_14_4h_lt_70 | (roc_9_1d_lt_100))
+            & ((rsi_3_1h_gt_35) | aroonu_14_4h_lt_70 | (roc_9_1d_lt_100))
             # 1h down move, 4h & 1d high
-            & ((rsi_3_1h > 35.0) | aroonu_14_4h_lt_100 | aroonu_14_1d_lt_100)
+            & ((rsi_3_1h_gt_35) | aroonu_14_4h_lt_100 | aroonu_14_1d_lt_100)
             # 1h down move, 1h still high, 1d downtrend
-            & ((rsi_3_1h > 35.0) | (stochrsi_k_1h < 50.0) | (roc_9_1d_gt_neg_30))
+            & ((rsi_3_1h_gt_35) | (stochrsi_k_1h < 50.0) | (roc_9_1d_gt_neg_30))
             # 1h & 1d down move, 1h high
-            & ((rsi_3_1h > 45.0) | (rsi_3_1d > 45.0) | aroonu_14_1h_lt_80)
+            & ((rsi_3_1h_gt_45) | (rsi_3_1d > 45.0) | aroonu_14_1h_lt_80)
             # 1h down move, 1h & 4h high
-            & ((rsi_3_1h > 45.0) | (aroonu_14_1h < 75.0) | aroonu_14_4h_lt_100)
+            & ((rsi_3_1h_gt_45) | (aroonu_14_1h < 75.0) | aroonu_14_4h_lt_100)
             # 1h down move, 4h high & overbought
-            & ((rsi_3_1h > 50.0) | (stochrsi_k_4h_lt_90) | (roc_9_4h < 25.0))
+            & ((rsi_3_1h_gt_50) | (stochrsi_k_4h_lt_90) | (roc_9_4h < 25.0))
             # 4h & 1d down move, 1d downtrend
-            & ((rsi_3_4h > 3.0) | (rsi_3_1d > 10.0) | (roc_9_1d_gt_neg_20))
+            & ((rsi_3_4h > 3.0) | (rsi_3_1d_gt_10) | (roc_9_1d_gt_neg_20))
             # 4h & 1d down move, 1d still high
-            & ((rsi_3_4h > 3.0) | (rsi_3_1d > 20.0) | (rsi_14_1d < 40.0))
+            & ((rsi_3_4h > 3.0) | (rsi_3_1d_gt_20) | (rsi_14_1d < 40.0))
             # 4h & 1d down move, 1d high
-            & ((rsi_3_4h > 5.0) | (rsi_3_1d > 45.0) | (aroonu_14_1d < 70.0))
+            & ((rsi_3_4h_gt_5) | (rsi_3_1d > 45.0) | (aroonu_14_1d_lt_70))
             # 4h down move, 4h still high, 4h downtrend
-            & ((rsi_3_4h > 5.0) | (aroonu_14_4h < 40.0) | (roc_9_4h > -10.0))
+            & ((rsi_3_4h_gt_5) | (aroonu_14_4h_lt_40) | (roc_9_4h > -10.0))
             # 4h down move, 1h high
-            & ((rsi_3_4h > 5.0) | (stochrsi_k_1h < 90.0))
+            & ((rsi_3_4h_gt_5) | (stochrsi_k_1h < 90.0))
             # 4h & 1d down move, 1h still high
-            & ((rsi_3_4h_gt_10) | (rsi_3_1d > 10.0) | (stochrsi_k_1h < 50.0))
+            & ((rsi_3_4h_gt_10) | (rsi_3_1d_gt_10) | (stochrsi_k_1h < 50.0))
             # 4h & 1d down move, 1h high
-            & ((rsi_3_4h_gt_10) | (rsi_3_1d > 15.0) | (stochrsi_k_1h < 70.0))
+            & ((rsi_3_4h_gt_10) | (rsi_3_1d_gt_15) | (stochrsi_k_1h < 70.0))
             # 4h down move, 15m still high, 1h still high
             & ((rsi_3_4h_gt_10) | (aroonu_14_15m < 40.0) | (stochrsi_k_1h < 50.0))
             # 4h down move, 1d still high, 1d downtrend
@@ -21688,11 +21740,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 4h & 1d downtrend
             & ((rsi_3_4h_gt_10) | (roc_9_4h > -15.0) | (roc_9_1d > -20.0))
             # 4h & 1d down move, 1d still high
-            & ((rsi_3_4h_gt_15) | (rsi_3_1d > 15.0) | (aroonu_14_1d < 50.0))
+            & ((rsi_3_4h_gt_15) | (rsi_3_1d_gt_15) | (aroonu_14_1d < 50.0))
             # 4h & 1d down move, 4h still high
-            & ((rsi_3_4h_gt_15) | (rsi_3_1d > 20.0) | (aroonu_14_4h < 40.0))
+            & ((rsi_3_4h_gt_15) | (rsi_3_1d_gt_20) | (aroonu_14_4h_lt_40))
             # 4h & 1d down move, 4h high
-            & ((rsi_3_4h_gt_15) | (rsi_3_1d > 25.0) | aroonu_14_4h_lt_70)
+            & ((rsi_3_4h_gt_15) | (rsi_3_1d_gt_25) | aroonu_14_4h_lt_70)
             # 4h & 1d down move, 15m high
             & ((rsi_3_4h_gt_15) | (rsi_3_1d > 30.0) | (stochrsi_k_15m < 80.0))
             # 4h & 1d down move, 4h still high
@@ -21700,105 +21752,105 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 1d still high, 4h still not low enough
             & ((rsi_3_4h_gt_15) | (rsi_14_1d < 40.0) | (stochrsi_k_4h < 30.0))
             # 4h down move, 15m still not low enough, 1d high
-            & ((rsi_3_4h_gt_15) | (aroonu_14_15m < 30.0) | (aroonu_14_1d < 70.0))
+            & ((rsi_3_4h_gt_15) | (aroonu_14_15m < 30.0) | (aroonu_14_1d_lt_70))
             # 4h down move, 4h still high, 4h downtrend
-            & ((rsi_3_4h_gt_15) | (aroonu_14_4h < 50.0) | (roc_9_4h > -10.0))
+            & ((rsi_3_4h_gt_15) | (aroonu_14_4h_lt_50) | (roc_9_4h > -10.0))
             # 4h down move, 4h still not low enough, 1d downtrend
             & ((rsi_3_4h_gt_15) | (stochrsi_k_4h < 20.0) | (roc_9_1d > -20.0))
             # 4h down move, 4h & 1d high
-            & (rsi_3_4h_gt_20 | aroonu_14_4h_lt_70 | (aroonu_14_1d < 70.0))
+            & (rsi_3_4h_gt_20 | aroonu_14_4h_lt_70 | (aroonu_14_1d_lt_70))
             # 4h down move, 4h high
             & (rsi_3_4h_gt_20 | aroonu_14_4h_lt_80)
             # 4h down move, 1d high & overbought
-            & (rsi_3_4h_gt_20 | (aroonu_14_1d < 80.0) | (roc_9_1d < 70.0))
+            & (rsi_3_4h_gt_20 | (aroonu_14_1d_lt_80) | (roc_9_1d < 70.0))
             # 4h down move, 4h still high, 4h downtrend
-            & (rsi_3_4h_gt_20 | (stochrsi_k_4h < 50.0) | (roc_9_4h_gt_neg_20))
+            & (rsi_3_4h_gt_20 | (stochrsi_k_4h_lt_50) | (roc_9_4h_gt_neg_20))
             # 4h down move, 4h high, 1d downtrend
-            & (rsi_3_4h_gt_20 | (stochrsi_k_4h < 70.0) | (roc_9_1d_gt_neg_20))
+            & (rsi_3_4h_gt_20 | (stochrsi_k_4h_lt_70) | (roc_9_1d_gt_neg_20))
             # 4h down move, 1d overbought
-            & (rsi_3_4h_gt_20 | (roc_9_1d < 80.0))
+            & (rsi_3_4h_gt_20 | (roc_9_1d_lt_80))
             # 4h & 1d down move, 4h overbought
-            & ((rsi_3_4h > 25.0) | (rsi_3_1d > 45.0) | (roc_9_4h < 5.0))
+            & ((rsi_3_4h_gt_25) | (rsi_3_1d > 45.0) | (roc_9_4h < 5.0))
             # 4h & 1d down move, 1d overbought
-            & ((rsi_3_4h > 25.0) | (rsi_3_1d > 45.0) | (roc_9_1d < 10.0))
+            & ((rsi_3_4h_gt_25) | (rsi_3_1d > 45.0) | (roc_9_1d < 10.0))
             # 4h down move, 15m still not low enough, 4h still high
-            & ((rsi_3_4h > 25.0) | (aroonu_14_15m < 30.0) | (stochrsi_k_4h < 40.0))
+            & ((rsi_3_4h_gt_25) | (aroonu_14_15m < 30.0) | (stochrsi_k_4h < 40.0))
             # 4h down move, 1d high, 4h overbought
-            & ((rsi_3_4h > 25.0) | (aroonu_14_1d < 80.0) | (roc_9_4h < 5.0))
+            & ((rsi_3_4h_gt_25) | (aroonu_14_1d_lt_80) | (roc_9_4h < 5.0))
             # 4h & 1d down move, 4h still high
-            & ((rsi_3_4h > 30.0) | (rsi_3_1d > 30.0) | (stochrsi_k_4h < 50.0))
+            & ((rsi_3_4h_gt_30) | (rsi_3_1d > 30.0) | (stochrsi_k_4h_lt_50))
             # 4h & 1d down move, 1d high
-            & ((rsi_3_4h > 30.0) | (rsi_3_1d > 60.0) | (aroonu_14_1d < 90.0))
+            & ((rsi_3_4h_gt_30) | (rsi_3_1d > 60.0) | (aroonu_14_1d_lt_90))
             # 4h down move, 4h high, 1d high
-            & ((rsi_3_4h > 30.0) | aroonu_14_4h_lt_70 | (stochrsi_k_1d < 80.0))
+            & ((rsi_3_4h_gt_30) | aroonu_14_4h_lt_70 | (stochrsi_k_1d < 80.0))
             # 4h down move, 1d stil high, 1d downtrend
-            & ((rsi_3_4h > 30.0) | (aroonu_14_1d < 40.0) | (roc_9_1d_gt_neg_30))
+            & ((rsi_3_4h_gt_30) | (aroonu_14_1d < 40.0) | (roc_9_1d_gt_neg_30))
             # 4h down move, 1h high, 1d downtrend
-            & ((rsi_3_4h > 30.0) | (stochrsi_k_1h_lt_80) | (roc_9_1d > -40.0))
+            & ((rsi_3_4h_gt_30) | (stochrsi_k_1h_lt_80) | (roc_9_1d_gt_neg_40))
             # 4h down move, 15m still high, 1h high
-            & ((rsi_3_4h > 35.0) | (aroonu_14_15m < 50.0) | (aroonu_14_1h < 100.0))
+            & ((rsi_3_4h_gt_35) | (aroonu_14_15m_lt_50) | (aroonu_14_1h_lt_100))
             # 4h down move, 4h still high, 1d downtrend
-            & ((rsi_3_4h > 35.0) | (stochrsi_k_4h < 40.0) | (roc_9_1d_gt_neg_30))
+            & ((rsi_3_4h_gt_35) | (stochrsi_k_4h < 40.0) | (roc_9_1d_gt_neg_30))
             # 4h down move, 1d high & overbought
-            & ((rsi_3_4h > 35.0) | (stochrsi_k_1d < 80.0) | (roc_9_1d < 20.0))
+            & ((rsi_3_4h_gt_35) | (stochrsi_k_1d < 80.0) | (roc_9_1d_lt_20))
             # 4h down move, 1h high
-            & ((rsi_3_4h > 40.0) | aroonu_14_1h_lt_80)
+            & ((rsi_3_4h_gt_40) | aroonu_14_1h_lt_80)
             # 4h down move, 1d high & overbought
-            & ((rsi_3_4h > 45.0) | (aroonu_14_1d < 70.0) | (roc_9_1d < 20.0))
+            & ((rsi_3_4h > 45.0) | (aroonu_14_1d_lt_70) | (roc_9_1d_lt_20))
             # 4h down move, 4h high, 1d downtrend
             & ((rsi_3_4h > 45.0) | (stochrsi_k_4h < 40.0) | (roc_9_1d > -25.0))
             # 4h down move, 1d high & overbought
-            & ((rsi_3_4h > 50.0) | (aroonu_14_1d < 85.0) | (roc_9_1d < 200.0))
+            & ((rsi_3_4h_gt_50) | (aroonu_14_1d < 85.0) | (roc_9_1d < 200.0))
             # 4h down move, 4h high & overbought
-            & ((rsi_3_4h > 50.0) | (stochrsi_k_4h < 70.0) | (roc_9_4h < 10.0))
+            & ((rsi_3_4h_gt_50) | (stochrsi_k_4h_lt_70) | (roc_9_4h_lt_10))
             # 4h down move, 4h still high, 1d downtrend
-            & ((rsi_3_4h > 50.0) | (stochrsi_k_4h < 50.0) | (roc_9_1d > -40.0))
+            & ((rsi_3_4h_gt_50) | (stochrsi_k_4h_lt_50) | (roc_9_1d_gt_neg_40))
             # 4h down move, 4h & 1d overbought
-            & ((rsi_3_4h > 50.0) | (roc_9_4h < 10.0) | roc_9_1d_lt_50)
+            & ((rsi_3_4h_gt_50) | (roc_9_4h_lt_10) | roc_9_1d_lt_50)
             # 4h down move, 1d high & overbought
-            & ((rsi_3_4h > 55.0) | (stochrsi_k_1d < 90.0) | (roc_9_1d < 80.0))
+            & ((rsi_3_4h > 55.0) | (stochrsi_k_1d_lt_90) | (roc_9_1d_lt_80))
             # 1d down move, 1d high, 4h downtrend
-            & ((rsi_3_1d > 15.0) | (aroonu_14_1d < 70.0) | (roc_9_4h > -40.0))
+            & ((rsi_3_1d_gt_15) | (aroonu_14_1d_lt_70) | (roc_9_4h > -40.0))
             # 1d down move, 1d high, 1d downtrend
-            & ((rsi_3_1d > 15.0) | (aroonu_14_1d < 70.0) | (roc_9_1d_gt_neg_20))
+            & ((rsi_3_1d_gt_15) | (aroonu_14_1d_lt_70) | (roc_9_1d_gt_neg_20))
             # 1d down move, 1h & 4h high
             & ((rsi_3_1d > 30.0) | aroonu_14_1h_lt_70 | aroonu_14_4h_lt_100)
             # 15m & 1h high, 4h overbought
-            & ((aroonu_14_15m < 70.0) | (aroonu_14_1h < 100.0) | (roc_9_4h < 15.0))
+            & ((aroonu_14_15m_lt_70) | (aroonu_14_1h_lt_100) | (roc_9_4h < 15.0))
             # 15m & 1h high, 1d overbought
-            & ((aroonu_14_15m < 70.0) | (aroonu_14_1h < 100.0) | (roc_9_1d_lt_100))
+            & ((aroonu_14_15m_lt_70) | (aroonu_14_1h_lt_100) | (roc_9_1d_lt_100))
             # 15m & 1h high, 1d downtrend
-            & ((aroonu_14_15m < 70.0) | (aroonu_14_1h < 100.0) | (roc_9_1d > -10.0))
+            & ((aroonu_14_15m_lt_70) | (aroonu_14_1h_lt_100) | (roc_9_1d > -10.0))
             # 15m & 4h & 1d high
-            & ((aroonu_14_15m < 70.0) | (aroonu_14_4h < 90.0) | aroonu_14_1d_lt_100)
+            & ((aroonu_14_15m_lt_70) | (aroonu_14_4h_lt_90) | aroonu_14_1d_lt_100)
             # 15m high, 1d high & overbought
-            & ((aroonu_14_15m < 70.0) | aroonu_14_1d_lt_100 | (roc_9_1d < 20.0))
+            & ((aroonu_14_15m_lt_70) | aroonu_14_1d_lt_100 | (roc_9_1d_lt_20))
             # 15m high, 1h & 4h overbought
-            & ((aroonu_14_15m < 70.0) | (roc_9_1h < 10.0) | (roc_9_4h < 10.0))
+            & ((aroonu_14_15m_lt_70) | (roc_9_1h_lt_10) | (roc_9_4h_lt_10))
             # 15m high, 4h overbought, 1d downtrend
             & ((aroonu_14_15m < 80.0) | (roc_9_4h_lt_20) | (roc_9_1d_gt_neg_30))
             # 15m & 1h high
-            & ((aroonu_14_15m < 90.0) | (aroonu_14_1h < 100.0))
+            & ((aroonu_14_15m < 90.0) | (aroonu_14_1h_lt_100))
             # 15m & 4h high
             & ((aroonu_14_15m < 90.0) | aroonu_14_4h_lt_100)
             # 1h & 1d high, 1d overbought
-            & ((aroonu_14_1h < 100.0) | aroonu_14_1d_lt_100 | (roc_9_1d < 10.0))
+            & ((aroonu_14_1h_lt_100) | aroonu_14_1d_lt_100 | (roc_9_1d < 10.0))
             # 1h & 4h high, 1h overbought
-            & ((aroonu_14_1h < 100.0) | aroonu_14_4h_lt_100 | (roc_9_1h < 10.0))
+            & ((aroonu_14_1h_lt_100) | aroonu_14_4h_lt_100 | (roc_9_1h_lt_10))
             # 1h & 4h high, 4h overbought
-            & ((aroonu_14_1h < 100.0) | aroonu_14_4h_lt_100 | (roc_9_4h < 10.0))
+            & ((aroonu_14_1h_lt_100) | aroonu_14_4h_lt_100 | (roc_9_4h_lt_10))
             # 4h & 1d high, 4h overbought
             & (aroonu_14_4h_lt_100 | aroonu_14_1d_lt_100 | (roc_9_4h < 20.0))
             # 4h & 1d high, 1d overbought
-            & (aroonu_14_4h_lt_100 | aroonu_14_1d_lt_100 | (roc_9_1d < 30.0))
+            & (aroonu_14_4h_lt_100 | aroonu_14_1d_lt_100 | (roc_9_1d_lt_30))
             # 4h high, 1h & 4h overbought
-            & (aroonu_14_4h_lt_100 | (roc_9_1h < 20.0) | (roc_9_4h < 40.0))
+            & (aroonu_14_4h_lt_100 | (roc_9_1h < 20.0) | (roc_9_4h_lt_40))
             # 1d high, 4h & 1d downtrend
             & ((aroonu_14_1d < 60.0) | (roc_9_4h_gt_neg_20) | (roc_9_1d_gt_neg_30))
             # 1d high, 4h & 1d overbought
             & (aroonu_14_1d_lt_100 | (roc_9_4h < 60.0) | (roc_9_1d < 100.0))
             # 15m high, 4h & 1d overbought
-            & ((stochrsi_k_15m < 70.0) | (roc_9_4h_lt_20) | (roc_9_1d < 20.0))
+            & ((stochrsi_k_15m < 70.0) | (roc_9_4h_lt_20) | (roc_9_1d_lt_20))
             # 1h high, 1h & 1d overbought
             & ((stochrsi_k_1h < 80.0) | (roc_9_1h < 20.0) | (roc_9_1d_lt_100))
             # 4h high, 4h overbought, 1d downtrend
@@ -21825,167 +21877,167 @@ class NostalgiaForInfinityX7(IStrategy):
 
           long_entry_logic.append(
             # 5m & 4h & 1d down move
-            ((rsi_3 > 3.0) | (rsi_3_4h_gt_10) | (rsi_3_1d > 10.0))
+            ((rsi_3_gt_3) | (rsi_3_4h_gt_10) | (rsi_3_1d_gt_10))
             # 5m & 4h down move, 4h still high
-            & ((rsi_3 > 3.0) | (rsi_3_4h_gt_10) | (stochrsi_k_4h < 50.0))
+            & ((rsi_3_gt_3) | (rsi_3_4h_gt_10) | (stochrsi_k_4h_lt_50))
             # 15m & 1h down move, 1h still not low enough
-            & (rsi_3_15m_gt_3 | (rsi_3_1h > 3.0) | (aroonu_14_1h < 25.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_3) | (aroonu_14_1h < 25.0))
             # 15m & 1h & 4h down move
-            & (rsi_3_15m_gt_3 | (rsi_3_1h > 5.0) | (rsi_3_4h_gt_10))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_5) | (rsi_3_4h_gt_10))
             # 15m & 1h down move, 15m still high
             & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_15) | (aroonu_14_15m < 40.0))
             # 15m & 1h down move, 4h still high
-            & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_15) | (aroonu_14_4h < 40.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_15) | (aroonu_14_4h_lt_40))
             # 15m & 1h down move, 1h still high
             & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_15) | (stochrsi_k_1h < 50.0))
             # 15m & 1h down move, 4h high
             & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_15) | (stochrsi_k_4h < 90.0))
             # 15m & 1h down move, 15m high
-            & (rsi_3_15m_gt_3 | (rsi_3_1h > 30.0) | (aroonu_14_15m < 70.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_30) | (aroonu_14_15m_lt_70))
             # 15m & 1h down move, 1d downtrend
-            & (rsi_3_15m_gt_3 | (rsi_3_1h > 35.0) | (roc_9_1d_gt_neg_30))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_35) | (roc_9_1d_gt_neg_30))
             # 15m & 1h down move, 4h high
-            & (rsi_3_15m_gt_3 | (rsi_3_1h > 40.0) | (aroonu_14_1h < 85.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_40) | (aroonu_14_1h < 85.0))
             # 15m & 4h down move, 4h still high
-            & (rsi_3_15m_gt_3 | (rsi_3_4h_gt_15) | (aroonu_14_4h < 50.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_4h_gt_15) | (aroonu_14_4h_lt_50))
             # 15m & 4h down move, 15m still high
-            & (rsi_3_15m_gt_3 | rsi_3_4h_gt_20 | (aroonu_14_15m < 50.0))
+            & (rsi_3_15m_gt_3 | rsi_3_4h_gt_20 | (aroonu_14_15m_lt_50))
             # 15m & 1d down move, 4h still high
-            & (rsi_3_15m_gt_3 | (rsi_3_1d > 20.0) | (stochrsi_k_4h < 50.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1d_gt_20) | (stochrsi_k_4h_lt_50))
             # 15m & 4h down move, 1d still high
-            & ((rsi_3_15m > 5.0) | (rsi_3_4h > 5.0) | (rsi_14_1d < 40.0))
+            & ((rsi_3_15m_gt_5) | (rsi_3_4h_gt_5) | (rsi_14_1d < 40.0))
             # 15m & 1h down move, 4h still high
-            & ((rsi_3_15m > 5.0) | (rsi_3_1h_gt_10) | (rsi_14_4h < 40.0))
+            & ((rsi_3_15m_gt_5) | (rsi_3_1h_gt_10) | (rsi_14_4h < 40.0))
             # 15m & 1h down move, 1d high
-            & ((rsi_3_15m > 5.0) | (rsi_3_1h_gt_15) | (aroonu_14_1d < 100.0))
+            & ((rsi_3_15m_gt_5) | (rsi_3_1h_gt_15) | (aroonu_14_1d < 100.0))
             # 15m & 4h down move, 15m still not low enough
-            & ((rsi_3_15m > 5.0) | (rsi_3_4h_gt_10) | (aroonu_14_15m < 30.0))
+            & ((rsi_3_15m_gt_5) | (rsi_3_4h_gt_10) | (aroonu_14_15m < 30.0))
             # 15m & 4h down move, 4h high
-            & ((rsi_3_15m > 5.0) | (rsi_3_4h_gt_10) | (aroonu_14_4h < 80.0))
+            & ((rsi_3_15m_gt_5) | (rsi_3_4h_gt_10) | (aroonu_14_4h < 80.0))
             # 15m & 4h down move, 1h still high
-            & ((rsi_3_15m > 5.0) | (rsi_3_4h_gt_10) | (stochrsi_k_1h < 40.0))
+            & ((rsi_3_15m_gt_5) | (rsi_3_4h_gt_10) | (stochrsi_k_1h < 40.0))
             # 15m & 4h down move, 1d downtrend
-            & ((rsi_3_15m > 5.0) | (rsi_3_4h_gt_10) | (roc_9_1d > -20.0))
+            & ((rsi_3_15m_gt_5) | (rsi_3_4h_gt_10) | (roc_9_1d > -20.0))
             # 15m & 1d down move, 1h still high
-            & ((rsi_3_15m > 5.0) | (rsi_3_1d > 10.0) | (aroonu_14_1h < 50.0))
+            & ((rsi_3_15m_gt_5) | (rsi_3_1d_gt_10) | (aroonu_14_1h_lt_50))
             # 15m & 1d down move, 1h still high
-            & (rsi_3_15m_gt_3 | (rsi_3_1d > 25.0) | (stochrsi_k_1h_lt_50))
+            & (rsi_3_15m_gt_3 | (rsi_3_1d_gt_25) | (stochrsi_k_1h_lt_50))
             # 15m down move, 1h high, 4h overbought
-            & (rsi_3_15m_gt_3 | aroonu_14_1h_lt_70 | (roc_9_4h < 10.0))
+            & (rsi_3_15m_gt_3 | aroonu_14_1h_lt_70 | (roc_9_4h_lt_10))
             # 15m down move, 4h high, 1d downtrend
-            & (rsi_3_15m_gt_3 | (stochrsi_k_4h < 70.0) | (roc_9_1d_gt_neg_20))
+            & (rsi_3_15m_gt_3 | (stochrsi_k_4h_lt_70) | (roc_9_1d_gt_neg_20))
             # 15m down move, 15m still high, 1d downtrend
-            & ((rsi_3_15m > 5.0) | (aroonu_14_15m < 50.0) | (roc_9_1d_gt_neg_20))
+            & ((rsi_3_15m_gt_5) | (aroonu_14_15m_lt_50) | (roc_9_1d_gt_neg_20))
             # 15m down move, 1h high, 1d overbought
-            & ((rsi_3_15m > 5.0) | (stochrsi_k_1h_lt_50) | (roc_9_1d < 40.0))
+            & ((rsi_3_15m_gt_5) | (stochrsi_k_1h_lt_50) | (roc_9_1d_lt_40))
             # 15m & 1h down move, 1h high
-            & ((rsi_3_15m > 10.0) | (rsi_3_1h_gt_10) | (aroonu_14_1h < 60.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_10) | (aroonu_14_1h < 60.0))
             # 15m & 1h down move, 4h high
-            & ((rsi_3_15m > 10.0) | (rsi_3_1h_gt_10) | (aroonu_14_4h < 60.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_10) | (aroonu_14_4h_lt_60))
             # 15m & 1h down move, 1h high
-            & ((rsi_3_15m > 10.0) | rsi_3_1h_gt_20 | aroonu_14_1h_lt_80)
+            & ((rsi_3_15m_gt_10) | rsi_3_1h_gt_20 | aroonu_14_1h_lt_80)
             # 15m & 1h down move, 1h high
-            & ((rsi_3_15m > 10.0) | (rsi_3_1h > 25.0) | (stochrsi_k_1h_lt_70))
+            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_25) | (stochrsi_k_1h_lt_70))
             # 15m & 1h down move, 1h high
-            & ((rsi_3_15m > 10.0) | (rsi_3_1h > 30.0) | (stochrsi_k_1h_lt_70))
+            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_30) | (stochrsi_k_1h_lt_70))
             # 15m & 4h down move, 1h still high
-            & ((rsi_3_15m > 10.0) | (rsi_3_4h_gt_10) | (stochrsi_k_1h < 50.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_4h_gt_10) | (stochrsi_k_1h < 50.0))
             # 15m & 4h down move, 1h high
-            & ((rsi_3_15m > 10.0) | rsi_3_4h_gt_20 | (stochrsi_k_1h_lt_70))
+            & ((rsi_3_15m_gt_10) | rsi_3_4h_gt_20 | (stochrsi_k_1h_lt_70))
             # 15m & 4h down move, 4h overbought
-            & ((rsi_3_15m > 10.0) | (rsi_3_4h > 35.0) | (roc_9_4h < 10.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_4h_gt_35) | (roc_9_4h_lt_10))
             # 15m & 1d down move, 1h high
-            & ((rsi_3_15m > 10.0) | (rsi_3_1d > 10.0) | (stochrsi_k_1h_lt_70))
+            & ((rsi_3_15m_gt_10) | (rsi_3_1d_gt_10) | (stochrsi_k_1h_lt_70))
             # 15m & 1d down move, 4h still high
-            & ((rsi_3_15m > 10.0) | (rsi_3_1d > 10.0) | (stochrsi_k_4h < 40.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_1d_gt_10) | (stochrsi_k_4h < 40.0))
             # 15m & 4h down move, 15m high
-            & ((rsi_3_15m > 10.0) | (rsi_3_4h > 40.0) | (aroonu_14_15m < 70.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_4h_gt_40) | (aroonu_14_15m_lt_70))
             # 15m down move, 15m high, 1d high
-            & ((rsi_3_15m > 10.0) | (aroonu_14_15m < 60.0) | aroonu_14_1d_lt_100)
+            & ((rsi_3_15m_gt_10) | (aroonu_14_15m < 60.0) | aroonu_14_1d_lt_100)
             # 15m down move, 1h & 1d high
-            & ((rsi_3_15m > 10.0) | (aroonu_14_1h < 90.0) | aroonu_14_1d_lt_100)
+            & ((rsi_3_15m_gt_10) | (aroonu_14_1h_lt_90) | aroonu_14_1d_lt_100)
             # 15m down move, 4h high, 1d overbought
-            & ((rsi_3_15m > 10.0) | aroonu_14_4h_lt_70 | (roc_9_1d_lt_100))
+            & ((rsi_3_15m_gt_10) | aroonu_14_4h_lt_70 | (roc_9_1d_lt_100))
             # 15m down move, 1h still high, 1d downtrend
-            & ((rsi_3_15m > 10.0) | (stochrsi_k_1h < 50.0) | (roc_9_1d_gt_neg_20))
+            & ((rsi_3_15m_gt_10) | (stochrsi_k_1h < 50.0) | (roc_9_1d_gt_neg_20))
             # 15m & 4h down move, 1h high
-            & ((rsi_3_15m > 15.0) | (rsi_3_4h > 35.0) | (aroonu_14_1h < 90.0))
+            & ((rsi_3_15m_gt_15) | (rsi_3_4h_gt_35) | (aroonu_14_1h_lt_90))
             # 1h & 1d down move, 1d still high
-            & ((rsi_3_1h > 3.0) | (rsi_3_1d > 25.0) | (stochrsi_k_1d < 40.0))
+            & ((rsi_3_1h_gt_3) | (rsi_3_1d_gt_25) | (stochrsi_k_1d < 40.0))
             # 1h & 4h down move, 1d downtrend
-            & ((rsi_3_1h > 5.0) | (rsi_3_4h > 5.0) | (roc_9_1d_gt_neg_30))
+            & ((rsi_3_1h_gt_5) | (rsi_3_4h_gt_5) | (roc_9_1d_gt_neg_30))
             # 1h & 4h down move, 1d still high
-            & ((rsi_3_1h > 5.0) | (rsi_3_4h_gt_10) | (aroonu_14_1d < 50.0))
+            & ((rsi_3_1h_gt_5) | (rsi_3_4h_gt_10) | (aroonu_14_1d < 50.0))
             # 1h & 4h & 1d down move
-            & ((rsi_3_1h > 5.0) | (rsi_3_4h_gt_10) | (rsi_3_1d > 20.0))
+            & ((rsi_3_1h_gt_5) | (rsi_3_4h_gt_10) | (rsi_3_1d_gt_20))
             # 1h & 4h down move, 4h still not low enough
-            & ((rsi_3_1h > 5.0) | (rsi_3_4h_gt_15) | (aroonu_14_4h < 30.0))
+            & ((rsi_3_1h_gt_5) | (rsi_3_4h_gt_15) | (aroonu_14_4h < 30.0))
             # 1h down move, 4h & 1d downtrend
-            & ((rsi_3_1h > 5.0) | (roc_9_4h > -10.0) | (roc_9_1d_gt_neg_20))
+            & ((rsi_3_1h_gt_5) | (roc_9_4h > -10.0) | (roc_9_1d_gt_neg_20))
             # 1h & 4h down move, 1d still not low enough
             & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_10) | (stochrsi_k_1d < 20.0))
             # 1h & 4h down move, 15m still not low enough
             & ((rsi_3_1h_gt_15) | (rsi_3_4h > 3.0) | (stochrsi_k_15m < 30.0))
             # 1h & 4h down move, 4h high
-            & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_15) | (aroonu_14_4h < 60.0))
+            & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_15) | (aroonu_14_4h_lt_60))
             # 1h down move, 1h still not low enough, 1d overbought
             & ((rsi_3_1h_gt_15) | (stochrsi_k_1h < 30.0) | roc_9_1d_lt_50)
             # 1h down move, 1h still high, 1d downtrend
             & ((rsi_3_1h_gt_15) | (stochrsi_k_1h < 40.0) | (roc_9_1d > -20.0))
             # 1h down move, 1d high & overbought
-            & ((rsi_3_1h_gt_15) | (stochrsi_k_1d < 90.0) | (roc_9_1d < 40.0))
+            & ((rsi_3_1h_gt_15) | (stochrsi_k_1d_lt_90) | (roc_9_1d_lt_40))
             # 1h & 4h down move, 1h high
             & (rsi_3_1h_gt_20 | rsi_3_4h_gt_20 | aroonu_14_1h_lt_70)
             # 1h & 4h down move, 1d high
-            & (rsi_3_1h_gt_20 | (rsi_3_4h > 25.0) | (aroonu_14_1d < 80.0))
+            & (rsi_3_1h_gt_20 | (rsi_3_4h_gt_25) | (aroonu_14_1d_lt_80))
             # 1h & 4h down move, 4h high
-            & (rsi_3_1h_gt_20 | (rsi_3_4h > 35.0) | aroonu_14_4h_lt_70)
+            & (rsi_3_1h_gt_20 | (rsi_3_4h_gt_35) | aroonu_14_4h_lt_70)
             # 1h & 4h down move, 4h high
-            & (rsi_3_1h_gt_20 | (rsi_3_4h > 50.0) | aroonu_14_4h_lt_100)
+            & (rsi_3_1h_gt_20 | (rsi_3_4h_gt_50) | aroonu_14_4h_lt_100)
             # 1h & 1d down move, 1d overbought
-            & (rsi_3_1h_gt_20 | (rsi_3_1d > 40.0) | (roc_9_1d < 30.0))
+            & (rsi_3_1h_gt_20 | (rsi_3_1d > 40.0) | (roc_9_1d_lt_30))
             # 1h down move, 1d high, 1d downtrend
-            & (rsi_3_1h_gt_20 | (aroonu_14_1d < 70.0) | (roc_9_1d_gt_neg_20))
+            & (rsi_3_1h_gt_20 | (aroonu_14_1d_lt_70) | (roc_9_1d_gt_neg_20))
             # 1h down move, 1h & 4h high
-            & ((rsi_3_1h > 25.0) | aroonu_14_1h_lt_80 | aroonu_14_4h_lt_100)
+            & ((rsi_3_1h_gt_25) | aroonu_14_1h_lt_80 | aroonu_14_4h_lt_100)
             # 1h down move, 4h & 1d overbought
-            & ((rsi_3_1h > 25.0) | (roc_9_4h_lt_20) | (roc_9_1d < 30.0))
+            & ((rsi_3_1h_gt_25) | (roc_9_4h_lt_20) | (roc_9_1d_lt_30))
             # 1h & 4h down move, 1h high
-            & ((rsi_3_1h > 30.0) | (rsi_3_4h > 30.0) | (stochrsi_k_1h < 60.0))
+            & ((rsi_3_1h_gt_30) | (rsi_3_4h_gt_30) | (stochrsi_k_1h < 60.0))
             # 1h down move, 15m still high, 1h high
-            & ((rsi_3_1h > 30.0) | (aroonu_14_15m < 50.0) | (aroonu_14_1h < 85.0))
+            & ((rsi_3_1h_gt_30) | (aroonu_14_15m_lt_50) | (aroonu_14_1h < 85.0))
             # 1h & 1d down move, 1h high
-            & ((rsi_3_1h > 45.0) | (rsi_3_1d > 45.0) | aroonu_14_1h_lt_80)
+            & ((rsi_3_1h_gt_45) | (rsi_3_1d > 45.0) | aroonu_14_1h_lt_80)
             # 4h & 1d down move, 15m still not low enough
-            & ((rsi_3_4h > 3.0) | (rsi_3_1d > 15.0) | (aroonu_14_15m < 20.0))
+            & ((rsi_3_4h > 3.0) | (rsi_3_1d_gt_15) | (aroonu_14_15m < 20.0))
             # 4h & 1d down move, 1d high
-            & ((rsi_3_4h > 3.0) | (rsi_3_1d > 25.0) | (aroonu_14_1d < 70.0))
+            & ((rsi_3_4h > 3.0) | (rsi_3_1d_gt_25) | (aroonu_14_1d_lt_70))
             # 4h & 1d down move, 1d downtrend
-            & ((rsi_3_4h > 5.0) | (rsi_3_1d > 5.0) | (roc_9_1d_gt_neg_30))
+            & ((rsi_3_4h_gt_5) | (rsi_3_1d > 5.0) | (roc_9_1d_gt_neg_30))
             # 4h & 1d down move, 1h still high
-            & ((rsi_3_4h > 5.0) | (rsi_3_1d > 10.0) | (stochrsi_k_1h_lt_50))
+            & ((rsi_3_4h_gt_5) | (rsi_3_1d_gt_10) | (stochrsi_k_1h_lt_50))
             # 4h down move, 4h still high, 1d downtrend
-            & ((rsi_3_4h > 5.0) | (stochrsi_k_4h < 40.0) | (roc_9_1d_gt_neg_20))
+            & ((rsi_3_4h_gt_5) | (stochrsi_k_4h < 40.0) | (roc_9_1d_gt_neg_20))
             # 4h & 1d down move, 1d high
-            & ((rsi_3_4h_gt_10) | (rsi_3_1d > 15.0) | (aroonu_14_1d < 70.0))
+            & ((rsi_3_4h_gt_10) | (rsi_3_1d_gt_15) | (aroonu_14_1d_lt_70))
             # 4h & 1d down move, 15m still high
-            & ((rsi_3_4h_gt_10) | (rsi_3_1d > 20.0) | (stochrsi_k_15m < 40.0))
+            & ((rsi_3_4h_gt_10) | (rsi_3_1d_gt_20) | (stochrsi_k_15m < 40.0))
             # 4h down move, 1d high & overbought
             & ((rsi_3_4h_gt_10) | (aroonu_14_1d < 100.0) | (roc_9_1d < 10.0))
             # 4h down move, 1h high, 1d downtrend
             & ((rsi_3_4h_gt_10) | (stochrsi_k_1h < 50.0) | (roc_9_1d > -30.0))
             # 4h down move, 4h & 1d downtrend
-            & ((rsi_3_4h_gt_10) | (roc_9_4h > -20.0) | (roc_9_1d > -40.0))
+            & ((rsi_3_4h_gt_10) | (roc_9_4h > -20.0) | (roc_9_1d_gt_neg_40))
             # 4h & 1d down move, 1d high
-            & ((rsi_3_4h_gt_15) | (rsi_3_1d > 20.0) | (aroonu_14_1d < 60.0))
+            & ((rsi_3_4h_gt_15) | (rsi_3_1d_gt_20) | (aroonu_14_1d < 60.0))
             # 4h & 1d down move, 4h high
             & ((rsi_3_4h_gt_15) | (rsi_3_1d > 30.0) | (stochrsi_k_4h < 60.0))
             # 4h down move, 1d still high, 4h still not low enough
             & ((rsi_3_4h_gt_15) | (rsi_14_1d < 40.0) | (stochrsi_k_4h < 30.0))
             # 1h down move, 1h still high, 1d downtrend
-            & ((rsi_3_1h_gt_15) | (aroonu_14_1h < 50.0) | (roc_9_1d > -30.0))
+            & ((rsi_3_1h_gt_15) | (aroonu_14_1h_lt_50) | (roc_9_1d > -30.0))
             # 4h down move, 4h & 1d high
-            & ((rsi_3_4h_gt_15) | aroonu_14_4h_lt_70 | (aroonu_14_1d < 70.0))
+            & ((rsi_3_4h_gt_15) | aroonu_14_4h_lt_70 | (aroonu_14_1d_lt_70))
             # 4h down move, 1h still not low enough, 1d downtrend
             & ((rsi_3_4h_gt_15) | (stochrsi_k_1h < 20.0) | (roc_9_1d > -20.0))
             # 4h down move, 1h high
@@ -21993,31 +22045,31 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 1h downtrend, 1d overbought
             & ((rsi_3_4h_gt_15) | (roc_9_1h > -10.0) | (roc_9_1d < 200.0))
             # 4h & 1d down move, 1d still high
-            & (rsi_3_4h_gt_20 | (rsi_3_1d > 20.0) | (aroonu_14_1d < 50.0))
+            & (rsi_3_4h_gt_20 | (rsi_3_1d_gt_20) | (aroonu_14_1d < 50.0))
             # 4h down move, 4h & 1d high
-            & (rsi_3_4h_gt_20 | aroonu_14_4h_lt_70 | (aroonu_14_1d < 70.0))
+            & (rsi_3_4h_gt_20 | aroonu_14_4h_lt_70 | (aroonu_14_1d_lt_70))
             # 4h down move, 1d high & overbought
-            & (rsi_3_4h_gt_20 | (aroonu_14_1d < 80.0) | (roc_9_1d < 70.0))
+            & (rsi_3_4h_gt_20 | (aroonu_14_1d_lt_80) | (roc_9_1d < 70.0))
             # 4h down move, 4h high, 1d downtrend
             & (rsi_3_4h_gt_20 | (stochrsi_k_4h < 60.0) | (roc_9_1d_gt_neg_20))
             # 4h & 1d down move, 1d overbought
-            & ((rsi_3_4h > 25.0) | (rsi_3_1d > 40.0) | (roc_9_1d < 30.0))
+            & ((rsi_3_4h_gt_25) | (rsi_3_1d > 40.0) | (roc_9_1d_lt_30))
             # 4h down move, 1h high, 1d downtrend
-            & ((rsi_3_4h > 25.0) | (stochrsi_k_1h < 60.0) | (roc_9_1d_gt_neg_20))
+            & ((rsi_3_4h_gt_25) | (stochrsi_k_1h < 60.0) | (roc_9_1d_gt_neg_20))
             # 4h down move, 15m still high, 1h high
-            & ((rsi_3_4h > 35.0) | (aroonu_14_15m < 50.0) | (aroonu_14_1h < 100.0))
+            & ((rsi_3_4h_gt_35) | (aroonu_14_15m_lt_50) | (aroonu_14_1h_lt_100))
             # 4h down move, 1h high
-            & ((rsi_3_4h > 40.0) | aroonu_14_1h_lt_80)
+            & ((rsi_3_4h_gt_40) | aroonu_14_1h_lt_80)
             # 4h down move, 4h high, 1d downtrend
             & ((rsi_3_4h > 45.0) | (stochrsi_k_4h < 80.0) | (roc_9_1d_gt_neg_20))
             # 1h high, 4h & 1d overbought
-            & (aroonu_14_1h_lt_70 | (roc_9_4h < 40.0) | (roc_9_1d < 80.0))
+            & (aroonu_14_1h_lt_70 | (roc_9_4h_lt_40) | (roc_9_1d_lt_80))
             # 1h & 4h high, 1d overbought
-            & ((aroonu_14_1h < 85.0) | aroonu_14_4h_lt_100 | (roc_9_1d < 40.0))
+            & ((aroonu_14_1h < 85.0) | aroonu_14_4h_lt_100 | (roc_9_1d_lt_40))
             # 1d high, 4h & 1d downtrend
             & ((aroonu_14_1d < 60.0) | (roc_9_4h_gt_neg_20) | (roc_9_1d_gt_neg_30))
             # 4h high, 4h & 1d overbought
-            & ((stochrsi_k_4h < 90.0) | (roc_9_4h_lt_20) | (roc_9_1d < 20.0))
+            & ((stochrsi_k_4h < 90.0) | (roc_9_4h_lt_20) | (roc_9_1d_lt_20))
           )
 
           # Logic
@@ -22038,91 +22090,91 @@ class NostalgiaForInfinityX7(IStrategy):
 
           long_entry_logic.append(
             # 5m & 1h down move, 1h still not low enough
-            ((rsi_3 > 3.0) | (rsi_3_1h_gt_10) | (aroonu_14_1h < 30.0))
+            ((rsi_3_gt_3) | (rsi_3_1h_gt_10) | (aroonu_14_1h < 30.0))
             # 5m & 4h down move, 15m still high
-            & ((rsi_3 > 3.0) | (rsi_3_4h > 5.0) | (aroonu_14_15m < 40.0))
+            & ((rsi_3_gt_3) | (rsi_3_4h_gt_5) | (aroonu_14_15m < 40.0))
             # 5m & 4h & 1d down move
-            & ((rsi_3 > 3.0) | (rsi_3_4h_gt_10) | (rsi_3_1d > 10.0))
+            & ((rsi_3_gt_3) | (rsi_3_4h_gt_10) | (rsi_3_1d_gt_10))
             # 5m & 4h down move, 1d downtrend
-            & ((rsi_3 > 3.0) | (rsi_3_4h_gt_10) | (roc_9_1d > -10.0))
+            & ((rsi_3_gt_3) | (rsi_3_4h_gt_10) | (roc_9_1d > -10.0))
             # 5m & 4h down move, 15m high
             & ((rsi_3 > 10.0) | (rsi_3_4h_gt_10) | (aroonu_14_15m < 40.0))
             # 15m & 1h down move, 1h still not low enough
-            & (rsi_3_15m_gt_3 | (rsi_3_1h > 3.0) | (aroonu_14_1h < 25.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_3) | (aroonu_14_1h < 25.0))
             # 15m & 1h down move, 1d high
-            & ((rsi_3_15m > 5.0) | (rsi_3_1h > 5.0) | (aroonu_14_1d < 70.0))
+            & ((rsi_3_15m_gt_5) | (rsi_3_1h_gt_5) | (aroonu_14_1d_lt_70))
             # 15m & 1h down move, 1d high
-            & ((rsi_3_15m > 5.0) | (rsi_3_1h_gt_10) | (aroonu_14_1d < 100.0))
+            & ((rsi_3_15m_gt_5) | (rsi_3_1h_gt_10) | (aroonu_14_1d < 100.0))
             # 15m & 1h down move, 1d overbought
-            & ((rsi_3_15m > 5.0) | (rsi_3_1h > 30.0) | (roc_9_1d < 30.0))
+            & ((rsi_3_15m_gt_5) | (rsi_3_1h_gt_30) | (roc_9_1d_lt_30))
             # 15m & 4h down move, 4h downtrend
-            & ((rsi_3_15m > 5.0) | (rsi_3_4h > 5.0) | (roc_9_4h_gt_neg_20))
+            & ((rsi_3_15m_gt_5) | (rsi_3_4h_gt_5) | (roc_9_4h_gt_neg_20))
             # 15m & 4h down move, 4h still high
-            & ((rsi_3_15m > 5.0) | (rsi_3_4h > 30.0) | (stochrsi_k_4h < 40.0))
+            & ((rsi_3_15m_gt_5) | (rsi_3_4h_gt_30) | (stochrsi_k_4h < 40.0))
             # 15m down move, 1d high & overbought
-            & ((rsi_3_15m > 5.0) | aroonu_14_1d_lt_100 | (roc_9_1d < 40.0))
+            & ((rsi_3_15m_gt_5) | aroonu_14_1d_lt_100 | (roc_9_1d_lt_40))
             # 15m & 4h down move, 4h still not low enough
-            & ((rsi_3_15m > 10.0) | (rsi_3_4h_gt_10) | (rsi_14_4h < 20.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_4h_gt_10) | (rsi_14_4h < 20.0))
             # 15m & 4h down move, 4h high
-            & ((rsi_3_15m > 10.0) | (rsi_3_4h > 45.0) | aroonu_14_4h_lt_70)
+            & ((rsi_3_15m_gt_10) | (rsi_3_4h > 45.0) | aroonu_14_4h_lt_70)
             # 15m down move, 4h high, 1d overbought
-            & ((rsi_3_15m > 10.0) | aroonu_14_4h_lt_80 | roc_9_1d_lt_50)
+            & ((rsi_3_15m_gt_10) | aroonu_14_4h_lt_80 | roc_9_1d_lt_50)
             # 15m & 1h down move, 15m still high
-            & ((rsi_3_15m > 15.0) | (rsi_3_1h_gt_15) | (stochrsi_k_15m < 50.0))
+            & ((rsi_3_15m_gt_15) | (rsi_3_1h_gt_15) | (stochrsi_k_15m < 50.0))
             # 15m & 1h down move, 1d overbought
-            & ((rsi_3_15m > 15.0) | rsi_3_1h_gt_20 | (roc_9_1d < 30.0))
+            & ((rsi_3_15m_gt_15) | rsi_3_1h_gt_20 | (roc_9_1d_lt_30))
             # 15m & 1h down move, 4h high
-            & ((rsi_3_15m > 15.0) | (rsi_3_1h > 35.0) | aroonu_14_4h_lt_100)
+            & ((rsi_3_15m_gt_15) | (rsi_3_1h_gt_35) | aroonu_14_4h_lt_100)
             # 15m & 4h down move, 15m still high
-            & ((rsi_3_15m > 15.0) | (rsi_3_4h_gt_15) | (aroonu_14_15m < 40.0))
+            & ((rsi_3_15m_gt_15) | (rsi_3_4h_gt_15) | (aroonu_14_15m < 40.0))
             # 15m down move, 4h & 1d overbought
-            & ((rsi_3_15m > 15.0) | (roc_9_4h_lt_20) | (roc_9_1d < 200.0))
+            & ((rsi_3_15m_gt_15) | (roc_9_4h_lt_20) | (roc_9_1d < 200.0))
             # 15m & 1h down move, 4h high
-            & ((rsi_3_15m > 25.0) | (rsi_3_1h > 30.0) | aroonu_14_4h_lt_100)
+            & ((rsi_3_15m_gt_25) | (rsi_3_1h_gt_30) | aroonu_14_4h_lt_100)
             # 15m & 1h down move, 4h high
-            & ((rsi_3_15m > 25.0) | (rsi_3_1h > 40.0) | (stochrsi_k_4h_lt_90))
+            & ((rsi_3_15m_gt_25) | (rsi_3_1h_gt_40) | (stochrsi_k_4h_lt_90))
             # 15m down move, 4h high, 1d downtrend
-            & ((rsi_3_15m > 25.0) | (stochrsi_k_4h < 80.0) | (roc_9_1d_gt_neg_30))
+            & ((rsi_3_15m_gt_25) | (stochrsi_k_4h < 80.0) | (roc_9_1d_gt_neg_30))
             # 15m & 1h down move, 15m high
-            & ((rsi_3_15m > 45.0) | (rsi_3_1h > 45.0) | (stochrsi_k_15m < 70.0))
+            & ((rsi_3_15m > 45.0) | (rsi_3_1h_gt_45) | (stochrsi_k_15m < 70.0))
             # 15m down move, 4h high, 1d overbought
-            & ((rsi_3_15m > 10.0) | aroonu_14_4h_lt_70 | (roc_9_1d_lt_100))
+            & ((rsi_3_15m_gt_10) | aroonu_14_4h_lt_70 | (roc_9_1d_lt_100))
             # 15m & 4h down move, 1d downtrend
-            & ((rsi_3_15m > 15.0) | (rsi_3_4h_gt_15) | (roc_9_1d > -20.0))
+            & ((rsi_3_15m_gt_15) | (rsi_3_4h_gt_15) | (roc_9_1d > -20.0))
             # 15m & 1h down move, 4h high
-            & ((rsi_3_15m > 15.0) | (rsi_3_1h > 30.0) | (stochrsi_k_4h_lt_80))
+            & ((rsi_3_15m_gt_15) | (rsi_3_1h_gt_30) | (stochrsi_k_4h_lt_80))
             # 15m down move, 4h high & overbought
-            & ((rsi_3_15m > 20.0) | aroonu_14_4h_lt_100 | (roc_9_4h < 30.0))
+            & ((rsi_3_15m_gt_20) | aroonu_14_4h_lt_100 | (roc_9_4h_lt_30))
             # 15m down move, 15m still high, 4h high
-            & ((rsi_3_15m > 25.0) | (aroonu_14_15m < 50.0) | aroonu_14_4h_lt_80)
+            & ((rsi_3_15m_gt_25) | (aroonu_14_15m_lt_50) | aroonu_14_4h_lt_80)
             # 15m down move, 4h high & overbought
-            & ((rsi_3_15m > 25.0) | (stochrsi_k_4h < 80.0) | (roc_9_4h_lt_20))
+            & ((rsi_3_15m_gt_25) | (stochrsi_k_4h < 80.0) | (roc_9_4h_lt_20))
             # 15m down move, 4h high, 1d downtrend
-            & ((rsi_3_15m > 25.0) | (stochrsi_k_4h < 90.0) | (roc_9_1d_gt_neg_30))
+            & ((rsi_3_15m_gt_25) | (stochrsi_k_4h < 90.0) | (roc_9_1d_gt_neg_30))
             # 15m down move, 1h & 4h overbought
-            & ((rsi_3_15m > 25.0) | (roc_9_1h < 10.0) | (roc_9_4h < 30.0))
+            & ((rsi_3_15m_gt_25) | (roc_9_1h_lt_10) | (roc_9_4h_lt_30))
             # 15m down move, 1h & 4h high
-            & ((rsi_3_15m > 30.0) | aroonu_14_1h_lt_80 | aroonu_14_4h_lt_100)
+            & ((rsi_3_15m_gt_30) | aroonu_14_1h_lt_80 | aroonu_14_4h_lt_100)
             # 15m down move, 15m & 4h high
-            & ((rsi_3_15m > 35.0) | (aroonu_14_15m < 70.0) | (aroonu_14_4h < 90.0))
+            & ((rsi_3_15m > 35.0) | (aroonu_14_15m_lt_70) | (aroonu_14_4h_lt_90))
             # 1h & 4h down move, 1h downtrend
-            & ((rsi_3_1h > 3.0) | (rsi_3_4h_gt_10) | (cmf_20_1h > -0.20))
+            & ((rsi_3_1h_gt_3) | (rsi_3_4h_gt_10) | (cmf_20_1h > -0.20))
             # 1h & 4h down move, 1d still high
-            & ((rsi_3_1h > 3.0) | (rsi_3_4h_gt_10) | (stochrsi_k_1d < 40.0))
+            & ((rsi_3_1h_gt_3) | (rsi_3_4h_gt_10) | (stochrsi_k_1d < 40.0))
             # 1h & 4h down move, 4h still high
-            & ((rsi_3_1h > 3.0) | rsi_3_4h_gt_20 | (stochrsi_k_4h < 40.0))
+            & ((rsi_3_1h_gt_3) | rsi_3_4h_gt_20 | (stochrsi_k_4h < 40.0))
             # 1h & 4h down move, 15m still high
-            & ((rsi_3_1h > 3.0) | (rsi_3_4h > 30.0) | (stochrsi_k_15m < 50.0))
+            & ((rsi_3_1h_gt_3) | (rsi_3_4h_gt_30) | (stochrsi_k_15m < 50.0))
             # 1h & 4h down move, 15m still not low enough
-            & ((rsi_3_1h > 5.0) | (rsi_3_4h > 5.0) | (stochrsi_k_15m < 20.0))
+            & ((rsi_3_1h_gt_5) | (rsi_3_4h_gt_5) | (stochrsi_k_15m < 20.0))
             # 1h & 4h down move, 1d still high
-            & ((rsi_3_1h > 5.0) | rsi_3_4h_gt_20 | (aroonu_14_1d < 50.0))
+            & ((rsi_3_1h_gt_5) | rsi_3_4h_gt_20 | (aroonu_14_1d < 50.0))
             # 1h & 4h down move, 4h still not low enough
-            & ((rsi_3_1h > 5.0) | (rsi_3_4h > 40.0) | (stochrsi_k_4h < 30.0))
+            & ((rsi_3_1h_gt_5) | (rsi_3_4h_gt_40) | (stochrsi_k_4h < 30.0))
             # 1h & 1d down move, 1h still high
-            & ((rsi_3_1h > 5.0) | (rsi_3_1d > 5.0) | (aroonu_14_1h < 40.0))
+            & ((rsi_3_1h_gt_5) | (rsi_3_1d > 5.0) | (aroonu_14_1h < 40.0))
             # 1h down move, 1d high & overbought
-            & ((rsi_3_1h > 5.0) | (aroonu_14_1d < 90.0) | (roc_9_1d < 20.0))
+            & ((rsi_3_1h_gt_5) | (aroonu_14_1d_lt_90) | (roc_9_1d_lt_20))
             # 1h & 4h down move, 4h still not low enough
             & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_15) | (stochrsi_k_4h < 30.0))
             # 1h & 4h down move, 15m still high
@@ -22130,157 +22182,157 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 1d downtrend
             & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_15) | (roc_9_1d > -20.0))
             # 1h & 4h down move, 4h still high
-            & ((rsi_3_1h_gt_10) | (rsi_3_4h > 25.0) | (stochrsi_k_4h < 50.0))
+            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_25) | (stochrsi_k_4h_lt_50))
             # 1h & 1d down move, 4h high
-            & ((rsi_3_1h_gt_10) | (rsi_3_1d > 10.0) | (stochrsi_k_4h < 70.0))
+            & ((rsi_3_1h_gt_10) | (rsi_3_1d_gt_10) | (stochrsi_k_4h_lt_70))
             # 1h & 1d down move, 1d high
-            & ((rsi_3_1h_gt_10) | (rsi_3_1d > 20.0) | (aroonu_14_1d < 70.0))
+            & ((rsi_3_1h_gt_10) | (rsi_3_1d_gt_20) | (aroonu_14_1d_lt_70))
             # 1h down move, 1d high, 1h downtrend
-            & ((rsi_3_1h_gt_10) | (aroonu_14_1d < 70.0) | (roc_9_1h > -10.0))
+            & ((rsi_3_1h_gt_10) | (aroonu_14_1d_lt_70) | (roc_9_1h > -10.0))
             # 1h & 4h down move, 15m still not low enough
             & ((rsi_3_1h_gt_15) | (rsi_3_4h > 3.0) | (stochrsi_k_15m < 30.0))
             # 1h & 4h down move, 1h high
-            & ((rsi_3_1h_gt_15) | (rsi_3_4h > 25.0) | (aroonu_14_1h < 70.0))
+            & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_25) | (aroonu_14_1h < 70.0))
             # 1h & 4h down move, 4h high
-            & ((rsi_3_1h_gt_15) | (rsi_3_4h > 30.0) | aroonu_14_4h_lt_70)
+            & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_30) | aroonu_14_4h_lt_70)
             # 1h & 4h down move, 1d downtrend
-            & ((rsi_3_1h_gt_15) | (rsi_3_4h > 45.0) | (roc_9_1d > -40.0))
+            & ((rsi_3_1h_gt_15) | (rsi_3_4h > 45.0) | (roc_9_1d_gt_neg_40))
             # 1h & 1d down move, 1d high
-            & ((rsi_3_1h_gt_15) | (rsi_3_1d > 25.0) | (aroonu_14_1d < 80.0))
+            & ((rsi_3_1h_gt_15) | (rsi_3_1d_gt_25) | (aroonu_14_1d_lt_80))
             # 1h down move, 4h still high, 1d overbought
-            & ((rsi_3_1h_gt_15) | (aroonu_14_4h < 50.0) | (roc_9_1d < 40.0))
+            & ((rsi_3_1h_gt_15) | (aroonu_14_4h_lt_50) | (roc_9_1d_lt_40))
             # 1h down move, 1d high, 4h downtrend
-            & ((rsi_3_1h_gt_15) | (aroonu_14_1d < 70.0) | (roc_9_4h > -20.0))
+            & ((rsi_3_1h_gt_15) | (aroonu_14_1d_lt_70) | (roc_9_4h > -20.0))
             # 1h down move, 1d high & overbought
-            & ((rsi_3_1h_gt_15) | (aroonu_14_1d < 80.0) | (roc_9_1d < 10.0))
+            & ((rsi_3_1h_gt_15) | (aroonu_14_1d_lt_80) | (roc_9_1d < 10.0))
             # 1h down move, 4h high & overbought
             & ((rsi_3_1h_gt_15) | (stochrsi_k_4h < 80.0) | (roc_9_4h < 20.0))
             # 1h down move, 4h high, 1d downtrend
             & ((rsi_3_1h_gt_15) | (stochrsi_k_4h < 80.0) | (roc_9_1d > -30.0))
             # 1h & 4h down move, 4h still high
-            & (rsi_3_1h_gt_20 | rsi_3_4h_gt_20 | (aroonu_14_4h < 40.0))
+            & (rsi_3_1h_gt_20 | rsi_3_4h_gt_20 | (aroonu_14_4h_lt_40))
             # 1h & 4h down move, 1d high
-            & (rsi_3_1h_gt_20 | (rsi_3_4h > 25.0) | aroonu_14_1d_lt_100)
+            & (rsi_3_1h_gt_20 | (rsi_3_4h_gt_25) | aroonu_14_1d_lt_100)
             # 1h & 4h down move, 4h high
-            & (rsi_3_1h_gt_20 | (rsi_3_4h > 35.0) | aroonu_14_4h_lt_80)
+            & (rsi_3_1h_gt_20 | (rsi_3_4h_gt_35) | aroonu_14_4h_lt_80)
             # 1h & 4h down move, 4h overbought
-            & (rsi_3_1h_gt_20 | (rsi_3_4h > 35.0) | (roc_9_4h < 10.0))
+            & (rsi_3_1h_gt_20 | (rsi_3_4h_gt_35) | (roc_9_4h_lt_10))
             # 1h & 1d down move, 1h still high
-            & (rsi_3_1h_gt_20 | (rsi_3_1d > 25.0) | (aroonu_14_1h < 50.0))
+            & (rsi_3_1h_gt_20 | (rsi_3_1d_gt_25) | (aroonu_14_1h_lt_50))
             # 1h down move, 4h high & overbought
             & (rsi_3_1h_gt_20 | aroonu_14_4h_lt_80 | (roc_9_4h < 70.0))
             # 1h down move, 1h high, 1h still not low enough
-            & (rsi_3_1h_gt_20 | (aroonu_14_1d < 80.0) | (stochrsi_k_1h < 20.0))
+            & (rsi_3_1h_gt_20 | (aroonu_14_1d_lt_80) | (stochrsi_k_1h < 20.0))
             # 1h down move, 1d high & overbought
-            & (rsi_3_1h_gt_20 | aroonu_14_1d_lt_100 | (roc_9_1d < 20.0))
+            & (rsi_3_1h_gt_20 | aroonu_14_1d_lt_100 | (roc_9_1d_lt_20))
             # 1h down move, 4h still high, 1d downtrend
-            & (rsi_3_1h_gt_20 | (stochrsi_k_4h < 40.0) | (roc_9_1d > -40.0))
+            & (rsi_3_1h_gt_20 | (stochrsi_k_4h < 40.0) | (roc_9_1d_gt_neg_40))
             # 1h & 4h down move, 15m high
-            & ((rsi_3_1h > 25.0) | (rsi_3_4h > 25.0) | (stochrsi_k_15m < 70.0))
+            & ((rsi_3_1h_gt_25) | (rsi_3_4h_gt_25) | (stochrsi_k_15m < 70.0))
             # 1h & 4h down move, 4h still not low enough
-            & ((rsi_3_1h > 25.0) | (rsi_3_4h > 25.0) | (stochrsi_k_4h < 30.0))
+            & ((rsi_3_1h_gt_25) | (rsi_3_4h_gt_25) | (stochrsi_k_4h < 30.0))
             # 1h & 4h down move, 1d overbought
-            & ((rsi_3_1h > 25.0) | (rsi_3_4h > 25.0) | (roc_9_1d_lt_100))
+            & ((rsi_3_1h_gt_25) | (rsi_3_4h_gt_25) | (roc_9_1d_lt_100))
             # 1h & 4h down move, 4h high
-            & ((rsi_3_1h > 25.0) | (rsi_3_4h > 30.0) | (aroonu_14_4h < 60.0))
+            & ((rsi_3_1h_gt_25) | (rsi_3_4h_gt_30) | (aroonu_14_4h_lt_60))
             # 1h & 1d down move, 1d high
-            & ((rsi_3_1h > 25.0) | (rsi_3_1d > 25.0) | (aroonu_14_1d < 70.0))
+            & ((rsi_3_1h_gt_25) | (rsi_3_1d_gt_25) | (aroonu_14_1d_lt_70))
             # 1h down move, 4h & 1d high
-            & ((rsi_3_1h > 25.0) | aroonu_14_4h_lt_70 | aroonu_14_1d_lt_100)
+            & ((rsi_3_1h_gt_25) | aroonu_14_4h_lt_70 | aroonu_14_1d_lt_100)
             # 1h & 4h down move, 1d high
-            & ((rsi_3_1h > 30.0) | (rsi_3_4h > 35.0) | (rsi_14_1d < 80.0))
+            & ((rsi_3_1h_gt_30) | (rsi_3_4h_gt_35) | (rsi_14_1d < 80.0))
             # 1h down move, 1h & 4h high
-            & ((rsi_3_1h > 30.0) | aroonu_14_1h_lt_70 | aroonu_14_4h_lt_100)
+            & ((rsi_3_1h_gt_30) | aroonu_14_1h_lt_70 | aroonu_14_4h_lt_100)
             # 1h down move, 1h high, 4h high
-            & ((rsi_3_1h > 30.0) | aroonu_14_1h_lt_80 | (stochrsi_k_4h < 80.0))
+            & ((rsi_3_1h_gt_30) | aroonu_14_1h_lt_80 | (stochrsi_k_4h < 80.0))
             # 1h down move, 4h high, 1h overbought
-            & ((rsi_3_1h > 40.0) | aroonu_14_4h_lt_80 | (roc_9_1h < 10.0))
+            & ((rsi_3_1h_gt_40) | aroonu_14_4h_lt_80 | (roc_9_1h_lt_10))
             # 1h down move, 1h high, 15m high
-            & ((rsi_3_1h > 50.0) | aroonu_14_1h_lt_70 | (stochrsi_k_15m < 70.0))
+            & ((rsi_3_1h_gt_50) | aroonu_14_1h_lt_70 | (stochrsi_k_15m < 70.0))
             # 4h & 1d down move, 15m still not low enough
-            & ((rsi_3_4h > 3.0) | (rsi_3_1d > 15.0) | (aroonu_14_15m < 20.0))
+            & ((rsi_3_4h > 3.0) | (rsi_3_1d_gt_15) | (aroonu_14_15m < 20.0))
             # 4h & 1d down move, 1d still high
-            & ((rsi_3_4h > 3.0) | (rsi_3_1d > 20.0) | (stochrsi_k_1d < 40.0))
+            & ((rsi_3_4h > 3.0) | (rsi_3_1d_gt_20) | (stochrsi_k_1d < 40.0))
             # 4h & 1d down move, 1d high
-            & ((rsi_3_4h > 3.0) | (rsi_3_1d > 25.0) | (aroonu_14_1d < 70.0))
+            & ((rsi_3_4h > 3.0) | (rsi_3_1d_gt_25) | (aroonu_14_1d_lt_70))
             # 4h down move, 15m high
             & ((rsi_3_4h > 3.0) | (stochrsi_k_15m < 60.0))
             # 4h down move, 15m still high, 4h still not low enough
-            & ((rsi_3_4h > 5.0) | (stochrsi_k_15m < 50.0) | (aroonu_14_4h < 30.0))
+            & ((rsi_3_4h_gt_5) | (stochrsi_k_15m < 50.0) | (aroonu_14_4h < 30.0))
             # 4h & 1d down move, 15m still high
-            & ((rsi_3_4h_gt_10) | (rsi_3_1d > 15.0) | (stochrsi_k_15m < 40.0))
+            & ((rsi_3_4h_gt_10) | (rsi_3_1d_gt_15) | (stochrsi_k_15m < 40.0))
             # 4h down move, 4h still not low enough, 1d downtrend
             & ((rsi_3_4h_gt_10) | (aroonu_14_4h < 20.0) | (roc_9_1d > -10.0))
             # 4h down move, 4h still high, 4h downtrend
-            & ((rsi_3_4h_gt_10) | (aroonu_14_4h < 40.0) | (roc_9_4h > -20.0))
+            & ((rsi_3_4h_gt_10) | (aroonu_14_4h_lt_40) | (roc_9_4h > -20.0))
             # 4h down move, 1d still high, 1d downtrend
             & ((rsi_3_4h_gt_10) | (aroonu_14_1d < 40.0) | (roc_9_1d > -30.0))
             # 4h down move, 1d high, 15m high
-            & ((rsi_3_4h_gt_10) | (aroonu_14_1d < 80.0) | (stochrsi_k_15m < 60.0))
+            & ((rsi_3_4h_gt_10) | (aroonu_14_1d_lt_80) | (stochrsi_k_15m < 60.0))
             # 4h down move, 1d high, 4h downtrend
             & ((rsi_3_4h_gt_10) | (aroonu_14_1d < 100.0) | (roc_9_4h > -10.0))
             # 4h down move, 4h & 1d downtrend
             & ((rsi_3_4h_gt_10) | (roc_9_4h > -10.0) | (roc_9_1d > -20.0))
             # 4h & 1d down move, 1d still high
-            & ((rsi_3_4h_gt_15) | (rsi_3_1d > 15.0) | (aroonu_14_1d < 50.0))
+            & ((rsi_3_4h_gt_15) | (rsi_3_1d_gt_15) | (aroonu_14_1d < 50.0))
             # 4h & 1d down move, 4h still high
-            & ((rsi_3_4h_gt_15) | (rsi_3_1d > 30.0) | (stochrsi_k_4h < 50.0))
+            & ((rsi_3_4h_gt_15) | (rsi_3_1d > 30.0) | (stochrsi_k_4h_lt_50))
             # 4h & 1d down move, 4h still high
             & ((rsi_3_4h_gt_15) | (rsi_3_1d > 45.0) | (stochrsi_k_4h < 40.0))
             # 4h down move, 4h still not low enough, 1d high
-            & ((rsi_3_4h_gt_15) | (aroonu_14_4h < 30.0) | (aroonu_14_1d < 70.0))
+            & ((rsi_3_4h_gt_15) | (aroonu_14_4h < 30.0) | (aroonu_14_1d_lt_70))
             # 4h down move, 1d high & overbought
-            & ((rsi_3_4h_gt_15) | (aroonu_14_1d < 100.0) | (roc_9_1d < 30.0))
+            & ((rsi_3_4h_gt_15) | (aroonu_14_1d < 100.0) | (roc_9_1d_lt_30))
             # 4h down move, 15m high
             & ((rsi_3_4h_gt_15) | (stochrsi_k_15m < 70.0))
             # 4h & 1d down move, 1d downtrend
-            & (rsi_3_4h_gt_20 | (rsi_3_1d > 25.0) | (roc_9_1d_gt_neg_30))
+            & (rsi_3_4h_gt_20 | (rsi_3_1d_gt_25) | (roc_9_1d_gt_neg_30))
             # 4h down move, 1d high & overbought
-            & (rsi_3_4h_gt_20 | (aroonu_14_1d < 80.0) | (roc_9_1d < 70.0))
+            & (rsi_3_4h_gt_20 | (aroonu_14_1d_lt_80) | (roc_9_1d < 70.0))
             # 4h & 1d down move, 4h overbought
-            & ((rsi_3_4h > 25.0) | (rsi_3_1d > 45.0) | (roc_9_4h < 5.0))
+            & ((rsi_3_4h_gt_25) | (rsi_3_1d > 45.0) | (roc_9_4h < 5.0))
             # 4h & 1d down move, 1d overbought
-            & ((rsi_3_4h > 25.0) | (rsi_3_1d > 45.0) | (roc_9_1d < 10.0))
+            & ((rsi_3_4h_gt_25) | (rsi_3_1d > 45.0) | (roc_9_1d < 10.0))
             # 4h & 1d down move, 1d overbought
-            & ((rsi_3_4h > 30.0) | (rsi_3_1d > 70.0) | (roc_9_1d < 20.0))
+            & ((rsi_3_4h_gt_30) | (rsi_3_1d > 70.0) | (roc_9_1d_lt_20))
             # 4h down move, 4h high, 1d high
-            & ((rsi_3_4h > 30.0) | aroonu_14_4h_lt_70 | (stochrsi_k_1d < 80.0))
+            & ((rsi_3_4h_gt_30) | aroonu_14_4h_lt_70 | (stochrsi_k_1d < 80.0))
             # 4h down move, 1d stil high, 1d downtrend
-            & ((rsi_3_4h > 30.0) | (aroonu_14_1d < 40.0) | (roc_9_1d_gt_neg_30))
+            & ((rsi_3_4h_gt_30) | (aroonu_14_1d < 40.0) | (roc_9_1d_gt_neg_30))
             # 4h down move, 4h still high, 4h downtrend
-            & ((rsi_3_4h > 30.0) | (stochrsi_k_4h < 40.0) | (roc_9_4h > -15.0))
+            & ((rsi_3_4h_gt_30) | (stochrsi_k_4h < 40.0) | (roc_9_4h > -15.0))
             # 4h down move, 4h still high, 1d downtrend
-            & ((rsi_3_4h > 35.0) | (stochrsi_k_4h < 40.0) | (roc_9_1d_gt_neg_20))
+            & ((rsi_3_4h_gt_35) | (stochrsi_k_4h < 40.0) | (roc_9_1d_gt_neg_20))
             # 4h down move, 1d high & overbought
-            & ((rsi_3_4h > 55.0) | (stochrsi_k_1d < 90.0) | (roc_9_1d_lt_100))
+            & ((rsi_3_4h > 55.0) | (stochrsi_k_1d_lt_90) | (roc_9_1d_lt_100))
             # 1d down move, 4h still not low enough, 4h downtrend
-            & ((rsi_3_1d > 10.0) | (stochrsi_k_4h < 30.0) | (roc_9_4h > -15.0))
+            & ((rsi_3_1d_gt_10) | (stochrsi_k_4h < 30.0) | (roc_9_4h > -15.0))
             # 1d down move, 4h & 1d downtrend
-            & ((rsi_3_1d > 10.0) | (roc_9_4h_gt_neg_20) | (roc_9_1d_gt_neg_20))
+            & ((rsi_3_1d_gt_10) | (roc_9_4h_gt_neg_20) | (roc_9_1d_gt_neg_20))
             # 1d down move, 1d high, 4h downtrend
-            & ((rsi_3_1d > 15.0) | (aroonu_14_1d < 70.0) | (roc_9_4h_gt_neg_20))
+            & ((rsi_3_1d_gt_15) | (aroonu_14_1d_lt_70) | (roc_9_4h_gt_neg_20))
             # 1d down move, 1h & 4h high
-            & ((rsi_3_1d > 25.0) | aroonu_14_1h_lt_70 | aroonu_14_4h_lt_100)
+            & ((rsi_3_1d_gt_25) | aroonu_14_1h_lt_70 | aroonu_14_4h_lt_100)
             # 1d down move, 1h & 4h high
             & ((rsi_3_1d > 30.0) | aroonu_14_1h_lt_70 | aroonu_14_4h_lt_100)
             # 1h high, 4h & 1d overbought
-            & (aroonu_14_1h_lt_70 | (roc_9_4h < 40.0) | (roc_9_1d < 80.0))
+            & (aroonu_14_1h_lt_70 | (roc_9_4h_lt_40) | (roc_9_1d_lt_80))
             # 4h & 1d high, 1h overbought
-            & ((aroonu_14_4h < 85.0) | aroonu_14_1d_lt_100 | (roc_9_1h < 10.0))
+            & ((aroonu_14_4h < 85.0) | aroonu_14_1d_lt_100 | (roc_9_1h_lt_10))
             # 4h high, 4h & 1d overbought
-            & ((aroonu_14_4h < 90.0) | (roc_9_4h < 30.0) | (roc_9_1d < 60.0))
+            & ((aroonu_14_4h_lt_90) | (roc_9_4h_lt_30) | (roc_9_1d < 60.0))
             # 15m high, 4h & 1d overbought
-            & ((stochrsi_k_15m < 80.0) | (roc_9_4h_lt_20) | (roc_9_1d < 20.0))
+            & ((stochrsi_k_15m < 80.0) | (roc_9_4h_lt_20) | (roc_9_1d_lt_20))
             # 15m still high, 4h & 1d overbought
-            & ((stochrsi_k_15m < 50.0) | (roc_9_4h < 40.0) | (roc_9_1d_lt_100))
+            & ((stochrsi_k_15m < 50.0) | (roc_9_4h_lt_40) | (roc_9_1d_lt_100))
             # 4h high, 4h & 1d overbought
-            & ((stochrsi_k_4h_lt_90) | (roc_9_4h < 30.0) | (roc_9_1d < 60.0))
+            & ((stochrsi_k_4h_lt_90) | (roc_9_4h_lt_30) | (roc_9_1d < 60.0))
             # 1d high, 4h & 1d overbought
-            & ((stochrsi_k_1d < 90.0) | (roc_9_4h < 30.0) | (roc_9_1d_lt_100))
+            & ((stochrsi_k_1d_lt_90) | (roc_9_4h_lt_30) | (roc_9_1d_lt_100))
             # 4h & 1d overbought
             & ((roc_9_4h < 100.0) | (roc_9_1d < 200.0))
             # 1d P&D, 4h overbought
-            & ((change_pct_1d > -10.0) | (change_pct_1d.shift(288) < 50.0) | (roc_9_4h < 30.0))
+            & ((change_pct_1d > -10.0) | (change_pct_1d.shift(288) < 50.0) | (roc_9_4h_lt_30))
           )
 
           # Logic
@@ -22302,69 +22354,69 @@ class NostalgiaForInfinityX7(IStrategy):
 
           long_entry_logic.append(
             # 5m & 4h down move, 1d downtrend
-            ((rsi_3 > 3.0) | (rsi_3_4h > 3.0) | (roc_9_1d_gt_neg_20))
+            ((rsi_3_gt_3) | (rsi_3_4h > 3.0) | (roc_9_1d_gt_neg_20))
             # 5m down move, 15m & 1h high
-            & ((rsi_3 > 10.0) | (aroonu_14_15m < 85.0) | (aroonu_14_1h < 100.0))
+            & ((rsi_3 > 10.0) | (aroonu_14_15m < 85.0) | (aroonu_14_1h_lt_100))
             # 15m & 1h & 4h down move
-            & (rsi_3_15m_gt_3 | (rsi_3_1h > 3.0) | (rsi_3_4h > 5.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_3) | (rsi_3_4h_gt_5))
             # 15m & 1h down move, 1h downtrend
-            & (rsi_3_15m_gt_3 | (rsi_3_1h > 3.0) | (roc_9_1h > -20.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_3) | (roc_9_1h > -20.0))
             # 15m & 1h down move, 1h still not low enough
             & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_10) | (stochrsi_k_1h < 20.0))
             # 15m & 1h down move, 4h high
-            & ((rsi_3_15m > 5.0) | (rsi_3_1h_gt_10) | aroonu_14_4h_lt_70)
+            & ((rsi_3_15m_gt_5) | (rsi_3_1h_gt_10) | aroonu_14_4h_lt_70)
             # 15m & 1h down move, 1h high
-            & ((rsi_3_15m > 10.0) | (rsi_3_1h > 35.0) | aroonu_14_1h_lt_70)
+            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_35) | aroonu_14_1h_lt_70)
             # 15m & 4h down move, 4h still not low enough
-            & ((rsi_3_15m > 10.0) | (rsi_3_4h_gt_10) | (aroonu_14_4h < 30.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_4h_gt_10) | (aroonu_14_4h < 30.0))
             # 15m & 1h down move, 1h high
-            & ((rsi_3_15m > 15.0) | (rsi_3_1h_gt_15) | (aroonu_14_1h < 70.0))
+            & ((rsi_3_15m_gt_15) | (rsi_3_1h_gt_15) | (aroonu_14_1h < 70.0))
             # 15m & 1h down move, 1h high
-            & ((rsi_3_15m > 15.0) | (rsi_3_1h > 40.0) | (aroonu_14_1h < 90.0))
+            & ((rsi_3_15m_gt_15) | (rsi_3_1h_gt_40) | (aroonu_14_1h_lt_90))
             # 15m & 4h down move, 1d high
-            & ((rsi_3_15m > 15.0) | (rsi_3_4h_gt_15) | (aroonu_14_1d < 90.0))
+            & ((rsi_3_15m_gt_15) | (rsi_3_4h_gt_15) | (aroonu_14_1d_lt_90))
             # 15m & 4h down move, 1h high
-            & ((rsi_3_15m > 15.0) | (rsi_3_4h > 35.0) | (aroonu_14_1h < 90.0))
+            & ((rsi_3_15m_gt_15) | (rsi_3_4h_gt_35) | (aroonu_14_1h_lt_90))
             # 15m down move, 15m downtrend, 1h high
-            & ((rsi_3_15m > 15.0) | (cmf_20_15m > -0.40) | (aroonu_14_1h < 60.0))
+            & ((rsi_3_15m_gt_15) | (cmf_20_15m > -0.40) | (aroonu_14_1h < 60.0))
             # 15m down move, 15m still high, 4h high
-            & ((rsi_3_15m > 15.0) | (aroonu_14_15m < 40.0) | (stochrsi_k_4h < 60.0))
+            & ((rsi_3_15m_gt_15) | (aroonu_14_15m < 40.0) | (stochrsi_k_4h < 60.0))
             # 15m down move, 1h high, 1d downtrend
-            & ((rsi_3_15m > 15.0) | (aroonu_14_1h < 90.0) | (roc_9_1d_gt_neg_30))
+            & ((rsi_3_15m_gt_15) | (aroonu_14_1h_lt_90) | (roc_9_1d_gt_neg_30))
             # 15m & 1h down move, 1d downtrend
-            & ((rsi_3_15m > 20.0) | rsi_3_1h_gt_20 | (roc_9_1d_gt_neg_30))
+            & ((rsi_3_15m_gt_20) | rsi_3_1h_gt_20 | (roc_9_1d_gt_neg_30))
             # 15m & 4h down move, 15m still high
-            & ((rsi_3_15m > 20.0) | rsi_3_4h_gt_20 | (stochrsi_k_15m < 50.0))
+            & ((rsi_3_15m_gt_20) | rsi_3_4h_gt_20 | (stochrsi_k_15m < 50.0))
             # 15m down move, 15m & 1h high
-            & ((rsi_3_15m > 20.0) | (aroonu_14_15m < 70.0) | (aroonu_14_1h < 100.0))
+            & ((rsi_3_15m_gt_20) | (aroonu_14_15m_lt_70) | (aroonu_14_1h_lt_100))
             # 15m & 1h down move, 15m still high
-            & ((rsi_3_15m > 25.0) | (rsi_3_1h > 35.0) | (stochrsi_k_15m < 50.0))
+            & ((rsi_3_15m_gt_25) | (rsi_3_1h_gt_35) | (stochrsi_k_15m < 50.0))
             # 15m down move, 15m still high, 1d overbought
-            & ((rsi_3_15m > 25.0) | (stochrsi_k_15m < 50.0) | (roc_9_1d < 30.0))
+            & ((rsi_3_15m_gt_25) | (stochrsi_k_15m < 50.0) | (roc_9_1d_lt_30))
             # 15m & 4h down move, 1h high
-            & ((rsi_3_15m > 30.0) | (rsi_3_4h > 30.0) | (stochrsi_k_1h_lt_70))
+            & ((rsi_3_15m_gt_30) | (rsi_3_4h_gt_30) | (stochrsi_k_1h_lt_70))
             # 15m down move, 15m & 4h high
-            & ((rsi_3_15m > 30.0) | (aroonu_14_15m < 70.0) | aroonu_14_4h_lt_70)
+            & ((rsi_3_15m_gt_30) | (aroonu_14_15m_lt_70) | aroonu_14_4h_lt_70)
             # 15m down move, 15m high, 1h high
-            & ((rsi_3_15m > 30.0) | (aroonu_14_15m < 70.0) | (stochrsi_k_1h_lt_70))
+            & ((rsi_3_15m_gt_30) | (aroonu_14_15m_lt_70) | (stochrsi_k_1h_lt_70))
             # 15m down move, 15m high, 4h high
-            & ((rsi_3_15m > 30.0) | (aroonu_14_15m < 70.0) | (stochrsi_k_4h_lt_80))
+            & ((rsi_3_15m_gt_30) | (aroonu_14_15m_lt_70) | (stochrsi_k_4h_lt_80))
             # 15m down move, 1h high, 1d overbought
-            & ((rsi_3_15m > 30.0) | aroonu_14_1h_lt_80 | (roc_9_1d < 20.0))
+            & ((rsi_3_15m_gt_30) | aroonu_14_1h_lt_80 | (roc_9_1d_lt_20))
             # 15m down move, 4h & 1d overbought
-            & ((rsi_3_15m > 35.0) | (roc_9_4h < 30.0) | (roc_9_1d < 80.0))
+            & ((rsi_3_15m > 35.0) | (roc_9_4h_lt_30) | (roc_9_1d_lt_80))
             # 1h & 4h down move, 4h still high
-            & ((rsi_3_1h > 3.0) | rsi_3_4h_gt_20 | (aroonu_14_4h < 40.0))
+            & ((rsi_3_1h_gt_3) | rsi_3_4h_gt_20 | (aroonu_14_4h_lt_40))
             # 1h down move, 4h still high, 1d high
-            & ((rsi_3_1h > 3.0) | (aroonu_14_4h < 50.0) | (aroonu_14_1d < 90.0))
+            & ((rsi_3_1h_gt_3) | (aroonu_14_4h_lt_50) | (aroonu_14_1d_lt_90))
             # 1h & 1d down move, 1d still high
-            & ((rsi_3_1h > 5.0) | (rsi_3_1d > 20.0) | (aroonu_14_1d < 40.0))
+            & ((rsi_3_1h_gt_5) | (rsi_3_1d_gt_20) | (aroonu_14_1d < 40.0))
             # 1h & 1d down move, 1h still not low enough
-            & ((rsi_3_1h > 5.0) | (rsi_3_1d > 25.0) | (aroonu_14_1h < 20.0))
+            & ((rsi_3_1h_gt_5) | (rsi_3_1d_gt_25) | (aroonu_14_1h < 20.0))
             # 1h & 4h & 1d down move
-            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_10) | (rsi_3_1d > 15.0))
+            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_10) | (rsi_3_1d_gt_15))
             # 1h & 4h down move, 4h still high
-            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_10) | (aroonu_14_4h < 40.0))
+            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_10) | (aroonu_14_4h_lt_40))
             # 1h & 4h down move, 4h downtrend
             & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_10) | (roc_9_4h > -10.0))
             # 1h & 4h down move, 1d downtrend
@@ -22372,89 +22424,89 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 15m high
             & ((rsi_3_1h_gt_10) | rsi_3_4h_gt_20 | (stochrsi_k_15m < 80.0))
             # 1h & 4h down move, 1d downtrend
-            & ((rsi_3_1h_gt_10) | (rsi_3_4h > 25.0) | roc_9_1d_gt_neg_50)
+            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_25) | roc_9_1d_gt_neg_50)
             # 1h & 4h down move, 4h high
-            & ((rsi_3_1h_gt_10) | (rsi_3_4h > 35.0) | (aroonu_14_4h < 90.0))
+            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_35) | (aroonu_14_4h_lt_90))
             # 1h & 1d down move, 1h still not low enough
-            & ((rsi_3_1h_gt_10) | (rsi_3_1d > 20.0) | (aroonu_14_1h < 30.0))
+            & ((rsi_3_1h_gt_10) | (rsi_3_1d_gt_20) | (aroonu_14_1h < 30.0))
             # 1h down move, 15m downtrend, 1d high
-            & ((rsi_3_1h_gt_10) | (cmf_20_15m > -0.40) | (aroonu_14_1d < 70.0))
+            & ((rsi_3_1h_gt_10) | (cmf_20_15m > -0.40) | (aroonu_14_1d_lt_70))
             # 1h down move, 4h still high, 1d overbought
-            & ((rsi_3_1h_gt_10) | (aroonu_14_4h < 40.0) | (roc_9_1d < 40.0))
+            & ((rsi_3_1h_gt_10) | (aroonu_14_4h_lt_40) | (roc_9_1d_lt_40))
             # 1h down move, 1d still high, 1d downtrend
             & ((rsi_3_1h_gt_10) | (aroonu_14_1d < 50.0) | (roc_9_1d > -20.0))
             # 1h & 4h & 1d down move
-            & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_15) | (rsi_3_1d > 20.0))
+            & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_15) | (rsi_3_1d_gt_20))
             # 1h & 4h down move, 15m still not low enough
             & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_15) | (stochrsi_k_15m < 30.0))
             # 1h & 4h down move, 15m still high
-            & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_15) | (aroonu_14_15m < 50.0))
+            & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_15) | (aroonu_14_15m_lt_50))
             # 1h & 4h down move, 4h high
-            & ((rsi_3_1h_gt_15) | (rsi_3_4h > 25.0) | (aroonu_14_4h < 60.0))
+            & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_25) | (aroonu_14_4h_lt_60))
             # 1h & 4h down move, 1d downtrend
-            & ((rsi_3_1h_gt_15) | (rsi_3_4h > 30.0) | (roc_9_1d > -40.0))
+            & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_30) | (roc_9_1d_gt_neg_40))
             # 1h down move, 1h still high, 4h high
-            & ((rsi_3_1h_gt_15) | (aroonu_14_1h < 40.0) | (aroonu_14_4h < 60.0))
+            & ((rsi_3_1h_gt_15) | (aroonu_14_1h < 40.0) | (aroonu_14_4h_lt_60))
             # 1h down move, 1h still high, 4h overbought
-            & ((rsi_3_1h_gt_15) | (aroonu_14_1h < 50.0) | (roc_9_4h < 10.0))
+            & ((rsi_3_1h_gt_15) | (aroonu_14_1h_lt_50) | (roc_9_4h_lt_10))
             # 1h down move, 1h high, 1d downtrend
             & ((rsi_3_1h_gt_15) | (aroonu_14_1h < 60.0) | (roc_9_1d > -30.0))
             # 1h down move, 4h & 1d overbought
-            & ((rsi_3_1h_gt_15) | (roc_9_4h < 30.0) | roc_9_1d_lt_50)
+            & ((rsi_3_1h_gt_15) | (roc_9_4h_lt_30) | roc_9_1d_lt_50)
             # 1h & 4h down move, 4h high
-            & (rsi_3_1h_gt_20 | (rsi_3_4h > 35.0) | aroonu_14_4h_lt_70)
+            & (rsi_3_1h_gt_20 | (rsi_3_4h_gt_35) | aroonu_14_4h_lt_70)
             # 1h & 4h down move, 4h high
             & (rsi_3_1h_gt_20 | (rsi_3_4h > 45.0) | (stochrsi_k_4h_lt_80))
             # 1h & 1d down move, 4h still high
-            & (rsi_3_1h_gt_20 | (rsi_3_1d > 20.0) | (stochrsi_k_4h < 50.0))
+            & (rsi_3_1h_gt_20 | (rsi_3_1d_gt_20) | (stochrsi_k_4h_lt_50))
             # 1h & 1d down move, 1h still high
-            & (rsi_3_1h_gt_20 | (rsi_3_1d > 25.0) | (aroonu_14_1h < 50.0))
+            & (rsi_3_1h_gt_20 | (rsi_3_1d_gt_25) | (aroonu_14_1h_lt_50))
             # 1h down move, 15m still high, 1h high
             & (rsi_3_1h_gt_20 | (aroonu_14_15m < 40.0) | aroonu_14_1h_lt_80)
             # 1h down move, 1h high, 1d overbought
-            & (rsi_3_1h_gt_20 | aroonu_14_1h_lt_70 | (roc_9_1d < 20.0))
+            & (rsi_3_1h_gt_20 | aroonu_14_1h_lt_70 | (roc_9_1d_lt_20))
             # 1h down move, 4h high & overbought
             & (rsi_3_1h_gt_20 | aroonu_14_4h_lt_80 | (roc_9_4h < 60.0))
             # 1h down move, 1h still not low enough, 1d downtrend
             & (rsi_3_1h_gt_20 | (stochrsi_k_1h < 30.0) | (roc_9_1d_gt_neg_30))
             # 1h & 4h down move, 1h high
-            & ((rsi_3_1h > 25.0) | (rsi_3_4h > 35.0) | aroonu_14_1h_lt_70)
+            & ((rsi_3_1h_gt_25) | (rsi_3_4h_gt_35) | aroonu_14_1h_lt_70)
             # 1h & 4h down move, 1d overbought
-            & ((rsi_3_1h > 25.0) | (rsi_3_4h > 35.0) | (roc_9_1d < 20.0))
+            & ((rsi_3_1h_gt_25) | (rsi_3_4h_gt_35) | (roc_9_1d_lt_20))
             # 1h down move, 1h still high, 4h high
-            & ((rsi_3_1h > 25.0) | (aroonu_14_1h < 50.0) | (aroonu_14_4h < 85.0))
+            & ((rsi_3_1h_gt_25) | (aroonu_14_1h_lt_50) | (aroonu_14_4h < 85.0))
             # 1h down move, 1h high, 1d overbought
-            & ((rsi_3_1h > 25.0) | aroonu_14_1h_lt_80 | (roc_9_1d < 30.0))
+            & ((rsi_3_1h_gt_25) | aroonu_14_1h_lt_80 | (roc_9_1d_lt_30))
             # 1h down move, 1h still high, 4h downtrend
-            & ((rsi_3_1h > 25.0) | (stochrsi_k_1h < 50.0) | (roc_9_4h_gt_neg_20))
+            & ((rsi_3_1h_gt_25) | (stochrsi_k_1h < 50.0) | (roc_9_4h_gt_neg_20))
             # 1h down move, 1d overbought
-            & ((rsi_3_1h > 25.0) | (roc_9_1d < 80.0))
+            & ((rsi_3_1h_gt_25) | (roc_9_1d_lt_80))
             # 1h down move, 1h high, 1d overbought
-            & ((rsi_3_1h > 30.0) | aroonu_14_1h_lt_70 | (roc_9_1d < 40.0))
+            & ((rsi_3_1h_gt_30) | aroonu_14_1h_lt_70 | (roc_9_1d_lt_40))
             # 1h & 4h down move, 4h high
-            & ((rsi_3_1h > 35.0) | (rsi_3_4h > 40.0) | (stochrsi_k_4h_lt_80))
+            & ((rsi_3_1h_gt_35) | (rsi_3_4h_gt_40) | (stochrsi_k_4h_lt_80))
             # 1h down move, 1h still high, 1d overbought
-            & ((rsi_3_1h > 35.0) | (aroonu_14_1h < 40.0) | (roc_9_1d < 40.0))
+            & ((rsi_3_1h_gt_35) | (aroonu_14_1h < 40.0) | (roc_9_1d_lt_40))
             # 1h down move, 4h high & overbought
-            & ((rsi_3_1h > 35.0) | (aroonu_14_4h < 90.0) | (roc_9_4h < 60.0))
+            & ((rsi_3_1h_gt_35) | (aroonu_14_4h_lt_90) | (roc_9_4h < 60.0))
             # 1h down move, 4h high, 1d downtrend
-            & ((rsi_3_1h > 35.0) | (stochrsi_k_4h < 90.0) | (roc_9_1d_gt_neg_20))
+            & ((rsi_3_1h_gt_35) | (stochrsi_k_4h < 90.0) | (roc_9_1d_gt_neg_20))
             # 1h down move, 1h high, 1d downtrend
-            & ((rsi_3_1h > 40.0) | aroonu_14_1h_lt_70 | (roc_9_1d > -30.0))
+            & ((rsi_3_1h_gt_40) | aroonu_14_1h_lt_70 | (roc_9_1d > -30.0))
             # 1h down move, 1h high, 1d downtrend
-            & ((rsi_3_1h > 40.0) | (stochrsi_k_1h < 70.0) | (roc_9_1d_gt_neg_30))
+            & ((rsi_3_1h_gt_40) | (stochrsi_k_1h < 70.0) | (roc_9_1d_gt_neg_30))
             # 1h down move, 1h & 4h high
-            & ((rsi_3_1h > 45.0) | aroonu_14_1h_lt_80 | aroonu_14_4h_lt_100)
+            & ((rsi_3_1h_gt_45) | aroonu_14_1h_lt_80 | aroonu_14_4h_lt_100)
             # 1h down move, 1h high, 4h overbought
-            & ((rsi_3_1h > 50.0) | aroonu_14_1h_lt_80 | (roc_9_4h < 10.0))
+            & ((rsi_3_1h_gt_50) | aroonu_14_1h_lt_80 | (roc_9_4h_lt_10))
             # 1h down move, 4h high & overbought
-            & ((rsi_3_1h > 50.0) | (stochrsi_k_4h_lt_90) | (roc_9_4h < 25.0))
+            & ((rsi_3_1h_gt_50) | (stochrsi_k_4h_lt_90) | (roc_9_4h < 25.0))
             # 4h down move, 4h & 1d downtrend
-            & ((rsi_3_4h > 5.0) | (roc_9_4h > -15.0) | (roc_9_1d_gt_neg_20))
+            & ((rsi_3_4h_gt_5) | (roc_9_4h > -15.0) | (roc_9_1d_gt_neg_20))
             # 4h & 1d down move, 1d still high
             & ((rsi_3_4h_gt_10) | (rsi_3_1d > 30.0) | (stochrsi_k_1d < 50.0))
             # 4h down move, 4h & 1d high
-            & ((rsi_3_4h_gt_10) | (aroonu_14_4h < 60.0) | (aroonu_14_1d < 70.0))
+            & ((rsi_3_4h_gt_10) | (aroonu_14_4h_lt_60) | (aroonu_14_1d_lt_70))
             # 4h down move, 1d still high, 1d downtrend
             & ((rsi_3_4h_gt_10) | (aroonu_14_1d < 50.0) | (roc_9_1d > -30.0))
             # 4h down move, 15m & 1h still not low enough
@@ -22462,53 +22514,53 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 15m stil high, 4h downtrend
             & ((rsi_3_4h_gt_10) | (stochrsi_k_15m < 50.0) | (roc_9_4h > -20.0))
             # 4h & 1d down move, 1d downtrend
-            & ((rsi_3_4h_gt_15) | (rsi_3_1d > 25.0) | (roc_9_1d > -30.0))
+            & ((rsi_3_4h_gt_15) | (rsi_3_1d_gt_25) | (roc_9_1d > -30.0))
             # 4h & 1d down move, 1h still high
             & ((rsi_3_4h_gt_15) | (rsi_3_1d > 30.0) | (stochrsi_k_1h < 50.0))
             # 4h & 1d down move, 4h high
-            & ((rsi_3_4h_gt_15) | (rsi_3_1d > 35.0) | (stochrsi_k_4h < 70.0))
+            & ((rsi_3_4h_gt_15) | (rsi_3_1d > 35.0) | (stochrsi_k_4h_lt_70))
             # 4h down move, 4h high
             & ((rsi_3_4h_gt_15) | (stochrsi_k_4h < 60.0))
             # 4h down move, 4h & 1d high
-            & (rsi_3_4h_gt_20 | aroonu_14_4h_lt_70 | (aroonu_14_1d < 70.0))
+            & (rsi_3_4h_gt_20 | aroonu_14_4h_lt_70 | (aroonu_14_1d_lt_70))
             # 4h down move, 15m high
             & (rsi_3_4h_gt_20 | (stochrsi_k_15m < 90.0))
             # 4h down move, 1d high & overbought
-            & (rsi_3_4h_gt_20 | (aroonu_14_1d < 90.0) | (roc_9_1d < 30.0))
+            & (rsi_3_4h_gt_20 | (aroonu_14_1d_lt_90) | (roc_9_1d_lt_30))
             # 4h & 1d down move, 1d overbought
-            & ((rsi_3_4h > 25.0) | (rsi_3_1d > 40.0) | (roc_9_1d < 10.0))
+            & ((rsi_3_4h_gt_25) | (rsi_3_1d > 40.0) | (roc_9_1d < 10.0))
             # 4h & 1d down move, 1d high
-            & ((rsi_3_4h > 25.0) | (rsi_3_1d > 45.0) | (aroonu_14_1d < 80.0))
+            & ((rsi_3_4h_gt_25) | (rsi_3_1d > 45.0) | (aroonu_14_1d_lt_80))
             # 4h down move, 15m high, 1d overbought
-            & ((rsi_3_4h > 30.0) | (stochrsi_k_15m < 90.0) | (roc_9_1d < 10.0))
+            & ((rsi_3_4h_gt_30) | (stochrsi_k_15m < 90.0) | (roc_9_1d < 10.0))
             # 4h down move, 4h still high, 1d downtrend
-            & ((rsi_3_4h > 35.0) | (stochrsi_k_4h < 40.0) | (roc_9_1d_gt_neg_30))
+            & ((rsi_3_4h_gt_35) | (stochrsi_k_4h < 40.0) | (roc_9_1d_gt_neg_30))
             # 4h down move, 4h high, 1d overbought
-            & ((rsi_3_4h > 40.0) | (aroonu_14_4h < 60.0) | (roc_9_1d < 40.0))
+            & ((rsi_3_4h_gt_40) | (aroonu_14_4h_lt_60) | (roc_9_1d_lt_40))
             # 4h & 1d down move, 1h high
             & ((rsi_3_4h > 45.0) | (rsi_3_1d > 45.0) | (stochrsi_k_1h_lt_70))
             # 4h down move, 1d high & overbought
-            & ((rsi_3_4h > 55.0) | (stochrsi_k_1d < 90.0) | (roc_9_1d < 80.0))
+            & ((rsi_3_4h > 55.0) | (stochrsi_k_1d_lt_90) | (roc_9_1d_lt_80))
             # 1d down move, 1d high, 1d downtrend
-            & ((rsi_3_1d > 15.0) | (aroonu_14_1d < 70.0) | (roc_9_1d_gt_neg_20))
+            & ((rsi_3_1d_gt_15) | (aroonu_14_1d_lt_70) | (roc_9_1d_gt_neg_20))
             # 1d down move, 1h high
-            & ((rsi_3_1d > 20.0) | (stochrsi_k_1h_lt_70))
+            & ((rsi_3_1d_gt_20) | (stochrsi_k_1h_lt_70))
             # 1d down move, 1h high, 1d downtrend
-            & ((rsi_3_1d > 25.0) | (stochrsi_k_1h < 60.0) | (roc_9_1d_gt_neg_30))
+            & ((rsi_3_1d_gt_25) | (stochrsi_k_1h < 60.0) | (roc_9_1d_gt_neg_30))
             # 1d down move, 1d high, 4h downtrend
-            & ((rsi_3_1d > 35.0) | (aroonu_14_1d < 70.0) | (roc_9_4h > -10.0))
+            & ((rsi_3_1d > 35.0) | (aroonu_14_1d_lt_70) | (roc_9_4h > -10.0))
             # 1d down move, 4h high, 1d overbought
-            & ((rsi_3_1d > 60.0) | aroonu_14_4h_lt_70 | (roc_9_1d < 40.0))
+            & ((rsi_3_1d > 60.0) | aroonu_14_4h_lt_70 | (roc_9_1d_lt_40))
             # 15m high, 1d high & overbought
-            & ((aroonu_14_15m < 70.0) | aroonu_14_1d_lt_100 | (roc_9_1d < 100.0))
+            & ((aroonu_14_15m_lt_70) | aroonu_14_1d_lt_100 | (roc_9_1d < 100.0))
             # 15m high, 4h overbought, 1d downtrend
             & ((aroonu_14_15m < 80.0) | (roc_9_4h_lt_20) | (roc_9_1d_gt_neg_30))
             # 1h & 4h high, 4h overbought
-            & (aroonu_14_1h_lt_70 | aroonu_14_4h_lt_100 | (roc_9_4h < 10.0))
+            & (aroonu_14_1h_lt_70 | aroonu_14_4h_lt_100 | (roc_9_4h_lt_10))
             # 1h high, 1d overbought
-            & ((aroonu_14_1h < 85.0) | (roc_9_1d < 80.0))
+            & ((aroonu_14_1h < 85.0) | (roc_9_1d_lt_80))
             # 1h high, 4h & 1d downtrend
-            & ((aroonu_14_1h < 100.0) | (roc_9_4h > -10.0) | (roc_9_1d > -25.0))
+            & ((aroonu_14_1h_lt_100) | (roc_9_4h > -10.0) | (roc_9_1d > -25.0))
             # 4h & 1d high, 1d overbought
             & (aroonu_14_4h_lt_100 | aroonu_14_1d_lt_100 | (roc_9_1d < 60.0))
             # 1h high, 4h & 1d downtrend
@@ -22534,49 +22586,49 @@ class NostalgiaForInfinityX7(IStrategy):
           # 5m down move, 15m high
           long_entry_logic.append((rsi_3 > 15.0) | (aroonu_14_15m < 80.0))
           # 15m & 1h down move, 4h high
-          long_entry_logic.append((rsi_3_15m > 25.0) | (rsi_3_1h > 35.0) | aroonu_14_4h_lt_70)
+          long_entry_logic.append((rsi_3_15m_gt_25) | (rsi_3_1h_gt_35) | aroonu_14_4h_lt_70)
           # 15m & 4h down move, 4h still high
-          long_entry_logic.append((rsi_3_15m > 25.0) | (rsi_3_4h > 50.0) | (aroonu_14_4h < 50.0))
+          long_entry_logic.append((rsi_3_15m_gt_25) | (rsi_3_4h_gt_50) | (aroonu_14_4h_lt_50))
           # 15m down move, 15m high
-          long_entry_logic.append((rsi_3_15m > 25.0) | (aroonu_14_15m < 80.0))
+          long_entry_logic.append((rsi_3_15m_gt_25) | (aroonu_14_15m < 80.0))
           # 15m down move, 4h still high, 1d high
-          long_entry_logic.append((rsi_3_15m > 25.0) | (stochrsi_k_4h < 50.0) | (aroonu_14_1d < 90.0))
+          long_entry_logic.append((rsi_3_15m_gt_25) | (stochrsi_k_4h_lt_50) | (aroonu_14_1d_lt_90))
           # 15m & 1h down move, 15m still high
-          long_entry_logic.append((rsi_3_15m > 30.0) | (rsi_3_1h > 60.0) | (aroonu_14_15m < 50.0))
+          long_entry_logic.append((rsi_3_15m_gt_30) | (rsi_3_1h > 60.0) | (aroonu_14_15m_lt_50))
           # 15m down move, 15m & 4h still high
-          long_entry_logic.append((rsi_3_15m > 30.0) | (stochrsi_k_15m < 50.0) | (stochrsi_k_4h < 50.0))
+          long_entry_logic.append((rsi_3_15m_gt_30) | (stochrsi_k_15m < 50.0) | (stochrsi_k_4h_lt_50))
           # 15m & 4h down move, 4h high
           long_entry_logic.append((rsi_3_15m > 35.0) | (rsi_3_4h > 60.0) | aroonu_14_4h_lt_80)
           # 15m & 1h down move, 1h high
-          long_entry_logic.append((rsi_3_15m > 40.0) | (rsi_3_1h > 40.0) | aroonu_14_1h_lt_70)
+          long_entry_logic.append((rsi_3_15m > 40.0) | (rsi_3_1h_gt_40) | aroonu_14_1h_lt_70)
           # 15m & 1h down move, 1h still high
-          long_entry_logic.append((rsi_3_15m > 40.0) | (rsi_3_1h > 40.0) | (stochrsi_k_1h_lt_50))
+          long_entry_logic.append((rsi_3_15m > 40.0) | (rsi_3_1h_gt_40) | (stochrsi_k_1h_lt_50))
           # 15m & 1h down move, 4h high
           long_entry_logic.append((rsi_3_15m > 40.0) | (rsi_3_1h > 60.0) | aroonu_14_4h_lt_80)
           # 15m & 4h down move, 15m high
-          long_entry_logic.append((rsi_3_15m > 40.0) | (rsi_3_4h > 40.0) | (stochrsi_k_15m < 50.0))
+          long_entry_logic.append((rsi_3_15m > 40.0) | (rsi_3_4h_gt_40) | (stochrsi_k_15m < 50.0))
           # 15m & 4h down move, 15m high
           long_entry_logic.append((rsi_3_15m > 40.0) | (rsi_3_4h > 60.0) | (stochrsi_k_15m < 70.0))
           # 15m down move, 15m & 1h still high
-          long_entry_logic.append((rsi_3_15m > 40.0) | (aroonu_14_15m < 50.0) | (stochrsi_k_1h_lt_50))
+          long_entry_logic.append((rsi_3_15m > 40.0) | (aroonu_14_15m_lt_50) | (stochrsi_k_1h_lt_50))
           # 15m down move, 15m & 1h still high
           long_entry_logic.append((rsi_3_15m > 40.0) | (stochrsi_k_15m < 50.0) | (stochrsi_k_1h_lt_50))
           # 15m down move, 4h still high, 1d overbought
-          long_entry_logic.append((rsi_3_15m > 40.0) | (aroonu_14_4h < 50.0) | (roc_9_1d_lt_100))
+          long_entry_logic.append((rsi_3_15m > 40.0) | (aroonu_14_4h_lt_50) | (roc_9_1d_lt_100))
           # 15m & 1h down move, 1h still high
-          long_entry_logic.append((rsi_3_15m > 45.0) | (rsi_3_1h > 45.0) | (stochrsi_k_1h < 40.0))
+          long_entry_logic.append((rsi_3_15m > 45.0) | (rsi_3_1h_gt_45) | (stochrsi_k_1h < 40.0))
           # 15m down move, 15m high, 1d overbought
           long_entry_logic.append((rsi_3_15m > 45.0) | (aroonu_14_15m < 60.0) | roc_9_1d_lt_50)
           # 15m down move, 15m high, 4h still high
-          long_entry_logic.append((rsi_3_15m > 45.0) | (aroonu_14_15m < 70.0) | (stochrsi_k_4h < 50.0))
+          long_entry_logic.append((rsi_3_15m > 45.0) | (aroonu_14_15m_lt_70) | (stochrsi_k_4h_lt_50))
           # 15m down move, 15m still not low enough, 4h still high
-          long_entry_logic.append((rsi_3_15m > 45.0) | (stochrsi_k_15m < 30.0) | (stochrsi_k_4h < 50.0))
+          long_entry_logic.append((rsi_3_15m > 45.0) | (stochrsi_k_15m < 30.0) | (stochrsi_k_4h_lt_50))
           # 15m down move, 15m & 1h still high
           long_entry_logic.append((rsi_3_15m > 45.0) | (stochrsi_k_15m < 45.0) | (stochrsi_k_1h < 40.0))
           # 15m down move, 15m still not low enough, 4h high
           long_entry_logic.append((rsi_3_15m > 50.0) | (stochrsi_k_15m < 30.0) | (stochrsi_k_4h_lt_90))
           # 15m down move, 15m still high, 1d overbought
-          long_entry_logic.append((rsi_3_15m > 50.0) | (aroonu_14_15m < 50.0) | roc_9_1d_lt_50)
+          long_entry_logic.append((rsi_3_15m > 50.0) | (aroonu_14_15m_lt_50) | roc_9_1d_lt_50)
           # 15m down move, 15m still high, 1h high
           long_entry_logic.append((rsi_3_15m > 55.0) | (stochrsi_k_15m < 40.0) | (stochrsi_k_1h_lt_70))
           # 15m down move, 15m still high, 4h high
@@ -22584,68 +22636,68 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m down move, 15m & 1h still high
           long_entry_logic.append((rsi_3_15m > 55.0) | (stochrsi_k_15m < 50.0) | (stochrsi_k_1h_lt_50))
           # 1h down move, 4h still high, 1d high
-          long_entry_logic.append((rsi_3_1h > 25.0) | (aroonu_14_4h < 50.0) | (stochrsi_k_1d < 90.0))
+          long_entry_logic.append((rsi_3_1h_gt_25) | (aroonu_14_4h_lt_50) | (stochrsi_k_1d_lt_90))
           # 1h & 4h down move, 1h still high
-          long_entry_logic.append((rsi_3_1h > 30.0) | (rsi_3_4h > 65.0) | (aroonu_14_1h < 50.0))
-          long_entry_logic.append((rsi_3_1h > 30.0) | (stochrsi_k_1h < 40.0) | (stochrsi_k_1d < 90.0))
+          long_entry_logic.append((rsi_3_1h_gt_30) | (rsi_3_4h > 65.0) | (aroonu_14_1h_lt_50))
+          long_entry_logic.append((rsi_3_1h_gt_30) | (stochrsi_k_1h < 40.0) | (stochrsi_k_1d_lt_90))
           # 1h & 4h down move, 4h still high
-          long_entry_logic.append((rsi_3_1h > 35.0) | (rsi_3_4h > 55.0) | (stochrsi_k_4h < 50.0))
+          long_entry_logic.append((rsi_3_1h_gt_35) | (rsi_3_4h > 55.0) | (stochrsi_k_4h_lt_50))
           # 1h & 4h down move, 4h high
-          long_entry_logic.append((rsi_3_1h > 35.0) | (rsi_3_4h > 60.0) | (stochrsi_k_4h_lt_80))
+          long_entry_logic.append((rsi_3_1h_gt_35) | (rsi_3_4h > 60.0) | (stochrsi_k_4h_lt_80))
           # 1h down move, 15m & 1h still high
-          long_entry_logic.append((rsi_3_1h > 40.0) | (stochrsi_k_15m < 50.0) | (stochrsi_k_1h_lt_50))
+          long_entry_logic.append((rsi_3_1h_gt_40) | (stochrsi_k_15m < 50.0) | (stochrsi_k_1h_lt_50))
           # 1h down move, 1h still high, 4h high
-          long_entry_logic.append((rsi_3_1h > 40.0) | (stochrsi_k_1h_lt_50) | (stochrsi_k_4h < 70.0))
+          long_entry_logic.append((rsi_3_1h_gt_40) | (stochrsi_k_1h_lt_50) | (stochrsi_k_4h_lt_70))
           # 1h down move, 1h high
-          long_entry_logic.append((rsi_3_1h > 40.0) | (stochrsi_k_1h < 60.0))
+          long_entry_logic.append((rsi_3_1h_gt_40) | (stochrsi_k_1h < 60.0))
           # 1h down move, 4h & 1d high
-          long_entry_logic.append((rsi_3_1h > 40.0) | (aroonu_14_4h < 85.0) | (aroonu_14_1d < 90.0))
+          long_entry_logic.append((rsi_3_1h_gt_40) | (aroonu_14_4h < 85.0) | (aroonu_14_1d_lt_90))
           # 1h down move, 1h still high, 4h high
-          long_entry_logic.append((rsi_3_1h > 45.0) | (aroonu_14_1h < 50.0) | (aroonu_14_4h < 90.0))
+          long_entry_logic.append((rsi_3_1h_gt_45) | (aroonu_14_1h_lt_50) | (aroonu_14_4h_lt_90))
           # 1h down move, 1h still high, 1d high
-          long_entry_logic.append((rsi_3_1h > 45.0) | (aroonu_14_1h < 50.0) | (aroonu_14_1d < 90.0))
+          long_entry_logic.append((rsi_3_1h_gt_45) | (aroonu_14_1h_lt_50) | (aroonu_14_1d_lt_90))
           # 1h down move, 1h high
-          long_entry_logic.append((rsi_3_1h > 45.0) | (stochrsi_k_1h < 60.0))
+          long_entry_logic.append((rsi_3_1h_gt_45) | (stochrsi_k_1h < 60.0))
           # 1h & 4h down move, 15m high
-          long_entry_logic.append((rsi_3_1h > 50.0) | (rsi_3_4h > 60.0) | (aroonu_14_15m < 70.0))
+          long_entry_logic.append((rsi_3_1h_gt_50) | (rsi_3_4h > 60.0) | (aroonu_14_15m_lt_70))
           # 1h down move, 15m still high, 4h high
-          long_entry_logic.append((rsi_3_1h > 50.0) | (aroonu_14_15m < 50.0) | aroonu_14_4h_lt_80)
+          long_entry_logic.append((rsi_3_1h_gt_50) | (aroonu_14_15m_lt_50) | aroonu_14_4h_lt_80)
           # 1h down move, 15m high, 1h still high
-          long_entry_logic.append((rsi_3_1h > 50.0) | (aroonu_14_15m < 70.0) | (stochrsi_k_1h < 40.0))
+          long_entry_logic.append((rsi_3_1h_gt_50) | (aroonu_14_15m_lt_70) | (stochrsi_k_1h < 40.0))
           # 1h down move, 15m still high, 4h high
-          long_entry_logic.append((rsi_3_1h > 50.0) | (stochrsi_k_15m < 50.0) | (stochrsi_k_4h_lt_80))
+          long_entry_logic.append((rsi_3_1h_gt_50) | (stochrsi_k_15m < 50.0) | (stochrsi_k_4h_lt_80))
           # 1h down move, 15m & 1h high
-          long_entry_logic.append((rsi_3_1h > 50.0) | (stochrsi_k_15m < 60.0) | (aroonu_14_1h < 60.0))
+          long_entry_logic.append((rsi_3_1h_gt_50) | (stochrsi_k_15m < 60.0) | (aroonu_14_1h < 60.0))
           # 1h down move, 1h & 1d high
-          long_entry_logic.append((rsi_3_1h > 50.0) | aroonu_14_1h_lt_70 | (stochrsi_k_1d < 80.0))
+          long_entry_logic.append((rsi_3_1h_gt_50) | aroonu_14_1h_lt_70 | (stochrsi_k_1d < 80.0))
           # 1h down move, 4h still high, 1d high
-          long_entry_logic.append((rsi_3_1h > 50.0) | (stochrsi_k_4h < 50.0) | (stochrsi_k_1d < 90.0))
+          long_entry_logic.append((rsi_3_1h_gt_50) | (stochrsi_k_4h_lt_50) | (stochrsi_k_1d_lt_90))
           # 1h down move, 1h still high, 1d high
-          long_entry_logic.append((rsi_3_1h > 50.0) | (aroonu_14_1h < 50.0) | (aroonu_14_1d < 90.0))
+          long_entry_logic.append((rsi_3_1h_gt_50) | (aroonu_14_1h_lt_50) | (aroonu_14_1d_lt_90))
           # 1h down move, 4h overbought
-          long_entry_logic.append((rsi_3_1h > 50.0) | (roc_9_4h < 40.0))
+          long_entry_logic.append((rsi_3_1h_gt_50) | (roc_9_4h_lt_40))
           # 1h down move, 1h & 4h high
           long_entry_logic.append((rsi_3_1h > 55.0) | aroonu_14_1h_lt_70 | aroonu_14_4h_lt_100)
           # 1h down move, 5m up move, 1h still high
           long_entry_logic.append((rsi_3_1h > 60.0) | (rsi_3 < 60.0) | (stochrsi_k_1h_lt_50))
           # 1h down move, 15m still not low enough, 4h high
-          long_entry_logic.append((rsi_3_1h > 60.0) | (aroonu_14_15m < 70.0) | (stochrsi_k_4h_lt_90))
+          long_entry_logic.append((rsi_3_1h > 60.0) | (aroonu_14_15m_lt_70) | (stochrsi_k_4h_lt_90))
           # 1h down move, 15m still not low enough, 1h high
           long_entry_logic.append((rsi_3_1h > 60.0) | (stochrsi_k_15m < 30.0) | aroonu_14_1h_lt_70)
           # 1h down move, 15m still not low enough, 1h high
           long_entry_logic.append((rsi_3_1h > 60.0) | (stochrsi_k_15m < 30.0) | (stochrsi_k_1h < 60.0))
           # 1h down move, 15m & 4h still high
-          long_entry_logic.append((rsi_3_1h > 60.0) | (stochrsi_k_15m < 50.0) | (stochrsi_k_4h < 50.0))
+          long_entry_logic.append((rsi_3_1h > 60.0) | (stochrsi_k_15m < 50.0) | (stochrsi_k_4h_lt_50))
           # 1h down move, 15m & 1h high
-          long_entry_logic.append((rsi_3_1h > 60.0) | (aroonu_14_15m < 70.0) | (aroonu_14_1h < 90.0))
+          long_entry_logic.append((rsi_3_1h > 60.0) | (aroonu_14_15m_lt_70) | (aroonu_14_1h_lt_90))
           # 1h down move, 1h still high, 4h high
-          long_entry_logic.append((rsi_3_1h > 60.0) | (aroonu_14_1h < 50.0) | (stochrsi_k_4h_lt_90))
+          long_entry_logic.append((rsi_3_1h > 60.0) | (aroonu_14_1h_lt_50) | (stochrsi_k_4h_lt_90))
           # 1h down move, 1h high, 4h still high
-          long_entry_logic.append((rsi_3_1h > 60.0) | aroonu_14_1h_lt_80 | (aroonu_14_4h < 40.0))
+          long_entry_logic.append((rsi_3_1h > 60.0) | aroonu_14_1h_lt_80 | (aroonu_14_4h_lt_40))
           # 1h down move, 1h still high, 4h high
           long_entry_logic.append((rsi_3_1h > 60.0) | (stochrsi_k_1h < 40.0) | aroonu_14_4h_lt_70)
           # 1h down move, 1h & 1d high
-          long_entry_logic.append((rsi_3_1h > 60.0) | (stochrsi_k_1h_lt_70) | (aroonu_14_1d < 90.0))
+          long_entry_logic.append((rsi_3_1h > 60.0) | (stochrsi_k_1h_lt_70) | (aroonu_14_1d_lt_90))
           # 1h down move, 4h & 1d high
           long_entry_logic.append((rsi_3_1h > 60.0) | (rsi_14_4h < 70.0) | (rsi_14_1d < 80.0))
           # 15m & 1h & 4h down move, 4h high
@@ -22653,75 +22705,75 @@ class NostalgiaForInfinityX7(IStrategy):
           # 4h down move, 15m high
           long_entry_logic.append(rsi_3_4h_gt_20 | (aroonu_14_15m < 80.0))
           # 4h down move, 1h high
-          long_entry_logic.append((rsi_3_4h > 25.0) | (stochrsi_k_1h_lt_80))
+          long_entry_logic.append((rsi_3_4h_gt_25) | (stochrsi_k_1h_lt_80))
           # 4h down move, 15m & 4h still high
-          long_entry_logic.append((rsi_3_4h > 30.0) | (aroonu_14_15m < 50.0) | (aroonu_14_4h < 50.0))
+          long_entry_logic.append((rsi_3_4h_gt_30) | (aroonu_14_15m_lt_50) | (aroonu_14_4h_lt_50))
           # 4h down move, 15m still high, 1d overbought
-          long_entry_logic.append((rsi_3_4h > 30.0) | (stochrsi_k_15m < 50.0) | (roc_9_1d < 10.0))
+          long_entry_logic.append((rsi_3_4h_gt_30) | (stochrsi_k_15m < 50.0) | (roc_9_1d < 10.0))
           # 4h down move, 1h & 4h still high
-          long_entry_logic.append((rsi_3_4h > 35.0) | (stochrsi_k_1h_lt_50) | (aroonu_14_4h < 50.0))
+          long_entry_logic.append((rsi_3_4h_gt_35) | (stochrsi_k_1h_lt_50) | (aroonu_14_4h_lt_50))
           # 4h down move, 1d high & overbought
-          long_entry_logic.append((rsi_3_4h > 35.0) | (stochrsi_k_1d < 80.0) | (roc_9_1d < 40.0))
+          long_entry_logic.append((rsi_3_4h_gt_35) | (stochrsi_k_1d < 80.0) | (roc_9_1d_lt_40))
           # 4h down move, 15m & 1h high
-          long_entry_logic.append((rsi_3_4h > 40.0) | (aroonu_14_15m < 80.0) | (stochrsi_k_1h_lt_70))
+          long_entry_logic.append((rsi_3_4h_gt_40) | (aroonu_14_15m < 80.0) | (stochrsi_k_1h_lt_70))
           # 4h down move, 1d high & overbought
-          long_entry_logic.append((rsi_3_4h > 40.0) | (aroonu_14_1d < 80.0) | (roc_9_1d < 20.0))
+          long_entry_logic.append((rsi_3_4h_gt_40) | (aroonu_14_1d_lt_80) | (roc_9_1d_lt_20))
           # 4h down move, 15m still high, 1h high
-          long_entry_logic.append((rsi_3_4h > 40.0) | (stochrsi_k_15m < 40.0) | (stochrsi_k_1h_lt_80))
+          long_entry_logic.append((rsi_3_4h_gt_40) | (stochrsi_k_15m < 40.0) | (stochrsi_k_1h_lt_80))
           # 4h down move, 1h & 4h still high
-          long_entry_logic.append((rsi_3_4h > 40.0) | (stochrsi_k_1h_lt_50) | (rsi_14_4h < 50.0))
+          long_entry_logic.append((rsi_3_4h_gt_40) | (stochrsi_k_1h_lt_50) | (rsi_14_4h < 50.0))
           # 4h down move, 1h still high, 4h still moving down
-          long_entry_logic.append((rsi_3_4h > 40.0) | (stochrsi_k_1h_lt_50) | (cci_20_change_pct_4h > -0.0))
+          long_entry_logic.append((rsi_3_4h_gt_40) | (stochrsi_k_1h_lt_50) | (cci_20_change_pct_4h > -0.0))
           # 4h down move, 1d high & overbought
-          long_entry_logic.append((rsi_3_4h > 40.0) | (stochrsi_k_1d < 80.0) | (roc_9_1d < 10.0))
+          long_entry_logic.append((rsi_3_4h_gt_40) | (stochrsi_k_1d < 80.0) | (roc_9_1d < 10.0))
           # 4h down move, 1h high, 4h still high
-          long_entry_logic.append((rsi_3_4h > 45.0) | aroonu_14_1h_lt_70 | (aroonu_14_4h < 50.0))
+          long_entry_logic.append((rsi_3_4h > 45.0) | aroonu_14_1h_lt_70 | (aroonu_14_4h_lt_50))
           # 4h down move, 15m high, 4h still high
-          long_entry_logic.append((rsi_3_4h > 50.0) | (aroonu_14_15m < 70.0) | (stochrsi_k_4h < 40.0))
+          long_entry_logic.append((rsi_3_4h_gt_50) | (aroonu_14_15m_lt_70) | (stochrsi_k_4h < 40.0))
           # 4h down move, 15m still high, 1h high
-          long_entry_logic.append((rsi_3_4h > 50.0) | (stochrsi_k_15m < 40.0) | (stochrsi_k_1h_lt_70))
+          long_entry_logic.append((rsi_3_4h_gt_50) | (stochrsi_k_15m < 40.0) | (stochrsi_k_1h_lt_70))
           # 4h down move, 15m & 4h still high
-          long_entry_logic.append((rsi_3_4h > 50.0) | (stochrsi_k_15m < 50.0) | (aroonu_14_4h < 50.0))
+          long_entry_logic.append((rsi_3_4h_gt_50) | (stochrsi_k_15m < 50.0) | (aroonu_14_4h_lt_50))
           # 4h down move, 15m high, 4h still not low enough
-          long_entry_logic.append((rsi_3_4h > 50.0) | (stochrsi_k_15m < 70.0) | (stochrsi_k_4h < 30.0))
+          long_entry_logic.append((rsi_3_4h_gt_50) | (stochrsi_k_15m < 70.0) | (stochrsi_k_4h < 30.0))
           # 4h down move, 1h still high, 4h high
-          long_entry_logic.append((rsi_3_4h > 50.0) | (stochrsi_k_1h_lt_50) | aroonu_14_4h_lt_70)
+          long_entry_logic.append((rsi_3_4h_gt_50) | (stochrsi_k_1h_lt_50) | aroonu_14_4h_lt_70)
           # 4h down move, 15m & 1d high
-          long_entry_logic.append((rsi_3_4h > 50.0) | (aroonu_14_15m < 70.0) | (aroonu_14_1d < 90.0))
+          long_entry_logic.append((rsi_3_4h_gt_50) | (aroonu_14_15m_lt_70) | (aroonu_14_1d_lt_90))
           # 4h down move, 1d high & overbought
-          long_entry_logic.append((rsi_3_4h > 50.0) | (aroonu_14_1d < 90.0) | (roc_9_1d < 20.0))
+          long_entry_logic.append((rsi_3_4h_gt_50) | (aroonu_14_1d_lt_90) | (roc_9_1d_lt_20))
           # 4h down move, 15m & 4h high
-          long_entry_logic.append((rsi_3_4h > 60.0) | (aroonu_14_15m < 70.0) | aroonu_14_4h_lt_70)
+          long_entry_logic.append((rsi_3_4h > 60.0) | (aroonu_14_15m_lt_70) | aroonu_14_4h_lt_70)
           # 4h down move, 15m high, 4h still high
-          long_entry_logic.append((rsi_3_4h > 60.0) | (aroonu_14_15m < 80.0) | (aroonu_14_4h < 40.0))
+          long_entry_logic.append((rsi_3_4h > 60.0) | (aroonu_14_15m < 80.0) | (aroonu_14_4h_lt_40))
           # 4h down move, 15m still high, 1h high
           long_entry_logic.append((rsi_3_4h > 60.0) | (stochrsi_k_15m < 50.0) | aroonu_14_1h_lt_70)
           # 4h down move, 15m still high, 4h high
-          long_entry_logic.append((rsi_3_4h > 60.0) | (stochrsi_k_15m < 50.0) | (stochrsi_k_4h < 70.0))
+          long_entry_logic.append((rsi_3_4h > 60.0) | (stochrsi_k_15m < 50.0) | (stochrsi_k_4h_lt_70))
           # 4h down move, 15m & 4h high
           long_entry_logic.append((rsi_3_4h > 60.0) | (stochrsi_k_15m < 70.0) | (stochrsi_k_4h < 60.0))
           # 4h down move, 1h & 4h high
           long_entry_logic.append((rsi_3_4h > 60.0) | (stochrsi_k_1h_lt_70) | aroonu_14_4h_lt_70)
           # 4h down move, 4h still high, 1d high
-          long_entry_logic.append((rsi_3_4h > 60.0) | (stochrsi_k_4h < 50.0) | (stochrsi_k_1d < 80.0))
+          long_entry_logic.append((rsi_3_4h > 60.0) | (stochrsi_k_4h_lt_50) | (stochrsi_k_1d < 80.0))
           # 15m still high, 1d high & overbought
-          long_entry_logic.append((aroonu_14_15m < 50.0) | aroonu_14_1d_lt_100 | (roc_9_1d < 100.0))
+          long_entry_logic.append((aroonu_14_15m_lt_50) | aroonu_14_1d_lt_100 | (roc_9_1d < 100.0))
           # 15m high, 4h high
-          long_entry_logic.append((aroonu_14_15m < 70.0) | (aroonu_14_4h < 85.0))
+          long_entry_logic.append((aroonu_14_15m_lt_70) | (aroonu_14_4h < 85.0))
           # 15m & 1d high, 1d overbought
-          long_entry_logic.append((aroonu_14_15m < 70.0) | (aroonu_14_1d < 90.0) | (roc_9_1d < 20.0))
+          long_entry_logic.append((aroonu_14_15m_lt_70) | (aroonu_14_1d_lt_90) | (roc_9_1d_lt_20))
           # 15m & 1d high, 4h overbought
-          long_entry_logic.append((aroonu_14_15m < 70.0) | aroonu_14_1d_lt_100 | (roc_9_4h < 10.0))
+          long_entry_logic.append((aroonu_14_15m_lt_70) | aroonu_14_1d_lt_100 | (roc_9_4h_lt_10))
           # 15m high, 4h still high
-          long_entry_logic.append((aroonu_14_15m < 80.0) | (stochrsi_k_4h < 50.0))
+          long_entry_logic.append((aroonu_14_15m < 80.0) | (stochrsi_k_4h_lt_50))
           # 4h & 1d high, 1d overbought
-          long_entry_logic.append(aroonu_14_4h_lt_100 | aroonu_14_1d_lt_100 | (roc_9_1d < 20.0))
+          long_entry_logic.append(aroonu_14_4h_lt_100 | aroonu_14_1d_lt_100 | (roc_9_1d_lt_20))
           # 4h high, 4h overbought
-          long_entry_logic.append(aroonu_14_4h_lt_70 | (roc_9_4h < 40.0))
+          long_entry_logic.append(aroonu_14_4h_lt_70 | (roc_9_4h_lt_40))
           # 4h high, 1d overbought
-          long_entry_logic.append(aroonu_14_4h_lt_70 | (roc_9_1d < 40.0))
+          long_entry_logic.append(aroonu_14_4h_lt_70 | (roc_9_1d_lt_40))
           # 1d high, 4h overbought
-          long_entry_logic.append((aroonu_14_1d < 90.0) | (roc_9_4h < 40.0))
+          long_entry_logic.append((aroonu_14_1d_lt_90) | (roc_9_4h_lt_40))
           # 1d high & overbought
           long_entry_logic.append(aroonu_14_1d_lt_100 | (roc_9_1d < 200.0))
           # 15m high, 1h still high
@@ -22733,11 +22785,11 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m high, 1h still not low enough
           long_entry_logic.append((stochrsi_k_15m < 80.0) | (stochrsi_k_1h < 30.0))
           # 1d high, 4h overbought
-          long_entry_logic.append((stochrsi_k_1d < 80.0) | (roc_9_4h < 40.0))
+          long_entry_logic.append((stochrsi_k_1d < 80.0) | (roc_9_4h_lt_40))
           # 1d high & overbought
-          long_entry_logic.append((stochrsi_k_1d < 90.0) | (roc_9_1d < 30.0))
+          long_entry_logic.append((stochrsi_k_1d_lt_90) | (roc_9_1d_lt_30))
           # 4h & 1d overbought
-          long_entry_logic.append((roc_9_4h < 40.0) | (roc_9_1d < 40.0))
+          long_entry_logic.append((roc_9_4h_lt_40) | (roc_9_1d_lt_40))
           # 1d green with top wick, 1d overbought
           long_entry_logic.append((change_pct_1d < 25.0) | (top_wick_pct_1d < 25.0) | roc_9_1d_lt_50)
 
@@ -22765,137 +22817,137 @@ class NostalgiaForInfinityX7(IStrategy):
           long_entry_logic.append(num_empty_288 <= allowed_empty_candles_288)
           long_entry_logic.append(protections_long_global == True)
 
-          long_entry_logic.append((rsi_3 > 5.0) & (rsi_3_15m > 5.0) & (roc_9_15m > -10.0) & (roc_9_1d < 200.0))
+          long_entry_logic.append((rsi_3 > 5.0) & (rsi_3_15m_gt_5) & (roc_9_15m > -10.0) & (roc_9_1d < 200.0))
 
           long_entry_logic.append(
             # 15m & 1h down move, 4h high
-            ((rsi_3_15m > 10.0) | rsi_3_1h_gt_20 | (stochrsi_k_4h < 70.0))
+            ((rsi_3_15m_gt_10) | rsi_3_1h_gt_20 | (stochrsi_k_4h_lt_70))
             # 15m & 4h down move, 1h still high
-            & ((rsi_3_15m > 10.0) | (rsi_3_4h > 40.0) | (rsi_14_1h < 50.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_4h_gt_40) | (rsi_14_1h < 50.0))
             # 15m & 1d down move, 4h high
-            & ((rsi_3_15m > 10.0) | (rsi_3_1d > 20.0) | (aroonu_14_4h < 90.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_1d_gt_20) | (aroonu_14_4h_lt_90))
             # 15m down move, 15m still high, 1h high
-            & ((rsi_3_15m > 10.0) | (aroonu_14_15m < 50.0) | aroonu_14_1h_lt_80)
+            & ((rsi_3_15m_gt_10) | (aroonu_14_15m_lt_50) | aroonu_14_1h_lt_80)
             # 15m down move, 15m high
-            & ((rsi_3_15m > 10.0) | (aroonu_14_15m < 70.0))
+            & ((rsi_3_15m_gt_10) | (aroonu_14_15m_lt_70))
             # 15m down move, 1h & 1d high
-            & ((rsi_3_15m > 10.0) | (aroonu_14_1h < 90.0) | aroonu_14_1d_lt_100)
+            & ((rsi_3_15m_gt_10) | (aroonu_14_1h_lt_90) | aroonu_14_1d_lt_100)
             # 15m down move, 4h & 1d high
-            & ((rsi_3_15m > 10.0) | (aroonu_14_4h < 75.0) | aroonu_14_1d_lt_100)
+            & ((rsi_3_15m_gt_10) | (aroonu_14_4h < 75.0) | aroonu_14_1d_lt_100)
             # 15m down move, 1d high, 1d downtrend
-            & ((rsi_3_15m > 10.0) | (aroonu_14_1d < 85.0) | (cmf_20_1d > -0.40))
+            & ((rsi_3_15m_gt_10) | (aroonu_14_1d < 85.0) | (cmf_20_1d > -0.40))
             # 15m & 1h down move, 15m still not low enough
-            & ((rsi_3_15m > 15.0) | rsi_3_1h_gt_20 | (stochrsi_k_15m < 30.0))
+            & ((rsi_3_15m_gt_15) | rsi_3_1h_gt_20 | (stochrsi_k_15m < 30.0))
             # 15m & 1h down nove, 1h still high
-            & ((rsi_3_15m > 15.0) | rsi_3_1h_gt_20 | (stochrsi_k_1h_lt_50))
+            & ((rsi_3_15m_gt_15) | rsi_3_1h_gt_20 | (stochrsi_k_1h_lt_50))
             # 15m & 1h down move, 4h high
-            & ((rsi_3_15m > 15.0) | (rsi_3_1h > 30.0) | aroonu_14_4h_lt_100)
+            & ((rsi_3_15m_gt_15) | (rsi_3_1h_gt_30) | aroonu_14_4h_lt_100)
             # 15m & 1h down move, 4h high
-            & ((rsi_3_15m > 15.0) | (rsi_3_1h > 35.0) | (stochrsi_k_4h_lt_90))
+            & ((rsi_3_15m_gt_15) | (rsi_3_1h_gt_35) | (stochrsi_k_4h_lt_90))
             # 15m down move, 4h high, 4h downtrend
-            & ((rsi_3_15m > 15.0) | (aroonu_14_4h < 60.0) | (roc_9_4h_gt_neg_20))
+            & ((rsi_3_15m_gt_15) | (aroonu_14_4h_lt_60) | (roc_9_4h_gt_neg_20))
             # 15m down move, 4h & 1d downtrend
-            & ((rsi_3_15m > 15.0) | (roc_9_4h > -10.0) | (roc_9_1d > -40.0))
+            & ((rsi_3_15m_gt_15) | (roc_9_4h > -10.0) | (roc_9_1d_gt_neg_40))
             # 15m & 1h down move, 1h high
-            & ((rsi_3_15m > 20.0) | (rsi_3_1h > 25.0) | aroonu_14_1h_lt_70)
+            & ((rsi_3_15m_gt_20) | (rsi_3_1h_gt_25) | aroonu_14_1h_lt_70)
             # 15m down move, 4h high & overbought
-            & ((rsi_3_15m > 20.0) | aroonu_14_4h_lt_70 | (roc_9_4h_lt_20))
+            & ((rsi_3_15m_gt_20) | aroonu_14_4h_lt_70 | (roc_9_4h_lt_20))
             # 15m & 1h down move, 4h high
-            & ((rsi_3_15m > 25.0) | (rsi_3_1h > 25.0) | (stochrsi_k_4h_lt_90))
+            & ((rsi_3_15m_gt_25) | (rsi_3_1h_gt_25) | (stochrsi_k_4h_lt_90))
             # 15m down move, 15m high, 1d overbought
-            & ((rsi_3_15m > 25.0) | (aroonu_14_15m < 60.0) | (roc_9_1d < 150.0))
+            & ((rsi_3_15m_gt_25) | (aroonu_14_15m < 60.0) | (roc_9_1d < 150.0))
             # 15m down move, 1h & 4h high
             & ((rsi_3_15m > 35.0) | aroonu_14_1h_lt_80 | (rsi_14_4h < 80.0))
             # 1h & 4h down move, 15m stil high
-            & ((rsi_3_1h > 3.0) | (rsi_3_4h_gt_10) | (stochrsi_k_15m < 50.0))
+            & ((rsi_3_1h_gt_3) | (rsi_3_4h_gt_10) | (stochrsi_k_15m < 50.0))
             # 1h & 4h down move, 1h still high
-            & ((rsi_3_1h > 3.0) | (rsi_3_4h > 25.0) | (aroonu_14_1h < 40.0))
+            & ((rsi_3_1h_gt_3) | (rsi_3_4h_gt_25) | (aroonu_14_1h < 40.0))
             # 1h & 4h down move, 4h high
-            & ((rsi_3_1h > 5.0) | rsi_3_4h_gt_20 | (aroonu_14_4h < 60.0))
+            & ((rsi_3_1h_gt_5) | rsi_3_4h_gt_20 | (aroonu_14_4h_lt_60))
             # 1h & 4h down move, 4h high
-            & ((rsi_3_1h > 5.0) | (rsi_3_4h > 30.0) | (aroonu_14_4h < 90.0))
+            & ((rsi_3_1h_gt_5) | (rsi_3_4h_gt_30) | (aroonu_14_4h_lt_90))
             # 1h down move, 4h high, 1d overbought
-            & ((rsi_3_1h > 5.0) | (aroonu_14_4h < 60.0) | (roc_9_1d < 10.0))
+            & ((rsi_3_1h_gt_5) | (aroonu_14_4h_lt_60) | (roc_9_1d < 10.0))
             # 1h & 4h down move, 4h still high
-            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_10) | (aroonu_14_4h < 50.0))
+            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_10) | (aroonu_14_4h_lt_50))
             # 1h & 3h down move, 1d high
-            & ((rsi_3_1h_gt_10) | (rsi_3_4h > 40.0) | (aroonu_14_1d < 80.0))
+            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_40) | (aroonu_14_1d_lt_80))
             # 1h & 4h down move, 4h high
             & ((rsi_3_1h_gt_15) | rsi_3_4h_gt_20 | aroonu_14_4h_lt_70)
             # 1h down move, 1h downtrend, 1d overbought
-            & ((rsi_3_1h_gt_15) | (roc_9_1h > -30.0) | (roc_9_1d < 80.0))
+            & ((rsi_3_1h_gt_15) | (roc_9_1h > -30.0) | (roc_9_1d_lt_80))
             # 1h & 4h down move, 4h high
-            & (rsi_3_1h_gt_20 | (rsi_3_4h > 35.0) | aroonu_14_4h_lt_70)
+            & (rsi_3_1h_gt_20 | (rsi_3_4h_gt_35) | aroonu_14_4h_lt_70)
             # 1h & 4h down move, 1d downtrend
-            & ((rsi_3_1h_gt_15) | (rsi_3_4h > 25.0) | (roc_9_1d > -30.0))
+            & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_25) | (roc_9_1d > -30.0))
             # 1h down move, 1h & 1d high
             & ((rsi_3_1h_gt_15) | (aroonu_14_1h < 60.0) | (aroonu_14_1d < 85.0))
             # 1h down move, 1h high, 1d overbought
             & ((rsi_3_1h_gt_15) | (aroonu_14_1h < 60.0) | roc_9_1d_lt_50)
             # 1h down move, 1d high & overbought
-            & ((rsi_3_1h_gt_15) | (stochrsi_k_1d < 90.0) | (roc_9_1d < 40.0))
+            & ((rsi_3_1h_gt_15) | (stochrsi_k_1d_lt_90) | (roc_9_1d_lt_40))
             # 1h down move, 1h high, 1d overbought
-            & ((rsi_3_1h > 25.0) | (aroonu_14_1h < 60.0) | (roc_9_1d_lt_100))
+            & ((rsi_3_1h_gt_25) | (aroonu_14_1h < 60.0) | (roc_9_1d_lt_100))
             # 1h down move, 1h high
-            & ((rsi_3_1h > 25.0) | (aroonu_14_1h < 90.0))
+            & ((rsi_3_1h_gt_25) | (aroonu_14_1h_lt_90))
             # 1h & 4h down move, 4h high
-            & ((rsi_3_1h > 30.0) | (rsi_3_4h > 35.0) | (stochrsi_k_4h < 70.0))
+            & ((rsi_3_1h_gt_30) | (rsi_3_4h_gt_35) | (stochrsi_k_4h_lt_70))
             # 1h down move, 1h high, 4h overbought
-            & ((rsi_3_1h > 30.0) | (aroonu_14_1h < 60.0) | (roc_9_4h < 50.0))
+            & ((rsi_3_1h_gt_30) | (aroonu_14_1h < 60.0) | (roc_9_4h < 50.0))
             # 1h down move, 4h high & overbought
-            & ((rsi_3_1h > 35.0) | (stochrsi_k_4h_lt_80) | (roc_9_4h < 30.0))
+            & ((rsi_3_1h_gt_35) | (stochrsi_k_4h_lt_80) | (roc_9_4h_lt_30))
             # 1h down move, 1h high, 4h downtrend
-            & ((rsi_3_1h > 40.0) | (stochrsi_k_1h < 80.0) | (roc_9_4h_gt_neg_20))
+            & ((rsi_3_1h_gt_40) | (stochrsi_k_1h < 80.0) | (roc_9_4h_gt_neg_20))
             # 1h down move, 15m still high, 1d overbought
-            & ((rsi_3_1h > 45.0) | (aroonu_14_15m < 50.0) | roc_9_1d_lt_50)
+            & ((rsi_3_1h_gt_45) | (aroonu_14_15m_lt_50) | roc_9_1d_lt_50)
             # 1h down move, 4h & 1d overbought
-            & ((rsi_3_1h > 45.0) | (roc_9_4h < 10.0) | roc_9_1d_lt_50)
+            & ((rsi_3_1h_gt_45) | (roc_9_4h_lt_10) | roc_9_1d_lt_50)
             # 1h down move,  4h high, 1d overbought
-            & ((rsi_3_1h > 50.0) | (stochrsi_k_4h_lt_90) | (roc_9_1d < 150.0))
+            & ((rsi_3_1h_gt_50) | (stochrsi_k_4h_lt_90) | (roc_9_1d < 150.0))
             # 4h down move, 1d high
-            & ((rsi_3_4h > 3.0) | (aroonu_14_1d < 90.0))
+            & ((rsi_3_4h > 3.0) | (aroonu_14_1d_lt_90))
             # 4h down move, 15m still high
             & ((rsi_3_4h > 3.0) | (stochrsi_k_15m < 50.0))
             # 4h down move, 1d high
-            & ((rsi_3_4h > 3.0) | (stochrsi_k_1d < 90.0))
+            & ((rsi_3_4h > 3.0) | (stochrsi_k_1d_lt_90))
             # 4h down move, 1d overbought
-            & ((rsi_3_4h > 3.0) | (roc_9_1d < 40.0))
+            & ((rsi_3_4h > 3.0) | (roc_9_1d_lt_40))
             # 4h & 1d down move
-            & ((rsi_3_4h > 5.0) | (rsi_3_1d > 10.0))
+            & ((rsi_3_4h_gt_5) | (rsi_3_1d_gt_10))
             # 4h down move, 1d high, 1h downtrend
             & ((rsi_3_4h_gt_10) | (aroonu_14_1d < 85.0) | (roc_9_1h > -30.0))
             # 4h down move, 1h & 4h downtrend
             & ((rsi_3_4h_gt_10) | (roc_9_1h > -40.0) | (roc_9_4h > -40.0))
             # 4h & 1d down move, 4h still not low enough
-            & (rsi_3_4h_gt_20 | (rsi_3_1d > 20.0) | (stochrsi_k_4h < 30.0))
+            & (rsi_3_4h_gt_20 | (rsi_3_1d_gt_20) | (stochrsi_k_4h < 30.0))
             # 4h down move, 4h still high, 1d downtrend
-            & ((rsi_3_4h > 30.0) | (aroonu_14_4h < 50.0) | (roc_9_1d > -40.0))
+            & ((rsi_3_4h_gt_30) | (aroonu_14_4h_lt_50) | (roc_9_1d_gt_neg_40))
             # 4h down move, 15m still high, 1d overbought
-            & ((rsi_3_4h > 40.0) | (aroonu_14_15m < 50.0) | roc_9_1d_lt_50)
+            & ((rsi_3_4h_gt_40) | (aroonu_14_15m_lt_50) | roc_9_1d_lt_50)
             # 4h down move, 4h & 1d overbought
-            & ((rsi_3_4h > 40.0) | (roc_9_4h < 10.0) | roc_9_1d_lt_50)
+            & ((rsi_3_4h_gt_40) | (roc_9_4h_lt_10) | roc_9_1d_lt_50)
             # 1d down move, 1h high
             & ((rsi_3_1d > 3.0) | (stochrsi_k_1h_lt_70))
             # 1d down move, 15m still high
-            & ((rsi_3_1d > 3.0) | (aroonu_14_15m < 50.0))
+            & ((rsi_3_1d > 3.0) | (aroonu_14_15m_lt_50))
             # 1d down move, 15m still high, 1h high
-            & ((rsi_3_1d > 10.0) | (aroonu_14_15m < 40.0) | (stochrsi_k_1h_lt_70))
+            & ((rsi_3_1d_gt_10) | (aroonu_14_15m < 40.0) | (stochrsi_k_1h_lt_70))
             # 1d down move, 1h & 4h high
-            & ((rsi_3_1d > 10.0) | aroonu_14_1h_lt_70 | (aroonu_14_4h < 90.0))
+            & ((rsi_3_1d_gt_10) | aroonu_14_1h_lt_70 | (aroonu_14_4h_lt_90))
             # 1d down move, 4h high
-            & ((rsi_3_1d > 20.0) | (rsi_14_4h < 80.0))
+            & ((rsi_3_1d_gt_20) | (rsi_14_4h < 80.0))
             # 1d downtrend, 1d high & overbought
             & ((cmf_20_1d > -0.30) | (aroonu_14_1d < 85.0) | (roc_9_1d_lt_100))
             # 1h & 4h high, 1d overbought
-            & (aroonu_14_1h_lt_70 | aroonu_14_4h_lt_70 | (roc_9_1d < 30.0))
+            & (aroonu_14_1h_lt_70 | aroonu_14_4h_lt_70 | (roc_9_1d_lt_30))
             # 1h & 4h high, 1d overbought
-            & ((aroonu_14_1h < 90.0) | (aroonu_14_4h < 90.0) | (roc_9_1d < 20.0))
+            & ((aroonu_14_1h_lt_90) | (aroonu_14_4h_lt_90) | (roc_9_1d_lt_20))
             # 1h & 4h high
-            & ((aroonu_14_1h < 100.0) | aroonu_14_4h_lt_100)
+            & ((aroonu_14_1h_lt_100) | aroonu_14_4h_lt_100)
             # 4h & 1d high, 4h overbought
-            & (aroonu_14_4h_lt_80 | aroonu_14_1d_lt_100 | (roc_9_4h < 30.0))
+            & (aroonu_14_4h_lt_80 | aroonu_14_1d_lt_100 | (roc_9_4h_lt_30))
             # 4h high, 4h & 1d overbought
-            & (aroonu_14_4h_lt_80 | (roc_9_4h < 20.0) | (roc_9_1d < 20.0))
+            & (aroonu_14_4h_lt_80 | (roc_9_4h < 20.0) | (roc_9_1d_lt_20))
             # 1d still high, 1h & 4h downtrend
             & ((aroonu_14_1d < 50.0) | (roc_9_1h > -20.0) | (roc_9_4h_gt_neg_20))
             # 1h high, 1h overbought
@@ -22903,39 +22955,39 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h high, 1d downtrend
             & ((stochrsi_k_1h_lt_80) | (roc_9_1d > -60.0))
             # 4h high, 1h overbought, 1d downtrend
-            & ((stochrsi_k_4h_lt_80) | (roc_9_1h < 10.0) | (roc_9_1d > -70.0))
+            & ((stochrsi_k_4h_lt_80) | (roc_9_1h_lt_10) | (roc_9_1d > -70.0))
             # 4h high, 1h & 4h overbought
             & ((stochrsi_k_4h_lt_90) | (roc_9_1h < 20.0) | (roc_9_4h < 50.0))
             # 1h & 4h overbought
             & ((roc_9_1h < 100.0) | (roc_9_4h < 100.0))
             # 1h P&D, 1h down move
-            & ((change_pct_1h > -10.0) | (change_pct_1h.shift(12) < 10.0) | (rsi_3_1h > 50.0))
+            & ((change_pct_1h > -10.0) | (change_pct_1h.shift(12) < 10.0) | (rsi_3_1h_gt_50))
             # 4h P&D, 4h high
-            & ((change_pct_4h > -15.0) | (change_pct_4h.shift(48) < 30.0) | (aroonu_14_4h < 90.0))
+            & ((change_pct_4h > -15.0) | (change_pct_4h.shift(48) < 30.0) | (aroonu_14_4h_lt_90))
             # 4h green, 15m & 1h down move
-            & ((change_pct_4h < 10.0) | (rsi_3_15m > 10.0) | (rsi_3_1h > 35.0))
+            & ((change_pct_4h < 10.0) | (rsi_3_15m_gt_10) | (rsi_3_1h_gt_35))
             # 4h green, 1h down move
-            & ((change_pct_4h < 40.0) | (rsi_3_1h > 50.0))
+            & ((change_pct_4h < 40.0) | (rsi_3_1h_gt_50))
             # 4h green with top wick
             & ((change_pct_4h < 50.0) | (change_pct_4h < 50.0))
             # 1d green with top wick, 15m still high
-            & ((change_pct_1d < 10.0) | (top_wick_pct_1d < 8.0) | (aroonu_14_15m < 50.0))
+            & ((change_pct_1d < 10.0) | (top_wick_pct_1d < 8.0) | (aroonu_14_15m_lt_50))
             # 1d green, 4h down move, 4h still high
-            & ((change_pct_1d < 40.0) | (rsi_3_4h > 35.0) | (aroonu_14_4h < 50.0))
+            & ((change_pct_1d < 40.0) | (rsi_3_4h_gt_35) | (aroonu_14_4h_lt_50))
             # 1d green with top wick, 4h down move
             & ((change_pct_1d < 40.0) | (top_wick_pct_1d < 8.0) | (rsi_3_4h > 55.0))
             # 1d top wick, 4h still high
-            & ((top_wick_pct_1d < 50.0) | (aroonu_14_4h < 50.0))
+            & ((top_wick_pct_1d < 50.0) | (aroonu_14_4h_lt_50))
             # big drop in last 4 days, 1d down move
-            & ((close > (high_max_24_4h * 0.20)) | (rsi_3_1d > 20.0))
+            & ((close > (high_max_24_4h * 0.20)) | (rsi_3_1d_gt_20))
             # big drop in the last 20 days, 4h down move
             & ((close > (high_max_20_1d * 0.15)) | rsi_3_4h_gt_20)
             # big drop in the last 20 days, 1d down move
-            & ((close > (high_max_20_1d * 0.05)) | (rsi_3_1d > 20.0))
+            & ((close > (high_max_20_1d * 0.05)) | (rsi_3_1d_gt_20))
             # big drop in the last 20 days, 1h still high
             & ((close > (high_max_20_1d * 0.05)) | (stochrsi_k_1h < 45.0))
             # big drop in the last 20 days, 4h high
-            & ((close > (high_max_20_1d * 0.05)) | (stochrsi_k_4h < 70.0))
+            & ((close > (high_max_20_1d * 0.05)) | (stochrsi_k_4h_lt_70))
           )
 
           # Logic
@@ -22955,161 +23007,159 @@ class NostalgiaForInfinityX7(IStrategy):
           long_entry_logic.append(num_empty_288 <= allowed_empty_candles_288)
           long_entry_logic.append(protections_long_global == True)
 
-          long_entry_logic.append((rsi_3 > 10.0) & (rsi_3_15m > 10.0) & rsi_3_1h_gt_20)
+          long_entry_logic.append((rsi_3 > 10.0) & (rsi_3_15m_gt_10) & rsi_3_1h_gt_20)
 
           long_entry_logic.append(
             # 5m & 15m & 4h down mnove, 4h high
-            ((rsi_3 > 15.0) | (rsi_3_15m > 20.0) | (rsi_3_4h > 40.0) | aroonu_14_4h_lt_80)
+            ((rsi_3 > 15.0) | (rsi_3_15m_gt_20) | (rsi_3_4h_gt_40) | aroonu_14_4h_lt_80)
             # 5m & 15m & 1d down move, 1h high
-            & ((rsi_3 > 15.0) | (rsi_3_15m > 25.0) | (rsi_3_1d > 25.0) | (aroonu_14_1h < 90.0))
+            & ((rsi_3 > 15.0) | (rsi_3_15m_gt_25) | (rsi_3_1d_gt_25) | (aroonu_14_1h_lt_90))
             # 5m & 1h down move, 15m still high, 4h high
-            & ((rsi_3 > 20.0) | (rsi_3_1h > 40.0) | (rsi_14_15m < 40.0) | aroonu_14_4h_lt_100)
+            & ((rsi_3 > 20.0) | (rsi_3_1h_gt_40) | (rsi_14_15m < 40.0) | aroonu_14_4h_lt_100)
             # 5m & 1h & 15m down move, 1h still not low enough
-            & ((rsi_3 > 15.0) | (rsi_3_1h > 30.0) | (rsi_3_1d > 15.0) | (aroonu_14_1h < 30.0))
+            & ((rsi_3 > 15.0) | (rsi_3_1h_gt_30) | (rsi_3_1d_gt_15) | (aroonu_14_1h < 30.0))
             # 15m & 4h down move, 4h high
-            & ((rsi_3 > 15.0) | (rsi_3_4h > 35.0) | (stochrsi_k_4h < 70.0))
+            & ((rsi_3 > 15.0) | (rsi_3_4h_gt_35) | (stochrsi_k_4h_lt_70))
             # 5m & 4h down move, 15m high
             & ((rsi_3 > 15.0) | (rsi_3_4h > 45.0) | (aroonu_14_15m < 60.0))
             # 15m & 1h down move, 1h high
-            & ((rsi_3_15m > 12.0) | (rsi_3_1h > 40.0) | (aroonu_14_1h < 100.0))
+            & ((rsi_3_15m > 12.0) | (rsi_3_1h_gt_40) | (aroonu_14_1h_lt_100))
             # 15m & 1h & 4h & 1d down move
-            & ((rsi_3_15m > 15.0) | (rsi_3_1h > 25.0) | (rsi_3_4h > 25.0) | (rsi_3_1d > 25.0))
+            & ((rsi_3_15m_gt_15) | (rsi_3_1h_gt_25) | (rsi_3_4h_gt_25) | (rsi_3_1d_gt_25))
             # 15m & 1h down move, 1h & 4h high
-            & ((rsi_3_15m > 15.0) | (rsi_3_1h > 25.0) | (aroonu_14_1h < 75.0) | aroonu_14_4h_lt_100)
+            & ((rsi_3_15m_gt_15) | (rsi_3_1h_gt_25) | (aroonu_14_1h < 75.0) | aroonu_14_4h_lt_100)
             # 15m & 1h & 4h down move, 1d overbought
-            & ((rsi_3_15m > 15.0) | (rsi_3_1h > 30.0) | (rsi_3_4h > 35.0) | (roc_9_1d < 40.0))
+            & ((rsi_3_15m_gt_15) | (rsi_3_1h_gt_30) | (rsi_3_4h_gt_35) | (roc_9_1d_lt_40))
             # 15m & 1h & 4h down move, 1h downtrend, 4h high
-            & ((rsi_3_15m > 15.0) | (rsi_3_1h > 30.0) | (rsi_3_4h > 55.0) | (cmf_20_1h > -0.10) | aroonu_14_4h_lt_80)
+            & ((rsi_3_15m_gt_15) | (rsi_3_1h_gt_30) | (rsi_3_4h > 55.0) | (cmf_20_1h > -0.10) | aroonu_14_4h_lt_80)
             # 15m & 1h down move, 15m high
-            & ((rsi_3_15m > 15.0) | (rsi_3_1h > 30.0) | (aroonu_14_15m < 60.0))
+            & ((rsi_3_15m_gt_15) | (rsi_3_1h_gt_30) | (aroonu_14_15m < 60.0))
             # 15m & 1h down move, 4h high
-            & ((rsi_3_15m > 15.0) | (rsi_3_1h > 30.0) | (rsi_14_4h < 85.0))
+            & ((rsi_3_15m_gt_15) | (rsi_3_1h_gt_30) | (rsi_14_4h < 85.0))
             # 15m & 1h down move, 15m still high
-            & ((rsi_3_15m > 15.0) | (rsi_3_1h > 30.0) | (aroonu_14_15m < 40.0))
+            & ((rsi_3_15m_gt_15) | (rsi_3_1h_gt_30) | (aroonu_14_15m < 40.0))
             # 15m & 1h down move, 1h high
-            & ((rsi_3_15m > 15.0) | (rsi_3_1h > 30.0) | aroonu_14_1h_lt_70)
+            & ((rsi_3_15m_gt_15) | (rsi_3_1h_gt_30) | aroonu_14_1h_lt_70)
             # 15m & 1h down move, 1h high
-            & ((rsi_3_15m > 15.0) | (rsi_3_1h > 30.0) | (stochrsi_k_1h_lt_70))
+            & ((rsi_3_15m_gt_15) | (rsi_3_1h_gt_30) | (stochrsi_k_1h_lt_70))
             # 15m & 1h down move, 1d overbought
-            & ((rsi_3_15m > 15.0) | (rsi_3_1h > 30.0) | (roc_9_1d < 30.0))
+            & ((rsi_3_15m_gt_15) | (rsi_3_1h_gt_30) | (roc_9_1d_lt_30))
             # 15m & 1h & 4h down move, 4h high
-            & ((rsi_3_15m > 15.0) | (rsi_3_1h > 35.0) | (rsi_3_4h > 65.0) | (df["MFI_14_4h"] < 85.0))
+            & ((rsi_3_15m_gt_15) | (rsi_3_1h_gt_35) | (rsi_3_4h > 65.0) | (df["MFI_14_4h"] < 85.0))
             # 15m & 1h & 1d down move, 15m high
-            & ((rsi_3_15m > 15.0) | (rsi_3_1h > 35.0) | (rsi_3_1d > 40.0) | (aroonu_14_15m < 60.0))
+            & ((rsi_3_15m_gt_15) | (rsi_3_1h_gt_35) | (rsi_3_1d > 40.0) | (aroonu_14_15m < 60.0))
             # 15m & 1h down move, 15m high
-            & ((rsi_3_15m > 15.0) | (rsi_3_1h > 35.0) | (aroonu_14_15m < 70.0))
+            & ((rsi_3_15m_gt_15) | (rsi_3_1h_gt_35) | (aroonu_14_15m_lt_70))
             # 15m & 1h down move, 1h high
-            & ((rsi_3_15m > 15.0) | (rsi_3_1h > 35.0) | (stochrsi_k_1h < 85.0))
+            & ((rsi_3_15m_gt_15) | (rsi_3_1h_gt_35) | (stochrsi_k_1h < 85.0))
             # 15m & 1h down move, 15m still not low enough, 1h & 4h high
-            & (
-              (rsi_3_15m > 15.0) | (rsi_3_1h > 40.0) | (aroonu_14_15m < 30.0) | aroonu_14_1h_lt_80 | aroonu_14_4h_lt_80
-            )
+            & ((rsi_3_15m_gt_15) | (rsi_3_1h_gt_40) | (aroonu_14_15m < 30.0) | aroonu_14_1h_lt_80 | aroonu_14_4h_lt_80)
             # 15m & 1h down move, 4h high & overbought
-            & ((rsi_3_15m > 15.0) | (rsi_3_1h > 45.0) | (rsi_14_4h < 70.0) | (roc_9_4h < 50.0))
+            & ((rsi_3_15m_gt_15) | (rsi_3_1h_gt_45) | (rsi_14_4h < 70.0) | (roc_9_4h < 50.0))
             # 15m & 1h down move, 1h high
-            & ((rsi_3_15m > 15.0) | (rsi_3_1h > 50.0) | (stochrsi_k_1h < 90.0))
+            & ((rsi_3_15m_gt_15) | (rsi_3_1h_gt_50) | (stochrsi_k_1h < 90.0))
             # 15m & 4h down move, 15m high
-            & ((rsi_3_15m > 15.0) | (rsi_3_4h > 30.0) | (aroonu_14_15m < 60.0))
+            & ((rsi_3_15m_gt_15) | (rsi_3_4h_gt_30) | (aroonu_14_15m < 60.0))
             # 15m & 4h down move, 4h high
-            & ((rsi_3_15m > 15.0) | (rsi_3_4h > 30.0) | aroonu_14_4h_lt_80)
+            & ((rsi_3_15m_gt_15) | (rsi_3_4h_gt_30) | aroonu_14_4h_lt_80)
             # 15m & 4h down move, 1h still high
-            & ((rsi_3_15m > 15.0) | (rsi_3_4h > 40.0) | (aroonu_14_1h < 40.0))
+            & ((rsi_3_15m_gt_15) | (rsi_3_4h_gt_40) | (aroonu_14_1h < 40.0))
             # 15m & 4h down move, 1d high
-            & ((rsi_3_15m > 15.0) | (rsi_3_4h > 35.0) | (stochrsi_k_1d < 90.0))
+            & ((rsi_3_15m_gt_15) | (rsi_3_4h_gt_35) | (stochrsi_k_1d_lt_90))
             # 15m & 4h down move, 1h high
-            & ((rsi_3_15m > 15.0) | (rsi_3_4h > 35.0) | (stochrsi_k_1h < 60.0))
+            & ((rsi_3_15m_gt_15) | (rsi_3_4h_gt_35) | (stochrsi_k_1h < 60.0))
             # 15m & 4h down move, 1h high
-            & ((rsi_3_15m > 15.0) | (rsi_3_4h > 50.0) | (stochrsi_k_1h_lt_80))
+            & ((rsi_3_15m_gt_15) | (rsi_3_4h_gt_50) | (stochrsi_k_1h_lt_80))
             # 15m down move, 4h & 1d up move, 1d downtrend
-            & ((rsi_3_15m > 15.0) | (rsi_3_4h < 90.0) | (rsi_3_1d < 80.0) | (cmf_20_1d > -0.2))
+            & ((rsi_3_15m_gt_15) | (rsi_3_4h < 90.0) | (rsi_3_1d < 80.0) | (cmf_20_1d > -0.2))
             # 15m & 1d down move, 4h high
-            & ((rsi_3_15m > 15.0) | (rsi_3_1d > 10.0) | (stochrsi_k_4h < 70.0))
+            & ((rsi_3_15m_gt_15) | (rsi_3_1d_gt_10) | (stochrsi_k_4h_lt_70))
             # 15m & 1h down move, 1h & 4h still high
-            & ((rsi_3_15m > 15.0) | (rsi_3_1d > 15.0) | (aroonu_14_1h < 50.0) | (aroonu_14_4h < 50.0))
+            & ((rsi_3_15m_gt_15) | (rsi_3_1d_gt_15) | (aroonu_14_1h_lt_50) | (aroonu_14_4h_lt_50))
             # 15m & 1d down move, 1h high
-            & ((rsi_3_15m > 15.0) | (rsi_3_1d > 15.0) | (aroonu_14_1h < 100.0))
+            & ((rsi_3_15m_gt_15) | (rsi_3_1d_gt_15) | (aroonu_14_1h_lt_100))
             # 15m & 1d down move, 1d high
-            & ((rsi_3_15m > 15.0) | (rsi_3_1d > 20.0) | (aroonu_14_1d < 80.0))
+            & ((rsi_3_15m_gt_15) | (rsi_3_1d_gt_20) | (aroonu_14_1d_lt_80))
             # 15m & 1d down move, 1d overbought
-            & ((rsi_3_15m > 15.0) | (rsi_3_1d > 40.0) | roc_9_1d_lt_50)
+            & ((rsi_3_15m_gt_15) | (rsi_3_1d > 40.0) | roc_9_1d_lt_50)
             # 15m & 1d down move, 1d high
-            & ((rsi_3_15m > 15.0) | (rsi_3_1d > 50.0) | (aroonu_14_1d < 70.0))
+            & ((rsi_3_15m_gt_15) | (rsi_3_1d > 50.0) | (aroonu_14_1d_lt_70))
             # 15m & 1d down move, 1d high
-            & ((rsi_3_15m > 15.0) | (rsi_3_1d > 60.0) | (stochrsi_k_1d < 80.0))
+            & ((rsi_3_15m_gt_15) | (rsi_3_1d > 60.0) | (stochrsi_k_1d < 80.0))
             # 15m down move, 15m & 4h high
-            & ((rsi_3_15m > 15.0) | (aroonu_14_15m < 70.0) | aroonu_14_4h_lt_80)
+            & ((rsi_3_15m_gt_15) | (aroonu_14_15m_lt_70) | aroonu_14_4h_lt_80)
             # 15m down move, 15m & 1h high
-            & ((rsi_3_15m > 15.0) | (aroonu_14_15m < 75.0) | (aroonu_14_1h < 100.0))
+            & ((rsi_3_15m_gt_15) | (aroonu_14_15m < 75.0) | (aroonu_14_1h_lt_100))
             # 15m down move, 1h high, 1d overbought
-            & ((rsi_3_15m > 15.0) | (aroonu_14_1h < 90.0) | (roc_9_1d < 80.0))
+            & ((rsi_3_15m_gt_15) | (aroonu_14_1h_lt_90) | (roc_9_1d_lt_80))
             # 15m down move, 1h high, 1d overbought
-            & ((rsi_3_15m > 15.0) | (aroonu_14_1h < 100.0) | (roc_9_1d < 40.0))
+            & ((rsi_3_15m_gt_15) | (aroonu_14_1h_lt_100) | (roc_9_1d_lt_40))
             # 15m down move, 4h still high, 4h downtrend
-            & ((rsi_3_15m > 15.0) | (aroonu_14_4h < 40.0) | (roc_9_4h_gt_neg_20))
+            & ((rsi_3_15m_gt_15) | (aroonu_14_4h_lt_40) | (roc_9_4h_gt_neg_20))
             # 15m down move, 1d high & overbought
-            & ((rsi_3_15m > 15.0) | aroonu_14_1d_lt_100 | (roc_9_1d < 100.0))
+            & ((rsi_3_15m_gt_15) | aroonu_14_1d_lt_100 | (roc_9_1d < 100.0))
             # 15m down move, 15m still not low enough, 4h high
-            & ((rsi_3_15m > 15.0) | (stochrsi_k_15m < 30.0) | (stochrsi_k_4h < 50.0))
+            & ((rsi_3_15m_gt_15) | (stochrsi_k_15m < 30.0) | (stochrsi_k_4h_lt_50))
             # 15m down move, 15m & 1h high
-            & ((rsi_3_15m > 15.0) | (stochrsi_k_15m < 50.0) | (stochrsi_k_1h_lt_50))
+            & ((rsi_3_15m_gt_15) | (stochrsi_k_15m < 50.0) | (stochrsi_k_1h_lt_50))
             # 15m down move, 1h high, 1d overbought
-            & ((rsi_3_15m > 15.0) | (stochrsi_k_1h_lt_70) | (roc_9_1d < 30.0))
+            & ((rsi_3_15m_gt_15) | (stochrsi_k_1h_lt_70) | (roc_9_1d_lt_30))
             # 15m down move, 1h high, 1d overbought
-            & ((rsi_3_15m > 15.0) | (stochrsi_k_1h_lt_70) | (roc_9_1d < 150.0))
+            & ((rsi_3_15m_gt_15) | (stochrsi_k_1h_lt_70) | (roc_9_1d < 150.0))
             # 15m down move, 1h high & overbought
-            & ((rsi_3_15m > 15.0) | (stochrsi_k_1h_lt_80) | (roc_9_1h < 20.0))
+            & ((rsi_3_15m_gt_15) | (stochrsi_k_1h_lt_80) | (roc_9_1h < 20.0))
             # 15m down move, 1h high, 1d overbought
-            & ((rsi_3_15m > 15.0) | (stochrsi_k_1h < 80.0) | (roc_9_1d_lt_100))
+            & ((rsi_3_15m_gt_15) | (stochrsi_k_1h < 80.0) | (roc_9_1d_lt_100))
             # 15m down move, 4h high, 1d overbought
-            & ((rsi_3_15m > 15.0) | (stochrsi_k_4h_lt_80) | (roc_9_1d < 25.0))
+            & ((rsi_3_15m_gt_15) | (stochrsi_k_4h_lt_80) | (roc_9_1d < 25.0))
             # 15m down move, 4h high & overbought
-            & ((rsi_3_15m > 15.0) | (stochrsi_k_4h_lt_90) | (roc_9_4h < 25.0))
+            & ((rsi_3_15m_gt_15) | (stochrsi_k_4h_lt_90) | (roc_9_4h < 25.0))
             # 15m down move, 4h high
-            & ((rsi_3_15m > 15.0) | (rsi_14_4h < 70.0) | (stochrsi_k_4h_lt_90) | (ema_9 < (ema_26 * 0.972)))
+            & ((rsi_3_15m_gt_15) | (rsi_14_4h < 70.0) | (stochrsi_k_4h_lt_90) | (ema_9 < (ema_26 * 0.972)))
             # 15m down move, 4h high and downtrend
-            & ((rsi_3_15m > 15.0) | (cmf_20_4h > -0.2) | aroonu_14_4h_lt_80)
+            & ((rsi_3_15m_gt_15) | (cmf_20_4h > -0.2) | aroonu_14_4h_lt_80)
             # 15m down move, 1h high, 4h overbought
-            & ((rsi_3_15m > 15.0) | (aroonu_14_1h < 90.0) | (roc_9_4h_lt_20))
+            & ((rsi_3_15m_gt_15) | (aroonu_14_1h_lt_90) | (roc_9_4h_lt_20))
             # 15m down move, 4h & 1d downtrend
-            & ((rsi_3_15m > 15.0) | (roc_9_4h_gt_neg_20) | (roc_9_1d_gt_neg_20))
+            & ((rsi_3_15m_gt_15) | (roc_9_4h_gt_neg_20) | (roc_9_1d_gt_neg_20))
             # 16m & 1h down move, 1h still high
-            & ((rsi_3_15m > 20.0) | (rsi_3_1h > 25.0) | (stochrsi_k_1h < 40.0))
+            & ((rsi_3_15m_gt_20) | (rsi_3_1h_gt_25) | (stochrsi_k_1h < 40.0))
             # 15m & 1h down move, 1h downtrend, 1h downtrend, 15m still high, 1h high
             & (
-              (rsi_3_15m > 20.0)
-              | (rsi_3_1h > 35.0)
+              (rsi_3_15m_gt_20)
+              | (rsi_3_1h_gt_35)
               | (cmf_20_1h > -0.10)
               | (aroonu_14_15m < 40.0)
               | (aroonu_14_1h < 85.0)
             )
             # 15m & 1h down move, 4h high & overbought
-            & ((rsi_3_15m > 20.0) | (rsi_3_1h > 45.0) | (rsi_14_4h < 70.0) | (roc_9_4h < 50.0))
+            & ((rsi_3_15m_gt_20) | (rsi_3_1h_gt_45) | (rsi_14_4h < 70.0) | (roc_9_4h < 50.0))
             # 15m & 4h down move, 15m high
-            & ((rsi_3_15m > 20.0) | (rsi_3_4h > 25.0) | (aroonu_14_15m < 60.0))
+            & ((rsi_3_15m_gt_20) | (rsi_3_4h_gt_25) | (aroonu_14_15m < 60.0))
             # 15m & 4h down move, 1h high
-            & ((rsi_3_15m > 20.0) | (rsi_3_4h > 35.0) | (aroonu_14_1h < 100.0))
+            & ((rsi_3_15m_gt_20) | (rsi_3_4h_gt_35) | (aroonu_14_1h_lt_100))
             # 15m & 1d down move, 4h high
-            & ((rsi_3_15m > 20.0) | (rsi_3_1d > 20.0) | (stochrsi_k_4h < 70.0))
+            & ((rsi_3_15m_gt_20) | (rsi_3_1d_gt_20) | (stochrsi_k_4h_lt_70))
             # 15m down move, 15m still high, 4h high
-            & ((rsi_3_15m > 20.0) | (rsi_14_15m < 40.0) | (rsi_14_4h < 75.0) | aroonu_14_4h_lt_100)
+            & ((rsi_3_15m_gt_20) | (rsi_14_15m < 40.0) | (rsi_14_4h < 75.0) | aroonu_14_4h_lt_100)
             # 15m down move, 4h downtrend, 4h overbought
-            & ((rsi_3_15m > 20.0) | (cmf_20_4h > -0.0) | (roc_9_4h < 40.0))
+            & ((rsi_3_15m_gt_20) | (cmf_20_4h > -0.0) | (roc_9_4h_lt_40))
             # 15m down move, 1h & 4h high, 1f overbought
-            & ((rsi_3_15m > 20.0) | (aroonu_14_1h < 85.0) | (rsi_14_4h < 70.0) | (roc_9_1d < 80.0))
+            & ((rsi_3_15m_gt_20) | (aroonu_14_1h < 85.0) | (rsi_14_4h < 70.0) | (roc_9_1d_lt_80))
             # 15m down move, 1h & 4h high
-            & ((rsi_3_15m > 20.0) | (aroonu_14_1h < 90.0) | aroonu_14_4h_lt_100)
+            & ((rsi_3_15m_gt_20) | (aroonu_14_1h_lt_90) | aroonu_14_4h_lt_100)
             # 15m down move, 1d high, 4h overbought
-            & ((rsi_3_15m > 20.0) | aroonu_14_1d_lt_100 | (roc_9_4h < 30.0))
+            & ((rsi_3_15m_gt_20) | aroonu_14_1d_lt_100 | (roc_9_4h_lt_30))
             # 15m down move, 1h high & overbought
-            & ((rsi_3_15m > 20.0) | (stochrsi_k_1h_lt_80) | (roc_9_1h < 10.0))
+            & ((rsi_3_15m_gt_20) | (stochrsi_k_1h_lt_80) | (roc_9_1h_lt_10))
             # 15m & 1d down move, 1d high
-            & ((rsi_3_15m > 25.0) | (rsi_3_1d > 40.0) | (aroonu_14_1d < 80.0))
+            & ((rsi_3_15m_gt_25) | (rsi_3_1d > 40.0) | (aroonu_14_1d_lt_80))
             # 15m down move, 4h high, 1d downtrend
-            & ((rsi_3_15m > 25.0) | (stochrsi_k_4h < 90.0) | (roc_9_1d_gt_neg_30))
+            & ((rsi_3_15m_gt_25) | (stochrsi_k_4h < 90.0) | (roc_9_1d_gt_neg_30))
             # 15m & 1h down move, 15m still not low enough, 1h & 4h high
             & (
-              (rsi_3_15m > 30.0)
-              | (rsi_3_1h > 45.0)
+              (rsi_3_15m_gt_30)
+              | (rsi_3_1h_gt_45)
               | (rsi_14_15m < 30.0)
               | (rsi_14_1h < 50.0)
               | (rsi_14_4h < 70.0)
@@ -23118,95 +23168,95 @@ class NostalgiaForInfinityX7(IStrategy):
               | aroonu_14_4h_lt_100
             )
             # 15m & 4h down move, 4h overbought
-            & ((rsi_3_15m > 30.0) | (rsi_3_4h > 60.0) | (roc_9_4h < 60.0))
+            & ((rsi_3_15m_gt_30) | (rsi_3_4h > 60.0) | (roc_9_4h < 60.0))
             # 15m & 4h down move, 4h high
-            & ((rsi_3_15m > 35.0) | (rsi_3_4h > 35.0) | (stochrsi_k_4h_lt_80))
+            & ((rsi_3_15m > 35.0) | (rsi_3_4h_gt_35) | (stochrsi_k_4h_lt_80))
             # 1h & 4h down move, 1d high
-            & ((rsi_3_1h > 25.0) | (rsi_3_4h > 30.0) | (stochrsi_k_1d < 80.0))
+            & ((rsi_3_1h_gt_25) | (rsi_3_4h_gt_30) | (stochrsi_k_1d < 80.0))
             # 1h & 4h down move, 4h high
-            & ((rsi_3_1h > 25.0) | (rsi_3_4h > 40.0) | aroonu_14_4h_lt_70)
+            & ((rsi_3_1h_gt_25) | (rsi_3_4h_gt_40) | aroonu_14_4h_lt_70)
             # 1h & 4h down move, 4h high
-            & ((rsi_3_1h > 25.0) | (rsi_3_4h > 45.0) | (stochrsi_k_4h_lt_80))
+            & ((rsi_3_1h_gt_25) | (rsi_3_4h > 45.0) | (stochrsi_k_4h_lt_80))
             # 1h & 4h down move, 1d high
-            & ((rsi_3_1h > 25.0) | (rsi_3_4h > 65.0) | aroonu_14_1d_lt_100)
+            & ((rsi_3_1h_gt_25) | (rsi_3_4h > 65.0) | aroonu_14_1d_lt_100)
             # 1h & 1d down move, 1d high
-            & ((rsi_3_1h > 25.0) | (rsi_3_1d > 40.0) | (aroonu_14_1d < 70.0))
+            & ((rsi_3_1h_gt_25) | (rsi_3_1d > 40.0) | (aroonu_14_1d_lt_70))
             # 1h down move, 15m downtrend, 4h still high
-            & ((rsi_3_1h > 25.0) | (cmf_20_15m > -0.4) | (aroonu_14_4h < 50.0))
+            & ((rsi_3_1h_gt_25) | (cmf_20_15m > -0.4) | (aroonu_14_4h_lt_50))
             # 1h down move, 4h downtrend, 4h high
-            & ((rsi_3_1h > 25.0) | (cmf_20_4h > -0.25) | aroonu_14_4h_lt_70)
+            & ((rsi_3_1h_gt_25) | (cmf_20_4h > -0.25) | aroonu_14_4h_lt_70)
             # 1h down move, 15m still high, 1d downtrend
-            & ((rsi_3_1h > 25.0) | (aroonu_14_15m < 40.0) | (roc_9_1d_gt_neg_20))
+            & ((rsi_3_1h_gt_25) | (aroonu_14_15m < 40.0) | (roc_9_1d_gt_neg_20))
             # 1h down move, 1h & 4h high
-            & ((rsi_3_1h > 25.0) | (aroonu_14_1h < 60.0) | aroonu_14_4h_lt_100)
+            & ((rsi_3_1h_gt_25) | (aroonu_14_1h < 60.0) | aroonu_14_4h_lt_100)
             # 1h down move, 1h high, 1d downtrend
-            & ((rsi_3_1h > 25.0) | (aroonu_14_1h < 90.0) | (cmf_20_1d > -0.2))
+            & ((rsi_3_1h_gt_25) | (aroonu_14_1h_lt_90) | (cmf_20_1d > -0.2))
             # 1h down move, 4h high & overbought
-            & ((rsi_3_1h > 25.0) | (aroonu_14_4h < 90.0) | (roc_9_4h_lt_20))
+            & ((rsi_3_1h_gt_25) | (aroonu_14_4h_lt_90) | (roc_9_4h_lt_20))
             # 1h down move, 1h still not low enough, 1d downtrend
-            & ((rsi_3_1h > 25.0) | (stochrsi_k_1h < 30.0) | (roc_9_1d > -40.0))
+            & ((rsi_3_1h_gt_25) | (stochrsi_k_1h < 30.0) | (roc_9_1d_gt_neg_40))
             # 1h down move, 4h high, 1d overbought
-            & ((rsi_3_1h > 25.0) | (stochrsi_k_4h_lt_90) | (roc_9_1d < 25.0))
+            & ((rsi_3_1h_gt_25) | (stochrsi_k_4h_lt_90) | (roc_9_1d < 25.0))
             # 1h & 4h down move, 1h still high
-            & ((rsi_3_1h > 30.0) | (rsi_3_4h > 30.0) | (aroonu_14_1h < 40.0))
+            & ((rsi_3_1h_gt_30) | (rsi_3_4h_gt_30) | (aroonu_14_1h < 40.0))
             # 1h & 1d down move, 1d still high
-            & ((rsi_3_1h > 30.0) | (rsi_3_1d > 30.0) | (aroonu_14_1d < 40.0))
+            & ((rsi_3_1h_gt_30) | (rsi_3_1d > 30.0) | (aroonu_14_1d < 40.0))
             # 1h down move, 15m & 4h high
-            & ((rsi_3_1h > 30.0) | (aroonu_14_15m < 60.0) | (stochrsi_k_4h < 95.0))
+            & ((rsi_3_1h_gt_30) | (aroonu_14_15m < 60.0) | (stochrsi_k_4h < 95.0))
             # 1h down move, 15m & 4h high
-            & ((rsi_3_1h > 30.0) | (aroonu_14_15m < 70.0) | (aroonu_14_4h < 90.0))
+            & ((rsi_3_1h_gt_30) | (aroonu_14_15m_lt_70) | (aroonu_14_4h_lt_90))
             # 1h down move, 1h high
-            & ((rsi_3_1h > 30.0) | (mfi_14_1h < 80.0) | (aroonu_14_1h < 90.0))
+            & ((rsi_3_1h_gt_30) | (mfi_14_1h < 80.0) | (aroonu_14_1h_lt_90))
             # 1h down move, 1h still high, 1d overbought
-            & ((rsi_3_1h > 30.0) | (aroonu_14_1h < 50.0) | (roc_9_1d < 40.0))
+            & ((rsi_3_1h_gt_30) | (aroonu_14_1h_lt_50) | (roc_9_1d_lt_40))
             # 1h down move, 1h & 4h high
-            & ((rsi_3_1h > 30.0) | aroonu_14_1h_lt_80 | aroonu_14_4h_lt_100)
+            & ((rsi_3_1h_gt_30) | aroonu_14_1h_lt_80 | aroonu_14_4h_lt_100)
             # 1h down move, 1h high, 1d downtrend
-            & ((rsi_3_1h > 30.0) | (aroonu_14_1h < 90.0) | (cmf_20_1d > -0.2))
+            & ((rsi_3_1h_gt_30) | (aroonu_14_1h_lt_90) | (cmf_20_1d > -0.2))
             # 1h down move, 1h highm 1d overbought
-            & ((rsi_3_1h > 30.0) | (aroonu_14_1h < 90.0) | (roc_9_1d < 40.0))
+            & ((rsi_3_1h_gt_30) | (aroonu_14_1h_lt_90) | (roc_9_1d_lt_40))
             # 1h down move, 4h high & overbought
-            & ((rsi_3_1h > 30.0) | aroonu_14_4h_lt_100 | (roc_9_4h < 30.0))
+            & ((rsi_3_1h_gt_30) | aroonu_14_4h_lt_100 | (roc_9_4h_lt_30))
             # 1h down move, 1d high, 4h overbought
-            & ((rsi_3_1h > 30.0) | aroonu_14_1d_lt_100 | (roc_9_4h < 20.0))
+            & ((rsi_3_1h_gt_30) | aroonu_14_1d_lt_100 | (roc_9_4h < 20.0))
             # 1h & 4h down move, 1h still high, 4h high
-            & ((rsi_3_1h > 35.0) | (rsi_3_4h > 60.0) | (rsi_14_1h < 50.0) | (rsi_14_4h < 70.0))
+            & ((rsi_3_1h_gt_35) | (rsi_3_4h > 60.0) | (rsi_14_1h < 50.0) | (rsi_14_4h < 70.0))
             # 1h down move, 15m still not low enough, 1h high
-            & ((rsi_3_1h > 35.0) | (aroonu_14_15m < 30.0) | aroonu_14_1h_lt_80)
+            & ((rsi_3_1h_gt_35) | (aroonu_14_15m < 30.0) | aroonu_14_1h_lt_80)
             # 1h down move, 1h & 1d high
-            & ((rsi_3_1h > 35.0) | (aroonu_14_1h < 60.0) | aroonu_14_1d_lt_100)
+            & ((rsi_3_1h_gt_35) | (aroonu_14_1h < 60.0) | aroonu_14_1d_lt_100)
             # 1h down move, 1h high, 4h overbought
-            & ((rsi_3_1h > 35.0) | aroonu_14_1h_lt_70 | (roc_9_4h < 25.0))
+            & ((rsi_3_1h_gt_35) | aroonu_14_1h_lt_70 | (roc_9_4h < 25.0))
             # 1h down move, 1h & 4h high
-            & ((rsi_3_1h > 35.0) | aroonu_14_1h_lt_70 | (aroonu_14_4h < 90.0))
+            & ((rsi_3_1h_gt_35) | aroonu_14_1h_lt_70 | (aroonu_14_4h_lt_90))
             # 1h down move, 1h & 1d high
-            & ((rsi_3_1h > 35.0) | (aroonu_14_1h < 90.0) | (aroonu_14_1d < 90.0))
+            & ((rsi_3_1h_gt_35) | (aroonu_14_1h_lt_90) | (aroonu_14_1d_lt_90))
             # 1h down move, 4h & 1d overbought
-            & ((rsi_3_1h > 35.0) | (roc_9_4h_lt_20) | (roc_9_1d < 80.0))
+            & ((rsi_3_1h_gt_35) | (roc_9_4h_lt_20) | (roc_9_1d_lt_80))
             # 1h & 1d down move, 1d high
-            & ((rsi_3_1h > 40.0) | (rsi_3_1d > 55.0) | aroonu_14_1d_lt_100)
+            & ((rsi_3_1h_gt_40) | (rsi_3_1d > 55.0) | aroonu_14_1d_lt_100)
             # 1h down move, 1h high, 4h overbought
-            & ((rsi_3_1h > 40.0) | aroonu_14_1h_lt_70 | (roc_9_4h < 40.0))
+            & ((rsi_3_1h_gt_40) | aroonu_14_1h_lt_70 | (roc_9_4h_lt_40))
             # 1h down move, 1h & 4h high
-            & ((rsi_3_1h > 40.0) | aroonu_14_1h_lt_80 | aroonu_14_4h_lt_80)
+            & ((rsi_3_1h_gt_40) | aroonu_14_1h_lt_80 | aroonu_14_4h_lt_80)
             # 1h down move, 1h high, 1d overbought
-            & ((rsi_3_1h > 40.0) | (aroonu_14_1h < 85.0) | (roc_9_1d < 80.0))
+            & ((rsi_3_1h_gt_40) | (aroonu_14_1h < 85.0) | (roc_9_1d_lt_80))
             # 1h down move, 1h high, 15m downtrend
-            & ((rsi_3_1h > 40.0) | (aroonu_14_1h < 90.0) | (roc_9_15m > -10.0))
+            & ((rsi_3_1h_gt_40) | (aroonu_14_1h_lt_90) | (roc_9_15m > -10.0))
             # 1h down move, 1h high, 1d downtrend
-            & ((rsi_3_1h > 40.0) | (stochrsi_k_1h_lt_80) | (roc_9_1d > -40.0))
+            & ((rsi_3_1h_gt_40) | (stochrsi_k_1h_lt_80) | (roc_9_1d_gt_neg_40))
             # 1h & 4h down move, 1d overbought
-            & ((rsi_3_1h > 45.0) | (rsi_3_4h > 65.0) | (roc_9_1d < 200.0))
+            & ((rsi_3_1h_gt_45) | (rsi_3_4h > 65.0) | (roc_9_1d < 200.0))
             # 1h & 1d down move, 4h high
-            & ((rsi_3_1h > 45.0) | (rsi_3_1d > 50.0) | (stochrsi_k_4h_lt_90))
+            & ((rsi_3_1h_gt_45) | (rsi_3_1d > 50.0) | (stochrsi_k_4h_lt_90))
             # 1h down move, 1h high, 4h overbought
-            & ((rsi_3_1h > 45.0) | (aroonu_14_1h < 100.0) | (roc_9_4h < 10.0))
+            & ((rsi_3_1h_gt_45) | (aroonu_14_1h_lt_100) | (roc_9_4h_lt_10))
             # 1h & 4h down move, 1h & 4h high
-            & ((rsi_3_1h > 50.0) | (rsi_3_4h > 65.0) | (aroonu_14_1h < 85.0) | aroonu_14_4h_lt_100)
+            & ((rsi_3_1h_gt_50) | (rsi_3_4h > 65.0) | (aroonu_14_1h < 85.0) | aroonu_14_4h_lt_100)
             # 1h down move, 15m & 1h high
-            & ((rsi_3_1h > 50.0) | (aroonu_14_15m < 60.0) | (stochrsi_k_1h_lt_80))
+            & ((rsi_3_1h_gt_50) | (aroonu_14_15m < 60.0) | (stochrsi_k_1h_lt_80))
             # 1h down move, 4h & 1d high
-            & ((rsi_3_1h > 50.0) | (aroonu_14_4h < 90.0) | (aroonu_14_1d < 90.0))
+            & ((rsi_3_1h_gt_50) | (aroonu_14_4h_lt_90) | (aroonu_14_1d_lt_90))
             # 1h down move, 4h high, 1h overbought
             & ((rsi_3_1h > 55.0) | aroonu_14_4h_lt_100 | (roc_9_1h < 20.0))
             # 1h down move, 15m & 1h high, 1d downtrend
@@ -23214,83 +23264,83 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h high, 1d downtrend
             & ((rsi_3_1h > 60.0) | (stochrsi_k_1h < 90.0) | (roc_9_1d_gt_neg_20))
             # 4h down move, 15m high
-            & ((rsi_3_4h > 3.0) | (aroonu_14_15m < 50.0))
+            & ((rsi_3_4h > 3.0) | (aroonu_14_15m_lt_50))
             # 4h & 1d down move, 1d high
-            & ((rsi_3_4h_gt_10) | (rsi_3_1d > 50.0) | (aroonu_14_1d < 90.0))
+            & ((rsi_3_4h_gt_10) | (rsi_3_1d > 50.0) | (aroonu_14_1d_lt_90))
             # 4h down move, 15m still not low enough, 4h downtrend
             & ((rsi_3_4h_gt_10) | (aroonu_14_15m < 30.0) | (cmf_20_4h > -0.30))
             # 4h down move, 15m & 1h still not low enough
             & ((rsi_3_4h_gt_10) | (aroonu_14_15m < 30.0) | (stochrsi_k_1h < 25.0))
             # 4h down move, 4h still high
-            & ((rsi_3_4h_gt_10) | (aroonu_14_4h < 40.0))
+            & ((rsi_3_4h_gt_10) | (aroonu_14_4h_lt_40))
             # 4h down move, 1h still high, 4h downtrend
             & ((rsi_3_4h_gt_10) | (stochrsi_k_1h < 50.0) | (cmf_20_4h > -0.3))
             # 4h down move, 1d still high, 1d downtrend
             & ((rsi_3_4h_gt_15) | (rsi_14_1d < 40.0) | (roc_9_1d > -10.0))
             # 4h down move, 4h high
-            & ((rsi_3_4h_gt_15) | (aroonu_14_4h < 60.0))
+            & ((rsi_3_4h_gt_15) | (aroonu_14_4h_lt_60))
             # 4h down move, 1d high & overbought
-            & ((rsi_3_4h_gt_15) | (stochrsi_k_1d < 90.0) | (roc_9_1d < 20.0))
+            & ((rsi_3_4h_gt_15) | (stochrsi_k_1d_lt_90) | (roc_9_1d_lt_20))
             # 4h down move, 15m still high, 1d overbought
-            & (rsi_3_4h_gt_20 | (aroonu_14_15m < 40.0) | (roc_9_1d < 20.0))
+            & (rsi_3_4h_gt_20 | (aroonu_14_15m < 40.0) | (roc_9_1d_lt_20))
             # 4h & 1d down move, 1h & 4h low
-            & ((rsi_3_4h > 25.0) | (rsi_3_1d > 25.0) | (cmf_20_1h > -0.3) | (cmf_20_4h > -0.4))
+            & ((rsi_3_4h_gt_25) | (rsi_3_1d_gt_25) | (cmf_20_1h > -0.3) | (cmf_20_4h > -0.4))
             # 4h down move, 4h still high 1d downtrend
-            & ((rsi_3_4h > 25.0) | (aroonu_14_4h < 50.0) | (roc_9_1d_gt_neg_20))
+            & ((rsi_3_4h_gt_25) | (aroonu_14_4h_lt_50) | (roc_9_1d_gt_neg_20))
             # 4h down move, 1d high & overbought
-            & ((rsi_3_4h > 25.0) | (stochrsi_k_1d < 80.0) | (roc_9_1d < 25.0))
+            & ((rsi_3_4h_gt_25) | (stochrsi_k_1d < 80.0) | (roc_9_1d < 25.0))
             # 4h down move, 4h & 1d high
-            & ((rsi_3_4h > 35.0) | aroonu_14_4h_lt_70 | aroonu_14_1d_lt_100)
+            & ((rsi_3_4h_gt_35) | aroonu_14_4h_lt_70 | aroonu_14_1d_lt_100)
             # 4h down move, 15m still high, 1d overbought
-            & ((rsi_3_4h > 40.0) | (aroonu_14_15m < 50.0) | roc_9_1d_lt_50)
+            & ((rsi_3_4h_gt_40) | (aroonu_14_15m_lt_50) | roc_9_1d_lt_50)
             # 4h down move, 4h high, 1d overbought
-            & ((rsi_3_4h > 40.0) | aroonu_14_4h_lt_80 | (roc_9_1d < 20.0))
+            & ((rsi_3_4h_gt_40) | aroonu_14_4h_lt_80 | (roc_9_1d_lt_20))
             # 4h down move, 1h high, 1d downtrend
-            & ((rsi_3_4h > 40.0) | (stochrsi_k_1h < 80.0) | (roc_9_1d_gt_neg_20))
+            & ((rsi_3_4h_gt_40) | (stochrsi_k_1h < 80.0) | (roc_9_1d_gt_neg_20))
             # 4h down move, 4h & 1d overbought
-            & ((rsi_3_4h > 40.0) | (roc_9_4h < 10.0) | roc_9_1d_lt_50)
+            & ((rsi_3_4h_gt_40) | (roc_9_4h_lt_10) | roc_9_1d_lt_50)
             # 4h down move, 4h high, 1d overbought
-            & ((rsi_3_4h > 45.0) | aroonu_14_4h_lt_70 | (roc_9_1d < 20.0))
+            & ((rsi_3_4h > 45.0) | aroonu_14_4h_lt_70 | (roc_9_1d_lt_20))
             # 4h down move, 1d high, 4h overbought
-            & ((rsi_3_4h > 45.0) | (aroonu_14_1d < 90.0) | (roc_9_4h < 10.0))
+            & ((rsi_3_4h > 45.0) | (aroonu_14_1d_lt_90) | (roc_9_4h_lt_10))
             # 4h down move, 4h still high, 1d downtrend
-            & ((rsi_3_4h > 50.0) | (rsi_14_4h < 40.0) | (roc_9_1d_gt_neg_30))
+            & ((rsi_3_4h_gt_50) | (rsi_14_4h < 40.0) | (roc_9_1d_gt_neg_30))
             # 4h down move, 4h high & overbought
-            & ((rsi_3_4h > 50.0) | aroonu_14_4h_lt_70 | (roc_9_4h < 10.0))
+            & ((rsi_3_4h_gt_50) | aroonu_14_4h_lt_70 | (roc_9_4h_lt_10))
             # 4h down move, 15m still high, 1d overbought
             & ((rsi_3_4h > 55.0) | (aroonu_14_15m < 40.0) | (roc_9_1d_lt_100))
             # 4h & 1d down move, 4h high, 1d overbought
-            & ((rsi_3_4h > 60.0) | (rsi_3_1d > 60.0) | (aroonu_14_4h < 75.0) | (roc_9_1d < 40.0))
+            & ((rsi_3_4h > 60.0) | (rsi_3_1d > 60.0) | (aroonu_14_4h < 75.0) | (roc_9_1d_lt_40))
             # 4h down move, 4h & 1d high
-            & ((rsi_3_4h > 70.0) | (aroonu_14_4h < 90.0) | aroonu_14_1d_lt_100)
+            & ((rsi_3_4h > 70.0) | (aroonu_14_4h_lt_90) | aroonu_14_1d_lt_100)
             # 1d down move, 4h high
             & ((rsi_3_1d > 3.0) | (stochrsi_k_4h < 60.0))
             # 1d down move, 1h high
             & ((rsi_3_1d > 5.0) | (stochrsi_k_1h_lt_80))
             # 1d down move, 15m & 1h still high
-            & ((rsi_3_1d > 10.0) | (rsi_14_15m < 40.0) | (stochrsi_k_1h_lt_50))
+            & ((rsi_3_1d_gt_10) | (rsi_14_15m < 40.0) | (stochrsi_k_1h_lt_50))
             # 1d down move, 1h & 4h high
-            & ((rsi_3_1d > 10.0) | aroonu_14_1h_lt_80 | (aroonu_14_4h < 90.0))
+            & ((rsi_3_1d_gt_10) | aroonu_14_1h_lt_80 | (aroonu_14_4h_lt_90))
             # 1d down move, 1h & 4h still high
-            & ((rsi_3_1d > 10.0) | (stochrsi_k_1h < 40.0) | (aroonu_14_4h < 40.0))
+            & ((rsi_3_1d_gt_10) | (stochrsi_k_1h < 40.0) | (aroonu_14_4h_lt_40))
             # 1d down move, 1h high & overbought
-            & ((rsi_3_1d > 20.0) | (stochrsi_k_1h_lt_80) | (roc_9_1h < 20.0))
+            & ((rsi_3_1d_gt_20) | (stochrsi_k_1h_lt_80) | (roc_9_1h < 20.0))
             # 1d down move, 1d high & overbought
-            & ((rsi_3_1d > 40.0) | (aroonu_14_1d < 70.0) | (roc_9_1d < 20.0))
+            & ((rsi_3_1d > 40.0) | (aroonu_14_1d_lt_70) | (roc_9_1d_lt_20))
             # 1d down move, 4h high & overbought
-            & ((rsi_3_1d > 45.0) | aroonu_14_4h_lt_80 | (roc_9_4h < 30.0))
+            & ((rsi_3_1d > 45.0) | aroonu_14_4h_lt_80 | (roc_9_4h_lt_30))
             # 1d down move, 1h high, 1d overbought
-            & ((rsi_3_1d > 60.0) | aroonu_14_1h_lt_80 | (roc_9_1d < 80.0))
+            & ((rsi_3_1d > 60.0) | aroonu_14_1h_lt_80 | (roc_9_1d_lt_80))
             # 1d down move, 15m still high, 1d overbought
             & ((rsi_3_1d > 65.0) | (aroonu_14_15m < 40.0) | (roc_9_1d_lt_100))
             # 1d down move, 4h & 1d high
-            & ((rsi_3_1d > 65.0) | (roc_9_4h < 10.0) | (roc_9_1d < 10.0))
+            & ((rsi_3_1d > 65.0) | (roc_9_4h_lt_10) | (roc_9_1d < 10.0))
             # 5m still high, 1h down move, 15m still high, 1h high
-            & ((rsi_3 < 40.0) | (rsi_3_1h > 30.0) | (aroonu_14_15m < 50.0) | (aroonu_14_4h < 90.0))
+            & ((rsi_3 < 40.0) | (rsi_3_1h_gt_30) | (aroonu_14_15m_lt_50) | (aroonu_14_4h_lt_90))
             # 5m still high, 15m high
-            & ((rsi_3 < 45.0) | (aroonu_14_15m < 70.0))
+            & ((rsi_3 < 45.0) | (aroonu_14_15m_lt_70))
             # 5m still high, 1h down move, 4h high
-            & ((rsi_3 < 50.0) | (rsi_3_1h > 30.0) | aroonu_14_4h_lt_100)
+            & ((rsi_3 < 50.0) | (rsi_3_1h_gt_30) | aroonu_14_4h_lt_100)
             # 15m down move, 1h high
             & ((rsi_14_15m > 25.0) | (stochrsi_k_1h_lt_80))
             # 15m down move, 4h & 1d high
@@ -23298,45 +23348,45 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h downtrend, 4h high, 1d downtrend
             & ((cmf_20_1h > -0.2) | (stochrsi_k_4h_lt_90) | (cmf_20_1d > -0.25))
             # 15m & 1h high, 1d overbought
-            & ((aroonu_14_15m < 60.0) | (aroonu_14_1h < 100.0) | (roc_9_1d < 20.0))
+            & ((aroonu_14_15m < 60.0) | (aroonu_14_1h_lt_100) | (roc_9_1d_lt_20))
             # 4h high, 4h & 1d overbought
-            & (aroonu_14_4h_lt_80 | (roc_9_4h < 20.0) | (roc_9_1d < 20.0))
+            & (aroonu_14_4h_lt_80 | (roc_9_4h < 20.0) | (roc_9_1d_lt_20))
             # 4h & 1d high, 1d overbought
             & ((aroonu_14_4h < 85.0) | (aroonu_14_1d < 85.0) | (roc_9_1d < 60.0))
             # 4h & 1d high, 1d overbought
-            & (aroonu_14_4h_lt_100 | aroonu_14_1d_lt_100 | (roc_9_1d < 30.0))
+            & (aroonu_14_4h_lt_100 | aroonu_14_1d_lt_100 | (roc_9_1d_lt_30))
             # 1d still high, 4h & 1d downtrend
             & ((aroonu_14_1d < 50.0) | (roc_9_4h_gt_neg_20) | (roc_9_1d_gt_neg_30))
             # 4h top wick, 15m & 1h down move
-            & ((df["top_wick_pct_4h"] < 10.0) | (rsi_3_15m > 15.0) | (rsi_3_1h > 40.0))
+            & ((df["top_wick_pct_4h"] < 10.0) | (rsi_3_15m_gt_15) | (rsi_3_1h_gt_40))
             # 4h top wick, 1h down move, 1h high
-            & ((df["top_wick_pct_4h"] < 10.0) | (rsi_3_1h > 30.0) | aroonu_14_1h_lt_70)
+            & ((df["top_wick_pct_4h"] < 10.0) | (rsi_3_1h_gt_30) | aroonu_14_1h_lt_70)
             # 1d red, 1h down move, 1h still high
-            & ((change_pct_1d > -15.0) | (rsi_3_1h > 25.0) | (aroonu_14_1h < 50.0))
+            & ((change_pct_1d > -15.0) | (rsi_3_1h_gt_25) | (aroonu_14_1h_lt_50))
             # 1d P&D, 1h high
             & ((change_pct_1d > -15.0) | (change_pct_1d.shift(288) < 15.0) | (stochrsi_k_1h_lt_80))
             # 1d P&D, 1d downtrend
             & ((change_pct_1d > -5.0) | (change_pct_1d.shift(288) < 30.0) | (cmf_20_1d > -0.1))
             # 1d P&D, 15m high
-            & ((change_pct_1d > -10.0) | (change_pct_1d.shift(288) < 40.0) | (aroonu_14_15m < 50.0))
+            & ((change_pct_1d > -10.0) | (change_pct_1d.shift(288) < 40.0) | (aroonu_14_15m_lt_50))
             # 1d P&D, 1h high
             & ((change_pct_1d > -10.0) | (change_pct_1d.shift(288) < 40.0) | (stochrsi_k_1h_lt_70))
             # 1d red with top wick, 1h high
             & ((change_pct_1d > -10.0) | (top_wick_pct_1d < 10.0) | aroonu_14_1h_lt_80)
             # 1d green, 4m down move, 4h high
-            & ((change_pct_1d < 25.0) | (rsi_3_4h > 55.0) | (aroonu_14_4h < 50.0))
+            & ((change_pct_1d < 25.0) | (rsi_3_4h > 55.0) | (aroonu_14_4h_lt_50))
             # 1d green with top wick, 1d low
             & ((change_pct_1d < 25.0) | (top_wick_pct_1d < 10.0) | (cmf_20_1d > -0.2))
             # 1d top wick, 1h still high
-            & ((top_wick_pct_1d < 25.0) | (aroonu_14_1h < 50.0))
+            & ((top_wick_pct_1d < 25.0) | (aroonu_14_1h_lt_50))
             # 1d top wick, 4h still high
-            & ((top_wick_pct_1d < 30.0) | (stochrsi_k_4h < 50.0))
+            & ((top_wick_pct_1d < 30.0) | (stochrsi_k_4h_lt_50))
             # 1d top wick, 1h down move
-            & ((top_wick_pct_1d < 50.0) | (rsi_3_1h > 30.0))
+            & ((top_wick_pct_1d < 50.0) | (rsi_3_1h_gt_30))
             # big drop in the last 12 days, 1h down move, 1h high
-            & ((close > (high_max_12_1d * 0.35)) | (rsi_3_1h > 35.0) | aroonu_14_1h_lt_70)
+            & ((close > (high_max_12_1d * 0.35)) | (rsi_3_1h_gt_35) | aroonu_14_1h_lt_70)
             # big drop in the last 20 days, 1h down move, 1h high
-            & ((close > (high_max_20_1d * 0.30)) | (rsi_3_1h > 30.0) | (stochrsi_k_1h < 75.0))
+            & ((close > (high_max_20_1d * 0.30)) | (rsi_3_1h_gt_30) | (stochrsi_k_1h < 75.0))
             # big drop in the last 20 days, 1d high, 1d downtrend
             & ((close > (high_max_20_1d * 0.20)) | (stochrsi_k_1d < 70.0) | (roc_9_1d > -15.0))
           )
@@ -23467,7 +23517,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m up move, 1d lost, 1h low
           short_entry_logic.append((rsi_3_15m_lt_95) | (rsi_14_1d > 40.0) | (aroonu_14_1h > 40.0))
           # 15m up move, 15m & 4h uptrend
-          short_entry_logic.append((rsi_3_15m_lt_95) | (aroonu_14_15m < 90.0) | (aroonu_14_4h < 90.0))
+          short_entry_logic.append((rsi_3_15m_lt_95) | (aroonu_14_15m < 90.0) | (aroonu_14_4h_lt_90))
           # 15m up move, 15m stil not high enough, 1h low
           short_entry_logic.append((rsi_3_15m_lt_95) | (stochrsi_k_15m > 70.0) | (stochrsi_k_1h > 10.0))
           # 15m up move, 1h still not high enough, 4h low
@@ -23477,7 +23527,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m up move, 4h still not high enough
           short_entry_logic.append((rsi_3_15m_lt_95) | (aroonu_14_4h > 70.0))
           # 15m up move, 4h & 1d uptrend
-          short_entry_logic.append((rsi_3_15m_lt_95) | (roc_9_4h < 30.0) | roc_9_1d_lt_50)
+          short_entry_logic.append((rsi_3_15m_lt_95) | (roc_9_4h_lt_30) | roc_9_1d_lt_50)
           # 15m up move, 1h up move, 1h still not high enough
           short_entry_logic.append((rsi_3_15m_lt_95) | (rsi_3_change_pct_1h < 80.0) | (stochrsi_k_1h_gt_50))
           # 15m & 1h up move, 1h still not high enough
@@ -23487,7 +23537,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m & 1h up move, 1d stil not high enough
           short_entry_logic.append((rsi_3_15m_lt_90) | (rsi_3_1h_lt_90) | (rsi_14_1h > 80.0))
           # 15m & 1h up move, 1d uptrend
-          short_entry_logic.append((rsi_3_15m_lt_90) | (rsi_3_1h_lt_80) | (roc_9_1d < 40.0))
+          short_entry_logic.append((rsi_3_15m_lt_90) | (rsi_3_1h_lt_80) | (roc_9_1d_lt_40))
           # 15m & 1h up move, 15m still not high enough
           short_entry_logic.append((rsi_3_15m_lt_90) | (rsi_3_1h_lt_80) | (stochrsi_k_15m > 60.0))
           # 15m & 4h up move, 1h still not high enough
@@ -23545,7 +23595,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1h & 4h up move, 4h still low
           short_entry_logic.append((rsi_3_1h_lt_95) | (rsi_3_4h_lt_85) | (stochrsi_k_4h_gt_50))
           # 1h & 4h up move, 4h uptrend
-          short_entry_logic.append((rsi_3_1h_lt_95) | (rsi_3_4h_lt_85) | (roc_9_4h < 40.0))
+          short_entry_logic.append((rsi_3_1h_lt_95) | (rsi_3_4h_lt_85) | (roc_9_4h_lt_40))
           # 1h & 1d strong up move
           short_entry_logic.append((rsi_3_1h_lt_95) | (rsi_3_1d < 95.0))
           # 1h up move, 4h still low
@@ -23569,7 +23619,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1h up move, 1h still not high enough, 1d low
           short_entry_logic.append((rsi_3_1h_lt_90) | (stochrsi_k_1h_gt_70) | (stochrsi_k_1d > 30.0))
           # 1h up move, 4h low, 1h uptrend
-          short_entry_logic.append((rsi_3_1h_lt_90) | (stochrsi_k_4h > 20.0) | (roc_9_1h < 10.0))
+          short_entry_logic.append((rsi_3_1h_lt_90) | (stochrsi_k_4h > 20.0) | (roc_9_1h_lt_10))
           # 1h up move, 4h low, 1h overbought
           short_entry_logic.append((rsi_3_1h_lt_90) | (stochrsi_k_4h > 40.0) | (roc_9_1h < 30.0))
           # 1h up move, 15m & 1h uptrend
@@ -23613,15 +23663,15 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1d up move, 1h & 4h still not low enough
           short_entry_logic.append((rsi_3_1d < 90.0) | (stochrsi_k_1h > 80.0) | (stochrsi_k_4h_gt_50))
           # 4h still not high enough, 4h overbought, 4h uptrend
-          short_entry_logic.append((rsi_14_4h > 80.0) | (roc_9_4h < 40.0) | (cci_20_change_pct_4h < 0.0))
+          short_entry_logic.append((rsi_14_4h > 80.0) | (roc_9_4h_lt_40) | (cci_20_change_pct_4h < 0.0))
           # 15m & 1h uptrend, 4h still low
           short_entry_logic.append((cmf_20_15m < 0.30) | (cmf_20_1h < 0.30) | (stochrsi_k_4h > 60.0))
           # 15m uptrend, 1h low
           short_entry_logic.append((aroonu_14_15m < 100.0) | (stochrsi_k_1h > 20.0))
           # 1h & 4h uptrend
-          short_entry_logic.append((aroonu_14_1h < 100.0) | aroonu_14_4h_lt_100)
+          short_entry_logic.append((aroonu_14_1h_lt_100) | aroonu_14_4h_lt_100)
           # 1h uptrend, 4h uptrend
-          short_entry_logic.append((aroonu_14_1h < 100.0) | (roc_9_4h_lt_20))
+          short_entry_logic.append((aroonu_14_1h_lt_100) | (roc_9_4h_lt_20))
           # 4h uptrend, 1d uptrend
           short_entry_logic.append(aroonu_14_4h_lt_100 | aroonu_14_1d_lt_100)
           # 4h uptrend, 15m uptrend
@@ -23635,11 +23685,11 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m still not high enough, 1h & 4h overbought
           short_entry_logic.append((stochrsi_k_15m > 70.0) | (roc_9_1h < 30.0) | (roc_9_4h < 60.0))
           # 1h & 4h overbought, 1h uptrend
-          short_entry_logic.append((roc_9_1h < 10.0) | (roc_9_4h < 40.0) | (cci_20_change_pct_1h < 0.0))
+          short_entry_logic.append((roc_9_1h_lt_10) | (roc_9_4h_lt_40) | (cci_20_change_pct_1h < 0.0))
           # 1h & 4h overbought, 4h uptrend
-          short_entry_logic.append((roc_9_1h < 10.0) | (roc_9_4h < 40.0) | (cci_20_change_pct_4h < 0.0))
+          short_entry_logic.append((roc_9_1h_lt_10) | (roc_9_4h_lt_40) | (cci_20_change_pct_4h < 0.0))
           # 1h & 4h & 1d uptrend
-          short_entry_logic.append((roc_9_1h < 10.0) | (roc_9_4h < 10.0) | (roc_9_1d < 20.0))
+          short_entry_logic.append((roc_9_1h_lt_10) | (roc_9_4h_lt_10) | (roc_9_1d_lt_20))
           # 5m green, 15m still not high enough
           short_entry_logic.append((df["change_pct"] < 5.0) | (aroond_14_15m < 50.0))
           # 5m green, 15m still not high enough
@@ -23649,7 +23699,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # pump in the last half hour, 15m still low
           short_entry_logic.append((close < (df["close_min_6"] * 1.20)) | (stochrsi_k_15m > 40.0))
           # pump in the last half hour, 1d uptrend
-          short_entry_logic.append((close < (df["close_min_6"] * 1.20)) | (roc_9_1d < 20.0))
+          short_entry_logic.append((close < (df["close_min_6"] * 1.20)) | (roc_9_1d_lt_20))
           # big pump in the last 4 hours, 15m still low
           short_entry_logic.append((close < (df["close_min_48"] * 1.50)) | (aroonu_14_15m > 50.0))
 
@@ -23712,7 +23762,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m up move, 1h still low, 1d low
           short_entry_logic.append((rsi_3_15m_lt_90) | (aroonu_14_1h > 50.0) | (aroonu_14_1d > 30.0))
           # 15m up move, 1h high
-          short_entry_logic.append((rsi_3_15m_lt_90) | (aroonu_14_1h < 100.0))
+          short_entry_logic.append((rsi_3_15m_lt_90) | (aroonu_14_1h_lt_100))
           # 15m up move, 1h still low
           short_entry_logic.append((rsi_3_15m_lt_90) | (stochrsi_k_1h_gt_50))
           # 15m up move, 4h uptrend
@@ -23748,7 +23798,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1h up move, 1d low
           short_entry_logic.append((rsi_3_1h_lt_90) | (stochrsi_k_1d > 10.0))
           # 1h up move, 1h & 4h uptrend
-          short_entry_logic.append((rsi_3_1h_lt_90) | (roc_9_1h < 30.0) | (roc_9_4h < 30.0))
+          short_entry_logic.append((rsi_3_1h_lt_90) | (roc_9_1h < 30.0) | (roc_9_4h_lt_30))
           # 1h up move, 4h uptrend
           short_entry_logic.append((rsi_3_1h_lt_90) | (roc_9_4h_lt_20))
           # 1h up move, 4h still low
@@ -23861,11 +23911,11 @@ class NostalgiaForInfinityX7(IStrategy):
           # 5m & 4h strong down move, 4h still not low enough
           short_entry_logic.append((rsi_3 < 95.0) | (rsi_3_1h_lt_95) | (stochrsi_k_4h > 60.0))
           # 5m down move, 1h high, 1d overbought
-          short_entry_logic.append((rsi_3_lt_90) | (roc_9_1h < 15.0) | (roc_9_1d > -40.0))
+          short_entry_logic.append((rsi_3_lt_90) | (roc_9_1h < 15.0) | (roc_9_1d_gt_neg_40))
           # 5m down move, 1h & 4h high
           short_entry_logic.append((rsi_3_lt_90) | (df["UO_7_14_28_1h"] > 40.0) | (stochrsi_k_4h_gt_30))
           # 5m down move, 1h high, 4h downtrend
-          short_entry_logic.append((rsi_3 < 98.0) | (stochrsi_k_1h > 10.0) | (roc_9_4h < 10.0))
+          short_entry_logic.append((rsi_3 < 98.0) | (stochrsi_k_1h > 10.0) | (roc_9_4h_lt_10))
           # 5m & 1h down move, 4h down
           short_entry_logic.append((rsi_3_lt_90) | (rsi_3_1h_lt_85) | (cmf_20_4h > -0.2))
           # 5m down move, 1h high
@@ -23953,7 +24003,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1h still high, 4h & 1d downtrend
           short_entry_logic.append((aroond_14_1h < 25.0) | (roc_9_4h_lt_20) | roc_9_1d_lt_50)
           # 4h moving down, 1d P&D
-          short_entry_logic.append((roc_9_4h < 30.0) | (df["RSI_3_change_pct_1d"] < 50.0) | roc_9_1d_gt_neg_50)
+          short_entry_logic.append((roc_9_4h_lt_30) | (df["RSI_3_change_pct_1d"] < 50.0) | roc_9_1d_gt_neg_50)
           # 1d strong downtrend, 4h still high
           short_entry_logic.append((roc_2_1d < 20.0) | roc_9_1d_lt_50 | (stochrsi_k_4h_gt_70))
           # 1d P&D, 1d overbought
@@ -23972,10 +24022,10 @@ class NostalgiaForInfinityX7(IStrategy):
           )
           # 4h red, 4h still not low enough, 1h downtrend, 1h overbought
           short_entry_logic.append(
-            (change_pct_4h < 10.0) | (aroond_14_4h < 25.0) | (roc_9_1h < 20.0) | (roc_9_1d > -40.0)
+            (change_pct_4h < 10.0) | (aroond_14_4h < 25.0) | (roc_9_1h < 20.0) | (roc_9_1d_gt_neg_40)
           )
           # 4h red, 4h still high, 1d downtrend
-          short_entry_logic.append((change_pct_4h < 10.0) | (stochrsi_k_4h_gt_30) | (roc_9_1d < 40.0))
+          short_entry_logic.append((change_pct_4h < 10.0) | (stochrsi_k_4h_gt_30) | (roc_9_1d_lt_40))
           # 1d P&D, 1d overbought
           short_entry_logic.append((change_pct_1d < 10.0) | (change_pct_1d.shift(288) > -10.0) | (roc_9_1d > -100.0))
           # 1d P&D, 4h still high
@@ -24054,7 +24104,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m down move, 1h strong down move
           short_entry_logic.append((rsi_3_15m_lt_95) | (df["RSI_14_change_pct_1h"] < 70.0))
           # 15m down move, 4h & 1d downtrend
-          short_entry_logic.append((rsi_3_15m_lt_95) | (roc_9_4h < 30.0) | roc_9_1d_lt_50)
+          short_entry_logic.append((rsi_3_15m_lt_95) | (roc_9_4h_lt_30) | roc_9_1d_lt_50)
           # 15m down move, 1h strong down move, 4h stil high
           short_entry_logic.append((rsi_3_15m_lt_90) | (rsi_3_1h_lt_95) | (stochrsi_k_4h_gt_50))
           # 15m down move, 1h & 4h still high
@@ -24154,7 +24204,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m up move, 15m & 4h high
           short_entry_logic.append((rsi_3_15m_lt_90) | (aroonu_14_15m < 100.0) | (aroonu_14_4h < 100.0))
           # 15m up move, 15m still not high enough, 1d uptrend
-          short_entry_logic.append((rsi_3_15m_lt_90) | (stochrsi_k_15m > 80.0) | (roc_9_1d < 80.0))
+          short_entry_logic.append((rsi_3_15m_lt_90) | (stochrsi_k_15m > 80.0) | (roc_9_1d_lt_80))
           # 15m & 4h up move, 15m still not high enough
           short_entry_logic.append((rsi_3_15m_lt_85) | (rsi_3_4h_lt_90) | (stochrsi_k_15m > 70.0))
           # 15m & 4h up move, 1d uptrend
@@ -24212,11 +24262,11 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1h & 4h up move, 1d low
           short_entry_logic.append((rsi_3_1h_lt_80) | (rsi_3_4h < 70.0) | (stochrsi_k_1d > 30.0))
           # 1h up move, 1d still low, 1d uptrend
-          short_entry_logic.append((rsi_3_1h_lt_80) | (aroonu_14_1d > 50.0) | (roc_9_1d < 30.0))
+          short_entry_logic.append((rsi_3_1h_lt_80) | (aroonu_14_1d > 50.0) | (roc_9_1d_lt_30))
           # 1h up move, 1d low
           short_entry_logic.append((rsi_3_1h_lt_80) | (stochrsi_k_1d > 20.0))
           # 1h up move, 4h & 1d uptrend
-          short_entry_logic.append((rsi_3_1h_lt_80) | (roc_9_4h_lt_20) | (roc_9_1d < 40.0))
+          short_entry_logic.append((rsi_3_1h_lt_80) | (roc_9_4h_lt_20) | (roc_9_1d_lt_40))
           # 4h up move, 1d low
           short_entry_logic.append((rsi_3_4h_lt_95) | (rsi_14_1d > 40.0))
           # 4h down move, 15m still not high enough, 1d low
@@ -24226,7 +24276,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 4h up move, 15m low
           short_entry_logic.append((rsi_3_4h_lt_90) | (stochrsi_k_15m > 45.0))
           # 4h up move, 4h & 1d uptrend
-          short_entry_logic.append((rsi_3_4h_lt_90) | (roc_9_4h_lt_20) | (roc_9_1d < 40.0))
+          short_entry_logic.append((rsi_3_4h_lt_90) | (roc_9_4h_lt_20) | (roc_9_1d_lt_40))
           # 4h up move, 15m still not high enough
           short_entry_logic.append((rsi_3_4h_lt_85) | (aroonu_14_15m > 60.0))
           # 4h up move, 15m low
@@ -24240,9 +24290,9 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1d up move, 4h low
           short_entry_logic.append((rsi_3_1d < 85.0) | (stochrsi_k_4h > 40.0))
           # 4h still not high enough, 4h overbought, 4h uptrend
-          short_entry_logic.append((rsi_14_4h > 80.0) | (roc_9_4h < 40.0) | (cci_20_change_pct_4h < 0.0))
+          short_entry_logic.append((rsi_14_4h > 80.0) | (roc_9_4h_lt_40) | (cci_20_change_pct_4h < 0.0))
           # 15m & 1h high, 4h uptrend
-          short_entry_logic.append((aroonu_14_15m < 100.0) | (aroonu_14_1h < 100.0) | (roc_9_4h_lt_20))
+          short_entry_logic.append((aroonu_14_15m < 100.0) | (aroonu_14_1h_lt_100) | (roc_9_4h_lt_20))
           # 15m & 4h high, 1h uptrend
           short_entry_logic.append((aroonu_14_15m < 100.0) | aroonu_14_4h_lt_100 | (roc_9_1h < 20.0))
           # 15m high, 1d low
@@ -24252,13 +24302,13 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m high, 1h & 4h uptrend
           short_entry_logic.append((aroonu_14_15m < 100.0) | (roc_9_1h < 20.0) | (roc_9_4h_lt_20))
           # 1h high, 15m uptrend
-          short_entry_logic.append((aroonu_14_1h < 100.0) | (roc_9_15m < 20.0))
+          short_entry_logic.append((aroonu_14_1h_lt_100) | (roc_9_15m < 20.0))
           # 15m & 4h still not high enough
           short_entry_logic.append((stochrsi_k_15m > 70.0) | (stochrsi_k_4h_gt_70))
           # 1h & 4h overbought, 1h uptrend
-          short_entry_logic.append((roc_9_1h < 10.0) | (roc_9_4h < 40.0) | (cci_20_change_pct_1h < 0.0))
+          short_entry_logic.append((roc_9_1h_lt_10) | (roc_9_4h_lt_40) | (cci_20_change_pct_1h < 0.0))
           # 1h & 4h overbought, 4h uptrend
-          short_entry_logic.append((roc_9_1h < 10.0) | (roc_9_4h < 40.0) | (cci_20_change_pct_4h < 0.0))
+          short_entry_logic.append((roc_9_1h_lt_10) | (roc_9_4h_lt_40) | (cci_20_change_pct_4h < 0.0))
           # 1d bot wick, 4h still not high enough
           short_entry_logic.append((df["bot_wick_pct_1d"] < 30.0) | (stochrsi_k_4h > 80.0))
           # rise in the last 12 hours, relatively stable before the 12 hours
@@ -24344,7 +24394,7 @@ class NostalgiaForInfinityX7(IStrategy):
           )
           # 4h red, 4h moving down, 4h still high, 1d downtrend
           short_entry_logic.append(
-            (change_pct_4h < 10.0) | (cci_20_change_pct_4h < 0.0) | (stochrsi_k_4h_gt_50) | (roc_9_1d < 40.0)
+            (change_pct_4h < 10.0) | (cci_20_change_pct_4h < 0.0) | (stochrsi_k_4h_gt_50) | (roc_9_1d_lt_40)
           )
 
           # Logic


### PR DESCRIPTION
## Summary
- Reuses high-frequency entry-trend RSI/ROC comparison masks inside `populate_entry_trend()`.
- This branch is independent on latest upstream `main`.

## Safety
- Only already-read values are reused inside the same call.
- Indicator formulas, candle selection, order classification, profit arithmetic, thresholds, condition order, and return values are unchanged.
- No v3 grind-entry code is touched.
- Touched function(s): `populate_entry_trend`.

## Backtest scope
- Full backtesting was not required because this patch only aliases Series fields that are already read by the same condition ladder. Indicator formulas, candle selection, thresholds, and condition order are unchanged.

## Checks
- `python3 ~/.codex/skills/nfi-upstream-pr/scripts/validate_nfi_pr.py --base origin/main`
- `git merge-tree` conflict simulation against `origin/main` (via validator)
- AST undefined-local scan for introduced `last_*` / `previous_*` / `current_*` locals (via validator)
- `git diff --check` (via validator)
- `ruff format --check NostalgiaForInfinityX7.py` (via validator)
- `ruff check NostalgiaForInfinityX7.py` (via validator)
- `PYTHONDONTWRITEBYTECODE=1 python3 -m py_compile NostalgiaForInfinityX7.py` (via validator)
