### PR TITLE
Reuse X7 v3 grind-adjust config reads

### DIFF
--- a/NostalgiaForInfinityX7.py
+++ b/NostalgiaForInfinityX7.py
@@ -42376,7 +42376,8 @@ class NostalgiaForInfinityX7(IStrategy):
     dp = self.dp
     send_msg = self.dp.send_msg
     notification_msg = self.notification_msg
-    stake_currency = self.config["stake_currency"]
+    config = self.config
+    stake_currency = config["stake_currency"]
     is_futures_mode = self.is_futures_mode
     scale_stakes_for_min_stake = self.scale_stakes_for_min_stake
     trade_pair = trade.pair
@@ -42407,7 +42408,7 @@ class NostalgiaForInfinityX7(IStrategy):
     if dp.runmode.value in ("live", "dry_run"):
       ticker = dp.ticker(trade_pair)
       if ("bid" in ticker) and ("ask" in ticker):
-        exit_price_side = self.config["exit_pricing"]["price_side"]
+        exit_price_side = config["exit_pricing"]["price_side"]
         if trade.is_short:
           if exit_price_side in ["ask", "other"]:
             if ticker["ask"] is not None:
@@ -65776,7 +65777,8 @@ class NostalgiaForInfinityX7(IStrategy):
     dp = self.dp
     send_msg = self.dp.send_msg
     notification_msg = self.notification_msg
-    stake_currency = self.config["stake_currency"]
+    config = self.config
+    stake_currency = config["stake_currency"]
     is_futures_mode = self.is_futures_mode
     scale_stakes_for_min_stake = self.scale_stakes_for_min_stake
     trade_pair = trade.pair
@@ -65807,7 +65809,7 @@ class NostalgiaForInfinityX7(IStrategy):
     if dp.runmode.value in ("live", "dry_run"):
       ticker = dp.ticker(trade_pair)
       if ("bid" in ticker) and ("ask" in ticker):
-        exit_price_side = self.config["exit_pricing"]["price_side"]
+        exit_price_side = config["exit_pricing"]["price_side"]
         if trade.is_short:
           if exit_price_side in ["ask", "other"]:
             if ticker["ask"] is not None:


### PR DESCRIPTION
## Summary
- Reuse the local X7 config reference in long/short v3 grind-adjust paths.
- Keep the branch independent on latest upstream `main`.

## Safety
- Behavior is preserved: this only reuses `self.config` inside the same call before reading `stake_currency` and `exit_pricing.price_side`.
- Touched active runtime functions: `long_grind_adjust_trade_position_v3`, `short_grind_adjust_trade_position_v3`.
- No indicators, candle selection, order classification, profit arithmetic, thresholds, condition order, stake sizing, or return values were changed.
- No v3 grind-entry code is touched.

## Backtest scope
- Full backtesting was not required for this patch because it only reuses the same config object already read in the same function call.
- The validation scope is static/runtime-safety focused for a local lookup-reuse change.

## Checks
- `python3 ~/.codex/skills/nfi-upstream-pr/scripts/validate_nfi_pr.py --base origin/main`
- AST undefined-local/self-assignment scan via `validate_nfi_pr.py`
- `git merge-tree` conflict simulation against `origin/main`
- targeted `git diff origin/main...HEAD -- NostalgiaForInfinityX7.py` review
- `git diff --check origin/main...HEAD`
- `ruff format --check NostalgiaForInfinityX7.py`
- `ruff check NostalgiaForInfinityX7.py`
- `PYTHONDONTWRITEBYTECODE=1 python3 -m py_compile NostalgiaForInfinityX7.py`
