### PR TITLE
Reuse X7 entry RSI 1d mask

### DIFF
--- a/NostalgiaForInfinityX7.py
+++ b/NostalgiaForInfinityX7.py
@@ -12611,11 +12611,6 @@ class NostalgiaForInfinityX7(IStrategy):
     roc_9_1h = df["ROC_9_1h"]
     stochrsi_k_15m = df["STOCHRSIk_14_14_3_3_15m"]
     stochrsi_k_1d = df["STOCHRSIk_14_14_3_3_1d"]
-    stochrsi_k_4h_lt_80 = stochrsi_k_4h < 80.0
-    stochrsi_k_1h_lt_50 = stochrsi_k_1h < 50.0
-    stochrsi_k_1h_lt_80 = stochrsi_k_1h < 80.0
-    stochrsi_k_1h_lt_70 = stochrsi_k_1h < 70.0
-    stochrsi_k_4h_lt_90 = stochrsi_k_4h < 90.0
     rsi_3 = df["RSI_3"]
     close = df["close"]
     open_rate = df["open"]
@@ -12683,80 +12678,85 @@ class NostalgiaForInfinityX7(IStrategy):
     top_wick_pct_1d = df["top_wick_pct_1d"]
     willr_14 = df["WILLR_14"]
 
+    rsi_3_gt_3 = rsi_3 > 3.0
     rsi_3_15m_gt_3 = rsi_3_15m > 3.0
+    rsi_3_15m_gt_5 = rsi_3_15m > 5.0
+    rsi_3_15m_gt_10 = rsi_3_15m > 10.0
+    rsi_3_15m_gt_15 = rsi_3_15m > 15.0
+    rsi_3_15m_gt_20 = rsi_3_15m > 20.0
+    rsi_3_15m_gt_25 = rsi_3_15m > 25.0
+    rsi_3_15m_gt_30 = rsi_3_15m > 30.0
+    rsi_3_1h_gt_3 = rsi_3_1h > 3.0
+    rsi_3_1h_gt_5 = rsi_3_1h > 5.0
     rsi_3_1h_gt_10 = rsi_3_1h > 10.0
     rsi_3_1h_gt_15 = rsi_3_1h > 15.0
     rsi_3_1h_gt_20 = rsi_3_1h > 20.0
+    rsi_3_1h_gt_25 = rsi_3_1h > 25.0
+    rsi_3_1h_gt_30 = rsi_3_1h > 30.0
+    rsi_3_1h_gt_35 = rsi_3_1h > 35.0
+    rsi_3_1h_gt_40 = rsi_3_1h > 40.0
+    rsi_3_1h_gt_45 = rsi_3_1h > 45.0
+    rsi_3_1h_gt_50 = rsi_3_1h > 50.0
+    rsi_3_4h_gt_5 = rsi_3_4h > 5.0
     rsi_3_4h_gt_10 = rsi_3_4h > 10.0
     rsi_3_4h_gt_15 = rsi_3_4h > 15.0
     rsi_3_4h_gt_20 = rsi_3_4h > 20.0
+    rsi_3_4h_gt_25 = rsi_3_4h > 25.0
+    rsi_3_4h_gt_30 = rsi_3_4h > 30.0
+    rsi_3_4h_gt_35 = rsi_3_4h > 35.0
+    rsi_3_4h_gt_40 = rsi_3_4h > 40.0
+    rsi_3_4h_gt_50 = rsi_3_4h > 50.0
+    rsi_3_1d_gt_10 = rsi_3_1d > 10.0
+    rsi_3_1d_gt_15 = rsi_3_1d > 15.0
+    rsi_3_1d_gt_20 = rsi_3_1d > 20.0
+    rsi_3_1d_gt_25 = rsi_3_1d > 25.0
+    rsi_3_1d_gt_60 = rsi_3_1d > 60.0
 
+    aroonu_14_15m_lt_50 = aroonu_14_15m < 50.0
+    aroonu_14_15m_lt_70 = aroonu_14_15m < 70.0
+    aroonu_14_1h_lt_50 = aroonu_14_1h < 50.0
     aroonu_14_1h_lt_70 = aroonu_14_1h < 70.0
     aroonu_14_1h_lt_80 = aroonu_14_1h < 80.0
+    aroonu_14_1h_lt_90 = aroonu_14_1h < 90.0
+    aroonu_14_1h_lt_100 = aroonu_14_1h < 100.0
+    aroonu_14_4h_lt_40 = aroonu_14_4h < 40.0
+    aroonu_14_4h_lt_50 = aroonu_14_4h < 50.0
+    aroonu_14_4h_lt_60 = aroonu_14_4h < 60.0
     aroonu_14_4h_lt_70 = aroonu_14_4h < 70.0
     aroonu_14_4h_lt_80 = aroonu_14_4h < 80.0
+    aroonu_14_4h_lt_90 = aroonu_14_4h < 90.0
     aroonu_14_4h_lt_100 = aroonu_14_4h < 100.0
+    aroonu_14_1d_lt_70 = aroonu_14_1d < 70.0
+    aroonu_14_1d_lt_80 = aroonu_14_1d < 80.0
+    aroonu_14_1d_lt_90 = aroonu_14_1d < 90.0
     aroonu_14_1d_lt_100 = aroonu_14_1d < 100.0
 
+    roc_9_1h_lt_10 = roc_9_1h < 10.0
+    roc_9_4h_gt_neg_30 = roc_9_4h > -30.0
     roc_9_4h_gt_neg_20 = roc_9_4h > -20.0
+    roc_9_4h_lt_10 = roc_9_4h < 10.0
     roc_9_4h_lt_20 = roc_9_4h < 20.0
+    roc_9_4h_lt_30 = roc_9_4h < 30.0
+    roc_9_4h_lt_40 = roc_9_4h < 40.0
     roc_9_1d_gt_neg_50 = roc_9_1d > -50.0
+    roc_9_1d_gt_neg_40 = roc_9_1d > -40.0
     roc_9_1d_gt_neg_30 = roc_9_1d > -30.0
     roc_9_1d_gt_neg_20 = roc_9_1d > -20.0
+    roc_9_1d_lt_20 = roc_9_1d < 20.0
+    roc_9_1d_lt_30 = roc_9_1d < 30.0
+    roc_9_1d_lt_40 = roc_9_1d < 40.0
     roc_9_1d_lt_50 = roc_9_1d < 50.0
+    roc_9_1d_lt_80 = roc_9_1d < 80.0
     roc_9_1d_lt_100 = roc_9_1d < 100.0
 
-    # Reused entry-trend RSI and ROC masks
-    rsi_3_15m_gt_10 = rsi_3_15m > 10.0
-    rsi_3_15m_gt_15 = rsi_3_15m > 15.0
-    rsi_3_1h_gt_30 = rsi_3_1h > 30.0
-    rsi_3_1h_gt_25 = rsi_3_1h > 25.0
-    rsi_3_15m_gt_5 = rsi_3_15m > 5.0
-    rsi_3_15m_gt_20 = rsi_3_15m > 20.0
-    rsi_3_4h_gt_30 = rsi_3_4h > 30.0
-    rsi_3_4h_gt_25 = rsi_3_4h > 25.0
-    rsi_3_1h_gt_5 = rsi_3_1h > 5.0
-    aroonu_14_15m_lt_70 = aroonu_14_15m < 70.0
-    rsi_3_1h_gt_35 = rsi_3_1h > 35.0
-    rsi_3_15m_gt_25 = rsi_3_15m > 25.0
-    roc_9_4h_lt_10 = roc_9_4h < 10.0
-    rsi_3_1h_gt_40 = rsi_3_1h > 40.0
-    aroonu_14_4h_lt_90 = aroonu_14_4h < 90.0
-    rsi_3_1h_gt_3 = rsi_3_1h > 3.0
-    aroonu_14_1d_lt_90 = aroonu_14_1d < 90.0
-    roc_9_1d_lt_20 = roc_9_1d < 20.0
-    roc_9_1d_lt_40 = roc_9_1d < 40.0
-    aroonu_14_1d_lt_80 = aroonu_14_1d < 80.0
-    rsi_3_4h_gt_35 = rsi_3_4h > 35.0
-    aroonu_14_4h_lt_50 = aroonu_14_4h < 50.0
-    roc_9_1d_gt_neg_40 = roc_9_1d > -40.0
-    aroonu_14_1d_lt_70 = aroonu_14_1d < 70.0
-    rsi_3_gt_3 = rsi_3 > 3.0
-    rsi_3_4h_gt_40 = rsi_3_4h > 40.0
-    aroonu_14_15m_lt_50 = aroonu_14_15m < 50.0
-    roc_9_4h_lt_30 = roc_9_4h < 30.0
-    aroonu_14_1h_lt_50 = aroonu_14_1h < 50.0
+    stochrsi_k_1h_lt_50 = stochrsi_k_1h < 50.0
+    stochrsi_k_1h_lt_70 = stochrsi_k_1h < 70.0
+    stochrsi_k_1h_lt_80 = stochrsi_k_1h < 80.0
     stochrsi_k_4h_lt_50 = stochrsi_k_4h < 50.0
-    rsi_3_1d_gt_20 = rsi_3_1d > 20.0
-    roc_9_1d_lt_30 = roc_9_1d < 30.0
-    aroonu_14_1h_lt_90 = aroonu_14_1h < 90.0
-    rsi_3_4h_gt_50 = rsi_3_4h > 50.0
-    rsi_3_4h_gt_5 = rsi_3_4h > 5.0
-    roc_9_1h_lt_10 = roc_9_1h < 10.0
     stochrsi_k_4h_lt_70 = stochrsi_k_4h < 70.0
-    rsi_3_1d_gt_15 = rsi_3_1d > 15.0
+    stochrsi_k_4h_lt_80 = stochrsi_k_4h < 80.0
+    stochrsi_k_4h_lt_90 = stochrsi_k_4h < 90.0
     stochrsi_k_1d_lt_90 = stochrsi_k_1d < 90.0
-    rsi_3_1h_gt_50 = rsi_3_1h > 50.0
-    rsi_3_1d_gt_25 = rsi_3_1d > 25.0
-    rsi_3_1h_gt_45 = rsi_3_1h > 45.0
-    rsi_3_1d_gt_10 = rsi_3_1d > 10.0
-    aroonu_14_4h_lt_40 = aroonu_14_4h < 40.0
-    roc_9_1d_lt_80 = roc_9_1d < 80.0
-    aroonu_14_4h_lt_60 = aroonu_14_4h < 60.0
-    rsi_3_15m_gt_30 = rsi_3_15m > 30.0
-    aroonu_14_1h_lt_100 = aroonu_14_1h < 100.0
-    roc_9_4h_gt_neg_30 = roc_9_4h > -30.0
-    roc_9_4h_lt_40 = roc_9_4h < 40.0
 
     is_backtest = self.dp.runmode.value in ["backtest", "hyperopt", "plot", "webserver"]
     # the number of free slots
@@ -13129,7 +13129,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1d down move, 4h still high, 1d overbought
             & ((rsi_3_1d > 50.0) | (aroonu_14_4h_lt_50) | (roc_9_1d < 200.0))
             # 1d down move, 1d high & overbought
-            & ((rsi_3_1d > 60.0) | (aroonu_14_1d_lt_80) | roc_9_1d_lt_50)
+            & ((rsi_3_1d_gt_60) | (aroonu_14_1d_lt_80) | roc_9_1d_lt_50)
             # 1h down move, 4h high, 1d overbought
             & ((rsi_3_change_pct_1h > -75.0) | (aroonu_14_4h_lt_90) | (roc_9_1d_lt_100))
             # 15m & 1h & 4h downtrend
@@ -13786,7 +13786,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 4h high, 4h downtrend
             & ((rsi_3_4h_gt_25) | aroonu_14_4h_lt_70 | (roc_9_4h_gt_neg_30))
             # 4h & 1d down move, 1d overbought
-            & ((rsi_3_4h_gt_30) | (rsi_3_1d > 60.0) | (roc_9_1d < 60.0))
+            & ((rsi_3_4h_gt_30) | (rsi_3_1d_gt_60) | (roc_9_1d < 60.0))
             # 4h down move, 1d downtrend
             & ((rsi_3_4h_gt_30) | roc_9_1d_gt_neg_50)
             # 4h down move, 4h & 1d overbought
@@ -14155,7 +14155,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 1d down move, 1d overbought
             & ((rsi_3_1h_gt_15) | (rsi_3_1d > 35.0) | (roc_9_1d < 10.0))
             # 1h & 1d down move, 1d overbought
-            & ((rsi_3_1h_gt_15) | (rsi_3_1d > 60.0) | (roc_9_1d_lt_40))
+            & ((rsi_3_1h_gt_15) | (rsi_3_1d_gt_60) | (roc_9_1d_lt_40))
             # 1h down move, 1h still not low enough, 1d downtrend
             & ((rsi_3_1h_gt_15) | (stochrsi_k_1h < 30.0) | (roc_9_1d > -30.0))
             # 1h & 4h down move, 1d high
@@ -15762,7 +15762,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 4h high & overbought
             & ((rsi_3_1h > 55.0) | aroonu_14_4h_lt_100 | (roc_9_4h_lt_10))
             # 1h & 1d down move, 1h high
-            & ((rsi_3_1h > 60.0) | (rsi_3_1d > 60.0) | aroonu_14_1h_lt_70)
+            & ((rsi_3_1h > 60.0) | (rsi_3_1d_gt_60) | aroonu_14_1h_lt_70)
             # 1h down move, 4 high, 1h overbought
             & ((rsi_3_1h > 60.0) | aroonu_14_4h_lt_100 | (roc_9_1h_lt_10))
             # 1h down move, 1d high, 1h overbought
@@ -15838,7 +15838,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 4h high, 1d downtrend
             & ((rsi_3_4h > 45.0) | aroonu_14_4h_lt_70 | (roc_9_1d_gt_neg_30))
             # 4h & 1d down move, 1d high
-            & ((rsi_3_4h_gt_40) | (rsi_3_1d > 60.0) | aroonu_14_1d_lt_100)
+            & ((rsi_3_4h_gt_40) | (rsi_3_1d_gt_60) | aroonu_14_1d_lt_100)
             # 4h down move, 4h high, 1d downtrend
             & ((rsi_3_4h_gt_40) | (stochrsi_k_4h_lt_70) | (roc_9_1d > -60.0))
             # 4h down move, 1d high & overbought
@@ -15884,7 +15884,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1d down move, 1d high & overbought
             & ((rsi_3_1d > 40.0) | (aroonu_14_1d_lt_80) | (roc_9_1d < 10.0))
             # 1d down move, 1h high, 1d overbought
-            & ((rsi_3_1d > 60.0) | aroonu_14_1h_lt_70 | (roc_9_1d < 100.0))
+            & ((rsi_3_1d_gt_60) | aroonu_14_1h_lt_70 | (roc_9_1d < 100.0))
             # 4h downtrend, 4h high & over
             & ((cmf_20_4h > -0.10) | aroonu_14_4h_lt_100 | (roc_9_4h_lt_30))
             # 15m still high, 4h high, 1h overbought
@@ -16131,7 +16131,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1d down move, 4h high & overbought
             & ((rsi_3_1d > 45.0) | aroonu_14_4h_lt_80 | (roc_9_4h_lt_30))
             # 1d down move, 1h high, 1d overbought
-            & ((rsi_3_1d > 60.0) | (aroonu_14_1h < 75.0) | (roc_9_1d_lt_20))
+            & ((rsi_3_1d_gt_60) | (aroonu_14_1h < 75.0) | (roc_9_1d_lt_20))
             # 1d down move, 1h & 4h high
             & ((rsi_3_1d > 65.0) | (aroonu_14_1h_lt_90) | aroonu_14_4h_lt_100)
             # 1d downtrend, 1d high & overbought
@@ -19215,7 +19215,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h& 1d down move, 1h still high
             & ((rsi_3_1h_gt_10) | (rsi_3_1d_gt_25) | (aroonu_14_1h < 40.0))
             # 1h & 1d down move, 1d high
-            & ((rsi_3_1h_gt_10) | (rsi_3_1d > 60.0) | (aroonu_14_1d_lt_80))
+            & ((rsi_3_1h_gt_10) | (rsi_3_1d_gt_60) | (aroonu_14_1d_lt_80))
             # 1h & 4h down move, 1d high
             & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_15) | (rsi_14_1d < 60.0))
             # 1h & 4h down move, 4h still high
@@ -20485,7 +20485,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 4h down move, 4h high, 1d downtrend
           long_entry_logic.append((rsi_3_4h_gt_35) | (stochrsi_k_4h_lt_70) | (roc_9_1d_gt_neg_30))
           # 4h & 1d down move, 1d high
-          long_entry_logic.append((rsi_3_4h_gt_40) | (rsi_3_1d > 60.0) | aroonu_14_1d_lt_100)
+          long_entry_logic.append((rsi_3_4h_gt_40) | (rsi_3_1d_gt_60) | aroonu_14_1d_lt_100)
           # 4h down move, 4h high, 1d downtrend
           long_entry_logic.append((rsi_3_4h > 60.0) | (stochrsi_k_4h < 80.0) | (roc_9_1d_gt_neg_20))
           # 4h down move, 15m high, 4h overbought
@@ -21335,7 +21335,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 4h high & overbought
             & ((rsi_3_1h_gt_50) | (stochrsi_k_4h_lt_90) | (roc_9_4h < 25.0))
             # 1h & 1d down move, 1h high
-            & ((rsi_3_1h > 60.0) | (rsi_3_1d > 60.0) | aroonu_14_1h_lt_70)
+            & ((rsi_3_1h > 60.0) | (rsi_3_1d_gt_60) | aroonu_14_1h_lt_70)
             # 4h & 1d down move, 1d still high
             & ((rsi_3_4h > 3.0) | (rsi_3_1d_gt_20) | (rsi_14_1d < 40.0))
             # 4h down move, 1h still not low enough, 4h downtrend
@@ -21405,7 +21405,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h & 1d down move, 4h still high
             & ((rsi_3_4h_gt_30) | (rsi_3_1d > 30.0) | (stochrsi_k_4h_lt_50))
             # 4h & 1d down move, 1d high
-            & ((rsi_3_4h_gt_30) | (rsi_3_1d > 60.0) | (aroonu_14_1d_lt_90))
+            & ((rsi_3_4h_gt_30) | (rsi_3_1d_gt_60) | (aroonu_14_1d_lt_90))
             # 4h down move, 15m & 4h high
             & ((rsi_3_4h_gt_30) | (aroonu_14_15m_lt_70) | aroonu_14_4h_lt_70)
             # 4h down move, 1h high, 1d downtrend
@@ -21433,7 +21433,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1d down move, 1d high & overbought
             & ((rsi_3_1d > 55.0) | (stochrsi_k_1d < 80.0) | (roc_9_1d < 10.0))
             # 1d down move, 1d overbought
-            & ((rsi_3_1d > 60.0) | (roc_9_1d < 200.0))
+            & ((rsi_3_1d_gt_60) | (roc_9_1d < 200.0))
             # 15m & 1h high, 4h overbought
             & ((aroonu_14_15m_lt_70) | (aroonu_14_1h_lt_100) | (roc_9_4h < 15.0))
             # 15m & 1h high, 1d overbought
@@ -21798,7 +21798,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h & 1d down move, 4h still high
             & ((rsi_3_4h_gt_30) | (rsi_3_1d > 30.0) | (stochrsi_k_4h_lt_50))
             # 4h & 1d down move, 1d high
-            & ((rsi_3_4h_gt_30) | (rsi_3_1d > 60.0) | (aroonu_14_1d_lt_90))
+            & ((rsi_3_4h_gt_30) | (rsi_3_1d_gt_60) | (aroonu_14_1d_lt_90))
             # 4h down move, 4h high, 1d high
             & ((rsi_3_4h_gt_30) | aroonu_14_4h_lt_70 | (stochrsi_k_1d < 80.0))
             # 4h down move, 1d stil high, 1d downtrend
@@ -22572,7 +22572,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1d down move, 1d high, 4h downtrend
             & ((rsi_3_1d > 35.0) | (aroonu_14_1d_lt_70) | (roc_9_4h > -10.0))
             # 1d down move, 4h high, 1d overbought
-            & ((rsi_3_1d > 60.0) | aroonu_14_4h_lt_70 | (roc_9_1d_lt_40))
+            & ((rsi_3_1d_gt_60) | aroonu_14_4h_lt_70 | (roc_9_1d_lt_40))
             # 15m high, 1d high & overbought
             & ((aroonu_14_15m_lt_70) | aroonu_14_1d_lt_100 | (roc_9_1d < 100.0))
             # 15m high, 4h overbought, 1d downtrend
@@ -22618,7 +22618,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m & 1h down move, 15m still high
           long_entry_logic.append((rsi_3_15m_gt_30) | (rsi_3_1h > 60.0) | (aroonu_14_15m_lt_50))
           # 15m & 4h & 1d down move, 15m high
-          long_entry_logic.append((rsi_3_15m_gt_30) | (rsi_3_4h_gt_50) | (rsi_3_1d > 60.0) | (aroonu_14_15m_lt_70))
+          long_entry_logic.append((rsi_3_15m_gt_30) | (rsi_3_4h_gt_50) | (rsi_3_1d_gt_60) | (aroonu_14_15m_lt_70))
           # 15m down move, 15m & 4h still high
           long_entry_logic.append((rsi_3_15m_gt_30) | (stochrsi_k_15m < 50.0) | (stochrsi_k_4h_lt_50))
           # 15m & 4h down move, 4h high
@@ -23109,7 +23109,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1d down move, 1d high
             & ((rsi_3_15m_gt_15) | (rsi_3_1d > 50.0) | (aroonu_14_1d_lt_70))
             # 15m & 1d down move, 1d high
-            & ((rsi_3_15m_gt_15) | (rsi_3_1d > 60.0) | (stochrsi_k_1d < 80.0))
+            & ((rsi_3_15m_gt_15) | (rsi_3_1d_gt_60) | (stochrsi_k_1d < 80.0))
             # 15m down move, 15m & 4h high
             & ((rsi_3_15m_gt_15) | (aroonu_14_15m_lt_70) | aroonu_14_4h_lt_80)
             # 15m down move, 15m & 1h high
@@ -23334,7 +23334,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 15m still high, 1d overbought
             & ((rsi_3_4h > 55.0) | (aroonu_14_15m < 40.0) | (roc_9_1d_lt_100))
             # 4h & 1d down move, 4h high, 1d overbought
-            & ((rsi_3_4h > 60.0) | (rsi_3_1d > 60.0) | (aroonu_14_4h < 75.0) | (roc_9_1d_lt_40))
+            & ((rsi_3_4h > 60.0) | (rsi_3_1d_gt_60) | (aroonu_14_4h < 75.0) | (roc_9_1d_lt_40))
             # 4h down move, 4h & 1d high
             & ((rsi_3_4h > 70.0) | (aroonu_14_4h_lt_90) | aroonu_14_1d_lt_100)
             # 1d down move, 4h high
@@ -23354,7 +23354,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1d down move, 4h high & overbought
             & ((rsi_3_1d > 45.0) | aroonu_14_4h_lt_80 | (roc_9_4h_lt_30))
             # 1d down move, 1h high, 1d overbought
-            & ((rsi_3_1d > 60.0) | aroonu_14_1h_lt_80 | (roc_9_1d_lt_80))
+            & ((rsi_3_1d_gt_60) | aroonu_14_1h_lt_80 | (roc_9_1d_lt_80))
             # 1d down move, 15m still high, 1d overbought
             & ((rsi_3_1d > 65.0) | (aroonu_14_15m < 40.0) | (roc_9_1d_lt_100))
             # 1d down move, 4h & 1d high


### PR DESCRIPTION
## Summary
- Reuses the repeated X7 entry-trend `rsi_3_1d > 60.0` comparison as `rsi_3_1d_gt_60` inside `populate_entry_trend()`.
- Keeps the entry mask definitions in the maintainer-style order: RSI first, then AROONU, ROC, and STOCHRSI, with lower-to-higher timeframes.
- Independent on latest upstream `main`.

## Safety
- Behavior is preserved: the new mask is the same local Series comparison used by the replaced inline expressions.
- No indicator formulas, candle selection, order classification, profit arithmetic, thresholds, condition order, return values, or v3 grind-entry code are changed.
- Touched function: `populate_entry_trend()`.

## Backtest scope
- Full backtesting was not required for this patch because it only reuses an already-read local Series comparison inside the same call and reorders local mask definitions.

## Checks
- `python3 ~/.codex/skills/nfi-upstream-pr/scripts/validate_nfi_pr.py --base origin/main`
- `git merge-tree` conflict simulation against `origin/main`: `NO_CONFLICT`
- `git diff --check origin/main...HEAD`
- targeted `git diff origin/main...HEAD -- NostalgiaForInfinityX7.py` review
- `ruff format --check NostalgiaForInfinityX7.py`
- `ruff check NostalgiaForInfinityX7.py`
- `PYTHONDONTWRITEBYTECODE=1 python3 -m py_compile NostalgiaForInfinityX7.py`