### PR TITLE
Guard X7 Bybit futures min stake floor

### DIFF
--- a/NostalgiaForInfinityX7.py
+++ b/NostalgiaForInfinityX7.py
@@ -12352,7 +12352,7 @@ class NostalgiaForInfinityX7(IStrategy):
   def correct_min_stake(self, min_stake: float) -> float:
     if self.config["exchange"]["name"] == "bybit":
       if self.is_futures_mode:
-        if min_stake < 5.0 / self.futures_mode_leverage:
+        if (min_stake is None) or (min_stake < 5.0 / self.futures_mode_leverage):
           min_stake = 5.0 / self.futures_mode_leverage
     elif self.config["exchange"]["name"] == "krakenfutures":
       if self.is_futures_mode:


### PR DESCRIPTION
## Summary
- Add the same `min_stake is None` guard to the Bybit futures floor path that Kraken futures now has.
- Keep the existing `5.0 / futures_mode_leverage` floor and leave stake multipliers, grind logic, exits, and signal behavior unchanged.

## Safety
- Only `correct_min_stake()` is touched.
- The existing Bybit futures floor is unchanged for numeric values; this only prevents `None` from reaching later stake comparisons/arithmetic.
- No indicator formulas, candle selection, order classification, profit arithmetic, thresholds, condition order, return values, or v3 grind-entry code are changed.

## Backtest scope
- A full backtest was not required because this is a guard for an Optional `min_stake` value before existing stake-floor arithmetic. I ran a targeted reproduction for Bybit/Kraken futures `None`, below-floor, and above-floor inputs instead.

## Checks
- `targeted Python reproduction for Bybit/Kraken futures min_stake None and floor behavior`
- `PYTHONDONTWRITEBYTECODE=1 python3 -m py_compile NostalgiaForInfinityX7.py`
- `python3 ~/.codex/skills/nfi-upstream-pr/scripts/validate_nfi_pr.py --base origin/main`
- `git merge-tree conflict simulation against origin/main: NO_CONFLICT`
- `git diff --check`
- `ruff format --check NostalgiaForInfinityX7.py`
- `ruff check NostalgiaForInfinityX7.py`
