### PR TITLE
Preserve X7 CCXT option overrides

### DIFF
--- a/NostalgiaForInfinityX7.py
+++ b/NostalgiaForInfinityX7.py
@@ -981,19 +981,41 @@ class NostalgiaForInfinityX7(IStrategy):
     if "ccxt_async_config" not in exchange_config:
       exchange_config["ccxt_async_config"] = {}
 
-    options = {
-      "brokerId": None,
-      "broker": {"spot": None, "margin": None, "future": None, "delivery": None},
-      "partner": {
-        "spot": {"id": None, "key": None},
-        "future": {"id": None, "key": None},
-        "id": None,
-        "key": None,
-      },
+    nfi_ccxt_broker_options = {
+      "spot": None,
+      "margin": None,
+      "future": None,
+      "delivery": None,
+      "swap": None,
+      "option": None,
+      "inverse": None,
+    }
+    nfi_ccxt_partner_options = {
+      "spot": {"id": None, "key": None},
+      "future": {"id": None, "key": None},
+      "id": None,
+      "key": None,
     }
 
-    exchange_config["ccxt_config"]["options"] = options
-    exchange_config["ccxt_async_config"]["options"] = options
+    for ccxt_config_key in ["ccxt_config", "ccxt_async_config"]:
+      configured_options = exchange_config[ccxt_config_key].get("options")
+      options = {
+        "brokerId": None,
+        "broker": dict(nfi_ccxt_broker_options),
+        "partner": dict(nfi_ccxt_partner_options),
+      }
+
+      if type(configured_options) is dict:
+        configured_broker = configured_options.get("broker")
+        configured_partner = configured_options.get("partner")
+
+        options.update({key: value for key, value in configured_options.items() if key not in ["broker", "partner"]})
+        if type(configured_broker) is dict:
+          options["broker"].update(configured_broker)
+        if type(configured_partner) is dict:
+          options["partner"].update(configured_partner)
+
+      exchange_config[ccxt_config_key]["options"] = options
     super().__init__(config)
 
     strategy_config = self.config


### PR DESCRIPTION
## Summary
- Preserve explicit `ccxt_config.options` and `ccxt_async_config.options` values when X7 installs the NFI CCXT option defaults.
- Keep the existing NFI default broker/partner neutral values for users without custom CCXT options.
- Add the CCXT broker market-type keys used by current Binance-style defaults: `swap`, `option`, and `inverse`.
- Independent on latest upstream `main`.

## Safety
- This only changes X7 exchange option preparation during strategy initialization.
- Existing users without explicit CCXT `options` keep the same neutral NFI defaults.
- Users who explicitly configure `brokerId`, `broker`, `partner`, or other CCXT option keys no longer have those values discarded by X7 initialization.
- No indicator formulas, CMF logic, candle selection, entry/exit conditions, order classification, profit arithmetic, thresholds, condition order, return values, or signal behavior are changed.
- Touched function: `__init__()` only.
- No v3 grind-entry code is touched.

## Backtest scope
- A full backtest was not required because this patch does not change strategy indicators, signals, thresholds, or trade arithmetic.
- Validation focused on static checks, merge simulation, and targeted review of the exchange-option initialization path.

## Checks
- `python3 ~/.codex/skills/nfi-upstream-pr/scripts/validate_nfi_pr.py --base origin/main`
- `git merge-tree` conflict simulation against `origin/main`
- Targeted touched-function review: `__init__()` only
- Targeted CCXT source check against `ccxt@4.5.56` for `partner` and broker market-type option usage
- `git diff --check`
- `ruff format --check NostalgiaForInfinityX7.py`
- `ruff check NostalgiaForInfinityX7.py`
- `PYTHONDONTWRITEBYTECODE=1 python3 -m py_compile NostalgiaForInfinityX7.py`
