### PR TITLE
Reuse X7 entry AROONU masks

### DIFF
--- a/NostalgiaForInfinityX7.py
+++ b/NostalgiaForInfinityX7.py
@@ -13038,22 +13038,51 @@ class NostalgiaForInfinityX7(IStrategy):
     rsi_3_1d_gt_60 = rsi_3_1d > 60.0
     rsi_3_1d_gt_65 = rsi_3_1d > 65.0
 
+    aroonu_14_lt_25 = aroonu_14 < 25.0
+    aroonu_14_lt_30 = aroonu_14 < 30.0
+    aroonu_14_15m_lt_20 = aroonu_14_15m < 20.0
+    aroonu_14_15m_lt_25 = aroonu_14_15m < 25.0
+    aroonu_14_15m_lt_30 = aroonu_14_15m < 30.0
+    aroonu_14_15m_lt_40 = aroonu_14_15m < 40.0
     aroonu_14_15m_lt_50 = aroonu_14_15m < 50.0
+    aroonu_14_15m_lt_60 = aroonu_14_15m < 60.0
     aroonu_14_15m_lt_70 = aroonu_14_15m < 70.0
+    aroonu_14_15m_lt_75 = aroonu_14_15m < 75.0
+    aroonu_14_15m_lt_80 = aroonu_14_15m < 80.0
+    aroonu_14_15m_lt_85 = aroonu_14_15m < 85.0
+    aroonu_14_15m_lt_90 = aroonu_14_15m < 90.0
+    aroonu_14_15m_lt_100 = aroonu_14_15m < 100.0
+    aroonu_14_1h_lt_20 = aroonu_14_1h < 20.0
+    aroonu_14_1h_lt_25 = aroonu_14_1h < 25.0
+    aroonu_14_1h_lt_30 = aroonu_14_1h < 30.0
+    aroonu_14_1h_lt_40 = aroonu_14_1h < 40.0
     aroonu_14_1h_lt_50 = aroonu_14_1h < 50.0
+    aroonu_14_1h_lt_60 = aroonu_14_1h < 60.0
     aroonu_14_1h_lt_70 = aroonu_14_1h < 70.0
+    aroonu_14_1h_lt_75 = aroonu_14_1h < 75.0
     aroonu_14_1h_lt_80 = aroonu_14_1h < 80.0
+    aroonu_14_1h_lt_85 = aroonu_14_1h < 85.0
     aroonu_14_1h_lt_90 = aroonu_14_1h < 90.0
     aroonu_14_1h_lt_100 = aroonu_14_1h < 100.0
+    aroonu_14_4h_lt_20 = aroonu_14_4h < 20.0
+    aroonu_14_4h_lt_30 = aroonu_14_4h < 30.0
     aroonu_14_4h_lt_40 = aroonu_14_4h < 40.0
     aroonu_14_4h_lt_50 = aroonu_14_4h < 50.0
     aroonu_14_4h_lt_60 = aroonu_14_4h < 60.0
     aroonu_14_4h_lt_70 = aroonu_14_4h < 70.0
+    aroonu_14_4h_lt_75 = aroonu_14_4h < 75.0
     aroonu_14_4h_lt_80 = aroonu_14_4h < 80.0
+    aroonu_14_4h_lt_85 = aroonu_14_4h < 85.0
     aroonu_14_4h_lt_90 = aroonu_14_4h < 90.0
     aroonu_14_4h_lt_100 = aroonu_14_4h < 100.0
+    aroonu_14_1d_lt_30 = aroonu_14_1d < 30.0
+    aroonu_14_1d_lt_40 = aroonu_14_1d < 40.0
+    aroonu_14_1d_lt_50 = aroonu_14_1d < 50.0
+    aroonu_14_1d_lt_60 = aroonu_14_1d < 60.0
     aroonu_14_1d_lt_70 = aroonu_14_1d < 70.0
+    aroonu_14_1d_lt_75 = aroonu_14_1d < 75.0
     aroonu_14_1d_lt_80 = aroonu_14_1d < 80.0
+    aroonu_14_1d_lt_85 = aroonu_14_1d < 85.0
     aroonu_14_1d_lt_90 = aroonu_14_1d < 90.0
     aroonu_14_1d_lt_100 = aroonu_14_1d < 100.0
 
@@ -13149,17 +13178,17 @@ class NostalgiaForInfinityX7(IStrategy):
             # 5m & 1h down move
             & ((rsi_3_gt_3) | (rsi_3_1h_gt_5))
             # 5m & 1h down move, 15m still not low enough
-            & ((rsi_3_gt_5) | (rsi_3_1h_gt_10) | (aroonu_14_15m < 30.0))
+            & ((rsi_3_gt_5) | (rsi_3_1h_gt_10) | (aroonu_14_15m_lt_30))
             # 5m & 1h down move, 4h high
             & ((rsi_3_gt_3) | (rsi_3_1h_gt_25) | (stochrsi_k_4h_lt_80))
             # 15m & 1h down move, 1d still high
             & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_3) | (stochrsi_k_1d < 50.0))
             # 5m & 1h down move, 15m still not low enough
-            & ((rsi_3_gt_3) | (rsi_3_1h_gt_15) | (aroonu_14_15m < 30.0))
+            & ((rsi_3_gt_3) | (rsi_3_1h_gt_15) | (aroonu_14_15m_lt_30))
             # 5m & 4h down move, 4h high
             & ((rsi_3_gt_3) | (rsi_3_4h_gt_25) | aroonu_14_4h_lt_70)
             # 5m down move, 15m high
-            & ((rsi_3_gt_3) | (aroonu_14_15m < 80.0))
+            & ((rsi_3_gt_3) | (aroonu_14_15m_lt_80))
             # 5m down move, 1h high, 4h overbought
             & ((rsi_3_gt_3) | (stochrsi_k_1h < 80.0) | (roc_9_4h_lt_20))
             # 5m & 4h down move, 4h high
@@ -13171,13 +13200,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 1h still high
             & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_10) | (aroonu_14_1h_lt_50))
             # 15m & 1h down move, 1d high
-            & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_10) | (aroonu_14_1d < 100.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_10) | (aroonu_14_1d_lt_100))
             # 15m & 1h down move, 1h still high
             & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_10) | (stochrsi_k_1h < 40.0))
             # 15m & 1h & 4h & 1d down move
             & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_15) | (rsi_3_4h_gt_15) | (rsi_3_1d_gt_15))
             # 15m & 1h down move, 15m still high
-            & (rsi_3_15m_gt_3 | rsi_3_1h_gt_20 | (aroonu_14_15m < 40.0))
+            & (rsi_3_15m_gt_3 | rsi_3_1h_gt_20 | (aroonu_14_15m_lt_40))
             # 15m & 1h down move, 1h high
             & (rsi_3_15m_gt_3 | rsi_3_1h_gt_20 | aroonu_14_1h_lt_70)
             # 15m & 1h down move, 1h high
@@ -13199,13 +13228,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 15m downtrend
             & (rsi_3_15m_gt_3 | (cmf_20_15m > -0.40) | (roc_9_15m > -20.0))
             # 15m down move, 15m still high, 15m downtrend
-            & (rsi_3_15m_gt_3 | (aroonu_14_15m < 40.0) | (roc_9_15m > -20.0))
+            & (rsi_3_15m_gt_3 | (aroonu_14_15m_lt_40) | (roc_9_15m > -20.0))
             # 15m down move, 1h & 4h high
-            & (rsi_3_15m_gt_3 | (aroonu_14_1h < 85.0) | (aroonu_14_4h_lt_90))
+            & (rsi_3_15m_gt_3 | (aroonu_14_1h_lt_85) | (aroonu_14_4h_lt_90))
             # 15m down move, 4h high, 15m downtrend
             & (rsi_3_15m_gt_3 | aroonu_14_4h_lt_70 | (roc_9_15m > -20.0))
             # 15m down move, 4h high, 1d overbought
-            & (rsi_3_15m_gt_3 | (aroonu_14_4h < 85.0) | (roc_9_1d_lt_100))
+            & (rsi_3_15m_gt_3 | (aroonu_14_4h_lt_85) | (roc_9_1d_lt_100))
             # 15m down move, 1h high, 4h overbought
             & (rsi_3_15m_gt_3 | (stochrsi_k_1h < 90.0) | (roc_9_4h_lt_10))
             # 15m down move, 4h high & overbought
@@ -13235,7 +13264,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 15m still high, 1d overbought
             & ((rsi_3_15m_gt_5) | (aroonu_14_15m_lt_50) | (roc_9_1d_lt_80))
             # 15m down move, 15m high
-            & ((rsi_3_15m_gt_5) | (aroonu_14_15m < 80.0))
+            & ((rsi_3_15m_gt_5) | (aroonu_14_15m_lt_80))
             # 15m down move, 4h high, 1d overbought
             & ((rsi_3_15m_gt_5) | (aroonu_14_4h_lt_60) | (roc_9_1d_lt_80))
             # 15m & 1h down move, 1h still high
@@ -13253,7 +13282,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 4h overbought
             & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_25) | (roc_9_4h < 80.0))
             # 15m & 4h down move, 1h high
-            & ((rsi_3_15m_gt_10) | (rsi_3_4h_gt_10) | (aroonu_14_1h < 75.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_4h_gt_10) | (aroonu_14_1h_lt_75))
             # 15m & 4h down move, 15m still high
             & ((rsi_3_15m_gt_10) | (rsi_3_4h_gt_10) | (stochrsi_k_15m < 50.0))
             # 15m & 4h down move, 1h still high
@@ -13263,7 +13292,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 4h down move, 1d overbought
             & ((rsi_3_15m_gt_10) | (rsi_3_4h_gt_25) | (roc_9_1d_lt_30))
             # 15m & 4h down move, 1h high
-            & ((rsi_3_15m_gt_10) | (rsi_3_4h_gt_30) | (aroonu_14_1h < 85.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_4h_gt_30) | (aroonu_14_1h_lt_85))
             # 15m & 4h down move, 4h high
             & ((rsi_3_15m_gt_10) | (rsi_3_4h_gt_60) | (stochrsi_k_4h_lt_90))
             # 15m & 1d down move, 1d high
@@ -13295,9 +13324,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 15m & 1h high
             & ((rsi_3_15m_gt_15) | (aroonu_14_15m_lt_70) | (aroonu_14_1h_lt_100))
             # 15m down move, 15m & 1h high
-            & ((rsi_3_15m_gt_15) | (aroonu_14_15m < 80.0) | (aroonu_14_1h_lt_90))
+            & ((rsi_3_15m_gt_15) | (aroonu_14_15m_lt_80) | (aroonu_14_1h_lt_90))
             # 15m & 4h down move, 15m still high
-            & ((rsi_3_15m_gt_20) | (rsi_3_4h_gt_35) | (aroonu_14_15m < 40.0))
+            & ((rsi_3_15m_gt_20) | (rsi_3_4h_gt_35) | (aroonu_14_15m_lt_40))
             # 15m down move, 1h & 4h high
             & ((rsi_3_15m_gt_20) | (aroonu_14_1h_lt_100) | aroonu_14_4h_lt_100)
             # 15m down move, 1h high & overbought
@@ -13327,7 +13356,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 1d downtrend
             & ((rsi_3_1h_gt_5) | (rsi_3_4h_gt_10) | (roc_9_1d_gt_neg_40))
             # 1h & 4h down move, 4h still not low enough
-            & ((rsi_3_1h_gt_5) | (rsi_3_4h_gt_15) | (aroonu_14_4h < 30.0))
+            & ((rsi_3_1h_gt_5) | (rsi_3_4h_gt_15) | (aroonu_14_4h_lt_30))
             # 1h & 4h down move, 4h high
             & ((rsi_3_1h_gt_5) | (rsi_3_4h_gt_50) | aroonu_14_4h_lt_70)
             # 1h & 4h down move, 1d overbought
@@ -13339,35 +13368,35 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1d high, 4h downtrend
             & ((rsi_3_1h_gt_5) | (aroonu_14_1d_lt_90) | (roc_9_4h_gt_neg_30))
             # 1h & 4h down move, 15m still not low enough
-            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_10) | (aroonu_14_15m < 30.0))
+            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_10) | (aroonu_14_15m_lt_30))
             # 1h & 4h down move, 1h still high
             & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_10) | (stochrsi_k_1h < 50.0))
             # 1h & 4h & 1d down move, 4h downtrend, 1d still high
-            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_15) | (rsi_3_1d_gt_25) | (rsi_14_4h > 30.0) | (aroonu_14_1d < 40.0))
+            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_15) | (rsi_3_1d_gt_25) | (rsi_14_4h > 30.0) | (aroonu_14_1d_lt_40))
             # 1h & 1d down move, 4h high
-            & ((rsi_3_1h_gt_10) | (rsi_3_1d_gt_20) | (aroonu_14_4h < 80.0))
+            & ((rsi_3_1h_gt_10) | (rsi_3_1d_gt_20) | (aroonu_14_4h_lt_80))
             # 1h down move, 4h high
             & ((rsi_3_1h_gt_10) | (rsi_14_4h < 75.0))
             # 1h down move, 15m downtrend, 1d high
             & ((rsi_3_1h_gt_10) | (cmf_20_15m > -0.40) | (aroonu_14_1d_lt_70))
             # 1h down move, 1h high, 4h overbought
-            & ((rsi_3_1h_gt_10) | (aroonu_14_1h < 70.0) | (roc_9_4h_lt_10))
+            & ((rsi_3_1h_gt_10) | (aroonu_14_1h_lt_70) | (roc_9_4h_lt_10))
             # 1h down move, 4h overbought
             & ((rsi_3_1h_gt_10) | (roc_9_4h < 50.0))
             # 1h & 4h down move, 4h still high
             & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_15) | (aroonu_14_4h_lt_40))
             # 1h & 4h down move, 4h high
-            & ((rsi_3_1h_gt_15) | rsi_3_4h_gt_20 | (aroonu_14_4h < 80.0))
+            & ((rsi_3_1h_gt_15) | rsi_3_4h_gt_20 | (aroonu_14_4h_lt_80))
             # 1h & 4h down move, 1d overbought
             & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_25) | (roc_9_1d_lt_40))
             # 15m down move, 1h high, 1d downtrend
-            & ((rsi_3_1h_gt_15) | (aroonu_14_1h < 70.0) | (roc_9_1d > -20.0))
+            & ((rsi_3_1h_gt_15) | (aroonu_14_1h_lt_70) | (roc_9_1d > -20.0))
             # 1h down move, 1h high, 1d overbought
-            & ((rsi_3_1h_gt_15) | (aroonu_14_1h < 70.0) | roc_9_1d_lt_50)
+            & ((rsi_3_1h_gt_15) | (aroonu_14_1h_lt_70) | roc_9_1d_lt_50)
             # 1h down move, 1h high
-            & ((rsi_3_1h_gt_15) | (aroonu_14_1h < 80.0))
+            & ((rsi_3_1h_gt_15) | (aroonu_14_1h_lt_80))
             # 1h down mve, 4h high, 1d overbought
-            & ((rsi_3_1h_gt_15) | (aroonu_14_4h < 80.0) | (roc_9_1d_lt_30))
+            & ((rsi_3_1h_gt_15) | (aroonu_14_4h_lt_80) | (roc_9_1d_lt_30))
             # 1h down move, 1d high & overbought
             & ((rsi_3_1h_gt_15) | (aroonu_14_1d_lt_80) | (roc_9_1d_lt_40))
             # 1h down move, 1h & 4h downtrend
@@ -13375,7 +13404,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 4h overbought
             & (rsi_3_1h_gt_20 | (rsi_3_4h_gt_50) | (roc_9_4h < 80.0))
             # 1h down move, 1h still high, 4h downtrend
-            & (rsi_3_1h_gt_20 | (aroonu_14_1h < 40.0) | (roc_9_4h_gt_neg_30))
+            & (rsi_3_1h_gt_20 | (aroonu_14_1h_lt_40) | (roc_9_4h_gt_neg_30))
             # 1h down move, 4h high, 1d overbought
             & (rsi_3_1h_gt_20 | aroonu_14_4h_lt_70 | (roc_9_1d < 200.0))
             # 1h down move, 4h high, 1d overbought
@@ -13401,7 +13430,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h downtrend, 1h high
             & ((rsi_3_1h_gt_40) | (cmf_20_1h > -0.25) | (aroonu_14_1h_lt_90))
             # 1h down move, 1h & 4h high
-            & ((rsi_3_1h_gt_40) | (aroonu_14_1h < 60.0) | aroonu_14_4h_lt_100)
+            & ((rsi_3_1h_gt_40) | (aroonu_14_1h_lt_60) | aroonu_14_4h_lt_100)
             # 1h down move, 1h high, 15m downtrend
             & ((rsi_3_1h_gt_40) | aroonu_14_1h_lt_80 | (roc_9_15m > -15.0))
             # 1h down move, 1h high, 1d overbought
@@ -13415,17 +13444,17 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h still high, 4h high
             & ((rsi_3_1h_gt_60) | (aroonu_14_1h_lt_50) | (rsi_14_4h < 90.0))
             # 4h & 1d down move, 1d high
-            & ((rsi_3_4h_gt_5) | (rsi_3_1d_gt_20) | (aroonu_14_1d < 40.0))
+            & ((rsi_3_4h_gt_5) | (rsi_3_1d_gt_20) | (aroonu_14_1d_lt_40))
             # 4h down move, 4h & 1d downtrend
             & ((rsi_3_4h_gt_5) | (roc_9_4h_gt_neg_30) | (roc_9_1d_gt_neg_40))
             # 4h & 1d down move, 4h still not low enough
-            & ((rsi_3_4h_gt_10) | (rsi_3_1d_gt_15) | (aroonu_14_4h < 20.0))
+            & ((rsi_3_4h_gt_10) | (rsi_3_1d_gt_15) | (aroonu_14_4h_lt_20))
             # 4h & 1d down move, 1d still high
             & ((rsi_3_4h_gt_10) | (rsi_3_1d_gt_25) | (stochrsi_k_1d < 50.0))
             # 4h down move, 4h still high
             & ((rsi_3_4h_gt_10) | (aroonu_14_4h_lt_50))
             # 4h down move, 1d high
-            & ((rsi_3_4h_gt_10) | (aroonu_14_1d < 100.0))
+            & ((rsi_3_4h_gt_10) | (aroonu_14_1d_lt_100))
             # 4h down move, 1h high, 1d downtrend
             & ((rsi_3_4h_gt_10) | (stochrsi_k_1h < 60.0) | (roc_9_1d_gt_neg_40))
             # 4h down move, 4h still not low enough, 1d downtrend
@@ -13465,13 +13494,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m high, 1d overbought
             & ((aroonu_14_15m_lt_70) | (roc_9_1d_lt_80))
             # 1h still high, 1h & 4h downtrend
-            & ((aroonu_14_1h < 40.0) | (roc_9_1h > -20.0) | (roc_9_4h_gt_neg_30))
+            & ((aroonu_14_1h_lt_40) | (roc_9_1h > -20.0) | (roc_9_4h_gt_neg_30))
             # 1h & 4h high, 1h overbought
-            & ((aroonu_14_1h < 85.0) | (aroonu_14_4h_lt_90) | (roc_9_1h < 20.0))
+            & ((aroonu_14_1h_lt_85) | (aroonu_14_4h_lt_90) | (roc_9_1h < 20.0))
             # 1h high, 1h & 4h overbought
-            & ((aroonu_14_1h < 85.0) | (roc_9_1h_lt_10) | (roc_9_1d_lt_30))
+            & ((aroonu_14_1h_lt_85) | (roc_9_1h_lt_10) | (roc_9_1d_lt_30))
             # 1h high, 1h overbought, 1d downtrend
-            & ((aroonu_14_1h < 85.0) | (roc_9_1h < 20.0) | (roc_9_1d_gt_neg_40))
+            & ((aroonu_14_1h_lt_85) | (roc_9_1h < 20.0) | (roc_9_1d_gt_neg_40))
             # 4h & 1d high, 1d overbought
             & (aroonu_14_4h_lt_80 | aroonu_14_1d_lt_100 | roc_9_1d_lt_50)
             # 4h high, 1h downtrend
@@ -13479,7 +13508,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h high, 1d downtrend
             & (aroonu_14_4h_lt_80 | (roc_9_1d_gt_neg_40))
             # 1d high, 4h downtrend, 1d overbought
-            & ((aroonu_14_1d < 85.0) | (roc_9_4h > -25.0) | roc_9_1d_lt_50)
+            & ((aroonu_14_1d_lt_85) | (roc_9_4h > -25.0) | roc_9_1d_lt_50)
             # 1d high, 1h & 4h downtrend
             & ((aroonu_14_1d_lt_90) | (roc_9_1h > -10.0) | (roc_9_4h_gt_neg_20))
             # 1d high, 4h & 1d overbought
@@ -13491,13 +13520,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h high, 1d downtrend
             & ((stochrsi_k_4h_lt_70) | (roc_9_1d_gt_neg_40))
             # 5m down move, 15m still not low enough, 1h high
-            & ((roc_2 > -10.0) | (aroonu_14_15m < 30.0) | aroonu_14_1h_lt_80)
+            & ((roc_2 > -10.0) | (aroonu_14_15m_lt_30) | aroonu_14_1h_lt_80)
             # 5m down move, 15m still high
             & ((roc_2 > -10.0) | (aroonu_14_15m_lt_50))
             # 5m down move, 15m & 1h down move, 15m still high
             & ((roc_9 > -15.0) | (rsi_3_15m_gt_5) | (rsi_3_1h_gt_35) | (aroonu_14_15m_lt_50))
             # 5m down move, 4h down move, 15m downtrend, 1h high
-            & ((roc_9 > -15.0) | (rsi_3_4h_gt_45) | (cmf_20_15m > -0.3) | (aroonu_14_1h < 60.0))
+            & ((roc_9 > -15.0) | (rsi_3_4h_gt_45) | (cmf_20_15m > -0.3) | (aroonu_14_1h_lt_60))
             # 1h downtrend, 4h high & overbought
             & ((roc_9_1h > -25.0) | aroonu_14_4h_lt_80 | (roc_9_4h < 80.0))
             # 1h & 4h overbought, 1d downtrend
@@ -13515,7 +13544,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # big drop in the last hour, 15m downtrend
             & ((close > (close_max_12 * 0.65)) | (cmf_20_15m > -0.5))
             # big drop in the last 6 hours, 1h down move, 1h high
-            & ((close > (df["high_max_6_1h"] * 0.60)) | rsi_3_1h_gt_20 | (aroonu_14_1h < 60.0))
+            & ((close > (df["high_max_6_1h"] * 0.60)) | rsi_3_1h_gt_20 | (aroonu_14_1h_lt_60))
             # big drop in the last 24 hours,  1h still high
             & ((close > (df["high_max_24_1h"] * 0.40)) | (stochrsi_k_1h < 45.0))
             # big drop in the last 4 days, 1h high
@@ -13540,7 +13569,7 @@ class NostalgiaForInfinityX7(IStrategy):
 
           long_entry_logic.append(
             # 5m & 1h down move, 1h still not low enough
-            ((rsi_3_gt_3) | (rsi_3_1h_gt_10) | (aroonu_14_1h < 30.0))
+            ((rsi_3_gt_3) | (rsi_3_1h_gt_10) | (aroonu_14_1h_lt_30))
             # 5m & 1h down move, 1d high
             & ((rsi_3_gt_3) | rsi_3_1h_gt_20 | aroonu_14_1d_lt_100)
             # 5m & 1h down move, 1h still high
@@ -13556,7 +13585,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 5m & 4h down move, 15m still high
             & ((rsi_3_gt_5) | (rsi_3_4h_gt_25) | (stochrsi_k_15m < 50.0))
             # 5m & 1d down move, 1h still high
-            & ((rsi_3_gt_3) | (rsi_3_1d_gt_10) | (aroonu_14_1h < 40.0))
+            & ((rsi_3_gt_3) | (rsi_3_1d_gt_10) | (aroonu_14_1h_lt_40))
             # 5m & 1d down move, 1h still high
             & ((rsi_3_gt_3) | (rsi_3_1d_gt_10) | (stochrsi_k_1h_lt_50))
             # 5m & 1d down move, 1d downtrend
@@ -13592,15 +13621,15 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 15m downtrend
             & ((rsi_3_15m_gt_3) | (rsi_3_1h_gt_5) | (cmf_20_15m > -0.30))
             # 15m & 1h down move, 15m still not low enough
-            & ((rsi_3_15m_gt_3) | (rsi_3_1h_gt_5) | (aroonu_14_15m < 30.0))
+            & ((rsi_3_15m_gt_3) | (rsi_3_1h_gt_5) | (aroonu_14_15m_lt_30))
             # 15m & 1h down move, 1h still not low enough
-            & ((rsi_3_15m_gt_3) | (rsi_3_1h_gt_5) | (aroonu_14_1h < 25.0))
+            & ((rsi_3_15m_gt_3) | (rsi_3_1h_gt_5) | (aroonu_14_1h_lt_25))
             # 15m & 1h down move, 1h still not low enough
             & ((rsi_3_15m_gt_3) | (rsi_3_1h_gt_5) | (stochrsi_k_1h < 30.0))
             # 15m & 1h & 4h down move
             & ((rsi_3_15m_gt_3) | (rsi_3_1h_gt_10) | (rsi_3_4h_gt_10))
             # 15m & 1h & 4h down move, 4h still not low enough, 1d still high
-            & ((rsi_3_15m_gt_3) | (rsi_3_1h_gt_10) | (rsi_3_4h_gt_20) | (aroonu_14_4h < 20.0) | (rsi_14_1d < 50.0))
+            & ((rsi_3_15m_gt_3) | (rsi_3_1h_gt_10) | (rsi_3_4h_gt_20) | (aroonu_14_4h_lt_20) | (rsi_14_1d < 50.0))
             # 15m & 1h down move, 1h high
             & ((rsi_3_15m_gt_3) | (rsi_3_1h_gt_10) | (stochrsi_k_1h < 30.0))
             # 15m & 1h down move, 1d downtrend
@@ -13616,11 +13645,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 4h high
             & ((rsi_3_15m_gt_3) | (rsi_3_1h_gt_20) | (stochrsi_k_4h < 60.0))
             # 15m & 1h down move, 1h high
-            & ((rsi_3_15m_gt_3) | (rsi_3_1h_gt_30) | (aroonu_14_1h < 60.0))
+            & ((rsi_3_15m_gt_3) | (rsi_3_1h_gt_30) | (aroonu_14_1h_lt_60))
             # 15m & 1h down move, 1h high
             & ((rsi_3_15m_gt_3) | (rsi_3_1h_gt_30) | (stochrsi_k_1h_lt_70))
             # 15m & 1h down move, 1h still high
-            & ((rsi_3_15m_gt_3) | (rsi_3_1h_gt_35) | (aroonu_14_1h < 40.0))
+            & ((rsi_3_15m_gt_3) | (rsi_3_1h_gt_35) | (aroonu_14_1h_lt_40))
             # 15m & 1h down move, 1d high
             & ((rsi_3_15m_gt_3) | (rsi_3_1h_gt_35) | (stochrsi_k_1d < 70.0))
             # 15m & 1h down move, 1h high
@@ -13628,7 +13657,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 4h high
             & ((rsi_3_15m_gt_3) | (rsi_3_1h_gt_40) | (stochrsi_k_4h_lt_80))
             # 15m & 1h down move, 1h high
-            & ((rsi_3_15m_gt_3) | (rsi_3_1h_gt_45) | (aroonu_14_1h < 85.0))
+            & ((rsi_3_15m_gt_3) | (rsi_3_1h_gt_45) | (aroonu_14_1h_lt_85))
             # 15m & 1h down move, 1h high
             & ((rsi_3_15m_gt_3) | (rsi_3_1h_gt_60) | (stochrsi_k_1h_lt_80))
             # 15m & 4h down move, 4h still not low enough
@@ -13644,9 +13673,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 4h down move, 4h still high
             & ((rsi_3_15m_gt_3) | (rsi_3_4h_gt_35) | (stochrsi_k_4h_lt_50))
             # 15m down move, 15m still not low enough, 1h high
-            & ((rsi_3_15m_gt_3) | (aroonu_14_15m < 20.0) | (stochrsi_k_1h < 60.0))
+            & ((rsi_3_15m_gt_3) | (aroonu_14_15m_lt_20) | (stochrsi_k_1h < 60.0))
             # 15m down move, 15m still not low enough, 1h still high
-            & ((rsi_3_15m_gt_3) | (aroonu_14_15m < 30.0) | (stochrsi_k_1h_lt_50))
+            & ((rsi_3_15m_gt_3) | (aroonu_14_15m_lt_30) | (stochrsi_k_1h_lt_50))
             # 15m down move, 1h high, 1d overbought
             & ((rsi_3_15m_gt_3) | (aroonu_14_1h_lt_70) | (roc_9_1d_lt_20))
             # 15m down move, 4h still high, 15m downtrend
@@ -13660,9 +13689,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 4h still high
             & ((rsi_3_15m_gt_5) | (rsi_3_1h_gt_10) | (rsi_14_4h < 40.0))
             # 15m & 1h down move, 1h still high
-            & ((rsi_3_15m_gt_5) | (rsi_3_1h_gt_10) | (aroonu_14_1h < 40.0))
+            & ((rsi_3_15m_gt_5) | (rsi_3_1h_gt_10) | (aroonu_14_1h_lt_40))
             # 15m & 1h down move, 4h high
-            & ((rsi_3_15m_gt_5) | (rsi_3_1h_gt_10) | (aroonu_14_4h < 100.0))
+            & ((rsi_3_15m_gt_5) | (rsi_3_1h_gt_10) | (aroonu_14_4h_lt_100))
             # 15m & 1h down move, 4h high
             & ((rsi_3_15m_gt_5) | (rsi_3_1h_gt_15) | (stochrsi_k_4h < 60.0))
             # 15m & 1h & 4h & 1d down move, 1d high
@@ -13678,7 +13707,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 4h down move, 1d high
             & ((rsi_3_15m_gt_5) | (rsi_3_4h_gt_10) | (stochrsi_k_1d < 70.0))
             # 15m & 4h down move, 15m still high
-            & ((rsi_3_15m_gt_5) | (rsi_3_4h_gt_15) | (aroonu_14_15m < 40.0))
+            & ((rsi_3_15m_gt_5) | (rsi_3_4h_gt_15) | (aroonu_14_15m_lt_40))
             # 15m & 4h down move, 1h still high
             & ((rsi_3_15m_gt_5) | (rsi_3_4h_gt_15) | (stochrsi_k_1h < 50.0))
             # 15m & 4h down move, 4h still high
@@ -13688,15 +13717,15 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 4h down move, 4h still high
             & ((rsi_3_15m_gt_5) | (rsi_3_4h_gt_45) | (aroonu_14_4h_lt_40))
             # 15m & 1d down move, 15m still not low enough
-            & ((rsi_3_15m_gt_5) | (rsi_3_1d_gt_10) | (aroonu_14_15m < 30.0))
+            & ((rsi_3_15m_gt_5) | (rsi_3_1d_gt_10) | (aroonu_14_15m_lt_30))
             # 15m & 1d down move, 1h high
             & ((rsi_3_15m_gt_5) | (rsi_3_1d_gt_40) | (stochrsi_k_1h < 90.0))
             # 15m down move, 15m downtrend, 4h still not low enough
             & ((rsi_3_15m_gt_5) | (cmf_20_15m > -0.30) | (stochrsi_k_4h < 30.0))
             # 15m down move, 15m still not low enough, 4h high
-            & ((rsi_3_15m_gt_5) | (aroonu_14_15m < 20.0) | (stochrsi_k_4h_lt_70))
+            & ((rsi_3_15m_gt_5) | (aroonu_14_15m_lt_20) | (stochrsi_k_4h_lt_70))
             # 15m down move, 15m stil high, 1h still high
-            & ((rsi_3_15m_gt_5) | (aroonu_14_15m < 40.0) | (stochrsi_k_1h_lt_50))
+            & ((rsi_3_15m_gt_5) | (aroonu_14_15m_lt_40) | (stochrsi_k_1h_lt_50))
             # 15m down move, 1d high & overbought
             & ((rsi_3_15m_gt_5) | (aroonu_14_1d_lt_80) | (roc_9_1d_lt_20))
             # 15m down move, 15m still not low enough, 1h still high
@@ -13714,13 +13743,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 1d high
             & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_10) | (stochrsi_k_1d < 70.0))
             # 15m & 1h down move, 1h high
-            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_15) | (aroonu_14_1h < 80.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_15) | (aroonu_14_1h_lt_80))
             # 15m & 1h down move, 4h high
             & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_20) | (stochrsi_k_4h_lt_70))
             # 15m & 1h & 4h down move, 1d high
             & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_25) | (rsi_3_4h_gt_25) | (stochrsi_k_1d < 70.0))
             # 15m & 1h down move, 4h high
-            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_25) | (aroonu_14_4h < 75.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_25) | (aroonu_14_4h_lt_75))
             # 15m & 1h down move, 4h still high
             & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_25) | (aroonu_14_4h_lt_50))
             # 15m & 1h down move, 1d downtrend
@@ -13800,31 +13829,31 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 4h high & overbought
             & ((rsi_3_15m_gt_15) | (rsi_3_1h_gt_55) | (aroonu_14_4h_lt_60) | (roc_9_4h_lt_30))
             # 15m & 4h down move, 1h high
-            & ((rsi_3_15m_gt_15) | (rsi_3_4h_gt_15) | (aroonu_14_1h < 70.0))
+            & ((rsi_3_15m_gt_15) | (rsi_3_4h_gt_15) | (aroonu_14_1h_lt_70))
             # 15m & 4h down move, 4h downtrend
             & ((rsi_3_15m_gt_15) | (rsi_3_4h_gt_15) | (roc_9_4h > -20.0))
             # 15m & 4h down move, 1d high
             & ((rsi_3_15m_gt_15) | (rsi_3_4h_gt_20) | (aroonu_14_1d_lt_90))
             # 15m & 1d down move, 1h still high
-            & ((rsi_3_15m_gt_15) | (rsi_3_1d_gt_15) | (aroonu_14_1h < 40.0))
+            & ((rsi_3_15m_gt_15) | (rsi_3_1d_gt_15) | (aroonu_14_1h_lt_40))
             # 15m & 1d down move, 4h high
             & ((rsi_3_15m_gt_15) | (rsi_3_1d_gt_30) | (aroonu_14_4h_lt_90))
             # 15m down move, 15m still not low enough, 4h high
-            & ((rsi_3_15m_gt_15) | (aroonu_14_15m < 25.0) | (aroonu_14_4h_lt_60))
+            & ((rsi_3_15m_gt_15) | (aroonu_14_15m_lt_25) | (aroonu_14_4h_lt_60))
             # 15m down move, 15m still not low enough, 1h high
-            & ((rsi_3_15m_gt_15) | (aroonu_14_15m < 30.0) | (aroonu_14_1h_lt_70))
+            & ((rsi_3_15m_gt_15) | (aroonu_14_15m_lt_30) | (aroonu_14_1h_lt_70))
             # 15m down move, 15m & 4h still high
-            & ((rsi_3_15m_gt_15) | (aroonu_14_15m < 40.0) | (aroonu_14_4h_lt_40))
+            & ((rsi_3_15m_gt_15) | (aroonu_14_15m_lt_40) | (aroonu_14_4h_lt_40))
             # 15m down move, 1h still high, 4h overbought
             & ((rsi_3_15m_gt_15) | (aroonu_14_1h_lt_50) | (roc_9_4h < 60.0))
             # 15m down move, 1h & 4h high
-            & ((rsi_3_15m_gt_15) | (aroonu_14_1h < 60.0) | (aroonu_14_4h_lt_90))
+            & ((rsi_3_15m_gt_15) | (aroonu_14_1h_lt_60) | (aroonu_14_4h_lt_90))
             # 15m down move, 1h & 1d high
             & ((rsi_3_15m_gt_15) | aroonu_14_1h_lt_70 | (aroonu_14_1d_lt_90))
             # 15m down move, 4h high, 4h downtrend
             & ((rsi_3_15m_gt_15) | (aroonu_14_4h_lt_60) | (roc_9_4h_gt_neg_20))
             # 15m down move, 4h & 1d high
-            & ((rsi_3_15m_gt_15) | (aroonu_14_4h < 75.0) | (aroonu_14_1d_lt_100))
+            & ((rsi_3_15m_gt_15) | (aroonu_14_4h_lt_75) | (aroonu_14_1d_lt_100))
             # 15m down move, 4h high & overbought
             & ((rsi_3_15m_gt_15) | aroonu_14_4h_lt_80 | (roc_9_4h_lt_10))
             # 15m down move, 15m still high, 1d overbought
@@ -13834,7 +13863,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 4h high, 1d overbought
             & ((rsi_3_15m_gt_15) | (stochrsi_k_4h_lt_70) | (roc_9_1d < 10.0))
             # 15m & 1h down move, 15m still not low enough
-            & ((rsi_3_15m_gt_20) | (rsi_3_1h_gt_20) | (aroonu_14_15m < 30.0))
+            & ((rsi_3_15m_gt_20) | (rsi_3_1h_gt_20) | (aroonu_14_15m_lt_30))
             # 15m & 1h down move, 4h overbought
             & ((rsi_3_15m_gt_20) | (rsi_3_1h_gt_20) | (roc_9_4h < 50.0))
             # 15m & 1h down move, 15m high
@@ -13866,7 +13895,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 4h down move, 1h overbought
             & ((rsi_3_15m_gt_25) | (rsi_3_4h_gt_35) | (roc_9_1h < 100.0))
             # 15m down move, 15m still not low enough, 1h high
-            & ((rsi_3_15m_gt_25) | (aroonu_14_15m < 20.0) | (stochrsi_k_1h < 90.0))
+            & ((rsi_3_15m_gt_25) | (aroonu_14_15m_lt_20) | (stochrsi_k_1h < 90.0))
             # 15m down move, 1h & 4h high
             & ((rsi_3_15m_gt_25) | (aroonu_14_1h_lt_70) | (aroonu_14_4h_lt_100))
             # 15m down move, 1h high, 1d overbought
@@ -13894,7 +13923,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 1d downtrend
             & ((rsi_3_1h > 1.0) | (rsi_3_4h_gt_15) | (roc_9_1d > -10.0))
             # 1h down move, 15m downtrend, 1h still high
-            & ((rsi_3_1h_gt_3) | (cmf_20_15m > -0.40) | (aroonu_14_1h < 40.0))
+            & ((rsi_3_1h_gt_3) | (cmf_20_15m > -0.40) | (aroonu_14_1h_lt_40))
             # 1h & 4h down move, 15m downtrend
             & ((rsi_3_1h_gt_3) | (rsi_3_4h_gt_3) | (roc_9_15m > -30.0))
             # 1h & 4h down move, 4h still high
@@ -13904,7 +13933,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 4h still high
             & ((rsi_3_1h_gt_3) | (rsi_3_4h_gt_15) | (rsi_14_4h < 40.0))
             # 1h & 4h down move, 1h still not low enough
-            & ((rsi_3_1h_gt_3) | rsi_3_4h_gt_20 | (aroonu_14_1h < 20.0))
+            & ((rsi_3_1h_gt_3) | rsi_3_4h_gt_20 | (aroonu_14_1h_lt_20))
             # 1h & 4h down move, 1d high
             & ((rsi_3_1h_gt_3) | rsi_3_4h_gt_20 | (aroonu_14_1d_lt_80))
             # 1h & 4h down move, 1d overbought
@@ -13934,13 +13963,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h & 1d down move
             & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_10) | (rsi_3_1d_gt_15))
             # 1h & 4h down move, 1d still high
-            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_10) | (aroonu_14_1d < 40.0))
+            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_10) | (aroonu_14_1d_lt_40))
             # 1h & 4h down move, 1h still not low enough
             & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_10) | (stochrsi_k_1h < 20.0))
             # 1h & 4h down move, 1d downtrend
             & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_10) | (roc_9_1d > -20.0))
             # 1h & 4h & 1d down move, 4h downtrend, 1d still high
-            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_15) | (rsi_3_1d_gt_25) | (rsi_14_4h > 30.0) | (aroonu_14_1d < 40.0))
+            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_15) | (rsi_3_1d_gt_25) | (rsi_14_4h > 30.0) | (aroonu_14_1d_lt_40))
             # 1h & 4h down move, 15m high
             & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_15) | (stochrsi_k_15m < 70.0))
             # 1h & 4h down move, 1d downtrend
@@ -13952,11 +13981,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 4h still high
             & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_35) | (rsi_14_4h < 40.0))
             # 1h down move, 1h still not low enough 1d overbought
-            & ((rsi_3_1h_gt_10) | (aroonu_14_1h < 30.0) | (roc_9_1d < 100.0))
+            & ((rsi_3_1h_gt_10) | (aroonu_14_1h_lt_30) | (roc_9_1d < 100.0))
             # 1h & 4h down move, 1d high
             & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_15) | (rsi_14_1d < 60.0))
             # 1h & 4h down move, 1h still not low enough
-            & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_15) | (aroonu_14_1h < 20.0))
+            & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_15) | (aroonu_14_1h_lt_20))
             # 1h & 4h down move, 15m still high
             & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_15) | (stochrsi_k_15m < 50.0))
             # 1h & 4h down move, 4h downtrend
@@ -13978,9 +14007,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 1d down move, 1d overbought
             & ((rsi_3_1h_gt_15) | (rsi_3_1d_gt_35) | (roc_9_1d < 10.0))
             # 1h down move, 1h still high, 1d downtrend
-            & ((rsi_3_1h_gt_15) | (aroonu_14_1h < 40.0) | (roc_9_1d_gt_neg_40))
+            & ((rsi_3_1h_gt_15) | (aroonu_14_1h_lt_40) | (roc_9_1d_gt_neg_40))
             # 1h down move, 4h high, 1d high
-            & ((rsi_3_1h_gt_15) | (aroonu_14_4h_lt_60) | (aroonu_14_1d < 100.0))
+            & ((rsi_3_1h_gt_15) | (aroonu_14_4h_lt_60) | (aroonu_14_1d_lt_100))
             # 1h down move, 4h high, 1d overbought
             & ((rsi_3_1h_gt_15) | (aroonu_14_4h_lt_60) | roc_9_1d_lt_50)
             # 1h down move, 4h high & overbought
@@ -13994,7 +14023,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 4h still high
             & (rsi_3_1h_gt_20 | (rsi_3_4h_gt_35) | (stochrsi_k_4h_lt_50))
             # 1h & 4h down move, 4h high
-            & (rsi_3_1h_gt_20 | (rsi_3_4h_gt_50) | (aroonu_14_4h < 85.0))
+            & (rsi_3_1h_gt_20 | (rsi_3_4h_gt_50) | (aroonu_14_4h_lt_85))
             # 1h & 1d down move, 1h still high
             & (rsi_3_1h_gt_20 | (rsi_3_1d_gt_30) | (stochrsi_k_1h_lt_50))
             # 1h down move, 1h high, 4h downtrend
@@ -14012,9 +14041,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 1d downtrend
             & ((rsi_3_1h_gt_25) | (rsi_3_4h_gt_30) | (roc_9_1d_gt_neg_30))
             # 1h down move, 1h & 4h high
-            & ((rsi_3_1h_gt_25) | (aroonu_14_1h < 60.0) | (aroonu_14_4h_lt_90))
+            & ((rsi_3_1h_gt_25) | (aroonu_14_1h_lt_60) | (aroonu_14_4h_lt_90))
             # 1h down move, 1h high
-            & ((rsi_3_1h_gt_25) | (aroonu_14_1h < 85.0))
+            & ((rsi_3_1h_gt_25) | (aroonu_14_1h_lt_85))
             # 1h down move, 4h high, 4h downtrend
             & ((rsi_3_1h_gt_25) | aroonu_14_4h_lt_70 | (cmf_20_4h > -0.50))
             # 1h down move, 1d high & overbought
@@ -14024,7 +14053,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 4h downtrend
             & ((rsi_3_1h_gt_30) | (rsi_3_4h_gt_30) | (roc_9_4h_gt_neg_20))
             # 1h down move, 1h & 4h high
-            & ((rsi_3_1h_gt_30) | (aroonu_14_1h < 60.0) | aroonu_14_4h_lt_100)
+            & ((rsi_3_1h_gt_30) | (aroonu_14_1h_lt_60) | aroonu_14_4h_lt_100)
             # 1h down move, 1h high, 4h overbought
             & ((rsi_3_1h_gt_30) | aroonu_14_1h_lt_70 | (roc_9_4h_lt_10))
             # 1h down move, 4h & 1d high
@@ -14042,9 +14071,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h high, 1d downtrend
             & ((rsi_3_1h_gt_35) | aroonu_14_1h_lt_70 | (roc_9_1d > -25.0))
             # 1h down move, 4h high & overbought
-            & ((rsi_3_1h_gt_35) | (aroonu_14_4h < 85.0) | (roc_9_4h < 100.0))
+            & ((rsi_3_1h_gt_35) | (aroonu_14_4h_lt_85) | (roc_9_4h < 100.0))
             # 1h down move, 4h high, 1d overbought
-            & ((rsi_3_1h_gt_35) | (aroonu_14_4h < 85.0) | (roc_9_1d_lt_100))
+            & ((rsi_3_1h_gt_35) | (aroonu_14_4h_lt_85) | (roc_9_1d_lt_100))
             # 1h down move, 1d high, 4h overbought
             & ((rsi_3_1h_gt_35) | aroonu_14_1d_lt_100 | (roc_9_4h_lt_40))
             # 1h down move, 1h still high, 1d overbought
@@ -14068,7 +14097,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h high & overbought
             & ((rsi_3_1h_gt_50) | aroonu_14_1h_lt_80 | (roc_9_1h_lt_10))
             # 1h down move, 4h high, 1h overbought
-            & ((rsi_3_1h_gt_50) | (aroonu_14_4h < 85.0) | (roc_9_1h < 20.0))
+            & ((rsi_3_1h_gt_50) | (aroonu_14_4h_lt_85) | (roc_9_1h < 20.0))
             # 1h down move, 4h high, 1d downtrend
             & ((rsi_3_1h_gt_50) | (stochrsi_k_4h < 60.0) | (roc_9_1d > -60.0))
             # 1h down move, 4h high & overbought
@@ -14082,7 +14111,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h high & overbought
             & ((rsi_3_1h_gt_55) | (stochrsi_k_1h_lt_80) | (roc_9_1h_lt_10))
             # 4h & 1d down move, 1d still high
-            & ((rsi_3_4h_gt_3) | (rsi_3_1d_gt_15) | (aroonu_14_1d < 40.0))
+            & ((rsi_3_4h_gt_3) | (rsi_3_1d_gt_15) | (aroonu_14_1d_lt_40))
             # 4h & 1d down move, 1d still high
             & ((rsi_3_4h_gt_3) | (rsi_3_1d_gt_20) | (stochrsi_k_1d < 40.0))
             # 4h & 1d down move, 1d downtrend
@@ -14098,17 +14127,17 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h & 1d down move, 1d downtrend
             & ((rsi_3_4h_gt_10) | (rsi_3_1d_gt_20) | (roc_9_1d > -25.0))
             # 4h & 1d down move, 1d high
-            & ((rsi_3_4h_gt_10) | (rsi_3_1d_gt_35) | (aroonu_14_1d < 100.0))
+            & ((rsi_3_4h_gt_10) | (rsi_3_1d_gt_35) | (aroonu_14_1d_lt_100))
             # 4h & 1d down move, 1d overbought
             & ((rsi_3_4h_gt_10) | (rsi_3_1d_gt_45) | (roc_9_1d < 10.0))
             # 4h down move, 1d still high, 1d downtrend
-            & ((rsi_3_4h_gt_10) | (aroonu_14_1d < 40.0) | (roc_9_1d > -20.0))
+            & ((rsi_3_4h_gt_10) | (aroonu_14_1d_lt_40) | (roc_9_1d > -20.0))
             # 4h down move, 1d high & overbought
             & ((rsi_3_4h_gt_10) | (aroonu_14_1d_lt_90) | (roc_9_1d_lt_40))
             # 4h down move, 4h still high, 1d downtrend
             & ((rsi_3_4h_gt_10) | (stochrsi_k_4h < 40.0) | (roc_9_1d > -20.0))
             # 4h & 1d down move, 1d high
-            & ((rsi_3_4h_gt_15) | (rsi_3_1d_gt_20) | (aroonu_14_1d < 60.0))
+            & ((rsi_3_4h_gt_15) | (rsi_3_1d_gt_20) | (aroonu_14_1d_lt_60))
             # 4h down move, 4h still high, 1d downtrend
             & ((rsi_3_4h_gt_15) | (aroonu_14_4h_lt_50) | (roc_9_1d > -20.0))
             # 4h & 1d down move, 4h still high
@@ -14154,7 +14183,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 4h high & overbought
             & ((rsi_3_4h_gt_50) | aroonu_14_4h_lt_70 | (roc_9_4h_lt_10))
             # 4h down move, 1d high & overbought
-            & ((rsi_3_4h_gt_50) | (aroonu_14_1d < 85.0) | (roc_9_1d_lt_80))
+            & ((rsi_3_4h_gt_50) | (aroonu_14_1d_lt_85) | (roc_9_1d_lt_80))
             # 4h down move, 1d high, 4h overbought
             & ((rsi_3_4h_gt_55) | (stochrsi_k_1d_lt_90) | (roc_9_4h_lt_10))
             # 4h down move, 4h high & overbought
@@ -14190,7 +14219,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1d down move, 1d still high, 4h still high
             & ((rsi_3_1d_gt_50) | (rsi_14_1d < 50.0) | (stochrsi_k_4h_lt_50))
             # 1d downtrend, 1d high & overbought
-            & ((cmf_20_1d > -0.40) | (aroonu_14_1d < 85.0) | (roc_9_1d_lt_20))
+            & ((cmf_20_1d > -0.40) | (aroonu_14_1d_lt_85) | (roc_9_1d_lt_20))
             # 1h high, 4h & 1d overbought
             & (aroonu_14_1h_lt_70 | (roc_9_4h < 50.0) | (roc_9_1d < 200.0))
             # 1h & 4h high, 1d overbought
@@ -14224,9 +14253,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1d high, 1d downtrend
             & ((aroonu_14_1d_lt_80) | (roc_9_1d_gt_neg_30))
             # 1d high, 1h & 4h downtrend
-            & ((aroonu_14_1d < 85.0) | (roc_9_1h > -30.0) | (roc_9_4h > -50.0))
+            & ((aroonu_14_1d_lt_85) | (roc_9_1h > -30.0) | (roc_9_4h > -50.0))
             # 1d high, 4h & 1d overbought
-            & ((aroonu_14_1d < 85.0) | (roc_9_4h < 60.0) | (roc_9_1d < 60.0))
+            & ((aroonu_14_1d_lt_85) | (roc_9_4h < 60.0) | (roc_9_1d < 60.0))
             # 1d high, 1h & 4h down move
             & (aroonu_14_1d_lt_100 | (roc_9_1h < 25.0) | (roc_9_4h < 60.0))
             # 15m high, 1d overbought
@@ -14256,7 +14285,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # Logic
           long_entry_logic.append(
             # (df["RSI_3"] > 5.0)
-            (aroonu_14 < 30.0)
+            (aroonu_14_lt_30)
             & (stochrsi_k < 30.0)
             # & (rsi_3_15m > 5.0)
             & (aroonu_14_15m_lt_50)
@@ -14297,13 +14326,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 4h down move, 15m still high
             & ((rsi_3_15m_gt_10) | rsi_3_4h_gt_20 | (aroonu_14_15m_lt_50))
             # 15m down move, 15m still high, 1h high
-            & ((rsi_3_15m_gt_10) | (aroonu_14_15m < 40.0) | (stochrsi_k_1h < 90.0))
+            & ((rsi_3_15m_gt_10) | (aroonu_14_15m_lt_40) | (stochrsi_k_1h < 90.0))
             # 15m down move, 15m still high, 1h high
             & ((rsi_3_15m_gt_10) | (aroonu_14_15m_lt_50) | (stochrsi_k_1h_lt_80))
             # 15m down move, 15m still high, 1d overbought
             & ((rsi_3_15m_gt_10) | (aroonu_14_15m_lt_50) | (roc_9_1d_lt_100))
             # 15m down move, 15m high, 1d overbought
-            & ((rsi_3_15m_gt_10) | (aroonu_14_15m < 60.0) | roc_9_1d_lt_50)
+            & ((rsi_3_15m_gt_10) | (aroonu_14_15m_lt_60) | roc_9_1d_lt_50)
             # 15m down move, 4h high, 1d downtrend
             & ((rsi_3_15m_gt_10) | (stochrsi_k_4h < 80.0) | (roc_9_1d_gt_neg_20))
             # 15m & 1h down move, 4h still high
@@ -14313,7 +14342,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 1h high
             & ((rsi_3_15m_gt_15) | (rsi_3_1h_gt_45) | (stochrsi_k_1h_lt_80))
             # 15m & 1h down move, 1h high
-            & ((rsi_3_15m_gt_15) | (rsi_3_1h_gt_50) | (aroonu_14_1h < 75.0))
+            & ((rsi_3_15m_gt_15) | (rsi_3_1h_gt_50) | (aroonu_14_1h_lt_75))
             # 15m & 4h down move, 4h high
             & ((rsi_3_15m_gt_15) | (rsi_3_4h_gt_15) | aroonu_14_4h_lt_70)
             # 15m & 4h down move, 1d downtrend
@@ -14325,15 +14354,15 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1d down move, 15m high
             & ((rsi_3_15m_gt_15) | (rsi_3_1d_gt_15) | (aroonu_14_15m_lt_70))
             # 15m down move, 4h downtrend. 15m high
-            & ((rsi_3_15m_gt_15) | (cmf_20_4h > -0.30) | (aroonu_14_15m < 60.0))
+            & ((rsi_3_15m_gt_15) | (cmf_20_4h > -0.30) | (aroonu_14_15m_lt_60))
             # 15m down move, 15m still high, 1h still high
-            & ((rsi_3_15m_gt_15) | (aroonu_14_15m < 40.0) | (aroonu_14_1h_lt_50))
+            & ((rsi_3_15m_gt_15) | (aroonu_14_15m_lt_40) | (aroonu_14_1h_lt_50))
             # 15m down move, 15m high, 4h downtrend
-            & ((rsi_3_15m_gt_15) | (aroonu_14_15m < 60.0) | (roc_9_4h_gt_neg_20))
+            & ((rsi_3_15m_gt_15) | (aroonu_14_15m_lt_60) | (roc_9_4h_gt_neg_20))
             # 15m down move, 15m high, 1d downtrend
-            & ((rsi_3_15m_gt_15) | (aroonu_14_15m < 60.0) | (roc_9_1d > -70.0))
+            & ((rsi_3_15m_gt_15) | (aroonu_14_15m_lt_60) | (roc_9_1d > -70.0))
             # 15m down move, 15m high, 1d overbought
-            & ((rsi_3_15m_gt_15) | (aroonu_14_15m < 60.0) | (roc_9_1d_lt_100))
+            & ((rsi_3_15m_gt_15) | (aroonu_14_15m_lt_60) | (roc_9_1d_lt_100))
             # 15m down move, 15m & 1h high
             & ((rsi_3_15m_gt_15) | (aroonu_14_15m_lt_70) | aroonu_14_1h_lt_70)
             # 15m down move, 15m & 4h high
@@ -14351,17 +14380,17 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 4h & 1d overbought
             & ((rsi_3_15m_gt_15) | (roc_9_4h < 25.0) | (roc_9_1d_lt_100))
             # 15m & 1h down move, 1h still high
-            & ((rsi_3_15m_gt_20) | (rsi_3_1h_gt_25) | (aroonu_14_1h < 40.0))
+            & ((rsi_3_15m_gt_20) | (rsi_3_1h_gt_25) | (aroonu_14_1h_lt_40))
             # 15m & 1h down move, 1h high
-            & ((rsi_3_15m_gt_20) | (rsi_3_1h_gt_45) | (aroonu_14_1h < 85.0))
+            & ((rsi_3_15m_gt_20) | (rsi_3_1h_gt_45) | (aroonu_14_1h_lt_85))
             # 15m & 1h down move, 4h high
             & ((rsi_3_15m_gt_20) | (rsi_3_1h_gt_45) | aroonu_14_4h_lt_80)
             # 15m & 1h down move, 1d high
             & ((rsi_3_15m_gt_20) | (rsi_3_1h_gt_45) | aroonu_14_1d_lt_100)
             # 15m & 4h down move, 15m high
-            & ((rsi_3_15m_gt_20) | rsi_3_4h_gt_20 | (aroonu_14_15m < 60.0))
+            & ((rsi_3_15m_gt_20) | rsi_3_4h_gt_20 | (aroonu_14_15m_lt_60))
             # 15m & 4h down move, 15m high
-            & ((rsi_3_15m_gt_20) | (rsi_3_4h_gt_30) | (aroonu_14_15m < 75.0))
+            & ((rsi_3_15m_gt_20) | (rsi_3_4h_gt_30) | (aroonu_14_15m_lt_75))
             # 15m & 4h down move, 1d high
             & ((rsi_3_15m_gt_20) | (rsi_3_4h_gt_30) | (stochrsi_k_1d_lt_90))
             # 15m & 4h down move, 4h high
@@ -14375,9 +14404,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m &1d down move, 1d overbought
             & ((rsi_3_15m_gt_20) | (rsi_3_1d > 50.0) | (roc_9_1d_lt_20))
             # 15m down move, 15m still not low enough, 4h overbought
-            & ((rsi_3_15m_gt_20) | (aroonu_14_15m < 30.0) | (roc_9_4h < 60.0))
+            & ((rsi_3_15m_gt_20) | (aroonu_14_15m_lt_30) | (roc_9_4h < 60.0))
             # 15m down move, 15m still high, 4h high
-            & ((rsi_3_15m_gt_20) | (aroonu_14_15m < 40.0) | (stochrsi_k_4h_lt_90))
+            & ((rsi_3_15m_gt_20) | (aroonu_14_15m_lt_40) | (stochrsi_k_4h_lt_90))
             # 15m down move, 15m still high, 1h high
             & ((rsi_3_15m_gt_20) | (aroonu_14_15m_lt_50) | (aroonu_14_1h_lt_100))
             # 15m down move, 15m still high, 4h high
@@ -14385,9 +14414,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 15m still high, 1d overbought
             & ((rsi_3_15m_gt_20) | (aroonu_14_15m_lt_50) | roc_9_1d_lt_50)
             # 15m down move, 15m high, 4h downtrend
-            & ((rsi_3_15m_gt_20) | (aroonu_14_15m < 60.0) | (roc_9_4h > -40.0))
+            & ((rsi_3_15m_gt_20) | (aroonu_14_15m_lt_60) | (roc_9_4h > -40.0))
             # 15m down move, 15m high, 4h overbought
-            & ((rsi_3_15m_gt_20) | (aroonu_14_15m < 60.0) | (roc_9_4h_lt_10))
+            & ((rsi_3_15m_gt_20) | (aroonu_14_15m_lt_60) | (roc_9_4h_lt_10))
             # 15m down move, 15m high, 4h overbought
             & ((rsi_3_15m_gt_20) | (aroonu_14_15m_lt_70) | (roc_9_4h_lt_20))
             # 15m down move, 15m high, 4h downtrend
@@ -14415,7 +14444,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 15m high
             & ((rsi_3_15m_gt_25) | (rsi_3_1h_gt_30) | (aroonu_14_15m_lt_70))
             # 15m & 4h down move, 15m high
-            & ((rsi_3_15m_gt_25) | (rsi_3_4h_gt_40) | (aroonu_14_15m < 75.0))
+            & ((rsi_3_15m_gt_25) | (rsi_3_4h_gt_40) | (aroonu_14_15m_lt_75))
             # 15m & 4h down move, 1h high
             & ((rsi_3_15m_gt_25) | (rsi_3_4h_gt_50) | (aroonu_14_1h_lt_100))
             # 15m & 4h down move, 1h high
@@ -14423,7 +14452,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 4h down move, 4h high
             & ((rsi_3_15m_gt_25) | (rsi_3_4h_gt_60) | aroonu_14_4h_lt_80)
             # 15m & 1d down move, 1d high
-            & ((rsi_3_15m_gt_25) | (rsi_3_1d_gt_30) | (aroonu_14_1d < 75.0))
+            & ((rsi_3_15m_gt_25) | (rsi_3_1d_gt_30) | (aroonu_14_1d_lt_75))
             # 15m & 1d down move, 1d high
             & ((rsi_3_15m_gt_25) | (rsi_3_1d_gt_45) | (aroonu_14_1d_lt_90))
             # 15m down move, 15m high, 4h downtrend
@@ -14457,7 +14486,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 1d high, 15m high
             & ((rsi_3_15m_gt_30) | (rsi_14_1d < 70.0) | (aroonu_14_15m_lt_70))
             # 15m down move, 15m high, 1d downtrend
-            & ((rsi_3_15m_gt_30) | (aroonu_14_15m < 60.0) | (roc_9_1d_gt_neg_40))
+            & ((rsi_3_15m_gt_30) | (aroonu_14_15m_lt_60) | (roc_9_1d_gt_neg_40))
             # 15m down move, 15m high, 15m downtrend
             & ((rsi_3_15m_gt_30) | (aroonu_14_15m_lt_70) | (cmf_20_15m > -0.30))
             # 15m down move, 15m high, 1d overbought
@@ -14473,7 +14502,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 15m still high, 1h high
             & ((rsi_3_15m_gt_35) | (rsi_3_1h_gt_40) | (aroonu_14_15m_lt_50) | (aroonu_14_1h_lt_90))
             # 15m down move, 15m high, 4h high
-            & ((rsi_3_15m_gt_35) | (aroonu_14_15m < 60.0) | (stochrsi_k_4h_lt_90))
+            & ((rsi_3_15m_gt_35) | (aroonu_14_15m_lt_60) | (stochrsi_k_4h_lt_90))
             # 15m down move, 15m high, 4h overbought
             & ((rsi_3_15m_gt_35) | (aroonu_14_15m_lt_70) | (roc_9_4h < 80.0))
             # 15m down move, 1h high, 4h overbought
@@ -14487,7 +14516,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 15m high, 1h downtrend
             & ((rsi_3_15m_gt_40) | (aroonu_14_15m_lt_70) | (roc_9_1h > -20.0))
             # 15m down move, 15m & 4h high
-            & ((rsi_3_15m_gt_40) | (aroonu_14_15m < 75.0) | (aroonu_14_4h < 75.0))
+            & ((rsi_3_15m_gt_40) | (aroonu_14_15m_lt_75) | (aroonu_14_4h_lt_75))
             # 15m down move, 4h high & overbought
             & ((rsi_3_15m_gt_40) | (stochrsi_k_4h_lt_80) | (roc_9_4h_lt_30))
             # 1h & 4h down move, 15m still high
@@ -14529,11 +14558,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 4h downtrend, 1d overbought
             & ((rsi_3_1h_gt_25) | (roc_9_4h > -40.0) | roc_9_1d_lt_50)
             # 1h down move, 15m & 1h still high
-            & ((rsi_3_1h_gt_30) | (aroonu_14_15m < 40.0) | (aroonu_14_1h_lt_50))
+            & ((rsi_3_1h_gt_30) | (aroonu_14_15m_lt_40) | (aroonu_14_1h_lt_50))
             # 1h down move, 1h still high 1d overbought
             & ((rsi_3_1h_gt_30) | (aroonu_14_1h_lt_50) | (roc_9_1d < 200.0))
             # 1h down move, 1h high, 4h downtrend
-            & ((rsi_3_1h_gt_30) | (aroonu_14_1h < 60.0) | (roc_9_4h_gt_neg_20))
+            & ((rsi_3_1h_gt_30) | (aroonu_14_1h_lt_60) | (roc_9_4h_gt_neg_20))
             # 1h down move, 1h high, 1d overbought
             & ((rsi_3_1h_gt_30) | aroonu_14_1h_lt_70 | (roc_9_1d_lt_30))
             # 1h down move, 4h high & overbought
@@ -14541,15 +14570,15 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 4h & 1h overbought
             & ((rsi_3_1h_gt_30) | (roc_9_4h_lt_30) | (roc_9_1d_lt_40))
             # 1h & 1d down move, 1h high
-            & ((rsi_3_1h_gt_35) | (rsi_3_1d_gt_35) | (aroonu_14_1h < 75.0))
+            & ((rsi_3_1h_gt_35) | (rsi_3_1d_gt_35) | (aroonu_14_1h_lt_75))
             # 1h down move, 15m still high, 4h  high
-            & ((rsi_3_1h_gt_35) | (aroonu_14_15m < 40.0) | aroonu_14_4h_lt_80)
+            & ((rsi_3_1h_gt_35) | (aroonu_14_15m_lt_40) | aroonu_14_4h_lt_80)
             # 1h down move, 15m still high, 4h high
-            & ((rsi_3_1h_gt_35) | (aroonu_14_15m < 40.0) | (stochrsi_k_4h_lt_70))
+            & ((rsi_3_1h_gt_35) | (aroonu_14_15m_lt_40) | (stochrsi_k_4h_lt_70))
             # 1h down move, 15m still high, 4h high
             & ((rsi_3_1h_gt_35) | (aroonu_14_15m_lt_50) | aroonu_14_4h_lt_70)
             # 1h down move, 15m & 1d high
-            & ((rsi_3_1h_gt_35) | (aroonu_14_15m < 60.0) | (aroonu_14_1d_lt_80))
+            & ((rsi_3_1h_gt_35) | (aroonu_14_15m_lt_60) | (aroonu_14_1d_lt_80))
             # 1h down move, 1h & 4h high
             & ((rsi_3_1h_gt_35) | aroonu_14_1h_lt_70 | (stochrsi_k_4h < 90.0))
             # 1h down move, 1h & 1d high
@@ -14579,7 +14608,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h high, 4h overbought
             & ((rsi_3_1h_gt_40) | aroonu_14_1h_lt_70 | (roc_9_4h < 20.0))
             # 1h down move, 1h high, 1d downtrend
-            & ((rsi_3_1h_gt_40) | (aroonu_14_1h < 85.0) | (roc_9_1d > -60.0))
+            & ((rsi_3_1h_gt_40) | (aroonu_14_1h_lt_85) | (roc_9_1d > -60.0))
             # 1h down move, 1h & 4h high
             & ((rsi_3_1h_gt_40) | (aroonu_14_1h_lt_90) | aroonu_14_4h_lt_100)
             # 1h down move, 1h high, 1d downtrend
@@ -14667,7 +14696,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 1h & 4h downtrend
             & ((rsi_3_4h_gt_15) | (roc_9_1h > -30.0) | (roc_9_4h_gt_neg_30))
             # 4h & 1d down move, 1h still high
-            & (rsi_3_4h_gt_20 | (rsi_3_1d_gt_20) | (aroonu_14_1h < 40.0))
+            & (rsi_3_4h_gt_20 | (rsi_3_1d_gt_20) | (aroonu_14_1h_lt_40))
             # 4h & 1d down move, 15m high
             & (rsi_3_4h_gt_20 | (rsi_3_1d_gt_25) | (stochrsi_k_15m < 70.0))
             # 4h & 1d down move, 1d overbought
@@ -14719,7 +14748,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 1d downtrend, 1d overbought
             & ((rsi_3_4h_gt_30) | (cmf_20_1d > -0.30) | (roc_9_1d_lt_40))
             # 4h down move, 15m high, 4h high
-            & ((rsi_3_4h_gt_30) | (aroonu_14_15m < 60.0) | (aroonu_14_4h_lt_90))
+            & ((rsi_3_4h_gt_30) | (aroonu_14_15m_lt_60) | (aroonu_14_4h_lt_90))
             # 4h down move, 1h high, 1d downtrend
             & ((rsi_3_4h_gt_30) | (aroonu_14_1h_lt_90) | (roc_9_1d_gt_neg_20))
             # 4h down move, 1h high, 1d downtrend
@@ -14729,7 +14758,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 1d high & overbought
             & ((rsi_3_4h_gt_30) | (stochrsi_k_1d < 80.0) | (roc_9_1d < 10.0))
             # 4h down move, 15m still high, 1h high
-            & ((rsi_3_4h_gt_35) | (aroonu_14_15m < 40.0) | (stochrsi_k_1h < 90.0))
+            & ((rsi_3_4h_gt_35) | (aroonu_14_15m_lt_40) | (stochrsi_k_1h < 90.0))
             # 4h down move, 15m still high, 4h high
             & ((rsi_3_4h_gt_35) | (aroonu_14_15m_lt_50) | aroonu_14_4h_lt_80)
             # 4h down move, 15m high, 1h high
@@ -14755,7 +14784,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 4h & 1d overbought
             & ((rsi_3_4h_gt_40) | (roc_9_4h_lt_10) | (roc_9_1d_lt_30))
             # 4h down move, 15m still high, 4h high
-            & ((rsi_3_4h_gt_45) | (aroonu_14_15m < 40.0) | (aroonu_14_4h_lt_90))
+            & ((rsi_3_4h_gt_45) | (aroonu_14_15m_lt_40) | (aroonu_14_4h_lt_90))
             # 45 down move, 15m high, 1h high
             & ((rsi_3_4h_gt_45) | (aroonu_14_15m_lt_70) | (stochrsi_k_1h_lt_70))
             # 4h down move, 15m high, 4h high
@@ -14781,7 +14810,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 4h high, 1d overbought
             & ((rsi_3_4h_gt_50) | aroonu_14_4h_lt_70 | (roc_9_1d_lt_40))
             # 4h down move, 1d high & overbought
-            & ((rsi_3_4h_gt_50) | (aroonu_14_1d < 85.0) | (roc_9_1d_lt_80))
+            & ((rsi_3_4h_gt_50) | (aroonu_14_1d_lt_85) | (roc_9_1d_lt_80))
             # 4h down move, 1d high, 4h overbought
             & ((rsi_3_4h_gt_50) | (aroonu_14_1d_lt_90) | (roc_9_4h_lt_10))
             # 4h down move, 4h high, 1d downtrend
@@ -14797,7 +14826,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 4h high & overbought
             & ((rsi_3_4h_gt_55) | (stochrsi_k_4h_lt_80) | (roc_9_4h_lt_10))
             # 4h down move, 15m high, 1h high
-            & ((rsi_3_4h_gt_60) | (aroonu_14_15m < 60.0) | (stochrsi_k_1h < 90.0))
+            & ((rsi_3_4h_gt_60) | (aroonu_14_15m_lt_60) | (stochrsi_k_1h < 90.0))
             # 4h down move, 4h high & overbought
             & ((rsi_3_4h_gt_60) | aroonu_14_4h_lt_70 | (roc_9_4h_lt_30))
             # 4h down move, 4h still high, 1d downtrend
@@ -14817,11 +14846,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1d down move, 4h & 1d downtrend
             & ((rsi_3_1d_gt_10) | (roc_9_4h_gt_neg_30) | roc_9_1d_gt_neg_50)
             # 1d down move, 1h high, 1d downtrend
-            & ((rsi_3_1d_gt_15) | (aroonu_14_1h < 85.0) | (roc_9_1d_gt_neg_30))
+            & ((rsi_3_1d_gt_15) | (aroonu_14_1h_lt_85) | (roc_9_1d_gt_neg_30))
             # 1d down move, 4h & 1d downtrend
             & ((rsi_3_1d_gt_15) | (roc_9_4h > -10.0) | (roc_9_1d_gt_neg_40))
             # 1d down move, 15m high, 1h high
-            & ((rsi_3_1d_gt_20) | (aroonu_14_15m < 60.0) | (stochrsi_k_1h_lt_80))
+            & ((rsi_3_1d_gt_20) | (aroonu_14_15m_lt_60) | (stochrsi_k_1h_lt_80))
             # 1d down move, 15m high, 1h high
             & ((rsi_3_1d_gt_20) | (aroonu_14_15m_lt_70) | (aroonu_14_1h_lt_100))
             # 1d down move, 4h high, 4h downtrend
@@ -14835,7 +14864,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1d down move, 1d still high, 1d downtrend
             & ((rsi_3_1d_gt_25) | (stochrsi_k_1d < 50.0) | (roc_9_1d_gt_neg_20))
             # 1d down move, 1d high & overbought
-            & ((rsi_3_1d_gt_30) | (aroonu_14_1d < 60.0) | (roc_9_1d < 10.0))
+            & ((rsi_3_1d_gt_30) | (aroonu_14_1d_lt_60) | (roc_9_1d < 10.0))
             # 1d down move, 1h high, 1d downtrend
             & ((rsi_3_1d_gt_30) | (stochrsi_k_1h_lt_70) | (roc_9_1d_lt_20))
             # 1d down move, 1h & 1d high
@@ -14853,13 +14882,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m still high, 1h downtrend, 4h overbought
             & ((aroonu_14_15m_lt_50) | (roc_9_1h > -10.0) | (roc_9_4h_lt_40))
             # 15m high, 4h high & overbought
-            & ((aroonu_14_15m < 60.0) | aroonu_14_4h_lt_70 | (roc_9_4h_lt_20))
+            & ((aroonu_14_15m_lt_60) | aroonu_14_4h_lt_70 | (roc_9_4h_lt_20))
             # 15m & 4h high, 1d overbought
-            & ((aroonu_14_15m < 60.0) | aroonu_14_4h_lt_70 | (roc_9_1d < 10.0))
+            & ((aroonu_14_15m_lt_60) | aroonu_14_4h_lt_70 | (roc_9_1d < 10.0))
             # 15m high, 15m & 4h overbought
-            & ((aroonu_14_15m < 60.0) | (roc_9_15m < 10.0) | (roc_9_4h_lt_20))
+            & ((aroonu_14_15m_lt_60) | (roc_9_15m < 10.0) | (roc_9_4h_lt_20))
             # 15m high, 4h downtrend
-            & ((aroonu_14_15m < 60.0) | (roc_9_4h_gt_neg_30))
+            & ((aroonu_14_15m_lt_60) | (roc_9_4h_gt_neg_30))
             # 15m & 1h & 4h high
             & ((aroonu_14_15m_lt_70) | (aroonu_14_1h_lt_100) | aroonu_14_4h_lt_100)
             # 15m & 4h & 1d high
@@ -14873,7 +14902,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m high, 4h downtrend, 1d overbought
             & ((aroonu_14_15m_lt_70) | (roc_9_4h_gt_neg_30) | (roc_9_1d < 200.0))
             # 4h down move, 1h still high, 1d downtrend
-            & ((rsi_3_4h_gt_15) | (aroonu_14_1h < 40.0) | roc_9_1d_gt_neg_50)
+            & ((rsi_3_4h_gt_15) | (aroonu_14_1h_lt_40) | roc_9_1d_gt_neg_50)
             # 1h & 4h high, 4h overbought
             & (aroonu_14_1h_lt_80 | aroonu_14_4h_lt_100 | (roc_9_4h_lt_10))
             # 1h high, 1d high & overbought
@@ -14889,11 +14918,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1d high, 4h & 1d downtrend
             & ((aroonu_14_1d_lt_80) | (roc_9_4h_gt_neg_20) | (roc_9_1d_gt_neg_20))
             # 1d high, 1h & 4h downtrend
-            & ((aroonu_14_1d < 85.0) | (roc_9_1h > -30.0) | (roc_9_4h > -50.0))
+            & ((aroonu_14_1d_lt_85) | (roc_9_1h > -30.0) | (roc_9_4h > -50.0))
             # 1d high, 4h downtrend
-            & ((aroonu_14_1d < 85.0) | (roc_9_4h_gt_neg_30))
+            & ((aroonu_14_1d_lt_85) | (roc_9_4h_gt_neg_30))
             # 1d high, 4h downtrend, 1d overbought
-            & ((aroonu_14_1d < 85.0) | (roc_9_4h_gt_neg_30) | (roc_9_1d < 70.0))
+            & ((aroonu_14_1d_lt_85) | (roc_9_4h_gt_neg_30) | (roc_9_1d < 70.0))
             # 1d high, 4h & 1d overbought
             & (aroonu_14_1d_lt_100 | (roc_9_4h_lt_30) | (roc_9_1d_lt_40))
             # 15m & 1h high, 1d overbought
@@ -14950,11 +14979,11 @@ class NostalgiaForInfinityX7(IStrategy):
           long_entry_logic.append(
             rsi_3_15m_gt_3
             # 5m & 1h down move, 1d still high
-            & ((rsi_3_gt_3) | (rsi_3_1h_gt_3) | (aroonu_14_1d < 40.0))
+            & ((rsi_3_gt_3) | (rsi_3_1h_gt_3) | (aroonu_14_1d_lt_40))
             # 5m & 1h & 4h down move
             & ((rsi_3_gt_3) | (rsi_3_1h_gt_5) | (rsi_3_4h_gt_10))
             # 5m & 1h down move, 1h still not low enough
-            & ((rsi_3_gt_3) | (rsi_3_1h_gt_10) | (aroonu_14_1h < 30.0))
+            & ((rsi_3_gt_3) | (rsi_3_1h_gt_10) | (aroonu_14_1h_lt_30))
             # 5m & 1h down move, 1d high
             & ((rsi_3_gt_3) | (rsi_3_1h_gt_15) | (aroonu_14_1d_lt_80))
             # 5m & 1h down move, 1d high
@@ -14976,9 +15005,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 5m down move, 4h high, 1h overbought
             & ((rsi_3_gt_10) | aroonu_14_4h_lt_100 | (roc_9_1h < 30.0))
             # 15m & 1h down move, 1d still high
-            & ((rsi_3_15m_gt_5) | (rsi_3_1h_gt_5) | (aroonu_14_1d < 40.0))
+            & ((rsi_3_15m_gt_5) | (rsi_3_1h_gt_5) | (aroonu_14_1d_lt_40))
             # 15m & 1h down move, 1d still high
-            & ((rsi_3_15m_gt_5) | (rsi_3_1h_gt_10) | (aroonu_14_1d < 50.0))
+            & ((rsi_3_15m_gt_5) | (rsi_3_1h_gt_10) | (aroonu_14_1d_lt_50))
             # 15m & 1h down move, 1h still high
             & ((rsi_3_15m_gt_5) | (rsi_3_1h_gt_30) | (stochrsi_k_1h < 40.0))
             # 15m & 1h down move, 1d overbought
@@ -15036,7 +15065,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 4h high, 4h overbought
             & ((rsi_3_15m_gt_25) | (aroonu_14_4h_lt_60) | (roc_9_4h < 50.0))
             # 15m & 1h down move, 4h high
-            & ((rsi_3_15m_gt_30) | (rsi_3_1h_gt_40) | (aroonu_14_4h < 85.0))
+            & ((rsi_3_15m_gt_30) | (rsi_3_1h_gt_40) | (aroonu_14_4h_lt_85))
             # 15m & 1h down move, 4h overbought
             & ((rsi_3_15m_gt_40) | (rsi_3_1h_gt_50) | (roc_9_4h < 50.0))
             # 1h & 4h down move, 15m downtrend
@@ -15080,7 +15109,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 1d down move, 1d high
             & ((rsi_3_1h_gt_10) | (rsi_3_1d_gt_45) | (aroonu_14_1d_lt_70))
             # 1h down move, 4h high
-            & ((rsi_3_1h_gt_10) | (aroonu_14_4h < 85.0))
+            & ((rsi_3_1h_gt_10) | (aroonu_14_4h_lt_85))
             # 1h down move, 1d high, 15m downtrend
             & ((rsi_3_1h_gt_10) | (aroonu_14_1d_lt_70) | (roc_9_15m > -50.0))
             # 1h down move, 4h & 1d downtrend
@@ -15088,7 +15117,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 4h still high
             & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_15) | (rsi_14_4h < 40.0))
             # 1h & 4h down move, 1h still not low enough
-            & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_15) | (aroonu_14_1h < 20.0))
+            & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_15) | (aroonu_14_1h_lt_20))
             # 1h & 4h down move, 4h still not low enough
             & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_25) | (stochrsi_k_4h < 30.0))
             # 1h & 1d down move, 1d still high
@@ -15096,7 +15125,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 1d down move, 1d high
             & ((rsi_3_1h_gt_15) | (rsi_3_1d_gt_25) | (aroonu_14_1d_lt_80))
             # 1h down move, 1h still high, 4h downtrend
-            & ((rsi_3_1h_gt_15) | (aroonu_14_1h < 40.0) | (roc_9_4h_gt_neg_30))
+            & ((rsi_3_1h_gt_15) | (aroonu_14_1h_lt_40) | (roc_9_4h_gt_neg_30))
             # 1h down move, 1d high, 4h downtrend
             & ((rsi_3_1h_gt_15) | (aroonu_14_1d_lt_90) | (roc_9_4h > -20.0))
             # 1h down move, 1d high & overbought
@@ -15122,7 +15151,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 1h high
             & ((rsi_3_1h_gt_30) | (rsi_3_4h_gt_50) | (stochrsi_k_1h_lt_70))
             # 1h down move, 15m still high, 1h high
-            & ((rsi_3_1h_gt_30) | (stochrsi_k_15m < 40.0) | (aroonu_14_1h < 60.0))
+            & ((rsi_3_1h_gt_30) | (stochrsi_k_15m < 40.0) | (aroonu_14_1h_lt_60))
             # 1h down move, 1h still high, 4h high
             & ((rsi_3_1h_gt_30) | (stochrsi_k_1h < 40.0) | (stochrsi_k_4h_lt_70))
             # 1h down move, 4h & 1d downtrend
@@ -15132,7 +15161,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h high, 1d overbought
             & ((rsi_3_1h_gt_35) | aroonu_14_1h_lt_70 | (roc_9_1d_lt_20))
             # 1h down move, 4h high, 1d overbought
-            & ((rsi_3_1h_gt_35) | (aroonu_14_4h < 85.0) | (roc_9_1d_lt_100))
+            & ((rsi_3_1h_gt_35) | (aroonu_14_4h_lt_85) | (roc_9_1d_lt_100))
             # 1h down move, 1h still high, 1d overbought
             & ((rsi_3_1h_gt_35) | (stochrsi_k_1h_lt_50) | (roc_9_1d < 200.0))
             # 1h down move, 1h high, 4h downtrend
@@ -15158,15 +15187,15 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 4h & 1d downtrend
             & ((rsi_3_4h_gt_5) | (roc_9_4h > -15.0) | (roc_9_1d_gt_neg_20))
             # 4h & 1d down move, 1h still high
-            & ((rsi_3_4h_gt_10) | (rsi_3_1d_gt_10) | (aroonu_14_1h < 40.0))
+            & ((rsi_3_4h_gt_10) | (rsi_3_1d_gt_10) | (aroonu_14_1h_lt_40))
             # 4h & 1d down move, 1h high
             & ((rsi_3_4h_gt_10) | (rsi_3_1d_gt_15) | (stochrsi_k_1h < 70.0))
             # 4h & 1d down move, 1d still high
-            & ((rsi_3_4h_gt_10) | (rsi_3_1d_gt_25) | (aroonu_14_1d < 40.0))
+            & ((rsi_3_4h_gt_10) | (rsi_3_1d_gt_25) | (aroonu_14_1d_lt_40))
             # 4h & 1d down move, 1d still high
             & ((rsi_3_4h_gt_10) | (rsi_3_1d_gt_25) | (stochrsi_k_1d < 50.0))
             # 4h & 1d down move, 1d high
-            & ((rsi_3_4h_gt_15) | (rsi_3_1d_gt_20) | (aroonu_14_1d < 60.0))
+            & ((rsi_3_4h_gt_15) | (rsi_3_1d_gt_20) | (aroonu_14_1d_lt_60))
             # 4h & 1d down move, 4h high
             & ((rsi_3_4h_gt_15) | (rsi_3_1d_gt_25) | aroonu_14_4h_lt_70)
             # 4h down move, 1d high & overbought
@@ -15188,7 +15217,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 4h & 1d overbought
             & ((rsi_3_4h_gt_60) | (roc_9_4h_lt_20) | (roc_9_1d_lt_20))
             # 1h still high, 4h & 1d downtrend
-            & ((aroonu_14_1h < 40.0) | (roc_9_4h_gt_neg_20) | (roc_9_1d_gt_neg_40))
+            & ((aroonu_14_1h_lt_40) | (roc_9_4h_gt_neg_20) | (roc_9_1d_gt_neg_40))
             # 1h & 4h high, 1h overbought
             & (aroonu_14_1h_lt_70 | aroonu_14_4h_lt_100 | (roc_9_1h < 80.0))
             # 1h high, 1d overbought
@@ -15198,7 +15227,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 1d high, 1h overbought
             & (aroonu_14_1h_lt_80 | (aroonu_14_1d_lt_90) | (roc_9_1h < 30.0))
             # 4h still not low enough, 4h & 1d downtrend
-            & ((aroonu_14_4h < 30.0) | (roc_9_4h > -40.0) | (roc_9_1d_gt_neg_40))
+            & ((aroonu_14_4h_lt_30) | (roc_9_4h > -40.0) | (roc_9_1d_gt_neg_40))
             # 4h still high, 5m downtrend
             & ((aroonu_14_4h_lt_40) | (roc_9 > -40.0))
             # 4h high, 4h & 1d overbought
@@ -15227,7 +15256,7 @@ class NostalgiaForInfinityX7(IStrategy):
 
           # Logic
           long_entry_logic.append(
-            (aroonu_14 < 25.0) & (aroonu_14_15m < 25.0) & (close < (ema_9 * 0.946)) & (close < (ema_20 * 0.960))
+            (aroonu_14_lt_25) & (aroonu_14_15m_lt_25) & (close < (ema_9 * 0.946)) & (close < (ema_20 * 0.960))
           )
 
         # Condition #5 - Normal mode (Long).
@@ -15239,7 +15268,7 @@ class NostalgiaForInfinityX7(IStrategy):
           long_entry_logic.append(
             (rsi_3_15m_gt_20)
             # 5m & 1h down move, 1h still not low enough
-            & ((rsi_3_gt_3) | (rsi_3_1h_gt_10) | (aroonu_14_1h < 30.0))
+            & ((rsi_3_gt_3) | (rsi_3_1h_gt_10) | (aroonu_14_1h_lt_30))
             # 5m & 1h down move, 1d high
             & ((rsi_3_gt_3) | rsi_3_1h_gt_20 | aroonu_14_1d_lt_100)
             # 5m & 1h down move, 1h still high
@@ -15257,13 +15286,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 1h high
             & ((rsi_3_15m_gt_25) | (rsi_3_1h_gt_40) | aroonu_14_1h_lt_80)
             # 15m & 1h down move, 1h high
-            & ((rsi_3_15m_gt_25) | (rsi_3_1h_gt_50) | (aroonu_14_1h < 85.0))
+            & ((rsi_3_15m_gt_25) | (rsi_3_1h_gt_50) | (aroonu_14_1h_lt_85))
             # 15m & 1h down move, 1h high
             & ((rsi_3_15m_gt_25) | (rsi_3_1h_gt_55) | (stochrsi_k_1h_lt_80))
             # 15m down move, 15m stil not low enough, 4h high
-            & ((rsi_3_15m_gt_25) | (aroonu_14_15m < 30.0) | (aroonu_14_4h_lt_60))
+            & ((rsi_3_15m_gt_25) | (aroonu_14_15m_lt_30) | (aroonu_14_4h_lt_60))
             # 15m down move, 15m high, 1h high
-            & ((rsi_3_15m_gt_25) | (aroonu_14_15m < 60.0) | (stochrsi_k_1h_lt_70))
+            & ((rsi_3_15m_gt_25) | (aroonu_14_15m_lt_60) | (stochrsi_k_1h_lt_70))
             # 15m down move, 1h & 4h overbought
             & ((rsi_3_15m_gt_25) | (roc_9_1h < 40.0) | (roc_9_4h_lt_40))
             # 15m down move, 4h & 1d overbought
@@ -15271,17 +15300,17 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 4h down move, 4h high
             & ((rsi_3_15m_gt_30) | (rsi_3_4h_gt_50) | aroonu_14_4h_lt_80)
             # 15m & 1h down move, 1h high
-            & ((rsi_3_15m_gt_30) | (rsi_3_1h_gt_30) | (aroonu_14_1h < 85.0))
+            & ((rsi_3_15m_gt_30) | (rsi_3_1h_gt_30) | (aroonu_14_1h_lt_85))
             # 15m down move, 15m still high, 1d high
             & ((rsi_3_15m_gt_30) | (aroonu_14_15m_lt_50) | (stochrsi_k_1d < 70.0))
             # 15m down move, 15m high, 4h high
-            & ((rsi_3_15m_gt_30) | (aroonu_14_15m < 60.0) | (stochrsi_k_4h_lt_70))
+            & ((rsi_3_15m_gt_30) | (aroonu_14_15m_lt_60) | (stochrsi_k_4h_lt_70))
             # 15m down move, 1h & 4h high
-            & ((rsi_3_15m_gt_30) | (aroonu_14_1h < 85.0) | aroonu_14_4h_lt_100)
+            & ((rsi_3_15m_gt_30) | (aroonu_14_1h_lt_85) | aroonu_14_4h_lt_100)
             # 15m down move, 4h & 1d high
             & ((rsi_3_15m_gt_30) | aroonu_14_4h_lt_80 | aroonu_14_1d_lt_100)
             # 15m down move, 4h high, 1h downtrend
-            & ((rsi_3_15m < 30.0) | (aroonu_14_4h < 85.0) | (roc_9_1h > -40.0))
+            & ((rsi_3_15m < 30.0) | (aroonu_14_4h_lt_85) | (roc_9_1h > -40.0))
             # 15m down move, 4h high & overbought
             & ((rsi_3_15m_gt_30) | aroonu_14_4h_lt_100 | (roc_9_4h < 25.0))
             # 15m & 4h down move, 4h high
@@ -15289,13 +15318,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 15m high, 4h overbought
             & ((rsi_3_15m_gt_35) | (aroonu_14_15m_lt_70) | (roc_9_4h_lt_10))
             # 15m down move, 1h high, 4h overbought
-            & ((rsi_3_15m_gt_35) | (aroonu_14_1h < 85.0) | (roc_9_4h < 80.0))
+            & ((rsi_3_15m_gt_35) | (aroonu_14_1h_lt_85) | (roc_9_4h < 80.0))
             # 15m down move, 4h high, 1h overbought
             & ((rsi_3_15m_gt_35) | aroonu_14_4h_lt_100 | (roc_9_1h < 20.0))
             # 15m & 1h down move, 1h high
             & ((rsi_3_15m_gt_40) | (rsi_3_1h_gt_40) | (aroonu_14_1h_lt_100))
             # 15m down move, 15m still high, 1h high
-            & ((rsi_3_15m_gt_45) | (aroonu_14_15m_lt_50) | (aroonu_14_1h < 85.0))
+            & ((rsi_3_15m_gt_45) | (aroonu_14_15m_lt_50) | (aroonu_14_1h_lt_85))
             # 1h & 4h down move, 1d high
             & ((rsi_3_1h_gt_3) | (rsi_3_4h_gt_5) | (aroonu_14_1d_lt_70))
             # 1h & 4h down move, 4h still high
@@ -15327,15 +15356,15 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 4h still high
             & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_45) | (stochrsi_k_4h < 40.0))
             # 1h down move, 4h downtrend. 4h still not low enough
-            & ((rsi_3_1h_gt_10) | (roc_9_4h > -20.0) | (aroonu_14_4h < 30.0))
+            & ((rsi_3_1h_gt_10) | (roc_9_4h > -20.0) | (aroonu_14_4h_lt_30))
             # 1h down move, 15m still high, 4h high
-            & ((rsi_3_1h_gt_10) | (aroonu_14_15m < 40.0) | (stochrsi_k_4h < 90.0))
+            & ((rsi_3_1h_gt_10) | (aroonu_14_15m_lt_40) | (stochrsi_k_4h < 90.0))
             # 1h down move, 15m high, 4h downtrend
             & ((rsi_3_1h_gt_10) | (aroonu_14_15m_lt_70) | (roc_9_4h > -10.0))
             # 1h down move, 1h still high, 15m downtrend
-            & ((rsi_3_1h_gt_10) | (aroonu_14_1h < 40.0) | (cmf_20_15m > -0.30))
+            & ((rsi_3_1h_gt_10) | (aroonu_14_1h_lt_40) | (cmf_20_15m > -0.30))
             # 1h down move, 1d high, 4h overbought
-            & ((rsi_3_1h_gt_10) | (aroonu_14_1d < 100.0) | (roc_9_4h < 20.0))
+            & ((rsi_3_1h_gt_10) | (aroonu_14_1d_lt_100) | (roc_9_4h < 20.0))
             # 1h down move, 1h still high, 1d downtrend
             & ((rsi_3_1h_gt_10) | (stochrsi_k_1h < 50.0) | (roc_9_1d_gt_neg_40))
             # 1h down move, 1d high & overbought
@@ -15347,19 +15376,19 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 1d downtrend
             & ((rsi_3_1h_gt_15) | rsi_3_4h_gt_20 | (roc_9_1d_gt_neg_40))
             # 1h & 4h down move, 4h high
-            & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_50) | (aroonu_14_4h < 100.0))
+            & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_50) | (aroonu_14_4h_lt_100))
             # 1h & 1d down move, 4h high
             & ((rsi_3_1h_gt_15) | (rsi_3_1d_gt_15) | (stochrsi_k_4h < 80.0))
             # 1h down move, 4h high, 1d overbought
             & ((rsi_3_1h_gt_15) | (aroonu_14_4h_lt_60) | roc_9_1d_lt_50)
             # 1h down move, 4h high, 1d high
-            & ((rsi_3_1h_gt_15) | (aroonu_14_4h < 80.0) | (stochrsi_k_1d < 80.0))
+            & ((rsi_3_1h_gt_15) | (aroonu_14_4h_lt_80) | (stochrsi_k_1d < 80.0))
             # 1h down move, 1d high, 1d downtrend
             & ((rsi_3_1h_gt_15) | (aroonu_14_1d_lt_70) | (roc_9_1d > -20.0))
             # 1h down move, 1d high, 4h overbought
-            & ((rsi_3_1h_gt_15) | (aroonu_14_1d < 100.0) | (roc_9_4h < 60.0))
+            & ((rsi_3_1h_gt_15) | (aroonu_14_1d_lt_100) | (roc_9_4h < 60.0))
             # 1h down move, 1d high & overbought
-            & ((rsi_3_1h_gt_15) | (aroonu_14_1d < 100.0) | (roc_9_1d < 10.0))
+            & ((rsi_3_1h_gt_15) | (aroonu_14_1d_lt_100) | (roc_9_1d < 10.0))
             # 1h down move, 1h downtrend, 1d overbought
             & ((rsi_3_1h_gt_15) | (roc_9_1h > -30.0) | (roc_9_1d_lt_80))
             # 1h down move, 4h & 1d overbought
@@ -15379,9 +15408,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 4h high, 1d downtrend
             & ((rsi_3_1h_gt_25) | (stochrsi_k_4h < 80.0) | (roc_9_1d_gt_neg_30))
             # 1h & 4h down move, 4h high
-            & ((rsi_3_1h_gt_30) | (rsi_3_4h_gt_50) | (aroonu_14_4h < 85.0))
+            & ((rsi_3_1h_gt_30) | (rsi_3_4h_gt_50) | (aroonu_14_4h_lt_85))
             # 1h down move, 1h & 4h high
-            & ((rsi_3_1h_gt_30) | aroonu_14_1h_lt_70 | (aroonu_14_4h < 85.0))
+            & ((rsi_3_1h_gt_30) | aroonu_14_1h_lt_70 | (aroonu_14_4h_lt_85))
             # 1h down move, 1h high, 4h overbought
             & ((rsi_3_1h_gt_30) | aroonu_14_1h_lt_70 | (roc_9_4h < 20.0))
             # 1h down move, 4h high, 1d overbought
@@ -15389,7 +15418,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 4h high & overbought
             & ((rsi_3_1h_gt_30) | (aroonu_14_4h_lt_90) | (roc_9_4h < 100.0))
             # 1h down move, 15m still high, 1h high
-            & ((rsi_3_1h_gt_30) | (stochrsi_k_15m < 40.0) | (aroonu_14_1h < 60.0))
+            & ((rsi_3_1h_gt_30) | (stochrsi_k_15m < 40.0) | (aroonu_14_1h_lt_60))
             # 1h down move, 1h high, 1d downtrend
             & ((rsi_3_1h_gt_30) | (stochrsi_k_1h_lt_70) | (roc_9_1d_gt_neg_40))
             # 1h down move, 4h high, 1d downtrend
@@ -15407,9 +15436,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h still high, 1d overbought
             & ((rsi_3_1h_gt_35) | (stochrsi_k_1h_lt_50) | (roc_9_1d < 200.0))
             # 1h down move, 15m high, 1h high
-            & ((rsi_3_1h_gt_40) | (aroonu_14_15m < 60.0) | aroonu_14_1h_lt_70)
+            & ((rsi_3_1h_gt_40) | (aroonu_14_15m_lt_60) | aroonu_14_1h_lt_70)
             # 1h down move, 1h still high, 1d overbought
-            & ((rsi_3_1h_gt_40) | (aroonu_14_1h < 40.0) | (roc_9_1d_lt_100))
+            & ((rsi_3_1h_gt_40) | (aroonu_14_1h_lt_40) | (roc_9_1d_lt_100))
             # 1h down move, 1h high, 4h overbought
             & ((rsi_3_1h_gt_40) | aroonu_14_1h_lt_70 | (roc_9_4h_lt_30))
             # 1h down move, 1h & 4h high
@@ -15423,7 +15452,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 1d overbought
             & ((rsi_3_1h_gt_45) | (rsi_3_4h_gt_65) | (roc_9_1d < 200.0))
             # 1h down move, 15m still high, 1h high
-            & ((rsi_3_1h_gt_45) | (aroonu_14_15m_lt_50) | (aroonu_14_1h < 85.0))
+            & ((rsi_3_1h_gt_45) | (aroonu_14_15m_lt_50) | (aroonu_14_1h_lt_85))
             # 1h down move, 1h high, 4h overbought
             & ((rsi_3_1h_gt_45) | aroonu_14_1h_lt_80 | (roc_9_4h < 50.0))
             # 1h down move, 1h high, 1d overbought
@@ -15439,7 +15468,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 4h & 1d overbought
             & ((rsi_3_1h_gt_50) | (roc_9_4h_lt_20) | (roc_9_1d_lt_80))
             # 1h down move, 15m high, 1h high
-            & ((rsi_3_1h_gt_55) | (aroonu_14_15m < 60.0) | (stochrsi_k_1h_lt_80))
+            & ((rsi_3_1h_gt_55) | (aroonu_14_15m_lt_60) | (stochrsi_k_1h_lt_80))
             # 1h down move, 1h high & overbought
             & ((rsi_3_1h_gt_55) | (stochrsi_k_1h < 60.0) | (roc_9_1d < 10.0))
             # 1h down move, 4h & 1d overbought
@@ -15481,7 +15510,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h & 1ddown move, 1d high
             & (rsi_3_4h_gt_20 | (rsi_3_1d_gt_20) | (aroonu_14_1d_lt_80))
             # 4h & 1d down move, 1h still high, 4h still high
-            & (rsi_3_4h_gt_20 | (rsi_3_1d_gt_25) | (aroonu_14_1h < 40.0) | (aroonu_14_4h_lt_50))
+            & (rsi_3_4h_gt_20 | (rsi_3_1d_gt_25) | (aroonu_14_1h_lt_40) | (aroonu_14_4h_lt_50))
             # 4h down move, 1d high, 1d downtrend
             & (rsi_3_4h_gt_20 | (aroonu_14_1d_lt_80) | (roc_9_1d_gt_neg_30))
             # 4h down move, 1d high & overbought
@@ -15509,11 +15538,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h & 4h downtrend
             & ((cmf_20_15m > -0.30) | (cmf_20_1h > -0.30) | (cmf_20_4h > -0.30))
             # 1d downtrend, 1d high & overbought
-            & ((cmf_20_1d > -0.40) | (aroonu_14_1d < 85.0) | (roc_9_1d_lt_20))
+            & ((cmf_20_1d > -0.40) | (aroonu_14_1d_lt_85) | (roc_9_1d_lt_20))
             # 15m not low enough, 1h & 4h downtrend
-            & ((aroonu_14_15m < 20.0) | (roc_9_1h > -30.0) | (roc_9_4h > -50.0))
+            & ((aroonu_14_15m_lt_20) | (roc_9_1h > -30.0) | (roc_9_4h > -50.0))
             # 15m high, 1h high & overbought
-            & ((aroonu_14_15m_lt_70) | (aroonu_14_1h < 85.0) | (roc_9_1h_lt_10))
+            & ((aroonu_14_15m_lt_70) | (aroonu_14_1h_lt_85) | (roc_9_1h_lt_10))
             # 4h high, 4h & 1d overbought
             & (aroonu_14_4h_lt_70 | (roc_9_4h < 60.0) | (roc_9_1d_lt_80))
             # 1h & 4h high, 4h overbought
@@ -15529,9 +15558,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h & 1d high, 1d overbought
             & (aroonu_14_4h_lt_80 | aroonu_14_1d_lt_100 | (roc_9_1d_lt_80))
             # 4h high, 1h & 4h overbought
-            & ((aroonu_14_4h < 85.0) | (roc_9_1h < 80.0) | (roc_9_4h < 80.0))
+            & ((aroonu_14_4h_lt_85) | (roc_9_1h < 80.0) | (roc_9_4h < 80.0))
             # 4h high, 4h & 1d overbought
-            & ((aroonu_14_4h < 85.0) | (roc_9_4h_lt_10) | (roc_9_1d_lt_40))
+            & ((aroonu_14_4h_lt_85) | (roc_9_4h_lt_10) | (roc_9_1d_lt_40))
             # 4h & 1d high, 4h overbought
             & (aroonu_14_4h_lt_100 | aroonu_14_1d_lt_100 | (roc_9_4h_lt_40))
             # 4h high, 1h & 1d overbought
@@ -15571,7 +15600,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # Logic
           long_entry_logic.append(
             (rsi_3 < 50.0)
-            & (aroonu_14 < 25.0)
+            & (aroonu_14_lt_25)
             & (stochrsi_k < 30.0)
             & (ema_26 > ema_12)
             & ((ema_26 - ema_12) > (open_rate * 0.020))
@@ -15588,13 +15617,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 5m & 15m down move, 15m still high
             ((rsi_3_gt_3) | (rsi_3_15m_gt_10) | (stochrsi_k_15m < 40.0))
             # 5m & 15m down move, 15m still high
-            & ((rsi_3_gt_3) | (rsi_3_15m_gt_15) | (aroonu_14_15m < 40.0))
+            & ((rsi_3_gt_3) | (rsi_3_15m_gt_15) | (aroonu_14_15m_lt_40))
             # 5m & 15m down move, 1d downtrend
             & ((rsi_3_gt_3) | (rsi_3_15m_gt_15) | (roc_9_1d_gt_neg_20))
             # 5m & 15m down move, 1d downtrend
             & ((rsi_3_gt_3) | (rsi_3_15m_gt_25) | (roc_9_1d_gt_neg_30))
             # 5m & 1h down move, 1h still not low enough
-            & ((rsi_3_gt_3) | rsi_3_1h_gt_20 | (aroonu_14_1h < 30.0))
+            & ((rsi_3_gt_3) | rsi_3_1h_gt_20 | (aroonu_14_1h_lt_30))
             # 5m & 1h down move, 1h still high
             & ((rsi_3_gt_3) | (rsi_3_1h_gt_30) | (stochrsi_k_1h_lt_50))
             # 5m & 4h down move, 4h still high
@@ -15624,7 +15653,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 5m & 4h down move, 4h high
             & ((rsi_3_gt_5) | (rsi_3_4h_gt_60) | aroonu_14_4h_lt_80)
             # 5m down move, 15m still not low enough, 4h high
-            & ((rsi_3_gt_5) | (aroonu_14_15m < 20.0) | (stochrsi_k_4h_lt_70))
+            & ((rsi_3_gt_5) | (aroonu_14_15m_lt_20) | (stochrsi_k_4h_lt_70))
             # 5m down move, 1h & 1d high
             & ((rsi_3_gt_5) | aroonu_14_1h_lt_70 | aroonu_14_1d_lt_100)
             # 5m down move, 4h high & overbought
@@ -15636,11 +15665,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 1h still high
             & ((rsi_3_15m_gt_3) | (rsi_3_1h_gt_20) | (aroonu_14_1h_lt_50))
             # 15m & 1h down move, 4h still not low enough
-            & ((rsi_3_15m_gt_3) | (rsi_3_1h_gt_20) | (aroonu_14_4h < 20.0))
+            & ((rsi_3_15m_gt_3) | (rsi_3_1h_gt_20) | (aroonu_14_4h_lt_20))
             # 15m & 1h & 4h down move, 1d downtrend
             & ((rsi_3_15m_gt_3) | (rsi_3_1h_gt_25) | (rsi_14_4h < 40.0) | (roc_9_1d > -10.0))
             # 15m & 1h down move, 1h still not low enough
-            & ((rsi_3_15m_gt_3) | (rsi_3_1h_gt_25) | (aroonu_14_1h < 20.0))
+            & ((rsi_3_15m_gt_3) | (rsi_3_1h_gt_25) | (aroonu_14_1h_lt_20))
             # 15m & 1h down move, 4h still high
             & ((rsi_3_15m_gt_3) | (rsi_3_1h_gt_25) | (stochrsi_k_4h < 40.0))
             # 15m & 1h down move, 4h high
@@ -15650,21 +15679,21 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 4h down move, 1d downtrend
             & ((rsi_3_15m_gt_3) | (rsi_3_4h_gt_15) | (roc_9_1d > -10.0))
             # 15m & 4h down move, 4h still not low enough
-            & ((rsi_3_15m_gt_3) | (rsi_3_4h_gt_20) | (aroonu_14_4h < 20.0))
+            & ((rsi_3_15m_gt_3) | (rsi_3_4h_gt_20) | (aroonu_14_4h_lt_20))
             # 15m & 4h down move, 15m still not low enough
-            & ((rsi_3_15m_gt_3) | (rsi_3_4h_gt_30) | (aroonu_14_15m < 25.0))
+            & ((rsi_3_15m_gt_3) | (rsi_3_4h_gt_30) | (aroonu_14_15m_lt_25))
             # 15m & 4h down move, 1h still high
             & ((rsi_3_15m_gt_3) | (rsi_3_4h_gt_30) | (stochrsi_k_1h < 40.0))
             # 15m & 4h down move, 1h high
             & ((rsi_3_15m_gt_3) | (rsi_3_4h_gt_45) | (stochrsi_k_1h < 60.0))
             # 15m & 1d down move, 15m still not low enough
-            & ((rsi_3_15m_gt_3) | (rsi_3_1d_gt_10) | (aroonu_14_15m < 30.0))
+            & ((rsi_3_15m_gt_3) | (rsi_3_1d_gt_10) | (aroonu_14_15m_lt_30))
             # 15m & 1d down move, 4h high
             & ((rsi_3_15m_gt_3) | (rsi_3_1d_gt_55) | (stochrsi_k_4h_lt_70))
             # 1h & 1d downtrend, 1d high
             & ((rsi_3_15m_gt_3) | (aroonu_14_1d_lt_70) | (roc_9_1d < 10.0))
             # 15m & 1h down move, 1h high
-            & ((rsi_3_15m_gt_5) | (rsi_3_1h_gt_25) | (aroonu_14_1h < 60.0))
+            & ((rsi_3_15m_gt_5) | (rsi_3_1h_gt_25) | (aroonu_14_1h_lt_60))
             # 15m & 1h down move, 1h still high
             & ((rsi_3_15m_gt_5) | (rsi_3_1h_gt_25) | (stochrsi_k_1h < 40.0))
             # 15m & 1h down move, 4h still high
@@ -15678,11 +15707,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 4h high
             & ((rsi_3_15m_gt_5) | (rsi_3_1h_gt_55) | (aroonu_14_4h_lt_100))
             # 15m & 4h down move, 15m still not low enough
-            & ((rsi_3_15m_gt_5) | (rsi_3_4h_gt_20) | (aroonu_14_15m < 30.0))
+            & ((rsi_3_15m_gt_5) | (rsi_3_4h_gt_20) | (aroonu_14_15m_lt_30))
             # 15m & 4h down move, 4h high
             & ((rsi_3_15m_gt_5) | (rsi_3_4h_gt_35) | (stochrsi_k_4h < 60.0))
             # 15m down move, 15m still high, 1h still high
-            & ((rsi_3_15m_gt_5) | (aroonu_14_15m < 30.0) | (stochrsi_k_1h_lt_50))
+            & ((rsi_3_15m_gt_5) | (aroonu_14_15m_lt_30) | (stochrsi_k_1h_lt_50))
             # 15m down move, 1h still high, 1d high
             & ((rsi_3_15m_gt_5) | (stochrsi_k_1h < 40.0) | (aroonu_14_1d_lt_70))
             # 15m down move, 1h & 4h high
@@ -15750,13 +15779,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 4h down move, 4h high
             & ((rsi_3_15m_gt_10) | (rsi_3_4h_gt_45) | aroonu_14_4h_lt_70)
             # 15m & 4h down move, 4h high
-            & ((rsi_3_15m_gt_10) | (rsi_3_4h_gt_50) | (aroonu_14_4h < 75.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_4h_gt_50) | (aroonu_14_4h_lt_75))
             # 15m & 4h down move, 4h high
             & ((rsi_3_15m_gt_10) | (rsi_3_4h_gt_60) | (stochrsi_k_4h_lt_80))
             # 15m & 1d down move, 1h still high
             & ((rsi_3_15m_gt_10) | (rsi_3_1d_gt_10) | (stochrsi_k_1h < 40.0))
             # 15m & 1d down move, 1d high
-            & ((rsi_3_15m_gt_10) | (rsi_3_1d_gt_20) | (aroonu_14_1d < 75.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_1d_gt_20) | (aroonu_14_1d_lt_75))
             # 15m & 1d down move, 1d overbought
             & ((rsi_3_15m_gt_10) | (rsi_3_1d > 50.0) | (roc_9_1d_lt_20))
             # 15m down move, 15m downtrend, 4h still high
@@ -15764,9 +15793,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 1h downtrend, 4h still high
             & ((rsi_3_15m_gt_10) | (cmf_20_1h > -0.30) | (stochrsi_k_4h < 40.0))
             # 15m down move, 15m still not low enough, 4h high
-            & ((rsi_3_15m_gt_10) | (aroonu_14_15m < 30.0) | (aroonu_14_4h_lt_60))
+            & ((rsi_3_15m_gt_10) | (aroonu_14_15m_lt_30) | (aroonu_14_4h_lt_60))
             # 15m down move, 15m still high, 1h still high
-            & ((rsi_3_15m_gt_10) | (aroonu_14_15m < 40.0) | (stochrsi_k_1h_lt_50))
+            & ((rsi_3_15m_gt_10) | (aroonu_14_15m_lt_40) | (stochrsi_k_1h_lt_50))
             # 15m down move, 4h high & overbought
             & ((rsi_3_15m_gt_10) | (aroonu_14_4h_lt_90) | (roc_9_4h_lt_20))
             # 15m down move, 1h still not low enough, 1d overbought
@@ -15780,7 +15809,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h & 4h down move
             & ((rsi_3_15m_gt_15) | (rsi_3_1h_gt_15) | (rsi_3_1h_gt_15))
             # 15m & 1h down move, 1h still high
-            & ((rsi_3_15m_gt_15) | (rsi_3_1h_gt_15) | (aroonu_14_1h < 40.0))
+            & ((rsi_3_15m_gt_15) | (rsi_3_1h_gt_15) | (aroonu_14_1h_lt_40))
             # 15m & 1h down move, 1h downtrend
             & ((rsi_3_15m_gt_15) | rsi_3_1h_gt_20 | (cmf_20_1h > -0.30))
             # 15m & 1h down move, 1h still high
@@ -15822,19 +15851,19 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1d down move, 1d overbought
             & ((rsi_3_15m_gt_15) | (rsi_3_1d_gt_30) | (roc_9_1d < 10.0))
             # 15m down move, 15m still not low enough, 1h high
-            & ((rsi_3_15m_gt_15) | (aroonu_14_15m < 25.0) | (stochrsi_k_1h_lt_80))
+            & ((rsi_3_15m_gt_15) | (aroonu_14_15m_lt_25) | (stochrsi_k_1h_lt_80))
             # 15m down move, 15m still high, 4h high
-            & ((rsi_3_15m_gt_15) | (aroonu_14_15m < 40.0) | aroonu_14_4h_lt_70)
+            & ((rsi_3_15m_gt_15) | (aroonu_14_15m_lt_40) | aroonu_14_4h_lt_70)
             # 15m down move, 1h still high, 1d overbought
             & ((rsi_3_15m_gt_15) | (aroonu_14_1h_lt_50) | (roc_9_1d_lt_80))
             # 15m down move, 1h & 4h high
-            & ((rsi_3_15m_gt_15) | (aroonu_14_1h < 60.0) | (aroonu_14_4h_lt_90))
+            & ((rsi_3_15m_gt_15) | (aroonu_14_1h_lt_60) | (aroonu_14_4h_lt_90))
             # 15m down move, 1h & 4h high
-            & ((rsi_3_15m_gt_15) | aroonu_14_1h_lt_80 | (aroonu_14_4h < 85.0))
+            & ((rsi_3_15m_gt_15) | aroonu_14_1h_lt_80 | (aroonu_14_4h_lt_85))
             # 15m down move, 1h & 1d high
             & ((rsi_3_15m_gt_15) | aroonu_14_1h_lt_70 | (aroonu_14_1d_lt_70))
             # 15m down move, 1h & 4h high
-            & ((rsi_3_15m_gt_15) | (aroonu_14_1h < 85.0) | (stochrsi_k_4h_lt_90))
+            & ((rsi_3_15m_gt_15) | (aroonu_14_1h_lt_85) | (stochrsi_k_4h_lt_90))
             # 15m down move, 4h high, 4h downtrend
             & ((rsi_3_15m_gt_15) | (aroonu_14_4h_lt_60) | (roc_9_4h_gt_neg_20))
             # 15m down move, 4h & 1d high
@@ -15862,7 +15891,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 4h high
             & ((rsi_3_15m_gt_20) | (rsi_3_1h_gt_25) | (stochrsi_k_4h_lt_80))
             # 15m & 1h & 4h down move, 15m & 1h still high
-            & ((rsi_3_15m_gt_20) | (rsi_3_1h_gt_30) | (rsi_3_4h_gt_45) | (aroonu_14_15m < 40.0) | (aroonu_14_1h_lt_50))
+            & ((rsi_3_15m_gt_20) | (rsi_3_1h_gt_30) | (rsi_3_4h_gt_45) | (aroonu_14_15m_lt_40) | (aroonu_14_1h_lt_50))
             # 15m & 1h down move, 1d high
             & ((rsi_3_15m_gt_20) | (rsi_3_1h_gt_35) | (aroonu_14_1d_lt_100))
             # 15m & 1h down move, 1h high
@@ -15882,11 +15911,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1d down move, 15m still high
             & ((rsi_3_15m_gt_20) | (rsi_3_1d_gt_30) | (stochrsi_k_15m < 50.0))
             # 15m down move, 15m still not low enough, 1h high
-            & ((rsi_3_15m_gt_20) | (aroonu_14_15m < 25.0) | (stochrsi_k_1h < 90.0))
+            & ((rsi_3_15m_gt_20) | (aroonu_14_15m_lt_25) | (stochrsi_k_1h < 90.0))
             # 15m down move, 15m still high, 1h high
-            & ((rsi_3_15m_gt_20) | (aroonu_14_15m < 40.0) | aroonu_14_1h_lt_70)
+            & ((rsi_3_15m_gt_20) | (aroonu_14_15m_lt_40) | aroonu_14_1h_lt_70)
             # 15m down move, 15m still high, 4h high
-            & ((rsi_3_15m_gt_20) | (aroonu_14_15m < 40.0) | aroonu_14_4h_lt_70)
+            & ((rsi_3_15m_gt_20) | (aroonu_14_15m_lt_40) | aroonu_14_4h_lt_70)
             # 15m down move, 1h & 4h high
             & ((rsi_3_15m_gt_20) | aroonu_14_1h_lt_80 | aroonu_14_4h_lt_80)
             # 15m down move, 1h high, 1d overbought
@@ -15920,7 +15949,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 1d overbought
             & ((rsi_3_15m_gt_25) | (rsi_3_1h_gt_40) | (roc_9_1d_lt_80))
             # 15m & 1h down move, 1h high
-            & ((rsi_3_15m_gt_25) | (rsi_3_1h_gt_50) | (aroonu_14_1h < 85.0))
+            & ((rsi_3_15m_gt_25) | (rsi_3_1h_gt_50) | (aroonu_14_1h_lt_85))
             # 15m & 1h down move, 4h high
             & ((rsi_3_15m_gt_25) | (rsi_3_1h_gt_60) | aroonu_14_4h_lt_100)
             # 15m & 1h down move, 4h high
@@ -15930,15 +15959,15 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1d down move, 1h high
             & ((rsi_3_15m_gt_25) | (rsi_3_1d_gt_25) | aroonu_14_1h_lt_80)
             # 15m down move, 15m still not low enough, 1h high
-            & ((rsi_3_15m_gt_25) | (aroonu_14_15m < 25.0) | (stochrsi_k_1h < 90.0))
+            & ((rsi_3_15m_gt_25) | (aroonu_14_15m_lt_25) | (stochrsi_k_1h < 90.0))
             # 15m down move, 15m still high, 1h high
-            & ((rsi_3_15m_gt_25) | (aroonu_14_15m < 40.0) | (stochrsi_k_1h_lt_80))
+            & ((rsi_3_15m_gt_25) | (aroonu_14_15m_lt_40) | (stochrsi_k_1h_lt_80))
             # 15m down move, 1h high, 1d overbought
-            & ((rsi_3_15m_gt_25) | (aroonu_14_1h < 60.0) | (roc_9_1d < 60.0))
+            & ((rsi_3_15m_gt_25) | (aroonu_14_1h_lt_60) | (roc_9_1d < 60.0))
             # 15m down move, 1h high, 4h overbought
             & ((rsi_3_15m_gt_25) | aroonu_14_1h_lt_70 | (roc_9_4h_lt_40))
             # 15m down move, 1h & 4h high
-            & ((rsi_3_15m_gt_25) | (aroonu_14_1h < 85.0) | aroonu_14_4h_lt_100)
+            & ((rsi_3_15m_gt_25) | (aroonu_14_1h_lt_85) | aroonu_14_4h_lt_100)
             # 15m down move, 1h & 4h high
             & ((rsi_3_15m_gt_25) | (aroonu_14_1h_lt_90) | (aroonu_14_4h_lt_90))
             # 15m down move, 4h high & overbought
@@ -15964,7 +15993,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 1h high & overbought
             & ((rsi_3_15m_gt_30) | (aroonu_14_1h_lt_90) | (roc_9_1h_lt_10))
             # 15m down move, 15m still high, 4h high
-            & ((rsi_3_15m_gt_35) | (aroonu_14_15m < 40.0) | (aroonu_14_4h < 85.0))
+            & ((rsi_3_15m_gt_35) | (aroonu_14_15m_lt_40) | (aroonu_14_4h_lt_85))
             # 15m down move, 4h high & overbought
             & ((rsi_3_15m_gt_30) | (aroonu_14_4h_lt_100) | (roc_9_4h_lt_40))
             # 15m down move, 4h high & overbought
@@ -15976,11 +16005,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 4h down move, 4h high
             & ((rsi_3_15m_gt_35) | (rsi_3_4h_gt_35) | (stochrsi_k_4h_lt_80))
             # 15m down move, 15m still not low enough, 1h high
-            & ((rsi_3_15m_gt_35) | (aroonu_14_15m < 25.0) | aroonu_14_1h_lt_80)
+            & ((rsi_3_15m_gt_35) | (aroonu_14_15m_lt_25) | aroonu_14_1h_lt_80)
             # 15m down move, 15m still not low enough, 1h high
-            & ((rsi_3_15m_gt_35) | (aroonu_14_15m < 25.0) | (stochrsi_k_1h_lt_80))
+            & ((rsi_3_15m_gt_35) | (aroonu_14_15m_lt_25) | (stochrsi_k_1h_lt_80))
             # 15m down move, 1m still high, 4h overbought
-            & ((rsi_3_15m_gt_35) | (aroonu_14_15m < 40.0) | (roc_9_4h < 50.0))
+            & ((rsi_3_15m_gt_35) | (aroonu_14_15m_lt_40) | (roc_9_4h < 50.0))
             # 15m down move, 1h high, 4h overbought
             & ((rsi_3_15m_gt_35) | aroonu_14_1h_lt_80 | (roc_9_4h_lt_10))
             # 15m down move, 4h high & overbought
@@ -16024,7 +16053,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 1d downtrend
             & ((rsi_3_1h_gt_15) | rsi_3_4h_gt_20 | (roc_9_1d > -30.0))
             # 1h & 4h down move, 1h high
-            & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_35) | (aroonu_14_1h < 70.0))
+            & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_35) | (aroonu_14_1h_lt_70))
             # 1h & 4h down move, 4h still high
             & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_35) | (stochrsi_k_4h_lt_50))
             # 1h down move, 1d high & overbought
@@ -16036,7 +16065,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 1d down move, 1d high
             & (rsi_3_1h_gt_20 | (rsi_3_1d > 50.0) | (stochrsi_k_1d < 60.0))
             # 1h down move, 1h high, 1d overbought
-            & (rsi_3_1h_gt_20 | (aroonu_14_1h < 60.0) | roc_9_1d_lt_50)
+            & (rsi_3_1h_gt_20 | (aroonu_14_1h_lt_60) | roc_9_1d_lt_50)
             # 1h down move, 1h high, 1d overbought
             & (rsi_3_1h_gt_20 | aroonu_14_1h_lt_70 | (roc_9_1d_lt_20))
             # 1h down move, 1d high, 4h downtrend
@@ -16050,7 +16079,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 4h downtrend, 4h high
             & ((rsi_3_1h_gt_25) | (cmf_20_4h > -0.50) | aroonu_14_4h_lt_70)
             # 1h down move, 1h still high, 1d high
-            & ((rsi_3_1h_gt_25) | (aroonu_14_1h < 40.0) | (aroonu_14_1d_lt_90))
+            & ((rsi_3_1h_gt_25) | (aroonu_14_1h_lt_40) | (aroonu_14_1d_lt_90))
             # 1h down move, 1h still high, 4h overbought
             & ((rsi_3_1h_gt_25) | (aroonu_14_1h_lt_50) | (roc_9_4h < 60.0))
             # 1h down move, 4h high, 1d overbought
@@ -16066,13 +16095,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 4h high
             & ((rsi_3_1h_gt_30) | (rsi_3_4h_gt_60) | (stochrsi_k_4h_lt_80))
             # 1h & 1d down move, 1h high
-            & ((rsi_3_1h_gt_30) | (rsi_3_1d_gt_30) | (aroonu_14_1h < 60.0))
+            & ((rsi_3_1h_gt_30) | (rsi_3_1d_gt_30) | (aroonu_14_1h_lt_60))
             # 1h down move, 4h & 1d down move
             & ((rsi_3_1h_gt_30) | aroonu_14_4h_lt_70 | aroonu_14_1d_lt_100)
             # 1h down move, 4h high & overbought
-            & ((rsi_3_1h_gt_30) | (aroonu_14_4h < 85.0) | (roc_9_4h < 80.0))
+            & ((rsi_3_1h_gt_30) | (aroonu_14_4h_lt_85) | (roc_9_4h < 80.0))
             # 1h down move, 1d still high, 1d downtrend
-            & ((rsi_3_1h_gt_30) | (aroonu_14_1d < 40.0) | (roc_9_1d_gt_neg_20))
+            & ((rsi_3_1h_gt_30) | (aroonu_14_1d_lt_40) | (roc_9_1d_gt_neg_20))
             # 1h down move, 1d high, 4h downtrend
             & ((rsi_3_1h_gt_30) | aroonu_14_1d_lt_100 | (roc_9_4h_gt_neg_30))
             # 1h down move, 1d high & overbought
@@ -16080,9 +16109,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 4h & 1d downtrend
             & ((rsi_3_1h_gt_30) | (roc_9_4h > -25.0) | (roc_9_1d > -60.0))
             # 1h & 1d down move, 1h high
-            & ((rsi_3_1h_gt_35) | (rsi_3_1d_gt_35) | (aroonu_14_1h < 75.0))
+            & ((rsi_3_1h_gt_35) | (rsi_3_1d_gt_35) | (aroonu_14_1h_lt_75))
             # 1h down move, 1h & 4h high
-            & ((rsi_3_1h_gt_35) | (aroonu_14_1h < 60.0) | aroonu_14_4h_lt_70)
+            & ((rsi_3_1h_gt_35) | (aroonu_14_1h_lt_60) | aroonu_14_4h_lt_70)
             # 1h down move, 4h high, 1d downtrend
             & ((rsi_3_1h_gt_35) | aroonu_14_4h_lt_70 | (roc_9_1d_gt_neg_30))
             # 1h down move, 1d high, 4h overbought
@@ -16094,9 +16123,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 1h high
             & ((rsi_3_1h_gt_40) | (rsi_3_4h_gt_50) | (stochrsi_k_1h < 60.0))
             # 1h down move, 1h high, 1d overbought
-            & ((rsi_3_1h_gt_40) | (aroonu_14_1h < 60.0) | (roc_9_1d_lt_40))
+            & ((rsi_3_1h_gt_40) | (aroonu_14_1h_lt_60) | (roc_9_1d_lt_40))
             # 1h down move, 1h still high, 1d high
-            & ((rsi_3_1h_gt_40) | (aroonu_14_1h_lt_50) | (aroonu_14_1d < 85.0))
+            & ((rsi_3_1h_gt_40) | (aroonu_14_1h_lt_50) | (aroonu_14_1d_lt_85))
             # 1h down move, 1h still high, 1d overbought
             & ((rsi_3_1h_gt_40) | (aroonu_14_1h_lt_50) | (roc_9_1d_lt_20))
             # 1h down move, 1h high, 4h overbought
@@ -16112,11 +16141,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 1d overbought
             & ((rsi_3_1h_gt_45) | (rsi_3_4h_gt_65) | (roc_9_1d < 200.0))
             # 1h down move, 1h still not low enough, 1d downtrend
-            & ((rsi_3_1h_gt_45) | (aroonu_14_1h < 30.0) | (roc_9_1d > -25.0))
+            & ((rsi_3_1h_gt_45) | (aroonu_14_1h_lt_30) | (roc_9_1d > -25.0))
             # 1h down move, 1h still high, 1d overbought
             & ((rsi_3_1h_gt_45) | (stochrsi_k_1h < 40.0) | (roc_9_1d_lt_100))
             # 1h down move, 4h high, 1h overbought
-            & ((rsi_3_1h_gt_50) | (aroonu_14_4h < 85.0) | (roc_9_1h < 20.0))
+            & ((rsi_3_1h_gt_50) | (aroonu_14_4h_lt_85) | (roc_9_1h < 20.0))
             # 1h down move, 1d high, 4h overbought
             & ((rsi_3_1h_gt_50) | (aroonu_14_1d_lt_90) | (roc_9_4h_lt_20))
             # 1h down move, 1h high & overbought
@@ -16146,7 +16175,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h high, 1d overbought
             & ((rsi_3_1h_gt_65) | (stochrsi_k_1h < 90.0) | (roc_9_1d_lt_20))
             # 4h down move, 1h still not low enough, 4h downtrend
-            & ((rsi_3_4h_gt_3) | (aroonu_14_1h < 20.0) | (roc_9_4h > -10.0))
+            & ((rsi_3_4h_gt_3) | (aroonu_14_1h_lt_20) | (roc_9_4h > -10.0))
             # 4h down move, 4h & 1d downtrend
             & ((rsi_3_4h_gt_3) | (roc_9_4h > -10.0) | (roc_9_1d > -10.0))
             # 4h & 1d down move, 15m still high
@@ -16158,7 +16187,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h & 1d down move, 1d still high
             & ((rsi_3_4h_gt_10) | (rsi_3_1d_gt_20) | (stochrsi_k_1d < 50.0))
             # 4h & 1d down move, 1d high
-            & ((rsi_3_4h_gt_10) | (rsi_3_1d_gt_35) | (aroonu_14_1d < 100.0))
+            & ((rsi_3_4h_gt_10) | (rsi_3_1d_gt_35) | (aroonu_14_1d_lt_100))
             # 4h & 1d down move, 1d overbought
             & ((rsi_3_4h_gt_10) | (rsi_3_1d_gt_45) | (roc_9_1d < 10.0))
             # 4h down move, 15m high
@@ -16180,7 +16209,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 1h & 4h downtrend
             & ((rsi_3_4h_gt_15) | (roc_9_1h > -30.0) | (roc_9_4h_gt_neg_30))
             # 4h & 1d down move, 1d high
-            & (rsi_3_4h_gt_20 | (rsi_3_1d_gt_20) | (aroonu_14_1d < 60.0))
+            & (rsi_3_4h_gt_20 | (rsi_3_1d_gt_20) | (aroonu_14_1d_lt_60))
             # 4h & 1d down move, 4h still high
             & (rsi_3_4h_gt_20 | (rsi_3_1d_gt_20) | (stochrsi_k_4h < 40.0))
             # 4h & 1d down move, 1d overbought
@@ -16236,7 +16265,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 4h still high, 4h overbought
             & ((rsi_3_4h_gt_60) | (stochrsi_k_4h_lt_50) | (roc_9_4h_lt_10))
             # 4h down move, 4h high, 1d overbought
-            & ((rsi_3_4h_gt_65) | (aroonu_14_4h < 75.0) | (roc_9_1d_lt_30))
+            & ((rsi_3_4h_gt_65) | (aroonu_14_4h_lt_75) | (roc_9_1d_lt_30))
             # 4h down move, 4h high & overbought
             & ((rsi_3_4h_gt_65) | aroonu_14_4h_lt_80 | (roc_9_4h < 20.0))
             # 1d down move, 1d still not low enough, 1d downtrend
@@ -16260,11 +16289,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h downtrend, 4h high & over
             & ((cmf_20_4h > -0.10) | aroonu_14_4h_lt_100 | (roc_9_4h_lt_30))
             # 15m still high, 4h high, 1h overbought
-            & ((aroonu_14_15m < 40.0) | (aroonu_14_4h < 85.0) | (roc_9_1h < 20.0))
+            & ((aroonu_14_15m_lt_40) | (aroonu_14_4h_lt_85) | (roc_9_1h < 20.0))
             # 15m still high, 4h high, 1h overbought
-            & ((aroonu_14_15m < 40.0) | aroonu_14_4h_lt_100 | (roc_9_1h < 20.0))
+            & ((aroonu_14_15m_lt_40) | aroonu_14_4h_lt_100 | (roc_9_1h < 20.0))
             # 4h down move, 1h still high, 1d downtrend
-            & ((rsi_3_4h_gt_15) | (aroonu_14_1h < 40.0) | roc_9_1d_gt_neg_50)
+            & ((rsi_3_4h_gt_15) | (aroonu_14_1h_lt_40) | roc_9_1d_gt_neg_50)
             # 1h high, 4h high & overbought
             & (aroonu_14_1h_lt_80 | aroonu_14_4h_lt_80 | (roc_9_4h_lt_30))
             # 1h & 4h high, 1h overbought
@@ -16282,7 +16311,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h high, 1h overbought, 1d downtrend
             & (aroonu_14_1h_lt_80 | (roc_9_1h < 50.0) | roc_9_1d_gt_neg_50)
             # 1h high, 4h &1d overbought
-            & ((aroonu_14_1h < 85.0) | (roc_9_4h_lt_30) | (roc_9_1d_lt_30))
+            & ((aroonu_14_1h_lt_85) | (roc_9_4h_lt_30) | (roc_9_1d_lt_30))
             # 1h high, 4h & 1d overbought
             & ((aroonu_14_1h_lt_90) | (roc_9_4h_lt_10) | (roc_9_1d < 15.0))
             # 4h & 1d high, 4h overbought
@@ -16300,7 +16329,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1d high, 1d downtrend
             & ((aroonu_14_1d_lt_80) | (roc_9_1d_gt_neg_30))
             # 1d high, 1h & 4h downtrend
-            & ((aroonu_14_1d < 85.0) | (roc_9_1h > -30.0) | (roc_9_4h > -50.0))
+            & ((aroonu_14_1d_lt_85) | (roc_9_1h > -30.0) | (roc_9_4h > -50.0))
             # 1d high, 1h & 1d overbought
             & ((aroonu_14_1d_lt_90) | (roc_9_1h_lt_10) | roc_9_1d_lt_50)
             # 1d high, 4h & 1d overbought
@@ -16347,7 +16376,7 @@ class NostalgiaForInfinityX7(IStrategy):
           long_entry_logic.append(
             (rsi_20 < rsi_20.shift(1))
             & (rsi_3 < 46.0)
-            & (aroonu_14 < 25.0)
+            & (aroonu_14_lt_25)
             & (stochrsi_k < 20.0)
             & (aroonu_14_15m_lt_50)
             & (close < sma_16 * 0.960)
@@ -16389,11 +16418,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1d down move, 1h high
             & ((rsi_3_15m_gt_15) | (rsi_3_1d_gt_35) | (aroonu_14_1h_lt_90))
             # 15m down move, 15m still high, 4h high
-            & ((rsi_3_15m_gt_15) | (aroonu_14_15m < 40.0) | aroonu_14_4h_lt_100)
+            & ((rsi_3_15m_gt_15) | (aroonu_14_15m_lt_40) | aroonu_14_4h_lt_100)
             # 15m down move, 1h & 4h high
-            & ((rsi_3_15m_gt_15) | (aroonu_14_1h < 40.0) | aroonu_14_4h_lt_100)
+            & ((rsi_3_15m_gt_15) | (aroonu_14_1h_lt_40) | aroonu_14_4h_lt_100)
             # 15m down move, 1h high, 4h overbought
-            & ((rsi_3_15m_gt_15) | (aroonu_14_1h < 60.0) | (roc_9_4h < 80.0))
+            & ((rsi_3_15m_gt_15) | (aroonu_14_1h_lt_60) | (roc_9_4h < 80.0))
             # 15m down move, 4h high, 4h downtrend
             & ((rsi_3_15m_gt_15) | (aroonu_14_4h_lt_90) | (cmf_20_4h > -0.25))
             # 15m down move, 1h & 4h high
@@ -16401,7 +16430,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 4h & 1d overbought
             & ((rsi_3_15m_gt_15) | (roc_9_4h < 60.0) | (roc_9_1d_lt_80))
             # 15m down move, 1h & 4h high
-            & ((rsi_3_15m_gt_20) | (aroonu_14_1h < 60.0) | aroonu_14_4h_lt_100)
+            & ((rsi_3_15m_gt_20) | (aroonu_14_1h_lt_60) | aroonu_14_4h_lt_100)
             # 15m down move, 4h high, 1h overbought
             & ((rsi_3_15m_gt_20) | (stochrsi_k_4h_lt_80) | (roc_9_1h_lt_10))
             # 15m down move, 4h & 1d overbought
@@ -16411,7 +16440,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 1h high
             & ((rsi_3_15m_gt_25) | (rsi_3_1h_gt_55) | (aroonu_14_1h_lt_90))
             # 15m down move, 15m still high, 1d downtrend
-            & ((rsi_3_15m_gt_25) | (aroonu_14_15m < 40.0) | (roc_9_1d > -25.0))
+            & ((rsi_3_15m_gt_25) | (aroonu_14_15m_lt_40) | (roc_9_1d > -25.0))
             # 15m down move, 1h & 4h high
             & ((rsi_3_15m_gt_25) | (aroonu_14_1h_lt_90) | aroonu_14_4h_lt_100)
             # 15m down move, 4h high, 1h overbought
@@ -16473,7 +16502,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h high, 4h overbought
             & ((rsi_3_1h_gt_55) | aroonu_14_1h_lt_70 | (roc_9_4h_lt_40))
             # 1h down move, 4h high & overbought
-            & ((rsi_3_1h_gt_55) | (aroonu_14_4h < 85.0) | (roc_9_4h < 80.0))
+            & ((rsi_3_1h_gt_55) | (aroonu_14_4h_lt_85) | (roc_9_4h < 80.0))
             # 1h down move, 4h high & overbought
             & ((rsi_3_1h_gt_60) | aroonu_14_4h_lt_80 | (roc_9_4h < 100.0))
             # 1h down move, 1h & 1d overbought
@@ -16483,7 +16512,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h overbought
             & ((rsi_3_1h_gt_65) | (roc_9_1h < 40.0))
             # 4h down move, 1h high & overbought
-            & ((rsi_3_4h_gt_3) | (aroonu_14_1h < 85.0) | (roc_9_1h < 60.0))
+            & ((rsi_3_4h_gt_3) | (aroonu_14_1h_lt_85) | (roc_9_1h < 60.0))
             # 1d down move, 4h high & overbought
             & ((rsi_3_1d_gt_5) | (aroonu_14_4h_lt_90) | (roc_9_4h < 50.0))
             # 1d down move, 1h high
@@ -16503,13 +16532,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1d down move, 4h high & overbought
             & ((rsi_3_1d_gt_45) | aroonu_14_4h_lt_80 | (roc_9_4h_lt_30))
             # 1d down move, 1h high, 1d overbought
-            & ((rsi_3_1d_gt_60) | (aroonu_14_1h < 75.0) | (roc_9_1d_lt_20))
+            & ((rsi_3_1d_gt_60) | (aroonu_14_1h_lt_75) | (roc_9_1d_lt_20))
             # 1d down move, 1h & 4h high
             & ((rsi_3_1d_gt_65) | (aroonu_14_1h_lt_90) | aroonu_14_4h_lt_100)
             # 1d downtrend, 1d high & overbought
-            & ((cmf_20_1d > -0.40) | (aroonu_14_1d < 85.0) | (roc_9_1d_lt_20))
+            & ((cmf_20_1d > -0.40) | (aroonu_14_1d_lt_85) | (roc_9_1d_lt_20))
             # 15m not low enough, 1h high, 1d overbought
-            & ((aroonu_14_15m < 25.0) | (stochrsi_k_1h < 90.0) | (roc_9_1d < 200.0))
+            & ((aroonu_14_15m_lt_25) | (stochrsi_k_1h < 90.0) | (roc_9_1d < 200.0))
             # 1h still high, 1h & 4h overbought
             & ((aroonu_14_1h_lt_50) | (roc_9_1h < 40.0) | (roc_9_4h_lt_40))
             # 1h & 4h high, 4h overbought
@@ -16531,19 +16560,19 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h high, 4h overbought, 1d downtrend
             & (aroonu_14_1h_lt_80 | (roc_9_4h_lt_10) | roc_9_1d_gt_neg_50)
             # 1h & 4h high, 15m downtrend
-            & ((aroonu_14_1h < 85.0) | (aroonu_14_4h < 85.0) | (roc_9_15m > -40.0))
+            & ((aroonu_14_1h_lt_85) | (aroonu_14_4h_lt_85) | (roc_9_15m > -40.0))
             # 1h & 4h high, 1h overbought
             & ((aroonu_14_1h_lt_90) | (aroonu_14_4h_lt_90) | (roc_9_1h_lt_10))
             # 4h high, 1h overbought, 1d downtrend
             & (aroonu_14_4h_lt_80 | (roc_9_1h < 30.0) | (roc_9_1d > -30.0))
             # 4h & 1d high, 4h downtrend
-            & ((aroonu_14_4h < 85.0) | aroonu_14_1d_lt_100 | (cmf_20_4h > -0.30))
+            & ((aroonu_14_4h_lt_85) | aroonu_14_1d_lt_100 | (cmf_20_4h > -0.30))
             # 4h & 1d high, 1h overbought
-            & ((aroonu_14_4h < 85.0) | (aroonu_14_1d_lt_90) | (roc_9_1h < 20.0))
+            & ((aroonu_14_4h_lt_85) | (aroonu_14_1d_lt_90) | (roc_9_1h < 20.0))
             # 4h & 1d high, 4h overbought
-            & ((aroonu_14_4h < 85.0) | (aroonu_14_1d_lt_90) | (roc_9_4h < 60.0))
+            & ((aroonu_14_4h_lt_85) | (aroonu_14_1d_lt_90) | (roc_9_4h < 60.0))
             # 4h high, 1h & 4h overbought
-            & ((aroonu_14_4h < 85.0) | (roc_9_1h_lt_10) | (roc_9_4h_lt_20))
+            & ((aroonu_14_4h_lt_85) | (roc_9_1h_lt_10) | (roc_9_4h_lt_20))
             # 4h high, 1d high & overbought
             & ((aroonu_14_4h_lt_90) | aroonu_14_1d_lt_100 | (roc_9_1d_lt_30))
             # 4h high, 1h & 4h overbought
@@ -16574,7 +16603,7 @@ class NostalgiaForInfinityX7(IStrategy):
 
           # Logic
           long_entry_logic.append(
-            (aroonu_14 < 25.0)
+            (aroonu_14_lt_25)
             & (stochrsi_k < 20.0)
             & (aroonu_14_15m_lt_50)
             & (close < df["EMA_16"] * 0.960)
@@ -16595,11 +16624,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 1h still not low enough
             & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_5) | (stochrsi_k_1h < 30.0))
             # 15m & 1h & 4h down move, 4h still not low enough
-            & ((rsi_3_15m_gt_3) | (rsi_3_1h_gt_10) | (rsi_3_4h_gt_20) | (aroonu_14_4h < 20.0))
+            & ((rsi_3_15m_gt_3) | (rsi_3_1h_gt_10) | (rsi_3_4h_gt_20) | (aroonu_14_4h_lt_20))
             # 15m & 1h down move, 15m downtrend
             & ((rsi_3_15m_gt_3) | (rsi_3_1h_gt_10) | (cmf_20_15m > -0.40))
             # 15m & 1h down move, 4h high
-            & ((rsi_3_15m_gt_3) | (rsi_3_1h_gt_10) | (aroonu_14_4h < 80.0))
+            & ((rsi_3_15m_gt_3) | (rsi_3_1h_gt_10) | (aroonu_14_4h_lt_80))
             # 15m & 1h down move, 1h still high
             & ((rsi_3_15m_gt_3) | (rsi_3_1h_gt_10) | (stochrsi_k_1h < 40.0))
             # 15m & 1h down move, 4h high
@@ -16609,9 +16638,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 1h still high
             & ((rsi_3_15m_gt_3) | rsi_3_1h_gt_20 | (aroonu_14_1h_lt_50))
             # 15m & 1h down move, 1h high
-            & ((rsi_3_15m_gt_3) | (rsi_3_1h_gt_25) | (aroonu_14_1h < 60.0))
+            & ((rsi_3_15m_gt_3) | (rsi_3_1h_gt_25) | (aroonu_14_1h_lt_60))
             # 15m & 1h down move, 1d still high
-            & ((rsi_3_15m_gt_3) | (rsi_3_1h_gt_30) | (aroonu_14_1d < 50.0))
+            & ((rsi_3_15m_gt_3) | (rsi_3_1h_gt_30) | (aroonu_14_1d_lt_50))
             # 15m & 1h down move, 1h high
             & ((rsi_3_15m_gt_3) | (rsi_3_1h_gt_30) | (stochrsi_k_1h_lt_70))
             # 15m & 1h down move, 1h still high
@@ -16619,7 +16648,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 1d high
             & ((rsi_3_15m_gt_3) | (rsi_3_1h_gt_30) | (stochrsi_k_1d_lt_90))
             # 15m & 1h down move, 1h high
-            & ((rsi_3_15m_gt_3) | (rsi_3_1h_gt_45) | (aroonu_14_1h < 85.0))
+            & ((rsi_3_15m_gt_3) | (rsi_3_1h_gt_45) | (aroonu_14_1h_lt_85))
             # 15m & 1h down move, 1h high
             & ((rsi_3_15m_gt_3) | (rsi_3_1h_gt_45) | (stochrsi_k_1h < 75.0))
             # 15m & 4h down move, 4h high
@@ -16627,7 +16656,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 4h down move, 4h still high
             & ((rsi_3_15m_gt_3) | (rsi_3_4h_gt_40) | (stochrsi_k_4h_lt_50))
             # 15m down move, 15m still high, 1d high
-            & ((rsi_3_15m_gt_3) | (aroonu_14_15m < 40.0) | (aroonu_14_1d_lt_80))
+            & ((rsi_3_15m_gt_3) | (aroonu_14_15m_lt_40) | (aroonu_14_1d_lt_80))
             # 15m down move, 15m still high, 1d downtrend
             & ((rsi_3_15m_gt_3) | (aroonu_14_15m_lt_50) | (roc_9_1d_gt_neg_20))
             # 15m down move, 1h still high, 1d high
@@ -16673,15 +16702,15 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 4h & 1d overbought
             & ((rsi_3_15m_gt_5) | (roc_9_4h_lt_30) | (roc_9_1d_lt_100))
             # 15m & 1h down move, 1h high
-            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_10) | (aroonu_14_1h < 70.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_10) | (aroonu_14_1h_lt_70))
             # 15m & 1h down move, 1d high
             & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_10) | (stochrsi_k_1d < 70.0))
             # 15m & 1h down move, 1d downtrend
             & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_10) | (roc_9_1d > -30.0))
             # 15m & 1h down move, 1h high
-            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_15) | (aroonu_14_1h < 80.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_15) | (aroonu_14_1h_lt_80))
             # 15m & 1h down move, 4h high
-            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_15) | (aroonu_14_4h < 100.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_15) | (aroonu_14_4h_lt_100))
             # 15m & 1h down move, 4h high
             & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_15) | (stochrsi_k_4h_lt_70))
             # 15m & 1h down move, 1h still high
@@ -16705,21 +16734,21 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 1h high, 1d downtrend
             & ((rsi_3_15m_gt_10) | aroonu_14_1h_lt_80 | (roc_9_1d > -30.0))
             # 15m down move, 1h high, 1d overbought
-            & ((rsi_3_15m_gt_10) | (aroonu_14_1h < 85.0) | (roc_9_1d_lt_40))
+            & ((rsi_3_15m_gt_10) | (aroonu_14_1h_lt_85) | (roc_9_1d_lt_40))
             # 15m down move, 1h & 1d high
             & ((rsi_3_15m_gt_10) | (aroonu_14_1h_lt_90) | aroonu_14_1d_lt_100)
             # 15m down move, 1h & 4h high
             & ((rsi_3_15m_gt_10) | (aroonu_14_1h_lt_100) | aroonu_14_4h_lt_100)
             # 15m down move, 4h high, 1h downtrend
-            & ((rsi_3_15m_gt_10) | (aroonu_14_4h < 85.0) | (roc_9_1h > -25.0))
+            & ((rsi_3_15m_gt_10) | (aroonu_14_4h_lt_85) | (roc_9_1h > -25.0))
             # 15m down move, 4h & 1d high
             & ((rsi_3_15m_gt_10) | (aroonu_14_4h_lt_90) | aroonu_14_1d_lt_100)
             # 15m down move, 4h high, 15m downtrend
-            & ((rsi_3_15m_gt_10) | (aroonu_14_4h < 100.00) | (roc_9_15m > -30.0))
+            & ((rsi_3_15m_gt_10) | (aroonu_14_4h_lt_1000) | (roc_9_15m > -30.0))
             # 15m down move, 1h high & overbought
             & ((rsi_3_15m_gt_10) | aroonu_14_1d_lt_100 | (roc_9_1d < 60.0))
             # 15m down move, 1d high, 1d downtrend
-            & ((rsi_3_15m_gt_10) | (aroonu_14_1d < 85.0) | (cmf_20_1d > -0.40))
+            & ((rsi_3_15m_gt_10) | (aroonu_14_1d_lt_85) | (cmf_20_1d > -0.40))
             # 15m down move, 1h high, 15m downtrend
             & ((rsi_3_15m_gt_10) | (stochrsi_k_1h_lt_80) | (roc_9_15m > -10.0))
             # 15m down move, 1h high, 1d downtrend
@@ -16789,9 +16818,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1d down move, 1h high
             & ((rsi_3_15m_gt_25) | (rsi_3_1d_gt_25) | (aroonu_14_1h_lt_90))
             # 15m down move, 15m high, 1h high
-            & ((rsi_3_15m_gt_30) | (aroonu_14_15m < 60.0) | (aroonu_14_1h_lt_90))
+            & ((rsi_3_15m_gt_30) | (aroonu_14_15m_lt_60) | (aroonu_14_1h_lt_90))
             # 15m down move, 15m high, 4h downtrend
-            & ((rsi_3_15m_gt_25) | (aroonu_14_15m < 60.0) | (roc_9_4h_gt_neg_20))
+            & ((rsi_3_15m_gt_25) | (aroonu_14_15m_lt_60) | (roc_9_4h_gt_neg_20))
             # 15m down move, 1h high, 4h overbought
             & ((rsi_3_15m_gt_25) | (aroonu_14_1h_lt_90) | (roc_9_4h_lt_30))
             # 15m down move, 1h high, 4h overbought
@@ -16805,7 +16834,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 1d still high
             & ((rsi_3_1h_gt_3) | (rsi_3_4h_gt_3) | (stochrsi_k_1d < 50.0))
             # 1h & 4h down move, 1h still high
-            & ((rsi_3_1h_gt_3) | (rsi_3_4h_gt_25) | (aroonu_14_1h < 40.0))
+            & ((rsi_3_1h_gt_3) | (rsi_3_4h_gt_25) | (aroonu_14_1h_lt_40))
             # 1h & 4h down move, 4h high
             & ((rsi_3_1h_gt_3) | (rsi_3_4h_gt_45) | (stochrsi_k_4h_lt_70))
             # 1h down move, 15m & 1h downtrend
@@ -16827,7 +16856,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 1d overbought
             & ((rsi_3_1h_gt_5) | (rsi_3_4h_gt_10) | (roc_9_1d < 100.0))
             # 1h & 4h down move, 4h still not low enough
-            & ((rsi_3_1h_gt_5) | (rsi_3_4h_gt_15) | (aroonu_14_4h < 20.0))
+            & ((rsi_3_1h_gt_5) | (rsi_3_4h_gt_15) | (aroonu_14_4h_lt_20))
             # 1h & 4h down move, 4h still high
             & ((rsi_3_1h_gt_5) | (rsi_3_4h_gt_30) | (rsi_14_4h < 40.0))
             # 1h & 4h down move, 1h downtrend
@@ -16839,7 +16868,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h high, 1d high
             & ((rsi_3_1h_gt_5) | (aroonu_14_1h_lt_70) | (stochrsi_k_1d < 80.0))
             # 1h down move, 1d high, 1h downtrend
-            & ((rsi_3_1h_gt_5) | (aroonu_14_1d < 85.0) | (roc_9_1h > -50.0))
+            & ((rsi_3_1h_gt_5) | (aroonu_14_1d_lt_85) | (roc_9_1h > -50.0))
             # 1h down move, 1d high, 4h downtrend
             & ((rsi_3_1h_gt_5) | (aroonu_14_1d_lt_90) | (roc_9_4h_gt_neg_30))
             # 1h down move, 1d high, 1d downtrend
@@ -16853,7 +16882,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h & 1d down move
             & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_10) | (rsi_3_1d_gt_15))
             # 1h & 4h down move, 1h high
-            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_10) | (aroonu_14_1h < 80.0))
+            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_10) | (aroonu_14_1h_lt_80))
             # 1h & 4h down move, 1d high
             & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_10) | (aroonu_14_1d_lt_80))
             # 1h & 4h down move, 4h still high
@@ -16885,7 +16914,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 1d down move, 1h still not low enough
             & ((rsi_3_1h_gt_10) | (rsi_3_1d_gt_20) | (stochrsi_k_1h < 20.0))
             # 1h & 1d down move, 1h high
-            & ((rsi_3_1h_gt_10) | (rsi_3_1d_gt_25) | (aroonu_14_1h < 70.0))
+            & ((rsi_3_1h_gt_10) | (rsi_3_1d_gt_25) | (aroonu_14_1h_lt_70))
             # 1h & 1d down move, 1h downtrend
             & ((rsi_3_1h_gt_10) | (rsi_3_1d_gt_30) | (cmf_20_1h > -0.40))
             # 1h down move, 1d downtrend, 4h high
@@ -16893,9 +16922,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h still high, 4h overbought
             & ((rsi_3_1h_gt_10) | (aroonu_14_1h_lt_50) | (roc_9_4h < 20.0))
             # 1h down move, 1h & 4h high
-            & ((rsi_3_1h_gt_10) | (aroonu_14_1h < 60.0) | (aroonu_14_4h_lt_60))
+            & ((rsi_3_1h_gt_10) | (aroonu_14_1h_lt_60) | (aroonu_14_4h_lt_60))
             # 1h down move, 1h high, 1d high
-            & ((rsi_3_1h_gt_10) | (aroonu_14_1h < 60.0) | (stochrsi_k_1d_lt_90))
+            & ((rsi_3_1h_gt_10) | (aroonu_14_1h_lt_60) | (stochrsi_k_1d_lt_90))
             # 1h down move, 1d overbought
             & ((rsi_3_1h_gt_10) | roc_9_1d_lt_50)
             # 1h & 4h down move, 1h downtrend
@@ -16909,31 +16938,31 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 4h high
             & ((rsi_3_1h_gt_15) | rsi_3_4h_gt_20 | aroonu_14_4h_lt_70)
             # 1h & 4h down move, 1d high
-            & ((rsi_3_1h_gt_15) | rsi_3_4h_gt_20 | (aroonu_14_1d < 100.0))
+            & ((rsi_3_1h_gt_15) | rsi_3_4h_gt_20 | (aroonu_14_1d_lt_100))
             # 1h & 1d down move, 1h still high
             & ((rsi_3_1h_gt_15) | (rsi_3_1d_gt_30) | (stochrsi_k_1h < 40.0))
             # 1h & 1d down move, 1h high
-            & ((rsi_3_1h_gt_15) | (rsi_3_1d_gt_30) | (aroonu_14_1h < 80.0))
+            & ((rsi_3_1h_gt_15) | (rsi_3_1d_gt_30) | (aroonu_14_1h_lt_80))
             # 1h down move, 1h downtrend, 1h still high
             & ((rsi_3_1h_gt_15) | (cmf_20_1h > -0.30) | (stochrsi_k_1h < 40.0))
             # 1h down move, 1d downtrend, 1d high
             & ((rsi_3_1h_gt_15) | (cmf_20_1d > -0.30) | (stochrsi_k_1d < 80.0))
             # 1h down move, 1h & 1d high
-            & ((rsi_3_1h_gt_15) | (aroonu_14_1h < 70.0) | (aroonu_14_1d_lt_90))
+            & ((rsi_3_1h_gt_15) | (aroonu_14_1h_lt_70) | (aroonu_14_1d_lt_90))
             # 1h down move, 1h high, 1d overbought
-            & ((rsi_3_1h_gt_15) | (aroonu_14_1h < 70.0) | (roc_9_1d_lt_40))
+            & ((rsi_3_1h_gt_15) | (aroonu_14_1h_lt_70) | (roc_9_1d_lt_40))
             # 1h down move, 1h high, 1h downtrend
-            & ((rsi_3_1h_gt_15) | (aroonu_14_1h < 80.0) | (cmf_20_1h > -0.25))
+            & ((rsi_3_1h_gt_15) | (aroonu_14_1h_lt_80) | (cmf_20_1h > -0.25))
             # 1h down move, 1h high, 4h downtrend
-            & ((rsi_3_1h_gt_15) | (aroonu_14_1h < 80.0) | (roc_9_4h_gt_neg_30))
+            & ((rsi_3_1h_gt_15) | (aroonu_14_1h_lt_80) | (roc_9_4h_gt_neg_30))
             # 1h down move, 4h still high, 1d overbought
             & ((rsi_3_1h_gt_15) | (aroonu_14_4h_lt_50) | (roc_9_1d < 60.0))
             # 1h down move, 4h high, 15m downtrend
-            & ((rsi_3_1h_gt_15) | (aroonu_14_4h < 85.0) | (roc_9_15m > -15.0))
+            & ((rsi_3_1h_gt_15) | (aroonu_14_4h_lt_85) | (roc_9_15m > -15.0))
             # 1h down move, 4h high, 1h downtrend
-            & ((rsi_3_1h_gt_15) | (aroonu_14_4h < 85.0) | (roc_9_1h > -30.0))
+            & ((rsi_3_1h_gt_15) | (aroonu_14_4h_lt_85) | (roc_9_1h > -30.0))
             # 1h down move, 1d high, 4h overbought
-            & ((rsi_3_1h_gt_15) | (aroonu_14_1d < 100.0) | (roc_9_4h_lt_10))
+            & ((rsi_3_1h_gt_15) | (aroonu_14_1d_lt_100) | (roc_9_4h_lt_10))
             # 1h down move, 4h still not low enough, 1d downtrend
             & ((rsi_3_1h_gt_15) | (stochrsi_k_4h < 30.0) | (roc_9_1d > -30.0))
             # 1h down move, 4h high & overbought
@@ -16979,7 +17008,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h high, 4h overbought
             & ((rsi_3_1h_gt_25) | aroonu_14_1h_lt_80 | (roc_9_4h < 20.0))
             # 1h down move, 1h high, 1d overbought
-            & ((rsi_3_1h_gt_25) | (aroonu_14_1h < 85.0) | roc_9_1d_lt_50)
+            & ((rsi_3_1h_gt_25) | (aroonu_14_1h_lt_85) | roc_9_1d_lt_50)
             # 1h down move, 4h high
             & ((rsi_3_1h_gt_25) | (aroonu_14_4h_lt_90))
             # 1h down move, 1h still high, 1d overbought
@@ -17039,7 +17068,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h high & overbought
             & ((rsi_3_1h_gt_40) | aroonu_14_1h_lt_80 | (roc_9_1h_lt_10))
             # 1h down move, 1h high, 1d high
-            & ((rsi_3_1h_gt_40) | (aroonu_14_1h < 85.0) | (roc_9_1d_lt_80))
+            & ((rsi_3_1h_gt_40) | (aroonu_14_1h_lt_85) | (roc_9_1d_lt_80))
             # 1h down move, 1h high, 15m downtrend
             & ((rsi_3_1h_gt_40) | (aroonu_14_1h_lt_90) | (roc_9_15m > -10.0))
             # 1h down move, 1h  high & overbought
@@ -17053,7 +17082,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 4h high & overbought
             & ((rsi_3_1h_gt_45) | (stochrsi_k_4h_lt_80) | (roc_9_4h < 100.0))
             # 1h down move, 1h high, 1d downtrend
-            & ((rsi_3_1h_gt_50) | (aroonu_14_1h < 60.0) | (roc_9_1d > -70.0))
+            & ((rsi_3_1h_gt_50) | (aroonu_14_1h_lt_60) | (roc_9_1d > -70.0))
             # 1h down move, 1h high, 1d overbought
             & ((rsi_3_1h_gt_50) | (stochrsi_k_1h < 70.0) | (roc_9_1d_lt_100))
             # 1h down move, 4h high, 1d downtrend
@@ -17065,13 +17094,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 4h & 1d overbought
             & ((rsi_3_1h_gt_60) | (roc_9_4h_lt_30) | (roc_9_1d < 60.0))
             # 4h & 1d down move, 1d still not low enough
-            & ((rsi_3_4h_gt_3) | (rsi_3_1d_gt_30) | (aroonu_14_1d < 30.0))
+            & ((rsi_3_4h_gt_3) | (rsi_3_1d_gt_30) | (aroonu_14_1d_lt_30))
             # 4h down move, 4h high, 1h downtrend
             & ((rsi_3_4h_gt_3) | aroonu_14_4h_lt_70 | (roc_9_1h > -40.0))
             # 4h down move, 1h still high, 4h downtrend
             & ((rsi_3_4h_gt_3) | (stochrsi_k_1h_lt_50) | (roc_9_4h_gt_neg_30))
             # 4h & 1d down move, 1d still high
-            & ((rsi_3_4h_gt_5) | (rsi_3_1d_gt_20) | (aroonu_14_1d < 50.0))
+            & ((rsi_3_4h_gt_5) | (rsi_3_1d_gt_20) | (aroonu_14_1d_lt_50))
             # 4h down move, 15m still high, 1d downtrend
             & ((rsi_3_4h_gt_5) | (aroonu_14_15m_lt_50) | (roc_9_1d_gt_neg_30))
             # 4h & 1d down move, 1d downtrend
@@ -17111,7 +17140,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 1d high & overbought
             & ((rsi_3_1h_gt_45) | (rsi_3_4h_gt_55) | (aroonu_14_1d_lt_80) | (roc_9_1d_lt_50))
             # 4h down move, 1h high, 1d overbought
-            & ((rsi_3_4h_gt_45) | (aroonu_14_1h < 85.0) | roc_9_1d_lt_50)
+            & ((rsi_3_4h_gt_45) | (aroonu_14_1h_lt_85) | roc_9_1d_lt_50)
             # 4h down move, 1d high, 1d downtrend
             & ((rsi_3_4h_gt_45) | (aroonu_14_1d_lt_80) | (roc_9_1d > -15.0))
             # 4h down move, 1d high & overbought
@@ -17165,7 +17194,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h high, 4h & 1d overbought
             & (aroonu_14_1h_lt_80 | (roc_9_4h_lt_10) | (roc_9_1d_lt_40))
             # 1h high, 4h & 1d downtrend
-            & ((aroonu_14_1h < 85.0) | (roc_9_4h_gt_neg_20) | roc_9_1d_gt_neg_50)
+            & ((aroonu_14_1h_lt_85) | (roc_9_4h_gt_neg_20) | roc_9_1d_gt_neg_50)
             # 1h & 4h high, 1h overbought
             & ((aroonu_14_1h_lt_100) | aroonu_14_4h_lt_100 | (roc_9_1h_lt_10))
             # 4h high, 4h & 1d overbought
@@ -17181,11 +17210,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h & 1d high, 1h overbought
             & (aroonu_14_4h_lt_100 | aroonu_14_1d_lt_100 | (roc_9_1h < 50.0))
             # 1d still high, 4h & 1d downtrend
-            & ((aroonu_14_1d < 50.0) | (roc_9_4h > -50.0) | roc_9_1d_gt_neg_50)
+            & ((aroonu_14_1d_lt_50) | (roc_9_4h > -50.0) | roc_9_1d_gt_neg_50)
             # 1d high, 1h & 4h downtrend
-            & ((aroonu_14_1d < 85.0) | (roc_9_1h > -30.0) | (roc_9_4h > -50.0))
+            & ((aroonu_14_1d_lt_85) | (roc_9_1h > -30.0) | (roc_9_4h > -50.0))
             # 1d high, 4h downtrend, 1d overbought
-            & ((aroonu_14_1d < 85.0) | (roc_9_4h > -25.0) | roc_9_1d_lt_50)
+            & ((aroonu_14_1d_lt_85) | (roc_9_4h > -25.0) | roc_9_1d_lt_50)
             # 1d high, 4h & 1d overbought
             & ((aroonu_14_1d_lt_90) | (roc_9_4h_lt_10) | roc_9_1d_lt_50)
             # 1h high, 1d overbought
@@ -17206,7 +17235,7 @@ class NostalgiaForInfinityX7(IStrategy):
 
           # Logic
           long_entry_logic.append(
-            (rsi_3_gt_5) & (rsi_14 < 36.0) & (aroonu_14 < 25.0) & (aroond_14 > 75.0) & (ema_9 < (ema_26 * 0.960))
+            (rsi_3_gt_5) & (rsi_14 < 36.0) & (aroonu_14_lt_25) & (aroond_14 > 75.0) & (ema_9 < (ema_26 * 0.960))
           )
 
         # Condition #42 - Quick mode (Long).
@@ -17229,13 +17258,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 4h still high
             & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_10) | (aroonu_14_4h_lt_50))
             # 15m & 1h down move, 1d high
-            & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_10) | (aroonu_14_1d < 60.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_10) | (aroonu_14_1d_lt_60))
             # 15m & 1h down move, 1h high
-            & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_15) | (aroonu_14_1h < 60.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_15) | (aroonu_14_1h_lt_60))
             # 15m & 4h down move, 4h still high
             & (rsi_3_15m_gt_3 | (rsi_3_4h_gt_30) | (stochrsi_k_4h < 40.0))
             # 15m & 4h down move, 1d still high
-            & (rsi_3_15m_gt_3 | (rsi_3_4h_gt_15) | (aroonu_14_1d < 40.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_4h_gt_15) | (aroonu_14_1d_lt_40))
             # 15m & 1h down move, 1d downtrend
             & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_15) | (roc_9_1d > -30.0))
             # 15m down move, 4h still high, 1d downtrend
@@ -17243,7 +17272,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h & 4h down move
             & ((rsi_3_15m_gt_5) | (rsi_3_1h_gt_5) | rsi_3_4h_gt_20)
             # 15m & 1h down move, 1h still high
-            & ((rsi_3_15m_gt_5) | (rsi_3_1h_gt_5) | (aroonu_14_1h < 40.0))
+            & ((rsi_3_15m_gt_5) | (rsi_3_1h_gt_5) | (aroonu_14_1h_lt_40))
             # 15m & 1h down move, 1d high
             & ((rsi_3_15m_gt_5) | (rsi_3_1h_gt_5) | (aroonu_14_1d_lt_70))
             # 15m & 1h & 4h down move
@@ -17257,7 +17286,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 4h high
             & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_10) | aroonu_14_4h_lt_70)
             # 15m & 1h down move, 1d high
-            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_10) | (aroonu_14_1d < 100.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_10) | (aroonu_14_1d_lt_100))
             # 15m & 1h down move, 4h still high
             & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_10) | (stochrsi_k_4h < 40.0))
             # 15m & 1h down move, 1d high
@@ -17283,7 +17312,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 4h down move, 1d high
             & ((rsi_3_15m_gt_10) | rsi_3_4h_gt_20 | (stochrsi_k_1d < 80.0))
             # 15m & 1h down move, 1h high
-            & ((rsi_3_15m_gt_15) | (rsi_3_1h_gt_15) | (aroonu_14_1h < 70.0))
+            & ((rsi_3_15m_gt_15) | (rsi_3_1h_gt_15) | (aroonu_14_1h_lt_70))
             # 15m & 1h down move, 15m still high
             & ((rsi_3_15m_gt_15) | rsi_3_1h_gt_20 | (stochrsi_k_15m < 50.0))
             # 15m & 4h down move, 15m still high
@@ -17301,7 +17330,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 1h still high, 1d overbought
             & ((rsi_3_15m_gt_25) | (rsi_3_1h_gt_30) | (aroonu_14_1h_lt_50) | (roc_9_1d_lt_40))
             # 15m down move, 15m still not low enough, 1d downtrend
-            & ((rsi_3_15m_gt_25) | (aroonu_14_15m < 25.0) | (roc_9_1d_gt_neg_50))
+            & ((rsi_3_15m_gt_25) | (aroonu_14_15m_lt_25) | (roc_9_1d_gt_neg_50))
             # 15m down move, 15m still high, 4h high
             & ((rsi_3_15m_gt_25) | (aroonu_14_15m_lt_50) | (aroonu_14_4h_lt_80))
             # 15m down move, 4h high, 1d downtrend
@@ -17313,11 +17342,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move
             & ((rsi_3_1h_gt_3) | (rsi_3_4h_gt_3))
             # 1h & 4h down move, 1d still high
-            & ((rsi_3_1h_gt_3) | (rsi_3_4h_gt_15) | (aroonu_14_1d < 50.0))
+            & ((rsi_3_1h_gt_3) | (rsi_3_4h_gt_15) | (aroonu_14_1d_lt_50))
             # 1h & 4h down move, 1d still high
             & ((rsi_3_1h_gt_3) | (rsi_3_4h_gt_15) | (stochrsi_k_1d < 50.0))
             # 1h & 4h down move, 1h still high
-            & ((rsi_3_1h_gt_3) | rsi_3_4h_gt_20 | (aroonu_14_1h < 40.0))
+            & ((rsi_3_1h_gt_3) | rsi_3_4h_gt_20 | (aroonu_14_1h_lt_40))
             # 1h & 4h down move, 4h still not low enough
             & ((rsi_3_1h_gt_3) | rsi_3_4h_gt_20 | (stochrsi_k_4h < 30.0))
             # 1h & 4h down move, 4h high
@@ -17333,7 +17362,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 1d downtrend
             & ((rsi_3_1h_gt_5) | (rsi_3_4h_gt_5) | (roc_9_1d_gt_neg_30))
             # 1h & 4h down move, 1d still high
-            & ((rsi_3_1h_gt_5) | (rsi_3_4h_gt_15) | (aroonu_14_1d < 40.0))
+            & ((rsi_3_1h_gt_5) | (rsi_3_4h_gt_15) | (aroonu_14_1d_lt_40))
             # 1h & 4h down move, 1h high
             & ((rsi_3_1h_gt_5) | (rsi_3_4h_gt_25) | aroonu_14_1h_lt_70)
             # 1h & 4h down move, 1d high
@@ -17345,7 +17374,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 4h high
             & ((rsi_3_1h_gt_5) | (aroonu_14_4h_lt_90))
             # 1h & 4h down move, 1d high
-            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_10) | (aroonu_14_1d < 75.0))
+            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_10) | (aroonu_14_1d_lt_75))
             # 1h & 4h down move, 1d high
             & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_10) | (stochrsi_k_1d < 80.0))
             # 1h & 4h down move, 4h downtrend
@@ -17361,7 +17390,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 1d downtrend
             & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_15) | (roc_9_1d_gt_neg_40))
             # 1h & 4h down move, 1h still high
-            & ((rsi_3_1h_gt_10) | rsi_3_4h_gt_20 | (aroonu_14_1h < 40.0))
+            & ((rsi_3_1h_gt_10) | rsi_3_4h_gt_20 | (aroonu_14_1h_lt_40))
             # 1h & 4h down move, 4h high
             & ((rsi_3_1h_gt_10) | rsi_3_4h_gt_20 | aroonu_14_4h_lt_70)
             # 1h & 4h down move, 1d high
@@ -17369,7 +17398,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 1d overbought
             & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_25) | (roc_9_1d_lt_40))
             # 1h & 4h down move, 1d high
-            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_35) | (aroonu_14_1d < 100.0))
+            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_35) | (aroonu_14_1d_lt_100))
             # 1h & 4h down move, 4h high
             & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_35) | (stochrsi_k_4h_lt_70))
             # 1h & 1d down move, 1d still high
@@ -17377,23 +17406,23 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 1d down move, 1d still high
             & ((rsi_3_1h_gt_10) | (rsi_3_1d_gt_25) | (rsi_14_1d < 50.0))
             # 1h & 1d down move, 1h high
-            & ((rsi_3_1h_gt_10) | (rsi_3_1d_gt_25) | (aroonu_14_1h < 70.0))
+            & ((rsi_3_1h_gt_10) | (rsi_3_1d_gt_25) | (aroonu_14_1h_lt_70))
             # 1h & 1d down move, 1d high
             & ((rsi_3_1h_gt_10) | (rsi_3_1d_gt_45) | (aroonu_14_1d_lt_70))
             # 1h down move, 1h downtrend, 1h high
-            & ((rsi_3_1h_gt_10) | (cmf_20_1h > -0.30) | (aroonu_14_1h < 70.0))
+            & ((rsi_3_1h_gt_10) | (cmf_20_1h > -0.30) | (aroonu_14_1h_lt_70))
             # 1h down move, 1h high, 1d downtrend
-            & ((rsi_3_1h_gt_10) | (aroonu_14_1h < 40.0) | (roc_9_1d > -20.0))
+            & ((rsi_3_1h_gt_10) | (aroonu_14_1h_lt_40) | (roc_9_1d > -20.0))
             # 1h down move, 1h & 4h high
-            & ((rsi_3_1h_gt_10) | (aroonu_14_1h < 60.0) | aroonu_14_4h_lt_70)
+            & ((rsi_3_1h_gt_10) | (aroonu_14_1h_lt_60) | aroonu_14_4h_lt_70)
             # 1h down move, 1h high, 1d overbought
-            & ((rsi_3_1h_gt_10) | (aroonu_14_1h < 60.0) | (roc_9_1d_lt_20))
+            & ((rsi_3_1h_gt_10) | (aroonu_14_1h_lt_60) | (roc_9_1d_lt_20))
             # 1h down move, 4h still high, 1d downtrend
             & ((rsi_3_1h_gt_10) | (aroonu_14_4h_lt_40) | (roc_9_1d_gt_neg_40))
             # 1h down move, 4h high, 1d downtrend
             & ((rsi_3_1h_gt_10) | aroonu_14_4h_lt_70 | (roc_9_1d > -20.0))
             # 1h down move, 1d still high, 1d downtrend
-            & ((rsi_3_1h_gt_10) | (aroonu_14_1d < 40.0) | (roc_9_1d > -20.0))
+            & ((rsi_3_1h_gt_10) | (aroonu_14_1d_lt_40) | (roc_9_1d > -20.0))
             # 1h down move, 1d high & overbought
             & ((rsi_3_1h_gt_10) | (aroonu_14_1d_lt_90) | (roc_9_1d_lt_30))
             # 1h down move, 15m high
@@ -17423,13 +17452,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 1d down move, 1d overbought
             & ((rsi_3_1h_gt_15) | (rsi_3_1d_gt_35) | (roc_9_1d < 10.0))
             # 1h down move, 1h downtrend, 1h high
-            & ((rsi_3_1h_gt_15) | (cmf_20_1h > -0.30) | (aroonu_14_1h < 70.0))
+            & ((rsi_3_1h_gt_15) | (cmf_20_1h > -0.30) | (aroonu_14_1h_lt_70))
             # 1h down move, 1h still high, 4h downtrend
-            & ((rsi_3_1h_gt_15) | (aroonu_14_1h < 40.0) | (roc_9_4h_gt_neg_30))
+            & ((rsi_3_1h_gt_15) | (aroonu_14_1h_lt_40) | (roc_9_4h_gt_neg_30))
             # 1h down move, 1h still high, 1d downtrend
             & ((rsi_3_1h_gt_15) | (aroonu_14_1h_lt_50) | (roc_9_1d_gt_neg_40))
             # 1h down move, 1d still high, 4h downtrend
-            & ((rsi_3_1h_gt_15) | (aroonu_14_1d < 50.0) | (roc_9_4h > -20.0))
+            & ((rsi_3_1h_gt_15) | (aroonu_14_1d_lt_50) | (roc_9_4h > -20.0))
             # 1h down move, 1d high, 1d downtrend
             & ((rsi_3_1h_gt_15) | (aroonu_14_1d_lt_80) | (roc_9_1d > -20.0))
             # 1h down move, 1d high & overbought
@@ -17457,7 +17486,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 1d down move, 1d overbought
             & ((rsi_3_1h_gt_20) | (rsi_3_1d_gt_45) | (roc_9_1d_lt_20))
             # 1h down move, 1h high, 1d overbought
-            & ((rsi_3_1h_gt_20) | (aroonu_14_1h < 60.0) | (roc_9_1d_lt_30))
+            & ((rsi_3_1h_gt_20) | (aroonu_14_1h_lt_60) | (roc_9_1d_lt_30))
             # 1h down move, 1h high, 4h downtrend
             & ((rsi_3_1h_gt_20) | (aroonu_14_1h_lt_70) | (roc_9_4h > -20.0))
             # 1h down move, 1d high & overbought
@@ -17475,9 +17504,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 4h downtrend, 4h high
             & ((rsi_3_1h_gt_25) | (cmf_20_4h > -0.50) | aroonu_14_4h_lt_70)
             # 1h down move, 1h high, 1d overbought
-            & ((rsi_3_1h_gt_25) | (aroonu_14_1h < 60.0) | roc_9_1d_lt_50)
+            & ((rsi_3_1h_gt_25) | (aroonu_14_1h_lt_60) | roc_9_1d_lt_50)
             # 1h down move, 1h high, 1d downtrend
-            & ((rsi_3_1h_gt_25) | (aroonu_14_1h < 60.0) | (roc_9_1d_gt_neg_40))
+            & ((rsi_3_1h_gt_25) | (aroonu_14_1h_lt_60) | (roc_9_1d_gt_neg_40))
             # 1h down move, 4h high & overbought
             & ((rsi_3_1h_gt_25) | aroonu_14_4h_lt_70 | (roc_9_4h_lt_10))
             # 1h down move, 1d high & overbought
@@ -17491,9 +17520,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 1d downtrend
             & ((rsi_3_1h_gt_30) | (rsi_3_4h_gt_30) | roc_9_1d_gt_neg_50)
             # 1h & 4h down move, 15m high
-            & ((rsi_3_1h_gt_30) | (rsi_3_4h_gt_35) | (aroonu_14_15m < 80.0))
+            & ((rsi_3_1h_gt_30) | (rsi_3_4h_gt_35) | (aroonu_14_15m_lt_80))
             # 1h & 4h down move, 4h high
-            & ((rsi_3_1h_gt_30) | (rsi_3_4h_gt_40) | (aroonu_14_4h < 75.0))
+            & ((rsi_3_1h_gt_30) | (rsi_3_4h_gt_40) | (aroonu_14_4h_lt_75))
             # 1h & 4h down move, 15m high
             & ((rsi_3_1h_gt_30) | (rsi_3_4h_gt_40) | (stochrsi_k_15m < 80.0))
             # 1h & 4h down move, 4h high
@@ -17513,11 +17542,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 4h & 1d overbought
             & ((rsi_3_1h_gt_30) | (roc_9_4h_lt_10) | (roc_9_1d_lt_30))
             # 1h & 4h down move, 15m high
-            & ((rsi_3_1h_gt_35) | (rsi_3_4h_gt_45) | (aroonu_14_15m < 90.0))
+            & ((rsi_3_1h_gt_35) | (rsi_3_4h_gt_45) | (aroonu_14_15m_lt_90))
             # 1h & 4h down move, 4h high
             & ((rsi_3_1h_gt_35) | (rsi_3_4h_gt_45) | (aroonu_14_4h_lt_90))
             # 1h down move, 15m high, 1d downtrend
-            & ((rsi_3_1h_gt_35) | (aroonu_14_15m < 60.0) | (roc_9_1d_gt_neg_40))
+            & ((rsi_3_1h_gt_35) | (aroonu_14_15m_lt_60) | (roc_9_1d_gt_neg_40))
             # 1h down move, 1h still high, 1d high
             & ((rsi_3_1h_gt_35) | (aroonu_14_1h_lt_50) | (aroonu_14_1d_lt_90))
             # 1h down move, 1h & 4h high
@@ -17555,11 +17584,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h & 1d down move, 1d downtrend
             & ((rsi_3_4h_gt_5) | (rsi_3_1d_gt_15) | (roc_9_1d_gt_neg_20))
             # 4h & 1d down move, 1d still high
-            & ((rsi_3_4h_gt_5) | (rsi_3_1d_gt_20) | (aroonu_14_1d < 40.0))
+            & ((rsi_3_4h_gt_5) | (rsi_3_1d_gt_20) | (aroonu_14_1d_lt_40))
             # 4h & 1d down move, 1d still high
             & ((rsi_3_4h_gt_5) | (rsi_3_1d_gt_20) | (stochrsi_k_1d < 50.0))
             # 4h & 1d down move, 4h still not low enough
-            & ((rsi_3_4h_gt_5) | (rsi_3_1d_gt_30) | (aroonu_14_4h < 20.0))
+            & ((rsi_3_4h_gt_5) | (rsi_3_1d_gt_30) | (aroonu_14_4h_lt_20))
             # 4h & 1d down move, 1d high
             & ((rsi_3_4h_gt_5) | (rsi_3_1d_gt_30) | (aroonu_14_1d_lt_70))
             # 4h down move, 1h & 4h downtrend
@@ -17567,7 +17596,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 4h & 1d downtrend
             & ((rsi_3_4h_gt_5) | (roc_9_4h_gt_neg_20) | (roc_9_1d_gt_neg_20))
             # 4h & 1d down move, 15m still not low enough
-            & ((rsi_3_4h_gt_10) | (rsi_3_1d_gt_10) | (aroonu_14_15m < 30.0))
+            & ((rsi_3_4h_gt_10) | (rsi_3_1d_gt_10) | (aroonu_14_15m_lt_30))
             # 4h & 1d down move, 1d downtrend
             & ((rsi_3_4h_gt_10) | (rsi_3_1d_gt_10) | (roc_9_1d > -20.0))
             # 15m & 1d down move, 15m still high
@@ -17593,7 +17622,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h & 1d down move, 1d downtrend
             & ((rsi_3_4h_gt_15) | (rsi_3_1d_gt_15) | (roc_9_1d > -30.0))
             # 4h & 1d down move, 1d still high
-            & ((rsi_3_4h_gt_15) | (rsi_3_1d_gt_25) | (aroonu_14_1d < 40.0))
+            & ((rsi_3_4h_gt_15) | (rsi_3_1d_gt_25) | (aroonu_14_1d_lt_40))
             # 15m & 1d down move, 15m high
             & ((rsi_3_4h_gt_15) | (rsi_3_1d_gt_30) | (stochrsi_k_15m < 70.0))
             # 4h & 1d down move, 4h still high
@@ -17603,9 +17632,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h & 1d down move, 1d overbought
             & ((rsi_3_4h_gt_15) | (rsi_3_1d_gt_45) | (roc_9_1d_lt_30))
             # 4h & 1d down move, 1d still high
-            & ((rsi_3_4h_gt_15) | (rsi_3_1d_gt_45) | (aroonu_14_1d < 50.0))
+            & ((rsi_3_4h_gt_15) | (rsi_3_1d_gt_45) | (aroonu_14_1d_lt_50))
             # 4h down move, 1h still high, 1d downtrend
-            & ((rsi_3_4h_gt_15) | (aroonu_14_1h < 40.0) | roc_9_1d_gt_neg_50)
+            & ((rsi_3_4h_gt_15) | (aroonu_14_1h_lt_40) | roc_9_1d_gt_neg_50)
             # 4h down move, 1h high, 1d downtrend
             & ((rsi_3_4h_gt_15) | (aroonu_14_1h_lt_90) | (roc_9_1d > -30.0))
             # 4h down move, 4h still high, 4h downtrend
@@ -17659,7 +17688,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 1d overbought
             & ((rsi_3_4h_gt_25) | (roc_9_1d_lt_100))
             # 4h down move, 1h high, 4h downtrend
-            & ((rsi_3_4h_gt_30) | (aroonu_14_1h < 60.0) | (roc_9_4h > -10.0))
+            & ((rsi_3_4h_gt_30) | (aroonu_14_1h_lt_60) | (roc_9_4h > -10.0))
             # 4h down move, 4h still high, 1d high
             & ((rsi_3_4h_gt_30) | (aroonu_14_4h_lt_50) | aroonu_14_1d_lt_100)
             # 4h down move, 4h high, 1h downtrend
@@ -17703,7 +17732,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1d down move, 4h & 1d downtrend
             & ((rsi_3_1d_gt_15) | (roc_9_4h > -10.0) | (roc_9_1d_gt_neg_40))
             # 1d down move, 15m high
-            & ((rsi_3_1d_gt_20) | (aroonu_14_15m < 80.0))
+            & ((rsi_3_1d_gt_20) | (aroonu_14_15m_lt_80))
             # 1d down move, 4h high, 4h downtrend
             & ((rsi_3_1d_gt_20) | (aroonu_14_4h_lt_50) | (roc_9_4h > -40.0))
             # 1d down move, 1d high, 1d downtrend
@@ -17715,11 +17744,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h downtrend, 4h high
             & ((cmf_20_1h > -0.40) | (cmf_20_4h > -0.40) | aroonu_14_4h_lt_80)
             # 4h & 1d downtrend, 1d high
-            & ((cmf_20_4h > -0.50) | (cmf_20_1d > -0.50) | (aroonu_14_1d < 85.0))
+            & ((cmf_20_4h > -0.50) | (cmf_20_1d > -0.50) | (aroonu_14_1d_lt_85))
             # 15m & 1d high, 4h overbought
             & ((aroonu_14_15m_lt_70) | aroonu_14_1d_lt_100 | (roc_9_4h < 20.0))
             # 15m & 4h high, 1d downtrend
-            & ((aroonu_14_15m < 85.0) | (aroonu_14_4h < 85.0) | (roc_9_1d_gt_neg_20))
+            & ((aroonu_14_15m_lt_85) | (aroonu_14_4h_lt_85) | (roc_9_1d_gt_neg_20))
             # 1h still high, 1h & 4h downtrend
             & ((aroonu_14_1h_lt_50) | (roc_9_1h > -20.0) | (roc_9_4h_gt_neg_30))
             # 1h & 4h high, 4h overbought
@@ -17735,7 +17764,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1d high, 4h & 1d overbought
             & ((aroonu_14_1d_lt_70) | (roc_9_4h_lt_30) | (roc_9_1d < 200.0))
             # 1d high, 4h downtrend, 1d overbought
-            & ((aroonu_14_1d < 85.0) | (roc_9_4h_gt_neg_20) | (roc_9_1d < 200.0))
+            & ((aroonu_14_1d_lt_85) | (roc_9_4h_gt_neg_20) | (roc_9_1d < 200.0))
             # 1d high, 1h & 4h downtrend
             & (aroonu_14_1d_lt_100 | (roc_9_1h > -30.0) | (roc_9_4h_gt_neg_30))
             # 1d high, 1h & 1d overbought
@@ -17772,15 +17801,15 @@ class NostalgiaForInfinityX7(IStrategy):
 
           long_entry_logic.append(
             # 5m & 15m down move, 15m still high
-            ((rsi_3_gt_3) | (rsi_3_15m_gt_5) | (aroonu_14_15m < 40.0))
+            ((rsi_3_gt_3) | (rsi_3_15m_gt_5) | (aroonu_14_15m_lt_40))
             # 5m & 1h down move, 1h still not low enough
-            & ((rsi_3_gt_3) | (rsi_3_1h_gt_10) | (aroonu_14_1h < 30.0))
+            & ((rsi_3_gt_3) | (rsi_3_1h_gt_10) | (aroonu_14_1h_lt_30))
             # 5m & 1h down move, 1h still not low enough
             & ((rsi_3_gt_3) | (rsi_3_1h_gt_15) | (stochrsi_k_1h < 30.0))
             # 5m & 1h down move, 4h high
             & ((rsi_3_gt_3) | (rsi_3_1h_gt_50) | (stochrsi_k_4h < 60.0))
             # 5m & 1d down move, 1d still not low enough
-            & ((rsi_3_gt_3) | (rsi_3_1d_gt_15) | (aroonu_14_1d < 30.0))
+            & ((rsi_3_gt_3) | (rsi_3_1d_gt_15) | (aroonu_14_1d_lt_30))
             # 5m down move, 1h & 4h high
             & ((rsi_3_gt_3) | aroonu_14_1h_lt_80 | aroonu_14_4h_lt_100)
             # 5m down move, 4h high & overbought
@@ -17794,7 +17823,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 5m & 1d down move, 1h high
             & ((rsi_3_gt_5) | (rsi_3_1d_gt_20) | (aroonu_14_1h_lt_90))
             # 5m & 1h down move, 1h high
-            & ((rsi_3_gt_10) | (rsi_3_1h_gt_15) | (aroonu_14_1h < 85.0))
+            & ((rsi_3_gt_10) | (rsi_3_1h_gt_15) | (aroonu_14_1h_lt_85))
             # 15m & 1h down move
             & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_3))
             # 15m & 1h & 4h down move
@@ -17810,7 +17839,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1d down move, 1d overbought
             & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_10) | (roc_9_1d < 10.0))
             # 15m & 1h down move, 1h still high
-            & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_15) | (aroonu_14_1h < 40.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_15) | (aroonu_14_1h_lt_40))
             # 15m & 1h down move, 1d high
             & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_15) | (aroonu_14_1d_lt_90))
             # 15m & 1h down move, 4h high
@@ -17830,13 +17859,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 4h high
             & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_45) | (aroonu_14_4h_lt_90))
             # 15m & 4h down move, 1d high
-            & (rsi_3_15m_gt_3 | (rsi_3_4h_gt_15) | (aroonu_14_1d < 50.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_4h_gt_15) | (aroonu_14_1d_lt_50))
             # 15m & 4h down move, 15m high
             & (rsi_3_15m_gt_3 | rsi_3_4h_gt_20 | (aroonu_14_15m_lt_70))
             # 15m & 4h down move, 1d overbought
             & (rsi_3_15m_gt_3 | (rsi_3_4h_gt_35) | (roc_9_1d < 60.0))
             # 15m & 1d down move, 1d still high
-            & (rsi_3_15m_gt_3 | (rsi_3_1d_gt_10) | (aroonu_14_1d < 40.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1d_gt_10) | (aroonu_14_1d_lt_40))
             # 15m & 1d down move, 4h still high
             & (rsi_3_15m_gt_3 | (rsi_3_1d_gt_20) | (stochrsi_k_4h_lt_50))
             # 15m & 1d down move, 1d high
@@ -17880,7 +17909,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1d down move, 1h still high
             & ((rsi_3_15m_gt_5) | (rsi_3_1d_gt_20) | (stochrsi_k_1h_lt_50))
             # 15m down move, 15m & 1h still high
-            & ((rsi_3_15m_gt_5) | (aroonu_14_15m < 40.0) | (aroonu_14_1h_lt_50))
+            & ((rsi_3_15m_gt_5) | (aroonu_14_15m_lt_40) | (aroonu_14_1h_lt_50))
             # 15m down move, 1h high & overbought
             & ((rsi_3_15m_gt_5) | aroonu_14_1h_lt_70 | (roc_9_1h_lt_10))
             # 15m down move, 1h & 4h high
@@ -17942,13 +17971,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1d down move, 4h high
             & ((rsi_3_15m_gt_10) | (rsi_3_1d_gt_20) | (stochrsi_k_4h_lt_70))
             # 15m down move, 15m still high, 1d downtrend
-            & ((rsi_3_15m_gt_10) | (aroonu_14_15m < 40.0) | (roc_9_1d_gt_neg_30))
+            & ((rsi_3_15m_gt_10) | (aroonu_14_15m_lt_40) | (roc_9_1d_gt_neg_30))
             # 15m down move, 15m still high, 1d overbought
             & ((rsi_3_15m_gt_10) | (aroonu_14_15m_lt_50) | (roc_9_1d_lt_30))
             # 15m down move, 15m high, 1h high
-            & ((rsi_3_15m_gt_10) | (aroonu_14_15m < 60.0) | aroonu_14_1h_lt_80)
+            & ((rsi_3_15m_gt_10) | (aroonu_14_15m_lt_60) | aroonu_14_1h_lt_80)
             # 15m down move, 15m high, 4h downtrend
-            & ((rsi_3_15m_gt_10) | (aroonu_14_15m < 60.0) | (roc_9_4h > -10.0))
+            & ((rsi_3_15m_gt_10) | (aroonu_14_15m_lt_60) | (roc_9_4h > -10.0))
             # 15m down move, 1h & 4h high
             & ((rsi_3_15m_gt_10) | (aroonu_14_1h_lt_90) | aroonu_14_4h_lt_100)
             # 15m down move, 1h high, 1d downtrend
@@ -18022,9 +18051,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 4h still high
             & ((rsi_3_1h_gt_3) | (rsi_3_4h_gt_15) | (aroonu_14_4h_lt_40))
             # 1h & 4h down move, 1d still high
-            & ((rsi_3_1h_gt_3) | (rsi_3_4h_gt_15) | (aroonu_14_1d < 40.0))
+            & ((rsi_3_1h_gt_3) | (rsi_3_4h_gt_15) | (aroonu_14_1d_lt_40))
             # 1h & 4h down move, 1d high
-            & ((rsi_3_1h_gt_3) | rsi_3_4h_gt_20 | (aroonu_14_1d < 60.0))
+            & ((rsi_3_1h_gt_3) | rsi_3_4h_gt_20 | (aroonu_14_1d_lt_60))
             # 1h & 4h down move, 1d high
             & ((rsi_3_1h_gt_3) | (rsi_3_4h_gt_25) | (aroonu_14_1d_lt_70))
             # 1h & 4h down move, 1d overbought
@@ -18050,7 +18079,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 1d downtrend
             & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_10) | (roc_9_1d > -20.0))
             # 1h & 4h down move, 1h high
-            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_15) | (aroonu_14_1h < 60.0))
+            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_15) | (aroonu_14_1h_lt_60))
             # 1h & 4h down move, 1d high
             & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_15) | (aroonu_14_1d_lt_90))
             # 1h & 4h down move, 1d downtrend
@@ -18062,13 +18091,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 15m downtrend, 1d high
             & ((rsi_3_1h_gt_10) | (cmf_20_15m > -0.40) | (aroonu_14_1d_lt_70))
             # 1h down move, 1h high, 4h overbought
-            & ((rsi_3_1h_gt_10) | (aroonu_14_1h < 80.0) | (roc_9_4h_lt_10))
+            & ((rsi_3_1h_gt_10) | (aroonu_14_1h_lt_80) | (roc_9_4h_lt_10))
             # 1h down move, 1d high, 1d downtrend
             & ((rsi_3_1h_gt_10) | (aroonu_14_1d_lt_70) | (roc_9_1d > -20.0))
             # 1h down move, 4h high, 1d downtrend
             & ((rsi_3_1h_gt_10) | (stochrsi_k_4h < 60.0) | (roc_9_1d > -30.0))
             # 1h & 4h down move, 1h still not low enough
-            & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_15) | (aroonu_14_1h < 20.0))
+            & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_15) | (aroonu_14_1h_lt_20))
             # 1h & 4h down move, 4h high
             & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_15) | (aroonu_14_4h_lt_60))
             # 1h & 4h down move, 1h downtrend
@@ -18078,21 +18107,21 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 4h still high
             & ((rsi_3_1h_gt_15) | rsi_3_4h_gt_20 | (rsi_14_4h < 40.0))
             # 1h & 4h down move, 1h high
-            & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_30) | (aroonu_14_1h < 70.0))
+            & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_30) | (aroonu_14_1h_lt_70))
             # 1h & 4h down move, 1d high
             & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_40) | (aroonu_14_1d_lt_70))
             # 1h & 1d down move, 1d still high
-            & ((rsi_3_1h_gt_15) | (rsi_3_1d_gt_25) | (aroonu_14_1d < 50.0))
+            & ((rsi_3_1h_gt_15) | (rsi_3_1d_gt_25) | (aroonu_14_1d_lt_50))
             # 1h down move, 1h still high, 1d downtrend
-            & ((rsi_3_1h_gt_15) | (aroonu_14_1h < 30.0) | (roc_9_1d > -30.0))
+            & ((rsi_3_1h_gt_15) | (aroonu_14_1h_lt_30) | (roc_9_1d > -30.0))
             # 1h down move, 1h still high, 4h downtrend
-            & ((rsi_3_1h_gt_15) | (aroonu_14_1h < 40.0) | (roc_9_4h_gt_neg_30))
+            & ((rsi_3_1h_gt_15) | (aroonu_14_1h_lt_40) | (roc_9_4h_gt_neg_30))
             # 1h down move, 4h high & overbought
-            & ((rsi_3_1h_gt_15) | (aroonu_14_4h < 80.0) | (roc_9_4h_lt_10))
+            & ((rsi_3_1h_gt_15) | (aroonu_14_4h_lt_80) | (roc_9_4h_lt_10))
             # 1h & 4h down move, 1h still high
             & (rsi_3_1h_gt_20 | (rsi_3_4h_gt_30) | (stochrsi_k_1h_lt_50))
             # 1h & 4h down move, 4h high
-            & (rsi_3_1h_gt_20 | (rsi_3_4h_gt_50) | (aroonu_14_4h < 75.0))
+            & (rsi_3_1h_gt_20 | (rsi_3_4h_gt_50) | (aroonu_14_4h_lt_75))
             # 1h down move, 1h high, 4h overbought
             & (rsi_3_1h_gt_20 | aroonu_14_1h_lt_70 | (roc_9_4h_lt_10))
             # 1h down move, 1h high & overbought
@@ -18106,7 +18135,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 1d down move, 1h high
             & ((rsi_3_1h_gt_25) | (rsi_3_1d_gt_25) | aroonu_14_1h_lt_80)
             # 1h down move, 1h high, 1d downtrend
-            & ((rsi_3_1h_gt_25) | (aroonu_14_1h < 60.0) | (roc_9_1d_gt_neg_40))
+            & ((rsi_3_1h_gt_25) | (aroonu_14_1h_lt_60) | (roc_9_1d_gt_neg_40))
             # 1h down move, 1h & 1d high
             & ((rsi_3_1h_gt_25) | aroonu_14_1h_lt_70 | (aroonu_14_1d_lt_90))
             # 1h down move, 1h high & overbought
@@ -18162,7 +18191,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1d high, 4h overbought
             & ((rsi_3_1h_gt_45) | aroonu_14_1d_lt_100 | (roc_9_4h_lt_40))
             # 1h down move, 1h high, 1d downtrend
-            & ((rsi_3_1h_gt_50) | (aroonu_14_1h < 60.0) | (roc_9_1d > -70.0))
+            & ((rsi_3_1h_gt_50) | (aroonu_14_1h_lt_60) | (roc_9_1d > -70.0))
             # 1h down move, 1h & 1d high
             & ((rsi_3_1h_gt_50) | aroonu_14_1h_lt_80 | aroonu_14_1d_lt_100)
             # 4h & 1d down move, 15m still high
@@ -18184,7 +18213,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 4h still high
             & ((rsi_3_4h_gt_10) | (aroonu_14_4h_lt_50))
             # 4h down move, 1d still high, 1d downtrend
-            & ((rsi_3_4h_gt_10) | (aroonu_14_1d < 50.0) | (roc_9_1d > -30.0))
+            & ((rsi_3_4h_gt_10) | (aroonu_14_1d_lt_50) | (roc_9_1d > -30.0))
             # 4h down move, 4h still not low enough, 1d downtrend
             & ((rsi_3_4h_gt_10) | (stochrsi_k_4h < 30.0) | (roc_9_1d > -20.0))
             # 4h down move, 4h & 1d  downtrend
@@ -18222,7 +18251,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1d high, 1d overbought
             & ((aroonu_14_15m_lt_70) | (aroonu_14_1d_lt_90) | (roc_9_1d_lt_30))
             # 1h still high, 4h & 1d downtrend
-            & ((aroonu_14_1h < 40.0) | (roc_9_4h_gt_neg_20) | (roc_9_1d_gt_neg_40))
+            & ((aroonu_14_1h_lt_40) | (roc_9_4h_gt_neg_20) | (roc_9_1d_gt_neg_40))
             # 1h & 4h high, 1d downtrend
             & (aroonu_14_1h_lt_70 | aroonu_14_4h_lt_100 | (roc_9_1d > -20.0))
             # 1h & 4h high, 1d overbought
@@ -18240,7 +18269,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h & 1d high, 1d overbought
             & ((aroonu_14_4h_lt_60) | aroonu_14_1d_lt_100 | (roc_9_1d < 70.0))
             # 4h high, 1h & 4h overbought
-            & ((aroonu_14_4h < 85.0) | (roc_9_1h < 80.0) | (roc_9_4h < 80.0))
+            & ((aroonu_14_4h_lt_85) | (roc_9_1h < 80.0) | (roc_9_4h < 80.0))
             # 4h high, 1h downtrend, 4h overbought
             & ((aroonu_14_4h_lt_90) | (roc_9_1h > -40.0) | (roc_9_4h < 100.0))
             # 4h & 1d high, 4h overbought
@@ -18279,7 +18308,7 @@ class NostalgiaForInfinityX7(IStrategy):
           long_entry_logic.append(
             (rsi_14 < 40.0)
             & (mfi_14 < 40.0)
-            & (aroonu_14 < 25.0)
+            & (aroonu_14_lt_25)
             & (ema_26 > ema_12)
             & ((ema_26 - ema_12) > (open_rate * 0.024))
             & ((ema_26.shift() - ema_12.shift()) > (open_rate / 100.0))
@@ -18299,13 +18328,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h & 4h down move
             & ((rsi_3_15m_gt_3) | (rsi_3_1h_gt_3) | (rsi_3_4h_gt_10))
             # 15m & 1h down move, 1h high
-            & ((rsi_3_15m_gt_3) | (rsi_3_1h_gt_3) | (aroonu_14_1h < 60.0))
+            & ((rsi_3_15m_gt_3) | (rsi_3_1h_gt_3) | (aroonu_14_1h_lt_60))
             # 15m & 1h & 4h down move
             & ((rsi_3_15m_gt_3) | (rsi_3_1h_gt_5) | (rsi_3_4h_gt_10))
             # 15m & 1h down move, 1d downtrend
             & ((rsi_3_15m_gt_3) | (rsi_3_1h_gt_5) | (roc_9_1d_gt_neg_30))
             # 15m & 1h down move, 1d high
-            & ((rsi_3_15m_gt_3) | (rsi_3_1h_gt_10) | (aroonu_14_1d < 100.0))
+            & ((rsi_3_15m_gt_3) | (rsi_3_1h_gt_10) | (aroonu_14_1d_lt_100))
             # 15m & 1h down move, 1h high
             & ((rsi_3_15m_gt_3) | (rsi_3_1h_gt_20) | aroonu_14_1h_lt_80)
             # 15m & 4h down move, 4h still high
@@ -18319,7 +18348,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 4h down move, 1h still high
             & ((rsi_3_15m_gt_3) | (rsi_3_4h_gt_40) | (stochrsi_k_1h < 40.0))
             # 15m down move, 1h still high, 1d overbought
-            & ((rsi_3_15m_gt_3) | (aroonu_14_1h < 40.0) | (roc_9_1d < 70.0))
+            & ((rsi_3_15m_gt_3) | (aroonu_14_1h_lt_40) | (roc_9_1d < 70.0))
             # 15m down move, 4h high & overbought
             & ((rsi_3_15m_gt_3) | (aroonu_14_4h_lt_100) | (roc_9_4h < 100.0))
             # 15m down move, 1h high
@@ -18327,7 +18356,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 4h high, 15m downtrend
             & ((rsi_3_15m_gt_3) | (stochrsi_k_4h_lt_70) | (roc_9_15m > -30.0))
             # 15m & 1h down move, 1h high
-            & ((rsi_3_15m_gt_5) | (rsi_3_1h_gt_15) | (aroonu_14_1h < 70.0))
+            & ((rsi_3_15m_gt_5) | (rsi_3_1h_gt_15) | (aroonu_14_1h_lt_70))
             # 15m & 1h down move, 1h downtrend
             & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_10) | (roc_9_1h > -20.0))
             # 15m & 4h down move, 1h still not low enough
@@ -18337,7 +18366,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 4h down move, 4h high
             & ((rsi_3_15m_gt_15) | (rsi_3_4h_gt_25) | (aroonu_14_4h_lt_70))
             # 15m & 4h down move, 4h high
-            & ((rsi_3_15m_gt_15) | (rsi_3_4h_gt_40) | (aroonu_14_4h < 75.0))
+            & ((rsi_3_15m_gt_15) | (rsi_3_4h_gt_40) | (aroonu_14_4h_lt_75))
             # 15m & 4h down move, 4h high
             & ((rsi_3_15m_gt_15) | (rsi_3_4h_gt_45) | (aroonu_14_4h_lt_90))
             # 15m down move, 4h & 1d downtrend
@@ -18345,19 +18374,19 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 1h high & overbought
             & ((rsi_3_15m_gt_25) | (aroonu_14_1d_lt_90) | (roc_9_1d_lt_100))
             # 1h & 4h down move, 1h still not low enough
-            & ((rsi_3_1h_gt_3) | (rsi_3_4h_gt_3) | (aroonu_14_1h < 20.0))
+            & ((rsi_3_1h_gt_3) | (rsi_3_4h_gt_3) | (aroonu_14_1h_lt_20))
             # 1h & 4h down move
             & ((rsi_3_1h_gt_3) | (rsi_3_4h_gt_5))
             # 1h & 4h down move, 1d still high
-            & ((rsi_3_1h_gt_3) | (rsi_3_4h_gt_10) | (aroonu_14_1d < 50.0))
+            & ((rsi_3_1h_gt_3) | (rsi_3_4h_gt_10) | (aroonu_14_1d_lt_50))
             # 1h & 4h down move, 1d high
             & ((rsi_3_1h_gt_3) | (rsi_3_4h_gt_10) | (stochrsi_k_1d < 60.0))
             # 1h & 4h down move, 1d high
-            & ((rsi_3_1h_gt_3) | (rsi_3_4h_gt_20) | (aroonu_14_1d < 60.0))
+            & ((rsi_3_1h_gt_3) | (rsi_3_4h_gt_20) | (aroonu_14_1d_lt_60))
             # 1h & 4h down move, 4h high
             & ((rsi_3_1h_gt_3) | (rsi_3_4h_gt_20) | (stochrsi_k_4h < 60.0))
             # 1h & 4h down move, 1h & 4h still high
-            & ((rsi_3_1h_gt_3) | (rsi_3_4h_gt_35) | (aroonu_14_1h < 40.0) | (aroonu_14_4h_lt_40))
+            & ((rsi_3_1h_gt_3) | (rsi_3_4h_gt_35) | (aroonu_14_1h_lt_40) | (aroonu_14_4h_lt_40))
             # 1h down move, 1h & 4h still high
             & ((rsi_3_1h_gt_3) | (aroonu_14_1h_lt_50) | (aroonu_14_4h_lt_50))
             # 1h down move, 1h still high, 1h downtrend
@@ -18377,7 +18406,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 1d down move, 1d downtrend
             & ((rsi_3_1h_gt_5) | (rsi_3_1d_gt_5) | (roc_9_1d_gt_neg_20))
             # 1h down move, 1h high
-            & ((rsi_3_1h_gt_5) | (aroonu_14_1h < 60.0))
+            & ((rsi_3_1h_gt_5) | (aroonu_14_1h_lt_60))
             # 1h down move, 4h high
             & ((rsi_3_1h_gt_5) | aroonu_14_4h_lt_70)
             # 1h down move, 1d high & overbought
@@ -18401,23 +18430,23 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 4h high
             & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_25) | aroonu_14_4h_lt_70)
             # 1h & 4h down move, 1h high
-            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_60) | (aroonu_14_1h < 70.0))
+            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_60) | (aroonu_14_1h_lt_70))
             # 1h & 1d down move, 4h still high
             & ((rsi_3_1h_gt_10) | (rsi_3_1d_gt_10) | (aroonu_14_4h_lt_40))
             # 1h & 1d down move, 1h still high
             & ((rsi_3_1h_gt_10) | (rsi_3_1d_gt_15) | (aroonu_14_1h_lt_50))
             # 1h & 1d down move, 1h high
-            & ((rsi_3_1h_gt_10) | (rsi_3_1d_gt_40) | (aroonu_14_1h < 70.0))
+            & ((rsi_3_1h_gt_10) | (rsi_3_1d_gt_40) | (aroonu_14_1h_lt_70))
             # 1h down move, 1h still high, 4h downtrend
-            & ((rsi_3_1h_gt_10) | (aroonu_14_1h < 40.0) | (roc_9_4h_gt_neg_30))
+            & ((rsi_3_1h_gt_10) | (aroonu_14_1h_lt_40) | (roc_9_4h_gt_neg_30))
             # 1h down move, 1h still high, 1d high
             & ((rsi_3_1h_gt_10) | (aroonu_14_1h_lt_50) | (aroonu_14_1d_lt_90))
             # 1h down move, 1h high, 1h downtrend
-            & ((rsi_3_1h_gt_10) | (aroonu_14_1h < 60.0) | (roc_9_1h > -10.0))
+            & ((rsi_3_1h_gt_10) | (aroonu_14_1h_lt_60) | (roc_9_1h > -10.0))
             # 1h down move, 1h high, 1d downtrend
-            & ((rsi_3_1h_gt_10) | (aroonu_14_1h < 70.0) | (roc_9_1d > -30.0))
+            & ((rsi_3_1h_gt_10) | (aroonu_14_1h_lt_70) | (roc_9_1d > -30.0))
             # 1h down move, 1h high
-            & ((rsi_3_1h_gt_10) | (aroonu_14_1h < 80.0))
+            & ((rsi_3_1h_gt_10) | (aroonu_14_1h_lt_80))
             # 1h down move, 4h still high, 15m downtrend
             & ((rsi_3_1h_gt_10) | (aroonu_14_4h_lt_50) | (cmf_20_15m > -0.40))
             # 1h down move, 4h still high, 4h downtrend
@@ -18425,13 +18454,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 4h still high, 1d downtrend
             & ((rsi_3_1h_gt_10) | (aroonu_14_4h_lt_50) | (roc_9_1d > -30.0))
             # 1h down move, 4h & 1d high
-            & ((rsi_3_1h_gt_10) | (aroonu_14_4h_lt_60) | (aroonu_14_1d < 100.0))
+            & ((rsi_3_1h_gt_10) | (aroonu_14_4h_lt_60) | (aroonu_14_1d_lt_100))
             # 1h down move, 4h high, 1d overbought
             & ((rsi_3_1h_gt_10) | (aroonu_14_4h_lt_90) | (roc_9_1d < 100.0))
             # 1h down move, 4h high
-            & ((rsi_3_1h_gt_10) | (aroonu_14_4h < 100.0))
+            & ((rsi_3_1h_gt_10) | (aroonu_14_4h_lt_100))
             # 1h down move, 1d high & overbought
-            & ((rsi_3_1h_gt_10) | (aroonu_14_1d < 100.0) | (roc_9_1d < 60.0))
+            & ((rsi_3_1h_gt_10) | (aroonu_14_1d_lt_100) | (roc_9_1d < 60.0))
             # 1h down move, 4h overbought
             & ((rsi_3_1h_gt_10) | (roc_9_4h_lt_10))
             # 1h down move, 4h high & overbought
@@ -18439,19 +18468,19 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 4h & 1d downtrend
             & ((rsi_3_1h_gt_10) | (roc_9_4h_gt_neg_30) | roc_9_1d_gt_neg_50)
             # 1h & 4h down move, 4h high
-            & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_45) | (aroonu_14_4h < 80.0))
+            & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_45) | (aroonu_14_4h_lt_80))
             # 1h down move, 1h high, 1d downtrend
             & ((rsi_3_1h_gt_15) | (aroonu_14_1h_lt_50) | (roc_9_1d_gt_neg_40))
             # 1h down move, 1h & 1d high
-            & ((rsi_3_1h_gt_15) | (aroonu_14_1h < 60.0) | (aroonu_14_1d < 85.0))
+            & ((rsi_3_1h_gt_15) | (aroonu_14_1h_lt_60) | (aroonu_14_1d_lt_85))
             # 1h down move, 1h high, 1d downtrend
-            & ((rsi_3_1h_gt_15) | (aroonu_14_1h < 60.0) | (roc_9_1d > -30.0))
+            & ((rsi_3_1h_gt_15) | (aroonu_14_1h_lt_60) | (roc_9_1d > -30.0))
             # 1h down move, 1h high, 1d overbought
-            & ((rsi_3_1h_gt_15) | (aroonu_14_1h < 60.0) | roc_9_1d_lt_50)
+            & ((rsi_3_1h_gt_15) | (aroonu_14_1h_lt_60) | roc_9_1d_lt_50)
             # 1h down move, 1h high, 4h downtrend
-            & ((rsi_3_1h_gt_15) | (aroonu_14_1h < 70.0) | (roc_9_4h > -10.0))
+            & ((rsi_3_1h_gt_15) | (aroonu_14_1h_lt_70) | (roc_9_4h > -10.0))
             # 1h down move, 4h high & overbought
-            & ((rsi_3_1h_gt_15) | (aroonu_14_4h < 80.0) | (roc_9_4h < 100.0))
+            & ((rsi_3_1h_gt_15) | (aroonu_14_4h_lt_80) | (roc_9_4h < 100.0))
             # 1h down move, 1d high & overbought
             & ((rsi_3_1h_gt_15) | (aroonu_14_1d_lt_80) | (roc_9_1d < 100.0))
             # 1h down move, 1h & 4h downtrend
@@ -18463,7 +18492,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 4h high
             & (rsi_3_1h_gt_20 | (rsi_3_4h_gt_50) | (aroonu_14_4h_lt_90))
             # 1h down move, 1h still high, 4h downtrend
-            & (rsi_3_1h_gt_20 | (aroonu_14_1h < 40.0) | (roc_9_4h_gt_neg_30))
+            & (rsi_3_1h_gt_20 | (aroonu_14_1h_lt_40) | (roc_9_4h_gt_neg_30))
             # 1h down move, 4h high, 1d downtrend
             & (rsi_3_1h_gt_20 | (stochrsi_k_4h_lt_80) | (roc_9_1d_gt_neg_40))
             # 1h down move, 4h & 1d downtrend
@@ -18505,7 +18534,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 1h & 4h downtrend
             & ((rsi_3_4h_gt_10) | (roc_9_1h > -30.0) | (roc_9_4h_gt_neg_30))
             # 4h down move, 4h still not low enough, 1d overbought
-            & ((rsi_3_4h_gt_15) | (aroonu_14_4h < 30.0) | roc_9_1d_lt_50)
+            & ((rsi_3_4h_gt_15) | (aroonu_14_4h_lt_30) | roc_9_1d_lt_50)
             # 4h down move, 4h high
             & ((rsi_3_4h_gt_15) | (aroonu_14_4h_lt_60))
             # 4h down move, 4h still high, 1d overbought
@@ -18533,9 +18562,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h downtrend, 4h high
             & ((cmf_20_4h > -0.50) | aroonu_14_4h_lt_70)
             # 1h & 1d high, 4h downtrend
-            & ((aroonu_14_1h < 40.0) | (aroonu_14_1d_lt_70) | (roc_9_4h_gt_neg_20))
+            & ((aroonu_14_1h_lt_40) | (aroonu_14_1d_lt_70) | (roc_9_4h_gt_neg_20))
             # 1h still high, 1h & 4h downtrend
-            & ((aroonu_14_1h < 40.0) | (roc_9_1h > -20.0) | (roc_9_4h_gt_neg_30))
+            & ((aroonu_14_1h_lt_40) | (roc_9_1h > -20.0) | (roc_9_4h_gt_neg_30))
             # 1h & 4h high, 1d overbought
             & (aroonu_14_1h_lt_70 | aroonu_14_4h_lt_100 | (roc_9_1d_lt_20))
             # 1h high, 4h & 1d downtrend
@@ -18557,7 +18586,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h high, 1d downtrend
             & (aroonu_14_4h_lt_80 | (roc_9_1d > -30.0))
             # 1d still high, 1d downtrend
-            & ((aroonu_14_1d < 50.0) | (roc_9_1d_gt_neg_30))
+            & ((aroonu_14_1d_lt_50) | (roc_9_1d_gt_neg_30))
             # 1d high, 15m downtrend
             & ((aroonu_14_1d_lt_70) | (roc_9_15m > -50.0))
             # 1d high, 1h downtrend
@@ -18592,7 +18621,7 @@ class NostalgiaForInfinityX7(IStrategy):
           long_entry_logic.append(
             (rsi_3 < 40.0)
             & (rsi_3_15m < 50.0)
-            & (aroonu_14_15m < 25.0)
+            & (aroonu_14_15m_lt_25)
             & (stochrsi_k_15m < 20.0)
             & (df["EMA_26_15m"] > df["EMA_12_15m"])
             & ((df["EMA_26_15m"] - df["EMA_12_15m"]) > (df["open_15m"] * 0.050))
@@ -18624,7 +18653,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m & 1h down move, 4h high
           long_entry_logic.append((rsi_3_15m_gt_5) | (rsi_3_1h_gt_40) | (stochrsi_k_4h_lt_80))
           # 15m down move, 1h still not low enough
-          long_entry_logic.append((rsi_3_15m_gt_5) | (aroonu_14_1h < 30.0))
+          long_entry_logic.append((rsi_3_15m_gt_5) | (aroonu_14_1h_lt_30))
           # 15m down move, 4h high
           long_entry_logic.append((rsi_3_15m_gt_5) | (aroonu_14_4h_lt_90))
           # 15m & 1h & 1d down move
@@ -18648,7 +18677,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m down move, 1h high, 4h overbought
           long_entry_logic.append((rsi_3_15m_gt_10) | aroonu_14_1h_lt_70 | (roc_9_4h < 20.0))
           # 15m down move, 4h & 1d high
-          long_entry_logic.append((rsi_3_15m_gt_10) | (aroonu_14_4h < 75.0) | aroonu_14_1d_lt_100)
+          long_entry_logic.append((rsi_3_15m_gt_10) | (aroonu_14_4h_lt_75) | aroonu_14_1d_lt_100)
           # 15m down move, 4h high, 1h overbought
           long_entry_logic.append((rsi_3_15m_gt_10) | aroonu_14_4h_lt_100 | (roc_9_1h_lt_10))
           # 15m & 1h down move, 4h high
@@ -18664,11 +18693,11 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m & 1h down move, 1h high
           long_entry_logic.append((rsi_3_15m_gt_30) | (rsi_3_1h_gt_30) | aroonu_14_1h_lt_70)
           # 1h down move, 4h still not low enough
-          long_entry_logic.append((rsi_3_1h_gt_3) | (aroonu_14_4h < 30.0))
+          long_entry_logic.append((rsi_3_1h_gt_3) | (aroonu_14_4h_lt_30))
           # 1h & 4h down move, 1h still not low enough
-          long_entry_logic.append((rsi_3_1h_gt_5) | (rsi_3_4h_gt_30) | (aroonu_14_1h < 20.0))
+          long_entry_logic.append((rsi_3_1h_gt_5) | (rsi_3_4h_gt_30) | (aroonu_14_1h_lt_20))
           # 1h down move, 1h still not low enough
-          long_entry_logic.append((rsi_3_1h_gt_5) | (aroonu_14_1h < 30.0))
+          long_entry_logic.append((rsi_3_1h_gt_5) | (aroonu_14_1h_lt_30))
           # 1h down move, 1h still not low enough
           long_entry_logic.append((rsi_3_1h_gt_5) | (stochrsi_k_1h < 25.0))
           # 1h & 4h down move
@@ -18692,11 +18721,11 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1h & 4h down move, 4h still not low enough
           long_entry_logic.append((rsi_3_1h_gt_3) | (rsi_3_4h_gt_25) | (stochrsi_k_4h < 30.0))
           # 1h down move, 1h still not low enough, 1d high
-          long_entry_logic.append((rsi_3_1h_gt_10) | (stochrsi_k_1h < 20.0) | (aroonu_14_1d < 85.0))
+          long_entry_logic.append((rsi_3_1h_gt_10) | (stochrsi_k_1h < 20.0) | (aroonu_14_1d_lt_85))
           # 1h down move, 1h still not low enough
           long_entry_logic.append((rsi_3_1h_gt_10) | (stochrsi_k_1h < 25.0))
           # 1h down move, 4h high
-          long_entry_logic.append((rsi_3_1h_gt_10) | (aroonu_14_4h < 85.0))
+          long_entry_logic.append((rsi_3_1h_gt_10) | (aroonu_14_4h_lt_85))
           # 1h down move, 1d high & overbought
           long_entry_logic.append((rsi_3_1h_gt_10) | (aroonu_14_1d_lt_70) | roc_9_1d_lt_50)
           # 1h down move, 1d overbought
@@ -18708,7 +18737,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1h & 4h & 1d down move
           long_entry_logic.append((rsi_3_1h_gt_15) | rsi_3_4h_gt_20 | (rsi_3_1d_gt_30))
           # 1h & 4h down move, 1d high
-          long_entry_logic.append((rsi_3_1h_gt_15) | (rsi_3_4h_gt_30) | (aroonu_14_1d < 100.0))
+          long_entry_logic.append((rsi_3_1h_gt_15) | (rsi_3_4h_gt_30) | (aroonu_14_1d_lt_100))
           # 1h down move, 1h still high
           long_entry_logic.append((rsi_3_1h_gt_15) | (aroonu_14_1h_lt_50))
           # 1h down move, 1d high, 4h downtrend
@@ -18760,7 +18789,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 4h & 1d down move, 1d still high
           long_entry_logic.append((rsi_3_4h_gt_15) | (rsi_3_1d_gt_35) | (rsi_14_1d < 50.0))
           # 4h down move, 1h still not low enough
-          long_entry_logic.append((rsi_3_4h_gt_15) | (aroonu_14_1h < 30.0))
+          long_entry_logic.append((rsi_3_4h_gt_15) | (aroonu_14_1h_lt_30))
           # 4h & 1d down move, 1d high
           long_entry_logic.append(rsi_3_4h_gt_20 | (rsi_3_1d_gt_20) | (aroonu_14_1d_lt_80))
           # 4h down move, 4h still high, 1d high
@@ -18838,7 +18867,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # big drop in the last 12 days, 4h down move
           long_entry_logic.append((close > (high_max_12_1d * 0.40)) | (rsi_3_4h_gt_15))
           # big drop in the last 12 days, 1h still high
-          long_entry_logic.append((close > (high_max_12_1d * 0.25)) | (aroonu_14_1h < 75.0))
+          long_entry_logic.append((close > (high_max_12_1d * 0.25)) | (aroonu_14_1h_lt_75))
           # big drop in the last 20 days, 1h down move
           long_entry_logic.append((close > (high_max_20_1d * 0.35)) | (rsi_3_1h_gt_10))
           # big drop in the last 20 days, 1h down move
@@ -18852,7 +18881,7 @@ class NostalgiaForInfinityX7(IStrategy):
 
           # Logic
           long_entry_logic.append(rsi_3 < 50.0)
-          long_entry_logic.append(aroonu_14_15m < 25.0)
+          long_entry_logic.append(aroonu_14_15m_lt_25)
           long_entry_logic.append(stochrsi_k_15m < 20.0)
           long_entry_logic.append(df["close_15m"] < (df["EMA_20_15m"] * 0.924))
 
@@ -18880,7 +18909,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h & 4h down move
             & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_20) | (rsi_3_4h_gt_20))
             # 15m & 1h down move, 1h still high
-            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_20) | (aroonu_14_1h < 40.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_20) | (aroonu_14_1h_lt_40))
             # 15m & 1h down move, 4h still high
             & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_25) | (stochrsi_k_4h < 40.0))
             # 15m & 4h down move, 1d high
@@ -18898,7 +18927,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 4h high
             & ((rsi_3_15m_gt_15) | (rsi_3_1h_gt_20) | (aroonu_14_4h_lt_60))
             # 15m & 4h down move, 1h still high
-            & ((rsi_3_15m_gt_15) | (rsi_3_4h_gt_15) | (aroonu_14_1h < 40.0))
+            & ((rsi_3_15m_gt_15) | (rsi_3_4h_gt_15) | (aroonu_14_1h_lt_40))
             # 15m & 1h & 1d down move, 1h still not low enough, 1d high
             & ((rsi_3_15m_gt_20) | (rsi_3_1h_gt_20) | (rsi_3_1d_gt_30) | (rsi_14_1h < 30.0) | (aroonu_14_1d_lt_80))
             # 15m & 1h down move, 4h still high, 4h overbought
@@ -18906,11 +18935,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 4h high
             & ((rsi_3_15m_gt_20) | (rsi_3_1h_gt_20) | aroonu_14_4h_lt_70)
             # 15m down move, 1h & 4h still high
-            & ((rsi_3_15m_gt_20) | (aroonu_14_1h < 40.0) | (stochrsi_k_4h_lt_50))
+            & ((rsi_3_15m_gt_20) | (aroonu_14_1h_lt_40) | (stochrsi_k_4h_lt_50))
             # 15m & 1h & 4h down move, 1d high
             & ((rsi_3_15m_gt_25) | (rsi_3_1h_gt_25) | (rsi_3_4h_gt_25) | (roc_9_1d < 70.0))
             # 15m & 4h down move, 4h high
-            & ((rsi_3_15m_gt_25) | (rsi_3_4h_gt_45) | (aroonu_14_4h < 85.0))
+            & ((rsi_3_15m_gt_25) | (rsi_3_4h_gt_45) | (aroonu_14_4h_lt_85))
             # 15m & 1h down move, 15m still not low enough
             & ((rsi_3_15m_gt_30) | (rsi_3_1h_gt_30) | (aroonu_14_15m < 15.0))
             # 15m & 1h down move, 1h high
@@ -18918,7 +18947,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h & 1d down move, 1h high
             & ((rsi_3_15m_gt_35) | (rsi_3_1h_gt_35) | (rsi_3_1d_gt_35) | (aroonu_14_1h_lt_70))
             # 1h down move, 1h still not low enough, 1d high
-            & ((rsi_3_1h_gt_3) | (aroonu_14_1h < 20.0) | (aroonu_14_1d_lt_90))
+            & ((rsi_3_1h_gt_3) | (aroonu_14_1h_lt_20) | (aroonu_14_1d_lt_90))
             # 1h & 4h down move
             & ((rsi_3_1h_gt_5) | (rsi_3_4h_gt_10))
             # 1h & 4h down move, 4h downtrend
@@ -18936,7 +18965,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 4h still not low enough
             & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_30) | (rsi_14_4h < 40.0))
             # 1h & 4h down move, 4h still not low enough
-            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_30) | (aroonu_14_4h < 30.0))
+            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_30) | (aroonu_14_4h_lt_30))
             # 1h & 4h & 1d down move
             & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_30) | (rsi_3_1d_gt_30))
             # 1h & 4h down move, 1d overbought
@@ -18962,7 +18991,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h & 1d down move
             & ((rsi_3_1h_gt_15) | rsi_3_4h_gt_20 | (rsi_3_1d_gt_30))
             # 1h & 4h down move, 4h still not low enough
-            & ((rsi_3_1h_gt_15) | rsi_3_4h_gt_20 | (aroonu_14_4h < 30.0))
+            & ((rsi_3_1h_gt_15) | rsi_3_4h_gt_20 | (aroonu_14_4h_lt_30))
             # 1h & 4h down move, 1d overbought
             & ((rsi_3_1h_gt_15) | rsi_3_4h_gt_20 | roc_9_1d_lt_50)
             # 1h & 4h & 1d down move
@@ -18976,9 +19005,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 4h still high
             & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_50) | (aroonu_14_4h_lt_40))
             # 1h & 1d down move, 1d still high
-            & ((rsi_3_1h_gt_15) | (rsi_3_1d_gt_15) | (aroonu_14_1d < 50.0))
+            & ((rsi_3_1h_gt_15) | (rsi_3_1d_gt_15) | (aroonu_14_1d_lt_50))
             # 1h down move, 1h still high, 1d overbought
-            & ((rsi_3_1h_gt_15) | (aroonu_14_1h < 40.0) | roc_9_1d_lt_50)
+            & ((rsi_3_1h_gt_15) | (aroonu_14_1h_lt_40) | roc_9_1d_lt_50)
             # 1h down move, 1d high, 4h downtrend
             & ((rsi_3_1h_gt_15) | (aroonu_14_1d_lt_70) | (roc_9_4h > -20.0))
             # 1h down move, 1d high & overbought
@@ -18986,7 +19015,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 4h high
             & ((rsi_3_1h_gt_15) | (stochrsi_k_4h_lt_70))
             # 1h & 4h down move, 1h still not low enough
-            & (rsi_3_1h_gt_20 | rsi_3_4h_gt_20 | (aroonu_14_1h < 30.0))
+            & (rsi_3_1h_gt_20 | rsi_3_4h_gt_20 | (aroonu_14_1h_lt_30))
             # 1h & 4h down move, 4h still high
             & (rsi_3_1h_gt_20 | rsi_3_4h_gt_20 | (rsi_14_4h < 40.0))
             # 1h & 4h down move, 4h still high
@@ -19000,7 +19029,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 1d down move, 1d high
             & (rsi_3_1h_gt_20 | (rsi_3_1d_gt_20) | (aroonu_14_1d_lt_70))
             # 1h down move, 1h still high, 1d high
-            & (rsi_3_1h_gt_20 | (aroonu_14_1h < 40.0) | (aroonu_14_1d_lt_90))
+            & (rsi_3_1h_gt_20 | (aroonu_14_1h_lt_40) | (aroonu_14_1d_lt_90))
             # 4h down move, 4h still high, 1d high
             & (rsi_3_4h_gt_20 | (aroonu_14_4h_lt_50) | aroonu_14_1d_lt_100)
             # 1h down move, 4h still high, 1d downtrend
@@ -19008,7 +19037,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 4h & 1d high
             & (rsi_3_1h_gt_20 | (stochrsi_k_4h_lt_50) | (stochrsi_k_1d < 80.0))
             # 1h & 4h down move, 1h still high
-            & ((rsi_3_1h_gt_25) | (rsi_3_4h_gt_35) | (aroonu_14_1h < 40.0))
+            & ((rsi_3_1h_gt_25) | (rsi_3_4h_gt_35) | (aroonu_14_1h_lt_40))
             # 1h & 4h down move, 4h high
             & ((rsi_3_1h_gt_25) | (rsi_3_4h_gt_40) | aroonu_14_4h_lt_70)
             # 1h down move, 15m still not low enough, 4h high
@@ -19016,7 +19045,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 4h still high
             & ((rsi_3_1h_gt_25) | (rsi_3_4h_gt_35) | (stochrsi_k_4h_lt_50))
             # 1h down move, 1h high
-            & ((rsi_3_1h_gt_25) | (aroonu_14_1h < 60.0))
+            & ((rsi_3_1h_gt_25) | (aroonu_14_1h_lt_60))
             # 1h down move, 4h high
             & ((rsi_3_1h_gt_25) | aroonu_14_4h_lt_80)
             # 1h & 1d down move, 1d high
@@ -19050,11 +19079,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h & 1d down move, 1d high
             & ((rsi_3_4h_gt_10) | (rsi_3_1d > 50.0) | (aroonu_14_1d_lt_90))
             # 4h down move, 4h & 1d still high
-            & ((rsi_3_4h_gt_10) | (aroonu_14_4h_lt_50) | (aroonu_14_1d < 50.0))
+            & ((rsi_3_4h_gt_10) | (aroonu_14_4h_lt_50) | (aroonu_14_1d_lt_50))
             # 4h & 1d down move, 1d low
             & ((rsi_3_4h_gt_15) | (rsi_3_1d_gt_25) | (cmf_20_1d > -0.2))
             # 4h & 1d down move, 1d still high
-            & ((rsi_3_4h_gt_15) | (rsi_3_1d_gt_30) | (aroonu_14_1d < 50.0))
+            & ((rsi_3_4h_gt_15) | (rsi_3_1d_gt_30) | (aroonu_14_1d_lt_50))
             # 4h & 1d down move, 1d overbought
             & (rsi_3_4h_gt_20 | (rsi_3_1d_gt_45) | (roc_9_1d_lt_40))
             # 4h down move, 4h still not low enough, 1d downtrend
@@ -19126,7 +19155,7 @@ class NostalgiaForInfinityX7(IStrategy):
             (rsi_3 < 40.0)
             & (rsi_3_15m < 50.0)
             & (df["WILLR_14_15m"] < -50.0)
-            & (aroonu_14_15m < 25.0)
+            & (aroonu_14_15m_lt_25)
             & (stochrsi_k_15m < 20.0)
             & (willr_84_1h < -70.0)
             & (stochrsi_k_1h < 20.0)
@@ -19142,7 +19171,7 @@ class NostalgiaForInfinityX7(IStrategy):
 
           long_entry_logic.append(
             # 5m & 1h down move, 1h still not low enough
-            ((rsi_3_gt_3) | (rsi_3_1h_gt_10) | (aroonu_14_1h < 30.0))
+            ((rsi_3_gt_3) | (rsi_3_1h_gt_10) | (aroonu_14_1h_lt_30))
             # 5m & 1h down move, 1d high
             & ((rsi_3_gt_3) | rsi_3_1h_gt_20 | aroonu_14_1d_lt_100)
             # 5m & 4h down move, 4h high
@@ -19182,7 +19211,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 15m downtrend. 4h high
             & (rsi_3_15m_gt_3 | (cmf_20_15m > -0.50) | (aroonu_14_4h_lt_60))
             # 15m down move, 15m still not low enough
-            & (rsi_3_15m_gt_3 | (aroonu_14_15m < 30.0))
+            & (rsi_3_15m_gt_3 | (aroonu_14_15m_lt_30))
             # 15m down move, 4h high
             & (rsi_3_15m_gt_3 | aroonu_14_4h_lt_80)
             # 15m down move, 4h & 1d downtrend
@@ -19198,7 +19227,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 4h down move, 1h high
             & ((rsi_3_15m_gt_5) | rsi_3_4h_gt_20 | (stochrsi_k_1h_lt_80))
             # 15m down move, 15m still low, 4h still high
-            & ((rsi_3_15m_gt_5) | (aroonu_14_15m < 20.0) | (aroonu_14_4h_lt_50))
+            & ((rsi_3_15m_gt_5) | (aroonu_14_15m_lt_20) | (aroonu_14_4h_lt_50))
             # 15m down move, 15m still high
             & ((rsi_3_15m_gt_5) | (aroonu_14_15m_lt_50))
             # 15m down move, 1h high & overbought
@@ -19224,13 +19253,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 4h down move, 4h overbought
             & ((rsi_3_15m_gt_10) | (rsi_3_4h_gt_55) | (roc_9_4h < 50.0))
             # 15m down move, 15m still not low enough, 1d downtrend
-            & ((rsi_3_15m_gt_10) | (aroonu_14_15m < 30.0) | (roc_9_1d_gt_neg_30))
+            & ((rsi_3_15m_gt_10) | (aroonu_14_15m_lt_30) | (roc_9_1d_gt_neg_30))
             # 15m down move, 15m still high, 1d overbought
             & ((rsi_3_15m_gt_10) | (aroonu_14_15m_lt_50) | (roc_9_1d_lt_30))
             # 15m down move, 4h & 1d high
             & ((rsi_3_15m_gt_10) | (aroonu_14_4h_lt_60) | aroonu_14_1d_lt_100)
             # 15m down move, 1d high, 1d downtrend
-            & ((rsi_3_15m_gt_10) | (aroonu_14_1d < 85.0) | (cmf_20_1d > -0.40))
+            & ((rsi_3_15m_gt_10) | (aroonu_14_1d_lt_85) | (cmf_20_1d > -0.40))
             # 15m down move, 1h high & overbought
             & ((rsi_3_15m_gt_10) | (stochrsi_k_1h < 90.0) | (roc_9_1h < 20.0))
             # 15m down move, 4h high
@@ -19238,7 +19267,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 4h & 1d overbought
             & ((rsi_3_15m_gt_10) | (roc_9_4h_lt_10) | (roc_9_1d_lt_40))
             # 15m & 1h down move, 15m high
-            & ((rsi_3_15m_gt_15) | (rsi_3_1h_gt_15) | (aroonu_14_15m < 60.0))
+            & ((rsi_3_15m_gt_15) | (rsi_3_1h_gt_15) | (aroonu_14_15m_lt_60))
             # 15m & 1h down move, 1h still high
             & ((rsi_3_15m_gt_15) | (rsi_3_1h_gt_15) | (stochrsi_k_1h < 50.0))
             # 15m & 1h down move, 1h high
@@ -19258,7 +19287,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 4h & 1d overbought
             & ((rsi_3_15m_gt_15) | (roc_9_4h_lt_20) | (roc_9_1d < 60.0))
             # 15m & 1h down move, 15m high
-            & ((rsi_3_15m_gt_20) | rsi_3_1h_gt_20 | (aroonu_14_15m < 60.0))
+            & ((rsi_3_15m_gt_20) | rsi_3_1h_gt_20 | (aroonu_14_15m_lt_60))
             # 15m & 1h down move, 1h high
             & ((rsi_3_15m_gt_20) | rsi_3_1h_gt_20 | aroonu_14_1h_lt_70)
             # 15m & 1h down move, 4h high
@@ -19278,7 +19307,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 4h high
             & ((rsi_3_15m_gt_30) | (rsi_3_1h_gt_50) | aroonu_14_4h_lt_100)
             # 15m down move, 15m high, 4h high
-            & ((rsi_3_15m_gt_30) | (aroonu_14_15m < 60.0) | (stochrsi_k_4h_lt_70))
+            & ((rsi_3_15m_gt_30) | (aroonu_14_15m_lt_60) | (stochrsi_k_4h_lt_70))
             # 15m down move, 1h & 4h high
             & ((rsi_3_15m_gt_30) | (stochrsi_k_1h_lt_70) | (stochrsi_k_4h_lt_80))
             # 1h & 4h down move, 4h still not low enough
@@ -19288,11 +19317,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 1d still high
             & ((rsi_3_1h_gt_3) | (rsi_3_4h_gt_10) | (stochrsi_k_1d < 40.0))
             # 1h down move, 1h still not low enough
-            & ((rsi_3_1h_gt_3) | (aroonu_14_1h < 20.0))
+            & ((rsi_3_1h_gt_3) | (aroonu_14_1h_lt_20))
             # 1h & 4h down move, 1d downtrend
             & ((rsi_3_1h_gt_5) | (rsi_3_4h_gt_10) | (roc_9_1d_gt_neg_40))
             # 1h & 4h down move, 4h still not low enough
-            & ((rsi_3_1h_gt_5) | (rsi_3_4h_gt_15) | (aroonu_14_4h < 30.0))
+            & ((rsi_3_1h_gt_5) | (rsi_3_4h_gt_15) | (aroonu_14_4h_lt_30))
             # 1h & 4h down move, 1d high
             & ((rsi_3_1h_gt_5) | (rsi_3_4h_gt_15) | (roc_9_1d_lt_40))
             # 1h & 4h down move, 4h still not low enough
@@ -19314,9 +19343,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 1d overbought
             & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_30) | (roc_9_1d_lt_80))
             # 1h down move, 15m still high, 4h high
-            & ((rsi_3_1h_gt_10) | (aroonu_14_15m < 40.0) | (stochrsi_k_4h < 90.0))
+            & ((rsi_3_1h_gt_10) | (aroonu_14_15m_lt_40) | (stochrsi_k_4h < 90.0))
             # 1h down move, 1d high & overbought
-            & ((rsi_3_1h_gt_10) | (aroonu_14_1d < 100.0) | (roc_9_1d < 10.0))
+            & ((rsi_3_1h_gt_10) | (aroonu_14_1d_lt_100) | (roc_9_1d < 10.0))
             # 1h down move, 4h still high, 4d downtrend
             & ((rsi_3_1h_gt_10) | (stochrsi_k_4h_lt_50) | roc_9_1d_gt_neg_50)
             # 1h down move, 4h downtrend, 1d overbought
@@ -19324,7 +19353,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1d overbought
             & ((rsi_3_1h_gt_10) | (roc_9_1d < 100.0))
             # 1h & 4h down move, 4h high
-            & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_40) | (aroonu_14_4h < 80.0))
+            & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_40) | (aroonu_14_4h_lt_80))
             # 1h down move, 1d downtrend, 1d high
             & ((rsi_3_1h_gt_15) | (cmf_20_1d > -0.30) | (stochrsi_k_1d < 80.0))
             # 1h down move, 1h still high
@@ -19348,7 +19377,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 4h high, 1d downtrend
             & ((rsi_3_1h_gt_25) | (stochrsi_k_4h_lt_80) | (roc_9_1d_gt_neg_40))
             # 1h & 4h down move, 1h high
-            & ((rsi_3_1h_gt_30) | (rsi_3_4h_gt_35) | (aroonu_14_1h < 75.0))
+            & ((rsi_3_1h_gt_30) | (rsi_3_4h_gt_35) | (aroonu_14_1h_lt_75))
             # 1h & 4h down move, 15m & 4h high
             & ((rsi_3_1h_gt_30) | (rsi_3_4h_gt_50) | (aroonu_14_15m_lt_70) | (aroonu_14_1h_lt_70))
             # 1h down move, 1h high, 4h downtrend
@@ -19362,7 +19391,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h & 4h high
             & ((rsi_3_1h_gt_40) | aroonu_14_1h_lt_70 | (aroonu_14_4h_lt_90))
             # 1h down move, 1h high, 1d overbought
-            & ((rsi_3_1h_gt_40) | (aroonu_14_1h < 85.0) | (roc_9_1d_lt_80))
+            & ((rsi_3_1h_gt_40) | (aroonu_14_1h_lt_85) | (roc_9_1d_lt_80))
             # 1h down move, 1h high, 4h downtrend
             & ((rsi_3_1h_gt_40) | (stochrsi_k_1h < 80.0) | (roc_9_4h_gt_neg_20))
             # 1h down move, 1h high, 1h overbought
@@ -19376,7 +19405,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h & 1d down move, 1h still not low enough
             & ((rsi_3_4h_gt_3) | (rsi_3_1d_gt_15) | (stochrsi_k_1h < 30.0))
             # 4h & 1d down move, 1d still not low enough
-            & ((rsi_3_4h_gt_3) | (rsi_3_1d_gt_30) | (aroonu_14_1d < 30.0))
+            & ((rsi_3_4h_gt_3) | (rsi_3_1d_gt_30) | (aroonu_14_1d_lt_30))
             # 4h down move, 1d high
             & ((rsi_3_4h_gt_3) | (aroonu_14_1d_lt_90))
             # 4h down move, 1h still high, 4h downtrend
@@ -19396,7 +19425,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 1h high, 1d downtrend
             & ((rsi_3_4h_gt_10) | (stochrsi_k_1h < 60.0) | (roc_9_1d_gt_neg_40))
             # 4h & 1d down move, 1d high
-            & ((rsi_3_4h_gt_15) | (rsi_3_1d_gt_20) | (aroonu_14_1d < 60.0))
+            & ((rsi_3_4h_gt_15) | (rsi_3_1d_gt_20) | (aroonu_14_1d_lt_60))
             # 4h down move, 4h high, 1h downtrend
             & ((rsi_3_4h_gt_15) | (aroonu_14_4h_lt_60) | (roc_9_1h > -20.0))
             # 4h down move, 4h & 1d high
@@ -19416,7 +19445,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 4h & 1d overbought
             & ((rsi_3_4h_gt_40) | (roc_9_4h_lt_10) | roc_9_1d_lt_50)
             # 4h down move, 1h high, 1d overbought
-            & ((rsi_3_4h_gt_45) | (aroonu_14_1h < 85.0) | roc_9_1d_lt_50)
+            & ((rsi_3_4h_gt_45) | (aroonu_14_1h_lt_85) | roc_9_1d_lt_50)
             # 4h down move, 4h still high, 1d downtrend
             & ((rsi_3_4h_gt_50) | (rsi_14_4h < 40.0) | (roc_9_1d_gt_neg_30))
             # 4h down move, 4h high & overbought
@@ -19432,15 +19461,15 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1d down move, 1h high & overbought
             & ((rsi_3_1d_gt_35) | (stochrsi_k_1h < 90.0) | (roc_9_1h_lt_10))
             # 1d downtrend, 1d high & overbought
-            & ((cmf_20_1d > -0.30) | (aroonu_14_1d < 85.0) | (roc_9_1d_lt_100))
+            & ((cmf_20_1d > -0.30) | (aroonu_14_1d_lt_85) | (roc_9_1d_lt_100))
             # 15m high, 1h high & overbought
-            & ((aroonu_14_15m < 60.0) | (aroonu_14_1h < 85.0) | (roc_9_1h_lt_10))
+            & ((aroonu_14_15m_lt_60) | (aroonu_14_1h_lt_85) | (roc_9_1h_lt_10))
             # 1h high, 4h high, 1h overbought
             & (aroonu_14_1h_lt_70 | aroonu_14_4h_lt_100 | (roc_9_1h < 20.0))
             # 1h & 1d high, 1h overbought
             & (aroonu_14_1h_lt_70 | (aroonu_14_1d_lt_70) | (roc_9_1h < 20.0))
             # 1h & 4h high, 1d downtrend
-            & ((aroonu_14_1h < 85.0) | aroonu_14_4h_lt_100 | (roc_9_1d > -80.0))
+            & ((aroonu_14_1h_lt_85) | aroonu_14_4h_lt_100 | (roc_9_1d > -80.0))
             # 4h still high, 5m downtrend
             & ((aroonu_14_4h_lt_40) | (roc_9 > -40.0))
             # 4h high, 4h & 1d overbought
@@ -19452,9 +19481,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h high, 4h & 1d overbought
             & (aroonu_14_4h_lt_80 | (roc_9_4h < 20.0) | (roc_9_1d_lt_20))
             # 1d high, 1h & 4h downtrend
-            & ((aroonu_14_1d < 85.0) | (roc_9_1h > -30.0) | (roc_9_4h > -50.0))
+            & ((aroonu_14_1d_lt_85) | (roc_9_1h > -30.0) | (roc_9_4h > -50.0))
             # 1d high, 1h & 1d overbought
-            & ((aroonu_14_1d < 85.0) | (roc_9_1h < 20.0) | (roc_9_1d_lt_100))
+            & ((aroonu_14_1d_lt_85) | (roc_9_1h < 20.0) | (roc_9_1d_lt_100))
             # 1d high, 4h & 1d overbought
             & ((aroonu_14_1d_lt_90) | (roc_9_4h_lt_30) | (roc_9_1d < 60.0))
             # 1h high, 1d overbought
@@ -19472,7 +19501,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # Logic
           long_entry_logic.append(
             (rsi_3 < 50.0)
-            & (aroonu_14 < 25.0)
+            & (aroonu_14_lt_25)
             & (stochrsi_k < 30.0)
             & (ema_26 > ema_12)
             & ((ema_26 - ema_12) > (open_rate * 0.030))
@@ -19495,7 +19524,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 5m & 4h down move, 4h still not low enough
             & ((rsi_3_gt_5) | (rsi_3_4h_gt_15) | (stochrsi_k_4h < 20.0))
             # 15m & 1h down move, 1h still not low enough
-            & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_10) | (aroonu_14_1h < 20.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_10) | (aroonu_14_1h_lt_20))
             # 15m & 1h down move, 4h still not low enough
             & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_10) | (rsi_14_4h < 30.0))
             # 15m & 1h down move, 4h still high
@@ -19505,7 +19534,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 4h still high
             & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_25) | (aroonu_14_4h_lt_50))
             # 15m & 4h down move, 4h still not low enough
-            & (rsi_3_15m_gt_3 | (rsi_3_4h_gt_3) | (aroonu_14_4h < 20.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_4h_gt_3) | (aroonu_14_4h_lt_20))
             # 15m & 4h down move, 4h still high
             & (rsi_3_15m_gt_3 | rsi_3_4h_gt_20 | (aroonu_14_4h_lt_40))
             # 15m & 1h down move, 1h still not low enough
@@ -19529,17 +19558,17 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 15m high
             & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_10) | (aroonu_14_15m_lt_70))
             # 15m & 1h down move, 1h still not low enough
-            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_10) | (aroonu_14_1h < 30.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_10) | (aroonu_14_1h_lt_30))
             # 15m & 1h down move, 1h still high
-            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_15) | (aroonu_14_1h < 40.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_15) | (aroonu_14_1h_lt_40))
             # 15m & 1h down move, 1d high
-            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_10) | (aroonu_14_1d < 100.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_10) | (aroonu_14_1d_lt_100))
             # 15m & 1h down move, 4h high
             & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_15) | (aroonu_14_4h_lt_60))
             # 15m & 1h down move, 4h high
             & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_35) | (aroonu_14_4h_lt_90))
             # 15m & 4h down move, 15m still not low enough
-            & ((rsi_3_15m_gt_10) | (rsi_3_4h_gt_15) | (aroonu_14_15m < 20.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_4h_gt_15) | (aroonu_14_15m_lt_20))
             # 15m & 4h down move, 1d high
             & ((rsi_3_15m_gt_10) | rsi_3_4h_gt_20 | (stochrsi_k_1d_lt_90))
             # 15m & 4h down move, 4h still not low enough
@@ -19553,13 +19582,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 4h down move, 1d overbought
             & ((rsi_3_15m_gt_10) | (rsi_3_4h_gt_40) | (roc_9_1d < 200.0))
             # 15m & 1d down move, 1d high
-            & ((rsi_3_15m_gt_10) | (rsi_3_1d_gt_20) | (aroonu_14_1d < 75.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_1d_gt_20) | (aroonu_14_1d_lt_75))
             # 15m down move, 4h high, 1d downtrend
             & ((rsi_3_15m_gt_10) | aroonu_14_4h_lt_70 | (roc_9_1d > -25.0))
             # 15m & 1h & 4h & 1d down move, 4h still not low enough
-            & ((rsi_3_15m_gt_15) | (rsi_3_1h_gt_15) | (rsi_3_4h_gt_35) | (rsi_3_1d_gt_35) | (aroonu_14_4h < 30.0))
+            & ((rsi_3_15m_gt_15) | (rsi_3_1h_gt_15) | (rsi_3_4h_gt_35) | (rsi_3_1d_gt_35) | (aroonu_14_4h_lt_30))
             # 15m & 1h down move, 4h high
-            & ((rsi_3_15m_gt_15) | (rsi_3_1h_gt_15) | (aroonu_14_4h < 75.0))
+            & ((rsi_3_15m_gt_15) | (rsi_3_1h_gt_15) | (aroonu_14_4h_lt_75))
             # 15m & 4h down move, 4h high
             & ((rsi_3_15m_gt_15) | rsi_3_4h_gt_20 | (aroonu_14_4h_lt_60))
             # 15m & 4h down move, 4h still high
@@ -19567,7 +19596,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 15m downtrend, 4h high
             & ((rsi_3_15m_gt_15) | (cmf_20_15m > -0.30) | (aroonu_14_4h_lt_50))
             # 15m down move, 15m still high, 4h overbought
-            & ((rsi_3_15m_gt_15) | (aroonu_14_15m < 40.0) | (roc_9_4h_lt_40))
+            & ((rsi_3_15m_gt_15) | (aroonu_14_15m_lt_40) | (roc_9_4h_lt_40))
             # 15m down move, 4h & 1d high
             & ((rsi_3_15m_gt_15) | aroonu_14_4h_lt_80 | aroonu_14_1d_lt_100)
             # 15m down move, 1h & 4h high
@@ -19577,7 +19606,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 4h down move, 15m stil high
             & ((rsi_3_15m_gt_25) | (rsi_3_4h_gt_30) | (stochrsi_k_15m < 40.0))
             # 15m down move, 15m still not low enough, 1d downtrend
-            & ((rsi_3_15m_gt_25) | (aroonu_14_15m < 25.0) | roc_9_1d_gt_neg_50)
+            & ((rsi_3_15m_gt_25) | (aroonu_14_15m_lt_25) | roc_9_1d_gt_neg_50)
             # 15m down move, 15m still high, 4h high
             & ((rsi_3_15m_gt_25) | (aroonu_14_15m_lt_50) | aroonu_14_4h_lt_80)
             # 15m & 1h down move, 1h high
@@ -19601,7 +19630,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 4h still not low enough
             & ((rsi_3_1h_gt_5) | (rsi_3_4h_gt_5) | (stochrsi_k_4h < 30.0))
             # 1h & 4h down move, 4h still not low enough
-            & ((rsi_3_1h_gt_5) | (rsi_3_4h_gt_10) | (aroonu_14_4h < 20.0))
+            & ((rsi_3_1h_gt_5) | (rsi_3_4h_gt_10) | (aroonu_14_4h_lt_20))
             # 1h & 4h down move, 4h downtrend
             & ((rsi_3_1h_gt_5) | (rsi_3_4h_gt_15) | (roc_9_4h_gt_neg_30))
             # 1h & 4h down move, 4h still not low enough
@@ -19613,7 +19642,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 15m high
             & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_10) | (stochrsi_k_15m < 60.0))
             # 1h & 4h down move, 4h still not low enough
-            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_10) | (aroonu_14_4h < 30.0))
+            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_10) | (aroonu_14_4h_lt_30))
             # 1h & 4h down move, 1h downtrend
             & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_10) | (roc_9_1h > -20.0))
             # 1h & 4h down move, 1d downtrend
@@ -19627,9 +19656,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 4h still high
             & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_25) | (stochrsi_k_4h < 40.0))
             # 1h & 4h down move, 1h still not low enough
-            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_35) | (aroonu_14_1h < 30.0))
+            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_35) | (aroonu_14_1h_lt_30))
             # 1h& 1d down move, 1h still high
-            & ((rsi_3_1h_gt_10) | (rsi_3_1d_gt_25) | (aroonu_14_1h < 40.0))
+            & ((rsi_3_1h_gt_10) | (rsi_3_1d_gt_25) | (aroonu_14_1h_lt_40))
             # 1h & 1d down move, 1d high
             & ((rsi_3_1h_gt_10) | (rsi_3_1d_gt_60) | (aroonu_14_1d_lt_80))
             # 1h & 4h down move, 1d high
@@ -19669,7 +19698,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 4h still high, 1d downtrend
             & (rsi_3_1h_gt_20 | (aroonu_14_4h_lt_40) | (roc_9_1d_gt_neg_20))
             # 1h down move, 4h high
-            & (rsi_3_1h_gt_20 | (aroonu_14_4h < 85.0))
+            & (rsi_3_1h_gt_20 | (aroonu_14_4h_lt_85))
             # 1h down move, 1h still not low enough, 4h stil high
             & (rsi_3_1h_gt_20 | (stochrsi_k_1h < 20.0) | (aroonu_14_4h_lt_40))
             # 1h down move, 4h still high, 1d downtrend
@@ -19697,7 +19726,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 1d overbought
             & ((rsi_3_1h_gt_30) | (rsi_3_4h_gt_30) | (roc_9_1d_lt_100))
             # 1h & dh down move, 4h high
-            & ((rsi_3_1h_gt_30) | (rsi_3_4h_gt_50) | (aroonu_14_4h < 85.0))
+            & ((rsi_3_1h_gt_30) | (rsi_3_4h_gt_50) | (aroonu_14_4h_lt_85))
             # 1h down move, 4h & 1d downtrend
             & ((rsi_3_1h_gt_30) | (roc_9_4h > -25.0) | (roc_9_1d > -60.0))
             # 1h down move, 4h & 1h overbought
@@ -19731,9 +19760,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 4h & 1d overbought
             & ((rsi_3_1h_gt_60) | (roc_9_4h_lt_30) | (roc_9_1d_lt_100))
             # 4h & 1d down move, 1d still high
-            & ((rsi_3_4h_gt_5) | (rsi_3_1d_gt_20) | (aroonu_14_1d < 40.0))
+            & ((rsi_3_4h_gt_5) | (rsi_3_1d_gt_20) | (aroonu_14_1d_lt_40))
             # 4h & 1d down move, 4h still not low enough
-            & ((rsi_3_4h_gt_5) | (rsi_3_1d_gt_30) | (aroonu_14_4h < 20.0))
+            & ((rsi_3_4h_gt_5) | (rsi_3_1d_gt_30) | (aroonu_14_4h_lt_20))
             # 4h & 1d down move, 1d high
             & ((rsi_3_4h_gt_5) | (rsi_3_1d_gt_30) | (aroonu_14_1d_lt_70))
             # 4h down move, 1h high, 4h downtrend
@@ -19741,7 +19770,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 4h high
             & ((rsi_3_4h_gt_5) | (aroonu_14_4h_lt_60))
             # 4h & 1d down move, 1d still not low enough
-            & ((rsi_3_4h_gt_10) | (rsi_3_1d_gt_15) | (aroonu_14_1d < 30.0))
+            & ((rsi_3_4h_gt_10) | (rsi_3_1d_gt_15) | (aroonu_14_1d_lt_30))
             # 4h down move, 15m still high
             & ((rsi_3_4h_gt_10) | (stochrsi_k_15m < 40.0))
             # 4h down move, 1d still high, 1d downtrend
@@ -19773,7 +19802,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 4h high, 1d high
             & ((rsi_3_4h_gt_30) | aroonu_14_4h_lt_70 | (stochrsi_k_1d < 80.0))
             # 4h down move, 1d still high, 1d downtrend
-            & ((rsi_3_4h_gt_30) | (aroonu_14_1d < 40.0) | (roc_9_1d_gt_neg_20))
+            & ((rsi_3_4h_gt_30) | (aroonu_14_1d_lt_40) | (roc_9_1d_gt_neg_20))
             # 4h down move, 1d high & overbought
             & ((rsi_3_4h_gt_30) | aroonu_14_1d_lt_100 | (roc_9_1d_lt_20))
             # 4h down move, 4h still not low enough, 1d overbought
@@ -19801,9 +19830,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1d down move, 4h & 1d downtrend
             & ((rsi_3_1d_gt_15) | (roc_9_4h > -10.0) | (roc_9_1d_gt_neg_40))
             # 4h & 1d downtrend, 1d high
-            & ((cmf_20_4h > -0.50) | (cmf_20_1d > -0.50) | (aroonu_14_1d < 85.0))
+            & ((cmf_20_4h > -0.50) | (cmf_20_1d > -0.50) | (aroonu_14_1d_lt_85))
             # 4h still not low enough, 4h & 1d downtrend
-            & ((aroonu_14_4h < 30.0) | (roc_9_4h_gt_neg_20) | (roc_9_1d > -25.0))
+            & ((aroonu_14_4h_lt_30) | (roc_9_4h_gt_neg_20) | (roc_9_1d > -25.0))
             # 4h & 1d high, 4h overbought
             & (aroonu_14_4h_lt_70 | aroonu_14_1d_lt_100 | (roc_9_4h_lt_30))
             # 4h & 1d high, 1d overbought
@@ -19811,7 +19840,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h high, 1h & 4h overbought
             & (aroonu_14_4h_lt_80 | (roc_9_1h < 40.0) | (roc_9_4h_lt_40))
             # 1d high, 4h downtrend, 1d overbought
-            & ((aroonu_14_1d < 85.0) | (roc_9_4h_gt_neg_20) | (roc_9_1d < 200.0))
+            & ((aroonu_14_1d_lt_85) | (roc_9_4h_gt_neg_20) | (roc_9_1d < 200.0))
             # 1d high, 4h & 1d overbought
             & ((aroonu_14_1d_lt_90) | (roc_9_4h_lt_30) | (roc_9_1d < 60.0))
             # 4h high, 1h & 4h overbought
@@ -19825,7 +19854,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # Logic
           long_entry_logic.append(
             (rsi_3 < 40.0)
-            & (aroonu_14 < 30.0)
+            & (aroonu_14_lt_30)
             & (stochrsi_k < 20.0)
             & (stochrsi_k_15m < 70.0)
             & (willr_84_1h < -70.0)
@@ -19843,7 +19872,7 @@ class NostalgiaForInfinityX7(IStrategy):
           long_entry_logic.append(
             (rsi_3_15m_gt_5)
             # 5m & 1h down move, 1h still not low enough
-            & ((rsi_3_gt_3) | (rsi_3_1h_gt_10) | (aroonu_14_1h < 30.0))
+            & ((rsi_3_gt_3) | (rsi_3_1h_gt_10) | (aroonu_14_1h_lt_30))
             # 5m & 1d down move, 1d downtrend
             & ((rsi_3_gt_3) | (rsi_3_1d_gt_15) | (cmf_20_1d > -0.25))
             # 5m down move, 1h high, 4h overbought
@@ -19879,7 +19908,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1d down move, 1d high
             & ((rsi_3_15m_gt_10) | (rsi_3_1d_gt_10) | (aroonu_14_1d_lt_70))
             # 15m & 1d down move, 1d high
-            & ((rsi_3_15m_gt_10) | (rsi_3_1d_gt_20) | (aroonu_14_1d < 75.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_1d_gt_20) | (aroonu_14_1d_lt_75))
             # 15m down move, 15m still high, 4h high
             & ((rsi_3_15m_gt_10) | (aroonu_14_15m_lt_50) | aroonu_14_4h_lt_80)
             # 15m down move, 1h still high, 1d overbought
@@ -19895,11 +19924,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 1h high
             & ((rsi_3_15m_gt_15) | (rsi_3_1h_gt_25) | aroonu_14_1h_lt_70)
             # 15m & 4h down move, 15m still high
-            & ((rsi_3_15m_gt_15) | (rsi_3_4h_gt_25) | (aroonu_14_15m < 40.0))
+            & ((rsi_3_15m_gt_15) | (rsi_3_4h_gt_25) | (aroonu_14_15m_lt_40))
             # 15m & 4h down move, 1d high
             & ((rsi_3_15m_gt_15) | (rsi_3_4h_gt_35) | (stochrsi_k_1d_lt_90))
             # 15m & 4h down move, 15m high
-            & ((rsi_3_15m_gt_15) | (rsi_3_4h_gt_35) | (aroonu_14_15m < 60.0))
+            & ((rsi_3_15m_gt_15) | (rsi_3_4h_gt_35) | (aroonu_14_15m_lt_60))
             # 15m & 4h down move, 4h high
             & ((rsi_3_15m_gt_15) | (rsi_3_4h_gt_35) | (aroonu_14_4h_lt_60))
             # 15m & 1d down move, 4h high
@@ -19909,7 +19938,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 4h high, 4h downtrend
             & ((rsi_3_15m_gt_15) | (aroonu_14_4h_lt_60) | (roc_9_4h_gt_neg_20))
             # 15m down move, 4h & 1d high
-            & ((rsi_3_15m_gt_15) | (aroonu_14_4h < 75.0) | aroonu_14_1d_lt_100)
+            & ((rsi_3_15m_gt_15) | (aroonu_14_4h_lt_75) | aroonu_14_1d_lt_100)
             # 15m down move, 15m still not low enough, 1h still high
             & ((rsi_3_15m_gt_15) | (stochrsi_k_15m < 30.0) | (stochrsi_k_1h_lt_50))
             # 15m down move, 4h & 1d overbought
@@ -19917,9 +19946,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 1h high
             & ((rsi_3_15m_gt_20) | rsi_3_1h_gt_20 | (stochrsi_k_1h_lt_70))
             # 15m & 4h down move, 4h high
-            & ((rsi_3_15m_gt_20) | (rsi_3_4h_gt_50) | (aroonu_14_4h < 85.0))
+            & ((rsi_3_15m_gt_20) | (rsi_3_4h_gt_50) | (aroonu_14_4h_lt_85))
             # 15m down move, 1h high
-            & ((rsi_3_15m_gt_20) | (aroonu_14_1h < 75.0))
+            & ((rsi_3_15m_gt_20) | (aroonu_14_1h_lt_75))
             # 15m down move, 1d high & overbought
             & ((rsi_3_15m_gt_20) | (aroonu_14_1d_lt_90) | (roc_9_1d_lt_80))
             # 15m down move, 15m high, 4h downtrend
@@ -19945,9 +19974,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 15m still high, 1d high
             & ((rsi_3_15m_gt_30) | (aroonu_14_15m_lt_50) | (stochrsi_k_1d < 70.0))
             # 15m down move, 15m high, 4h high
-            & ((rsi_3_15m_gt_30) | (aroonu_14_15m < 60.0) | (stochrsi_k_4h_lt_70))
+            & ((rsi_3_15m_gt_30) | (aroonu_14_15m_lt_60) | (stochrsi_k_4h_lt_70))
             # 15m down move, 4h high, 1h downtrend
-            & ((rsi_3_15m_gt_30) | (aroonu_14_4h < 85.0) | (roc_9_1h > -40.0))
+            & ((rsi_3_15m_gt_30) | (aroonu_14_4h_lt_85) | (roc_9_1h > -40.0))
             # 15m down move, 4h high
             & ((rsi_3_15m_gt_30) | (stochrsi_k_4h_lt_90))
             # 15m & 1h down move, 15m high
@@ -19955,15 +19984,15 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 4h down move, 4h high
             & ((rsi_3_15m_gt_35) | (rsi_3_4h_gt_35) | (stochrsi_k_4h_lt_80))
             # 15m down move, 15m still high, 4h overbought
-            & ((rsi_3_15m_gt_35) | (aroonu_14_15m < 40.0) | (roc_9_4h_lt_20))
+            & ((rsi_3_15m_gt_35) | (aroonu_14_15m_lt_40) | (roc_9_4h_lt_20))
             # 15m down move, 15m still high, 1d overbought
-            & ((rsi_3_15m_gt_35) | (aroonu_14_15m < 40.0) | (roc_9_1d_lt_30))
+            & ((rsi_3_15m_gt_35) | (aroonu_14_15m_lt_40) | (roc_9_1d_lt_30))
             # 15m down move, 4h high & overbought
             & ((rsi_3_15m_gt_35) | (aroonu_14_4h_lt_60) | (roc_9_4h_lt_20))
             # 15m down move, 4h high & overbought
             & ((rsi_3_15m_gt_35) | (stochrsi_k_4h_lt_70) | (roc_9_4h_lt_20))
             # 15m still high, 4h high
-            & ((rsi_3_15m < 40.0) | (aroonu_14_4h < 85.0))
+            & ((rsi_3_15m < 40.0) | (aroonu_14_4h_lt_85))
             # 1h & 4h down move, 4h still not low enough
             & ((rsi_3_1h > 2.0) | (rsi_3_4h_gt_15) | (rsi_14_4h < 30.0))
             # 1h & 4h down move, 15m still not low enough
@@ -19983,9 +20012,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 1d down move, 1h downtrend
             & ((rsi_3_1h_gt_3) | (rsi_3_1d_gt_15) | (roc_9_1h > -40.0))
             # 1h down move, 15m downtrend, 1h still high
-            & ((rsi_3_1h_gt_3) | (cmf_20_15m > -0.40) | (aroonu_14_1h < 40.0))
+            & ((rsi_3_1h_gt_3) | (cmf_20_15m > -0.40) | (aroonu_14_1h_lt_40))
             # 1h down move, 15m still not low enough, 4h still high
-            & ((rsi_3_1h_gt_3) | (aroonu_14_15m < 30.0) | (stochrsi_k_4h < 40.0))
+            & ((rsi_3_1h_gt_3) | (aroonu_14_15m_lt_30) | (stochrsi_k_4h < 40.0))
             # 1h down move, 1h still not low enough
             & ((rsi_3_1h_gt_3) | (stochrsi_k_1h < 30.0))
             # 1h down move, 4h still high, 1d downtrend
@@ -19995,13 +20024,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 1d high
             & ((rsi_3_1h_gt_5) | (rsi_3_4h_gt_5) | (stochrsi_k_1d < 60.0))
             # 1h & 4h down move, 4h still not low enough
-            & ((rsi_3_1h_gt_5) | (rsi_3_4h_gt_10) | (aroonu_14_4h < 20.0))
+            & ((rsi_3_1h_gt_5) | (rsi_3_4h_gt_10) | (aroonu_14_4h_lt_20))
             # 1h & 4h down move, 4h downtrend
             & ((rsi_3_1h_gt_5) | (rsi_3_4h_gt_10) | (roc_9_4h > -20.0))
             # 1h & 4h down move, 4h still not low enough
-            & ((rsi_3_1h_gt_5) | (rsi_3_4h_gt_15) | (aroonu_14_4h < 30.0))
+            & ((rsi_3_1h_gt_5) | (rsi_3_4h_gt_15) | (aroonu_14_4h_lt_30))
             # 15m & 4h down move, 4h still not low enough, 15m still not low enough
-            & ((rsi_3_1h_gt_5) | (rsi_3_4h_gt_20) | (aroonu_14_4h < 20.0) | (stochrsi_k_15m < 20.0))
+            & ((rsi_3_1h_gt_5) | (rsi_3_4h_gt_20) | (aroonu_14_4h_lt_20) | (stochrsi_k_15m < 20.0))
             # 1h & 4h down move, 4h still high
             & ((rsi_3_1h_gt_5) | (rsi_3_4h_gt_35) | (rsi_14_4h < 40.0))
             # 1h down move, 1d high, 4h downtrend
@@ -20013,11 +20042,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 4h still not low enough
             & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_10) | (rsi_14_4h < 30.0))
             # 1h & 4h down move, 4h still not low enough
-            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_10) | (aroonu_14_4h < 30.0))
+            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_10) | (aroonu_14_4h_lt_30))
             # 1h & 4h down move, 15m still high
             & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_10) | (stochrsi_k_15m < 50.0))
             # 1h & 4h down move, 15m still not low enough
-            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_15) | (aroonu_14_15m < 30.0))
+            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_15) | (aroonu_14_15m_lt_30))
             # 1h & 4h down move, 1h still not low enough
             & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_15) | (stochrsi_k_1h < 20.0))
             # 1h & 4h down move, 1d high
@@ -20035,7 +20064,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 1d downtrend, 1d overbought
             & ((rsi_3_1h_gt_10) | (rsi_3_1d_gt_45) | (roc_9_1d < 10.0))
             # 1h down move, 1h downtrend, 1h still not low enough
-            & ((rsi_3_1h_gt_10) | (cmf_20_1h > -0.20) | (aroonu_14_1h < 30.0))
+            & ((rsi_3_1h_gt_10) | (cmf_20_1h > -0.20) | (aroonu_14_1h_lt_30))
             # 1h down move, 1h downtrend, 1h still not low enough
             & ((rsi_3_1h_gt_10) | (cmf_20_1h > -0.20) | (stochrsi_k_1h < 30.0))
             # 1h down move, 1h downtrend
@@ -20069,7 +20098,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 1d high
             & (rsi_3_1h_gt_20 | (rsi_3_4h_gt_25) | (aroonu_14_1d_lt_80))
             # 1h & 4h down move, 1h high
-            & (rsi_3_1h_gt_20 | (rsi_3_4h_gt_45) | (aroonu_14_1h < 60.0))
+            & (rsi_3_1h_gt_20 | (rsi_3_4h_gt_45) | (aroonu_14_1h_lt_60))
             # 1h & 1d down move, 1d high & overbought
             & (rsi_3_1h_gt_20 | (rsi_3_1d_gt_55) | (aroonu_14_1d_lt_90) | (roc_9_1d < 20.0))
             # 1h down move, 1h high, 1d overbought
@@ -20083,7 +20112,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h & 1d high
             & ((rsi_3_1h_gt_25) | (aroonu_14_1h_lt_70) | (aroonu_14_1d_lt_90))
             # 1h & 4h down move, 4h high
-            & ((rsi_3_1h_gt_25) | (rsi_3_4h_gt_50) | (aroonu_14_4h < 85.0))
+            & ((rsi_3_1h_gt_25) | (rsi_3_4h_gt_50) | (aroonu_14_4h_lt_85))
             # 1h & 4h down move, 1d overbought
             & ((rsi_3_1h_gt_25) | (rsi_3_4h_gt_50) | (roc_9_1d_lt_100))
             # 1h down move, 1h still not low enough, 4h still high
@@ -20091,7 +20120,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 4h high, 1d downtrend
             & ((rsi_3_1h_gt_25) | (stochrsi_k_4h_lt_80) | (roc_9_1d_gt_neg_40))
             # 1h down move, 1h still high, 1h downtrend
-            & ((rsi_3_1h_gt_25) | (aroonu_14_1h < 40.0) | (roc_9_1h > -50.0))
+            & ((rsi_3_1h_gt_25) | (aroonu_14_1h_lt_40) | (roc_9_1h > -50.0))
             # 1h down move, 4h high & overbought
             & ((rsi_3_1h_gt_25) | (aroonu_14_4h_lt_90) | (roc_9_4h_lt_20))
             # 1h down move, 1h still high, 1d overbought
@@ -20133,7 +20162,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h high, 1d downtrend
             & ((rsi_3_1h_gt_35) | aroonu_14_1h_lt_70 | (roc_9_1d > -25.0))
             # 1h down move, 4h high & overbought
-            & ((rsi_3_1h_gt_35) | (aroonu_14_4h < 85.0) | (roc_9_4h < 100.0))
+            & ((rsi_3_1h_gt_35) | (aroonu_14_4h_lt_85) | (roc_9_4h < 100.0))
             # 1h down move, 4h high & overbought
             & ((rsi_3_1h_gt_35) | aroonu_14_4h_lt_100 | (roc_9_4h < 20.0))
             # 1h down move, 4h high & overbought
@@ -20145,7 +20174,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1d high & overbought
             & ((rsi_3_1h_gt_40) | (rsi_14_1d < 80.0) | (roc_9_1d < 150.0))
             # 1h down move, 15m high, 1h high
-            & ((rsi_3_1h_gt_40) | (aroonu_14_15m < 60.0) | aroonu_14_1h_lt_70)
+            & ((rsi_3_1h_gt_40) | (aroonu_14_15m_lt_60) | aroonu_14_1h_lt_70)
             # 1h down move, 1h high, 1d overbought
             & ((rsi_3_1h_gt_40) | aroonu_14_1h_lt_80 | (roc_9_1d_lt_80))
             # 1h down move, 1h high, 4h overbought
@@ -20165,7 +20194,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 4h high, 1d downtrend
             & ((rsi_3_1h_gt_50) | (stochrsi_k_4h < 60.0) | (roc_9_1d > -60.0))
             # 1h down move, 15m high, 1h high
-            & ((rsi_3_1h_gt_55) | (aroonu_14_15m < 60.0) | (stochrsi_k_1h_lt_80))
+            & ((rsi_3_1h_gt_55) | (aroonu_14_15m_lt_60) | (stochrsi_k_1h_lt_80))
             # 1h down move, 1h high & overbought
             & ((rsi_3_1h_gt_55) | (aroonu_14_1h_lt_90) | (roc_9_1h_lt_10))
             # 4h down move, 1h still not low enough, 4h downtrend
@@ -20181,9 +20210,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h & 1d down move, 1d overbought
             & ((rsi_3_4h_gt_10) | (rsi_3_1d_gt_45) | (roc_9_1d < 10.0))
             # 4h down move, 1d still high, 1d downtrend
-            & ((rsi_3_4h_gt_10) | (aroonu_14_1d < 50.0) | (roc_9_1d > -30.0))
+            & ((rsi_3_4h_gt_10) | (aroonu_14_1d_lt_50) | (roc_9_1d > -30.0))
             # 4h down move, 1d high, 4h downtrend
-            & ((rsi_3_4h_gt_10) | (aroonu_14_1d < 85.0) | (roc_9_4h > -20.0))
+            & ((rsi_3_4h_gt_10) | (aroonu_14_1d_lt_85) | (roc_9_4h > -20.0))
             # 4h down move, 15m high, 15m downtrend
             & ((rsi_3_4h_gt_10) | (stochrsi_k_15m < 60.0) | (roc_9_15m > -10.0))
             # 4h down move, 1h still high, 1d downtrend
@@ -20195,7 +20224,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 4h downtrend, 1d overbought
             & ((rsi_3_4h_gt_10) | (roc_9_4h_gt_neg_30) | (roc_9_1d_lt_40))
             # 4h & 1d down move, 1d high
-            & ((rsi_3_4h_gt_15) | (rsi_3_1d_gt_20) | (aroonu_14_1d < 60.0))
+            & ((rsi_3_4h_gt_15) | (rsi_3_1d_gt_20) | (aroonu_14_1d_lt_60))
             # 4h & 1d down move, 1d high
             & ((rsi_3_4h_gt_15) | (rsi_3_1d_gt_40) | (aroonu_14_1d_lt_80))
             # 4h down move, 1h high
@@ -20207,13 +20236,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 15m still high
             & (rsi_3_4h_gt_20 | (aroonu_14_15m < 45.0))
             # 4h down move, 1h still not low enough, 1d downtrend
-            & (rsi_3_4h_gt_20 | (aroonu_14_1h < 30.0) | (roc_9_1d_gt_neg_20))
+            & (rsi_3_4h_gt_20 | (aroonu_14_1h_lt_30) | (roc_9_1d_gt_neg_20))
             # 4h down move, 4h still high, 1d high
             & (rsi_3_4h_gt_20 | (aroonu_14_4h_lt_50) | aroonu_14_1d_lt_100)
             # 4h down move, 1d high & overbought
             & (rsi_3_4h_gt_20 | (aroonu_14_1d_lt_80) | (roc_9_1d_lt_80))
             # 4h down move, 15m still high, 4h high
-            & ((rsi_3_4h_gt_25) | (aroonu_14_15m < 40.0) | aroonu_14_4h_lt_70)
+            & ((rsi_3_4h_gt_25) | (aroonu_14_15m_lt_40) | aroonu_14_4h_lt_70)
             # 4h down move, 1h & 4h still high
             & ((rsi_3_4h_gt_25) | (stochrsi_k_1h < 40.0) | (stochrsi_k_4h < 40.0))
             # 4h dowqn move, 4h still high, 1d downtrend
@@ -20253,21 +20282,21 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h & 1d downtrend, 1d high
             & ((cmf_20_4h > -0.30) | (cmf_20_1d > -0.30) | (stochrsi_k_1d < 60.0))
             # 1d downtrend, 1d high & overbought
-            & ((cmf_20_1d > -0.30) | (aroonu_14_1d < 85.0) | (roc_9_1d_lt_100))
+            & ((cmf_20_1d > -0.30) | (aroonu_14_1d_lt_85) | (roc_9_1d_lt_100))
             # 1d downtrend, 1d high & overbought
-            & ((cmf_20_1d > -0.40) | (aroonu_14_1d < 85.0) | (roc_9_1d_lt_20))
+            & ((cmf_20_1d > -0.40) | (aroonu_14_1d_lt_85) | (roc_9_1d_lt_20))
             # 15m still high, 1h overbought
-            & ((aroonu_14_15m < 40.0) | (roc_9_1h < 40.0))
+            & ((aroonu_14_15m_lt_40) | (roc_9_1h < 40.0))
             # 15m still high, 4h overbought
-            & ((aroonu_14_15m < 40.0) | (roc_9_4h < 80.0))
+            & ((aroonu_14_15m_lt_40) | (roc_9_4h < 80.0))
             # 15m still high, 1h high
-            & ((aroonu_14_15m_lt_50) | (aroonu_14_1h < 85.0))
+            & ((aroonu_14_15m_lt_50) | (aroonu_14_1h_lt_85))
             # 15m still high, 4h high & overbought
             & ((aroonu_14_15m_lt_50) | aroonu_14_4h_lt_70 | (roc_9_4h_lt_30))
             # 15m still high, 4h downtrend, 1d overbought
             & ((aroonu_14_15m_lt_50) | (roc_9_4h_gt_neg_20) | (roc_9_1d_lt_40))
             # 1h still high, 4h & 1d downtrend
-            & ((aroonu_14_1h < 40.0) | (roc_9_4h_gt_neg_20) | (roc_9_1d_gt_neg_40))
+            & ((aroonu_14_1h_lt_40) | (roc_9_4h_gt_neg_20) | (roc_9_1d_gt_neg_40))
             # 1h high, 4h high, 1h overbought
             & (aroonu_14_1h_lt_70 | aroonu_14_4h_lt_100 | (roc_9_1h < 20.0))
             # 1h & 4h high, 4h overbought
@@ -20279,7 +20308,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h high, 1d downtrend
             & (aroonu_14_1h_lt_80 | (roc_9_1d_gt_neg_40))
             # 4h still not low enough, 4h & 1d downtrend
-            & ((aroonu_14_4h < 30.0) | (roc_9_4h_gt_neg_20) | (roc_9_1d > -25.0))
+            & ((aroonu_14_4h_lt_30) | (roc_9_4h_gt_neg_20) | (roc_9_1d > -25.0))
             # 4h still high, 1d high, 4h downtrend
             & ((aroonu_14_4h_lt_50) | aroonu_14_1d_lt_100 | (roc_9_4h_gt_neg_30))
             # 4h high, 1h & 1d downtrend
@@ -20293,9 +20322,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1d high, 4h & 1d downtrend
             & ((aroonu_14_1d_lt_80) | (roc_9_4h_gt_neg_20) | (roc_9_1d_gt_neg_20))
             # 1d high, 1h & 4h downtrend
-            & ((aroonu_14_1d < 85.0) | (roc_9_1h > -30.0) | (roc_9_4h > -50.0))
+            & ((aroonu_14_1d_lt_85) | (roc_9_1h > -30.0) | (roc_9_4h > -50.0))
             # 1d high, 1h & 1d overbought
-            & ((aroonu_14_1d < 85.0) | (roc_9_1h < 20.0) | (roc_9_1d_lt_100))
+            & ((aroonu_14_1d_lt_85) | (roc_9_1h < 20.0) | (roc_9_1d_lt_100))
             # 1d high, 1h & 4h down move
             & (aroonu_14_1d_lt_100 | (roc_9_1h < 25.0) | (roc_9_4h < 60.0))
             # 1d high, 4h & 1d overbought
@@ -20334,7 +20363,7 @@ class NostalgiaForInfinityX7(IStrategy):
           long_entry_logic.append(
             (rsi_3 > 0.0)
             & (rsi_3 < 50.0)
-            & (aroonu_14 < 25.0)
+            & (aroonu_14_lt_25)
             & (ema_26 > ema_12)
             & ((ema_26 - ema_12) > (open_rate * 0.022))
             & ((ema_26.shift() - ema_12.shift()) > (open_rate / 100.0))
@@ -20359,19 +20388,19 @@ class NostalgiaForInfinityX7(IStrategy):
             # 5 & 15m down move, 1h high
             & ((rsi_3_gt_10) | (rsi_3_15m_gt_40) | (stochrsi_k_1h < 90.0))
             # 5m down move, 1h & 4h high
-            & ((rsi_3_gt_10) | (aroonu_14_1h < 85.0) | (aroonu_14_4h_lt_90))
+            & ((rsi_3_gt_10) | (aroonu_14_1h_lt_85) | (aroonu_14_4h_lt_90))
             # 15m & 1h & 4h & 1d down move, 1d still high
             & ((rsi_3_15m_gt_3) | (rsi_3_1h_gt_3) | (rsi_3_4h_gt_15) | (rsi_3_1d_gt_50) | (rsi_14_1d < 40.0))
             # 15m & 1h down move, 4h still not low enough
             & ((rsi_3_15m_gt_3) | (rsi_3_1h_gt_5) | (stochrsi_k_4h < 30.0))
             # 15m & 1h down move, 1d still high
-            & ((rsi_3_15m_gt_3) | (rsi_3_1h_gt_5) | (aroonu_14_1d < 40.0))
+            & ((rsi_3_15m_gt_3) | (rsi_3_1h_gt_5) | (aroonu_14_1d_lt_40))
             # 15m & 1h & 4h down move, 4h still not low enough, 1d still high
-            & ((rsi_3_15m_gt_3) | (rsi_3_1h_gt_10) | (rsi_3_4h_gt_20) | (aroonu_14_4h < 20.0) | (rsi_14_1d < 50.0))
+            & ((rsi_3_15m_gt_3) | (rsi_3_1h_gt_10) | (rsi_3_4h_gt_20) | (aroonu_14_4h_lt_20) | (rsi_14_1d < 50.0))
             # 15m & 1h down move, 4h still high
             & ((rsi_3_15m_gt_3) | (rsi_3_1h_gt_15) | (rsi_14_4h < 40.0))
             # 15m & 4h down move, 4h high
-            & ((rsi_3_15m_gt_3) | (rsi_3_1h_gt_30) | (aroonu_14_4h < 75.0))
+            & ((rsi_3_15m_gt_3) | (rsi_3_1h_gt_30) | (aroonu_14_4h_lt_75))
             # 15m & 1h down move, 1h still not low enough
             & ((rsi_3_15m_gt_3) | (rsi_3_1h_gt_35) | (stochrsi_k_1h < 30.0))
             # 15m & 4h down move, 4h still not low enough
@@ -20379,13 +20408,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 4h down move, 1d downtrend
             & ((rsi_3_15m_gt_3) | (rsi_3_4h_gt_10) | (roc_9_1d > -20.0))
             # 15m & 4h down move, 4h still not low enough
-            & ((rsi_3_15m_gt_3) | (rsi_3_4h_gt_25) | (aroonu_14_4h < 30.0))
+            & ((rsi_3_15m_gt_3) | (rsi_3_4h_gt_25) | (aroonu_14_4h_lt_30))
             # 15m & 4h down move, 4h still not low enough
             & ((rsi_3_15m_gt_3) | (rsi_3_4h_gt_25) | (stochrsi_k_4h < 30.0))
             # 15m down move, 15m still not low enough, 1h high
-            & ((rsi_3_15m_gt_3) | (aroonu_14_15m < 20.0) | (stochrsi_k_1h < 60.0))
+            & ((rsi_3_15m_gt_3) | (aroonu_14_15m_lt_20) | (stochrsi_k_1h < 60.0))
             # 15m down move, 15m still not low enough, 4h high
-            & ((rsi_3_15m_gt_3) | (aroonu_14_15m < 30.0) | (stochrsi_k_4h_lt_70))
+            & ((rsi_3_15m_gt_3) | (aroonu_14_15m_lt_30) | (stochrsi_k_4h_lt_70))
             # 15m down move, 4h high, 1d overbought
             & ((rsi_3_15m_gt_3) | aroonu_14_4h_lt_70 | (roc_9_1d_lt_30))
             # 15m & 1h & 1d down move
@@ -20421,7 +20450,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h & 4h down move, 1d high
             & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_25) | (rsi_3_4h_gt_25) | (stochrsi_k_1d < 70.0))
             # 15m & 1h down move, 1h still not low enough
-            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_25) | (aroonu_14_1h < 25.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_25) | (aroonu_14_1h_lt_25))
             # 15m & 1h down move, 1h still high
             & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_30) | (stochrsi_k_1h < 40.0))
             # 15m & 1h down move, 4h still high
@@ -20437,7 +20466,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 4h down move, 1d downtrend
             & ((rsi_3_15m_gt_10) | rsi_3_4h_gt_20 | (roc_9_1d > -25.0))
             # 15m & 4h down move, 1d high
-            & ((rsi_3_15m_gt_10) | (rsi_3_4h_gt_25) | (aroonu_14_1d < 85.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_4h_gt_25) | (aroonu_14_1d_lt_85))
             # 15m & 4h down move, 1h still high
             & ((rsi_3_15m_gt_10) | (rsi_3_4h_gt_30) | (stochrsi_k_1h_lt_50))
             # 15m & 4h down move, 4h high
@@ -20445,9 +20474,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1d down move, 1h still high
             & ((rsi_3_15m_gt_10) | (rsi_3_1d_gt_25) | (stochrsi_k_1h_lt_50))
             # 15m down move, 15m still not low enough, 1h still high
-            & ((rsi_3_15m_gt_10) | (aroonu_14_15m < 30.0) | (stochrsi_k_1h_lt_50))
+            & ((rsi_3_15m_gt_10) | (aroonu_14_15m_lt_30) | (stochrsi_k_1h_lt_50))
             # 15m down move, 1h still high, 4h high
-            & ((rsi_3_15m_gt_10) | (stochrsi_k_1h_lt_50) | (aroonu_14_4h < 85.0))
+            & ((rsi_3_15m_gt_10) | (stochrsi_k_1h_lt_50) | (aroonu_14_4h_lt_85))
             # 15m down move, 1h & 4h high
             & ((rsi_3_15m_gt_10) | (stochrsi_k_1h_lt_70) | (stochrsi_k_4h < 75.0))
             # 15m & 1h down move, 15m still not low enough
@@ -20467,17 +20496,17 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 4h down move, 1h still high
             & ((rsi_3_15m_gt_15) | rsi_3_4h_gt_20 | (stochrsi_k_1h_lt_50))
             # 15m & 4h down move, 15m still not low enough
-            & ((rsi_3_15m_gt_15) | (rsi_3_4h_gt_25) | (aroonu_14_15m < 30.0))
+            & ((rsi_3_15m_gt_15) | (rsi_3_4h_gt_25) | (aroonu_14_15m_lt_30))
             # 15m & 4h down move, 4h still high
             & ((rsi_3_15m_gt_15) | (rsi_3_4h_gt_50) | (aroonu_14_4h_lt_50))
             # 1h & 1d down move, 1d overbought
             & ((rsi_3_1h_gt_15) | (rsi_3_1d_gt_35) | (roc_9_1d < 10.0))
             # 15m down move, 15m still not low enough, 1h high
-            & ((rsi_3_15m_gt_15) | (aroonu_14_15m < 25.0) | (stochrsi_k_1h_lt_80))
+            & ((rsi_3_15m_gt_15) | (aroonu_14_15m_lt_25) | (stochrsi_k_1h_lt_80))
             # 15m down move, 4h high & overbought
             & ((rsi_3_15m_gt_15) | (aroonu_14_4h_lt_80) | (roc_9_4h_lt_40))
             # 15m down move, 1h & 4h high
-            & ((rsi_3_15m_gt_15) | (stochrsi_k_1h_lt_70) | (aroonu_14_4h < 85.0))
+            & ((rsi_3_15m_gt_15) | (stochrsi_k_1h_lt_70) | (aroonu_14_4h_lt_85))
             # 15m & 1h down move, 4h high
             & ((rsi_3_15m_gt_20) | (rsi_3_1h_gt_30) | (stochrsi_k_4h_lt_90))
             # 15m & 1d down move, 1h high
@@ -20491,9 +20520,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 1h high
             & ((rsi_3_15m_gt_25) | (rsi_3_1h_gt_25) | (stochrsi_k_1h < 60.0))
             # 15m & 1h down move, 1h high
-            & ((rsi_3_15m_gt_25) | (rsi_3_1h_gt_60) | (aroonu_14_1h < 85.0))
+            & ((rsi_3_15m_gt_25) | (rsi_3_1h_gt_60) | (aroonu_14_1h_lt_85))
             # 15m down move, 15m still not low enough, 4h high
-            & ((rsi_3_15m_gt_25) | (aroonu_14_15m < 25.0) | (aroonu_14_4h_lt_60))
+            & ((rsi_3_15m_gt_25) | (aroonu_14_15m_lt_25) | (aroonu_14_4h_lt_60))
             # 15m down move, 15m still not low enough, 1h high
             & ((rsi_3_15m_gt_25) | (stochrsi_k_15m < 30.0) | aroonu_14_1h_lt_80)
             # 15m & 1h down move, 1h high
@@ -20513,7 +20542,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 1d low
             & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_10) | (cmf_20_1d > -0.2))
             # 1h & 4h down move, 4h still not low enough
-            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_15) | (aroonu_14_4h < 20.0))
+            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_15) | (aroonu_14_4h_lt_20))
             # 1h & 4h down move, 4h still not low enough
             & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_25) | (stochrsi_k_4h < 30.0))
             # 1h & 1d down move, 5m moving down
@@ -20529,7 +20558,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 1h still not low enough
             & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_40) | (stochrsi_k_1h < 30.0))
             # 1h & 4h down move, 1h still high
-            & ((rsi_3_1h_gt_15) | (rsi_3_1d_gt_10) | (aroonu_14_1h < 40.0))
+            & ((rsi_3_1h_gt_15) | (rsi_3_1d_gt_10) | (aroonu_14_1h_lt_40))
             # 1h down move, 1d high & overbought
             & (rsi_3_1h_gt_20 | (aroonu_14_1d_lt_90) | (roc_9_1d_lt_30))
             # 1h down move, 1h still not low enough, 4h high
@@ -20561,7 +20590,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 15m still high
             & ((rsi_3_4h_gt_5) | (stochrsi_k_15m < 40.0))
             # 4h down move, 1d still high, 1d downtrend
-            & ((rsi_3_4h_gt_10) | (aroonu_14_1d < 40.0) | (roc_9_1d > -20.0))
+            & ((rsi_3_4h_gt_10) | (aroonu_14_1d_lt_40) | (roc_9_1d > -20.0))
             # 4h down move, 15m 4h still high
             & ((rsi_3_4h_gt_10) | (stochrsi_k_15m < 40.0) | (aroonu_14_4h_lt_50))
             # 4h & 1d down move, 4h high
@@ -20589,7 +20618,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 4h overbought
             & ((rsi_3_4h_gt_60) | (roc_9_4h_lt_20))
             # 1d down move, 1h still high, 4h high
-            & ((rsi_3_1d_gt_20) | (aroonu_14_1h_lt_50) | (aroonu_14_4h < 85.0))
+            & ((rsi_3_1d_gt_20) | (aroonu_14_1h_lt_50) | (aroonu_14_4h_lt_85))
             # 1d down move, 1h high & overbought
             & ((rsi_3_1d_gt_35) | (stochrsi_k_1h < 90.0) | (roc_9_1h_lt_10))
             # 1d down move, 4h high, 1d overbought
@@ -20599,7 +20628,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h high, 1d downtrend
             & ((aroonu_14_1d_lt_70) | (roc_9_1d_gt_neg_30))
             # 1d high, 4h & 1d overbought
-            & ((aroonu_14_1d < 85.0) | (roc_9_4h < 60.0) | (roc_9_1d < 60.0))
+            & ((aroonu_14_1d_lt_85) | (roc_9_4h < 60.0) | (roc_9_1d < 60.0))
             # 1d high, 4h & 1d overbought
             & (aroonu_14_1d_lt_100 | (roc_9_4h_lt_10) | (roc_9_1d_lt_20))
             # 1h high, 4h downtrend
@@ -20650,7 +20679,7 @@ class NostalgiaForInfinityX7(IStrategy):
           long_entry_logic.append(
             (rsi_3_gt_3)
             & (rsi_14 < 36.0)
-            & (aroonu_14 < 25.0)
+            & (aroonu_14_lt_25)
             & (stochrsi_k < 20.0)
             & (close < (sma_16 * 0.946))
             & (aroonu_14_15m_lt_50)
@@ -20670,7 +20699,7 @@ class NostalgiaForInfinityX7(IStrategy):
           long_entry_logic.append(
             ((rsi_3_gt_3) | (rsi_3_15m_gt_15) | (stochrsi_k_4h_lt_50))
             # 5m & 15m down move, 15m still high
-            & ((rsi_3_gt_3) | (rsi_3_15m_gt_20) | (aroonu_14_15m < 40.0))
+            & ((rsi_3_gt_3) | (rsi_3_15m_gt_20) | (aroonu_14_15m_lt_40))
             # 5m & 15m down move, 1h still high
             & ((rsi_3_gt_3) | (rsi_3_15m_gt_25) | (stochrsi_k_1h < 40.0))
             # 5m & 1h down move, 4h still high
@@ -20682,7 +20711,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 5m down move, 15m high
             & ((rsi_3_gt_3) | (aroonu_14_15m_lt_70))
             # 5m down move, 15m & 1h still high
-            & ((rsi_3_gt_3) | (stochrsi_k_15m < 40.0) | (aroonu_14_1h < 40.0))
+            & ((rsi_3_gt_3) | (stochrsi_k_15m < 40.0) | (aroonu_14_1h_lt_40))
             # 5m down move, 1h high
             & ((rsi_3_gt_3) | aroonu_14_1h_lt_70 | (stochrsi_k_1h < 50.0))
             # 5m & 1h down move, 1h high
@@ -20692,7 +20721,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 5m down move, 15m still high, 1h high
             & ((rsi_3_gt_5) | (rsi_14_15m < 40.0) | aroonu_14_1h_lt_80)
             # 5m down move, 15m still high, 1h high
-            & ((rsi_3_gt_5) | (aroonu_14_15m < 40.0) | (stochrsi_k_1h_lt_50))
+            & ((rsi_3_gt_5) | (aroonu_14_15m_lt_40) | (stochrsi_k_1h_lt_50))
             # 5m down move, 15m & 4h high
             & ((rsi_3_gt_5) | (stochrsi_k_15m < 70.0) | (stochrsi_k_4h_lt_90))
             # 5m & 15m down move, 4h high
@@ -20704,7 +20733,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 5m & 1h down move, 4h still high
             & ((rsi_3_gt_10) | (rsi_3_1h_gt_30) | (stochrsi_k_4h_lt_50))
             # 5m down move, 1h & 4h high
-            & ((rsi_3_gt_10) | (aroonu_14_1h < 85.0) | (aroonu_14_4h_lt_90))
+            & ((rsi_3_gt_10) | (aroonu_14_1h_lt_85) | (aroonu_14_4h_lt_90))
             # 5m down move, 4h high, 1d high
             & ((rsi_3_gt_10) | (aroonu_14_4h_lt_60) | (stochrsi_k_1d_lt_90))
             # 5m down move, 15m still high, 1h high
@@ -20712,7 +20741,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 5m down move, 15m still high, 4h high
             & ((rsi_3_gt_15) | (rsi_14_15m < 40.0) | (stochrsi_k_4h_lt_90))
             # 15m down move, 15m still not low enough, 1h high
-            & (rsi_3_15m_gt_3 | (aroonu_14_15m < 20.0) | (stochrsi_k_1h < 60.0))
+            & (rsi_3_15m_gt_3 | (aroonu_14_15m_lt_20) | (stochrsi_k_1h < 60.0))
             # 15m & 1h down move, 1d high
             & ((rsi_3_15m_gt_10) | rsi_3_1h_gt_20 | (aroonu_14_1d_lt_70))
             # 15m & 1h down move, 1h still not low enough
@@ -20720,7 +20749,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h & 4h down move, 1d high
             & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_25) | (rsi_3_4h_gt_25) | (stochrsi_k_1d < 70.0))
             # 15m & 1h down move, 1h still not low enough
-            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_25) | (aroonu_14_1h < 30.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_25) | (aroonu_14_1h_lt_30))
             # 15m & 1h down move, 1h still high
             & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_35) | (aroonu_14_1h_lt_50))
             # 15m & 1h down move, 1h still high
@@ -20728,7 +20757,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 4h still high
             & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_35) | aroonu_14_4h_lt_70)
             # 15m & 4h down move, 4h still not low enough
-            & ((rsi_3_15m_gt_10) | (rsi_3_4h_gt_15) | (aroonu_14_4h < 30.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_4h_gt_15) | (aroonu_14_4h_lt_30))
             # 15m& 4h down move, 15m still high
             & ((rsi_3_15m_gt_10) | (rsi_3_4h_gt_15) | (stochrsi_k_15m < 40.0))
             # 15m & 4h down move, 15m still high
@@ -20742,7 +20771,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 4h down move, 1h still high
             & ((rsi_3_15m_gt_10) | rsi_3_4h_gt_20 | (stochrsi_k_1h < 40.0))
             # 15m & 4h down move, 1d high
-            & ((rsi_3_15m_gt_10) | (rsi_3_4h_gt_25) | (aroonu_14_1d < 85.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_4h_gt_25) | (aroonu_14_1d_lt_85))
             # 15m & 4h down move, 1h still high
             & ((rsi_3_15m_gt_10) | (rsi_3_4h_gt_30) | (stochrsi_k_1h_lt_50))
             # 15m & 4h down move, 4h high
@@ -20750,13 +20779,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1d down move, 1h still high
             & ((rsi_3_15m_gt_10) | (rsi_3_1d_gt_25) | (stochrsi_k_1h_lt_50))
             # 15m down move, 15m still not low enough, 1h high
-            & ((rsi_3_15m_gt_10) | (aroonu_14_15m < 30.0) | (stochrsi_k_1h_lt_80))
+            & ((rsi_3_15m_gt_10) | (aroonu_14_15m_lt_30) | (stochrsi_k_1h_lt_80))
             # 15m down move, 1h high, 4h overbought
             & ((rsi_3_15m_gt_10) | aroonu_14_1h_lt_70 | (roc_9_4h < 50.0))
             # 15m down move, 1d high & overbought
             & ((rsi_3_15m_gt_10) | (aroonu_14_1d_lt_80) | (roc_9_1d_lt_20))
             # 15m & 1h down move, 1h still high
-            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_30) | (aroonu_14_1h < 40.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_30) | (aroonu_14_1h_lt_40))
             # 15m & 1h & 4h & 1d down move, 1d high
             & ((rsi_3_15m_gt_15) | (rsi_3_1h_gt_30) | (rsi_3_4h_gt_40) | (rsi_3_1d_gt_50) | (stochrsi_k_1d < 70.0))
             # 15m & 1h down move, 1h still high
@@ -20782,7 +20811,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 15m still not low enough, 4h high
             & ((rsi_3_15m_gt_15) | (rsi_14_15m < 35.0) | (stochrsi_k_4h_lt_90))
             # 15m down move, 15m still not low enough, 4h high
-            & ((rsi_3_15m_gt_15) | (aroonu_14_15m < 30.0) | (stochrsi_k_4h_lt_90))
+            & ((rsi_3_15m_gt_15) | (aroonu_14_15m_lt_30) | (stochrsi_k_4h_lt_90))
             # 15m down move, 15m & 4h still high
             & ((rsi_3_15m_gt_15) | (aroonu_14_15m_lt_50) | (aroonu_14_4h_lt_50))
             # 15m down move, 15m still high, 1h high
@@ -20792,11 +20821,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 4h still high 1d overbought
             & ((rsi_3_15m_gt_15) | (aroonu_14_4h_lt_50) | roc_9_1d_lt_50)
             # 15m & 1h down move, 15m still not low enough
-            & ((rsi_3_15m_gt_20) | rsi_3_1h_gt_20 | (aroonu_14_15m < 30.0))
+            & ((rsi_3_15m_gt_20) | rsi_3_1h_gt_20 | (aroonu_14_15m_lt_30))
             # 15m & 1h down move, 4h high
             & ((rsi_3_15m_gt_20) | (rsi_3_1h_gt_30) | (stochrsi_k_4h_lt_90))
             # 15m & 1h down move, 15m high
-            & ((rsi_3_15m_gt_20) | (rsi_3_1h_gt_40) | (aroonu_14_15m < 60.0))
+            & ((rsi_3_15m_gt_20) | (rsi_3_1h_gt_40) | (aroonu_14_15m_lt_60))
             # 15m & 4h down move, 1h high
             & ((rsi_3_15m_gt_20) | rsi_3_4h_gt_20 | (stochrsi_k_1h < 60.0))
             # 15m & 4h down move, 4h high
@@ -20806,11 +20835,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 15m still not low enough, 4h high
             & ((rsi_3_15m_gt_20) | (rsi_14_15m < 35.0) | (rsi_14_4h < 85.0))
             # 15m down move, 15m still not low enough, 1h high
-            & ((rsi_3_15m_gt_20) | (aroonu_14_15m < 30.0) | (stochrsi_k_1h_lt_80))
+            & ((rsi_3_15m_gt_20) | (aroonu_14_15m_lt_30) | (stochrsi_k_1h_lt_80))
             # 15m down move, 15m still not low enough, 4h high
-            & ((rsi_3_15m_gt_20) | (aroonu_14_15m < 30.0) | (stochrsi_k_4h_lt_70))
+            & ((rsi_3_15m_gt_20) | (aroonu_14_15m_lt_30) | (stochrsi_k_4h_lt_70))
             # 15m down move, 15m still high, 4d downtrend
-            & ((rsi_3_15m_gt_20) | (aroonu_14_15m < 40.0) | (roc_9_4h_gt_neg_20))
+            & ((rsi_3_15m_gt_20) | (aroonu_14_15m_lt_40) | (roc_9_4h_gt_neg_20))
             # 15m down move, 15m still not low enough, 1h still high
             & ((rsi_3_15m_gt_20) | (stochrsi_k_15m < 30.0) | (aroonu_14_1h_lt_50))
             # 15m down move, 15m & 1h still high
@@ -20824,7 +20853,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 1d high
             & ((rsi_3_15m_gt_25) | (rsi_3_1h_gt_40) | (stochrsi_k_1d_lt_90))
             # 15m & 1h down move, 1h high
-            & ((rsi_3_15m_gt_25) | (rsi_3_1h_gt_60) | (aroonu_14_1h < 85.0))
+            & ((rsi_3_15m_gt_25) | (rsi_3_1h_gt_60) | (aroonu_14_1h_lt_85))
             # 15m & 4h down move, 15m still high
             & ((rsi_3_15m_gt_25) | (rsi_3_4h_gt_40) | (aroonu_14_15m_lt_50))
             # 15m & 1d down move, 4h high
@@ -20838,7 +20867,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 15m high, 1d overbought
             & ((rsi_3_15m_gt_25) | (aroonu_14_15m_lt_70) | (roc_9_1d_lt_100))
             # 15m down move, 15m high
-            & ((rsi_3_15m_gt_25) | (aroonu_14_15m < 85.0))
+            & ((rsi_3_15m_gt_25) | (aroonu_14_15m_lt_85))
             # 15m down move, 1h & 4h high
             & ((rsi_3_15m_gt_25) | aroonu_14_1h_lt_80 | (aroonu_14_4h_lt_90))
             # 15m down move, 1h & 4h high
@@ -20846,7 +20875,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 4h high, 1d overbought
             & ((rsi_3_15m_gt_25) | aroonu_14_4h_lt_80 | roc_9_1d_lt_50)
             # 15m & 1h down move, 1h high
-            & ((rsi_3_15m_gt_30) | (rsi_3_1h_gt_45) | (aroonu_14_1h < 60.0))
+            & ((rsi_3_15m_gt_30) | (rsi_3_1h_gt_45) | (aroonu_14_1h_lt_60))
             # 15m down move, 15m high, 4h still high
             & ((rsi_3_15m_gt_30) | (aroonu_14_15m_lt_70) | (aroonu_14_4h_lt_50))
             # 15m down move, 15m still not low enough, 1h high
@@ -20860,7 +20889,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 15m & 4h high
             & ((rsi_3_15m_gt_35) | (aroonu_14_15m_lt_70) | (stochrsi_k_4h_lt_70))
             # 15m down move, 15m high
-            & ((rsi_3_15m_gt_35) | (aroonu_14_15m < 80.0))
+            & ((rsi_3_15m_gt_35) | (aroonu_14_15m_lt_80))
             # 15m down move, 4h still high, 4h overbought
             & ((rsi_3_15m_gt_35) | (stochrsi_k_4h_lt_50) | (roc_9_4h_lt_20))
             # 15m down move, 15m still high, 1h high
@@ -20868,7 +20897,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 15m high, 1h high
             & ((rsi_3_15m_gt_40) | (aroonu_14_15m_lt_70) | (aroonu_14_1h_lt_90))
             # 15m down move, 15m high
-            & ((rsi_3_15m_gt_45) | (aroonu_14_15m < 90.0))
+            & ((rsi_3_15m_gt_45) | (aroonu_14_15m_lt_90))
             # 1h & 4h down move, 4h still high
             & ((rsi_3_1h_gt_15) | rsi_3_4h_gt_20 | (rsi_14_4h < 40.0))
             # 1h & 4h down move, 1h still high
@@ -20902,7 +20931,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 4h high, 1d overbought
             & ((rsi_3_1h_gt_40) | (rsi_14_4h < 75.0) | (roc_9_1d_lt_100))
             # 1h down move, 1h still high, 1d high
-            & ((rsi_3_1h_gt_40) | (aroonu_14_1h_lt_50) | (aroonu_14_1d < 85.0))
+            & ((rsi_3_1h_gt_40) | (aroonu_14_1h_lt_50) | (aroonu_14_1d_lt_85))
             # 1h down move, 1h still high, 1d overbought
             & ((rsi_3_1h_gt_40) | (aroonu_14_1h_lt_50) | (roc_9_1d_lt_20))
             # 1h down move 1h high & overbought
@@ -20912,7 +20941,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1d high, 1h overbought
             & ((rsi_3_1h_gt_60) | (aroonu_14_1d_lt_90) | (roc_9_1h_lt_10))
             # 4h down move, 4h still not low enough, 1d overbought
-            & ((rsi_3_4h_gt_15) | (aroonu_14_4h < 30.0) | (roc_9_1d < 100.0))
+            & ((rsi_3_4h_gt_15) | (aroonu_14_4h_lt_30) | (roc_9_1d < 100.0))
             # 4h down move, 15m still high, 1d downtrend
             & ((rsi_3_4h_gt_15) | (stochrsi_k_15m < 50.0) | (roc_9_1d > -20.0))
             # 4h & 1d down move, 15m still not low enough
@@ -20922,7 +20951,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 1d high, 4h downtrend
             & ((rsi_3_4h_gt_30) | (stochrsi_k_1d_lt_90) | (roc_9_4h_gt_neg_20))
             # 4h & 1d down move, 4h still high, 1d high
-            & ((rsi_3_4h_gt_35) | (rsi_3_1d_gt_35) | (stochrsi_k_4h_lt_50) | (aroonu_14_1d < 60.0))
+            & ((rsi_3_4h_gt_35) | (rsi_3_1d_gt_35) | (stochrsi_k_4h_lt_50) | (aroonu_14_1d_lt_60))
             # 4h down move, 4h high, 1d downtrend
             & ((rsi_3_4h_gt_35) | (stochrsi_k_4h_lt_70) | (roc_9_1d_gt_neg_30))
             # 4h & 1d down move, 1d high
@@ -20936,13 +20965,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1d down move, 1h & 4h still not low enough
             & ((rsi_3_1d_gt_5) | (stochrsi_k_1h < 20.0) | (stochrsi_k_4h < 20.0))
             # 1d down move, 1h high, 1d downtrend
-            & ((rsi_3_1d_gt_10) | (aroonu_14_1h < 85.0) | (roc_9_1d_gt_neg_30))
+            & ((rsi_3_1d_gt_10) | (aroonu_14_1h_lt_85) | (roc_9_1d_gt_neg_30))
             # 1d down move, 15m still not low enough, 1h still high
-            & ((rsi_3_1d_gt_15) | (aroonu_14_15m < 30.0) | (stochrsi_k_1h_lt_50))
+            & ((rsi_3_1d_gt_15) | (aroonu_14_15m_lt_30) | (stochrsi_k_1h_lt_50))
             # 15m still not low enough, 1h high, 1d overbought
-            & ((aroonu_14_15m < 30.0) | (stochrsi_k_1h < 80.0) | (roc_9_1d_lt_100))
+            & ((aroonu_14_15m_lt_30) | (stochrsi_k_1h < 80.0) | (roc_9_1d_lt_100))
             # 15m still high, 4h high & overbought
-            & ((aroonu_14_15m < 40.0) | (stochrsi_k_4h_lt_80) | (roc_9_4h_lt_30))
+            & ((aroonu_14_15m_lt_40) | (stochrsi_k_4h_lt_80) | (roc_9_4h_lt_30))
             # 15m & 1h & 4h high
             & ((aroonu_14_15m_lt_70) | aroonu_14_1h_lt_80 | (aroonu_14_4h_lt_90))
             # 15m & 1h high, 4h overbought
@@ -20950,15 +20979,15 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1d high, 1d overbought
             & ((aroonu_14_15m_lt_70) | (aroonu_14_1d_lt_90) | (roc_9_1d_lt_100))
             # 15m high
-            & ((aroonu_14_15m < 80.0) | (stochrsi_k_15m < 60.0))
+            & ((aroonu_14_15m_lt_80) | (stochrsi_k_15m < 60.0))
             # 15m & 4h high
-            & ((aroonu_14_15m < 80.0) | (stochrsi_k_4h_lt_70))
+            & ((aroonu_14_15m_lt_80) | (stochrsi_k_4h_lt_70))
             # 15m high, 1d overbought
-            & ((aroonu_14_15m < 80.0) | roc_9_1d_lt_50)
+            & ((aroonu_14_15m_lt_80) | roc_9_1d_lt_50)
             # 15m & 4h high
-            & ((aroonu_14_15m < 90.0) | aroonu_14_4h_lt_70)
+            & ((aroonu_14_15m_lt_90) | aroonu_14_4h_lt_70)
             # 15m & 1h high
-            & ((aroonu_14_15m < 90.0) | (aroonu_14_1h_lt_90))
+            & ((aroonu_14_15m_lt_90) | (aroonu_14_1h_lt_90))
             # 1h still high, 4h high & overbought
             & ((aroonu_14_1h_lt_50) | (aroonu_14_4h_lt_90) | (roc_9_4h < 80.0))
             # 1h & 4h high, 1h overbought
@@ -21040,7 +21069,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m down move, 15m still high, 4h high
           long_entry_logic.append((rsi_3_15m_gt_20) | (aroonu_14_15m_lt_50) | (aroonu_14_4h_lt_90))
           # 15m down move, 15m & 1h high
-          long_entry_logic.append((rsi_3_15m_gt_20) | (aroonu_14_15m < 60.0) | aroonu_14_1h_lt_70)
+          long_entry_logic.append((rsi_3_15m_gt_20) | (aroonu_14_15m_lt_60) | aroonu_14_1h_lt_70)
           # 15m down move, 15m high, 4h still high
           long_entry_logic.append((rsi_3_15m_gt_20) | (aroonu_14_15m_lt_70) | (aroonu_14_4h_lt_50))
           # 15m down move, 15m & 1h still high
@@ -21068,9 +21097,9 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m down move, 15m & 1h high
           long_entry_logic.append((rsi_3_15m_gt_35) | (aroonu_14_15m_lt_70) | (stochrsi_k_1h_lt_80))
           # 15m down move, 1h high, 4h overbought
-          long_entry_logic.append((rsi_3_15m_gt_35) | (aroonu_14_1h < 85.0) | (roc_9_4h < 80.0))
+          long_entry_logic.append((rsi_3_15m_gt_35) | (aroonu_14_1h_lt_85) | (roc_9_4h < 80.0))
           # 1h & 4h down move, 1h still high
-          long_entry_logic.append((rsi_3_1h_gt_10) | rsi_3_4h_gt_20 | (aroonu_14_1h < 40.0))
+          long_entry_logic.append((rsi_3_1h_gt_10) | rsi_3_4h_gt_20 | (aroonu_14_1h_lt_40))
           # 1h & 4h down move, 15m still not low enough
           long_entry_logic.append((rsi_3_1h_gt_10) | rsi_3_4h_gt_20 | (stochrsi_k_15m < 20.0))
           # 1h down move, 1d high & overbought
@@ -21080,7 +21109,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1h down move, 4h still high, 4h downtrend
           long_entry_logic.append((rsi_3_1h_gt_15) | (aroonu_14_4h_lt_50) | (roc_9_4h > -20.0))
           # 1h down move, 15m still not low enough, 4h high
-          long_entry_logic.append(rsi_3_1h_gt_20 | (aroonu_14_15m < 25.0) | aroonu_14_4h_lt_80)
+          long_entry_logic.append(rsi_3_1h_gt_20 | (aroonu_14_15m_lt_25) | aroonu_14_4h_lt_80)
           # 1h down move, 4h & 1d high
           long_entry_logic.append((rsi_3_1h_gt_30) | aroonu_14_4h_lt_70 | (stochrsi_k_1d < 80.0))
           # 1h down move, 4h high & overbought
@@ -21102,7 +21131,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1h down move, 1d high & overbought
           long_entry_logic.append((rsi_3_1h_gt_45) | aroonu_14_1d_lt_100 | (roc_9_1d_lt_30))
           # 1h down move, 15m & 1h still high
-          long_entry_logic.append((rsi_3_1h_gt_50) | (aroonu_14_15m_lt_50) | (aroonu_14_1h < 85.0))
+          long_entry_logic.append((rsi_3_1h_gt_50) | (aroonu_14_15m_lt_50) | (aroonu_14_1h_lt_85))
           # 1h & 4h down move, 4h high
           long_entry_logic.append((rsi_3_1h_gt_60) | (rsi_3_4h_gt_60) | aroonu_14_4h_lt_80)
           # 1h & 4h down move, 4h high
@@ -21118,7 +21147,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 4h down move, 15m still high, 4h high
           long_entry_logic.append((rsi_3_4h_gt_25) | (stochrsi_k_15m < 50.0) | aroonu_14_4h_lt_70)
           # 4h down move, 15m still not low enough, 4h high
-          long_entry_logic.append((rsi_3_4h_gt_35) | (aroonu_14_15m < 30.0) | aroonu_14_4h_lt_70)
+          long_entry_logic.append((rsi_3_4h_gt_35) | (aroonu_14_15m_lt_30) | aroonu_14_4h_lt_70)
           # 4h down move, 1h high, 4h downtrend
           long_entry_logic.append((rsi_3_4h_gt_30) | aroonu_14_1h_lt_70 | (roc_9_4h > -10.0))
           # 4h down move, 4h still high, 1d downtrend
@@ -21136,13 +21165,13 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1d down move, 4h high
           long_entry_logic.append((rsi_3_1d_gt_10) | (stochrsi_k_4h_lt_80))
           # 1d down move, 15m still high, 1h high
-          long_entry_logic.append((rsi_3_1d_gt_15) | (aroonu_14_15m_lt_50) | (aroonu_14_1h < 85.0))
+          long_entry_logic.append((rsi_3_1d_gt_15) | (aroonu_14_15m_lt_50) | (aroonu_14_1h_lt_85))
           # 1d down move, 1h & 1d overbought
           long_entry_logic.append((rsi_3_1d_gt_45) | (roc_9_1h < 80.0) | (roc_9_1d_lt_80))
           # 15m still high, 1h & 4h high
           long_entry_logic.append((rsi_14_15m < 40.0) | aroonu_14_1h_lt_80 | (aroonu_14_4h_lt_90))
           # 15m & 1h still high, 4h high
-          long_entry_logic.append((rsi_14_15m < 45.0) | (aroonu_14_1h < 40.0) | (stochrsi_k_4h_lt_70))
+          long_entry_logic.append((rsi_14_15m < 45.0) | (aroonu_14_1h_lt_40) | (stochrsi_k_4h_lt_70))
           # 15m still high, 4h high & overbought
           long_entry_logic.append((rsi_14_15m < 50.0) | (aroonu_14_4h_lt_90) | (roc_9_4h < 80.0))
           # 15m still high, 1h high, 4h still high
@@ -21154,7 +21183,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m & 1h & 4h high
           long_entry_logic.append((aroonu_14_15m_lt_70) | (stochrsi_k_1h_lt_70) | (aroonu_14_4h_lt_90))
           # 1h & 1d high, 4h downtrend
-          long_entry_logic.append((aroonu_14_1h < 40.0) | (aroonu_14_1d_lt_70) | (roc_9_4h_gt_neg_20))
+          long_entry_logic.append((aroonu_14_1h_lt_40) | (aroonu_14_1d_lt_70) | (roc_9_4h_gt_neg_20))
           # 1h & 4h high, 4h overbought
           long_entry_logic.append(aroonu_14_1h_lt_70 | (aroonu_14_4h_lt_90) | (roc_9_4h_lt_10))
           # 1h high, 1h & 1d overbought
@@ -21202,7 +21231,7 @@ class NostalgiaForInfinityX7(IStrategy):
           long_entry_logic.append(rsi_4 < 45.0)
           long_entry_logic.append(rsi_14 > 35.0)
           long_entry_logic.append(rsi_20 < rsi_20.shift(1))
-          long_entry_logic.append(aroonu_14 < 25.0)
+          long_entry_logic.append(aroonu_14_lt_25)
           long_entry_logic.append(close < sma_16 * 0.960)
 
         # Condition #104 - Rapid mode (Long).
@@ -21224,7 +21253,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m & 1h down move, 4h still not low enough
           long_entry_logic.append(rsi_3_15m_gt_3 | (rsi_3_1h_gt_5) | (rsi_14_4h < 35.0))
           # 15m & 1h down move, 1d still high
-          long_entry_logic.append(rsi_3_15m_gt_3 | (rsi_3_1h_gt_10) | (aroonu_14_1d < 50.0))
+          long_entry_logic.append(rsi_3_15m_gt_3 | (rsi_3_1h_gt_10) | (aroonu_14_1d_lt_50))
           # 15m & 1h down move, 1h still not low enough
           long_entry_logic.append(rsi_3_15m_gt_3 | (rsi_3_1h_gt_15) | (stochrsi_k_1h < 30.0))
           # 15m & 4h down move, 4h still high
@@ -21234,7 +21263,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m & 1h & 4h down move, 15m downtrend
           long_entry_logic.append((rsi_3_15m_gt_5) | rsi_3_1h_gt_20 | rsi_3_4h_gt_20 | (cmf_20_15m > -0.20))
           # 15m & 1h down move, 4h still not low enough
-          long_entry_logic.append((rsi_3_15m_gt_5) | rsi_3_1h_gt_20 | (aroonu_14_4h < 20.0))
+          long_entry_logic.append((rsi_3_15m_gt_5) | rsi_3_1h_gt_20 | (aroonu_14_4h_lt_20))
           # 15m & 1h down move, 1h high
           long_entry_logic.append((rsi_3_15m_gt_5) | (rsi_3_1h_gt_30) | (stochrsi_k_1h_lt_50))
           # 15m & 4h down move, 4h still high
@@ -21274,7 +21303,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m & 1h down move, 1h high
           long_entry_logic.append((rsi_3_15m_gt_15) | (rsi_3_1h_gt_25) | (stochrsi_k_1h < 60.0))
           # 15m & 1h down move, 1h still high
-          long_entry_logic.append((rsi_3_15m_gt_15) | (rsi_3_1h_gt_30) | (aroonu_14_1h < 40.0))
+          long_entry_logic.append((rsi_3_15m_gt_15) | (rsi_3_1h_gt_30) | (aroonu_14_1h_lt_40))
           # 15m down move, 4h still high, 4h downtrend
           long_entry_logic.append((rsi_3_15m_gt_15) | (aroonu_14_4h_lt_40) | (roc_9_4h_gt_neg_20))
           # 15m down move, 1d high, 4h overbought
@@ -21300,7 +21329,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1h down move, 1h still high
           long_entry_logic.append((rsi_3_1h_gt_5) | (aroonu_14_1h_lt_50))
           # 1h down move, 4h high
-          long_entry_logic.append((rsi_3_1h_gt_5) | (aroonu_14_4h < 85.0))
+          long_entry_logic.append((rsi_3_1h_gt_5) | (aroonu_14_4h_lt_85))
           # 1h & 4h down move
           long_entry_logic.append((rsi_3_1h_gt_10) | (rsi_3_4h_gt_10))
           # 1h & 4h down move, 4h still not low enough
@@ -21310,7 +21339,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1h & 1d down move, 1h still moving lower
           long_entry_logic.append((rsi_3_1h_gt_10) | (rsi_3_1d_gt_15) | (cci_20_change_pct_1h > -0.0))
           # 1h down move, 1d high, 4h downtrend
-          long_entry_logic.append((rsi_3_1h_gt_10) | (aroonu_14_1d < 85.0) | (roc_9_4h > -10.0))
+          long_entry_logic.append((rsi_3_1h_gt_10) | (aroonu_14_1d_lt_85) | (roc_9_4h > -10.0))
           # 1h & 4h down move, 1h still high
           long_entry_logic.append((rsi_3_1h_gt_15) | (rsi_3_4h_gt_15) | (aroonu_14_1h_lt_50))
           # 1h & 4h & 1d down move
@@ -21322,13 +21351,13 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1h & 4h & 1d down move
           long_entry_logic.append((rsi_3_1h_gt_15) | (rsi_3_4h_gt_25) | (rsi_3_1d_gt_25))
           # 1h & 4h down move, 1h high
-          long_entry_logic.append((rsi_3_1h_gt_15) | (rsi_3_4h_gt_40) | (aroonu_14_1h < 80.0))
+          long_entry_logic.append((rsi_3_1h_gt_15) | (rsi_3_4h_gt_40) | (aroonu_14_1h_lt_80))
           # 1h & 1d down move, 1d high
           long_entry_logic.append((rsi_3_1h_gt_15) | (rsi_3_1d_gt_25) | (aroonu_14_1d_lt_70))
           # 1h & 1d down move, 1d high
           long_entry_logic.append((rsi_3_1h_gt_15) | (rsi_3_1d_gt_25) | (stochrsi_k_1d < 70.0))
           # 1h down move, 1h & 4h high
-          long_entry_logic.append((rsi_3_1h_gt_15) | (aroonu_14_1h < 60.0) | (aroonu_14_4h_lt_60))
+          long_entry_logic.append((rsi_3_1h_gt_15) | (aroonu_14_1h_lt_60) | (aroonu_14_4h_lt_60))
           # 1h & 4h down move, 1d overbought
           long_entry_logic.append(rsi_3_1h_gt_20 | rsi_3_4h_gt_20 | roc_9_1d_lt_50)
           # 1h & 4h down move, 1h still high
@@ -21350,9 +21379,9 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1h & 4h down move, 4h high
           long_entry_logic.append((rsi_3_1h_gt_30) | (rsi_3_4h_gt_45) | aroonu_14_4h_lt_80)
           # 1h & dh down move, 4h high
-          long_entry_logic.append((rsi_3_1h_gt_30) | (rsi_3_4h_gt_50) | (aroonu_14_4h < 85.0))
+          long_entry_logic.append((rsi_3_1h_gt_30) | (rsi_3_4h_gt_50) | (aroonu_14_4h_lt_85))
           # 1h down move, 4h still not low enough, 1d overbought
-          long_entry_logic.append((rsi_3_1h_gt_30) | (aroonu_14_4h < 30.0) | roc_9_1d_lt_50)
+          long_entry_logic.append((rsi_3_1h_gt_30) | (aroonu_14_4h_lt_30) | roc_9_1d_lt_50)
           # 1h down move, 1h still not low enough, 4h downtrend
           long_entry_logic.append((rsi_3_1h_gt_35) | (stochrsi_k_1h < 30.0) | (roc_9_4h_gt_neg_20))
           # 1h down move, 4h still high, 1d downtrend
@@ -21374,7 +21403,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 4h down move, 1d still not low enough, 1d downtrend
           long_entry_logic.append((rsi_3_4h_gt_5) | (stochrsi_k_1d < 30.0) | (roc_9_1d_gt_neg_20))
           # 4h down move, 1h downtrend, 1h still not low enough
-          long_entry_logic.append((rsi_3_4h_gt_10) | (cmf_20_1h > -0.25) | (aroonu_14_1h < 30.0))
+          long_entry_logic.append((rsi_3_4h_gt_10) | (cmf_20_1h > -0.25) | (aroonu_14_1h_lt_30))
           # 4h down move, 1h & 1d downtrend
           long_entry_logic.append((rsi_3_4h_gt_10) | (roc_9_1h > -20.0) | (roc_9_1d > -20.0))
           # 4h & 1d down move, 4h still high
@@ -21402,7 +21431,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1d down move, 1h still not low enough
           long_entry_logic.append((rsi_3_1d_gt_5) | (stochrsi_k_1h < 20.0))
           # 1h & 4h high, 4h overbought
-          long_entry_logic.append((aroonu_14_1h < 60.0) | aroonu_14_4h_lt_100 | (roc_9_4h_lt_30))
+          long_entry_logic.append((aroonu_14_1h_lt_60) | aroonu_14_4h_lt_100 | (roc_9_4h_lt_30))
           # 4h & 1d high, 4h overbought
           long_entry_logic.append((aroonu_14_4h_lt_60) | aroonu_14_1d_lt_100 | (roc_9_4h_lt_40))
           # 4h & 1d high,1d overbought
@@ -21436,9 +21465,9 @@ class NostalgiaForInfinityX7(IStrategy):
 
           # Logic
           long_entry_logic.append(rsi_3 < 40.0)
-          long_entry_logic.append(aroonu_14 < 25.0)
+          long_entry_logic.append(aroonu_14_lt_25)
           long_entry_logic.append(stochrsi_k < 20.0)
-          long_entry_logic.append(aroonu_14_15m < 25.0)
+          long_entry_logic.append(aroonu_14_15m_lt_25)
           long_entry_logic.append(stochrsi_k_15m < 30.0)
           long_entry_logic.append(close < df["EMA_16"] * 0.975)
           long_entry_logic.append(((df["EMA_50"] - df["EMA_200"]) / close * 100.0) < -5.5)
@@ -21464,7 +21493,7 @@ class NostalgiaForInfinityX7(IStrategy):
 
           # Logic
           long_entry_logic.append(
-            (stochrsi_k < 20.0) & (willr_14 < -80.0) & (aroonu_14 < 25.0) & (close < (ema_20 * 0.978))
+            (stochrsi_k < 20.0) & (willr_14 < -80.0) & (aroonu_14_lt_25) & (close < (ema_20 * 0.978))
           )
 
         # Condition #141 - Top Coins mode (Long).
@@ -21482,11 +21511,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 5m & 15m down move, 15m high
             & ((rsi_3_gt_3) | (rsi_3_15m_gt_20) | (aroonu_14_15m_lt_70))
             # 5m & 1h down move, 15m still high
-            & ((rsi_3_gt_3) | (rsi_3_1h_gt_15) | (aroonu_14_15m < 40.0))
+            & ((rsi_3_gt_3) | (rsi_3_1h_gt_15) | (aroonu_14_15m_lt_40))
             # 5m & 1h down move, 1h high
             & ((rsi_3_gt_3) | (rsi_3_1h_gt_45) | (stochrsi_k_1h_lt_80))
             # 5m & 4h down move, 15m still high
-            & ((rsi_3_gt_3) | (rsi_3_4h_gt_5) | (aroonu_14_15m < 40.0))
+            & ((rsi_3_gt_3) | (rsi_3_4h_gt_5) | (aroonu_14_15m_lt_40))
             # 5m & 4h down move, 15m still high
             & ((rsi_3_gt_3) | (rsi_3_4h_gt_5) | (stochrsi_k_15m < 40.0))
             # 5m & 4h down move, 15m still high
@@ -21502,7 +21531,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 5m down move, 1h high
             & ((rsi_3_gt_3) | (stochrsi_k_1h < 90.0))
             # 5m down move, 15m & 1d high
-            & ((rsi_3_gt_5) | (aroonu_14_15m < 60.0) | aroonu_14_1d_lt_100)
+            & ((rsi_3_gt_5) | (aroonu_14_15m_lt_60) | aroonu_14_1d_lt_100)
             # 5m down move, 1h & 1d high
             & ((rsi_3_gt_10) | aroonu_14_1h_lt_80 | aroonu_14_1d_lt_100)
             # 15m & 1h down move, 1d overbought
@@ -21524,7 +21553,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 1d high
             & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_30) | (aroonu_14_1d_lt_80))
             # 15m & 1h down move, 4h high
-            & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_40) | (aroonu_14_1h < 85.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_40) | (aroonu_14_1h_lt_85))
             # 15m & 1h down move, 1h high
             & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_40) | (stochrsi_k_1h_lt_80))
             # 15m & 1h down move, 1h high
@@ -21544,9 +21573,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 1h still high
             & ((rsi_3_15m_gt_5) | (rsi_3_1h_gt_25) | (stochrsi_k_1h_lt_50))
             # 15m & 1h & 4h down move, 15m still not low enough, 1h still not low enough
-            & (
-              (rsi_3_15m_gt_5) | (rsi_3_1h_gt_30) | (rsi_3_4h_gt_30) | (aroonu_14_15m < 30.0) | (stochrsi_k_1h < 30.0)
-            )
+            & ((rsi_3_15m_gt_5) | (rsi_3_1h_gt_30) | (rsi_3_4h_gt_30) | (aroonu_14_15m_lt_30) | (stochrsi_k_1h < 30.0))
             # 15m & 1h down move, 1h high
             & ((rsi_3_15m_gt_5) | (rsi_3_1h_gt_30) | (stochrsi_k_1h_lt_80))
             # 15m & 4h down move, 1d high
@@ -21554,15 +21581,15 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 4h down move, 1d high
             & ((rsi_3_15m_gt_5) | rsi_3_4h_gt_20 | (aroonu_14_1d_lt_80))
             # 15m & 1d down move, 1d still high
-            & ((rsi_3_15m_gt_5) | (rsi_3_1d_gt_10) | (aroonu_14_1d < 40.0))
+            & ((rsi_3_15m_gt_5) | (rsi_3_1d_gt_10) | (aroonu_14_1d_lt_40))
             # 15m down move, 15m downtrend, 1d high
             & ((rsi_3_15m_gt_5) | (cmf_20_15m > -0.40) | aroonu_14_1d_lt_100)
             # 15m down move, 4h high, 1h overbought
             & ((rsi_3_15m_gt_5) | aroonu_14_4h_lt_100 | (roc_9_1h_lt_10))
             # 15m & 1h down move, 4h high
-            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_10) | (aroonu_14_4h < 85.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_10) | (aroonu_14_4h_lt_85))
             # 15m & 1h down move, 1d high
-            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_10) | (aroonu_14_1d < 85.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_10) | (aroonu_14_1d_lt_85))
             # 15m & 1h down move, 15m still high
             & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_15) | (stochrsi_k_15m < 50.0))
             # 15m & 1h down move, 1h still high
@@ -21570,7 +21597,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 1d still high
             & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_15) | (stochrsi_k_1d < 50.0))
             # 15m & 1h down move, 15m high
-            & ((rsi_3_15m_gt_10) | rsi_3_1h_gt_20 | (aroonu_14_15m < 60.0))
+            & ((rsi_3_15m_gt_10) | rsi_3_1h_gt_20 | (aroonu_14_15m_lt_60))
             # 15m & 1h down move, 1h high
             & ((rsi_3_15m_gt_10) | rsi_3_1h_gt_20 | aroonu_14_1h_lt_80)
             # 15m & 1h down move, 1h high
@@ -21578,7 +21605,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 1d overbought
             & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_30) | (roc_9_1d < 60.0))
             # 15m & 4h down move, 15m still high
-            & ((rsi_3_15m_gt_10) | (rsi_3_4h_gt_10) | (aroonu_14_15m < 40.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_4h_gt_10) | (aroonu_14_15m_lt_40))
             # 15m & 4h down move, 1d high
             & ((rsi_3_15m_gt_10) | (rsi_3_4h_gt_10) | (aroonu_14_1d_lt_80))
             # 15m & 4h down move, 1d downtrend
@@ -21588,7 +21615,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 4h down move, 1d high
             & ((rsi_3_15m_gt_10) | rsi_3_4h_gt_20 | (rsi_14_1d < 70.0))
             # 15m & 4h down move, 15m high
-            & ((rsi_3_15m_gt_10) | rsi_3_4h_gt_20 | (aroonu_14_15m < 60.0))
+            & ((rsi_3_15m_gt_10) | rsi_3_4h_gt_20 | (aroonu_14_15m_lt_60))
             # 15m & 4h down move, 4h still high
             & ((rsi_3_15m_gt_10) | rsi_3_4h_gt_20 | (aroonu_14_4h_lt_50))
             # 15m & 4h down move, 1d high
@@ -21612,21 +21639,21 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1d down move, 1d high
             & ((rsi_3_15m_gt_10) | (rsi_3_1d_gt_30) | (stochrsi_k_1d < 60.0))
             # 15m down move, 15m & 1h high
-            & ((rsi_3_15m_gt_10) | (aroonu_14_15m < 60.0) | (aroonu_14_1h_lt_100))
+            & ((rsi_3_15m_gt_10) | (aroonu_14_15m_lt_60) | (aroonu_14_1h_lt_100))
             # 15m down move, 15m & 4h high
-            & ((rsi_3_15m_gt_10) | (aroonu_14_15m < 60.0) | aroonu_14_4h_lt_70)
+            & ((rsi_3_15m_gt_10) | (aroonu_14_15m_lt_60) | aroonu_14_4h_lt_70)
             # 15m down move, 15m high, 1h high
             & ((rsi_3_15m_gt_10) | (aroonu_14_15m_lt_70) | (stochrsi_k_1h_lt_80))
             # 15m down move, 4h high, 1d overbought
             & ((rsi_3_15m_gt_10) | aroonu_14_4h_lt_70 | (roc_9_1d_lt_100))
             # 15m down move, 1d high & overbought
-            & ((rsi_3_15m_gt_10) | (aroonu_14_1d < 85.0) | (roc_9_1d_lt_20))
+            & ((rsi_3_15m_gt_10) | (aroonu_14_1d_lt_85) | (roc_9_1d_lt_20))
             # 15m down move, 1h high, 1d overbought
             & ((rsi_3_15m_gt_10) | (stochrsi_k_1h_lt_50) | (roc_9_1d_lt_40))
             # 15m & 1h down move, 1h high
-            & ((rsi_3_15m_gt_15) | (rsi_3_1h_gt_15) | (aroonu_14_1h < 70.0))
+            & ((rsi_3_15m_gt_15) | (rsi_3_1h_gt_15) | (aroonu_14_1h_lt_70))
             # 15m & 1h down move, 4h high
-            & ((rsi_3_15m_gt_15) | (rsi_3_1h_gt_15) | (aroonu_14_4h < 80.0))
+            & ((rsi_3_15m_gt_15) | (rsi_3_1h_gt_15) | (aroonu_14_4h_lt_80))
             # 15m & 1h & 1d down move, 1h high
             & ((rsi_3_15m_gt_15) | (rsi_3_1h_gt_25) | (rsi_3_1d_gt_25) | (stochrsi_k_1h < 60.0))
             # 15m & 1h down move, 1h high
@@ -21646,7 +21673,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1d down move, 1h still high
             & ((rsi_3_15m_gt_15) | (rsi_3_1d_gt_15) | (stochrsi_k_1h < 30.0))
             # 15m down move, 15m downtrend, 1h high
-            & ((rsi_3_15m_gt_15) | (cmf_20_15m > -0.40) | (aroonu_14_1h < 60.0))
+            & ((rsi_3_15m_gt_15) | (cmf_20_15m > -0.40) | (aroonu_14_1h_lt_60))
             # 15m down move, 15m still high, 4h high
             & ((rsi_3_15m_gt_15) | (aroonu_14_15m_lt_50) | (stochrsi_k_4h_lt_80))
             # 15m down move, 15m high, 1d overbought
@@ -21698,11 +21725,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 15m high
             & ((rsi_3_1h_gt_5) | (rsi_3_4h_gt_25) | (stochrsi_k_15m < 60.0))
             # 1h & 4h down move, 1d still high
-            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_10) | (aroonu_14_1d < 50.0))
+            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_10) | (aroonu_14_1d_lt_50))
             # 1h & 4h down move, 15m still high
             & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_10) | (stochrsi_k_15m < 70.0))
             # 1h & 4h down move, 4h still not low enough
-            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_15) | (aroonu_14_4h < 30.0))
+            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_15) | (aroonu_14_4h_lt_30))
             # 1h & 4h down move, 4h still high
             & ((rsi_3_1h_gt_10) | rsi_3_4h_gt_20 | (aroonu_14_4h_lt_40))
             # 1h & 4h down move, 4h high
@@ -21710,15 +21737,15 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 4h high
             & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_40) | aroonu_14_4h_lt_70)
             # 1h & 1d down move, 1h still not low enough
-            & ((rsi_3_1h_gt_10) | (rsi_3_1d_gt_15) | (aroonu_14_1h < 20.0))
+            & ((rsi_3_1h_gt_10) | (rsi_3_1d_gt_15) | (aroonu_14_1h_lt_20))
             # 1h & 1d down move, 1h still not low enough
-            & ((rsi_3_1h_gt_10) | (rsi_3_1d_gt_20) | (aroonu_14_1h < 30.0))
+            & ((rsi_3_1h_gt_10) | (rsi_3_1d_gt_20) | (aroonu_14_1h_lt_30))
             # 1h down move, 15m downtrend, 1d high
             & ((rsi_3_1h_gt_10) | (cmf_20_15m > -0.40) | (aroonu_14_1d_lt_70))
             # 1h down move, 1h high, 4h high
-            & ((rsi_3_1h_gt_10) | (aroonu_14_1h < 70.0) | (stochrsi_k_4h < 80.0))
+            & ((rsi_3_1h_gt_10) | (aroonu_14_1h_lt_70) | (stochrsi_k_4h < 80.0))
             # 1h & 4h down move, 1h still high
-            & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_15) | (aroonu_14_1h < 40.0))
+            & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_15) | (aroonu_14_1h_lt_40))
             # 1h & 4h down move, 1h still high
             & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_15) | (stochrsi_k_1h < 50.0))
             # 1h & 4h down move, 1d downtrend
@@ -21726,7 +21753,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 1d down move, 4h downtrend
             & ((rsi_3_1h_gt_15) | (rsi_3_1d_gt_15) | (roc_9_4h_gt_neg_30))
             # 1h & 1d down move, 1d still high
-            & ((rsi_3_1h_gt_15) | (rsi_3_1d_gt_25) | (aroonu_14_1d < 50.0))
+            & ((rsi_3_1h_gt_15) | (rsi_3_1d_gt_25) | (aroonu_14_1d_lt_50))
             # 1h & 1d down move, 1d high
             & ((rsi_3_1h_gt_15) | (rsi_3_1d_gt_35) | (aroonu_14_1d_lt_70))
             # 1h down move, 1h still high, 1d high
@@ -21750,9 +21777,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 1d downtrend
             & (rsi_3_1h_gt_20 | (rsi_3_1d_gt_25) | (roc_9_1d_gt_neg_30))
             # 1h down move, 15m still high, 1d high
-            & (rsi_3_1h_gt_20 | (aroonu_14_15m < 40.0) | (aroonu_14_1d_lt_90))
+            & (rsi_3_1h_gt_20 | (aroonu_14_15m_lt_40) | (aroonu_14_1d_lt_90))
             # 1h down move, 1h high, 1d overbought
-            & (rsi_3_1h_gt_20 | (aroonu_14_1h < 60.0) | (roc_9_1d < 10.0))
+            & (rsi_3_1h_gt_20 | (aroonu_14_1h_lt_60) | (roc_9_1d < 10.0))
             # 1h & 4h down move, 15m high
             & ((rsi_3_1h_gt_25) | (rsi_3_4h_gt_25) | (stochrsi_k_15m < 70.0))
             # 1h & 4h down move, 1h high
@@ -21762,11 +21789,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 1d high
             & ((rsi_3_1h_gt_30) | (rsi_3_4h_gt_35) | (rsi_14_1d < 80.0))
             # 1h down move, 1d high & overbought
-            & ((rsi_3_1h_gt_30) | (aroonu_14_1d < 85.0) | (roc_9_1d_lt_40))
+            & ((rsi_3_1h_gt_30) | (aroonu_14_1d_lt_85) | (roc_9_1d_lt_40))
             # 1h down move, 1d high & overbought
             & ((rsi_3_1h_gt_30) | (stochrsi_k_1d < 80.0) | (roc_9_1d_lt_20))
             # 1h down move, 15m still high, 1h high
-            & ((rsi_3_1h_gt_30) | (aroonu_14_15m_lt_50) | (aroonu_14_1h < 85.0))
+            & ((rsi_3_1h_gt_30) | (aroonu_14_15m_lt_50) | (aroonu_14_1h_lt_85))
             # 1h down move, 4h high, 1d overbought
             & ((rsi_3_1h_gt_30) | (aroonu_14_4h_lt_90) | (roc_9_1d_lt_40))
             # 1h & 4h down move, 1h still high
@@ -21780,7 +21807,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 1d down move, 1h high
             & ((rsi_3_1h_gt_45) | (rsi_3_1d_gt_45) | aroonu_14_1h_lt_80)
             # 1h down move, 1h & 4h high
-            & ((rsi_3_1h_gt_45) | (aroonu_14_1h < 75.0) | aroonu_14_4h_lt_100)
+            & ((rsi_3_1h_gt_45) | (aroonu_14_1h_lt_75) | aroonu_14_4h_lt_100)
             # 1h down move, 1h high, 1d high & overbought
             & ((rsi_3_1h_gt_45) | (stochrsi_k_1h < 60.0) | (stochrsi_k_1d < 70.0) | (roc_9_1d < 40.0))
             # 1h down move, 4h high & overbought
@@ -21790,7 +21817,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h & 1d down move, 1d still high
             & ((rsi_3_4h_gt_3) | (rsi_3_1d_gt_20) | (rsi_14_1d < 40.0))
             # 4h down move, 1h still not low enough, 4h downtrend
-            & ((rsi_3_4h_gt_3) | (aroonu_14_1h < 20.0) | (roc_9_4h > -10.0))
+            & ((rsi_3_4h_gt_3) | (aroonu_14_1h_lt_20) | (roc_9_4h > -10.0))
             # 4h & 1d down move, 1d still high
             & ((rsi_3_4h_gt_5) | (rsi_3_1d_gt_30) | (stochrsi_k_1d < 40.0))
             # 4h down move, 1h high
@@ -21802,13 +21829,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h & 1d down move, 4h downtrend
             & ((rsi_3_4h_gt_10) | (rsi_3_1d_gt_10) | (roc_9_4h > -20.0))
             # 4h & 1d down move, 1d still high
-            & ((rsi_3_4h_gt_10) | (rsi_3_1d_gt_15) | (aroonu_14_1d < 40.0))
+            & ((rsi_3_4h_gt_10) | (rsi_3_1d_gt_15) | (aroonu_14_1d_lt_40))
             # 4h & 1d down move, 1d downtrend
             & ((rsi_3_4h_gt_10) | (rsi_3_1d_gt_15) | (roc_9_1d > -30.0))
             # 4h & 1d down move, 1h high
             & ((rsi_3_4h_gt_10) | (rsi_3_1d_gt_30) | (aroonu_14_1h_lt_100))
             # 4h down move, 15m still high, 1h still high
-            & ((rsi_3_4h_gt_10) | (aroonu_14_15m < 40.0) | (stochrsi_k_1h < 50.0))
+            & ((rsi_3_4h_gt_10) | (aroonu_14_15m_lt_40) | (stochrsi_k_1h < 50.0))
             # 4h down move, 4h still high, 4h downtrend
             & ((rsi_3_4h_gt_10) | (aroonu_14_4h_lt_40) | (roc_9_4h > -20.0))
             # 4h down move, 15m high
@@ -21820,7 +21847,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h & 1d down move, 1h still high
             & ((rsi_3_4h_gt_15) | (rsi_3_1d_gt_15) | (stochrsi_k_1h < 40.0))
             # 4h & 1d down move, 1d high
-            & ((rsi_3_4h_gt_15) | (rsi_3_1d_gt_20) | (aroonu_14_1d < 60.0))
+            & ((rsi_3_4h_gt_15) | (rsi_3_1d_gt_20) | (aroonu_14_1d_lt_60))
             # 4h & 1d down move, 4h high
             & ((rsi_3_4h_gt_15) | (rsi_3_1d_gt_25) | aroonu_14_4h_lt_70)
             # 4h & 1d down move, 4h still high
@@ -21834,7 +21861,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 4h still high, 4h downtrend
             & ((rsi_3_4h_gt_15) | (aroonu_14_4h_lt_50) | (roc_9_4h > -10.0))
             # 4h down move, 1d still high, 1d downtrend
-            & ((rsi_3_4h_gt_15) | (aroonu_14_1d < 50.0) | (roc_9_1d > -20.0))
+            & ((rsi_3_4h_gt_15) | (aroonu_14_1d_lt_50) | (roc_9_1d > -20.0))
             # 4h down move, 4h still not low enough, 1d downtrend
             & ((rsi_3_4h_gt_15) | (stochrsi_k_4h < 20.0) | (roc_9_1d > -20.0))
             # 4h down move, 1h downtrend, 1d overbought
@@ -21915,7 +21942,7 @@ class NostalgiaForInfinityX7(IStrategy):
 
           # Logic
           long_entry_logic.append(
-            (rsi_20 < rsi_20.shift(1)) & (rsi_3 < 30.0) & (aroonu_14 < 25.0) & (close < sma_16 * 0.960)
+            (rsi_20 < rsi_20.shift(1)) & (rsi_3 < 30.0) & (aroonu_14_lt_25) & (close < sma_16 * 0.960)
           )
 
         # Condition #142 - Top Coins mode (Long).
@@ -21927,17 +21954,17 @@ class NostalgiaForInfinityX7(IStrategy):
 
           long_entry_logic.append(
             # 5m & 4h down move, 15m high
-            ((rsi_3_gt_10) | (rsi_3_4h_gt_10) | (aroonu_14_15m < 40.0))
+            ((rsi_3_gt_10) | (rsi_3_4h_gt_10) | (aroonu_14_15m_lt_40))
             # 5m & 1d down move, 15m high
-            & ((rsi_3_gt_10) | (rsi_3_1d_gt_30) | (aroonu_14_15m < 80.0))
+            & ((rsi_3_gt_10) | (rsi_3_1d_gt_30) | (aroonu_14_15m_lt_80))
             # 5m down move, 1h & 1d high
             & ((rsi_3_gt_10) | aroonu_14_1h_lt_80 | aroonu_14_1d_lt_100)
             # 5m down move, 15m & 1h high
-            & ((rsi_3_gt_10) | (aroonu_14_15m < 85.0) | (aroonu_14_1h_lt_100))
+            & ((rsi_3_gt_10) | (aroonu_14_15m_lt_85) | (aroonu_14_1h_lt_100))
             # 15m & 1h & 4h down move
             & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_3) | (rsi_3_4h_gt_15))
             # 15m & 1h & 4h down move, 4h still not low enough
-            & ((rsi_3_15m_gt_3) | (rsi_3_1h_gt_10) | (rsi_3_4h_gt_20) | (aroonu_14_4h < 20.0))
+            & ((rsi_3_15m_gt_3) | (rsi_3_1h_gt_10) | (rsi_3_4h_gt_20) | (aroonu_14_4h_lt_20))
             # 15m & 1h down move, 1d high
             & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_10) | (aroonu_14_1d_lt_70))
             # 15m & 1h down move, 1h still high
@@ -21953,7 +21980,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 15m high
             & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_30) | (aroonu_14_15m_lt_70))
             # 15m & 1h down move, 1h high
-            & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_40) | (aroonu_14_1h < 75.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_40) | (aroonu_14_1h_lt_75))
             # 15m & 4h down move, 1d downtrend
             & (rsi_3_15m_gt_3 | (rsi_3_4h_gt_10) | (roc_9_1d > -20.0))
             # 15m & 4h down move, 4h still high
@@ -21967,7 +21994,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 4h high
             & (rsi_3_15m_gt_3 | (stochrsi_k_4h_lt_80))
             # 15m & 1d down move, 1d still high
-            & ((rsi_3_15m_gt_5) | (rsi_3_1h_gt_5) | (aroonu_14_1d < 40.0))
+            & ((rsi_3_15m_gt_5) | (rsi_3_1h_gt_5) | (aroonu_14_1d_lt_40))
             # 15m & 1h down move, 15m still not low enough
             & ((rsi_3_15m_gt_5) | (rsi_3_1h_gt_5) | (stochrsi_k_15m < 30.0))
             # 15m & 1h down move, 4h still high
@@ -21975,15 +22002,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 4h down move, 1d high
             & ((rsi_3_15m_gt_5) | (rsi_3_4h_gt_15) | (aroonu_14_1d_lt_70))
             # 15m & 4h down move, 15m high
-            & ((rsi_3_15m_gt_5) | rsi_3_4h_gt_20 | (aroonu_14_15m < 60.0))
+            & ((rsi_3_15m_gt_5) | rsi_3_4h_gt_20 | (aroonu_14_15m_lt_60))
             # 15m & 1h down move, 4h high
-            & ((rsi_3_15m_gt_5) | (rsi_3_1h_gt_15) | (aroonu_14_4h < 85.0))
+            & ((rsi_3_15m_gt_5) | (rsi_3_1h_gt_15) | (aroonu_14_4h_lt_85))
             # 15m & 1h down move, 4h high
             & ((rsi_3_15m_gt_5) | (rsi_3_1h_gt_15) | (stochrsi_k_4h < 60.0))
             # 15m & 1h & 4h down move, 15m still not low enough, 1h still high
-            & (
-              (rsi_3_15m_gt_5) | (rsi_3_1h_gt_30) | (rsi_3_4h_gt_30) | (aroonu_14_15m < 30.0) | (stochrsi_k_1h < 40.0)
-            )
+            & ((rsi_3_15m_gt_5) | (rsi_3_1h_gt_30) | (rsi_3_4h_gt_30) | (aroonu_14_15m_lt_30) | (stochrsi_k_1h < 40.0))
             # 15m & 4h down move, 1d high
             & ((rsi_3_15m_gt_5) | rsi_3_4h_gt_20 | (aroonu_14_1d_lt_80))
             # 15m down move, 4h high, 1h overbought
@@ -21991,7 +22016,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h & 4h & 1d down mode, 1d downtrend
             & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_10) | (rsi_3_4h_gt_20) | (rsi_3_1d_gt_20) | (roc_9_1d_gt_neg_50))
             # 15m & 1h down move, 4h high
-            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_10) | (aroonu_14_4h < 85.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_10) | (aroonu_14_4h_lt_85))
             # 15m & 1h down move, 1h still high
             & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_10) | (stochrsi_k_1h < 40.0))
             # 15m & 1h down move, 4h high
@@ -21999,15 +22024,15 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 1h still high
             & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_15) | (stochrsi_k_1h < 50.0))
             # 15m & 1h down move, 15m high
-            & ((rsi_3_15m_gt_10) | rsi_3_1h_gt_20 | (aroonu_14_15m < 60.0))
+            & ((rsi_3_15m_gt_10) | rsi_3_1h_gt_20 | (aroonu_14_15m_lt_60))
             # 15m & 1h down move, 15m still high
-            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_25) | (aroonu_14_15m < 40.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_25) | (aroonu_14_15m_lt_40))
             # 15m & 1h down move, 1h high
             & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_30) | (stochrsi_k_1h_lt_70))
             # 15m & 1h down move, 1d overbought
             & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_30) | (roc_9_1d < 60.0))
             # 15m & 4h down move, 1d still high
-            & ((rsi_3_15m_gt_10) | (rsi_3_4h_gt_10) | (aroonu_14_1d < 50.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_4h_gt_10) | (aroonu_14_1d_lt_50))
             # 15m & 4h down move, 15m still high
             & ((rsi_3_15m_gt_10) | (rsi_3_4h_gt_15) | (aroonu_14_15m_lt_50))
             # 15m & 4h down move, 1d high
@@ -22043,11 +22068,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 4h high, 1d overbought
             & ((rsi_3_15m_gt_10) | aroonu_14_4h_lt_70 | (roc_9_1d_lt_100))
             # 15m down move, 1d high & overbought
-            & ((rsi_3_15m_gt_10) | (aroonu_14_1d < 85.0) | (roc_9_1d_lt_20))
+            & ((rsi_3_15m_gt_10) | (aroonu_14_1d_lt_85) | (roc_9_1d_lt_20))
             # 15m down move, 1h high, 1d overbought
             & ((rsi_3_15m_gt_10) | (stochrsi_k_1h_lt_50) | (roc_9_1d_lt_40))
             # 15m & 1h down move, 1h high
-            & ((rsi_3_15m_gt_15) | (rsi_3_1h_gt_15) | (aroonu_14_1h < 70.0))
+            & ((rsi_3_15m_gt_15) | (rsi_3_1h_gt_15) | (aroonu_14_1h_lt_70))
             # 15m & 1h down move, 4h high
             & ((rsi_3_15m_gt_15) | (rsi_3_1h_gt_25) | aroonu_14_4h_lt_100)
             # 15m & 1h down move, 1h high
@@ -22065,7 +22090,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1d down move, 4h high
             & ((rsi_3_15m_gt_15) | (rsi_3_1d_gt_20) | (stochrsi_k_4h_lt_80))
             # 15m down move, 15m downtrend, 1h high
-            & ((rsi_3_15m_gt_15) | (cmf_20_15m > -0.40) | (aroonu_14_1h < 60.0))
+            & ((rsi_3_15m_gt_15) | (cmf_20_15m > -0.40) | (aroonu_14_1h_lt_60))
             # 15m down move, 15m still high, 4h high
             & ((rsi_3_15m_gt_15) | (aroonu_14_15m_lt_50) | (stochrsi_k_4h_lt_80))
             # 15m down move, 15m high, 1d overbought
@@ -22085,7 +22110,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 15m & 1h high
             & ((rsi_3_15m_gt_20) | (aroonu_14_15m_lt_70) | (aroonu_14_1h_lt_100))
             # 15m down move, 15m high, 1d high
-            & ((rsi_3_15m_gt_20) | (aroonu_14_15m < 90.0) | aroonu_14_1d_lt_100)
+            & ((rsi_3_15m_gt_20) | (aroonu_14_15m_lt_90) | aroonu_14_1d_lt_100)
             # 15m down move, 1h high, 1d downtrend
             & ((rsi_3_15m_gt_20) | (stochrsi_k_1h < 80.0) | (roc_9_1d_gt_neg_20))
             # 15m down move, 1h high & overbought
@@ -22105,15 +22130,15 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 15m & 4h high
             & ((rsi_3_15m_gt_35) | (aroonu_14_15m_lt_70) | (aroonu_14_4h_lt_90))
             # 15m down move, 15m high, 1d overbought
-            & ((rsi_3_15m_gt_35) | (aroonu_14_15m < 80.0) | roc_9_1d_lt_50)
+            & ((rsi_3_15m_gt_35) | (aroonu_14_15m_lt_80) | roc_9_1d_lt_50)
             # 15m down move, 1d high, 1h overbought
             & ((rsi_3_15m_gt_40) | (stochrsi_k_1d < 80.0) | (roc_9_1h < 20.0))
             # 1h & 4h down move, 1d still high
-            & ((rsi_3_1h_gt_3) | (rsi_3_4h_gt_10) | (aroonu_14_1d < 50.0))
+            & ((rsi_3_1h_gt_3) | (rsi_3_4h_gt_10) | (aroonu_14_1d_lt_50))
             # 1h & 4h down move, 1d overbought
             & ((rsi_3_1h_gt_3) | (rsi_3_4h_gt_25) | (roc_9_1d < 10.0))
             # 1h & 4h down move, 1d still high
-            & ((rsi_3_1h_gt_5) | (rsi_3_4h_gt_15) | (aroonu_14_1d < 40.0))
+            & ((rsi_3_1h_gt_5) | (rsi_3_4h_gt_15) | (aroonu_14_1d_lt_40))
             # 1h & 4h & 1d down move
             & ((rsi_3_1h_gt_5) | rsi_3_4h_gt_20 | (rsi_3_1d_gt_25))
             # 1h & 4h down move, 15m high
@@ -22125,17 +22150,17 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 15m still high
             & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_15) | (stochrsi_k_15m < 50.0))
             # 1h & 4h down move, 1h still not low enough
-            & ((rsi_3_1h_gt_10) | rsi_3_4h_gt_20 | (aroonu_14_1h < 30.0))
+            & ((rsi_3_1h_gt_10) | rsi_3_4h_gt_20 | (aroonu_14_1h_lt_30))
             # 1h & 4h down move, 1d overbought
             & ((rsi_3_1h_gt_10) | rsi_3_4h_gt_20 | (roc_9_1d < 100.0))
             # 1h & 1d downtrend, 1d high
             & ((rsi_3_1h_gt_10) | (rsi_3_1d_gt_45) | (aroonu_14_1d_lt_70))
             # 1h & 4h down move, 1h still not low enough
-            & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_15) | (aroonu_14_1h < 20.0))
+            & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_15) | (aroonu_14_1h_lt_20))
             # 1h & 4h down move. 4h high
             & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_15) | (aroonu_14_4h_lt_60))
             # 1h & 4h down move, 1d still high
-            & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_15) | (aroonu_14_1d < 50.0))
+            & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_15) | (aroonu_14_1d_lt_50))
             # 1h & 4h down move, 1h still not low enough
             & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_15) | (stochrsi_k_1h < 30.0))
             # 1h & 4h down move, 15m still not low enough
@@ -22147,7 +22172,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 1d down move, 1d high
             & ((rsi_3_1h_gt_15) | (rsi_3_1d_gt_35) | (aroonu_14_1d_lt_70))
             # 1h down move, 15m & 1d high
-            & ((rsi_3_1h_gt_15) | (aroonu_14_15m_lt_70) | (aroonu_14_1d < 100.0))
+            & ((rsi_3_1h_gt_15) | (aroonu_14_15m_lt_70) | (aroonu_14_1d_lt_100))
             # 1h down move, 1h still high, 4h overbought
             & ((rsi_3_1h_gt_15) | (aroonu_14_1h_lt_50) | (roc_9_4h_lt_10))
             # 1h down move, 1h still high, 1d downtrend
@@ -22181,7 +22206,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4g down move, 4h still high
             & ((rsi_3_1h_gt_30) | (rsi_3_4h_gt_30) | (stochrsi_k_4h_lt_50))
             # 1h down move, 15m still high, 1h high
-            & ((rsi_3_1h_gt_30) | (aroonu_14_15m_lt_50) | (aroonu_14_1h < 85.0))
+            & ((rsi_3_1h_gt_30) | (aroonu_14_15m_lt_50) | (aroonu_14_1h_lt_85))
             # 1h down move, 4h high, 1d overbought
             & ((rsi_3_1h_gt_35) | aroonu_14_4h_lt_70 | (roc_9_1d_lt_100))
             # 1h down move, 4h & 1d high
@@ -22191,7 +22216,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 1d down move, 1h high
             & ((rsi_3_1h_gt_45) | (rsi_3_1d_gt_45) | aroonu_14_1h_lt_80)
             # 1h down move, 1h & 4h high
-            & ((rsi_3_1h_gt_45) | (aroonu_14_1h < 75.0) | aroonu_14_4h_lt_100)
+            & ((rsi_3_1h_gt_45) | (aroonu_14_1h_lt_75) | aroonu_14_4h_lt_100)
             # 1h down move, 1h high, 1d high & overbought
             & ((rsi_3_1h_gt_45) | (stochrsi_k_1h < 60.0) | (stochrsi_k_1d < 70.0) | (roc_9_1d < 40.0))
             # 1h down move, 4h high & overbought
@@ -22211,9 +22236,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h & 1d down move, 1h high
             & ((rsi_3_4h_gt_10) | (rsi_3_1d_gt_15) | (stochrsi_k_1h < 70.0))
             # 4h down move, 15m still high, 1h still high
-            & ((rsi_3_4h_gt_10) | (aroonu_14_15m < 40.0) | (stochrsi_k_1h < 50.0))
+            & ((rsi_3_4h_gt_10) | (aroonu_14_15m_lt_40) | (stochrsi_k_1h < 50.0))
             # 4h down move, 1d still high, 1d downtrend
-            & ((rsi_3_4h_gt_10) | (aroonu_14_1d < 50.0) | (roc_9_1d > -30.0))
+            & ((rsi_3_4h_gt_10) | (aroonu_14_1d_lt_50) | (roc_9_1d > -30.0))
             # 4h down move, 15m high
             & ((rsi_3_4h_gt_10) | (stochrsi_k_15m < 80.0))
             # 4h down move, 15m still high, 1d downtrend
@@ -22225,7 +22250,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 4h & 1d downtrend
             & ((rsi_3_4h_gt_10) | (roc_9_4h > -15.0) | (roc_9_1d > -20.0))
             # 4h & 1d down move, 1d still high
-            & ((rsi_3_4h_gt_15) | (rsi_3_1d_gt_15) | (aroonu_14_1d < 50.0))
+            & ((rsi_3_4h_gt_15) | (rsi_3_1d_gt_15) | (aroonu_14_1d_lt_50))
             # 4h & 1d down move, 4h still high
             & ((rsi_3_4h_gt_15) | (rsi_3_1d_gt_20) | (aroonu_14_4h_lt_40))
             # 4h & 1d down move, 4h high
@@ -22237,7 +22262,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 1d still high, 4h still not low enough
             & ((rsi_3_4h_gt_15) | (rsi_14_1d < 40.0) | (stochrsi_k_4h < 30.0))
             # 4h down move, 15m still not low enough, 1d high
-            & ((rsi_3_4h_gt_15) | (aroonu_14_15m < 30.0) | (aroonu_14_1d_lt_70))
+            & ((rsi_3_4h_gt_15) | (aroonu_14_15m_lt_30) | (aroonu_14_1d_lt_70))
             # 4h down move, 4h still high, 4h downtrend
             & ((rsi_3_4h_gt_15) | (aroonu_14_4h_lt_50) | (roc_9_4h > -10.0))
             # 4h down move, 4h still not low enough, 1d downtrend
@@ -22259,7 +22284,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h & 1d down move, 1d overbought
             & ((rsi_3_4h_gt_25) | (rsi_3_1d_gt_45) | (roc_9_1d < 10.0))
             # 4h down move, 15m still not low enough, 4h still high
-            & ((rsi_3_4h_gt_25) | (aroonu_14_15m < 30.0) | (stochrsi_k_4h < 40.0))
+            & ((rsi_3_4h_gt_25) | (aroonu_14_15m_lt_30) | (stochrsi_k_4h < 40.0))
             # 4h down move, 1d high, 4h overbought
             & ((rsi_3_4h_gt_25) | (aroonu_14_1d_lt_80) | (roc_9_4h < 5.0))
             # 4h & 1d down move, 4h still high
@@ -22269,11 +22294,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 4h high, 1d high
             & ((rsi_3_4h_gt_30) | (aroonu_14_4h_lt_70) | (stochrsi_k_1d < 80.0))
             # 4h down move, 1d stil high, 1d downtrend
-            & ((rsi_3_4h_gt_30) | (aroonu_14_1d < 40.0) | (roc_9_1d_gt_neg_30))
+            & ((rsi_3_4h_gt_30) | (aroonu_14_1d_lt_40) | (roc_9_1d_gt_neg_30))
             # 4h down move, 1h high, 1d downtrend
             & ((rsi_3_4h_gt_30) | (stochrsi_k_1h_lt_80) | (roc_9_1d_gt_neg_40))
             # 4h & 1d down move, 4h still high, 1d high
-            & ((rsi_3_4h_gt_35) | (rsi_3_1d_gt_35) | (stochrsi_k_4h_lt_50) | (aroonu_14_1d < 60.0))
+            & ((rsi_3_4h_gt_35) | (rsi_3_1d_gt_35) | (stochrsi_k_4h_lt_50) | (aroonu_14_1d_lt_60))
             # 4h down move, 15m still high, 1h high
             & ((rsi_3_4h_gt_35) | (aroonu_14_15m_lt_50) | (aroonu_14_1h_lt_100))
             # 4h down move, 4h still high, 1d downtrend
@@ -22287,7 +22312,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 4h high, 1d downtrend
             & ((rsi_3_4h_gt_45) | (stochrsi_k_4h < 40.0) | (roc_9_1d > -25.0))
             # 4h down move, 1d high & overbought
-            & ((rsi_3_4h_gt_50) | (aroonu_14_1d < 85.0) | (roc_9_1d < 200.0))
+            & ((rsi_3_4h_gt_50) | (aroonu_14_1d_lt_85) | (roc_9_1d < 200.0))
             # 4h down move, 4h high & overbought
             & ((rsi_3_4h_gt_50) | (stochrsi_k_4h_lt_70) | (roc_9_4h_lt_10))
             # 4h down move, 4h still high, 1d downtrend
@@ -22315,11 +22340,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m high, 1h & 4h overbought
             & ((aroonu_14_15m_lt_70) | (roc_9_1h_lt_10) | (roc_9_4h_lt_10))
             # 15m high, 4h overbought, 1d downtrend
-            & ((aroonu_14_15m < 80.0) | (roc_9_4h_lt_20) | (roc_9_1d_gt_neg_30))
+            & ((aroonu_14_15m_lt_80) | (roc_9_4h_lt_20) | (roc_9_1d_gt_neg_30))
             # 15m & 1h high
-            & ((aroonu_14_15m < 90.0) | (aroonu_14_1h_lt_100))
+            & ((aroonu_14_15m_lt_90) | (aroonu_14_1h_lt_100))
             # 15m & 4h high
-            & ((aroonu_14_15m < 90.0) | aroonu_14_4h_lt_100)
+            & ((aroonu_14_15m_lt_90) | aroonu_14_4h_lt_100)
             # 1h & 1d high, 1d overbought
             & ((aroonu_14_1h_lt_100) | aroonu_14_1d_lt_100 | (roc_9_1d < 10.0))
             # 1h & 4h high, 1h overbought
@@ -22333,7 +22358,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h high, 1h & 4h overbought
             & (aroonu_14_4h_lt_100 | (roc_9_1h < 20.0) | (roc_9_4h_lt_40))
             # 1d high, 4h & 1d downtrend
-            & ((aroonu_14_1d < 60.0) | (roc_9_4h_gt_neg_20) | (roc_9_1d_gt_neg_30))
+            & ((aroonu_14_1d_lt_60) | (roc_9_4h_gt_neg_20) | (roc_9_1d_gt_neg_30))
             # 1d high, 4h & 1d overbought
             & (aroonu_14_1d_lt_100 | (roc_9_4h < 60.0) | (roc_9_1d < 100.0))
             # 15m high, 4h & 1d overbought
@@ -22368,13 +22393,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 5m & 4h down move, 4h still high
             & ((rsi_3_gt_3) | (rsi_3_4h_gt_10) | (stochrsi_k_4h_lt_50))
             # 15m & 1h down move, 1h still not low enough
-            & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_3) | (aroonu_14_1h < 25.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_3) | (aroonu_14_1h_lt_25))
             # 15m & 1h & 4h down move
             & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_5) | (rsi_3_4h_gt_10))
             # 15m & 1h & 4h down move, 15m still not low enough, 4h still not low enough
-            & ((rsi_3_15m_gt_3) | (rsi_3_1h_gt_10) | (rsi_3_4h_gt_20) | (aroonu_14_15m < 20.0) | (aroonu_14_4h < 20.0))
+            & ((rsi_3_15m_gt_3) | (rsi_3_1h_gt_10) | (rsi_3_4h_gt_20) | (aroonu_14_15m_lt_20) | (aroonu_14_4h_lt_20))
             # 15m & 1h down move, 15m still high
-            & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_15) | (aroonu_14_15m < 40.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_15) | (aroonu_14_15m_lt_40))
             # 15m & 1h down move, 4h still high
             & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_15) | (aroonu_14_4h_lt_40))
             # 15m & 1h down move, 1h still high
@@ -22386,7 +22411,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 1d downtrend
             & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_35) | (roc_9_1d_gt_neg_30))
             # 15m & 1h down move, 4h high
-            & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_40) | (aroonu_14_1h < 85.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_40) | (aroonu_14_1h_lt_85))
             # 15m & 4h down move, 4h still high
             & (rsi_3_15m_gt_3 | (rsi_3_4h_gt_15) | (aroonu_14_4h_lt_50))
             # 15m & 4h down move, 15m still high
@@ -22398,11 +22423,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 4h still high
             & ((rsi_3_15m_gt_5) | (rsi_3_1h_gt_10) | (rsi_14_4h < 40.0))
             # 15m & 1h down move, 1d high
-            & ((rsi_3_15m_gt_5) | (rsi_3_1h_gt_15) | (aroonu_14_1d < 100.0))
+            & ((rsi_3_15m_gt_5) | (rsi_3_1h_gt_15) | (aroonu_14_1d_lt_100))
             # 15m & 4h down move, 15m still not low enough
-            & ((rsi_3_15m_gt_5) | (rsi_3_4h_gt_10) | (aroonu_14_15m < 30.0))
+            & ((rsi_3_15m_gt_5) | (rsi_3_4h_gt_10) | (aroonu_14_15m_lt_30))
             # 15m & 4h down move, 4h high
-            & ((rsi_3_15m_gt_5) | (rsi_3_4h_gt_10) | (aroonu_14_4h < 80.0))
+            & ((rsi_3_15m_gt_5) | (rsi_3_4h_gt_10) | (aroonu_14_4h_lt_80))
             # 15m & 4h down move, 1h still high
             & ((rsi_3_15m_gt_5) | (rsi_3_4h_gt_10) | (stochrsi_k_1h < 40.0))
             # 15m & 4h down move, 1d downtrend
@@ -22422,7 +22447,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h & 4h & 1d down mode, 1d downtrend
             & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_10) | (rsi_3_4h_gt_20) | (rsi_3_1d_gt_20) | (roc_9_1d_gt_neg_50))
             # 15m & 1h down move, 1h high
-            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_10) | (aroonu_14_1h < 60.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_10) | (aroonu_14_1h_lt_60))
             # 15m & 1h down move, 4h high
             & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_10) | (aroonu_14_4h_lt_60))
             # 15m & 1h down move, 1h high
@@ -22448,7 +22473,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 4h down move, 15m high
             & ((rsi_3_15m_gt_10) | (rsi_3_4h_gt_40) | (aroonu_14_15m_lt_70))
             # 15m down move, 15m high, 1d high
-            & ((rsi_3_15m_gt_10) | (aroonu_14_15m < 60.0) | (aroonu_14_1d_lt_100))
+            & ((rsi_3_15m_gt_10) | (aroonu_14_15m_lt_60) | (aroonu_14_1d_lt_100))
             # 15m down move, 1h & 1d high
             & ((rsi_3_15m_gt_10) | (aroonu_14_1h_lt_90) | (aroonu_14_1d_lt_100))
             # 15m down move, 4h high, 1d overbought
@@ -22466,11 +22491,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 1d downtrend
             & ((rsi_3_1h_gt_5) | (rsi_3_4h_gt_5) | (roc_9_1d_gt_neg_30))
             # 1h & 4h down move, 1d still high
-            & ((rsi_3_1h_gt_5) | (rsi_3_4h_gt_10) | (aroonu_14_1d < 50.0))
+            & ((rsi_3_1h_gt_5) | (rsi_3_4h_gt_10) | (aroonu_14_1d_lt_50))
             # 1h & 4h & 1d down move
             & ((rsi_3_1h_gt_5) | (rsi_3_4h_gt_10) | (rsi_3_1d_gt_20))
             # 1h & 4h down move, 4h still not low enough
-            & ((rsi_3_1h_gt_5) | (rsi_3_4h_gt_15) | (aroonu_14_4h < 30.0))
+            & ((rsi_3_1h_gt_5) | (rsi_3_4h_gt_15) | (aroonu_14_4h_lt_30))
             # 1h down move, 4h & 1d downtrend
             & ((rsi_3_1h_gt_5) | (roc_9_4h > -10.0) | (roc_9_1d_gt_neg_20))
             # 1h & 4h down move, 1d still not low enough
@@ -22508,11 +22533,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 1h high
             & ((rsi_3_1h_gt_30) | (rsi_3_4h_gt_30) | (stochrsi_k_1h < 60.0))
             # 1h down move, 15m still high, 1h high
-            & ((rsi_3_1h_gt_30) | (aroonu_14_15m_lt_50) | (aroonu_14_1h < 85.0))
+            & ((rsi_3_1h_gt_30) | (aroonu_14_15m_lt_50) | (aroonu_14_1h_lt_85))
             # 1h & 1d down move, 1h high
             & ((rsi_3_1h_gt_45) | (rsi_3_1d_gt_45) | aroonu_14_1h_lt_80)
             # 4h & 1d down move, 15m still not low enough
-            & ((rsi_3_4h_gt_3) | (rsi_3_1d_gt_15) | (aroonu_14_15m < 20.0))
+            & ((rsi_3_4h_gt_3) | (rsi_3_1d_gt_15) | (aroonu_14_15m_lt_20))
             # 4h & 1d down move, 1d high
             & ((rsi_3_4h_gt_3) | (rsi_3_1d_gt_25) | (aroonu_14_1d_lt_70))
             # 4h & 1d down move, 1d downtrend
@@ -22526,13 +22551,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h & 1d down move, 15m still high
             & ((rsi_3_4h_gt_10) | (rsi_3_1d_gt_20) | (stochrsi_k_15m < 40.0))
             # 4h down move, 1d high & overbought
-            & ((rsi_3_4h_gt_10) | (aroonu_14_1d < 100.0) | (roc_9_1d < 10.0))
+            & ((rsi_3_4h_gt_10) | (aroonu_14_1d_lt_100) | (roc_9_1d < 10.0))
             # 4h down move, 1h high, 1d downtrend
             & ((rsi_3_4h_gt_10) | (stochrsi_k_1h < 50.0) | (roc_9_1d > -30.0))
             # 4h down move, 4h & 1d downtrend
             & ((rsi_3_4h_gt_10) | (roc_9_4h > -20.0) | (roc_9_1d_gt_neg_40))
             # 4h & 1d down move, 1d high
-            & ((rsi_3_4h_gt_15) | (rsi_3_1d_gt_20) | (aroonu_14_1d < 60.0))
+            & ((rsi_3_4h_gt_15) | (rsi_3_1d_gt_20) | (aroonu_14_1d_lt_60))
             # 4h & 1d down move, 4h high
             & ((rsi_3_4h_gt_15) | (rsi_3_1d_gt_30) | (stochrsi_k_4h < 60.0))
             # 4h down move, 1d still high, 4h still not low enough
@@ -22548,7 +22573,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 1h downtrend, 1d overbought
             & ((rsi_3_4h_gt_15) | (roc_9_1h > -10.0) | (roc_9_1d < 200.0))
             # 4h & 1d down move, 1d still high
-            & (rsi_3_4h_gt_20 | (rsi_3_1d_gt_20) | (aroonu_14_1d < 50.0))
+            & (rsi_3_4h_gt_20 | (rsi_3_1d_gt_20) | (aroonu_14_1d_lt_50))
             # 4h down move, 4h & 1d high
             & (rsi_3_4h_gt_20 | aroonu_14_4h_lt_70 | (aroonu_14_1d_lt_70))
             # 4h down move, 1d high & overbought
@@ -22568,9 +22593,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h high, 4h & 1d overbought
             & (aroonu_14_1h_lt_70 | (roc_9_4h_lt_40) | (roc_9_1d_lt_80))
             # 1h & 4h high, 1d overbought
-            & ((aroonu_14_1h < 85.0) | aroonu_14_4h_lt_100 | (roc_9_1d_lt_40))
+            & ((aroonu_14_1h_lt_85) | aroonu_14_4h_lt_100 | (roc_9_1d_lt_40))
             # 1d high, 4h & 1d downtrend
-            & ((aroonu_14_1d < 60.0) | (roc_9_4h_gt_neg_20) | (roc_9_1d_gt_neg_30))
+            & ((aroonu_14_1d_lt_60) | (roc_9_4h_gt_neg_20) | (roc_9_1d_gt_neg_30))
             # 4h high, 4h & 1d overbought
             & ((stochrsi_k_4h < 90.0) | (roc_9_4h_lt_20) | (roc_9_1d_lt_20))
           )
@@ -22593,31 +22618,29 @@ class NostalgiaForInfinityX7(IStrategy):
 
           long_entry_logic.append(
             # 5m & 1h down move, 1h still not low enough
-            ((rsi_3_gt_3) | (rsi_3_1h_gt_10) | (aroonu_14_1h < 30.0))
+            ((rsi_3_gt_3) | (rsi_3_1h_gt_10) | (aroonu_14_1h_lt_30))
             # 5m & 4h down move, 15m still high
-            & ((rsi_3_gt_3) | (rsi_3_4h_gt_5) | (aroonu_14_15m < 40.0))
+            & ((rsi_3_gt_3) | (rsi_3_4h_gt_5) | (aroonu_14_15m_lt_40))
             # 5m & 4h & 1d down move
             & ((rsi_3_gt_3) | (rsi_3_4h_gt_10) | (rsi_3_1d_gt_10))
             # 5m & 4h down move, 1d downtrend
             & ((rsi_3_gt_3) | (rsi_3_4h_gt_10) | (roc_9_1d > -10.0))
             # 5m & 4h down move, 15m high
-            & ((rsi_3_gt_10) | (rsi_3_4h_gt_10) | (aroonu_14_15m < 40.0))
+            & ((rsi_3_gt_10) | (rsi_3_4h_gt_10) | (aroonu_14_15m_lt_40))
             # 15m & 1h down move, 1h still not low enough
-            & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_3) | (aroonu_14_1h < 25.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_3) | (aroonu_14_1h_lt_25))
             # 15m & 1h & 4h down move, 15m still not low enough, 4h still not low enough
-            & ((rsi_3_15m_gt_3) | (rsi_3_1h_gt_10) | (rsi_3_4h_gt_20) | (aroonu_14_15m < 20.0) | (aroonu_14_4h < 20.0))
+            & ((rsi_3_15m_gt_3) | (rsi_3_1h_gt_10) | (rsi_3_4h_gt_20) | (aroonu_14_15m_lt_20) | (aroonu_14_4h_lt_20))
             # 15m & 1h & 1d down move, 4h still high, 4h downtrend
             & ((rsi_3_15m_gt_3) | (rsi_3_1h_gt_15) | (rsi_3_1d_gt_25) | (aroonu_14_4h_lt_40) | (roc_9_4h_gt_neg_20))
             # 15m & 1h down move, 1d high
             & ((rsi_3_15m_gt_5) | (rsi_3_1h_gt_5) | (aroonu_14_1d_lt_70))
             # 15m & 1h & 4h & 1d down move, 1h still not low enough
-            & ((rsi_3_15m_gt_5) | (rsi_3_1h_gt_10) | (rsi_3_4h_gt_30) | (rsi_3_1d_gt_30) | (aroonu_14_1h < 30.0))
+            & ((rsi_3_15m_gt_5) | (rsi_3_1h_gt_10) | (rsi_3_4h_gt_30) | (rsi_3_1d_gt_30) | (aroonu_14_1h_lt_30))
             # 15m & 1h down move, 1d high
-            & ((rsi_3_15m_gt_5) | (rsi_3_1h_gt_10) | (aroonu_14_1d < 100.0))
+            & ((rsi_3_15m_gt_5) | (rsi_3_1h_gt_10) | (aroonu_14_1d_lt_100))
             # 15m & 1h & 4h down move, 15m still not low enough, 1h still not low enough
-            & (
-              (rsi_3_15m_gt_5) | (rsi_3_1h_gt_30) | (rsi_3_4h_gt_30) | (aroonu_14_15m < 30.0) | (stochrsi_k_1h < 30.0)
-            )
+            & ((rsi_3_15m_gt_5) | (rsi_3_1h_gt_30) | (rsi_3_4h_gt_30) | (aroonu_14_15m_lt_30) | (stochrsi_k_1h < 30.0))
             # 15m & 1h down move, 1d overbought
             & ((rsi_3_15m_gt_5) | (rsi_3_1h_gt_30) | (roc_9_1d_lt_30))
             # 15m & 4h down move, 4h downtrend
@@ -22639,7 +22662,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 4h high
             & ((rsi_3_15m_gt_15) | (rsi_3_1h_gt_35) | aroonu_14_4h_lt_100)
             # 15m & 4h down move, 15m still high
-            & ((rsi_3_15m_gt_15) | (rsi_3_4h_gt_15) | (aroonu_14_15m < 40.0))
+            & ((rsi_3_15m_gt_15) | (rsi_3_4h_gt_15) | (aroonu_14_15m_lt_40))
             # 15m down move, 4h & 1d overbought
             & ((rsi_3_15m_gt_15) | (roc_9_4h_lt_20) | (roc_9_1d < 200.0))
             # 15m & 1h down move, 4h high
@@ -22683,15 +22706,15 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 15m still not low enough
             & ((rsi_3_1h_gt_5) | (rsi_3_4h_gt_5) | (stochrsi_k_15m < 20.0))
             # 1h & 4h down move, 1d still high
-            & ((rsi_3_1h_gt_5) | rsi_3_4h_gt_20 | (aroonu_14_1d < 50.0))
+            & ((rsi_3_1h_gt_5) | rsi_3_4h_gt_20 | (aroonu_14_1d_lt_50))
             # 1h & 4h down move, 4h still not low enough
             & ((rsi_3_1h_gt_5) | (rsi_3_4h_gt_40) | (stochrsi_k_4h < 30.0))
             # 1h & 1d down move, 1h still high
-            & ((rsi_3_1h_gt_5) | (rsi_3_1d_gt_5) | (aroonu_14_1h < 40.0))
+            & ((rsi_3_1h_gt_5) | (rsi_3_1d_gt_5) | (aroonu_14_1h_lt_40))
             # 1h down move, 1d high & overbought
             & ((rsi_3_1h_gt_5) | (aroonu_14_1d_lt_90) | (roc_9_1d_lt_20))
             # 1h & 4h & 1d down move, 4h downtrend, 1d still high
-            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_15) | (rsi_3_1d_gt_25) | (rsi_14_4h > 30.0) | (aroonu_14_1d < 40.0))
+            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_15) | (rsi_3_1d_gt_25) | (rsi_14_4h > 30.0) | (aroonu_14_1d_lt_40))
             # 1h & 4h down move, 4h still not low enough
             & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_15) | (stochrsi_k_4h < 30.0))
             # 1h & 4h down move, 15m still high
@@ -22709,7 +22732,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 15m still not low enough
             & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_3) | (stochrsi_k_15m < 30.0))
             # 1h & 4h down move, 1h high
-            & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_25) | (aroonu_14_1h < 70.0))
+            & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_25) | (aroonu_14_1h_lt_70))
             # 1h & 4h down move, 4h high
             & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_30) | aroonu_14_4h_lt_70)
             # 1h & 4h down move, 1d downtrend
@@ -22771,7 +22794,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h high, 15m high
             & ((rsi_3_1h_gt_50) | aroonu_14_1h_lt_70 | (stochrsi_k_15m < 70.0))
             # 4h & 1d down move, 15m still not low enough
-            & ((rsi_3_4h_gt_3) | (rsi_3_1d_gt_15) | (aroonu_14_15m < 20.0))
+            & ((rsi_3_4h_gt_3) | (rsi_3_1d_gt_15) | (aroonu_14_15m_lt_20))
             # 4h & 1d down move, 1d still high
             & ((rsi_3_4h_gt_3) | (rsi_3_1d_gt_20) | (stochrsi_k_1d < 40.0))
             # 4h & 1d down move, 1d high
@@ -22779,31 +22802,31 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 15m high
             & ((rsi_3_4h_gt_3) | (stochrsi_k_15m < 60.0))
             # 4h down move, 15m still high, 4h still not low enough
-            & ((rsi_3_4h_gt_5) | (stochrsi_k_15m < 50.0) | (aroonu_14_4h < 30.0))
+            & ((rsi_3_4h_gt_5) | (stochrsi_k_15m < 50.0) | (aroonu_14_4h_lt_30))
             # 4h & 1d down move, 15m still high
             & ((rsi_3_4h_gt_10) | (rsi_3_1d_gt_15) | (stochrsi_k_15m < 40.0))
             # 4h down move, 4h still not low enough, 1d downtrend
-            & ((rsi_3_4h_gt_10) | (aroonu_14_4h < 20.0) | (roc_9_1d > -10.0))
+            & ((rsi_3_4h_gt_10) | (aroonu_14_4h_lt_20) | (roc_9_1d > -10.0))
             # 4h down move, 4h still high, 4h downtrend
             & ((rsi_3_4h_gt_10) | (aroonu_14_4h_lt_40) | (roc_9_4h > -20.0))
             # 4h down move, 1d still high, 1d downtrend
-            & ((rsi_3_4h_gt_10) | (aroonu_14_1d < 40.0) | (roc_9_1d > -30.0))
+            & ((rsi_3_4h_gt_10) | (aroonu_14_1d_lt_40) | (roc_9_1d > -30.0))
             # 4h down move, 1d high, 15m high
             & ((rsi_3_4h_gt_10) | (aroonu_14_1d_lt_80) | (stochrsi_k_15m < 60.0))
             # 4h down move, 1d high, 4h downtrend
-            & ((rsi_3_4h_gt_10) | (aroonu_14_1d < 100.0) | (roc_9_4h > -10.0))
+            & ((rsi_3_4h_gt_10) | (aroonu_14_1d_lt_100) | (roc_9_4h > -10.0))
             # 4h down move, 4h & 1d downtrend
             & ((rsi_3_4h_gt_10) | (roc_9_4h > -10.0) | (roc_9_1d > -20.0))
             # 4h & 1d down move, 1d still high
-            & ((rsi_3_4h_gt_15) | (rsi_3_1d_gt_15) | (aroonu_14_1d < 50.0))
+            & ((rsi_3_4h_gt_15) | (rsi_3_1d_gt_15) | (aroonu_14_1d_lt_50))
             # 4h & 1d down move, 4h still high
             & ((rsi_3_4h_gt_15) | (rsi_3_1d_gt_30) | (stochrsi_k_4h_lt_50))
             # 4h & 1d down move, 4h still high
             & ((rsi_3_4h_gt_15) | (rsi_3_1d_gt_45) | (stochrsi_k_4h < 40.0))
             # 4h down move, 4h still not low enough, 1d high
-            & ((rsi_3_4h_gt_15) | (aroonu_14_4h < 30.0) | (aroonu_14_1d_lt_70))
+            & ((rsi_3_4h_gt_15) | (aroonu_14_4h_lt_30) | (aroonu_14_1d_lt_70))
             # 4h down move, 1d high & overbought
-            & ((rsi_3_4h_gt_15) | (aroonu_14_1d < 100.0) | (roc_9_1d_lt_30))
+            & ((rsi_3_4h_gt_15) | (aroonu_14_1d_lt_100) | (roc_9_1d_lt_30))
             # 4h down move, 15m high
             & ((rsi_3_4h_gt_15) | (stochrsi_k_15m < 70.0))
             # 4h & 1d down move, 1d downtrend
@@ -22819,11 +22842,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 4h high, 1d high
             & ((rsi_3_4h_gt_30) | (aroonu_14_4h_lt_70) | (stochrsi_k_1d < 80.0))
             # 4h down move, 1d stil high, 1d downtrend
-            & ((rsi_3_4h_gt_30) | (aroonu_14_1d < 40.0) | (roc_9_1d_gt_neg_30))
+            & ((rsi_3_4h_gt_30) | (aroonu_14_1d_lt_40) | (roc_9_1d_gt_neg_30))
             # 4h down move, 4h still high, 4h downtrend
             & ((rsi_3_4h_gt_30) | (stochrsi_k_4h < 40.0) | (roc_9_4h > -15.0))
             # 4h & 1d down move, 4h still high, 1d high
-            & ((rsi_3_4h_gt_35) | (rsi_3_1d_gt_35) | (stochrsi_k_4h_lt_50) | (aroonu_14_1d < 60.0))
+            & ((rsi_3_4h_gt_35) | (rsi_3_1d_gt_35) | (stochrsi_k_4h_lt_50) | (aroonu_14_1d_lt_60))
             # 4h down move, 4h still high, 1d downtrend
             & ((rsi_3_4h_gt_35) | (stochrsi_k_4h < 40.0) | (roc_9_1d_gt_neg_20))
             # 4h down move, 1d high & overbought
@@ -22841,7 +22864,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h high, 4h & 1d overbought
             & (aroonu_14_1h_lt_70 | (roc_9_4h_lt_40) | (roc_9_1d_lt_80))
             # 4h & 1d high, 1h overbought
-            & ((aroonu_14_4h < 85.0) | aroonu_14_1d_lt_100 | (roc_9_1h_lt_10))
+            & ((aroonu_14_4h_lt_85) | aroonu_14_1d_lt_100 | (roc_9_1h_lt_10))
             # 4h high, 4h & 1d overbought
             & ((aroonu_14_4h_lt_90) | (roc_9_4h_lt_30) | (roc_9_1d < 60.0))
             # 15m high, 4h & 1d overbought
@@ -22879,7 +22902,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 5m & 4h down move, 1d downtrend
             ((rsi_3_gt_3) | (rsi_3_4h_gt_3) | (roc_9_1d_gt_neg_20))
             # 5m down move, 15m & 1h high
-            & ((rsi_3_gt_10) | (aroonu_14_15m < 85.0) | (aroonu_14_1h_lt_100))
+            & ((rsi_3_gt_10) | (aroonu_14_15m_lt_85) | (aroonu_14_1h_lt_100))
             # 15m & 1h & 4h down move
             & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_3) | (rsi_3_4h_gt_5))
             # 15m & 1h down move, 1h downtrend
@@ -22891,9 +22914,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 1h high
             & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_35) | aroonu_14_1h_lt_70)
             # 15m & 4h down move, 4h still not low enough
-            & ((rsi_3_15m_gt_10) | (rsi_3_4h_gt_10) | (aroonu_14_4h < 30.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_4h_gt_10) | (aroonu_14_4h_lt_30))
             # 15m & 1h down move, 1h high
-            & ((rsi_3_15m_gt_15) | (rsi_3_1h_gt_15) | (aroonu_14_1h < 70.0))
+            & ((rsi_3_15m_gt_15) | (rsi_3_1h_gt_15) | (aroonu_14_1h_lt_70))
             # 15m & 1h down move, 1h high
             & ((rsi_3_15m_gt_15) | (rsi_3_1h_gt_40) | (aroonu_14_1h_lt_90))
             # 15m & 4h down move, 1d high
@@ -22901,9 +22924,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 4h down move, 1h high
             & ((rsi_3_15m_gt_15) | (rsi_3_4h_gt_35) | (aroonu_14_1h_lt_90))
             # 15m down move, 15m downtrend, 1h high
-            & ((rsi_3_15m_gt_15) | (cmf_20_15m > -0.40) | (aroonu_14_1h < 60.0))
+            & ((rsi_3_15m_gt_15) | (cmf_20_15m > -0.40) | (aroonu_14_1h_lt_60))
             # 15m down move, 15m still high, 4h high
-            & ((rsi_3_15m_gt_15) | (aroonu_14_15m < 40.0) | (stochrsi_k_4h < 60.0))
+            & ((rsi_3_15m_gt_15) | (aroonu_14_15m_lt_40) | (stochrsi_k_4h < 60.0))
             # 15m down move, 1h high, 1d downtrend
             & ((rsi_3_15m_gt_15) | (aroonu_14_1h_lt_90) | (roc_9_1d_gt_neg_30))
             # 15m & 1h down move, 1d downtrend
@@ -22933,9 +22956,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 4h still high, 1d high
             & ((rsi_3_1h_gt_3) | (aroonu_14_4h_lt_50) | (aroonu_14_1d_lt_90))
             # 1h & 1d down move, 1d still high
-            & ((rsi_3_1h_gt_5) | (rsi_3_1d_gt_20) | (aroonu_14_1d < 40.0))
+            & ((rsi_3_1h_gt_5) | (rsi_3_1d_gt_20) | (aroonu_14_1d_lt_40))
             # 1h & 1d down move, 1h still not low enough
-            & ((rsi_3_1h_gt_5) | (rsi_3_1d_gt_25) | (aroonu_14_1h < 20.0))
+            & ((rsi_3_1h_gt_5) | (rsi_3_1d_gt_25) | (aroonu_14_1h_lt_20))
             # 1h & 4h & 1d down move
             & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_10) | (rsi_3_1d_gt_15))
             # 1h & 4h down move, 4h still high
@@ -22951,13 +22974,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 4h high
             & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_35) | (aroonu_14_4h_lt_90))
             # 1h & 1d down move, 1h still not low enough
-            & ((rsi_3_1h_gt_10) | (rsi_3_1d_gt_20) | (aroonu_14_1h < 30.0))
+            & ((rsi_3_1h_gt_10) | (rsi_3_1d_gt_20) | (aroonu_14_1h_lt_30))
             # 1h down move, 15m downtrend, 1d high
             & ((rsi_3_1h_gt_10) | (cmf_20_15m > -0.40) | (aroonu_14_1d_lt_70))
             # 1h down move, 4h still high, 1d overbought
             & ((rsi_3_1h_gt_10) | (aroonu_14_4h_lt_40) | (roc_9_1d_lt_40))
             # 1h down move, 1d still high, 1d downtrend
-            & ((rsi_3_1h_gt_10) | (aroonu_14_1d < 50.0) | (roc_9_1d > -20.0))
+            & ((rsi_3_1h_gt_10) | (aroonu_14_1d_lt_50) | (roc_9_1d > -20.0))
             # 1h & 4h & 1d down move
             & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_15) | (rsi_3_1d_gt_20))
             # 1h & 4h down move, 15m still not low enough
@@ -22971,11 +22994,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 1d downtrend
             & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_30) | (roc_9_1d_gt_neg_40))
             # 1h down move, 1h still high, 4h high
-            & ((rsi_3_1h_gt_15) | (aroonu_14_1h < 40.0) | (aroonu_14_4h_lt_60))
+            & ((rsi_3_1h_gt_15) | (aroonu_14_1h_lt_40) | (aroonu_14_4h_lt_60))
             # 1h down move, 1h still high, 4h overbought
             & ((rsi_3_1h_gt_15) | (aroonu_14_1h_lt_50) | (roc_9_4h_lt_10))
             # 1h down move, 1h high, 1d downtrend
-            & ((rsi_3_1h_gt_15) | (aroonu_14_1h < 60.0) | (roc_9_1d > -30.0))
+            & ((rsi_3_1h_gt_15) | (aroonu_14_1h_lt_60) | (roc_9_1d > -30.0))
             # 1h down move, 4h & 1d overbought
             & ((rsi_3_1h_gt_15) | (roc_9_4h_lt_30) | (roc_9_1d_lt_50))
             # 1h & 4h down move, 4h high
@@ -22987,7 +23010,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 1d down move, 1h still high
             & ((rsi_3_1h_gt_20) | (rsi_3_1d_gt_25) | (aroonu_14_1h_lt_50))
             # 1h down move, 15m still high, 1h high
-            & ((rsi_3_1h_gt_20) | (aroonu_14_15m < 40.0) | (aroonu_14_1h_lt_80))
+            & ((rsi_3_1h_gt_20) | (aroonu_14_15m_lt_40) | (aroonu_14_1h_lt_80))
             # 1h down move, 1h high, 1d overbought
             & ((rsi_3_1h_gt_20) | (aroonu_14_1h_lt_70) | (roc_9_1d_lt_20))
             # 1h down move, 4h high & overbought
@@ -22999,7 +23022,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 1d overbought
             & ((rsi_3_1h_gt_25) | (rsi_3_4h_gt_35) | (roc_9_1d_lt_20))
             # 1h down move, 1h still high, 4h high
-            & ((rsi_3_1h_gt_25) | (aroonu_14_1h_lt_50) | (aroonu_14_4h < 85.0))
+            & ((rsi_3_1h_gt_25) | (aroonu_14_1h_lt_50) | (aroonu_14_4h_lt_85))
             # 1h down move, 1h high, 1d overbought
             & ((rsi_3_1h_gt_25) | aroonu_14_1h_lt_80 | (roc_9_1d_lt_30))
             # 1h down move, 1h still high, 4h downtrend
@@ -23011,7 +23034,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 4h high
             & ((rsi_3_1h_gt_35) | (rsi_3_4h_gt_40) | (stochrsi_k_4h_lt_80))
             # 1h down move, 1h still high, 1d overbought
-            & ((rsi_3_1h_gt_35) | (aroonu_14_1h < 40.0) | (roc_9_1d_lt_40))
+            & ((rsi_3_1h_gt_35) | (aroonu_14_1h_lt_40) | (roc_9_1d_lt_40))
             # 1h down move, 4h high & overbought
             & ((rsi_3_1h_gt_35) | (aroonu_14_4h_lt_90) | (roc_9_4h < 60.0))
             # 1h down move, 4h high, 1d downtrend
@@ -23033,7 +23056,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 4h & 1d high
             & ((rsi_3_4h_gt_10) | (aroonu_14_4h_lt_60) | (aroonu_14_1d_lt_70))
             # 4h down move, 1d still high, 1d downtrend
-            & ((rsi_3_4h_gt_10) | (aroonu_14_1d < 50.0) | (roc_9_1d > -30.0))
+            & ((rsi_3_4h_gt_10) | (aroonu_14_1d_lt_50) | (roc_9_1d > -30.0))
             # 4h down move, 15m & 1h still not low enough
             & ((rsi_3_4h_gt_10) | (stochrsi_k_15m < 30.0) | (stochrsi_k_1h < 30.0))
             # 4h down move, 15m stil high, 4h downtrend
@@ -23079,11 +23102,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m high, 1d high & overbought
             & ((aroonu_14_15m_lt_70) | aroonu_14_1d_lt_100 | (roc_9_1d < 100.0))
             # 15m high, 4h overbought, 1d downtrend
-            & ((aroonu_14_15m < 80.0) | (roc_9_4h_lt_20) | (roc_9_1d_gt_neg_30))
+            & ((aroonu_14_15m_lt_80) | (roc_9_4h_lt_20) | (roc_9_1d_gt_neg_30))
             # 1h & 4h high, 4h overbought
             & (aroonu_14_1h_lt_70 | aroonu_14_4h_lt_100 | (roc_9_4h_lt_10))
             # 1h high, 1d overbought
-            & ((aroonu_14_1h < 85.0) | (roc_9_1d_lt_80))
+            & ((aroonu_14_1h_lt_85) | (roc_9_1d_lt_80))
             # 1h high, 4h & 1d downtrend
             & ((aroonu_14_1h_lt_100) | (roc_9_4h > -10.0) | (roc_9_1d > -25.0))
             # 4h & 1d high, 1d overbought
@@ -23109,13 +23132,13 @@ class NostalgiaForInfinityX7(IStrategy):
           long_entry_logic.append(protections_long_global == True)
 
           # 5m down move, 15m high
-          long_entry_logic.append((rsi_3_gt_15) | (aroonu_14_15m < 80.0))
+          long_entry_logic.append((rsi_3_gt_15) | (aroonu_14_15m_lt_80))
           # 15m & 1h down move, 4h high
           long_entry_logic.append((rsi_3_15m_gt_25) | (rsi_3_1h_gt_35) | aroonu_14_4h_lt_70)
           # 15m & 4h down move, 4h still high
           long_entry_logic.append((rsi_3_15m_gt_25) | (rsi_3_4h_gt_50) | (aroonu_14_4h_lt_50))
           # 15m down move, 15m high
-          long_entry_logic.append((rsi_3_15m_gt_25) | (aroonu_14_15m < 80.0))
+          long_entry_logic.append((rsi_3_15m_gt_25) | (aroonu_14_15m_lt_80))
           # 15m down move, 4h still high, 1d high
           long_entry_logic.append((rsi_3_15m_gt_25) | (stochrsi_k_4h_lt_50) | (aroonu_14_1d_lt_90))
           # 15m & 1h down move, 15m still high
@@ -23145,7 +23168,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m & 1h down move, 1h still high
           long_entry_logic.append((rsi_3_15m_gt_45) | (rsi_3_1h_gt_45) | (stochrsi_k_1h < 40.0))
           # 15m down move, 15m high, 1d overbought
-          long_entry_logic.append((rsi_3_15m_gt_45) | (aroonu_14_15m < 60.0) | roc_9_1d_lt_50)
+          long_entry_logic.append((rsi_3_15m_gt_45) | (aroonu_14_15m_lt_60) | roc_9_1d_lt_50)
           # 15m down move, 15m high, 4h still high
           long_entry_logic.append((rsi_3_15m_gt_45) | (aroonu_14_15m_lt_70) | (stochrsi_k_4h_lt_50))
           # 15m down move, 15m still not low enough, 4h still high
@@ -23159,7 +23182,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m down move, 15m still high, 1h high
           long_entry_logic.append((rsi_3_15m_gt_55) | (stochrsi_k_15m < 40.0) | (stochrsi_k_1h_lt_70))
           # 15m down move, 15m still high, 4h high
-          long_entry_logic.append((rsi_3_15m_gt_55) | (stochrsi_k_15m < 50.0) | (aroonu_14_4h < 85.0))
+          long_entry_logic.append((rsi_3_15m_gt_55) | (stochrsi_k_15m < 50.0) | (aroonu_14_4h_lt_85))
           # 15m down move, 15m & 1h still high
           long_entry_logic.append((rsi_3_15m_gt_55) | (stochrsi_k_15m < 50.0) | (stochrsi_k_1h_lt_50))
           # 1h down move, 4h still high, 1d high
@@ -23178,7 +23201,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1h down move, 1h high
           long_entry_logic.append((rsi_3_1h_gt_40) | (stochrsi_k_1h < 60.0))
           # 1h down move, 4h & 1d high
-          long_entry_logic.append((rsi_3_1h_gt_40) | (aroonu_14_4h < 85.0) | (aroonu_14_1d_lt_90))
+          long_entry_logic.append((rsi_3_1h_gt_40) | (aroonu_14_4h_lt_85) | (aroonu_14_1d_lt_90))
           # 1h down move, 1h still high, 4h high
           long_entry_logic.append((rsi_3_1h_gt_45) | (aroonu_14_1h_lt_50) | (aroonu_14_4h_lt_90))
           # 1h down move, 1h still high, 1d high
@@ -23194,7 +23217,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1h down move, 15m still high, 4h high
           long_entry_logic.append((rsi_3_1h_gt_50) | (stochrsi_k_15m < 50.0) | (stochrsi_k_4h_lt_80))
           # 1h down move, 15m & 1h high
-          long_entry_logic.append((rsi_3_1h_gt_50) | (stochrsi_k_15m < 60.0) | (aroonu_14_1h < 60.0))
+          long_entry_logic.append((rsi_3_1h_gt_50) | (stochrsi_k_15m < 60.0) | (aroonu_14_1h_lt_60))
           # 1h down move, 1h & 1d high
           long_entry_logic.append((rsi_3_1h_gt_50) | aroonu_14_1h_lt_70 | (stochrsi_k_1d < 80.0))
           # 1h down move, 4h still high, 1d high
@@ -23228,9 +23251,9 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1h down move, 4h & 1d high
           long_entry_logic.append((rsi_3_1h_gt_60) | (rsi_14_4h < 70.0) | (rsi_14_1d < 80.0))
           # 15m & 1h & 4h down move, 4h high
-          long_entry_logic.append((rsi_3_15m_gt_50) | (rsi_3_1h_gt_65) | (rsi_3_4h_gt_65) | (aroonu_14_4h < 85.0))
+          long_entry_logic.append((rsi_3_15m_gt_50) | (rsi_3_1h_gt_65) | (rsi_3_4h_gt_65) | (aroonu_14_4h_lt_85))
           # 4h down move, 15m high
-          long_entry_logic.append(rsi_3_4h_gt_20 | (aroonu_14_15m < 80.0))
+          long_entry_logic.append(rsi_3_4h_gt_20 | (aroonu_14_15m_lt_80))
           # 4h down move, 1h high
           long_entry_logic.append((rsi_3_4h_gt_25) | (stochrsi_k_1h_lt_80))
           # 4h down move, 15m & 4h still high
@@ -23242,7 +23265,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 4h down move, 1d high & overbought
           long_entry_logic.append((rsi_3_4h_gt_35) | (stochrsi_k_1d < 80.0) | (roc_9_1d_lt_40))
           # 4h down move, 15m & 1h high
-          long_entry_logic.append((rsi_3_4h_gt_40) | (aroonu_14_15m < 80.0) | (stochrsi_k_1h_lt_70))
+          long_entry_logic.append((rsi_3_4h_gt_40) | (aroonu_14_15m_lt_80) | (stochrsi_k_1h_lt_70))
           # 4h down move, 1d high & overbought
           long_entry_logic.append((rsi_3_4h_gt_40) | (aroonu_14_1d_lt_80) | (roc_9_1d_lt_20))
           # 4h down move, 15m still high, 1h high
@@ -23272,7 +23295,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 4h down move, 15m & 4h high
           long_entry_logic.append((rsi_3_4h_gt_60) | (aroonu_14_15m_lt_70) | aroonu_14_4h_lt_70)
           # 4h down move, 15m high, 4h still high
-          long_entry_logic.append((rsi_3_4h_gt_60) | (aroonu_14_15m < 80.0) | (aroonu_14_4h_lt_40))
+          long_entry_logic.append((rsi_3_4h_gt_60) | (aroonu_14_15m_lt_80) | (aroonu_14_4h_lt_40))
           # 4h down move, 15m still high, 1h high
           long_entry_logic.append((rsi_3_4h_gt_60) | (stochrsi_k_15m < 50.0) | aroonu_14_1h_lt_70)
           # 4h down move, 15m still high, 4h high
@@ -23286,13 +23309,13 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m still high, 1d high & overbought
           long_entry_logic.append((aroonu_14_15m_lt_50) | aroonu_14_1d_lt_100 | (roc_9_1d < 100.0))
           # 15m high, 4h high
-          long_entry_logic.append((aroonu_14_15m_lt_70) | (aroonu_14_4h < 85.0))
+          long_entry_logic.append((aroonu_14_15m_lt_70) | (aroonu_14_4h_lt_85))
           # 15m & 1d high, 1d overbought
           long_entry_logic.append((aroonu_14_15m_lt_70) | (aroonu_14_1d_lt_90) | (roc_9_1d_lt_20))
           # 15m & 1d high, 4h overbought
           long_entry_logic.append((aroonu_14_15m_lt_70) | aroonu_14_1d_lt_100 | (roc_9_4h_lt_10))
           # 15m high, 4h still high
-          long_entry_logic.append((aroonu_14_15m < 80.0) | (stochrsi_k_4h_lt_50))
+          long_entry_logic.append((aroonu_14_15m_lt_80) | (stochrsi_k_4h_lt_50))
           # 4h & 1d high, 1d overbought
           long_entry_logic.append(aroonu_14_4h_lt_100 | aroonu_14_1d_lt_100 | (roc_9_1d_lt_20))
           # 4h high, 4h overbought
@@ -23322,7 +23345,7 @@ class NostalgiaForInfinityX7(IStrategy):
 
           # Logic
           long_entry_logic.append(rsi_14 < 50.0)
-          long_entry_logic.append(aroonu_14_15m < 90.0)
+          long_entry_logic.append(aroonu_14_15m_lt_90)
           long_entry_logic.append(stochrsi_k_15m < 90.0)
           long_entry_logic.append(
             (sma_21.shift(1) < sma_200.shift(1).infer_objects(copy=False).fillna(value=np.nan))
@@ -23360,9 +23383,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 1h & 1d high
             & ((rsi_3_15m_gt_10) | (aroonu_14_1h_lt_90) | aroonu_14_1d_lt_100)
             # 15m down move, 4h & 1d high
-            & ((rsi_3_15m_gt_10) | (aroonu_14_4h < 75.0) | aroonu_14_1d_lt_100)
+            & ((rsi_3_15m_gt_10) | (aroonu_14_4h_lt_75) | aroonu_14_1d_lt_100)
             # 15m down move, 1d high, 1d downtrend
-            & ((rsi_3_15m_gt_10) | (aroonu_14_1d < 85.0) | (cmf_20_1d > -0.40))
+            & ((rsi_3_15m_gt_10) | (aroonu_14_1d_lt_85) | (cmf_20_1d > -0.40))
             # 15m & 1h down move, 15m still not low enough
             & ((rsi_3_15m_gt_15) | rsi_3_1h_gt_20 | (stochrsi_k_15m < 30.0))
             # 15m & 1h down nove, 1h still high
@@ -23382,7 +23405,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 4h high
             & ((rsi_3_15m_gt_25) | (rsi_3_1h_gt_25) | (stochrsi_k_4h_lt_90))
             # 15m down move, 15m high, 1d overbought
-            & ((rsi_3_15m_gt_25) | (aroonu_14_15m < 60.0) | (roc_9_1d < 150.0))
+            & ((rsi_3_15m_gt_25) | (aroonu_14_15m_lt_60) | (roc_9_1d < 150.0))
             # 15m down move, 15m still high, 1d high, 1d downtrend
             & ((rsi_3_15m_gt_30) | (aroonu_14_15m_lt_50) | (stochrsi_k_1d < 70.0) | (roc_9_1d > -15.0))
             # 15m down move, 1h & 4h high
@@ -23390,7 +23413,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 15m stil high
             & ((rsi_3_1h_gt_3) | (rsi_3_4h_gt_10) | (stochrsi_k_15m < 50.0))
             # 1h & 4h down move, 1h still high
-            & ((rsi_3_1h_gt_3) | (rsi_3_4h_gt_25) | (aroonu_14_1h < 40.0))
+            & ((rsi_3_1h_gt_3) | (rsi_3_4h_gt_25) | (aroonu_14_1h_lt_40))
             # 1h & 4h down move, 4h high
             & ((rsi_3_1h_gt_5) | rsi_3_4h_gt_20 | (aroonu_14_4h_lt_60))
             # 1h & 4h down move, 4h high
@@ -23410,13 +23433,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 1d downtrend
             & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_25) | (roc_9_1d > -30.0))
             # 1h down move, 1h & 1d high
-            & ((rsi_3_1h_gt_15) | (aroonu_14_1h < 60.0) | (aroonu_14_1d < 85.0))
+            & ((rsi_3_1h_gt_15) | (aroonu_14_1h_lt_60) | (aroonu_14_1d_lt_85))
             # 1h down move, 1h high, 1d overbought
-            & ((rsi_3_1h_gt_15) | (aroonu_14_1h < 60.0) | roc_9_1d_lt_50)
+            & ((rsi_3_1h_gt_15) | (aroonu_14_1h_lt_60) | roc_9_1d_lt_50)
             # 1h down move, 1d high & overbought
             & ((rsi_3_1h_gt_15) | (stochrsi_k_1d_lt_90) | (roc_9_1d_lt_40))
             # 1h down move, 1h high, 1d overbought
-            & ((rsi_3_1h_gt_25) | (aroonu_14_1h < 60.0) | (roc_9_1d_lt_100))
+            & ((rsi_3_1h_gt_25) | (aroonu_14_1h_lt_60) | (roc_9_1d_lt_100))
             # 1h down move, 1h high
             & ((rsi_3_1h_gt_25) | (aroonu_14_1h_lt_90))
             # 1h & 4h down move, 4h high
@@ -23424,7 +23447,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 15m & 4h high
             & ((rsi_3_1h_gt_30) | (rsi_3_4h_gt_50) | (aroonu_14_15m_lt_70) | (aroonu_14_1h_lt_70))
             # 1h down move, 1h high, 4h overbought
-            & ((rsi_3_1h_gt_30) | (aroonu_14_1h < 60.0) | (roc_9_4h < 50.0))
+            & ((rsi_3_1h_gt_30) | (aroonu_14_1h_lt_60) | (roc_9_4h < 50.0))
             # 1h down move, 1h high, 1d overbought
             & ((rsi_3_1h_gt_30) | (aroonu_14_1h_lt_80) | (roc_9_1d_lt_80))
             # 1h down move, 1h & 4h high
@@ -23450,7 +23473,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h & 1d down move
             & ((rsi_3_4h_gt_5) | (rsi_3_1d_gt_10))
             # 4h down move, 1d high, 1h downtrend
-            & ((rsi_3_4h_gt_10) | (aroonu_14_1d < 85.0) | (roc_9_1h > -30.0))
+            & ((rsi_3_4h_gt_10) | (aroonu_14_1d_lt_85) | (roc_9_1h > -30.0))
             # 4h down move, 1h & 4h downtrend
             & ((rsi_3_4h_gt_10) | (roc_9_1h > -40.0) | (roc_9_4h > -40.0))
             # 4h & 1d down move, 4h still not low enough
@@ -23466,13 +23489,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1d down move, 15m still high
             & ((rsi_3_1d_gt_3) | (aroonu_14_15m_lt_50))
             # 1d down move, 15m still high, 1h high
-            & ((rsi_3_1d_gt_10) | (aroonu_14_15m < 40.0) | (stochrsi_k_1h_lt_70))
+            & ((rsi_3_1d_gt_10) | (aroonu_14_15m_lt_40) | (stochrsi_k_1h_lt_70))
             # 1d down move, 1h & 4h high
             & ((rsi_3_1d_gt_10) | aroonu_14_1h_lt_70 | (aroonu_14_4h_lt_90))
             # 1d down move, 4h high
             & ((rsi_3_1d_gt_20) | (rsi_14_4h < 80.0))
             # 1d downtrend, 1d high & overbought
-            & ((cmf_20_1d > -0.30) | (aroonu_14_1d < 85.0) | (roc_9_1d_lt_100))
+            & ((cmf_20_1d > -0.30) | (aroonu_14_1d_lt_85) | (roc_9_1d_lt_100))
             # 1h & 4h high, 1d overbought
             & (aroonu_14_1h_lt_70 | aroonu_14_4h_lt_70 | (roc_9_1d_lt_30))
             # 1h & 4h high, 1d overbought
@@ -23484,7 +23507,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h high, 4h & 1d overbought
             & (aroonu_14_4h_lt_80 | (roc_9_4h < 20.0) | (roc_9_1d_lt_20))
             # 1d still high, 1h & 4h downtrend
-            & ((aroonu_14_1d < 50.0) | (roc_9_1h > -20.0) | (roc_9_4h_gt_neg_20))
+            & ((aroonu_14_1d_lt_50) | (roc_9_1h > -20.0) | (roc_9_4h_gt_neg_20))
             # 1h high, 1h overbought
             & ((stochrsi_k_1h_lt_80) | (roc_9_1h < 50.0))
             # 1h high, 1d downtrend
@@ -23527,7 +23550,7 @@ class NostalgiaForInfinityX7(IStrategy):
 
           # Logic
           long_entry_logic.append(
-            (aroonu_14 < 25.0)
+            (aroonu_14_lt_25)
             & (aroond_14 > 75.0)
             & (stochrsi_k < 30.0)
             & (ema_26 > ema_12)
@@ -23552,27 +23575,27 @@ class NostalgiaForInfinityX7(IStrategy):
             # 5m & 1h down move, 15m still high, 4h high
             & ((rsi_3 > 20.0) | (rsi_3_1h_gt_40) | (rsi_14_15m < 40.0) | aroonu_14_4h_lt_100)
             # 5m & 1h & 15m down move, 1h still not low enough
-            & ((rsi_3_gt_15) | (rsi_3_1h_gt_30) | (rsi_3_1d_gt_15) | (aroonu_14_1h < 30.0))
+            & ((rsi_3_gt_15) | (rsi_3_1h_gt_30) | (rsi_3_1d_gt_15) | (aroonu_14_1h_lt_30))
             # 15m & 4h down move, 4h high
             & ((rsi_3_gt_15) | (rsi_3_4h_gt_35) | (stochrsi_k_4h_lt_70))
             # 5m & 4h down move, 15m high
-            & ((rsi_3_gt_15) | (rsi_3_4h_gt_45) | (aroonu_14_15m < 60.0))
+            & ((rsi_3_gt_15) | (rsi_3_4h_gt_45) | (aroonu_14_15m_lt_60))
             # 15m & 1h down move, 1h high
             & ((rsi_3_15m > 12.0) | (rsi_3_1h_gt_40) | (aroonu_14_1h_lt_100))
             # 15m & 1h & 4h & 1d down move
             & ((rsi_3_15m_gt_15) | (rsi_3_1h_gt_25) | (rsi_3_4h_gt_25) | (rsi_3_1d_gt_25))
             # 15m & 1h down move, 1h & 4h high
-            & ((rsi_3_15m_gt_15) | (rsi_3_1h_gt_25) | (aroonu_14_1h < 75.0) | aroonu_14_4h_lt_100)
+            & ((rsi_3_15m_gt_15) | (rsi_3_1h_gt_25) | (aroonu_14_1h_lt_75) | aroonu_14_4h_lt_100)
             # 15m & 1h & 4h down move, 1d overbought
             & ((rsi_3_15m_gt_15) | (rsi_3_1h_gt_30) | (rsi_3_4h_gt_35) | (roc_9_1d_lt_40))
             # 15m & 1h & 4h down move, 1h downtrend, 4h high
             & ((rsi_3_15m_gt_15) | (rsi_3_1h_gt_30) | (rsi_3_4h_gt_55) | (cmf_20_1h > -0.10) | aroonu_14_4h_lt_80)
             # 15m & 1h down move, 15m high
-            & ((rsi_3_15m_gt_15) | (rsi_3_1h_gt_30) | (aroonu_14_15m < 60.0))
+            & ((rsi_3_15m_gt_15) | (rsi_3_1h_gt_30) | (aroonu_14_15m_lt_60))
             # 15m & 1h down move, 4h high
             & ((rsi_3_15m_gt_15) | (rsi_3_1h_gt_30) | (rsi_14_4h < 85.0))
             # 15m & 1h down move, 15m still high
-            & ((rsi_3_15m_gt_15) | (rsi_3_1h_gt_30) | (aroonu_14_15m < 40.0))
+            & ((rsi_3_15m_gt_15) | (rsi_3_1h_gt_30) | (aroonu_14_15m_lt_40))
             # 15m & 1h down move, 1h high
             & ((rsi_3_15m_gt_15) | (rsi_3_1h_gt_30) | aroonu_14_1h_lt_70)
             # 15m & 1h down move, 1h high
@@ -23582,23 +23605,23 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h & 4h down move, 4h high
             & ((rsi_3_15m_gt_15) | (rsi_3_1h_gt_35) | (rsi_3_4h_gt_65) | (df["MFI_14_4h"] < 85.0))
             # 15m & 1h & 1d down move, 15m high
-            & ((rsi_3_15m_gt_15) | (rsi_3_1h_gt_35) | (rsi_3_1d_gt_40) | (aroonu_14_15m < 60.0))
+            & ((rsi_3_15m_gt_15) | (rsi_3_1h_gt_35) | (rsi_3_1d_gt_40) | (aroonu_14_15m_lt_60))
             # 15m & 1h down move, 15m high
             & ((rsi_3_15m_gt_15) | (rsi_3_1h_gt_35) | (aroonu_14_15m_lt_70))
             # 15m & 1h down move, 1h high
             & ((rsi_3_15m_gt_15) | (rsi_3_1h_gt_35) | (stochrsi_k_1h < 85.0))
             # 15m & 1h down move, 15m still not low enough, 1h & 4h high
-            & ((rsi_3_15m_gt_15) | (rsi_3_1h_gt_40) | (aroonu_14_15m < 30.0) | aroonu_14_1h_lt_80 | aroonu_14_4h_lt_80)
+            & ((rsi_3_15m_gt_15) | (rsi_3_1h_gt_40) | (aroonu_14_15m_lt_30) | aroonu_14_1h_lt_80 | aroonu_14_4h_lt_80)
             # 15m & 1h down move, 4h high & overbought
             & ((rsi_3_15m_gt_15) | (rsi_3_1h_gt_45) | (rsi_14_4h < 70.0) | (roc_9_4h < 50.0))
             # 15m & 1h down move, 1h high
             & ((rsi_3_15m_gt_15) | (rsi_3_1h_gt_50) | (stochrsi_k_1h < 90.0))
             # 15m & 4h down move, 15m high
-            & ((rsi_3_15m_gt_15) | (rsi_3_4h_gt_30) | (aroonu_14_15m < 60.0))
+            & ((rsi_3_15m_gt_15) | (rsi_3_4h_gt_30) | (aroonu_14_15m_lt_60))
             # 15m & 4h down move, 4h high
             & ((rsi_3_15m_gt_15) | (rsi_3_4h_gt_30) | aroonu_14_4h_lt_80)
             # 15m & 4h down move, 1h still high
-            & ((rsi_3_15m_gt_15) | (rsi_3_4h_gt_40) | (aroonu_14_1h < 40.0))
+            & ((rsi_3_15m_gt_15) | (rsi_3_4h_gt_40) | (aroonu_14_1h_lt_40))
             # 15m & 4h down move, 1d high
             & ((rsi_3_15m_gt_15) | (rsi_3_4h_gt_35) | (stochrsi_k_1d_lt_90))
             # 15m & 4h down move, 1h high
@@ -23624,7 +23647,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 15m & 4h high
             & ((rsi_3_15m_gt_15) | (aroonu_14_15m_lt_70) | (aroonu_14_4h_lt_80))
             # 15m down move, 15m & 1h high
-            & ((rsi_3_15m_gt_15) | (aroonu_14_15m < 75.0) | (aroonu_14_1h_lt_100))
+            & ((rsi_3_15m_gt_15) | (aroonu_14_15m_lt_75) | (aroonu_14_1h_lt_100))
             # 15m down move, 1h high, 1d overbought
             & ((rsi_3_15m_gt_15) | (aroonu_14_1h_lt_90) | (roc_9_1d_lt_80))
             # 15m down move, 1h high, 1d overbought
@@ -23661,18 +23684,14 @@ class NostalgiaForInfinityX7(IStrategy):
             & ((rsi_3_15m_gt_20) | (rsi_3_1h_gt_25) | (stochrsi_k_1h < 40.0))
             # 15m & 1h down move, 1h downtrend, 1h downtrend, 15m still high, 1h high
             & (
-              (rsi_3_15m_gt_20)
-              | (rsi_3_1h_gt_35)
-              | (cmf_20_1h > -0.10)
-              | (aroonu_14_15m < 40.0)
-              | (aroonu_14_1h < 85.0)
+              (rsi_3_15m_gt_20) | (rsi_3_1h_gt_35) | (cmf_20_1h > -0.10) | (aroonu_14_15m_lt_40) | (aroonu_14_1h_lt_85)
             )
             # 15m & 1h down move, 4h high & overbought
             & ((rsi_3_15m_gt_20) | (rsi_3_1h_gt_45) | (rsi_14_4h < 70.0) | (roc_9_4h < 50.0))
             # 15m & 1h down move, 1h high, 1d overbought
             & ((rsi_3_15m_gt_20) | (rsi_3_1h_gt_45) | (aroonu_14_1h_lt_90) | (roc_9_1d_lt_40))
             # 15m & 4h down move, 15m high
-            & ((rsi_3_15m_gt_20) | (rsi_3_4h_gt_25) | (aroonu_14_15m < 60.0))
+            & ((rsi_3_15m_gt_20) | (rsi_3_4h_gt_25) | (aroonu_14_15m_lt_60))
             # 15m & 4h down move, 1h high
             & ((rsi_3_15m_gt_20) | (rsi_3_4h_gt_35) | (aroonu_14_1h_lt_100))
             # 15m & 1d down move, 4h high
@@ -23682,7 +23701,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 4h downtrend, 4h overbought
             & ((rsi_3_15m_gt_20) | (cmf_20_4h > -0.0) | (roc_9_4h_lt_40))
             # 15m down move, 1h & 4h high, 1f overbought
-            & ((rsi_3_15m_gt_20) | (aroonu_14_1h < 85.0) | (rsi_14_4h < 70.0) | (roc_9_1d_lt_80))
+            & ((rsi_3_15m_gt_20) | (aroonu_14_1h_lt_85) | (rsi_14_4h < 70.0) | (roc_9_1d_lt_80))
             # 15m down move, 1h & 4h high
             & ((rsi_3_15m_gt_20) | (aroonu_14_1h_lt_90) | (aroonu_14_4h_lt_100))
             # 15m down move, 1d high, 4h overbought
@@ -23702,8 +23721,8 @@ class NostalgiaForInfinityX7(IStrategy):
               | (rsi_14_15m < 30.0)
               | (rsi_14_1h < 50.0)
               | (rsi_14_4h < 70.0)
-              | (aroonu_14_15m < 20.0)
-              | (aroonu_14_1h < 60.0)
+              | (aroonu_14_15m_lt_20)
+              | (aroonu_14_1h_lt_60)
               | aroonu_14_4h_lt_100
             )
             # 15m & 4h down move, 4h overbought
@@ -23725,9 +23744,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 4h downtrend, 4h high
             & ((rsi_3_1h_gt_25) | (cmf_20_4h > -0.25) | aroonu_14_4h_lt_70)
             # 1h down move, 15m still high, 1d downtrend
-            & ((rsi_3_1h_gt_25) | (aroonu_14_15m < 40.0) | (roc_9_1d_gt_neg_20))
+            & ((rsi_3_1h_gt_25) | (aroonu_14_15m_lt_40) | (roc_9_1d_gt_neg_20))
             # 1h down move, 1h & 4h high
-            & ((rsi_3_1h_gt_25) | (aroonu_14_1h < 60.0) | aroonu_14_4h_lt_100)
+            & ((rsi_3_1h_gt_25) | (aroonu_14_1h_lt_60) | aroonu_14_4h_lt_100)
             # 1h down move, 1h high, 1d downtrend
             & ((rsi_3_1h_gt_25) | (aroonu_14_1h_lt_90) | (cmf_20_1d > -0.2))
             # 1h down move, 4h high & overbought
@@ -23739,11 +23758,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h & 1d down move, 1d high & overbought
             & ((rsi_3_1h_gt_30) | (rsi_3_4h_gt_30) | (rsi_3_1d_gt_55) | (aroonu_14_1d_lt_80) | (roc_9_1d < 20.0))
             # 1h & 4h down move, 1h still high
-            & ((rsi_3_1h_gt_30) | (rsi_3_4h_gt_30) | (aroonu_14_1h < 40.0))
+            & ((rsi_3_1h_gt_30) | (rsi_3_4h_gt_30) | (aroonu_14_1h_lt_40))
             # 1h & 1d down move, 1d still high
-            & ((rsi_3_1h_gt_30) | (rsi_3_1d_gt_30) | (aroonu_14_1d < 40.0))
+            & ((rsi_3_1h_gt_30) | (rsi_3_1d_gt_30) | (aroonu_14_1d_lt_40))
             # 1h down move, 15m & 4h high
-            & ((rsi_3_1h_gt_30) | (aroonu_14_15m < 60.0) | (stochrsi_k_4h < 95.0))
+            & ((rsi_3_1h_gt_30) | (aroonu_14_15m_lt_60) | (stochrsi_k_4h < 95.0))
             # 1h down move, 15m & 4h high
             & ((rsi_3_1h_gt_30) | (aroonu_14_15m_lt_70) | (aroonu_14_4h_lt_90))
             # 1h down move, 1h high
@@ -23763,9 +23782,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 1h still high, 4h high
             & ((rsi_3_1h_gt_35) | (rsi_3_4h_gt_60) | (rsi_14_1h < 50.0) | (rsi_14_4h < 70.0))
             # 1h down move, 15m still not low enough, 1h high
-            & ((rsi_3_1h_gt_35) | (aroonu_14_15m < 30.0) | aroonu_14_1h_lt_80)
+            & ((rsi_3_1h_gt_35) | (aroonu_14_15m_lt_30) | aroonu_14_1h_lt_80)
             # 1h down move, 1h & 1d high
-            & ((rsi_3_1h_gt_35) | (aroonu_14_1h < 60.0) | aroonu_14_1d_lt_100)
+            & ((rsi_3_1h_gt_35) | (aroonu_14_1h_lt_60) | aroonu_14_1d_lt_100)
             # 1h down move, 1h high, 4h overbought
             & ((rsi_3_1h_gt_35) | aroonu_14_1h_lt_70 | (roc_9_4h < 25.0))
             # 1h down move, 1h & 4h high
@@ -23781,7 +23800,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h & 4h high
             & ((rsi_3_1h_gt_40) | aroonu_14_1h_lt_80 | aroonu_14_4h_lt_80)
             # 1h down move, 1h high, 1d overbought
-            & ((rsi_3_1h_gt_40) | (aroonu_14_1h < 85.0) | (roc_9_1d_lt_80))
+            & ((rsi_3_1h_gt_40) | (aroonu_14_1h_lt_85) | (roc_9_1d_lt_80))
             # 1h down move, 1h high, 15m downtrend
             & ((rsi_3_1h_gt_40) | (aroonu_14_1h_lt_90) | (roc_9_15m > -10.0))
             # 1h down move, 1h high, 1d downtrend
@@ -23793,9 +23812,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h high, 4h overbought
             & ((rsi_3_1h_gt_45) | (aroonu_14_1h_lt_100) | (roc_9_4h_lt_10))
             # 1h & 4h down move, 1h & 4h high
-            & ((rsi_3_1h_gt_50) | (rsi_3_4h_gt_65) | (aroonu_14_1h < 85.0) | aroonu_14_4h_lt_100)
+            & ((rsi_3_1h_gt_50) | (rsi_3_4h_gt_65) | (aroonu_14_1h_lt_85) | aroonu_14_4h_lt_100)
             # 1h down move, 15m & 1h high
-            & ((rsi_3_1h_gt_50) | (aroonu_14_15m < 60.0) | (stochrsi_k_1h_lt_80))
+            & ((rsi_3_1h_gt_50) | (aroonu_14_15m_lt_60) | (stochrsi_k_1h_lt_80))
             # 1h down move, 4h & 1d high
             & ((rsi_3_1h_gt_50) | (aroonu_14_4h_lt_90) | (aroonu_14_1d_lt_90))
             # 1h down move, 4h high, 1h overbought
@@ -23809,9 +23828,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h & 1d down move, 1d high
             & ((rsi_3_4h_gt_10) | (rsi_3_1d > 50.0) | (aroonu_14_1d_lt_90))
             # 4h down move, 15m still not low enough, 4h downtrend
-            & ((rsi_3_4h_gt_10) | (aroonu_14_15m < 30.0) | (cmf_20_4h > -0.30))
+            & ((rsi_3_4h_gt_10) | (aroonu_14_15m_lt_30) | (cmf_20_4h > -0.30))
             # 4h down move, 15m & 1h still not low enough
-            & ((rsi_3_4h_gt_10) | (aroonu_14_15m < 30.0) | (stochrsi_k_1h < 25.0))
+            & ((rsi_3_4h_gt_10) | (aroonu_14_15m_lt_30) | (stochrsi_k_1h < 25.0))
             # 4h down move, 4h still high
             & ((rsi_3_4h_gt_10) | (aroonu_14_4h_lt_40))
             # 4h down move, 1h still high, 4h downtrend
@@ -23823,7 +23842,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 1d high & overbought
             & ((rsi_3_4h_gt_15) | (stochrsi_k_1d_lt_90) | (roc_9_1d_lt_20))
             # 4h down move, 15m still high, 1d overbought
-            & (rsi_3_4h_gt_20 | (aroonu_14_15m < 40.0) | (roc_9_1d_lt_20))
+            & (rsi_3_4h_gt_20 | (aroonu_14_15m_lt_40) | (roc_9_1d_lt_20))
             # 4h & 1d down move, 1h & 4h low
             & ((rsi_3_4h_gt_25) | (rsi_3_1d_gt_25) | (cmf_20_1h > -0.3) | (cmf_20_4h > -0.4))
             # 4h down move, 4h still high 1d downtrend
@@ -23849,9 +23868,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 4h high & overbought
             & ((rsi_3_4h_gt_50) | aroonu_14_4h_lt_70 | (roc_9_4h_lt_10))
             # 4h down move, 15m still high, 1d overbought
-            & ((rsi_3_4h_gt_55) | (aroonu_14_15m < 40.0) | (roc_9_1d_lt_100))
+            & ((rsi_3_4h_gt_55) | (aroonu_14_15m_lt_40) | (roc_9_1d_lt_100))
             # 4h & 1d down move, 4h high, 1d overbought
-            & ((rsi_3_4h_gt_60) | (rsi_3_1d_gt_60) | (aroonu_14_4h < 75.0) | (roc_9_1d_lt_40))
+            & ((rsi_3_4h_gt_60) | (rsi_3_1d_gt_60) | (aroonu_14_4h_lt_75) | (roc_9_1d_lt_40))
             # 4h down move, 4h & 1d high
             & ((rsi_3_4h > 70.0) | (aroonu_14_4h_lt_90) | aroonu_14_1d_lt_100)
             # 1d down move, 4h high
@@ -23873,7 +23892,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1d down move, 1h high, 1d overbought
             & ((rsi_3_1d_gt_60) | aroonu_14_1h_lt_80 | (roc_9_1d_lt_80))
             # 1d down move, 15m still high, 1d overbought
-            & ((rsi_3_1d_gt_65) | (aroonu_14_15m < 40.0) | (roc_9_1d_lt_100))
+            & ((rsi_3_1d_gt_65) | (aroonu_14_15m_lt_40) | (roc_9_1d_lt_100))
             # 1d down move, 4h & 1d high
             & ((rsi_3_1d_gt_65) | (roc_9_4h_lt_10) | (roc_9_1d < 10.0))
             # 5m still high, 1h down move, 15m still high, 1h high
@@ -23889,15 +23908,15 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h downtrend, 4h high, 1d downtrend
             & ((cmf_20_1h > -0.2) | (stochrsi_k_4h_lt_90) | (cmf_20_1d > -0.25))
             # 15m & 1h high, 1d overbought
-            & ((aroonu_14_15m < 60.0) | (aroonu_14_1h_lt_100) | (roc_9_1d_lt_20))
+            & ((aroonu_14_15m_lt_60) | (aroonu_14_1h_lt_100) | (roc_9_1d_lt_20))
             # 4h high, 4h & 1d overbought
             & (aroonu_14_4h_lt_80 | (roc_9_4h < 20.0) | (roc_9_1d_lt_20))
             # 4h & 1d high, 1d overbought
-            & ((aroonu_14_4h < 85.0) | (aroonu_14_1d < 85.0) | (roc_9_1d < 60.0))
+            & ((aroonu_14_4h_lt_85) | (aroonu_14_1d_lt_85) | (roc_9_1d < 60.0))
             # 4h & 1d high, 1d overbought
             & (aroonu_14_4h_lt_100 | aroonu_14_1d_lt_100 | (roc_9_1d_lt_30))
             # 1d still high, 4h & 1d downtrend
-            & ((aroonu_14_1d < 50.0) | (roc_9_4h_gt_neg_20) | (roc_9_1d_gt_neg_30))
+            & ((aroonu_14_1d_lt_50) | (roc_9_4h_gt_neg_20) | (roc_9_1d_gt_neg_30))
             # 4h top wick, 15m & 1h down move
             & ((df["top_wick_pct_4h"] < 10.0) | (rsi_3_15m_gt_15) | (rsi_3_1h_gt_40))
             # 4h top wick, 1h down move, 1h high
@@ -23935,7 +23954,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # Logic
           long_entry_logic.append(
             (rsi_14 < 30.0)
-            & (aroonu_14 < 25.0)
+            & (aroonu_14_lt_25)
             & (aroond_14 > 75.0)
             & (stochrsi_k < 20.0)
             & (ema_9 < (ema_26 * 0.982))
@@ -24059,7 +24078,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m up move, 1d lost, 1h low
           short_entry_logic.append((rsi_3_15m_lt_95) | (rsi_14_1d > 40.0) | (aroonu_14_1h > 40.0))
           # 15m up move, 15m & 4h uptrend
-          short_entry_logic.append((rsi_3_15m_lt_95) | (aroonu_14_15m < 90.0) | (aroonu_14_4h_lt_90))
+          short_entry_logic.append((rsi_3_15m_lt_95) | (aroonu_14_15m_lt_90) | (aroonu_14_4h_lt_90))
           # 15m up move, 15m stil not high enough, 1h low
           short_entry_logic.append((rsi_3_15m_lt_95) | (stochrsi_k_15m > 70.0) | (stochrsi_k_1h > 10.0))
           # 15m up move, 1h still not high enough, 4h low
@@ -24209,7 +24228,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m & 1h uptrend, 4h still low
           short_entry_logic.append((cmf_20_15m < 0.30) | (cmf_20_1h < 0.30) | (stochrsi_k_4h > 60.0))
           # 15m uptrend, 1h low
-          short_entry_logic.append((aroonu_14_15m < 100.0) | (stochrsi_k_1h > 20.0))
+          short_entry_logic.append((aroonu_14_15m_lt_100) | (stochrsi_k_1h > 20.0))
           # 1h & 4h uptrend
           short_entry_logic.append((aroonu_14_1h_lt_100) | aroonu_14_4h_lt_100)
           # 1h uptrend, 4h uptrend
@@ -24339,7 +24358,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h up move, relative stable before the hour
             & ((rsi_3_1h_lt_95) | (df["close_min_12"] > (df["close_min_48"] * 1.10)))
             # 1h up move, 15m uptrend
-            & ((rsi_3_1h_lt_90) | (aroonu_14_15m < 100.0))
+            & ((rsi_3_1h_lt_90) | (aroonu_14_15m_lt_100))
             # 1h up move, 1d low
             & ((rsi_3_1h_lt_90) | (stochrsi_k_1d > 10.0))
             # 1h up move, 1h & 4h uptrend
@@ -24750,7 +24769,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m & 1d up move, 4h uptrend
           short_entry_logic.append((rsi_3_15m_lt_90) | (rsi_3_1d < 80.0) | (roc_9_4h_lt_20))
           # 15m up move, 15m & 4h high
-          short_entry_logic.append((rsi_3_15m_lt_90) | (aroonu_14_15m < 100.0) | (aroonu_14_4h < 100.0))
+          short_entry_logic.append((rsi_3_15m_lt_90) | (aroonu_14_15m_lt_100) | (aroonu_14_4h_lt_100))
           # 15m up move, 15m still not high enough, 1d uptrend
           short_entry_logic.append((rsi_3_15m_lt_90) | (stochrsi_k_15m > 80.0) | (roc_9_1d_lt_80))
           # 15m & 4h up move, 15m still not high enough
@@ -24788,7 +24807,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1h & 1d up move, 15m still low
           short_entry_logic.append((rsi_3_1h_lt_90) | (rsi_3_1d < 90.0) | (stochrsi_k_15m > 60.0))
           # 1h up move, 15m high
-          short_entry_logic.append((rsi_3_1h_lt_90) | (aroonu_14_15m < 100.0))
+          short_entry_logic.append((rsi_3_1h_lt_90) | (aroonu_14_15m_lt_100))
           # 1h up move, 4h low
           short_entry_logic.append((rsi_3_1h_lt_90) | (stochrsi_k_4h_gt_30))
           # 1h up move, 4h still low, 1h still moving higher
@@ -24830,7 +24849,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 4h up move, 15m low
           short_entry_logic.append((rsi_3_4h_lt_85) | (stochrsi_k_15m > 30.0))
           # 4h up move, 4h uptrend
-          short_entry_logic.append((rsi_3_4h_lt_80) | (aroonu_14_4h < 100.0) | (roc_9_4h_lt_20))
+          short_entry_logic.append((rsi_3_4h_lt_80) | (aroonu_14_4h_lt_100) | (roc_9_4h_lt_20))
           # 4h up move, 15m still low, 4h still not high enough
           short_entry_logic.append((rsi_3_4h_lt_80) | (stochrsi_k_15m > 60.0) | (aroonu_14_4h > 80.0))
           # 4h up move, 15m still low, 4h still not high enough
@@ -24840,15 +24859,15 @@ class NostalgiaForInfinityX7(IStrategy):
           # 4h still not high enough, 4h overbought, 4h uptrend
           short_entry_logic.append((rsi_14_4h > 80.0) | (roc_9_4h_lt_40) | (cci_20_change_pct_4h < 0.0))
           # 15m & 1h high, 4h uptrend
-          short_entry_logic.append((aroonu_14_15m < 100.0) | (aroonu_14_1h_lt_100) | (roc_9_4h_lt_20))
+          short_entry_logic.append((aroonu_14_15m_lt_100) | (aroonu_14_1h_lt_100) | (roc_9_4h_lt_20))
           # 15m & 4h high, 1h uptrend
-          short_entry_logic.append((aroonu_14_15m < 100.0) | aroonu_14_4h_lt_100 | (roc_9_1h < 20.0))
+          short_entry_logic.append((aroonu_14_15m_lt_100) | aroonu_14_4h_lt_100 | (roc_9_1h < 20.0))
           # 15m high, 1d low
-          short_entry_logic.append((aroonu_14_15m < 100.0) | (stochrsi_k_1d > 20.0))
+          short_entry_logic.append((aroonu_14_15m_lt_100) | (stochrsi_k_1d > 20.0))
           # 15m high & uptrend
-          short_entry_logic.append((aroonu_14_15m < 100.0) | (roc_9_15m < 30.0))
+          short_entry_logic.append((aroonu_14_15m_lt_100) | (roc_9_15m < 30.0))
           # 15m high, 1h & 4h uptrend
-          short_entry_logic.append((aroonu_14_15m < 100.0) | (roc_9_1h < 20.0) | (roc_9_4h_lt_20))
+          short_entry_logic.append((aroonu_14_15m_lt_100) | (roc_9_1h < 20.0) | (roc_9_4h_lt_20))
           # 1h high, 15m uptrend
           short_entry_logic.append((aroonu_14_1h_lt_100) | (roc_9_15m < 20.0))
           # 15m & 4h still not high enough


### PR DESCRIPTION
## Summary
- Add ordered `AROONU` comparison masks in `populate_entry_trend()` for repeated entry-side threshold checks.
- Reuse those masks where the same `AROONU` Series comparisons were repeated inline.
- Independent on latest upstream `main`.

## Safety
- Behavior is preserved: each replacement keeps the same Series, comparison operator, and threshold value.
- No indicator formulas, candle selection, order classification, profit arithmetic, thresholds, condition order, return values, or signal logic are changed.
- Touched function: `populate_entry_trend()`.
- No v3 grind-entry code is touched.

## Backtest scope
- A full backtest was not required for this patch because it only reuses already-read `AROONU` Series comparisons inside the same `populate_entry_trend()` call.
- The trading conditions are textually equivalent at the comparison level; validation focused on static checks, merge simulation, and targeted diff review.

## Checks
- `python3 ~/.codex/skills/nfi-upstream-pr/scripts/validate_nfi_pr.py --base origin/main`
- `git merge-tree` conflict simulation against `origin/main`
- targeted `git diff origin/main...HEAD -- NostalgiaForInfinityX7.py` review
- `git diff --check`
- `ruff format --check NostalgiaForInfinityX7.py`
- `ruff check NostalgiaForInfinityX7.py`
- `PYTHONDONTWRITEBYTECODE=1 python3 -m py_compile NostalgiaForInfinityX7.py`
