### PR TITLE
Reuse X7 entry STOCHRSI masks

### DIFF
--- a/NostalgiaForInfinityX7.py
+++ b/NostalgiaForInfinityX7.py
@@ -13057,13 +13057,44 @@ class NostalgiaForInfinityX7(IStrategy):
     aroonu_14_1d_lt_90 = aroonu_14_1d < 90.0
     aroonu_14_1d_lt_100 = aroonu_14_1d < 100.0
 
+    stochrsi_k_lt_20 = stochrsi_k < 20.0
+    stochrsi_k_lt_30 = stochrsi_k < 30.0
+    stochrsi_k_15m_lt_20 = stochrsi_k_15m < 20.0
+    stochrsi_k_15m_lt_30 = stochrsi_k_15m < 30.0
+    stochrsi_k_15m_lt_40 = stochrsi_k_15m < 40.0
+    stochrsi_k_15m_lt_50 = stochrsi_k_15m < 50.0
+    stochrsi_k_15m_lt_60 = stochrsi_k_15m < 60.0
+    stochrsi_k_15m_lt_70 = stochrsi_k_15m < 70.0
+    stochrsi_k_15m_lt_80 = stochrsi_k_15m < 80.0
+    stochrsi_k_15m_lt_90 = stochrsi_k_15m < 90.0
+    stochrsi_k_1h_lt_20 = stochrsi_k_1h < 20.0
+    stochrsi_k_1h_lt_25 = stochrsi_k_1h < 25.0
+    stochrsi_k_1h_lt_30 = stochrsi_k_1h < 30.0
+    stochrsi_k_1h_lt_40 = stochrsi_k_1h < 40.0
+    stochrsi_k_1h_lt_45 = stochrsi_k_1h < 45.0
     stochrsi_k_1h_lt_50 = stochrsi_k_1h < 50.0
+    stochrsi_k_1h_lt_60 = stochrsi_k_1h < 60.0
     stochrsi_k_1h_lt_70 = stochrsi_k_1h < 70.0
+    stochrsi_k_1h_lt_75 = stochrsi_k_1h < 75.0
     stochrsi_k_1h_lt_80 = stochrsi_k_1h < 80.0
+    stochrsi_k_1h_lt_85 = stochrsi_k_1h < 85.0
+    stochrsi_k_1h_lt_90 = stochrsi_k_1h < 90.0
+    stochrsi_k_4h_lt_10 = stochrsi_k_4h < 10.0
+    stochrsi_k_4h_lt_20 = stochrsi_k_4h < 20.0
+    stochrsi_k_4h_lt_30 = stochrsi_k_4h < 30.0
+    stochrsi_k_4h_lt_40 = stochrsi_k_4h < 40.0
     stochrsi_k_4h_lt_50 = stochrsi_k_4h < 50.0
+    stochrsi_k_4h_lt_60 = stochrsi_k_4h < 60.0
     stochrsi_k_4h_lt_70 = stochrsi_k_4h < 70.0
     stochrsi_k_4h_lt_80 = stochrsi_k_4h < 80.0
     stochrsi_k_4h_lt_90 = stochrsi_k_4h < 90.0
+    stochrsi_k_1d_lt_20 = stochrsi_k_1d < 20.0
+    stochrsi_k_1d_lt_30 = stochrsi_k_1d < 30.0
+    stochrsi_k_1d_lt_40 = stochrsi_k_1d < 40.0
+    stochrsi_k_1d_lt_50 = stochrsi_k_1d < 50.0
+    stochrsi_k_1d_lt_60 = stochrsi_k_1d < 60.0
+    stochrsi_k_1d_lt_70 = stochrsi_k_1d < 70.0
+    stochrsi_k_1d_lt_80 = stochrsi_k_1d < 80.0
     stochrsi_k_1d_lt_90 = stochrsi_k_1d < 90.0
 
     roc_9_1h_lt_10 = roc_9_1h < 10.0
@@ -13153,7 +13184,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 5m & 1h down move, 4h high
             & ((rsi_3_gt_3) | (rsi_3_1h_gt_25) | (stochrsi_k_4h_lt_80))
             # 15m & 1h down move, 1d still high
-            & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_3) | (stochrsi_k_1d < 50.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_3) | (stochrsi_k_1d_lt_50))
             # 5m & 1h down move, 15m still not low enough
             & ((rsi_3_gt_3) | (rsi_3_1h_gt_15) | (aroonu_14_15m < 30.0))
             # 5m & 4h down move, 4h high
@@ -13161,7 +13192,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 5m down move, 15m high
             & ((rsi_3_gt_3) | (aroonu_14_15m < 80.0))
             # 5m down move, 1h high, 4h overbought
-            & ((rsi_3_gt_3) | (stochrsi_k_1h < 80.0) | (roc_9_4h_lt_20))
+            & ((rsi_3_gt_3) | (stochrsi_k_1h_lt_80) | (roc_9_4h_lt_20))
             # 5m & 4h down move, 4h high
             & ((rsi_3_gt_5) | (rsi_3_4h_gt_35) | aroonu_14_4h_lt_70)
             # 15m down move, 1h downtrend, 1h high
@@ -13173,7 +13204,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 1d high
             & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_10) | (aroonu_14_1d < 100.0))
             # 15m & 1h down move, 1h still high
-            & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_10) | (stochrsi_k_1h < 40.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_10) | (stochrsi_k_1h_lt_40))
             # 15m & 1h & 4h & 1d down move
             & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_15) | (rsi_3_4h_gt_15) | (rsi_3_1d_gt_15))
             # 15m & 1h down move, 15m still high
@@ -13207,7 +13238,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 4h high, 1d overbought
             & (rsi_3_15m_gt_3 | (aroonu_14_4h < 85.0) | (roc_9_1d_lt_100))
             # 15m down move, 1h high, 4h overbought
-            & (rsi_3_15m_gt_3 | (stochrsi_k_1h < 90.0) | (roc_9_4h_lt_10))
+            & (rsi_3_15m_gt_3 | (stochrsi_k_1h_lt_90) | (roc_9_4h_lt_10))
             # 15m down move, 4h high & overbought
             & (rsi_3_15m_gt_3 | (stochrsi_k_4h_lt_80) | (roc_9_4h_lt_30))
             # 15m down move, drop in last half hour, 15m downtrend
@@ -13221,15 +13252,15 @@ class NostalgiaForInfinityX7(IStrategy):
             # 5m & 1h down move, 1h overbought
             & ((rsi_3_15m_gt_5) | (rsi_3_1h_gt_60) | (roc_9_1h < 40.0))
             # 15m & 4h down move, 1d still high
-            & ((rsi_3_15m_gt_5) | (rsi_3_4h_gt_5) | (stochrsi_k_1d < 40.0))
+            & ((rsi_3_15m_gt_5) | (rsi_3_4h_gt_5) | (stochrsi_k_1d_lt_40))
             # 15m & 4h down move, 1d downtrend
             & ((rsi_3_15m_gt_5) | (rsi_3_4h_gt_5) | (roc_9_1d_gt_neg_20))
             # 15m & 4h down move, 1h still high
-            & ((rsi_3_15m_gt_5) | (rsi_3_4h_gt_10) | (stochrsi_k_1h < 50.0))
+            & ((rsi_3_15m_gt_5) | (rsi_3_4h_gt_10) | (stochrsi_k_1h_lt_50))
             # 15m & 4h down move, 1d high
-            & ((rsi_3_15m_gt_5) | (rsi_3_4h_gt_15) | (stochrsi_k_1d < 60.0))
+            & ((rsi_3_15m_gt_5) | (rsi_3_4h_gt_15) | (stochrsi_k_1d_lt_60))
             # 15m & 4h down move, 15m still high
-            & ((rsi_3_15m_gt_5) | (rsi_3_4h_gt_30) | (stochrsi_k_15m < 50.0))
+            & ((rsi_3_15m_gt_5) | (rsi_3_4h_gt_30) | (stochrsi_k_15m_lt_50))
             # 15m down move, 15m & 4h still high
             & ((rsi_3_15m_gt_5) | (aroonu_14_15m_lt_50) | (aroonu_14_4h_lt_60))
             # 15m down move, 15m still high, 1d overbought
@@ -13239,11 +13270,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 4h high, 1d overbought
             & ((rsi_3_15m_gt_5) | (aroonu_14_4h_lt_60) | (roc_9_1d_lt_80))
             # 15m & 1h down move, 1h still high
-            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_10) | (stochrsi_k_1h < 40.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_10) | (stochrsi_k_1h_lt_40))
             # 15m & 1h down move, 4h high
             & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_10) | (stochrsi_k_4h_lt_70))
             # 15m & 1h down move, 1h still high
-            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_15) | (stochrsi_k_1h < 50.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_15) | (stochrsi_k_1h_lt_50))
             # 15m & 1h down move, 1d downtrend
             & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_15) | (roc_9_1d_gt_neg_40))
             # 15m & 1h down move, 4h high
@@ -13255,9 +13286,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 4h down move, 1h high
             & ((rsi_3_15m_gt_10) | (rsi_3_4h_gt_10) | (aroonu_14_1h < 75.0))
             # 15m & 4h down move, 15m still high
-            & ((rsi_3_15m_gt_10) | (rsi_3_4h_gt_10) | (stochrsi_k_15m < 50.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_4h_gt_10) | (stochrsi_k_15m_lt_50))
             # 15m & 4h down move, 1h still high
-            & ((rsi_3_15m_gt_10) | (rsi_3_4h_gt_10) | (stochrsi_k_1h < 40.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_4h_gt_10) | (stochrsi_k_1h_lt_40))
             # 15m & 4h down move, 4h downtrend
             & ((rsi_3_15m_gt_10) | (rsi_3_4h_gt_10) | (roc_9_4h > -20.0))
             # 15m & 4h down move, 1d overbought
@@ -13267,7 +13298,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 4h down move, 4h high
             & ((rsi_3_15m_gt_10) | (rsi_3_4h_gt_60) | (stochrsi_k_4h_lt_90))
             # 15m & 1d down move, 1d high
-            & ((rsi_3_15m_gt_10) | (rsi_3_1d > 50.0) | (stochrsi_k_1d < 80.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_1d > 50.0) | (stochrsi_k_1d_lt_80))
             # 15m down move & downtrend, 4h high
             & ((rsi_3_15m_gt_10) | (cmf_20_15m > -0.3) | aroonu_14_4h_lt_100)
             # 15m down move, 15m & 4h high
@@ -13283,7 +13314,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 1h high, 1d downtrend
             & ((rsi_3_15m_gt_10) | (stochrsi_k_1h_lt_70) | roc_9_1d_gt_neg_50)
             # 15m down move, 1h high & overbought
-            & ((rsi_3_15m_gt_10) | (stochrsi_k_1h < 90.0) | (roc_9_1h < 20.0))
+            & ((rsi_3_15m_gt_10) | (stochrsi_k_1h_lt_90) | (roc_9_1h < 20.0))
             # 15m down move, 1h & 1d overbought
             & ((rsi_3_15m_gt_10) | (roc_9_1h_lt_10) | (roc_9_1d_lt_80))
             # 15m down move, 4h high
@@ -13307,7 +13338,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 1d overbought
             & ((rsi_3_15m_gt_30) | (roc_9_1d_lt_80))
             # 15m & 4h down move, 15m high
-            & ((rsi_3_15m_gt_40) | (rsi_3_4h_gt_45) | (stochrsi_k_15m < 70.0))
+            & ((rsi_3_15m_gt_40) | (rsi_3_4h_gt_45) | (stochrsi_k_15m_lt_70))
             # 1h & 4h down move, 4h downtrend
             & ((rsi_3_1h_gt_3) | (rsi_3_4h_gt_10) | (roc_9_4h > -10.0))
             # 1h & 4h down move, 1h still high
@@ -13341,7 +13372,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 15m still not low enough
             & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_10) | (aroonu_14_15m < 30.0))
             # 1h & 4h down move, 1h still high
-            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_10) | (stochrsi_k_1h < 50.0))
+            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_10) | (stochrsi_k_1h_lt_50))
             # 1h & 4h & 1d down move, 4h downtrend, 1d still high
             & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_15) | (rsi_3_1d_gt_25) | (rsi_14_4h > 30.0) | (aroonu_14_1d < 40.0))
             # 1h & 1d down move, 4h high
@@ -13407,7 +13438,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h high, 1d overbought
             & ((rsi_3_1h_gt_40) | aroonu_14_1h_lt_80 | (roc_9_1d < 100.0))
             # 1h down move, 1h high, 4h overbought
-            & ((rsi_3_1h_gt_40) | (stochrsi_k_1h < 80.0) | (roc_9_4h_lt_20))
+            & ((rsi_3_1h_gt_40) | (stochrsi_k_1h_lt_80) | (roc_9_4h_lt_20))
             # 1h down move, 1h & 4h high
             & ((rsi_3_1h_gt_45) | aroonu_14_1h_lt_80 | aroonu_14_4h_lt_100)
             # 1h down move, 1h high & overbought
@@ -13421,15 +13452,15 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h & 1d down move, 4h still not low enough
             & ((rsi_3_4h_gt_10) | (rsi_3_1d_gt_15) | (aroonu_14_4h < 20.0))
             # 4h & 1d down move, 1d still high
-            & ((rsi_3_4h_gt_10) | (rsi_3_1d_gt_25) | (stochrsi_k_1d < 50.0))
+            & ((rsi_3_4h_gt_10) | (rsi_3_1d_gt_25) | (stochrsi_k_1d_lt_50))
             # 4h down move, 4h still high
             & ((rsi_3_4h_gt_10) | (aroonu_14_4h_lt_50))
             # 4h down move, 1d high
             & ((rsi_3_4h_gt_10) | (aroonu_14_1d < 100.0))
             # 4h down move, 1h high, 1d downtrend
-            & ((rsi_3_4h_gt_10) | (stochrsi_k_1h < 60.0) | (roc_9_1d_gt_neg_40))
+            & ((rsi_3_4h_gt_10) | (stochrsi_k_1h_lt_60) | (roc_9_1d_gt_neg_40))
             # 4h down move, 4h still not low enough, 1d downtrend
-            & ((rsi_3_4h_gt_10) | (stochrsi_k_4h < 30.0) | (roc_9_1d > -20.0))
+            & ((rsi_3_4h_gt_10) | (stochrsi_k_4h_lt_30) | (roc_9_1d > -20.0))
             # 4h down move, 1h & 4h downtrend
             & ((rsi_3_4h_gt_10) | (roc_9_1h > -30.0) | (roc_9_4h_gt_neg_30))
             # 4h down move, 4h & 1d downtrend
@@ -13445,9 +13476,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 4h high, 1d overbought
             & ((rsi_3_4h_gt_50) | aroonu_14_4h_lt_70 | (roc_9_1d_lt_40))
             # 4h down move, 1h high, 1d overbought
-            & ((rsi_3_4h_gt_60) | (stochrsi_k_1h < 90.0) | (roc_9_1d < 60.0))
+            & ((rsi_3_4h_gt_60) | (stochrsi_k_1h_lt_90) | (roc_9_1d < 60.0))
             # 1d down move, 1h high, 1d downtrend
-            & ((rsi_3_1d_gt_5) | (stochrsi_k_1h < 90.0) | (roc_9_1d_gt_neg_20))
+            & ((rsi_3_1d_gt_5) | (stochrsi_k_1h_lt_90) | (roc_9_1d_gt_neg_20))
             # 1d down move, 1h still high, 4h high
             & ((rsi_3_1d_gt_20) | (aroonu_14_1h_lt_50) | (aroonu_14_4h_lt_90))
             # 1d down move, 1h & 4h high
@@ -13517,11 +13548,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # big drop in the last 6 hours, 1h down move, 1h high
             & ((close > (df["high_max_6_1h"] * 0.60)) | rsi_3_1h_gt_20 | (aroonu_14_1h < 60.0))
             # big drop in the last 24 hours,  1h still high
-            & ((close > (df["high_max_24_1h"] * 0.40)) | (stochrsi_k_1h < 45.0))
+            & ((close > (df["high_max_24_1h"] * 0.40)) | (stochrsi_k_1h_lt_45))
             # big drop in the last 4 days, 1h high
             & ((close > (high_max_24_4h * 0.20)) | aroonu_14_1h_lt_70)
             # big drop in the last 20 days, 1d high, 1d downtrend
-            & ((close > (high_max_20_1d * 0.20)) | (stochrsi_k_1d < 70.0) | (roc_9_1d > -15.0))
+            & ((close > (high_max_20_1d * 0.20)) | (stochrsi_k_1d_lt_70) | (roc_9_1d > -15.0))
           )
 
           # Logic
@@ -13548,13 +13579,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 5m & 1h down move, 1d high
             & ((rsi_3_gt_3) | (rsi_3_1h_gt_35) | aroonu_14_1d_lt_100)
             # 5m & 4h down move, 15m still not low enough
-            & ((rsi_3_gt_3) | (rsi_3_4h_gt_3) | (stochrsi_k_15m < 30.0))
+            & ((rsi_3_gt_3) | (rsi_3_4h_gt_3) | (stochrsi_k_15m_lt_30))
             # 5m & 4h down move, 1d downtrend
             & ((rsi_3_gt_3) | (rsi_3_4h_gt_15) | (roc_9_1d > -30.0))
             # 5m & 4h down move, 4h high
             & ((rsi_3_gt_3) | (rsi_3_4h_gt_45) | (stochrsi_k_4h_lt_80))
             # 5m & 4h down move, 15m still high
-            & ((rsi_3_gt_5) | (rsi_3_4h_gt_25) | (stochrsi_k_15m < 50.0))
+            & ((rsi_3_gt_5) | (rsi_3_4h_gt_25) | (stochrsi_k_15m_lt_50))
             # 5m & 1d down move, 1h still high
             & ((rsi_3_gt_3) | (rsi_3_1d_gt_10) | (aroonu_14_1h < 40.0))
             # 5m & 1d down move, 1h still high
@@ -13562,7 +13593,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 5m & 1d down move, 1d downtrend
             & ((rsi_3_gt_3) | (rsi_3_1d_gt_15) | (cmf_20_1d > -0.25))
             # 5m & 1d down move, 15m still high
-            & ((rsi_3_gt_3) | (rsi_3_1d_gt_20) | (stochrsi_k_15m < 40.0))
+            & ((rsi_3_gt_3) | (rsi_3_1d_gt_20) | (stochrsi_k_15m_lt_40))
             # 5m down move, 1h high
             & ((rsi_3_gt_3) | aroonu_14_1h_lt_80)
             # 5m down move, 4h high, 1d overbought
@@ -13574,17 +13605,17 @@ class NostalgiaForInfinityX7(IStrategy):
             # 5m down move, 1d downtrend
             & ((rsi_3_gt_3) | (roc_9_1d_gt_neg_40))
             # 5m & 15m down move, 15m still high
-            & ((rsi_3_gt_5) | (rsi_3_15m_gt_10) | (stochrsi_k_15m < 40.0))
+            & ((rsi_3_gt_5) | (rsi_3_15m_gt_10) | (stochrsi_k_15m_lt_40))
             # 5m & 15m down move, 1h high
             & ((rsi_3_gt_5) | (rsi_3_15m_gt_30) | (stochrsi_k_1h_lt_80))
             # 5m & 4h down move, 1d downtrend
             & ((rsi_3_gt_5) | (rsi_3_4h_gt_10) | (roc_9_1d > -20.0))
             # 5m & 4h down move, 4h still not low enough
-            & ((rsi_3_gt_5) | (rsi_3_4h_gt_15) | (stochrsi_k_4h < 20.0))
+            & ((rsi_3_gt_5) | (rsi_3_4h_gt_15) | (stochrsi_k_4h_lt_20))
             # 5m down move, 4h high, 1h overbought
             & ((rsi_3_gt_10) | aroonu_14_4h_lt_100 | (roc_9_1h < 30.0))
             # 15m & 1h down move, 1h still high
-            & ((rsi_3_15m > 1.0) | (rsi_3_1h_gt_25) | (stochrsi_k_1h < 40.0))
+            & ((rsi_3_15m > 1.0) | (rsi_3_1h_gt_25) | (stochrsi_k_1h_lt_40))
             # 15m & 1h & 4h down move
             & ((rsi_3_15m_gt_3) | (rsi_3_1h_gt_3) | (rsi_3_4h_gt_15))
             # 15m & 1h down move, 4h still high
@@ -13596,13 +13627,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 1h still not low enough
             & ((rsi_3_15m_gt_3) | (rsi_3_1h_gt_5) | (aroonu_14_1h < 25.0))
             # 15m & 1h down move, 1h still not low enough
-            & ((rsi_3_15m_gt_3) | (rsi_3_1h_gt_5) | (stochrsi_k_1h < 30.0))
+            & ((rsi_3_15m_gt_3) | (rsi_3_1h_gt_5) | (stochrsi_k_1h_lt_30))
             # 15m & 1h & 4h down move
             & ((rsi_3_15m_gt_3) | (rsi_3_1h_gt_10) | (rsi_3_4h_gt_10))
             # 15m & 1h & 4h down move, 4h still not low enough, 1d still high
             & ((rsi_3_15m_gt_3) | (rsi_3_1h_gt_10) | (rsi_3_4h_gt_20) | (aroonu_14_4h < 20.0) | (rsi_14_1d < 50.0))
             # 15m & 1h down move, 1h high
-            & ((rsi_3_15m_gt_3) | (rsi_3_1h_gt_10) | (stochrsi_k_1h < 30.0))
+            & ((rsi_3_15m_gt_3) | (rsi_3_1h_gt_10) | (stochrsi_k_1h_lt_30))
             # 15m & 1h down move, 1d downtrend
             & ((rsi_3_15m_gt_3) | (rsi_3_1h_gt_10) | (roc_9_1d_gt_neg_40))
             # 15m & 1h down move, 15m downtrend
@@ -13614,7 +13645,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 1h still high
             & ((rsi_3_15m_gt_3) | (rsi_3_1h_gt_20) | (stochrsi_k_1h_lt_50))
             # 15m & 1h down move, 4h high
-            & ((rsi_3_15m_gt_3) | (rsi_3_1h_gt_20) | (stochrsi_k_4h < 60.0))
+            & ((rsi_3_15m_gt_3) | (rsi_3_1h_gt_20) | (stochrsi_k_4h_lt_60))
             # 15m & 1h down move, 1h high
             & ((rsi_3_15m_gt_3) | (rsi_3_1h_gt_30) | (aroonu_14_1h < 60.0))
             # 15m & 1h down move, 1h high
@@ -13622,7 +13653,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 1h still high
             & ((rsi_3_15m_gt_3) | (rsi_3_1h_gt_35) | (aroonu_14_1h < 40.0))
             # 15m & 1h down move, 1d high
-            & ((rsi_3_15m_gt_3) | (rsi_3_1h_gt_35) | (stochrsi_k_1d < 70.0))
+            & ((rsi_3_15m_gt_3) | (rsi_3_1h_gt_35) | (stochrsi_k_1d_lt_70))
             # 15m & 1h down move, 1h high
             & ((rsi_3_15m_gt_3) | (rsi_3_1h_gt_40) | (aroonu_14_1h_lt_70))
             # 15m & 1h down move, 4h high
@@ -13640,11 +13671,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 4h down move, 1d downtrend
             & ((rsi_3_15m_gt_3) | (rsi_3_4h_gt_10) | (roc_9_1d > -20.0))
             # 15m & 4h down move, 4h still high
-            & ((rsi_3_15m_gt_3) | (rsi_3_4h_gt_30) | (stochrsi_k_4h < 40.0))
+            & ((rsi_3_15m_gt_3) | (rsi_3_4h_gt_30) | (stochrsi_k_4h_lt_40))
             # 15m & 4h down move, 4h still high
             & ((rsi_3_15m_gt_3) | (rsi_3_4h_gt_35) | (stochrsi_k_4h_lt_50))
             # 15m down move, 15m still not low enough, 1h high
-            & ((rsi_3_15m_gt_3) | (aroonu_14_15m < 20.0) | (stochrsi_k_1h < 60.0))
+            & ((rsi_3_15m_gt_3) | (aroonu_14_15m < 20.0) | (stochrsi_k_1h_lt_60))
             # 15m down move, 15m still not low enough, 1h still high
             & ((rsi_3_15m_gt_3) | (aroonu_14_15m < 30.0) | (stochrsi_k_1h_lt_50))
             # 15m down move, 1h high, 1d overbought
@@ -13664,7 +13695,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 4h high
             & ((rsi_3_15m_gt_5) | (rsi_3_1h_gt_10) | (aroonu_14_4h < 100.0))
             # 15m & 1h down move, 4h high
-            & ((rsi_3_15m_gt_5) | (rsi_3_1h_gt_15) | (stochrsi_k_4h < 60.0))
+            & ((rsi_3_15m_gt_5) | (rsi_3_1h_gt_15) | (stochrsi_k_4h_lt_60))
             # 15m & 1h & 4h & 1d down move, 1d high
             & ((rsi_3_15m_gt_5) | (rsi_3_1h_gt_20) | (rsi_3_4h_gt_20) | (rsi_3_1d_gt_25) | (aroonu_14_1d_lt_70))
             # 15m & 1h down move, 1h high
@@ -13672,15 +13703,15 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 1h high
             & ((rsi_3_15m_gt_5) | (rsi_3_1h_gt_45) | (aroonu_14_1h_lt_80))
             # 15m & 4h down move, 1d still high
-            & ((rsi_3_15m_gt_5) | (rsi_3_4h_gt_5) | (stochrsi_k_1d < 40.0))
+            & ((rsi_3_15m_gt_5) | (rsi_3_4h_gt_5) | (stochrsi_k_1d_lt_40))
             # 15m & 4h down move, 15m still not low enough
-            & ((rsi_3_15m_gt_5) | (rsi_3_4h_gt_10) | (stochrsi_k_15m < 30.0))
+            & ((rsi_3_15m_gt_5) | (rsi_3_4h_gt_10) | (stochrsi_k_15m_lt_30))
             # 15m & 4h down move, 1d high
-            & ((rsi_3_15m_gt_5) | (rsi_3_4h_gt_10) | (stochrsi_k_1d < 70.0))
+            & ((rsi_3_15m_gt_5) | (rsi_3_4h_gt_10) | (stochrsi_k_1d_lt_70))
             # 15m & 4h down move, 15m still high
             & ((rsi_3_15m_gt_5) | (rsi_3_4h_gt_15) | (aroonu_14_15m < 40.0))
             # 15m & 4h down move, 1h still high
-            & ((rsi_3_15m_gt_5) | (rsi_3_4h_gt_15) | (stochrsi_k_1h < 50.0))
+            & ((rsi_3_15m_gt_5) | (rsi_3_4h_gt_15) | (stochrsi_k_1h_lt_50))
             # 15m & 4h down move, 4h still high
             & ((rsi_3_15m_gt_5) | (rsi_3_4h_gt_15) | (stochrsi_k_4h_lt_50))
             # 15m & 4h down move, 1d overbought
@@ -13690,9 +13721,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1d down move, 15m still not low enough
             & ((rsi_3_15m_gt_5) | (rsi_3_1d_gt_10) | (aroonu_14_15m < 30.0))
             # 15m & 1d down move, 1h high
-            & ((rsi_3_15m_gt_5) | (rsi_3_1d_gt_40) | (stochrsi_k_1h < 90.0))
+            & ((rsi_3_15m_gt_5) | (rsi_3_1d_gt_40) | (stochrsi_k_1h_lt_90))
             # 15m down move, 15m downtrend, 4h still not low enough
-            & ((rsi_3_15m_gt_5) | (cmf_20_15m > -0.30) | (stochrsi_k_4h < 30.0))
+            & ((rsi_3_15m_gt_5) | (cmf_20_15m > -0.30) | (stochrsi_k_4h_lt_30))
             # 15m down move, 15m still not low enough, 4h high
             & ((rsi_3_15m_gt_5) | (aroonu_14_15m < 20.0) | (stochrsi_k_4h_lt_70))
             # 15m down move, 15m stil high, 1h still high
@@ -13700,25 +13731,25 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 1d high & overbought
             & ((rsi_3_15m_gt_5) | (aroonu_14_1d_lt_80) | (roc_9_1d_lt_20))
             # 15m down move, 15m still not low enough, 1h still high
-            & ((rsi_3_15m_gt_5) | (stochrsi_k_15m < 20.0) | (stochrsi_k_1h_lt_50))
+            & ((rsi_3_15m_gt_5) | (stochrsi_k_15m_lt_20) | (stochrsi_k_1h_lt_50))
             # 15m down move, 1h still high, 4h overbought
             & ((rsi_3_15m_gt_5) | (stochrsi_k_1h_lt_50) | (roc_9_4h_lt_30))
             # 15m down move, 1h high & overbought
             & ((rsi_3_15m_gt_5) | (stochrsi_k_1h_lt_80) | (roc_9_1h < 20.0))
             # 15m & 1h down move, 15m high
-            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_10) | (stochrsi_k_15m < 50.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_10) | (stochrsi_k_15m_lt_50))
             # 15m & 1h down move, 1h still high
             & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_10) | (aroonu_14_1h_lt_50))
             # 15m & 1h down move, 4h high
             & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_10) | (aroonu_14_4h_lt_60))
             # 15m & 1h down move, 1d high
-            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_10) | (stochrsi_k_1d < 70.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_10) | (stochrsi_k_1d_lt_70))
             # 15m & 1h down move, 1h high
             & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_15) | (aroonu_14_1h < 80.0))
             # 15m & 1h down move, 4h high
             & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_20) | (stochrsi_k_4h_lt_70))
             # 15m & 1h & 4h down move, 1d high
-            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_25) | (rsi_3_4h_gt_25) | (stochrsi_k_1d < 70.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_25) | (rsi_3_4h_gt_25) | (stochrsi_k_1d_lt_70))
             # 15m & 1h down move, 4h high
             & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_25) | (aroonu_14_4h < 75.0))
             # 15m & 1h down move, 4h still high
@@ -13730,7 +13761,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 4h still high
             & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_35) | (rsi_14_4h < 50.0))
             # 15m & 1h down move, 1h high
-            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_35) | (stochrsi_k_1h < 60.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_35) | (stochrsi_k_1h_lt_60))
             # 15m & 1h down move, 4h high
             & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_40) | (stochrsi_k_4h_lt_80))
             # 15m & 1h down move, 1h high
@@ -13744,13 +13775,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 1h high
             & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_40) | (aroonu_14_1h_lt_70))
             # 15m & 4h down move, 4h still not low enough
-            & ((rsi_3_15m_gt_10) | (rsi_3_4h_gt_10) | (stochrsi_k_4h < 30.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_4h_gt_10) | (stochrsi_k_4h_lt_30))
             # 15m & 4h down move, 1d high
-            & ((rsi_3_15m_gt_10) | (rsi_3_4h_gt_10) | (stochrsi_k_1d < 80.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_4h_gt_10) | (stochrsi_k_1d_lt_80))
             # 15m & 4h down move, 1d overbought
             & ((rsi_3_15m_gt_10) | (rsi_3_4h_gt_10) | (roc_9_1d_lt_20))
             # 15m & 4h down move, 4h still not low enough
-            & ((rsi_3_15m_gt_10) | rsi_3_4h_gt_20 | (stochrsi_k_4h < 30.0))
+            & ((rsi_3_15m_gt_10) | rsi_3_4h_gt_20 | (stochrsi_k_4h_lt_30))
             # 15m & 4h down move, 1d high
             & ((rsi_3_15m_gt_10) | (rsi_3_4h_gt_30) | (aroonu_14_1d_lt_90))
             # 15m & 4h down move, 1d high
@@ -13762,13 +13793,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1d down move, 1d still high
             & ((rsi_3_15m_gt_10) | (rsi_3_1d_gt_10) | (rsi_14_1d < 40.0))
             # 15m & 1d down move, 1h high
-            & ((rsi_3_15m_gt_10) | (rsi_3_1d_gt_10) | (stochrsi_k_1h < 90.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_1d_gt_10) | (stochrsi_k_1h_lt_90))
             # 15m & 1d down move, 4h high
             & ((rsi_3_15m_gt_10) | (rsi_3_1d_gt_15) | (stochrsi_k_4h_lt_90))
             # 15m & 1d down move, 1h high
             & ((rsi_3_15m_gt_10) | (rsi_3_1d_gt_25) | (aroonu_14_1h_lt_70))
             # 15m & 1d down move, 1d high
-            & ((rsi_3_15m_gt_10) | (rsi_3_1d_gt_25) | (stochrsi_k_1d < 70.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_1d_gt_25) | (stochrsi_k_1d_lt_70))
             # 15m down move, 15m downtrend, 1h high
             & ((rsi_3_15m_gt_10) | (cmf_20_15m > -0.40) | (aroonu_14_1h_lt_80))
             # 15m down move, 1h high, 1d overbought
@@ -13778,11 +13809,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 4h high & overbought
             & ((rsi_3_15m_gt_10) | (aroonu_14_4h_lt_70) | (roc_9_4h_lt_10))
             # 15m down move, 15m still not low enough, 4h high
-            & ((rsi_3_15m_gt_10) | (stochrsi_k_15m < 20.0) | (aroonu_14_4h_lt_70))
+            & ((rsi_3_15m_gt_10) | (stochrsi_k_15m_lt_20) | (aroonu_14_4h_lt_70))
             # 15m down move, 15m sill high, 4h high
-            & ((rsi_3_15m_gt_10) | (stochrsi_k_15m < 40.0) | (aroonu_14_4h_lt_60))
+            & ((rsi_3_15m_gt_10) | (stochrsi_k_15m_lt_40) | (aroonu_14_4h_lt_60))
             # 15m down move, 4h high, 1d downtrend
-            & ((rsi_3_15m_gt_10) | (stochrsi_k_4h < 80.0) | (roc_9_1d_gt_neg_30))
+            & ((rsi_3_15m_gt_10) | (stochrsi_k_4h_lt_80) | (roc_9_1d_gt_neg_30))
             # 15m & 1h down move, 4h downtrend
             & ((rsi_3_15m_gt_15) | (rsi_3_1h_gt_15) | (roc_9_4h > -20.0))
             # 15m & 1h down move, 1h downtrend
@@ -13828,9 +13859,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 4h high & overbought
             & ((rsi_3_15m_gt_15) | aroonu_14_4h_lt_80 | (roc_9_4h_lt_10))
             # 15m down move, 15m still high, 1d overbought
-            & ((rsi_3_15m_gt_15) | (stochrsi_k_15m < 50.0) | (roc_9_1d_lt_100))
+            & ((rsi_3_15m_gt_15) | (stochrsi_k_15m_lt_50) | (roc_9_1d_lt_100))
             # 15m down move, 1h high & overbought
-            & ((rsi_3_15m_gt_15) | (stochrsi_k_1h < 90.0) | (roc_9_1h_lt_10))
+            & ((rsi_3_15m_gt_15) | (stochrsi_k_1h_lt_90) | (roc_9_1h_lt_10))
             # 15m down move, 4h high, 1d overbought
             & ((rsi_3_15m_gt_15) | (stochrsi_k_4h_lt_70) | (roc_9_1d < 10.0))
             # 15m & 1h down move, 15m still not low enough
@@ -13838,7 +13869,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 4h overbought
             & ((rsi_3_15m_gt_20) | (rsi_3_1h_gt_20) | (roc_9_4h < 50.0))
             # 15m & 1h down move, 15m high
-            & ((rsi_3_15m_gt_20) | (rsi_3_1h_gt_25) | (stochrsi_k_15m < 80.0))
+            & ((rsi_3_15m_gt_20) | (rsi_3_1h_gt_25) | (stochrsi_k_15m_lt_80))
             # 15m & 1h down move, 4h high
             & ((rsi_3_15m_gt_20) | (rsi_3_1h_gt_25) | (stochrsi_k_4h_lt_80))
             # 15m & 1h down move, 1h high
@@ -13856,17 +13887,17 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 1h high, 1d downtrend
             & ((rsi_3_15m_gt_20) | (aroonu_14_1h_lt_90) | (roc_9_1d_gt_neg_30))
             # 15m down move, 1h high, 1d overbought
-            & ((rsi_3_15m_gt_20) | (stochrsi_k_1h < 70.0) | (roc_9_1d_lt_100))
+            & ((rsi_3_15m_gt_20) | (stochrsi_k_1h_lt_70) | (roc_9_1d_lt_100))
             # 15m down move, 1h high, 1d downtrend
-            & ((rsi_3_15m_gt_20) | (stochrsi_k_1h < 80.0) | (roc_9_1d_gt_neg_20))
+            & ((rsi_3_15m_gt_20) | (stochrsi_k_1h_lt_80) | (roc_9_1d_gt_neg_20))
             # 15m down move, 1h high & overbought
-            & ((rsi_3_15m_gt_20) | (stochrsi_k_1h < 90.0) | (roc_9_1h_lt_10))
+            & ((rsi_3_15m_gt_20) | (stochrsi_k_1h_lt_90) | (roc_9_1h_lt_10))
             # 15m & 1h down move, 1d overbought
             & ((rsi_3_15m_gt_25) | (rsi_3_1h_gt_40) | (roc_9_1d_lt_80))
             # 15m & 4h down move, 1h overbought
             & ((rsi_3_15m_gt_25) | (rsi_3_4h_gt_35) | (roc_9_1h < 100.0))
             # 15m down move, 15m still not low enough, 1h high
-            & ((rsi_3_15m_gt_25) | (aroonu_14_15m < 20.0) | (stochrsi_k_1h < 90.0))
+            & ((rsi_3_15m_gt_25) | (aroonu_14_15m < 20.0) | (stochrsi_k_1h_lt_90))
             # 15m down move, 1h & 4h high
             & ((rsi_3_15m_gt_25) | (aroonu_14_1h_lt_70) | (aroonu_14_4h_lt_100))
             # 15m down move, 1h high, 1d overbought
@@ -13878,7 +13909,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 4h high & overbought
             & ((rsi_3_15m_gt_30) | (aroonu_14_4h_lt_70) | (roc_9_4h < 50.0))
             # 15m down move, 1h high, 1d downtrend
-            & ((rsi_3_15m_gt_30) | (stochrsi_k_1h < 80.0) | (roc_9_1d_gt_neg_20))
+            & ((rsi_3_15m_gt_30) | (stochrsi_k_1h_lt_80) | (roc_9_1d_gt_neg_20))
             # 15m down move, 4h high & overbought
             & ((rsi_3_15m_gt_30) | (stochrsi_k_4h_lt_80) | (roc_9_4h_lt_30))
             # 15m down move, 1h high, 4h overbought
@@ -13900,7 +13931,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 4h still high
             & ((rsi_3_1h_gt_3) | (rsi_3_4h_gt_5) | (aroonu_14_4h_lt_40))
             # 1h & 4h down move, 1d still high
-            & ((rsi_3_1h_gt_3) | (rsi_3_4h_gt_10) | (stochrsi_k_1d < 40.0))
+            & ((rsi_3_1h_gt_3) | (rsi_3_4h_gt_10) | (stochrsi_k_1d_lt_40))
             # 1h & 4h down move, 4h still high
             & ((rsi_3_1h_gt_3) | (rsi_3_4h_gt_15) | (rsi_14_4h < 40.0))
             # 1h & 4h down move, 1h still not low enough
@@ -13912,11 +13943,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 4h high
             & ((rsi_3_1h_gt_3) | (rsi_3_4h_gt_50) | aroonu_14_4h_lt_70)
             # 1h & 1d down move, 15m still high
-            & ((rsi_3_1h_gt_3) | (rsi_3_1d_gt_10) | (stochrsi_k_15m < 50.0))
+            & ((rsi_3_1h_gt_3) | (rsi_3_1d_gt_10) | (stochrsi_k_15m_lt_50))
             # 1h & 4h down move, 4h high
-            & ((rsi_3_1h_gt_5) | (rsi_3_4h_gt_5) | (stochrsi_k_4h < 40.0))
+            & ((rsi_3_1h_gt_5) | (rsi_3_4h_gt_5) | (stochrsi_k_4h_lt_40))
             # 1h & 4h down move, 1d still high
-            & ((rsi_3_1h_gt_5) | (rsi_3_4h_gt_5) | (stochrsi_k_1d < 50.0))
+            & ((rsi_3_1h_gt_5) | (rsi_3_4h_gt_5) | (stochrsi_k_1d_lt_50))
             # 1h & 4h down move, 1d downtrend
             & ((rsi_3_1h_gt_5) | (rsi_3_4h_gt_5) | (roc_9_1d_gt_neg_30))
             # 1h % 4h down move, 4h downtrend
@@ -13924,7 +13955,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 4h still high
             & ((rsi_3_1h_gt_5) | (rsi_3_4h_gt_60) | (stochrsi_k_4h_lt_50))
             # 1h & 4h down move, 15m high
-            & ((rsi_3_1h_gt_5) | (rsi_3_4h_gt_10) | (stochrsi_k_15m < 70.0))
+            & ((rsi_3_1h_gt_5) | (rsi_3_4h_gt_10) | (stochrsi_k_15m_lt_70))
             # 1h & 4h down move, 1h still high
             & ((rsi_3_1h_gt_5) | (rsi_3_4h_gt_15) | (aroonu_14_1h_lt_50))
             # 1h & 4h down move, 4h downtrend
@@ -13936,19 +13967,19 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 1d still high
             & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_10) | (aroonu_14_1d < 40.0))
             # 1h & 4h down move, 1h still not low enough
-            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_10) | (stochrsi_k_1h < 20.0))
+            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_10) | (stochrsi_k_1h_lt_20))
             # 1h & 4h down move, 1d downtrend
             & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_10) | (roc_9_1d > -20.0))
             # 1h & 4h & 1d down move, 4h downtrend, 1d still high
             & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_15) | (rsi_3_1d_gt_25) | (rsi_14_4h > 30.0) | (aroonu_14_1d < 40.0))
             # 1h & 4h down move, 15m high
-            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_15) | (stochrsi_k_15m < 70.0))
+            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_15) | (stochrsi_k_15m_lt_70))
             # 1h & 4h down move, 1d downtrend
             & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_15) | (roc_9_1d_gt_neg_40))
             # 1h & 4h down move, 4h still high
             & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_30) | (stochrsi_k_4h_lt_50))
             # 1h & 1d down move, 15m still high
-            & ((rsi_3_1h_gt_10) | (rsi_3_1d_gt_15) | (stochrsi_k_15m < 40.0))
+            & ((rsi_3_1h_gt_10) | (rsi_3_1d_gt_15) | (stochrsi_k_15m_lt_40))
             # 1h & 4h down move, 4h still high
             & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_35) | (rsi_14_4h < 40.0))
             # 1h down move, 1h still not low enough 1d overbought
@@ -13958,15 +13989,15 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 1h still not low enough
             & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_15) | (aroonu_14_1h < 20.0))
             # 1h & 4h down move, 15m still high
-            & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_15) | (stochrsi_k_15m < 50.0))
+            & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_15) | (stochrsi_k_15m_lt_50))
             # 1h & 4h down move, 4h downtrend
             & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_15) | (roc_9_4h > -20.0))
             # 1h & 4h down move, 4h still high
             & ((rsi_3_1h_gt_15) | rsi_3_4h_gt_20 | (rsi_14_4h < 40.0))
             # 1h & 4h down move, 4h still not low enough
-            & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_25) | (stochrsi_k_4h < 30.0))
+            & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_25) | (stochrsi_k_4h_lt_30))
             # 1h & 4h down move, 1d high
-            & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_30) | (stochrsi_k_1d < 80.0))
+            & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_30) | (stochrsi_k_1d_lt_80))
             # 1h & 4h down move, 4h downtrend
             & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_30) | (roc_9_4h_gt_neg_30))
             # 1h & 4h down move, 4h high
@@ -13984,7 +14015,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 4h high, 1d overbought
             & ((rsi_3_1h_gt_15) | (aroonu_14_4h_lt_60) | roc_9_1d_lt_50)
             # 1h down move, 4h high & overbought
-            & ((rsi_3_1h_gt_15) | (stochrsi_k_4h < 60.0) | (roc_9_4h_lt_10))
+            & ((rsi_3_1h_gt_15) | (stochrsi_k_4h_lt_60) | (roc_9_4h_lt_10))
             # 1h down move, 1d high & overbought
             & ((rsi_3_1h_gt_15) | (stochrsi_k_1d_lt_90) | (roc_9_1d_lt_40))
             # 1h down move, 4h & 1d downtrend
@@ -14002,11 +14033,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h high, 4h overbought
             & (rsi_3_1h_gt_20 | aroonu_14_1h_lt_70 | (roc_9_4h_lt_10))
             # 1h down move, 1h high, 1h still not low enough
-            & (rsi_3_1h_gt_20 | (aroonu_14_1d_lt_80) | (stochrsi_k_1h < 20.0))
+            & (rsi_3_1h_gt_20 | (aroonu_14_1d_lt_80) | (stochrsi_k_1h_lt_20))
             # 1h down move, 1d high & overbought
             & (rsi_3_1h_gt_20 | aroonu_14_1d_lt_100 | (roc_9_1d_lt_20))
             # 1h down move, 1d high, 4h downtrend
-            & (rsi_3_1h_gt_20 | (stochrsi_k_1d < 80.0) | (roc_9_4h_gt_neg_20))
+            & (rsi_3_1h_gt_20 | (stochrsi_k_1d_lt_80) | (roc_9_4h_gt_neg_20))
             # 1h & 4h down move, 4h high
             & ((rsi_3_1h_gt_25) | (rsi_3_4h_gt_30) | (aroonu_14_4h_lt_60))
             # 1h & 4h down move, 1d downtrend
@@ -14036,7 +14067,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 4h & 1d downtrend
             & ((rsi_3_1h_gt_30) | (roc_9_4h > -25.0) | (roc_9_1d > -60.0))
             # 1h & 4h down move, 1h still high
-            & ((rsi_3_1h_gt_35) | (rsi_3_4h_gt_35) | (stochrsi_k_1h < 40.0))
+            & ((rsi_3_1h_gt_35) | (rsi_3_4h_gt_35) | (stochrsi_k_1h_lt_40))
             # 1h down move, 1h still high, 4h downtrend
             & ((rsi_3_1h_gt_35) | (aroonu_14_1h_lt_50) | (roc_9_4h_gt_neg_20))
             # 1h down move, 1h high, 1d downtrend
@@ -14064,13 +14095,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 1d overbought
             & ((rsi_3_1h_gt_45) | (rsi_3_4h_gt_65) | (roc_9_1d < 200.0))
             # 1h down move, 1h high, 1d high & overbought
-            & ((rsi_3_1h_gt_45) | (stochrsi_k_1h < 60.0) | (stochrsi_k_1d < 70.0) | (roc_9_1d < 40.0))
+            & ((rsi_3_1h_gt_45) | (stochrsi_k_1h_lt_60) | (stochrsi_k_1d_lt_70) | (roc_9_1d < 40.0))
             # 1h down move, 1h high & overbought
             & ((rsi_3_1h_gt_50) | aroonu_14_1h_lt_80 | (roc_9_1h_lt_10))
             # 1h down move, 4h high, 1h overbought
             & ((rsi_3_1h_gt_50) | (aroonu_14_4h < 85.0) | (roc_9_1h < 20.0))
             # 1h down move, 4h high, 1d downtrend
-            & ((rsi_3_1h_gt_50) | (stochrsi_k_4h < 60.0) | (roc_9_1d > -60.0))
+            & ((rsi_3_1h_gt_50) | (stochrsi_k_4h_lt_60) | (roc_9_1d > -60.0))
             # 1h down move, 4h high & overbought
             & ((rsi_3_1h_gt_50) | (stochrsi_k_4h_lt_80) | (roc_9_4h < 100.0))
             # 1h down move, 1h & 4h overbought
@@ -14084,17 +14115,17 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h & 1d down move, 1d still high
             & ((rsi_3_4h_gt_3) | (rsi_3_1d_gt_15) | (aroonu_14_1d < 40.0))
             # 4h & 1d down move, 1d still high
-            & ((rsi_3_4h_gt_3) | (rsi_3_1d_gt_20) | (stochrsi_k_1d < 40.0))
+            & ((rsi_3_4h_gt_3) | (rsi_3_1d_gt_20) | (stochrsi_k_1d_lt_40))
             # 4h & 1d down move, 1d downtrend
             & ((rsi_3_4h_gt_5) | (rsi_3_1d_gt_15) | (roc_9_1d_gt_neg_20))
             # 4h down move, 4h still high, 1d high
             & ((rsi_3_4h_gt_5) | (aroonu_14_4h_lt_50) | (aroonu_14_1d_lt_100))
             # 4h down move, 15m still high
-            & ((rsi_3_4h_gt_5) | (stochrsi_k_15m < 50.0))
+            & ((rsi_3_4h_gt_5) | (stochrsi_k_15m_lt_50))
             # 4h & 1d down move, 1h still not low enough
-            & ((rsi_3_4h_gt_10) | (rsi_3_1d_gt_10) | (stochrsi_k_1h < 20.0))
+            & ((rsi_3_4h_gt_10) | (rsi_3_1d_gt_10) | (stochrsi_k_1h_lt_20))
             # 4h & 1d down move, 1d still high
-            & ((rsi_3_4h_gt_10) | (rsi_3_1d_gt_15) | (stochrsi_k_1d < 40.0))
+            & ((rsi_3_4h_gt_10) | (rsi_3_1d_gt_15) | (stochrsi_k_1d_lt_40))
             # 4h & 1d down move, 1d downtrend
             & ((rsi_3_4h_gt_10) | (rsi_3_1d_gt_20) | (roc_9_1d > -25.0))
             # 4h & 1d down move, 1d high
@@ -14106,15 +14137,15 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 1d high & overbought
             & ((rsi_3_4h_gt_10) | (aroonu_14_1d_lt_90) | (roc_9_1d_lt_40))
             # 4h down move, 4h still high, 1d downtrend
-            & ((rsi_3_4h_gt_10) | (stochrsi_k_4h < 40.0) | (roc_9_1d > -20.0))
+            & ((rsi_3_4h_gt_10) | (stochrsi_k_4h_lt_40) | (roc_9_1d > -20.0))
             # 4h & 1d down move, 1d high
             & ((rsi_3_4h_gt_15) | (rsi_3_1d_gt_20) | (aroonu_14_1d < 60.0))
             # 4h down move, 4h still high, 1d downtrend
             & ((rsi_3_4h_gt_15) | (aroonu_14_4h_lt_50) | (roc_9_1d > -20.0))
             # 4h & 1d down move, 4h still high
-            & (rsi_3_4h_gt_20 | (rsi_3_1d_gt_20) | (stochrsi_k_4h < 40.0))
+            & (rsi_3_4h_gt_20 | (rsi_3_1d_gt_20) | (stochrsi_k_4h_lt_40))
             # 4h & 1d down move, 1d high
-            & (rsi_3_4h_gt_20 | (rsi_3_1d_gt_20) | (stochrsi_k_1d < 80.0))
+            & (rsi_3_4h_gt_20 | (rsi_3_1d_gt_20) | (stochrsi_k_1d_lt_80))
             # 4h down move, 1h high, 1d downtrend
             & ((rsi_3_4h_gt_15) | (aroonu_14_1h_lt_90) | (roc_9_1d > -10.0))
             # 4h down move, 4h still high, 4h downtrend
@@ -14142,7 +14173,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 4h & 1d downtrend
             & ((rsi_3_4h_gt_40) | aroonu_14_4h_lt_80 | aroonu_14_1d_lt_100)
             # 4h down move, 4h still high, 1d overbought
-            & ((rsi_3_4h_gt_40) | (stochrsi_k_4h < 40.0) | roc_9_1d_lt_50)
+            & ((rsi_3_4h_gt_40) | (stochrsi_k_4h_lt_40) | roc_9_1d_lt_50)
             # 4h down move, 4h high, 1d downtrend
             & ((rsi_3_4h_gt_40) | (stochrsi_k_4h_lt_70) | (roc_9_1d > -60.0))
             # 4h down move, 1d high & overbought
@@ -14168,21 +14199,21 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1d down move, 1d high, 1d downtrend
             & ((rsi_3_1d_gt_5) | (aroonu_14_1d_lt_80) | (roc_9_1d_gt_neg_20))
             # 1d down move, 1h & 4h still not low enough
-            & ((rsi_3_1d_gt_5) | (stochrsi_k_1h < 20.0) | (stochrsi_k_4h < 20.0))
+            & ((rsi_3_1d_gt_5) | (stochrsi_k_1h_lt_20) | (stochrsi_k_4h_lt_20))
             # 1d down move, 1h & 4h high
             & ((rsi_3_1d_gt_10) | (aroonu_14_1h_lt_50) | (aroonu_14_4h_lt_90))
             # 1d down move, 1h high
             & ((rsi_3_1d_gt_10) | aroonu_14_1h_lt_70)
             # 1d down move, 1h high, 1d downtrend
-            & ((rsi_3_1d_gt_10) | (stochrsi_k_1h < 80.0) | (roc_9_1d_gt_neg_20))
+            & ((rsi_3_1d_gt_10) | (stochrsi_k_1h_lt_80) | (roc_9_1d_gt_neg_20))
             # 1d down move, 1h overbought, 1d downtrend
             & ((rsi_3_1d_gt_15) | (roc_9_1h < 20.0) | roc_9_1d_gt_neg_50)
             # 1d down move, 1h high, 1d downtrend
-            & ((rsi_3_1d_gt_20) | (stochrsi_k_1h < 90.0) | (roc_9_1d > -10.0))
+            & ((rsi_3_1d_gt_20) | (stochrsi_k_1h_lt_90) | (roc_9_1d > -10.0))
             # 1d down move, 1h high, 1d overbought
             & ((rsi_3_1d_gt_25) | aroonu_14_1h_lt_70 | (roc_9_1d < 25.0))
             # 1d down move, 1d still high, 1d downtrend
-            & ((rsi_3_1d_gt_25) | (stochrsi_k_1d < 50.0) | (roc_9_1d_gt_neg_20))
+            & ((rsi_3_1d_gt_25) | (stochrsi_k_1d_lt_50) | (roc_9_1d_gt_neg_20))
             # 1d down move, 1h high & overbought
             & ((rsi_3_1d_gt_40) | (aroonu_14_1d_lt_70) | (roc_9_1d_lt_80))
             # 1d down move, 4h high & overbought
@@ -14230,23 +14261,23 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1d high, 1h & 4h down move
             & (aroonu_14_1d_lt_100 | (roc_9_1h < 25.0) | (roc_9_4h < 60.0))
             # 15m high, 1d overbought
-            & ((stochrsi_k_15m < 70.0) | (roc_9_1d < 60.0))
+            & ((stochrsi_k_15m_lt_70) | (roc_9_1d < 60.0))
             # 1h high, 1d downtrend
             & ((stochrsi_k_1h_lt_70) | roc_9_1d_gt_neg_50)
             # 1h high, 1d overbought
             & ((stochrsi_k_1h_lt_70) | (roc_9_1d_lt_40))
             # 1h high, 4h downtrend
-            & ((stochrsi_k_1h < 80.0) | (roc_9_4h_gt_neg_20))
+            & ((stochrsi_k_1h_lt_80) | (roc_9_4h_gt_neg_20))
             # 1h high, 4h overbought
             & ((stochrsi_k_1h_lt_80) | (roc_9_4h < 80.0))
             # 4h high, 1h & 4h overbought
-            & ((stochrsi_k_4h < 80.0) | (roc_9_1h_lt_10) | (roc_9_4h_lt_20))
+            & ((stochrsi_k_4h_lt_80) | (roc_9_1h_lt_10) | (roc_9_4h_lt_20))
             # 1d high, 1h & 1d overbought
-            & ((stochrsi_k_1d < 80.0) | (roc_9_1h_lt_10) | (roc_9_1d_lt_80))
+            & ((stochrsi_k_1d_lt_80) | (roc_9_1h_lt_10) | (roc_9_1d_lt_80))
             # 1d high, 4h & 1d overbought
-            & ((stochrsi_k_1d < 80.0) | (roc_9_4h < 60.0) | (roc_9_1d < 60.0))
+            & ((stochrsi_k_1d_lt_80) | (roc_9_4h < 60.0) | (roc_9_1d < 60.0))
             # big drop in the last 20 days, 1d high, 1d downtrend
-            & ((close > (high_max_20_1d * 0.20)) | (stochrsi_k_1d < 70.0) | (roc_9_1d > -15.0))
+            & ((close > (high_max_20_1d * 0.20)) | (stochrsi_k_1d_lt_70) | (roc_9_1d > -15.0))
             # drop in last 20 days, 1h high, 1d downtrend
             & ((close > (high_max_20_1d * 0.20)) | aroonu_14_1h_lt_70 | (roc_9_1d > -70.0))
             # drop in last 20 days. 4h high
@@ -14257,7 +14288,7 @@ class NostalgiaForInfinityX7(IStrategy):
           long_entry_logic.append(
             # (df["RSI_3"] > 5.0)
             (aroonu_14 < 30.0)
-            & (stochrsi_k < 30.0)
+            & (stochrsi_k_lt_30)
             # & (rsi_3_15m > 5.0)
             & (aroonu_14_15m_lt_50)
             & (close < (ema_20 * 0.948))
@@ -14271,15 +14302,15 @@ class NostalgiaForInfinityX7(IStrategy):
 
           long_entry_logic.append(
             # 5m & 4h down move, 1h still high
-            ((rsi_3_gt_5) | (rsi_3_4h_gt_15) | (stochrsi_k_1h < 50.0))
+            ((rsi_3_gt_5) | (rsi_3_4h_gt_15) | (stochrsi_k_1h_lt_50))
             # 5m down move, 15m high, 1d overbought
             & ((rsi_3_gt_5) | (aroonu_14_15m_lt_70) | (roc_9_1d_lt_40))
             # 5m down move, 15m still high, 1d downtrend
-            & ((rsi_3_gt_5) | (stochrsi_k_15m < 50.0) | (roc_9_1d_gt_neg_20))
+            & ((rsi_3_gt_5) | (stochrsi_k_15m_lt_50) | (roc_9_1d_gt_neg_20))
             # 5m down move, 1h still high, 4h downtrend
             & ((rsi_3_gt_5) | (stochrsi_k_1h_lt_50) | (roc_9_4h > -10.0))
             # 5m down move, 1h high. 1d downtrend
-            & ((rsi_3_gt_5) | (stochrsi_k_1h < 80.0) | (roc_9_1d_gt_neg_30))
+            & ((rsi_3_gt_5) | (stochrsi_k_1h_lt_80) | (roc_9_1d_gt_neg_30))
             # 5m down move, 15m & 1h high
             & ((rsi_3_gt_10) | (aroonu_14_15m_lt_70) | (aroonu_14_1h_lt_100))
             # 5m down move, 15m & 1d high
@@ -14289,15 +14320,15 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h dowbn move, 1d high
             & ((rsi_3_15m_gt_5) | (rsi_3_1h_gt_25) | (stochrsi_k_1d_lt_90))
             # 15m & 1d down move, 1h high
-            & ((rsi_3_15m_gt_5) | (rsi_3_1d_gt_15) | (stochrsi_k_1h < 60.0))
+            & ((rsi_3_15m_gt_5) | (rsi_3_1d_gt_15) | (stochrsi_k_1h_lt_60))
             # 15m & 1h down move, 15m still high
             & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_35) | (aroonu_14_15m_lt_50))
             # 15m & 1h down move, 1h still high
-            & ((rsi_3_15m_gt_10) | (rsi_3_4h_gt_10) | (stochrsi_k_1h < 40.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_4h_gt_10) | (stochrsi_k_1h_lt_40))
             # 15m & 4h down move, 15m still high
             & ((rsi_3_15m_gt_10) | rsi_3_4h_gt_20 | (aroonu_14_15m_lt_50))
             # 15m down move, 15m still high, 1h high
-            & ((rsi_3_15m_gt_10) | (aroonu_14_15m < 40.0) | (stochrsi_k_1h < 90.0))
+            & ((rsi_3_15m_gt_10) | (aroonu_14_15m < 40.0) | (stochrsi_k_1h_lt_90))
             # 15m down move, 15m still high, 1h high
             & ((rsi_3_15m_gt_10) | (aroonu_14_15m_lt_50) | (stochrsi_k_1h_lt_80))
             # 15m down move, 15m still high, 1d overbought
@@ -14305,11 +14336,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 15m high, 1d overbought
             & ((rsi_3_15m_gt_10) | (aroonu_14_15m < 60.0) | roc_9_1d_lt_50)
             # 15m down move, 4h high, 1d downtrend
-            & ((rsi_3_15m_gt_10) | (stochrsi_k_4h < 80.0) | (roc_9_1d_gt_neg_20))
+            & ((rsi_3_15m_gt_10) | (stochrsi_k_4h_lt_80) | (roc_9_1d_gt_neg_20))
             # 15m & 1h down move, 4h still high
             & ((rsi_3_15m_gt_15) | (rsi_3_1h_gt_35) | (aroonu_14_4h_lt_50))
             # 15m & 1h down move, 1h high
-            & ((rsi_3_15m_gt_15) | (rsi_3_1h_gt_35) | (stochrsi_k_1h < 60.0))
+            & ((rsi_3_15m_gt_15) | (rsi_3_1h_gt_35) | (stochrsi_k_1h_lt_60))
             # 15m & 1h down move, 1h high
             & ((rsi_3_15m_gt_15) | (rsi_3_1h_gt_45) | (stochrsi_k_1h_lt_80))
             # 15m & 1h down move, 1h high
@@ -14319,7 +14350,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 4h down move, 1d downtrend
             & ((rsi_3_15m_gt_15) | (rsi_3_4h_gt_15) | (roc_9_1d > -30.0))
             # 15m & 4h down move, 15m still high
-            & ((rsi_3_15m_gt_15) | (rsi_3_4h_gt_15) | (stochrsi_k_15m < 50.0))
+            & ((rsi_3_15m_gt_15) | (rsi_3_4h_gt_15) | (stochrsi_k_15m_lt_50))
             # 15m & 4h down move, 1d high
             & ((rsi_3_15m_gt_15) | rsi_3_4h_gt_20 | aroonu_14_1d_lt_100)
             # 15m & 1d down move, 15m high
@@ -14367,7 +14398,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 4h down move, 4h high
             & ((rsi_3_15m_gt_20) | (rsi_3_4h_gt_60) | aroonu_14_4h_lt_70)
             # 15m & 1h down move, 15m still high
-            & ((rsi_3_15m_gt_20) | (rsi_3_1d_gt_25) | (stochrsi_k_15m < 50.0))
+            & ((rsi_3_15m_gt_20) | (rsi_3_1d_gt_25) | (stochrsi_k_15m_lt_50))
             # 15m & 1d down move, 1h still high
             & ((rsi_3_15m_gt_20) | (rsi_3_1d_gt_25) | (stochrsi_k_1h_lt_50))
             # 15m & 1d down move, 1h high
@@ -14401,15 +14432,15 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 4h high & overbought
             & ((rsi_3_15m_gt_20) | aroonu_14_4h_lt_70 | (roc_9_4h < 50.0))
             # 15m down move, 1h high, 4h downtrend
-            & ((rsi_3_15m_gt_20) | (stochrsi_k_1h < 60.0) | (roc_9_4h_gt_neg_20))
+            & ((rsi_3_15m_gt_20) | (stochrsi_k_1h_lt_60) | (roc_9_4h_gt_neg_20))
             # 15m down move, 1h high, 1d overbought
             & ((rsi_3_15m_gt_20) | (stochrsi_k_1h_lt_80) | (roc_9_1d_lt_30))
             # 15m down move, 1h high
-            & ((rsi_3_15m_gt_20) | (stochrsi_k_1h < 90.0))
+            & ((rsi_3_15m_gt_20) | (stochrsi_k_1h_lt_90))
             # 15m down move, 4h still high, 1d downtrend
-            & ((rsi_3_15m_gt_20) | (stochrsi_k_4h < 40.0) | (roc_9_1d_gt_neg_20))
+            & ((rsi_3_15m_gt_20) | (stochrsi_k_4h_lt_40) | (roc_9_1d_gt_neg_20))
             # 15m down move, 4h high, 1d downtrend
-            & ((rsi_3_15m_gt_20) | (stochrsi_k_4h < 80.0) | (roc_9_1d_gt_neg_30))
+            & ((rsi_3_15m_gt_20) | (stochrsi_k_4h_lt_80) | (roc_9_1d_gt_neg_30))
             # 15m down move, 4h & 1d overbought
             & ((rsi_3_15m_gt_20) | (roc_9_4h < 25.0) | (roc_9_1d_lt_100))
             # 15m & 1h down move, 15m high
@@ -14443,9 +14474,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 4h high & overbought
             & ((rsi_3_15m_gt_25) | aroonu_14_4h_lt_80 | (roc_9_4h_lt_10))
             # 15m down move, 15m still high, 1h still high
-            & ((rsi_3_15m_gt_25) | (stochrsi_k_15m < 50.0) | (aroonu_14_1h_lt_50))
+            & ((rsi_3_15m_gt_25) | (stochrsi_k_15m_lt_50) | (aroonu_14_1h_lt_50))
             # 15m down move, 1h high, 4h high
-            & ((rsi_3_15m_gt_25) | (stochrsi_k_1h < 70.0) | (aroonu_14_4h_lt_100))
+            & ((rsi_3_15m_gt_25) | (stochrsi_k_1h_lt_70) | (aroonu_14_4h_lt_100))
             # 15m down move, 4h & 1d overbought
             & ((rsi_3_15m_gt_25) | (roc_9_4h < 50.0) | (roc_9_1d_lt_50))
             # 15m & 1h down move, 1h high
@@ -14467,9 +14498,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 4h high & overbought
             & ((rsi_3_15m_gt_30) | (aroonu_14_4h_lt_70) | (roc_9_4h < 60.0))
             # 15m down move, 15m high, 4h overbought
-            & ((rsi_3_15m_gt_30) | (stochrsi_k_15m < 70.0) | (roc_9_4h < 70.0))
+            & ((rsi_3_15m_gt_30) | (stochrsi_k_15m_lt_70) | (roc_9_4h < 70.0))
             # 15m down move, 1h high, 1d overbought
-            & ((rsi_3_15m_gt_30) | (stochrsi_k_1h < 90.0) | (roc_9_1d_lt_50))
+            & ((rsi_3_15m_gt_30) | (stochrsi_k_1h_lt_90) | (roc_9_1d_lt_50))
             # 15m & 1h down move, 15m still high, 1h high
             & ((rsi_3_15m_gt_35) | (rsi_3_1h_gt_40) | (aroonu_14_15m_lt_50) | (aroonu_14_1h_lt_90))
             # 15m down move, 15m high, 4h high
@@ -14481,9 +14512,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 4h high, 1d overbought
             & ((rsi_3_15m_gt_35) | (aroonu_14_4h_lt_80) | (roc_9_1d < 200.0))
             # 15m down move, 1h high, 1d downtrend
-            & ((rsi_3_15m_gt_35) | (stochrsi_k_1h < 90.0) | roc_9_1d_gt_neg_50)
+            & ((rsi_3_15m_gt_35) | (stochrsi_k_1h_lt_90) | roc_9_1d_gt_neg_50)
             # 15m down move, 4h high & overbought
-            & ((rsi_3_15m_gt_35) | (stochrsi_k_4h < 90.0) | (roc_9_4h_lt_20))
+            & ((rsi_3_15m_gt_35) | (stochrsi_k_4h_lt_90) | (roc_9_4h_lt_20))
             # 15m down move, 15m high, 1h downtrend
             & ((rsi_3_15m_gt_40) | (aroonu_14_15m_lt_70) | (roc_9_1h > -20.0))
             # 15m down move, 15m & 4h high
@@ -14491,7 +14522,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 4h high & overbought
             & ((rsi_3_15m_gt_40) | (stochrsi_k_4h_lt_80) | (roc_9_4h_lt_30))
             # 1h & 4h down move, 15m still high
-            & ((rsi_3_1h_gt_5) | (rsi_3_4h_gt_10) | (stochrsi_k_15m < 50.0))
+            & ((rsi_3_1h_gt_5) | (rsi_3_4h_gt_10) | (stochrsi_k_15m_lt_50))
             # 1h & 4h down move, 4h still high
             & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_10) | (aroonu_14_4h_lt_50))
             # 1h down move, 4h still high, 4h downtrend
@@ -14509,7 +14540,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 1d down move, 1d overbought
             & ((rsi_3_1h_gt_15) | (rsi_3_1d_gt_60) | (roc_9_1d_lt_40))
             # 1h down move, 1h still not low enough, 1d downtrend
-            & ((rsi_3_1h_gt_15) | (stochrsi_k_1h < 30.0) | (roc_9_1d > -30.0))
+            & ((rsi_3_1h_gt_15) | (stochrsi_k_1h_lt_30) | (roc_9_1d > -30.0))
             # 1h & 4h down move, 1d high
             & (rsi_3_1h_gt_20 | (rsi_3_4h_gt_25) | (aroonu_14_1d_lt_80))
             # 1h & 4h down move, 1d overbought
@@ -14519,13 +14550,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 4h high
             & ((rsi_3_1h_gt_25) | (rsi_3_4h_gt_40) | aroonu_14_4h_lt_80)
             # 1h & 1d down move, 1d still high
-            & ((rsi_3_1h_gt_25) | (rsi_3_1d_gt_40) | (stochrsi_k_1d < 50.0))
+            & ((rsi_3_1h_gt_25) | (rsi_3_1d_gt_40) | (stochrsi_k_1d_lt_50))
             # 1h down move, 1h high, 1d overbought
             & ((rsi_3_1h_gt_25) | aroonu_14_1h_lt_70 | (roc_9_1d_lt_20))
             # 1h down move, 1d high & overbought
             & ((rsi_3_1h_gt_25) | (aroonu_14_1d_lt_80) | (roc_9_1d_lt_20))
             # 1h down move, 4h high, 1d downtrend
-            & ((rsi_3_1h_gt_25) | (stochrsi_k_4h < 60.0) | (roc_9_1d_gt_neg_20))
+            & ((rsi_3_1h_gt_25) | (stochrsi_k_4h_lt_60) | (roc_9_1d_gt_neg_20))
             # 1h down move, 4h downtrend, 1d overbought
             & ((rsi_3_1h_gt_25) | (roc_9_4h > -40.0) | roc_9_1d_lt_50)
             # 1h down move, 15m & 1h still high
@@ -14537,7 +14568,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h high, 1d overbought
             & ((rsi_3_1h_gt_30) | aroonu_14_1h_lt_70 | (roc_9_1d_lt_30))
             # 1h down move, 4h high & overbought
-            & ((rsi_3_1h_gt_30) | (stochrsi_k_4h < 60.0) | (roc_9_4h_lt_20))
+            & ((rsi_3_1h_gt_30) | (stochrsi_k_4h_lt_60) | (roc_9_4h_lt_20))
             # 1h down move, 4h & 1h overbought
             & ((rsi_3_1h_gt_30) | (roc_9_4h_lt_30) | (roc_9_1d_lt_40))
             # 1h & 1d down move, 1h high
@@ -14551,7 +14582,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 15m & 1d high
             & ((rsi_3_1h_gt_35) | (aroonu_14_15m < 60.0) | (aroonu_14_1d_lt_80))
             # 1h down move, 1h & 4h high
-            & ((rsi_3_1h_gt_35) | aroonu_14_1h_lt_70 | (stochrsi_k_4h < 90.0))
+            & ((rsi_3_1h_gt_35) | aroonu_14_1h_lt_70 | (stochrsi_k_4h_lt_90))
             # 1h down move, 1h & 1d high
             & ((rsi_3_1h_gt_35) | aroonu_14_1h_lt_80 | (aroonu_14_1d_lt_90))
             # 1h down move, 1h downtrend, 4h overbought
@@ -14565,9 +14596,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 1h high
             & ((rsi_3_1h_gt_40) | (rsi_3_4h_gt_50) | (stochrsi_k_1h_lt_70))
             # 1h & 4h down move, 4h high
-            & ((rsi_3_1h_gt_40) | (rsi_3_4h_gt_50) | (stochrsi_k_4h < 60.0))
+            & ((rsi_3_1h_gt_40) | (rsi_3_4h_gt_50) | (stochrsi_k_4h_lt_60))
             # 1h down move, 15m still high, 4h downtrend
-            & ((rsi_3_1h_gt_40) | (stochrsi_k_15m < 40.0) | (roc_9_4h > -15.0))
+            & ((rsi_3_1h_gt_40) | (stochrsi_k_15m_lt_40) | (roc_9_4h > -15.0))
             # 1h down move, 15m still high, 1d overbought
             & ((rsi_3_1h_gt_40) | (aroonu_14_15m_lt_50) | roc_9_1d_lt_50)
             # 1h down move, 15m & 4h high
@@ -14597,9 +14628,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1d high & overbought
             & ((rsi_3_1h_gt_45) | aroonu_14_1d_lt_100 | (roc_9_1d_lt_30))
             # 1h down move, 1h still high, 1d overbought
-            & ((rsi_3_1h_gt_45) | (stochrsi_k_1h < 40.0) | (roc_9_1d < 200.0))
+            & ((rsi_3_1h_gt_45) | (stochrsi_k_1h_lt_40) | (roc_9_1d < 200.0))
             # 1h down move, 1d high & overbought
-            & ((rsi_3_1h_gt_45) | (stochrsi_k_1d < 80.0) | (roc_9_1d < 10.0))
+            & ((rsi_3_1h_gt_45) | (stochrsi_k_1d_lt_80) | (roc_9_1d < 10.0))
             # 1h down move, 15m & 1h high
             & ((rsi_3_1h_gt_50) | (aroonu_14_15m_lt_70) | (aroonu_14_1h_lt_100))
             # 1h down move, 1h high, 4h overbought
@@ -14609,23 +14640,23 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 4h high & overbought
             & ((rsi_3_1h_gt_50) | aroonu_14_4h_lt_100 | (roc_9_4h < 50.0))
             # 1h down move, 1h & 4h high
-            & ((rsi_3_1h_gt_50) | (stochrsi_k_1h < 80.0) | aroonu_14_4h_lt_100)
+            & ((rsi_3_1h_gt_50) | (stochrsi_k_1h_lt_80) | aroonu_14_4h_lt_100)
             # 1h down move, 4h high & overbought
             & ((rsi_3_1h_gt_50) | (stochrsi_k_4h_lt_70) | (roc_9_4h_lt_10))
             # 1h down move, 1h high, 1d high
-            & ((rsi_3_1h_gt_55) | (stochrsi_k_1h < 70.0) | aroonu_14_1d_lt_100)
+            & ((rsi_3_1h_gt_55) | (stochrsi_k_1h_lt_70) | aroonu_14_1d_lt_100)
             # 1h down move, 1h high, 1d downtrend
-            & ((rsi_3_1h_gt_55) | (stochrsi_k_1h < 80.0) | (roc_9_1d_gt_neg_30))
+            & ((rsi_3_1h_gt_55) | (stochrsi_k_1h_lt_80) | (roc_9_1d_gt_neg_30))
             # 1h down move, 4h high & overbought
             & ((rsi_3_1h_gt_55) | (stochrsi_k_4h_lt_80) | (roc_9_4h < 100.0))
             # 1h down move, 1h high, 1d overbought
-            & ((rsi_3_1h_gt_60) | (stochrsi_k_1h < 80.0) | (roc_9_1d_lt_100))
+            & ((rsi_3_1h_gt_60) | (stochrsi_k_1h_lt_80) | (roc_9_1d_lt_100))
             # 1h down move, 15m & 1h high
             & ((rsi_3_1h_gt_65) | (aroonu_14_15m_lt_70) | (aroonu_14_1h_lt_100))
             # 1h down move, 1h high & overbought
             & ((rsi_3_1h_gt_65) | (stochrsi_k_1h_lt_80) | (roc_9_1h_lt_10))
             # 4h down move, 1h still high, 1d downtrend
-            & ((rsi_3_4h_gt_3) | (stochrsi_k_1h < 40.0) | (roc_9_1d_gt_neg_30))
+            & ((rsi_3_4h_gt_3) | (stochrsi_k_1h_lt_40) | (roc_9_1d_gt_neg_30))
             # 4h down move, 1h still high, 4h downtrend
             & ((rsi_3_4h_gt_3) | (stochrsi_k_1h_lt_50) | (roc_9_4h_gt_neg_30))
             # 4h down move, 4h & 1d downtrend
@@ -14633,61 +14664,61 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 15m high, 1h still high
             & ((rsi_3_4h_gt_5) | (aroonu_14_15m_lt_70) | (stochrsi_k_1h_lt_50))
             # 4h down move, 15m high
-            & ((rsi_3_4h_gt_5) | (stochrsi_k_15m < 70.0))
+            & ((rsi_3_4h_gt_5) | (stochrsi_k_15m_lt_70))
             # 4h down move, 4h still high, 1d downtrend
-            & ((rsi_3_4h_gt_5) | (stochrsi_k_4h < 40.0) | (roc_9_1d_gt_neg_20))
+            & ((rsi_3_4h_gt_5) | (stochrsi_k_4h_lt_40) | (roc_9_1d_gt_neg_20))
             # 4h & 1d down move, 1d still high
-            & ((rsi_3_4h_gt_10) | (rsi_3_1d_gt_20) | (stochrsi_k_1d < 50.0))
+            & ((rsi_3_4h_gt_10) | (rsi_3_1d_gt_20) | (stochrsi_k_1d_lt_50))
             # 4h & 1d down move, 1d downtrend
             & ((rsi_3_4h_gt_10) | (rsi_3_1d_gt_20) | (roc_9_1d > -20.0))
             # 4h & 1d down move, 4h still high
             & ((rsi_3_4h_gt_10) | (rsi_3_1d_gt_30) | (stochrsi_k_4h_lt_50))
             # 4h & 1d down move, 1d still high
-            & ((rsi_3_4h_gt_10) | (rsi_3_1d_gt_35) | (stochrsi_k_1d < 40.0))
+            & ((rsi_3_4h_gt_10) | (rsi_3_1d_gt_35) | (stochrsi_k_1d_lt_40))
             # 4h down move, 15m still not low enough, 1d downtrend
-            & ((rsi_3_4h_gt_10) | (stochrsi_k_15m < 30.0) | (roc_9_1d_gt_neg_40))
+            & ((rsi_3_4h_gt_10) | (stochrsi_k_15m_lt_30) | (roc_9_1d_gt_neg_40))
             # 4h down move, 15m high, 4h downtrend
-            & ((rsi_3_4h_gt_10) | (stochrsi_k_15m < 60.0) | (roc_9_4h > -50.0))
+            & ((rsi_3_4h_gt_10) | (stochrsi_k_15m_lt_60) | (roc_9_4h > -50.0))
             # 4h down move, 15m high
-            & ((rsi_3_4h_gt_10) | (stochrsi_k_15m < 70.0))
+            & ((rsi_3_4h_gt_10) | (stochrsi_k_15m_lt_70))
             # 4h & 1d down move, 15m high
-            & ((rsi_3_4h_gt_15) | (rsi_3_1d_gt_35) | (stochrsi_k_15m < 70.0))
+            & ((rsi_3_4h_gt_15) | (rsi_3_1d_gt_35) | (stochrsi_k_15m_lt_70))
             # 4h & 1d down move, 4h high
             & ((rsi_3_4h_gt_15) | (rsi_3_1d_gt_35) | (stochrsi_k_4h_lt_70))
             # 4h & 1d down move, 1d high
             & ((rsi_3_4h_gt_15) | (rsi_3_1d_gt_40) | (aroonu_14_1d_lt_70))
             # 4h down move, 15m still high, 1h high
-            & ((rsi_3_4h_gt_15) | (aroonu_14_15m_lt_50) | (stochrsi_k_1h < 60.0))
+            & ((rsi_3_4h_gt_15) | (aroonu_14_15m_lt_50) | (stochrsi_k_1h_lt_60))
             # 4h down move, 15m & 1d high
             & ((rsi_3_4h_gt_15) | (aroonu_14_15m_lt_70) | (aroonu_14_1d_lt_80))
             # 4h down move, 15m high
-            & ((rsi_3_4h_gt_15) | (stochrsi_k_15m < 80.0))
+            & ((rsi_3_4h_gt_15) | (stochrsi_k_15m_lt_80))
             # 4h down move, 1d high
-            & ((rsi_3_4h_gt_15) | (stochrsi_k_1d < 80.0))
+            & ((rsi_3_4h_gt_15) | (stochrsi_k_1d_lt_80))
             # 4h down move, 1h & 4h downtrend
             & ((rsi_3_4h_gt_15) | (roc_9_1h > -30.0) | (roc_9_4h_gt_neg_30))
             # 4h & 1d down move, 1h still high
             & (rsi_3_4h_gt_20 | (rsi_3_1d_gt_20) | (aroonu_14_1h < 40.0))
             # 4h & 1d down move, 15m high
-            & (rsi_3_4h_gt_20 | (rsi_3_1d_gt_25) | (stochrsi_k_15m < 70.0))
+            & (rsi_3_4h_gt_20 | (rsi_3_1d_gt_25) | (stochrsi_k_15m_lt_70))
             # 4h & 1d down move, 1d overbought
             & (rsi_3_4h_gt_20 | (rsi_3_1d_gt_55) | roc_9_1d_lt_50)
             # 4h down move, 15m & 4h still high
             & (rsi_3_4h_gt_20 | (aroonu_14_15m_lt_50) | (aroonu_14_4h_lt_50))
             # 4h down move, 15m high, 1d high
-            & (rsi_3_4h_gt_20 | (aroonu_14_15m_lt_70) | (stochrsi_k_1d < 70.0))
+            & (rsi_3_4h_gt_20 | (aroonu_14_15m_lt_70) | (stochrsi_k_1d_lt_70))
             # 4h down move, 4h still high, 1d downtrend
             & (rsi_3_4h_gt_20 | (aroonu_14_4h_lt_50) | (roc_9_1d_gt_neg_40))
             # 4h down move, 1d high & overbought
             & (rsi_3_4h_gt_20 | (aroonu_14_1d_lt_90) | (roc_9_1d < 10.0))
             # 4h down move, 15m high, 4h downtrend
-            & (rsi_3_4h_gt_20 | (stochrsi_k_15m < 80.0) | (roc_9_4h > -50.0))
+            & (rsi_3_4h_gt_20 | (stochrsi_k_15m_lt_80) | (roc_9_4h > -50.0))
             # 4h down move, 1h high, 1d downtrend
-            & (rsi_3_4h_gt_20 | (stochrsi_k_1h < 60.0) | (roc_9_1d_gt_neg_40))
+            & (rsi_3_4h_gt_20 | (stochrsi_k_1h_lt_60) | (roc_9_1d_gt_neg_40))
             # 4h down move, 4h still not low enough, 4h downtrend
-            & (rsi_3_4h_gt_20 | (stochrsi_k_4h < 30.0) | (roc_9_4h > -10.0))
+            & (rsi_3_4h_gt_20 | (stochrsi_k_4h_lt_30) | (roc_9_4h > -10.0))
             # 4h down move, 4h high, 1d downtrend
-            & (rsi_3_4h_gt_20 | (stochrsi_k_4h < 60.0) | (roc_9_1d > -60.0))
+            & (rsi_3_4h_gt_20 | (stochrsi_k_4h_lt_60) | (roc_9_1d > -60.0))
             # 4h & 1d down move, 1d overbought
             & ((rsi_3_4h_gt_25) | (rsi_3_1d_gt_40) | (roc_9_1d_lt_30))
             # 4h & 1d down move, 1d high
@@ -14709,7 +14740,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 4h high, 1d overbought
             & ((rsi_3_4h_gt_25) | aroonu_14_4h_lt_70 | (roc_9_1d_lt_40))
             # 4h down move, 1h still high, 1d overbought
-            & ((rsi_3_4h_gt_25) | (stochrsi_k_1h < 50.0) | (roc_9_1d_lt_100))
+            & ((rsi_3_4h_gt_25) | (stochrsi_k_1h_lt_50) | (roc_9_1d_lt_100))
             # 4h down move, 4h high, 1d downtrend
             & ((rsi_3_4h_gt_25) | (stochrsi_k_4h_lt_80) | roc_9_1d_gt_neg_50)
             # 4h down move, 1h high, 1h downtrend
@@ -14725,11 +14756,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 1h high, 1d downtrend
             & ((rsi_3_4h_gt_30) | (stochrsi_k_1h_lt_80) | (roc_9_1d_gt_neg_40))
             # 4h down move, 1h high, 1d overbought
-            & ((rsi_3_4h_gt_30) | (stochrsi_k_1h < 90.0) | roc_9_1d_lt_50)
+            & ((rsi_3_4h_gt_30) | (stochrsi_k_1h_lt_90) | roc_9_1d_lt_50)
             # 4h down move, 1d high & overbought
-            & ((rsi_3_4h_gt_30) | (stochrsi_k_1d < 80.0) | (roc_9_1d < 10.0))
+            & ((rsi_3_4h_gt_30) | (stochrsi_k_1d_lt_80) | (roc_9_1d < 10.0))
             # 4h down move, 15m still high, 1h high
-            & ((rsi_3_4h_gt_35) | (aroonu_14_15m < 40.0) | (stochrsi_k_1h < 90.0))
+            & ((rsi_3_4h_gt_35) | (aroonu_14_15m < 40.0) | (stochrsi_k_1h_lt_90))
             # 4h down move, 15m still high, 4h high
             & ((rsi_3_4h_gt_35) | (aroonu_14_15m_lt_50) | aroonu_14_4h_lt_80)
             # 4h down move, 15m high, 1h high
@@ -14737,7 +14768,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 4h & 1d high
             & ((rsi_3_4h_gt_35) | aroonu_14_4h_lt_80 | aroonu_14_1d_lt_100)
             # 4h down move, 1d high, 1d downtrend
-            & ((rsi_3_4h_gt_35) | (stochrsi_k_1d < 60.0) | (roc_9_1d_gt_neg_30))
+            & ((rsi_3_4h_gt_35) | (stochrsi_k_1d_lt_60) | (roc_9_1d_gt_neg_30))
             # 4h down move, 1d high & overbought
             & ((rsi_3_4h_gt_35) | (stochrsi_k_1d_lt_90) | (roc_9_1d_lt_40))
             # 4h down move, 15m still high, 1d overbought
@@ -14749,7 +14780,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 1d high & overbought
             & ((rsi_3_4h_gt_40) | aroonu_14_1d_lt_100 | (roc_9_1d_lt_20))
             # 4h down move, 15m high, 1h high
-            & ((rsi_3_4h_gt_40) | (stochrsi_k_15m < 70.0) | (aroonu_14_1h_lt_100))
+            & ((rsi_3_4h_gt_40) | (stochrsi_k_15m_lt_70) | (aroonu_14_1h_lt_100))
             # 4h down move, 1h high, 1d overbought
             & ((rsi_3_4h_gt_40) | (stochrsi_k_1h_lt_70) | (roc_9_1d < 60.0))
             # 4h down move, 4h & 1d overbought
@@ -14785,7 +14816,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 1d high, 4h overbought
             & ((rsi_3_4h_gt_50) | (aroonu_14_1d_lt_90) | (roc_9_4h_lt_10))
             # 4h down move, 4h high, 1d downtrend
-            & ((rsi_3_4h_gt_50) | (stochrsi_k_4h < 60.0) | (roc_9_1d_gt_neg_20))
+            & ((rsi_3_4h_gt_50) | (stochrsi_k_4h_lt_60) | (roc_9_1d_gt_neg_20))
             # 4h down move, 4h downtrend, 1d overbought
             & ((rsi_3_4h_gt_50) | (roc_9_4h_gt_neg_20) | (roc_9_1d_lt_20))
             # 4h down move, 1h high, 4h overbought
@@ -14797,7 +14828,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 4h high & overbought
             & ((rsi_3_4h_gt_55) | (stochrsi_k_4h_lt_80) | (roc_9_4h_lt_10))
             # 4h down move, 15m high, 1h high
-            & ((rsi_3_4h_gt_60) | (aroonu_14_15m < 60.0) | (stochrsi_k_1h < 90.0))
+            & ((rsi_3_4h_gt_60) | (aroonu_14_15m < 60.0) | (stochrsi_k_1h_lt_90))
             # 4h down move, 4h high & overbought
             & ((rsi_3_4h_gt_60) | aroonu_14_4h_lt_70 | (roc_9_4h_lt_30))
             # 4h down move, 4h still high, 1d downtrend
@@ -14833,7 +14864,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1d down move, 1h & 1d high
             & ((rsi_3_1d_gt_25) | aroonu_14_1h_lt_80 | (aroonu_14_1d_lt_80))
             # 1d down move, 1d still high, 1d downtrend
-            & ((rsi_3_1d_gt_25) | (stochrsi_k_1d < 50.0) | (roc_9_1d_gt_neg_20))
+            & ((rsi_3_1d_gt_25) | (stochrsi_k_1d_lt_50) | (roc_9_1d_gt_neg_20))
             # 1d down move, 1d high & overbought
             & ((rsi_3_1d_gt_30) | (aroonu_14_1d < 60.0) | (roc_9_1d < 10.0))
             # 1d down move, 1h high, 1d downtrend
@@ -14897,19 +14928,19 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1d high, 4h & 1d overbought
             & (aroonu_14_1d_lt_100 | (roc_9_4h_lt_30) | (roc_9_1d_lt_40))
             # 15m & 1h high, 1d overbought
-            & ((stochrsi_k_15m < 70.0) | (stochrsi_k_1h_lt_70) | roc_9_1d_lt_50)
+            & ((stochrsi_k_15m_lt_70) | (stochrsi_k_1h_lt_70) | roc_9_1d_lt_50)
             # 15m & 1d high
-            & ((stochrsi_k_15m < 90.0) | (stochrsi_k_1d_lt_90))
+            & ((stochrsi_k_15m_lt_90) | (stochrsi_k_1d_lt_90))
             # 1h high, 4h & 1d downtrend
-            & ((stochrsi_k_1h < 60.0) | (roc_9_4h_gt_neg_30) | (roc_9_1d_gt_neg_30))
+            & ((stochrsi_k_1h_lt_60) | (roc_9_4h_gt_neg_30) | (roc_9_1d_gt_neg_30))
             # 1h high, 4h downtrend
             & ((stochrsi_k_1h_lt_70) | (roc_9_4h_gt_neg_30))
             # 1h high, 1d downtrend
-            & ((stochrsi_k_1h < 70.0) | (roc_9_1d_gt_neg_20))
+            & ((stochrsi_k_1h_lt_70) | (roc_9_1d_gt_neg_20))
             # 4h high, 4h overbought, 1d downtrend
-            & ((stochrsi_k_4h < 90.0) | (roc_9_4h_lt_20) | (roc_9_1d_gt_neg_20))
+            & ((stochrsi_k_4h_lt_90) | (roc_9_4h_lt_20) | (roc_9_1d_gt_neg_20))
             # 1d still high, 4h & 1d downtrend
-            & ((stochrsi_k_1d < 50.0) | (roc_9_4h_gt_neg_30) | (roc_9_1d_gt_neg_30))
+            & ((stochrsi_k_1d_lt_50) | (roc_9_4h_gt_neg_30) | (roc_9_1d_gt_neg_30))
             # 1d P&D, 4h downtrend
             & ((change_pct_1d > -50.0) | (change_pct_1d.shift(288) < 50.0) | (rsi_3_4h_gt_15))
             # 1d P&D, 15m high
@@ -14927,7 +14958,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1d top wick, 4h down move, 1d overbought
             & ((top_wick_pct_1d < 50.0) | (rsi_3_4h_gt_35) | (roc_9_1d < 60.0))
             # big drop in the last 20 days, 1d high, 1d downtrend
-            & ((close > (high_max_20_1d * 0.20)) | (stochrsi_k_1d < 70.0) | (roc_9_1d > -15.0))
+            & ((close > (high_max_20_1d * 0.20)) | (stochrsi_k_1d_lt_70) | (roc_9_1d > -15.0))
           )
 
           # Logic
@@ -14936,7 +14967,7 @@ class NostalgiaForInfinityX7(IStrategy):
             & (rsi_4 < 45.0)
             & (rsi_14 > 30.0)
             & (aroonu_14 < 20.0)
-            & (stochrsi_k < 20.0)
+            & (stochrsi_k_lt_20)
             & (close < sma_16 * 0.965)
             & (close < df["SMA_16_1h"] * 0.985)
           )
@@ -14968,11 +14999,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 5m & 4h down move, 4h high
             & ((rsi_3_gt_3) | (rsi_3_4h_gt_25) | aroonu_14_4h_lt_70)
             # 5m & 1d down move, 15m still high
-            & ((rsi_3_gt_3) | (rsi_3_1d_gt_20) | (stochrsi_k_15m < 40.0))
+            & ((rsi_3_gt_3) | (rsi_3_1d_gt_20) | (stochrsi_k_15m_lt_40))
             # 5m down move, 1h high, 4h overbought
-            & ((rsi_3_gt_3) | (stochrsi_k_1h < 80.0) | (roc_9_4h_lt_20))
+            & ((rsi_3_gt_3) | (stochrsi_k_1h_lt_80) | (roc_9_4h_lt_20))
             # 5m & 4h down move, 15m still high
-            & ((rsi_3_gt_5) | (rsi_3_4h_gt_25) | (stochrsi_k_15m < 50.0))
+            & ((rsi_3_gt_5) | (rsi_3_4h_gt_25) | (stochrsi_k_15m_lt_50))
             # 5m down move, 4h high, 1h overbought
             & ((rsi_3_gt_10) | aroonu_14_4h_lt_100 | (roc_9_1h < 30.0))
             # 15m & 1h down move, 1d still high
@@ -14980,7 +15011,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 1d still high
             & ((rsi_3_15m_gt_5) | (rsi_3_1h_gt_10) | (aroonu_14_1d < 50.0))
             # 15m & 1h down move, 1h still high
-            & ((rsi_3_15m_gt_5) | (rsi_3_1h_gt_30) | (stochrsi_k_1h < 40.0))
+            & ((rsi_3_15m_gt_5) | (rsi_3_1h_gt_30) | (stochrsi_k_1h_lt_40))
             # 15m & 1h down move, 1d overbought
             & ((rsi_3_15m_gt_5) | (rsi_3_1h_gt_30) | roc_9_1d_lt_50)
             # 15m & 1h down move, 4h high
@@ -14994,11 +15025,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 1h & 1d high
             & ((rsi_3_15m_gt_5) | (roc_9_1h_lt_10) | (roc_9_1d_lt_40))
             # 15m & 1h down move, 15m stil high
-            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_10) | (stochrsi_k_15m < 50.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_10) | (stochrsi_k_15m_lt_50))
             # 15m & 1h down move, 4h downtrend
             & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_10) | (roc_9_4h > -40.0))
             # 15m & 1h down move, 1h still high
-            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_15) | (stochrsi_k_1h < 50.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_15) | (stochrsi_k_1h_lt_50))
             # 15m & 1h down move, 4h high
             & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_15) | aroonu_14_4h_lt_70)
             # 15m & 1h down move, 1d overbought
@@ -15014,9 +15045,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 1h high
             & ((rsi_3_15m_gt_10) | (stochrsi_k_1h_lt_80))
             # 15m & 1h down move, 1h still high
-            & ((rsi_3_15m_gt_15) | (rsi_3_1h_gt_25) | (stochrsi_k_1h < 40.0))
+            & ((rsi_3_15m_gt_15) | (rsi_3_1h_gt_25) | (stochrsi_k_1h_lt_40))
             # 15m & 4h down move, 1d high
-            & ((rsi_3_15m_gt_15) | (rsi_3_4h_gt_15) | (stochrsi_k_1d < 80.0))
+            & ((rsi_3_15m_gt_15) | (rsi_3_4h_gt_15) | (stochrsi_k_1d_lt_80))
             # 15m down move, 4h high & overbought
             & ((rsi_3_15m_gt_15) | aroonu_14_4h_lt_70 | (roc_9_4h_lt_20))
             # 15m down move, 4h high & overbought
@@ -15030,7 +15061,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 4h high, 1h overbought
             & ((rsi_3_15m_gt_20) | aroonu_14_4h_lt_100 | (roc_9_1h < 30.0))
             # 15m down move, 1h high & overbought
-            & ((rsi_3_15m_gt_20) | (stochrsi_k_1h < 90.0) | (roc_9_1h_lt_10))
+            & ((rsi_3_15m_gt_20) | (stochrsi_k_1h_lt_90) | (roc_9_1h_lt_10))
             # 15m & 4h down move, 4h high
             & ((rsi_3_15m_gt_25) | (rsi_3_4h_gt_50) | (stochrsi_k_4h_lt_80))
             # 15m down move, 4h high, 4h overbought
@@ -15044,13 +15075,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 15m downtrend
             & ((rsi_3_1h_gt_3) | (rsi_3_4h_gt_10) | (cmf_20_15m > -0.40))
             # 1h & 4h down move, 1d high
-            & ((rsi_3_1h_gt_3) | rsi_3_4h_gt_20 | (stochrsi_k_1d < 70.0))
+            & ((rsi_3_1h_gt_3) | rsi_3_4h_gt_20 | (stochrsi_k_1d_lt_70))
             # 1h down move, 1h high, 4h high
-            & ((rsi_3_1h_gt_3) | aroonu_14_1h_lt_70 | (stochrsi_k_4h < 80.0))
+            & ((rsi_3_1h_gt_3) | aroonu_14_1h_lt_70 | (stochrsi_k_4h_lt_80))
             # 1h down move, 15m still high
-            & ((rsi_3_1h_gt_3) | (stochrsi_k_15m < 50.0))
+            & ((rsi_3_1h_gt_3) | (stochrsi_k_15m_lt_50))
             # 1h down move, 1h still high, 4h overbought
-            & ((rsi_3_1h_gt_3) | (stochrsi_k_1h < 50.0) | (roc_9_4h_lt_20))
+            & ((rsi_3_1h_gt_3) | (stochrsi_k_1h_lt_50) | (roc_9_4h_lt_20))
             # 1h & 4h & 1d down move
             & ((rsi_3_1h_gt_5) | (rsi_3_4h_gt_5) | (rsi_3_1d_gt_10))
             # 1h & 4h down move, 1h downtrend
@@ -15090,9 +15121,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 1h still not low enough
             & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_15) | (aroonu_14_1h < 20.0))
             # 1h & 4h down move, 4h still not low enough
-            & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_25) | (stochrsi_k_4h < 30.0))
+            & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_25) | (stochrsi_k_4h_lt_30))
             # 1h & 1d down move, 1d still high
-            & ((rsi_3_1h_gt_15) | (rsi_3_1d_gt_20) | (stochrsi_k_1d < 40.0))
+            & ((rsi_3_1h_gt_15) | (rsi_3_1d_gt_20) | (stochrsi_k_1d_lt_40))
             # 1h & 1d down move, 1d high
             & ((rsi_3_1h_gt_15) | (rsi_3_1d_gt_25) | (aroonu_14_1d_lt_80))
             # 1h down move, 1h still high, 4h downtrend
@@ -15118,13 +15149,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 1d overbought
             & ((rsi_3_1h_gt_30) | (rsi_3_4h_gt_30) | (roc_9_1d_lt_40))
             # 1h & 4h down move, 15m high
-            & ((rsi_3_1h_gt_30) | (rsi_3_4h_gt_40) | (stochrsi_k_15m < 80.0))
+            & ((rsi_3_1h_gt_30) | (rsi_3_4h_gt_40) | (stochrsi_k_15m_lt_80))
             # 1h & 4h down move, 1h high
             & ((rsi_3_1h_gt_30) | (rsi_3_4h_gt_50) | (stochrsi_k_1h_lt_70))
             # 1h down move, 15m still high, 1h high
-            & ((rsi_3_1h_gt_30) | (stochrsi_k_15m < 40.0) | (aroonu_14_1h < 60.0))
+            & ((rsi_3_1h_gt_30) | (stochrsi_k_15m_lt_40) | (aroonu_14_1h < 60.0))
             # 1h down move, 1h still high, 4h high
-            & ((rsi_3_1h_gt_30) | (stochrsi_k_1h < 40.0) | (stochrsi_k_4h_lt_70))
+            & ((rsi_3_1h_gt_30) | (stochrsi_k_1h_lt_40) | (stochrsi_k_4h_lt_70))
             # 1h down move, 4h & 1d downtrend
             & ((rsi_3_1h_gt_30) | (roc_9_4h > -25.0) | (roc_9_1d > -60.0))
             # 1h down move, 4h & 1d overbought
@@ -15136,13 +15167,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h still high, 1d overbought
             & ((rsi_3_1h_gt_35) | (stochrsi_k_1h_lt_50) | (roc_9_1d < 200.0))
             # 1h down move, 1h high, 4h downtrend
-            & ((rsi_3_1h_gt_35) | (stochrsi_k_1h < 70.0) | (roc_9_4h_gt_neg_20))
+            & ((rsi_3_1h_gt_35) | (stochrsi_k_1h_lt_70) | (roc_9_4h_gt_neg_20))
             # 1h down move, 1h high, 4h overbought
-            & ((rsi_3_1h_gt_40) | (stochrsi_k_1h < 80.0) | (roc_9_4h_lt_20))
+            & ((rsi_3_1h_gt_40) | (stochrsi_k_1h_lt_80) | (roc_9_4h_lt_20))
             # 1h down move, 1h & 4h high
             & ((rsi_3_1h_gt_45) | aroonu_14_1h_lt_70 | aroonu_14_4h_lt_100)
             # 1h down move, 4h high, 1d downtrend
-            & ((rsi_3_1h_gt_50) | (stochrsi_k_4h < 60.0) | (roc_9_1d > -60.0))
+            & ((rsi_3_1h_gt_50) | (stochrsi_k_4h_lt_60) | (roc_9_1d > -60.0))
             # 1h down move, 4h high & overbought
             & ((rsi_3_1h_gt_50) | (stochrsi_k_4h_lt_90) | (roc_9_4h_lt_40))
             # 1h down move, 1h high & overbought
@@ -15152,7 +15183,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 4h high, 4h downtrend
             & ((rsi_3_4h_gt_3) | (aroonu_14_4h_lt_50) | (roc_9_4h > -40.0))
             # 4h & 1d down move, 1h still not low enough
-            & ((rsi_3_4h_gt_5) | (rsi_3_1d_gt_10) | (stochrsi_k_1h < 30.0))
+            & ((rsi_3_4h_gt_5) | (rsi_3_1d_gt_10) | (stochrsi_k_1h_lt_30))
             # 4h & 1d down move, 1d high
             & ((rsi_3_4h_gt_5) | (rsi_3_1d_gt_45) | (aroonu_14_1d_lt_70))
             # 4h down move, 4h & 1d downtrend
@@ -15160,11 +15191,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h & 1d down move, 1h still high
             & ((rsi_3_4h_gt_10) | (rsi_3_1d_gt_10) | (aroonu_14_1h < 40.0))
             # 4h & 1d down move, 1h high
-            & ((rsi_3_4h_gt_10) | (rsi_3_1d_gt_15) | (stochrsi_k_1h < 70.0))
+            & ((rsi_3_4h_gt_10) | (rsi_3_1d_gt_15) | (stochrsi_k_1h_lt_70))
             # 4h & 1d down move, 1d still high
             & ((rsi_3_4h_gt_10) | (rsi_3_1d_gt_25) | (aroonu_14_1d < 40.0))
             # 4h & 1d down move, 1d still high
-            & ((rsi_3_4h_gt_10) | (rsi_3_1d_gt_25) | (stochrsi_k_1d < 50.0))
+            & ((rsi_3_4h_gt_10) | (rsi_3_1d_gt_25) | (stochrsi_k_1d_lt_50))
             # 4h & 1d down move, 1d high
             & ((rsi_3_4h_gt_15) | (rsi_3_1d_gt_20) | (aroonu_14_1d < 60.0))
             # 4h & 1d down move, 4h high
@@ -15220,7 +15251,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h & 1d overbought
             & ((roc_9_4h < 100.0) | (roc_9_1d < 200.0))
             # big drop in the last 20 days, 1d high, 1d downtrend
-            & ((close > (high_max_20_1d * 0.20)) | (stochrsi_k_1d < 70.0) | (roc_9_1d > -15.0))
+            & ((close > (high_max_20_1d * 0.20)) | (stochrsi_k_1d_lt_70) | (roc_9_1d > -15.0))
             # drop in last 20 days, 1h high, 1d downtrend
             & ((close > (high_max_20_1d * 0.20)) | aroonu_14_1h_lt_70 | (roc_9_1d > -70.0))
           )
@@ -15245,9 +15276,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 5m & 1h down move, 1h still high
             & ((rsi_3_gt_3) | (rsi_3_1h_gt_30) | (stochrsi_k_1h_lt_50))
             # 5m & 4h down move, 15m still high
-            & ((rsi_3_gt_3) | (rsi_3_4h_gt_3) | (stochrsi_k_15m < 40.0))
+            & ((rsi_3_gt_3) | (rsi_3_4h_gt_3) | (stochrsi_k_15m_lt_40))
             # 15m & 1h down move, 4h high
-            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_30) | (stochrsi_k_4h < 60.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_30) | (stochrsi_k_4h_lt_60))
             # 15m & 1h down move, 1h still high
             & ((rsi_3_15m_gt_25) | (rsi_3_1h_gt_25) | (stochrsi_k_1h_lt_50))
             # 1h & 4h down move, 4h high
@@ -15273,7 +15304,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 1h high
             & ((rsi_3_15m_gt_30) | (rsi_3_1h_gt_30) | (aroonu_14_1h < 85.0))
             # 15m down move, 15m still high, 1d high
-            & ((rsi_3_15m_gt_30) | (aroonu_14_15m_lt_50) | (stochrsi_k_1d < 70.0))
+            & ((rsi_3_15m_gt_30) | (aroonu_14_15m_lt_50) | (stochrsi_k_1d_lt_70))
             # 15m down move, 15m high, 4h high
             & ((rsi_3_15m_gt_30) | (aroonu_14_15m < 60.0) | (stochrsi_k_4h_lt_70))
             # 15m down move, 1h & 4h high
@@ -15313,23 +15344,23 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 4h still high
             & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_10) | (aroonu_14_4h_lt_50))
             # 1h & 4h down move, 15m still high
-            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_10) | (stochrsi_k_15m < 50.0))
+            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_10) | (stochrsi_k_15m_lt_50))
             # 1h & 4h down move, 1h downtrend
             & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_10) | (roc_9_1h > -20.0))
             # 1h & 4h & 1d down move
             & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_15) | (rsi_3_1d_gt_15))
             # 1h & 4h down move, 15m high
-            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_15) | (stochrsi_k_15m < 70.0))
+            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_15) | (stochrsi_k_15m_lt_70))
             # 1h & 4h down move, 4h high
             & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_15) | (aroonu_14_4h_lt_60))
             # 1h & 4h down move, 1d overbought
             & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_30) | (roc_9_1d < 100.0))
             # 1h & 4h down move, 4h still high
-            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_45) | (stochrsi_k_4h < 40.0))
+            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_45) | (stochrsi_k_4h_lt_40))
             # 1h down move, 4h downtrend. 4h still not low enough
             & ((rsi_3_1h_gt_10) | (roc_9_4h > -20.0) | (aroonu_14_4h < 30.0))
             # 1h down move, 15m still high, 4h high
-            & ((rsi_3_1h_gt_10) | (aroonu_14_15m < 40.0) | (stochrsi_k_4h < 90.0))
+            & ((rsi_3_1h_gt_10) | (aroonu_14_15m < 40.0) | (stochrsi_k_4h_lt_90))
             # 1h down move, 15m high, 4h downtrend
             & ((rsi_3_1h_gt_10) | (aroonu_14_15m_lt_70) | (roc_9_4h > -10.0))
             # 1h down move, 1h still high, 15m downtrend
@@ -15337,23 +15368,23 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1d high, 4h overbought
             & ((rsi_3_1h_gt_10) | (aroonu_14_1d < 100.0) | (roc_9_4h < 20.0))
             # 1h down move, 1h still high, 1d downtrend
-            & ((rsi_3_1h_gt_10) | (stochrsi_k_1h < 50.0) | (roc_9_1d_gt_neg_40))
+            & ((rsi_3_1h_gt_10) | (stochrsi_k_1h_lt_50) | (roc_9_1d_gt_neg_40))
             # 1h down move, 1d high & overbought
-            & ((rsi_3_1h_gt_10) | (stochrsi_k_1d < 80.0) | (roc_9_1d_lt_30))
+            & ((rsi_3_1h_gt_10) | (stochrsi_k_1d_lt_80) | (roc_9_1d_lt_30))
             # 1h & 4h down move, 1h still high
             & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_15) | (aroonu_14_1h_lt_50))
             # 1h & 4h down move, 1h still not low enough
-            & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_15) | (stochrsi_k_1h < 30.0))
+            & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_15) | (stochrsi_k_1h_lt_30))
             # 1h & 4h down move, 1d downtrend
             & ((rsi_3_1h_gt_15) | rsi_3_4h_gt_20 | (roc_9_1d_gt_neg_40))
             # 1h & 4h down move, 4h high
             & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_50) | (aroonu_14_4h < 100.0))
             # 1h & 1d down move, 4h high
-            & ((rsi_3_1h_gt_15) | (rsi_3_1d_gt_15) | (stochrsi_k_4h < 80.0))
+            & ((rsi_3_1h_gt_15) | (rsi_3_1d_gt_15) | (stochrsi_k_4h_lt_80))
             # 1h down move, 4h high, 1d overbought
             & ((rsi_3_1h_gt_15) | (aroonu_14_4h_lt_60) | roc_9_1d_lt_50)
             # 1h down move, 4h high, 1d high
-            & ((rsi_3_1h_gt_15) | (aroonu_14_4h < 80.0) | (stochrsi_k_1d < 80.0))
+            & ((rsi_3_1h_gt_15) | (aroonu_14_4h < 80.0) | (stochrsi_k_1d_lt_80))
             # 1h down move, 1d high, 1d downtrend
             & ((rsi_3_1h_gt_15) | (aroonu_14_1d_lt_70) | (roc_9_1d > -20.0))
             # 1h down move, 1d high, 4h overbought
@@ -15377,7 +15408,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1d high & overbought
             & ((rsi_3_1h_gt_25) | (aroonu_14_1d_lt_90) | (roc_9_1d_lt_30))
             # 1h down move, 4h high, 1d downtrend
-            & ((rsi_3_1h_gt_25) | (stochrsi_k_4h < 80.0) | (roc_9_1d_gt_neg_30))
+            & ((rsi_3_1h_gt_25) | (stochrsi_k_4h_lt_80) | (roc_9_1d_gt_neg_30))
             # 1h & 4h down move, 4h high
             & ((rsi_3_1h_gt_30) | (rsi_3_4h_gt_50) | (aroonu_14_4h < 85.0))
             # 1h down move, 1h & 4h high
@@ -15389,7 +15420,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 4h high & overbought
             & ((rsi_3_1h_gt_30) | (aroonu_14_4h_lt_90) | (roc_9_4h < 100.0))
             # 1h down move, 15m still high, 1h high
-            & ((rsi_3_1h_gt_30) | (stochrsi_k_15m < 40.0) | (aroonu_14_1h < 60.0))
+            & ((rsi_3_1h_gt_30) | (stochrsi_k_15m_lt_40) | (aroonu_14_1h < 60.0))
             # 1h down move, 1h high, 1d downtrend
             & ((rsi_3_1h_gt_30) | (stochrsi_k_1h_lt_70) | (roc_9_1d_gt_neg_40))
             # 1h down move, 4h high, 1d downtrend
@@ -15435,13 +15466,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 4h & 1d high
             & ((rsi_3_1h_gt_50) | aroonu_14_4h_lt_100 | aroonu_14_1d_lt_100)
             # 1h down move, 4h high, 1d downtrend
-            & ((rsi_3_1h_gt_50) | (stochrsi_k_4h < 60.0) | (roc_9_1d > -60.0))
+            & ((rsi_3_1h_gt_50) | (stochrsi_k_4h_lt_60) | (roc_9_1d > -60.0))
             # 1h down move, 4h & 1d overbought
             & ((rsi_3_1h_gt_50) | (roc_9_4h_lt_20) | (roc_9_1d_lt_80))
             # 1h down move, 15m high, 1h high
             & ((rsi_3_1h_gt_55) | (aroonu_14_15m < 60.0) | (stochrsi_k_1h_lt_80))
             # 1h down move, 1h high & overbought
-            & ((rsi_3_1h_gt_55) | (stochrsi_k_1h < 60.0) | (roc_9_1d < 10.0))
+            & ((rsi_3_1h_gt_55) | (stochrsi_k_1h_lt_60) | (roc_9_1d < 10.0))
             # 1h down move, 4h & 1d overbought
             & ((rsi_3_1h_gt_60) | (roc_9_4h_lt_10) | (roc_9_1d_lt_40))
             # 1h down move, 4h high, 1d overbought
@@ -15449,25 +15480,25 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h & 1d down move, 4h downtrend
             & ((rsi_3_4h_gt_3) | (rsi_3_1d_gt_10) | (roc_9_4h_gt_neg_20))
             # 4h & 1d down move, 1h still not low enough
-            & ((rsi_3_4h_gt_5) | (rsi_3_1d_gt_10) | (stochrsi_k_1h < 30.0))
+            & ((rsi_3_4h_gt_5) | (rsi_3_1d_gt_10) | (stochrsi_k_1h_lt_30))
             # 4h down move, 1d high, 4h downtrend
             & ((rsi_3_4h_gt_5) | (aroonu_14_1d_lt_80) | (roc_9_4h > -10.0))
             # 4h & 1d down move, 15m high
-            & ((rsi_3_4h_gt_10) | (rsi_3_1d_gt_15) | (stochrsi_k_15m < 80.0))
+            & ((rsi_3_4h_gt_10) | (rsi_3_1d_gt_15) | (stochrsi_k_15m_lt_80))
             # 4h & 1d down move, 1d downtrend
             & ((rsi_3_4h_gt_10) | (rsi_3_1d_gt_15) | (roc_9_1d > -15.0))
             # 4h & 1d down move, 1d still high
-            & ((rsi_3_4h_gt_10) | (rsi_3_1d_gt_25) | (stochrsi_k_1d < 50.0))
+            & ((rsi_3_4h_gt_10) | (rsi_3_1d_gt_25) | (stochrsi_k_1d_lt_50))
             # 4h down move, 15m downtrend, 1d high
             & ((rsi_3_4h_gt_10) | (cmf_20_15m > -0.30) | (aroonu_14_1d_lt_80))
             # 4h down move, 15m still high, 1d downtrend
-            & ((rsi_3_4h_gt_10) | (stochrsi_k_15m < 50.0) | (roc_9_1d > -25.0))
+            & ((rsi_3_4h_gt_10) | (stochrsi_k_15m_lt_50) | (roc_9_1d > -25.0))
             # 4h down move, 15m high
-            & ((rsi_3_4h_gt_10) | (stochrsi_k_15m < 80.0))
+            & ((rsi_3_4h_gt_10) | (stochrsi_k_15m_lt_80))
             # 4h down move, 1h high, 1d downtrend
-            & ((rsi_3_4h_gt_10) | (stochrsi_k_1h < 70.0) | (roc_9_1d > -20.0))
+            & ((rsi_3_4h_gt_10) | (stochrsi_k_1h_lt_70) | (roc_9_1d > -20.0))
             # 4h down move, 4h still high, 1d downtrend
-            & ((rsi_3_4h_gt_10) | (stochrsi_k_4h < 40.0) | (roc_9_1d > -20.0))
+            & ((rsi_3_4h_gt_10) | (stochrsi_k_4h_lt_40) | (roc_9_1d > -20.0))
             # 4h down move, 4h downtrend, 1d overbought
             & ((rsi_3_4h_gt_10) | (roc_9_4h > -20.0) | (roc_9_1d_lt_40))
             # 4h & 1d down move, 4h downtrend
@@ -15489,11 +15520,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 4h still high. 4h downtrend
             & ((rsi_3_4h_gt_25) | (aroonu_14_4h_lt_50) | (cmf_20_4h > -0.40))
             # 4h down move, 4h high, 1d downtrend
-            & ((rsi_3_4h_gt_25) | (stochrsi_k_4h < 60.0) | (roc_9_1d > -70.0))
+            & ((rsi_3_4h_gt_25) | (stochrsi_k_4h_lt_60) | (roc_9_1d > -70.0))
             # 4h down move, 1h high, 4h downtrend
             & ((rsi_3_4h_gt_30) | aroonu_14_1h_lt_70 | (roc_9_4h > -10.0))
             # 4h down move, 1h high, 1d downtrend
-            & ((rsi_3_4h_gt_30) | (stochrsi_k_1h < 60.0) | (roc_9_1d_gt_neg_40))
+            & ((rsi_3_4h_gt_30) | (stochrsi_k_1h_lt_60) | (roc_9_1d_gt_neg_40))
             # 4h down move, 4h & 1d high
             & ((rsi_3_4h_gt_35) | aroonu_14_4h_lt_70 | aroonu_14_1d_lt_100)
             # 4h down move, 4h high & overbought
@@ -15505,7 +15536,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1d down move, 1d high, 1d downtrend
             & ((rsi_3_1d_gt_10) | (aroonu_14_1d_lt_70) | (roc_9_1d > -10.0))
             # 1d down move, 1h high, 4h downtrend
-            & ((rsi_3_1d_gt_30) | (stochrsi_k_1h < 90.0) | (roc_9_4h_gt_neg_30))
+            & ((rsi_3_1d_gt_30) | (stochrsi_k_1h_lt_90) | (roc_9_4h_gt_neg_30))
             # 15m & 1h & 4h downtrend
             & ((cmf_20_15m > -0.30) | (cmf_20_1h > -0.30) | (cmf_20_4h > -0.30))
             # 1d downtrend, 1d high & overbought
@@ -15545,13 +15576,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1d high, 4h & 1d overbought
             & (aroonu_14_1d_lt_100 | (roc_9_4h < 20.0) | (roc_9_1d_lt_80))
             # 15m high, 4h & 1d downtrend
-            & ((stochrsi_k_15m < 70.0) | (roc_9_4h_gt_neg_30) | (roc_9_1d_gt_neg_30))
+            & ((stochrsi_k_15m_lt_70) | (roc_9_4h_gt_neg_30) | (roc_9_1d_gt_neg_30))
             # 1h high, 4h & 1d overbought
-            & ((stochrsi_k_1h < 90.0) | (roc_9_4h_lt_20) | (roc_9_1d_lt_100))
+            & ((stochrsi_k_1h_lt_90) | (roc_9_4h_lt_20) | (roc_9_1d_lt_100))
             # 4h high, 1h overbought, 1d downtrend
             & ((stochrsi_k_4h_lt_80) | (roc_9_1h < 40.0) | (roc_9_1d > -70.0))
             # 4h high, 4h & 1d overbought
-            & ((stochrsi_k_4h < 80.0) | (roc_9_4h < 80.0) | (roc_9_1d_lt_100))
+            & ((stochrsi_k_4h_lt_80) | (roc_9_4h < 80.0) | (roc_9_1d_lt_100))
             # 4h high, 1h & 4h overbought
             & ((stochrsi_k_4h_lt_90) | (roc_9_1h_lt_10) | (roc_9_4h < 80.0))
             # 4h high, 1h & 4h overbought
@@ -15561,7 +15592,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1d P&D, dh downtrend
             & ((change_pct_1d > -50.0) | (change_pct_1d.shift(288) < 50.0) | (rsi_3_4h_gt_15))
             # big drop in the last 20 days, 1d high, 1d downtrend
-            & ((close > (high_max_20_1d * 0.20)) | (stochrsi_k_1d < 70.0) | (roc_9_1d > -15.0))
+            & ((close > (high_max_20_1d * 0.20)) | (stochrsi_k_1d_lt_70) | (roc_9_1d > -15.0))
             # drop in last 20 days, 1h high, 1d downtrend
             & ((close > (high_max_20_1d * 0.20)) | aroonu_14_1h_lt_70 | (roc_9_1d > -70.0))
             # drop in last 20 days. 4h high
@@ -15572,7 +15603,7 @@ class NostalgiaForInfinityX7(IStrategy):
           long_entry_logic.append(
             (rsi_3 < 50.0)
             & (aroonu_14 < 25.0)
-            & (stochrsi_k < 30.0)
+            & (stochrsi_k_lt_30)
             & (ema_26 > ema_12)
             & ((ema_26 - ema_12) > (open_rate * 0.020))
             & ((ema_26.shift() - ema_12.shift()) > (open_rate / 100.0))
@@ -15586,7 +15617,7 @@ class NostalgiaForInfinityX7(IStrategy):
 
           long_entry_logic.append(
             # 5m & 15m down move, 15m still high
-            ((rsi_3_gt_3) | (rsi_3_15m_gt_10) | (stochrsi_k_15m < 40.0))
+            ((rsi_3_gt_3) | (rsi_3_15m_gt_10) | (stochrsi_k_15m_lt_40))
             # 5m & 15m down move, 15m still high
             & ((rsi_3_gt_3) | (rsi_3_15m_gt_15) | (aroonu_14_15m < 40.0))
             # 5m & 15m down move, 1d downtrend
@@ -15606,7 +15637,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 5m & 4h down move, 4h still high
             & ((rsi_3_gt_3) | (rsi_3_4h_gt_55) | (aroonu_14_4h_lt_50))
             # 5m & 1d down move, 15m still high
-            & ((rsi_3_gt_3) | (rsi_3_1d_gt_20) | (stochrsi_k_15m < 40.0))
+            & ((rsi_3_gt_3) | (rsi_3_1d_gt_20) | (stochrsi_k_15m_lt_40))
             # 5m down move, 4h & 1d overbought
             & ((rsi_3_gt_3) | (roc_9_4h_lt_20) | (roc_9_1d_lt_40))
             # 5m & 1h down move, 4h high
@@ -15618,7 +15649,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 5m & 4h down move, 4h still high
             & ((rsi_3_gt_5) | (rsi_3_4h_gt_15) | (aroonu_14_4h_lt_40))
             # 5m & 4h down move, 15m still high
-            & ((rsi_3_gt_5) | (rsi_3_4h_gt_25) | (stochrsi_k_15m < 50.0))
+            & ((rsi_3_gt_5) | (rsi_3_4h_gt_25) | (stochrsi_k_15m_lt_50))
             # 5m & 4h down move, 1d overbought
             & ((rsi_3_gt_5) | (rsi_3_4h_gt_30) | (roc_9_1d < 60.0))
             # 5m & 4h down move, 4h high
@@ -15632,7 +15663,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 5m down move, 1h high
             & ((rsi_3_gt_5) | (stochrsi_k_1h_lt_80))
             # 5m & 1d down move, 1d still high
-            & ((rsi_3_gt_10) | (rsi_3_1d_gt_15) | (stochrsi_k_1d < 40.0))
+            & ((rsi_3_gt_10) | (rsi_3_1d_gt_15) | (stochrsi_k_1d_lt_40))
             # 15m & 1h down move, 1h still high
             & ((rsi_3_15m_gt_3) | (rsi_3_1h_gt_20) | (aroonu_14_1h_lt_50))
             # 15m & 1h down move, 4h still not low enough
@@ -15642,11 +15673,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 1h still not low enough
             & ((rsi_3_15m_gt_3) | (rsi_3_1h_gt_25) | (aroonu_14_1h < 20.0))
             # 15m & 1h down move, 4h still high
-            & ((rsi_3_15m_gt_3) | (rsi_3_1h_gt_25) | (stochrsi_k_4h < 40.0))
+            & ((rsi_3_15m_gt_3) | (rsi_3_1h_gt_25) | (stochrsi_k_4h_lt_40))
             # 15m & 1h down move, 4h high
             & ((rsi_3_15m_gt_3) | (rsi_3_1h_gt_40) | aroonu_14_4h_lt_70)
             # 15m & 4h down move, 1h still not low enough
-            & ((rsi_3_15m_gt_3) | (rsi_3_4h_gt_10) | (stochrsi_k_1h < 30.0))
+            & ((rsi_3_15m_gt_3) | (rsi_3_4h_gt_10) | (stochrsi_k_1h_lt_30))
             # 15m & 4h down move, 1d downtrend
             & ((rsi_3_15m_gt_3) | (rsi_3_4h_gt_15) | (roc_9_1d > -10.0))
             # 15m & 4h down move, 4h still not low enough
@@ -15654,9 +15685,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 4h down move, 15m still not low enough
             & ((rsi_3_15m_gt_3) | (rsi_3_4h_gt_30) | (aroonu_14_15m < 25.0))
             # 15m & 4h down move, 1h still high
-            & ((rsi_3_15m_gt_3) | (rsi_3_4h_gt_30) | (stochrsi_k_1h < 40.0))
+            & ((rsi_3_15m_gt_3) | (rsi_3_4h_gt_30) | (stochrsi_k_1h_lt_40))
             # 15m & 4h down move, 1h high
-            & ((rsi_3_15m_gt_3) | (rsi_3_4h_gt_45) | (stochrsi_k_1h < 60.0))
+            & ((rsi_3_15m_gt_3) | (rsi_3_4h_gt_45) | (stochrsi_k_1h_lt_60))
             # 15m & 1d down move, 15m still not low enough
             & ((rsi_3_15m_gt_3) | (rsi_3_1d_gt_10) | (aroonu_14_15m < 30.0))
             # 15m & 1d down move, 4h high
@@ -15666,9 +15697,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 1h high
             & ((rsi_3_15m_gt_5) | (rsi_3_1h_gt_25) | (aroonu_14_1h < 60.0))
             # 15m & 1h down move, 1h still high
-            & ((rsi_3_15m_gt_5) | (rsi_3_1h_gt_25) | (stochrsi_k_1h < 40.0))
+            & ((rsi_3_15m_gt_5) | (rsi_3_1h_gt_25) | (stochrsi_k_1h_lt_40))
             # 15m & 1h down move, 4h still high
-            & ((rsi_3_15m_gt_5) | (rsi_3_1h_gt_25) | (stochrsi_k_4h < 30.0))
+            & ((rsi_3_15m_gt_5) | (rsi_3_1h_gt_25) | (stochrsi_k_4h_lt_30))
             # 15m & 1h down move, 4h high
             & ((rsi_3_15m_gt_5) | (rsi_3_1h_gt_30) | (aroonu_14_4h_lt_90))
             # 15m & 1h & 4h down move, 15m downtrend
@@ -15680,53 +15711,53 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 4h down move, 15m still not low enough
             & ((rsi_3_15m_gt_5) | (rsi_3_4h_gt_20) | (aroonu_14_15m < 30.0))
             # 15m & 4h down move, 4h high
-            & ((rsi_3_15m_gt_5) | (rsi_3_4h_gt_35) | (stochrsi_k_4h < 60.0))
+            & ((rsi_3_15m_gt_5) | (rsi_3_4h_gt_35) | (stochrsi_k_4h_lt_60))
             # 15m down move, 15m still high, 1h still high
             & ((rsi_3_15m_gt_5) | (aroonu_14_15m < 30.0) | (stochrsi_k_1h_lt_50))
             # 15m down move, 1h still high, 1d high
-            & ((rsi_3_15m_gt_5) | (stochrsi_k_1h < 40.0) | (aroonu_14_1d_lt_70))
+            & ((rsi_3_15m_gt_5) | (stochrsi_k_1h_lt_40) | (aroonu_14_1d_lt_70))
             # 15m down move, 1h & 4h high
             & ((rsi_3_15m_gt_5) | (aroonu_14_1h_lt_70) | (aroonu_14_4h_lt_90))
             # 15m down move, 15m & 1h still not low enough
-            & ((rsi_3_15m_gt_5) | (stochrsi_k_15m < 30.0) | (stochrsi_k_1h < 30.0))
+            & ((rsi_3_15m_gt_5) | (stochrsi_k_15m_lt_30) | (stochrsi_k_1h_lt_30))
             # 15m & 1h down move, 1h still high
             & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_20) | (stochrsi_k_1h_lt_50))
             # 15m & 1h down move, 4h still high
             & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_20) | (aroonu_14_4h_lt_40))
             # 15m & 1h down move, 4h high
-            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_20) | (stochrsi_k_4h < 60.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_20) | (stochrsi_k_4h_lt_60))
             # 15m & 1h & 4h down move, 4h still not low enough
-            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_25) | (rsi_3_4h_gt_25) | (stochrsi_k_4h < 30.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_25) | (rsi_3_4h_gt_25) | (stochrsi_k_4h_lt_30))
             # 15m & 1h & 4h down move, 1d high
-            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_25) | (rsi_3_4h_gt_25) | (stochrsi_k_1d < 70.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_25) | (rsi_3_4h_gt_25) | (stochrsi_k_1d_lt_70))
             # 15m & 1h down move, 4h still high
             & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_25) | (aroonu_14_4h_lt_50))
             # 15m & 1h down move, 4h high
             & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_30) | (stochrsi_k_4h_lt_70))
             # 15m & 1h down move, 4h high
-            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_30) | (stochrsi_k_4h < 60.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_30) | (stochrsi_k_4h_lt_60))
             # 15m & 1h down move, 1d overbought
             & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_30) | (roc_9_1d_lt_30))
             # 15m & 1h down move, 1d downtrend
             & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_30) | (roc_9_1d_gt_neg_40))
             # 15m & 1h down move, 1h still high
-            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_35) | (stochrsi_k_1h < 40.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_35) | (stochrsi_k_1h_lt_40))
             # 15m & 1h down move, 1h still high
-            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_45) | (stochrsi_k_1h < 40.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_45) | (stochrsi_k_1h_lt_40))
             # 15m & 1h down move, 1d overbought
             & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_45) | (roc_9_1d < 150.0))
             # 15m & 1h down move, 4h high
             & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_50) | (stochrsi_k_4h_lt_80))
             # 15m & 1h down move, 1h high
-            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_55) | (stochrsi_k_1h < 60.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_55) | (stochrsi_k_1h_lt_60))
             # 15m & 1h down move, 1h high
             & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_65) | aroonu_14_1h_lt_80)
             # 15m & 4h down move, 1d high
             & ((rsi_3_15m_gt_10) | (rsi_3_4h_gt_10) | (aroonu_14_1d_lt_80))
             # 15m & 4h down move, 4h still not low enough
-            & ((rsi_3_15m_gt_10) | (rsi_3_4h_gt_10) | (stochrsi_k_4h < 30.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_4h_gt_10) | (stochrsi_k_4h_lt_30))
             # 15m & 4h down move, 1d high
-            & ((rsi_3_15m_gt_10) | (rsi_3_4h_gt_10) | (stochrsi_k_1d < 70.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_4h_gt_10) | (stochrsi_k_1d_lt_70))
             # 15m & 4h down move, 1d high
             & ((rsi_3_15m_gt_10) | (rsi_3_4h_gt_15) | (rsi_14_1d < 60.0))
             # 15m & 4h down move, 4h still high
@@ -15736,7 +15767,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 4h down move, 1h still high
             & ((rsi_3_15m_gt_10) | (rsi_3_4h_gt_20) | (stochrsi_k_1h_lt_50))
             # 15m & 4h down move, 4h still high
-            & ((rsi_3_15m_gt_10) | (rsi_3_4h_gt_20) | (stochrsi_k_4h < 40.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_4h_gt_20) | (stochrsi_k_4h_lt_40))
             # 15m & 4h down move, 1d high
             & ((rsi_3_15m_gt_10) | (rsi_3_4h_gt_20) | (stochrsi_k_1d_lt_90))
             # 15m & 4h down move, 1d overbought
@@ -15754,7 +15785,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 4h down move, 4h high
             & ((rsi_3_15m_gt_10) | (rsi_3_4h_gt_60) | (stochrsi_k_4h_lt_80))
             # 15m & 1d down move, 1h still high
-            & ((rsi_3_15m_gt_10) | (rsi_3_1d_gt_10) | (stochrsi_k_1h < 40.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_1d_gt_10) | (stochrsi_k_1h_lt_40))
             # 15m & 1d down move, 1d high
             & ((rsi_3_15m_gt_10) | (rsi_3_1d_gt_20) | (aroonu_14_1d < 75.0))
             # 15m & 1d down move, 1d overbought
@@ -15762,7 +15793,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 15m downtrend, 4h still high
             & ((rsi_3_15m_gt_10) | (cmf_20_15m > -0.40) | (stochrsi_k_4h_lt_50))
             # 15m down move, 1h downtrend, 4h still high
-            & ((rsi_3_15m_gt_10) | (cmf_20_1h > -0.30) | (stochrsi_k_4h < 40.0))
+            & ((rsi_3_15m_gt_10) | (cmf_20_1h > -0.30) | (stochrsi_k_4h_lt_40))
             # 15m down move, 15m still not low enough, 4h high
             & ((rsi_3_15m_gt_10) | (aroonu_14_15m < 30.0) | (aroonu_14_4h_lt_60))
             # 15m down move, 15m still high, 1h still high
@@ -15770,9 +15801,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 4h high & overbought
             & ((rsi_3_15m_gt_10) | (aroonu_14_4h_lt_90) | (roc_9_4h_lt_20))
             # 15m down move, 1h still not low enough, 1d overbought
-            & ((rsi_3_15m_gt_10) | (stochrsi_k_1h < 30.0) | (roc_9_1d_lt_100))
+            & ((rsi_3_15m_gt_10) | (stochrsi_k_1h_lt_30) | (roc_9_1d_lt_100))
             # 15m down move, 1h still high, 4h downtrend
-            & ((rsi_3_15m_gt_10) | (stochrsi_k_1h < 50.0) | (roc_9_4h_gt_neg_20))
+            & ((rsi_3_15m_gt_10) | (stochrsi_k_1h_lt_50) | (roc_9_4h_gt_neg_20))
             # 15m down move, 4h high & overbought
             & ((rsi_3_15m_gt_10) | (stochrsi_k_4h_lt_70) | (roc_9_4h_lt_10))
             # 15m down move, 4h high, 1d overbought
@@ -15788,11 +15819,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 4h high
             & ((rsi_3_15m_gt_15) | (rsi_3_1h_gt_25) | aroonu_14_4h_lt_70)
             # 15m & 1h down move, 1h still high
-            & ((rsi_3_15m_gt_15) | (rsi_3_1h_gt_25) | (stochrsi_k_1h < 40.0))
+            & ((rsi_3_15m_gt_15) | (rsi_3_1h_gt_25) | (stochrsi_k_1h_lt_40))
             # 15m & 1h down move, 1d overbought
             & ((rsi_3_15m_gt_15) | (rsi_3_1h_gt_25) | (roc_9_1d_lt_100))
             # 15m & 1h down move, 1d high
-            & ((rsi_3_15m_gt_15) | (rsi_3_1h_gt_30) | (stochrsi_k_1d < 80.0))
+            & ((rsi_3_15m_gt_15) | (rsi_3_1h_gt_30) | (stochrsi_k_1d_lt_80))
             # 15m & 1h down move, 4h high
             & ((rsi_3_15m_gt_15) | (rsi_3_1h_gt_50) | aroonu_14_4h_lt_100)
             # 15m & 1h down move, 1h high
@@ -15800,9 +15831,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 4h down move, 1d high
             & ((rsi_3_15m_gt_15) | rsi_3_4h_gt_20 | (aroonu_14_1d_lt_90))
             # 15m & 4h down move, 15m still high
-            & ((rsi_3_15m_gt_15) | rsi_3_4h_gt_20 | (stochrsi_k_15m < 50.0))
+            & ((rsi_3_15m_gt_15) | rsi_3_4h_gt_20 | (stochrsi_k_15m_lt_50))
             # 15m & 4h down move, 1h high
-            & ((rsi_3_15m_gt_15) | (rsi_3_4h_gt_30) | (stochrsi_k_1h < 60.0))
+            & ((rsi_3_15m_gt_15) | (rsi_3_4h_gt_30) | (stochrsi_k_1h_lt_60))
             # 15m & 4h down move, 4h high
             & ((rsi_3_15m_gt_15) | (rsi_3_4h_gt_35) | (aroonu_14_4h_lt_60))
             # 15m & 4h down move, 4h high
@@ -15816,7 +15847,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 4h down move, 4h high
             & ((rsi_3_15m_gt_15) | (rsi_3_4h_gt_55) | (stochrsi_k_4h_lt_70))
             # 15m & 1d down move, 1h still high
-            & ((rsi_3_15m_gt_15) | (rsi_3_1d_gt_15) | (stochrsi_k_1h < 30.0))
+            & ((rsi_3_15m_gt_15) | (rsi_3_1d_gt_15) | (stochrsi_k_1h_lt_30))
             # 15m & 1d down move, 1h still high
             & ((rsi_3_15m_gt_15) | (rsi_3_1d_gt_20) | (stochrsi_k_1h_lt_50))
             # 15m & 1d down move, 1d overbought
@@ -15848,17 +15879,17 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 1h still high, 4h overbought
             & ((rsi_3_15m_gt_15) | (stochrsi_k_1h_lt_50) | (roc_9_4h_lt_10))
             # 15m down move, 1h high, 4h downtrend
-            & ((rsi_3_15m_gt_15) | (stochrsi_k_1h < 80.0) | (roc_9_4h_gt_neg_20))
+            & ((rsi_3_15m_gt_15) | (stochrsi_k_1h_lt_80) | (roc_9_4h_gt_neg_20))
             # 15m down move, 4h high & overbought
-            & ((rsi_3_15m_gt_15) | (stochrsi_k_4h < 90.0) | (roc_9_4h_lt_20))
+            & ((rsi_3_15m_gt_15) | (stochrsi_k_4h_lt_90) | (roc_9_4h_lt_20))
             # 15m & 1h down move, 1h still high
-            & ((rsi_3_15m_gt_20) | rsi_3_1h_gt_20 | (stochrsi_k_1h < 20.0))
+            & ((rsi_3_15m_gt_20) | rsi_3_1h_gt_20 | (stochrsi_k_1h_lt_20))
             # 15m & 1h down move, 1d downtrend
             & ((rsi_3_15m_gt_20) | (rsi_3_1h_gt_30) | (roc_9_1d_gt_neg_30))
             # 15m & 1h down move, 1h overbought
             & ((rsi_3_15m_gt_20) | (rsi_3_1h_gt_50) | (roc_9_1h_lt_10))
             # 15m & 1h & 4h down move, 1h still not low enough
-            & ((rsi_3_15m_gt_20) | (rsi_3_1h_gt_25) | (rsi_3_4h_gt_30) | (stochrsi_k_1h < 30.0))
+            & ((rsi_3_15m_gt_20) | (rsi_3_1h_gt_25) | (rsi_3_4h_gt_30) | (stochrsi_k_1h_lt_30))
             # 15m & 1h down move, 4h high
             & ((rsi_3_15m_gt_20) | (rsi_3_1h_gt_25) | (stochrsi_k_4h_lt_80))
             # 15m & 1h & 4h down move, 15m & 1h still high
@@ -15880,9 +15911,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1d down move, 1h high
             & ((rsi_3_15m_gt_20) | (rsi_3_1d_gt_20) | aroonu_14_1h_lt_70)
             # 15m & 1d down move, 15m still high
-            & ((rsi_3_15m_gt_20) | (rsi_3_1d_gt_30) | (stochrsi_k_15m < 50.0))
+            & ((rsi_3_15m_gt_20) | (rsi_3_1d_gt_30) | (stochrsi_k_15m_lt_50))
             # 15m down move, 15m still not low enough, 1h high
-            & ((rsi_3_15m_gt_20) | (aroonu_14_15m < 25.0) | (stochrsi_k_1h < 90.0))
+            & ((rsi_3_15m_gt_20) | (aroonu_14_15m < 25.0) | (stochrsi_k_1h_lt_90))
             # 15m down move, 15m still high, 1h high
             & ((rsi_3_15m_gt_20) | (aroonu_14_15m < 40.0) | aroonu_14_1h_lt_70)
             # 15m down move, 15m still high, 4h high
@@ -15902,13 +15933,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 1d high, 1d overbought
             & ((rsi_3_15m_gt_20) | aroonu_14_1d_lt_100 | (roc_9_1d_lt_20))
             # 15m down move, 15m high, 4h downtrend
-            & ((rsi_3_15m_gt_20) | (stochrsi_k_15m < 60.0) | (roc_9_4h > -50.0))
+            & ((rsi_3_15m_gt_20) | (stochrsi_k_15m_lt_60) | (roc_9_4h > -50.0))
             # 15 down move, 1h high, 1d overbought
             & ((rsi_3_15m_gt_20) | (stochrsi_k_1h_lt_70) | (roc_9_1d < 10.0))
             # 15m down move, 4h high, 15m downtrend
             & ((rsi_3_15m_gt_20) | (stochrsi_k_4h_lt_70) | (cmf_20_15m > -0.40))
             # 15m & 1h down move, 15m high
-            & ((rsi_3_15m_gt_25) | (rsi_3_1h_gt_25) | (stochrsi_k_15m < 70.0))
+            & ((rsi_3_15m_gt_25) | (rsi_3_1h_gt_25) | (stochrsi_k_15m_lt_70))
             # 15m & 1h & 4h down move, 4h still high
             & ((rsi_3_15m_gt_25) | (rsi_3_1h_gt_30) | (rsi_3_4h_gt_45) | (stochrsi_k_4h_lt_50))
             # 15m & 1h & 4h down move, 4h high
@@ -15930,7 +15961,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1d down move, 1h high
             & ((rsi_3_15m_gt_25) | (rsi_3_1d_gt_25) | aroonu_14_1h_lt_80)
             # 15m down move, 15m still not low enough, 1h high
-            & ((rsi_3_15m_gt_25) | (aroonu_14_15m < 25.0) | (stochrsi_k_1h < 90.0))
+            & ((rsi_3_15m_gt_25) | (aroonu_14_15m < 25.0) | (stochrsi_k_1h_lt_90))
             # 15m down move, 15m still high, 1h high
             & ((rsi_3_15m_gt_25) | (aroonu_14_15m < 40.0) | (stochrsi_k_1h_lt_80))
             # 15m down move, 1h high, 1d overbought
@@ -15946,9 +15977,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 4h high, 1d overbought
             & ((rsi_3_15m_gt_25) | aroonu_14_4h_lt_80 | (roc_9_1d < 100.0))
             # 15m down move, 1h high, 1d downtrend
-            & ((rsi_3_15m_gt_25) | (stochrsi_k_1h < 70.0) | (roc_9_1d_gt_neg_20))
+            & ((rsi_3_15m_gt_25) | (stochrsi_k_1h_lt_70) | (roc_9_1d_gt_neg_20))
             # 15m down move, 1h high & overbought
-            & ((rsi_3_15m_gt_25) | (stochrsi_k_1h < 90.0) | (roc_9_1h < 20.0))
+            & ((rsi_3_15m_gt_25) | (stochrsi_k_1h_lt_90) | (roc_9_1h < 20.0))
             # 15m down move, 4h high & overbought
             & ((rsi_3_15m_gt_25) | (stochrsi_k_4h_lt_90) | (roc_9_4h_lt_30))
             # 15m & 1h down move, 1h high
@@ -15960,7 +15991,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 1h high
             & ((rsi_3_15m_gt_30) | (rsi_3_1h_gt_55) | (stochrsi_k_1h_lt_80))
             # 15m & 4h down move, 15m high
-            & ((rsi_3_15m_gt_30) | (rsi_3_4h_gt_30) | (stochrsi_k_15m < 70.0))
+            & ((rsi_3_15m_gt_30) | (rsi_3_4h_gt_30) | (stochrsi_k_15m_lt_70))
             # 15m down move, 1h high & overbought
             & ((rsi_3_15m_gt_30) | (aroonu_14_1h_lt_90) | (roc_9_1h_lt_10))
             # 15m down move, 15m still high, 4h high
@@ -15986,21 +16017,21 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 4h high & overbought
             & ((rsi_3_15m_gt_35) | aroonu_14_4h_lt_100 | (roc_9_4h < 70.0))
             # 15m down move, 1h high & overbought
-            & ((rsi_3_15m_gt_35) | (stochrsi_k_1h < 90.0) | (roc_9_1h < 40.0))
+            & ((rsi_3_15m_gt_35) | (stochrsi_k_1h_lt_90) | (roc_9_1h < 40.0))
             # 15m & 1h down move, 4h high
             & ((rsi_3_15m_gt_40) | (rsi_3_1h_gt_40) | aroonu_14_4h_lt_100)
             # 15m & 4h down move, 1h high
-            & ((rsi_3_15m_gt_40) | (rsi_3_4h_gt_45) | (stochrsi_k_1h < 90.0))
+            & ((rsi_3_15m_gt_40) | (rsi_3_4h_gt_45) | (stochrsi_k_1h_lt_90))
             # 15m down move, 15m still high, 1d high
-            & ((rsi_3_15m_gt_40) | (stochrsi_k_15m < 40.0) | (roc_9_1d_lt_100))
+            & ((rsi_3_15m_gt_40) | (stochrsi_k_15m_lt_40) | (roc_9_1d_lt_100))
             # 15m down move, 4h high & overbought
             & ((rsi_3_15m_gt_40) | aroonu_14_4h_lt_100 | (roc_9_4h_lt_40))
             # 15m down move, 1h high, 4h overbought
             & ((rsi_3_15m_gt_50) | (stochrsi_k_1h_lt_80) | (roc_9_4h_lt_40))
             # 1h & 4h down move, 1d high
-            & ((rsi_3_1h_gt_3) | (rsi_3_4h_gt_15) | (stochrsi_k_1d < 70.0))
+            & ((rsi_3_1h_gt_3) | (rsi_3_4h_gt_15) | (stochrsi_k_1d_lt_70))
             # 1h & 4h down move, 4h high
-            & ((rsi_3_1h_gt_5) | (rsi_3_4h_gt_5) | (stochrsi_k_4h < 40.0))
+            & ((rsi_3_1h_gt_5) | (rsi_3_4h_gt_5) | (stochrsi_k_4h_lt_40))
             # 1h & 4h down move, 4h high
             & ((rsi_3_1h_gt_5) | (rsi_3_4h_gt_30) | aroonu_14_4h_lt_70)
             # 1h & 4h down move, 4h still high
@@ -16012,15 +16043,15 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 1h still high
             & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_30) | (aroonu_14_1h_lt_50))
             # 1h & 4h down move, 15m still not low enough
-            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_40) | (stochrsi_k_15m < 30.0))
+            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_40) | (stochrsi_k_15m_lt_30))
             # 1h down move, 1d high, 1d downtrend
             & ((rsi_3_1h_gt_10) | (aroonu_14_1d_lt_70) | (roc_9_1d > -20.0))
             # 1h down move, 4h high, 1d downtrend
             & ((rsi_3_1h_gt_10) | (stochrsi_k_4h_lt_50) | (roc_9_1d_gt_neg_40))
             # 1h & 4h down move, 15m high
-            & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_15) | (stochrsi_k_15m < 70.0))
+            & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_15) | (stochrsi_k_15m_lt_70))
             # 1h & 4h down move, 4h still not low enough
-            & ((rsi_3_1h_gt_15) | rsi_3_4h_gt_20 | (stochrsi_k_4h < 30.0))
+            & ((rsi_3_1h_gt_15) | rsi_3_4h_gt_20 | (stochrsi_k_4h_lt_30))
             # 1h & 4h down move, 1d downtrend
             & ((rsi_3_1h_gt_15) | rsi_3_4h_gt_20 | (roc_9_1d > -30.0))
             # 1h & 4h down move, 1h high
@@ -16034,19 +16065,19 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 4h high
             & (rsi_3_1h_gt_20 | (rsi_3_4h_gt_35) | (stochrsi_k_4h_lt_70))
             # 1h & 1d down move, 1d high
-            & (rsi_3_1h_gt_20 | (rsi_3_1d > 50.0) | (stochrsi_k_1d < 60.0))
+            & (rsi_3_1h_gt_20 | (rsi_3_1d > 50.0) | (stochrsi_k_1d_lt_60))
             # 1h down move, 1h high, 1d overbought
             & (rsi_3_1h_gt_20 | (aroonu_14_1h < 60.0) | roc_9_1d_lt_50)
             # 1h down move, 1h high, 1d overbought
             & (rsi_3_1h_gt_20 | aroonu_14_1h_lt_70 | (roc_9_1d_lt_20))
             # 1h down move, 1d high, 4h downtrend
-            & (rsi_3_1h_gt_20 | (stochrsi_k_1d < 80.0) | (roc_9_4h_gt_neg_20))
+            & (rsi_3_1h_gt_20 | (stochrsi_k_1d_lt_80) | (roc_9_4h_gt_neg_20))
             # 1h down move, 4h downtrend, 1d overbought
             & (rsi_3_1h_gt_20 | (roc_9_4h > -10.0) | (roc_9_1d_lt_20))
             # 1h & 4h down move, 1h still high
-            & ((rsi_3_1h_gt_25) | (rsi_3_4h_gt_10) | (stochrsi_k_1h < 40.0))
+            & ((rsi_3_1h_gt_25) | (rsi_3_4h_gt_10) | (stochrsi_k_1h_lt_40))
             # 1h & 4h down move, 15m high
-            & ((rsi_3_1h_gt_25) | (rsi_3_4h_gt_30) | (stochrsi_k_15m < 70.0))
+            & ((rsi_3_1h_gt_25) | (rsi_3_4h_gt_30) | (stochrsi_k_15m_lt_70))
             # 1h down move, 4h downtrend, 4h high
             & ((rsi_3_1h_gt_25) | (cmf_20_4h > -0.50) | aroonu_14_4h_lt_70)
             # 1h down move, 1h still high, 1d high
@@ -16056,13 +16087,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 4h high, 1d overbought
             & ((rsi_3_1h_gt_25) | (aroonu_14_4h_lt_40) | (roc_9_1d_lt_100))
             # 1h down move, 1d still high, 1d downtrend
-            & ((rsi_3_1h_gt_25) | (stochrsi_k_1d < 50.0) | (roc_9_1d_gt_neg_20))
+            & ((rsi_3_1h_gt_25) | (stochrsi_k_1d_lt_50) | (roc_9_1d_gt_neg_20))
             # 1h & 4h down move, 1d high
             & ((rsi_3_1h_gt_30) | (rsi_3_4h_gt_35) | (rsi_14_1d < 80.0))
             # 1h & 4h down move, 4h high
             & ((rsi_3_1h_gt_30) | (rsi_3_4h_gt_40) | (aroonu_14_4h_lt_60))
             # 1h & 4h & 1d down move, 1d still high
-            & ((rsi_3_1h_gt_30) | (rsi_3_4h_gt_50) | (rsi_3_1d_gt_60) | (stochrsi_k_1d < 50.0))
+            & ((rsi_3_1h_gt_30) | (rsi_3_4h_gt_50) | (rsi_3_1d_gt_60) | (stochrsi_k_1d_lt_50))
             # 1h & 4h down move, 4h high
             & ((rsi_3_1h_gt_30) | (rsi_3_4h_gt_60) | (stochrsi_k_4h_lt_80))
             # 1h & 1d down move, 1h high
@@ -16092,7 +16123,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 1d down move, 1d high
             & ((rsi_3_1h_gt_35) | (rsi_3_1d_gt_45) | (aroonu_14_1d_lt_90))
             # 1h & 4h down move, 1h high
-            & ((rsi_3_1h_gt_40) | (rsi_3_4h_gt_50) | (stochrsi_k_1h < 60.0))
+            & ((rsi_3_1h_gt_40) | (rsi_3_4h_gt_50) | (stochrsi_k_1h_lt_60))
             # 1h down move, 1h high, 1d overbought
             & ((rsi_3_1h_gt_40) | (aroonu_14_1h < 60.0) | (roc_9_1d_lt_40))
             # 1h down move, 1h still high, 1d high
@@ -16114,7 +16145,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h still not low enough, 1d downtrend
             & ((rsi_3_1h_gt_45) | (aroonu_14_1h < 30.0) | (roc_9_1d > -25.0))
             # 1h down move, 1h still high, 1d overbought
-            & ((rsi_3_1h_gt_45) | (stochrsi_k_1h < 40.0) | (roc_9_1d_lt_100))
+            & ((rsi_3_1h_gt_45) | (stochrsi_k_1h_lt_40) | (roc_9_1d_lt_100))
             # 1h down move, 4h high, 1h overbought
             & ((rsi_3_1h_gt_50) | (aroonu_14_4h < 85.0) | (roc_9_1h < 20.0))
             # 1h down move, 1d high, 4h overbought
@@ -16140,55 +16171,55 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h high, 1d downtrend
             & ((rsi_3_1h_gt_60) | (stochrsi_k_1h_lt_70) | (roc_9_1d > -10.0))
             # 1h down move, 1h high, 1d overbought
-            & ((rsi_3_1h_gt_60) | (stochrsi_k_1h < 80.0) | (roc_9_1d_lt_100))
+            & ((rsi_3_1h_gt_60) | (stochrsi_k_1h_lt_80) | (roc_9_1d_lt_100))
             # 1h down move, 1h high, 4h overbought
             & ((rsi_3_1h_gt_65) | aroonu_14_1h_lt_70 | (roc_9_4h < 25.0))
             # 1h down move, 1h high, 1d overbought
-            & ((rsi_3_1h_gt_65) | (stochrsi_k_1h < 90.0) | (roc_9_1d_lt_20))
+            & ((rsi_3_1h_gt_65) | (stochrsi_k_1h_lt_90) | (roc_9_1d_lt_20))
             # 4h down move, 1h still not low enough, 4h downtrend
             & ((rsi_3_4h_gt_3) | (aroonu_14_1h < 20.0) | (roc_9_4h > -10.0))
             # 4h down move, 4h & 1d downtrend
             & ((rsi_3_4h_gt_3) | (roc_9_4h > -10.0) | (roc_9_1d > -10.0))
             # 4h & 1d down move, 15m still high
-            & ((rsi_3_4h_gt_5) | (rsi_3_1d_gt_25) | (stochrsi_k_15m < 40.0))
+            & ((rsi_3_4h_gt_5) | (rsi_3_1d_gt_25) | (stochrsi_k_15m_lt_40))
             # 4h & 1d down move, 1h still not low enough
-            & ((rsi_3_4h_gt_10) | (rsi_3_1d_gt_10) | (stochrsi_k_1h < 20.0))
+            & ((rsi_3_4h_gt_10) | (rsi_3_1d_gt_10) | (stochrsi_k_1h_lt_20))
             # 4h & 1d down move, 1d downtrend
             & ((rsi_3_4h_gt_10) | (rsi_3_1d_gt_15) | (roc_9_1d_gt_neg_40))
             # 4h & 1d down move, 1d still high
-            & ((rsi_3_4h_gt_10) | (rsi_3_1d_gt_20) | (stochrsi_k_1d < 50.0))
+            & ((rsi_3_4h_gt_10) | (rsi_3_1d_gt_20) | (stochrsi_k_1d_lt_50))
             # 4h & 1d down move, 1d high
             & ((rsi_3_4h_gt_10) | (rsi_3_1d_gt_35) | (aroonu_14_1d < 100.0))
             # 4h & 1d down move, 1d overbought
             & ((rsi_3_4h_gt_10) | (rsi_3_1d_gt_45) | (roc_9_1d < 10.0))
             # 4h down move, 15m high
-            & ((rsi_3_4h_gt_10) | (stochrsi_k_15m < 70.0))
+            & ((rsi_3_4h_gt_10) | (stochrsi_k_15m_lt_70))
             # 4h & 1d down move, 4h high
             & ((rsi_3_4h_gt_15) | (rsi_3_1d_gt_25) | aroonu_14_4h_lt_70)
             # 4h & 1d down move, 1h still high
-            & ((rsi_3_4h_gt_15) | (rsi_3_1d_gt_30) | (stochrsi_k_1h < 40.0))
+            & ((rsi_3_4h_gt_15) | (rsi_3_1d_gt_30) | (stochrsi_k_1h_lt_40))
             # 4h & 1d down move, 1d high
             & ((rsi_3_4h_gt_15) | (rsi_3_1d_gt_25) | (aroonu_14_1d_lt_70))
             # 4h & 1d down move, 1d downtrend
             & ((rsi_3_4h_gt_15) | (rsi_3_1d_gt_25) | (roc_9_1d > -15.0))
             # 4h & 1d down move, 4h still high
-            & ((rsi_3_4h_gt_15) | (rsi_3_1d > 50.0) | (stochrsi_k_4h < 40.0))
+            & ((rsi_3_4h_gt_15) | (rsi_3_1d > 50.0) | (stochrsi_k_4h_lt_40))
             # 4h down move, 1d still high, 4h still not low enough
-            & ((rsi_3_4h_gt_15) | (rsi_14_1d < 40.0) | (stochrsi_k_4h < 30.0))
+            & ((rsi_3_4h_gt_15) | (rsi_14_1d < 40.0) | (stochrsi_k_4h_lt_30))
             # 4h down move, 4h still not low enough, 1d downtrend
-            & ((rsi_3_4h_gt_15) | (stochrsi_k_4h < 20.0) | (roc_9_1d > -20.0))
+            & ((rsi_3_4h_gt_15) | (stochrsi_k_4h_lt_20) | (roc_9_1d > -20.0))
             # 4h down move, 1h & 4h downtrend
             & ((rsi_3_4h_gt_15) | (roc_9_1h > -30.0) | (roc_9_4h_gt_neg_30))
             # 4h & 1d down move, 1d high
             & (rsi_3_4h_gt_20 | (rsi_3_1d_gt_20) | (aroonu_14_1d < 60.0))
             # 4h & 1d down move, 4h still high
-            & (rsi_3_4h_gt_20 | (rsi_3_1d_gt_20) | (stochrsi_k_4h < 40.0))
+            & (rsi_3_4h_gt_20 | (rsi_3_1d_gt_20) | (stochrsi_k_4h_lt_40))
             # 4h & 1d down move, 1d overbought
             & (rsi_3_4h_gt_20 | (rsi_3_1d_gt_45) | (roc_9_1d_lt_40))
             # 4h down move, 15m high
-            & (rsi_3_4h_gt_20 | (stochrsi_k_15m < 80.0))
+            & (rsi_3_4h_gt_20 | (stochrsi_k_15m_lt_80))
             # 4h down move, 1h high, 4h downtrend
-            & (rsi_3_4h_gt_20 | (stochrsi_k_1h < 70.0) | (roc_9_4h_gt_neg_20))
+            & (rsi_3_4h_gt_20 | (stochrsi_k_1h_lt_70) | (roc_9_4h_gt_neg_20))
             # 4h down move, 4h still high, 4h downtrend
             & ((rsi_3_4h_gt_25) | (aroonu_14_4h_lt_50) | (cmf_20_4h > -0.40))
             # 4h down move, 4h high, 1d downtrend
@@ -16200,7 +16231,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 1h high, 4h downtrend
             & ((rsi_3_4h_gt_30) | aroonu_14_1h_lt_70 | (roc_9_4h > -10.0))
             # 4h down move, 1h still high, 1d overbought
-            & ((rsi_3_4h_gt_30) | (stochrsi_k_1h < 40.0) | (roc_9_1d_lt_30))
+            & ((rsi_3_4h_gt_30) | (stochrsi_k_1h_lt_40) | (roc_9_1d_lt_30))
             # 4h & 1d down move, 1d overbought
             & ((rsi_3_4h_gt_35) | (rsi_3_1d > 50.0) | (roc_9_1d_lt_100))
             # 4h down move, 4h & 1d high
@@ -16214,13 +16245,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 1d high & overbought
             & ((rsi_3_4h_gt_45) | (aroonu_14_1d_lt_70) | (roc_9_1d_lt_20))
             # 4h down move, 4h high & overbought
-            & ((rsi_3_4h_gt_45) | (stochrsi_k_4h < 60.0) | (roc_9_4h_lt_20))
+            & ((rsi_3_4h_gt_45) | (stochrsi_k_4h_lt_60) | (roc_9_4h_lt_20))
             # 4h down move, 4h high, 1d overbought
             & ((rsi_3_4h_gt_45) | (stochrsi_k_4h_lt_80) | (roc_9_1d < 10.0))
             # 4h down move, 4h high & overbought
             & ((rsi_3_4h_gt_50) | aroonu_14_4h_lt_80 | (roc_9_4h_lt_10))
             # 4h down move, 1h high, 1d downtrend
-            & ((rsi_3_4h_gt_50) | (stochrsi_k_1h < 80.0) | (roc_9_1d_gt_neg_30))
+            & ((rsi_3_4h_gt_50) | (stochrsi_k_1h_lt_80) | (roc_9_1d_gt_neg_30))
             # 4h down move, 4h high & overbought
             & ((rsi_3_4h_gt_55) | aroonu_14_4h_lt_70 | (roc_9_4h_lt_20))
             # 4h down move, 4h high, 1d overbought
@@ -16242,15 +16273,15 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1d down move, 1d still not low enough, 1d downtrend
             & ((rsi_3_1d_gt_5) | (aroonu_14_1d < 20.0) | (roc_9_1d_gt_neg_20))
             # 1d down move, 15m still high
-            & ((rsi_3_1d_gt_5) | (stochrsi_k_15m < 40.0))
+            & ((rsi_3_1d_gt_5) | (stochrsi_k_15m_lt_40))
             # 1d down move, 1h & 4h still not low enough
-            & ((rsi_3_1d_gt_5) | (stochrsi_k_1h < 20.0) | (stochrsi_k_4h < 20.0))
+            & ((rsi_3_1d_gt_5) | (stochrsi_k_1h_lt_20) | (stochrsi_k_4h_lt_20))
             # 1d down move, 1h high
             & ((rsi_3_1d_gt_10) | aroonu_14_1h_lt_70)
             # 1d down move, 4h downtrend, 4h high
             & ((rsi_3_1d_gt_20) | (cmf_20_4h > -0.25) | aroonu_14_4h_lt_70)
             # 1d down move, 1d still high, 1d downtrend
-            & ((rsi_3_1d_gt_25) | (stochrsi_k_1d < 50.0) | (roc_9_1d_gt_neg_20))
+            & ((rsi_3_1d_gt_25) | (stochrsi_k_1d_lt_50) | (roc_9_1d_gt_neg_20))
             # 1d down move, 4h & 1d high
             & ((rsi_3_1d_gt_40) | aroonu_14_4h_lt_70 | aroonu_14_1d_lt_100)
             # 1d down move, 1d high & overbought
@@ -16306,19 +16337,19 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1d high, 4h & 1d overbought
             & (aroonu_14_1d_lt_100 | (roc_9_4h_lt_10) | (roc_9_1d_lt_20))
             # 15m still not low enough, 4h high, 1d overbought
-            & ((stochrsi_k_15m < 30.0) | aroonu_14_4h_lt_100 | (roc_9_1d_lt_30))
+            & ((stochrsi_k_15m_lt_30) | aroonu_14_4h_lt_100 | (roc_9_1d_lt_30))
             # 15m still high, 4h high & overbought
-            & ((stochrsi_k_15m < 40.0) | (stochrsi_k_4h_lt_80) | (roc_9_4h_lt_30))
+            & ((stochrsi_k_15m_lt_40) | (stochrsi_k_4h_lt_80) | (roc_9_4h_lt_30))
             # 1h high, 1d overbought
             & ((stochrsi_k_1h_lt_70) | (roc_9_1d_lt_40))
             # 1h high, 1h overbought, 4h downtrend
             & ((stochrsi_k_1h_lt_80) | (roc_9_1h_lt_10) | (roc_9_4h > -10.0))
             # 1h high, 4h & 1d downtrend
-            & ((stochrsi_k_1h < 80.0) | (roc_9_4h_gt_neg_20) | (roc_9_1d > -80.0))
+            & ((stochrsi_k_1h_lt_80) | (roc_9_4h_gt_neg_20) | (roc_9_1d > -80.0))
             # 1h down move, 1h & 1d overbought
-            & ((stochrsi_k_1h < 90.0) | (roc_9_1h_lt_10) | roc_9_1d_lt_50)
+            & ((stochrsi_k_1h_lt_90) | (roc_9_1h_lt_10) | roc_9_1d_lt_50)
             # 1h high & overbought
-            & ((stochrsi_k_1h < 90.0) | (roc_9_1h < 40.0))
+            & ((stochrsi_k_1h_lt_90) | (roc_9_1h < 40.0))
             # 4h high, 1h & 4h overbought
             & ((stochrsi_k_4h_lt_70) | (roc_9_1h_lt_10) | (roc_9_4h_lt_20))
             # 4h high, 1h & 1d overbought
@@ -16336,7 +16367,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1d P&D, dh downtrend
             & ((change_pct_1d > -50.0) | (change_pct_1d.shift(288) < 50.0) | (rsi_3_4h_gt_15))
             # big drop in the last 20 days, 1d high, 1d downtrend
-            & ((close > (high_max_20_1d * 0.20)) | (stochrsi_k_1d < 70.0) | (roc_9_1d > -15.0))
+            & ((close > (high_max_20_1d * 0.20)) | (stochrsi_k_1d_lt_70) | (roc_9_1d > -15.0))
             # drop in last 20 days, 1h high, 1d downtrend
             & ((close > (high_max_20_1d * 0.20)) | aroonu_14_1h_lt_70 | (roc_9_1d > -70.0))
             # drop in last 20 days. 4h high
@@ -16348,7 +16379,7 @@ class NostalgiaForInfinityX7(IStrategy):
             (rsi_20 < rsi_20.shift(1))
             & (rsi_3 < 46.0)
             & (aroonu_14 < 25.0)
-            & (stochrsi_k < 20.0)
+            & (stochrsi_k_lt_20)
             & (aroonu_14_15m_lt_50)
             & (close < sma_16 * 0.960)
           )
@@ -16383,7 +16414,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 4h high & overbought
             & ((rsi_3_15m_gt_10) | (stochrsi_k_4h_lt_80) | (roc_9_4h_lt_30))
             # 15m down move, 1d high, 1d downtrend
-            & ((rsi_3_15m_gt_10) | (stochrsi_k_1d < 70.0) | (roc_9_1d > -15.0))
+            & ((rsi_3_15m_gt_10) | (stochrsi_k_1d_lt_70) | (roc_9_1d > -15.0))
             # 15m & 1h down move, 4h overbought
             & ((rsi_3_15m_gt_15) | (rsi_3_1h_gt_35) | (roc_9_4h < 100.0))
             # 15m & 1d down move, 1h high
@@ -16419,7 +16450,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 4h high, 1d overbought
             & ((rsi_3_15m_gt_25) | aroonu_14_4h_lt_100 | (roc_9_1d < 100.0))
             # 15m down move, 1h high & overbought
-            & ((rsi_3_15m_gt_25) | (stochrsi_k_1h < 90.0) | (roc_9_1h < 20.0))
+            & ((rsi_3_15m_gt_25) | (stochrsi_k_1h_lt_90) | (roc_9_1h < 20.0))
             # 15m down move, 1h & 4h overbought
             & ((rsi_3_15m_gt_25) | (roc_9_1h < 40.0) | (roc_9_4h_lt_40))
             # 15m down move, 4h high & overbought
@@ -16433,7 +16464,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 4h high
             & (rsi_3_1h_gt_20 | (roc_9_4h < 50.0) | aroonu_14_4h_lt_80)
             # 1h & 4h down move, 1h still high
-            & (rsi_3_1h_gt_20 | (roc_9_4h < 50.0) | (stochrsi_k_1h < 40.0))
+            & (rsi_3_1h_gt_20 | (roc_9_4h < 50.0) | (stochrsi_k_1h_lt_40))
             # 1h & 4h down move, 4h overbought
             & (rsi_3_1h_gt_20 | (roc_9_4h < 50.0) | (roc_9_4h_lt_10))
             # 1h down move, 1h & 4h high
@@ -16443,7 +16474,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 4h high & overbought
             & (rsi_3_1h_gt_20 | aroonu_14_4h_lt_100 | (roc_9_4h < 50.0))
             # 1h down move, 1h still high, 1d overbought
-            & (rsi_3_1h_gt_20 | (stochrsi_k_1h < 40.0) | (roc_9_4h_lt_10))
+            & (rsi_3_1h_gt_20 | (stochrsi_k_1h_lt_40) | (roc_9_4h_lt_10))
             # 1h down move, 4h & 1d overbought
             & (rsi_3_1h_gt_20 | (roc_9_4h_lt_40) | (roc_9_1d_lt_100))
             # 1h down move, 1d high, 4h overbought
@@ -16467,7 +16498,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h high & overbought
             & ((rsi_3_1h_gt_50) | (aroonu_14_1h_lt_90) | (roc_9_1h_lt_10))
             # 1h down move, 1h high, 1d downtrend
-            & ((rsi_3_1h_gt_50) | (stochrsi_k_1h < 70.0) | (roc_9_1d_gt_neg_20))
+            & ((rsi_3_1h_gt_50) | (stochrsi_k_1h_lt_70) | (roc_9_1d_gt_neg_20))
             # 1h down move, 1h & 1d overbought
             & ((rsi_3_1h_gt_50) | (roc_9_1h < 25.0) | (roc_9_1d < 200.0))
             # 1h down move, 1h high, 4h overbought
@@ -16509,7 +16540,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1d downtrend, 1d high & overbought
             & ((cmf_20_1d > -0.40) | (aroonu_14_1d < 85.0) | (roc_9_1d_lt_20))
             # 15m not low enough, 1h high, 1d overbought
-            & ((aroonu_14_15m < 25.0) | (stochrsi_k_1h < 90.0) | (roc_9_1d < 200.0))
+            & ((aroonu_14_15m < 25.0) | (stochrsi_k_1h_lt_90) | (roc_9_1d < 200.0))
             # 1h still high, 1h & 4h overbought
             & ((aroonu_14_1h_lt_50) | (roc_9_1h < 40.0) | (roc_9_4h_lt_40))
             # 1h & 4h high, 4h overbought
@@ -16523,7 +16554,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 1d high, 4h overbought
             & ((aroonu_14_1h_lt_90) | (aroonu_14_1d_lt_90) | (roc_9_4h_lt_30))
             # 1h & 4h high, 1h overbought
-            & (aroonu_14_1h_lt_80 | (stochrsi_k_4h < 90.0) | (roc_9_1h_lt_10))
+            & (aroonu_14_1h_lt_80 | (stochrsi_k_4h_lt_90) | (roc_9_1h_lt_10))
             # 1h high & overbought
             & (aroonu_14_1h_lt_80 | (roc_9_1h < 80.0))
             # 1h high, 1h & 4h overbought
@@ -16555,17 +16586,17 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1d high, 1h & 4h overbought
             & (aroonu_14_1d_lt_100 | (roc_9_1h_lt_10) | (roc_9_4h < 20.0))
             # 1h high, 1h & 4h overbought
-            & ((stochrsi_k_1h < 60.0) | (roc_9_1h < 40.0) | (roc_9_4h_lt_40))
+            & ((stochrsi_k_1h_lt_60) | (roc_9_1h < 40.0) | (roc_9_4h_lt_40))
             # 1h high, 1h overbought
             & ((stochrsi_k_1h_lt_80) | (roc_9_1h_lt_10))
             # 1h high, 4h overbought. 1d downtrend
             & ((stochrsi_k_1h_lt_80) | (roc_9_4h_lt_40) | (cmf_20_1d > -0.25))
             # 4h high, 1h & 4h overbought
-            & ((stochrsi_k_4h < 90.0) | (roc_9_1h_lt_10) | (roc_9_4h_lt_20))
+            & ((stochrsi_k_4h_lt_90) | (roc_9_1h_lt_10) | (roc_9_4h_lt_20))
             # 4h high & 4h & 1d overbought
-            & ((stochrsi_k_4h < 90.0) | (roc_9_4h_lt_20) | (roc_9_1d_lt_20))
+            & ((stochrsi_k_4h_lt_90) | (roc_9_4h_lt_20) | (roc_9_1d_lt_20))
             # 1d high, 1h & 4h overbought
-            & ((stochrsi_k_1d < 80.0) | (roc_9_1h_lt_10) | (roc_9_4h_lt_20))
+            & ((stochrsi_k_1d_lt_80) | (roc_9_1h_lt_10) | (roc_9_4h_lt_20))
             # 1d hihg, 1h & 1d overbought
             & ((stochrsi_k_1d_lt_90) | (roc_9_1h < 30.0) | (roc_9_1d_lt_100))
             # 1d high, 4h & 1d overbought
@@ -16575,7 +16606,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # Logic
           long_entry_logic.append(
             (aroonu_14 < 25.0)
-            & (stochrsi_k < 20.0)
+            & (stochrsi_k_lt_20)
             & (aroonu_14_15m_lt_50)
             & (close < df["EMA_16"] * 0.960)
             & (((df["EMA_50"] - df["EMA_200"]) / close * 100.0) > 6.0)
@@ -16591,9 +16622,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 5m & 1d down move, 4h still high
             ((rsi_3_gt_15) | (rsi_3_1d_gt_30) | (aroonu_14_4h_lt_40))
             # 15m & 1h down move, 1d still high
-            & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_3) | (stochrsi_k_1d < 50.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_3) | (stochrsi_k_1d_lt_50))
             # 15m & 1h down move, 1h still not low enough
-            & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_5) | (stochrsi_k_1h < 30.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_5) | (stochrsi_k_1h_lt_30))
             # 15m & 1h & 4h down move, 4h still not low enough
             & ((rsi_3_15m_gt_3) | (rsi_3_1h_gt_10) | (rsi_3_4h_gt_20) | (aroonu_14_4h < 20.0))
             # 15m & 1h down move, 15m downtrend
@@ -16601,9 +16632,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 4h high
             & ((rsi_3_15m_gt_3) | (rsi_3_1h_gt_10) | (aroonu_14_4h < 80.0))
             # 15m & 1h down move, 1h still high
-            & ((rsi_3_15m_gt_3) | (rsi_3_1h_gt_10) | (stochrsi_k_1h < 40.0))
+            & ((rsi_3_15m_gt_3) | (rsi_3_1h_gt_10) | (stochrsi_k_1h_lt_40))
             # 15m & 1h down move, 4h high
-            & ((rsi_3_15m_gt_3) | (rsi_3_1h_gt_10) | (stochrsi_k_4h < 60.0))
+            & ((rsi_3_15m_gt_3) | (rsi_3_1h_gt_10) | (stochrsi_k_4h_lt_60))
             # 15m & 1h down move, 1d downtrend
             & ((rsi_3_15m_gt_3) | (rsi_3_1h_gt_15) | (roc_9_1d > -20.0))
             # 15m & 1h down move, 1h still high
@@ -16621,7 +16652,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 1h high
             & ((rsi_3_15m_gt_3) | (rsi_3_1h_gt_45) | (aroonu_14_1h < 85.0))
             # 15m & 1h down move, 1h high
-            & ((rsi_3_15m_gt_3) | (rsi_3_1h_gt_45) | (stochrsi_k_1h < 75.0))
+            & ((rsi_3_15m_gt_3) | (rsi_3_1h_gt_45) | (stochrsi_k_1h_lt_75))
             # 15m & 4h down move, 4h high
             & ((rsi_3_15m_gt_3) | (rsi_3_4h_gt_5) | aroonu_14_4h_lt_80)
             # 15m & 4h down move, 4h still high
@@ -16639,7 +16670,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 1h & 4h high
             & ((rsi_3_15m_gt_3) | (stochrsi_k_1h_lt_80) | (stochrsi_k_4h_lt_80))
             # 15m down move, 1h high, 4h overbought
-            & ((rsi_3_15m_gt_3) | (stochrsi_k_1h < 90.0) | (roc_9_4h_lt_10))
+            & ((rsi_3_15m_gt_3) | (stochrsi_k_1h_lt_90) | (roc_9_4h_lt_10))
             # 15m down move, 4h high & overbought
             & ((rsi_3_15m_gt_3) | (stochrsi_k_4h_lt_80) | (roc_9_4h_lt_10))
             # 15m down move, 4h & 1d downtrend
@@ -16649,7 +16680,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 1d high
             & ((rsi_3_15m_gt_5) | (rsi_3_1h_gt_10) | (aroonu_14_1d_lt_80))
             # 15m & 1h down move, 4h high
-            & ((rsi_3_15m_gt_5) | (rsi_3_1h_gt_10) | (stochrsi_k_4h < 80.0))
+            & ((rsi_3_15m_gt_5) | (rsi_3_1h_gt_10) | (stochrsi_k_4h_lt_80))
             # 15m & 1h down move, 1h high
             & ((rsi_3_15m_gt_5) | (rsi_3_1h_gt_30) | aroonu_14_1h_lt_70)
             # 15m & 1h down move, 4h high
@@ -16675,7 +16706,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 1h high
             & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_10) | (aroonu_14_1h < 70.0))
             # 15m & 1h down move, 1d high
-            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_10) | (stochrsi_k_1d < 70.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_10) | (stochrsi_k_1d_lt_70))
             # 15m & 1h down move, 1d downtrend
             & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_10) | (roc_9_1d > -30.0))
             # 15m & 1h down move, 1h high
@@ -16723,11 +16754,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 1h high, 15m downtrend
             & ((rsi_3_15m_gt_10) | (stochrsi_k_1h_lt_80) | (roc_9_15m > -10.0))
             # 15m down move, 1h high, 1d downtrend
-            & ((rsi_3_15m_gt_10) | (stochrsi_k_1h < 90.0) | (roc_9_1d_gt_neg_30))
+            & ((rsi_3_15m_gt_10) | (stochrsi_k_1h_lt_90) | (roc_9_1d_gt_neg_30))
             # 15m down move, 1h high, 1d overbought
-            & ((rsi_3_15m_gt_10) | (stochrsi_k_1h < 90.0) | (roc_9_1d_lt_30))
+            & ((rsi_3_15m_gt_10) | (stochrsi_k_1h_lt_90) | (roc_9_1d_lt_30))
             # 15m down move, 4h high & overbought
-            & ((rsi_3_15m_gt_10) | (stochrsi_k_4h < 90.0) | (roc_9_4h_lt_20))
+            & ((rsi_3_15m_gt_10) | (stochrsi_k_4h_lt_90) | (roc_9_4h_lt_20))
             # 15m & 1h down move, 1d overbought
             & ((rsi_3_15m_gt_15) | (rsi_3_1h_gt_15) | (roc_9_1d_lt_30))
             # 15m & 1h down move, 1d high
@@ -16785,7 +16816,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 4h high, 1d overbought
             & ((rsi_3_15m_gt_20) | aroonu_14_4h_lt_80 | (roc_9_1d < 60.0))
             # 15m & 4h down move, 4h high
-            & ((rsi_3_15m_gt_25) | (rsi_3_4h_gt_25) | (stochrsi_k_4h < 60.0))
+            & ((rsi_3_15m_gt_25) | (rsi_3_4h_gt_25) | (stochrsi_k_4h_lt_60))
             # 15m & 1d down move, 1h high
             & ((rsi_3_15m_gt_25) | (rsi_3_1d_gt_25) | (aroonu_14_1h_lt_90))
             # 15m down move, 15m high, 1h high
@@ -16803,7 +16834,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 1h & 4h high
             & ((rsi_3_15m_gt_30) | (aroonu_14_1h_lt_90) | (aroonu_14_4h_lt_90))
             # 1h & 4h down move, 1d still high
-            & ((rsi_3_1h_gt_3) | (rsi_3_4h_gt_3) | (stochrsi_k_1d < 50.0))
+            & ((rsi_3_1h_gt_3) | (rsi_3_4h_gt_3) | (stochrsi_k_1d_lt_50))
             # 1h & 4h down move, 1h still high
             & ((rsi_3_1h_gt_3) | (rsi_3_4h_gt_25) | (aroonu_14_1h < 40.0))
             # 1h & 4h down move, 4h high
@@ -16821,7 +16852,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 4h still high, 1d downtrend
             & ((rsi_3_1h_gt_3) | (stochrsi_k_4h_lt_50) | (roc_9_1h > -20.0))
             # 1h down move, 1d high & overbought
-            & ((rsi_3_1h_gt_3) | (stochrsi_k_1d < 60.0) | (roc_9_1d_lt_20))
+            & ((rsi_3_1h_gt_3) | (stochrsi_k_1d_lt_60) | (roc_9_1d_lt_20))
             # 1h & 4h & 1d down move
             & ((rsi_3_1h_gt_5) | (rsi_3_4h_gt_10) | (rsi_3_1d_gt_20))
             # 1h & 4h down move, 1d overbought
@@ -16837,7 +16868,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 1d down move, 1h still high
             & ((rsi_3_1h_gt_5) | (rsi_3_1d_gt_10) | (stochrsi_k_1h_lt_50))
             # 1h down move, 1h high, 1d high
-            & ((rsi_3_1h_gt_5) | (aroonu_14_1h_lt_70) | (stochrsi_k_1d < 80.0))
+            & ((rsi_3_1h_gt_5) | (aroonu_14_1h_lt_70) | (stochrsi_k_1d_lt_80))
             # 1h down move, 1d high, 1h downtrend
             & ((rsi_3_1h_gt_5) | (aroonu_14_1d < 85.0) | (roc_9_1h > -50.0))
             # 1h down move, 1d high, 4h downtrend
@@ -16859,7 +16890,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 4h still high
             & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_10) | (stochrsi_k_4h_lt_50))
             # 1h & 4h down move, 1d still not low enough
-            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_10) | (stochrsi_k_1d < 20.0))
+            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_10) | (stochrsi_k_1d_lt_20))
             # 1h & 4h down move, 4h downtrend
             & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_10) | (roc_9_4h > -35.0))
             # 1h & 4h down move, 1d downtrend
@@ -16883,13 +16914,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 1d down move, 4h high
             & ((rsi_3_1h_gt_10) | (rsi_3_1d_gt_15) | (stochrsi_k_4h_lt_70))
             # 1h & 1d down move, 1h still not low enough
-            & ((rsi_3_1h_gt_10) | (rsi_3_1d_gt_20) | (stochrsi_k_1h < 20.0))
+            & ((rsi_3_1h_gt_10) | (rsi_3_1d_gt_20) | (stochrsi_k_1h_lt_20))
             # 1h & 1d down move, 1h high
             & ((rsi_3_1h_gt_10) | (rsi_3_1d_gt_25) | (aroonu_14_1h < 70.0))
             # 1h & 1d down move, 1h downtrend
             & ((rsi_3_1h_gt_10) | (rsi_3_1d_gt_30) | (cmf_20_1h > -0.40))
             # 1h down move, 1d downtrend, 4h high
-            & ((rsi_3_1h_gt_10) | (cmf_20_1d > -0.30) | (stochrsi_k_4h < 90.0))
+            & ((rsi_3_1h_gt_10) | (cmf_20_1d > -0.30) | (stochrsi_k_4h_lt_90))
             # 1h down move, 1h still high, 4h overbought
             & ((rsi_3_1h_gt_10) | (aroonu_14_1h_lt_50) | (roc_9_4h < 20.0))
             # 1h down move, 1h & 4h high
@@ -16911,13 +16942,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 1d high
             & ((rsi_3_1h_gt_15) | rsi_3_4h_gt_20 | (aroonu_14_1d < 100.0))
             # 1h & 1d down move, 1h still high
-            & ((rsi_3_1h_gt_15) | (rsi_3_1d_gt_30) | (stochrsi_k_1h < 40.0))
+            & ((rsi_3_1h_gt_15) | (rsi_3_1d_gt_30) | (stochrsi_k_1h_lt_40))
             # 1h & 1d down move, 1h high
             & ((rsi_3_1h_gt_15) | (rsi_3_1d_gt_30) | (aroonu_14_1h < 80.0))
             # 1h down move, 1h downtrend, 1h still high
-            & ((rsi_3_1h_gt_15) | (cmf_20_1h > -0.30) | (stochrsi_k_1h < 40.0))
+            & ((rsi_3_1h_gt_15) | (cmf_20_1h > -0.30) | (stochrsi_k_1h_lt_40))
             # 1h down move, 1d downtrend, 1d high
-            & ((rsi_3_1h_gt_15) | (cmf_20_1d > -0.30) | (stochrsi_k_1d < 80.0))
+            & ((rsi_3_1h_gt_15) | (cmf_20_1d > -0.30) | (stochrsi_k_1d_lt_80))
             # 1h down move, 1h & 1d high
             & ((rsi_3_1h_gt_15) | (aroonu_14_1h < 70.0) | (aroonu_14_1d_lt_90))
             # 1h down move, 1h high, 1d overbought
@@ -16935,9 +16966,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1d high, 4h overbought
             & ((rsi_3_1h_gt_15) | (aroonu_14_1d < 100.0) | (roc_9_4h_lt_10))
             # 1h down move, 4h still not low enough, 1d downtrend
-            & ((rsi_3_1h_gt_15) | (stochrsi_k_4h < 30.0) | (roc_9_1d > -30.0))
+            & ((rsi_3_1h_gt_15) | (stochrsi_k_4h_lt_30) | (roc_9_1d > -30.0))
             # 1h down move, 4h high & overbought
-            & ((rsi_3_1h_gt_15) | (stochrsi_k_4h < 80.0) | (roc_9_4h < 100.0))
+            & ((rsi_3_1h_gt_15) | (stochrsi_k_4h_lt_80) | (roc_9_4h < 100.0))
             # 1h down move, 1h downtrend, 1d overbought
             & ((rsi_3_1h_gt_15) | (roc_9_1h > -30.0) | (roc_9_1d < 35.0))
             # 1h down move, 4h downtrend, 1d overbought
@@ -16961,7 +16992,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h high, 4h overbought
             & (rsi_3_1h_gt_20 | (stochrsi_k_1h_lt_70) | (roc_9_4h_lt_10))
             # 1h down move, 1d high, 1d downtrend
-            & (rsi_3_1h_gt_20 | (stochrsi_k_1d < 80.0) | roc_9_1d_gt_neg_50)
+            & (rsi_3_1h_gt_20 | (stochrsi_k_1d_lt_80) | roc_9_1d_gt_neg_50)
             # 1h down move, 1d high & overbought
             & (rsi_3_1h_gt_20 | (stochrsi_k_1d_lt_90) | (roc_9_1d_lt_40))
             # 1h down move, 1h & 4h overbought
@@ -17055,9 +17086,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h high, 1d downtrend
             & ((rsi_3_1h_gt_50) | (aroonu_14_1h < 60.0) | (roc_9_1d > -70.0))
             # 1h down move, 1h high, 1d overbought
-            & ((rsi_3_1h_gt_50) | (stochrsi_k_1h < 70.0) | (roc_9_1d_lt_100))
+            & ((rsi_3_1h_gt_50) | (stochrsi_k_1h_lt_70) | (roc_9_1d_lt_100))
             # 1h down move, 4h high, 1d downtrend
-            & ((rsi_3_1h_gt_50) | (stochrsi_k_4h < 60.0) | (roc_9_1d > -60.0))
+            & ((rsi_3_1h_gt_50) | (stochrsi_k_4h_lt_60) | (roc_9_1d > -60.0))
             # 1h down move, 1h high
             & ((rsi_3_1h_gt_60) | (stochrsi_k_1h_lt_80))
             # 1h down move, 1h overbought
@@ -17081,15 +17112,15 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 1h & 4h downtrend
             & ((rsi_3_4h_gt_10) | (roc_9_1h > -30.0) | (roc_9_4h_gt_neg_30))
             # 4h down move, 1d high & overbought
-            & ((rsi_3_4h_gt_10) | (stochrsi_k_1d < 70.0) | (roc_9_1d < 35.0))
+            & ((rsi_3_4h_gt_10) | (stochrsi_k_1d_lt_70) | (roc_9_1d < 35.0))
             # 4h down move, 4h & 1d downtrend
             & ((rsi_3_4h_gt_10) | (roc_9_4h > -15.0) | (roc_9_1d > -35.0))
             # 4h down move, 4h still high, 1d overbought
             & ((rsi_3_4h_gt_15) | (aroonu_14_4h_lt_40) | (roc_9_1d_lt_40))
             # 4h down move, 1h still not low enough, 1d downtrend
-            & ((rsi_3_4h_gt_15) | (stochrsi_k_1h < 20.0) | (roc_9_1d > -20.0))
+            & ((rsi_3_4h_gt_15) | (stochrsi_k_1h_lt_20) | (roc_9_1d > -20.0))
             # 4h & 1d down move, 1d high
-            & (rsi_3_4h_gt_20 | (rsi_3_1d_gt_20) | (stochrsi_k_1d < 70.0))
+            & (rsi_3_4h_gt_20 | (rsi_3_1d_gt_20) | (stochrsi_k_1d_lt_70))
             # 4h down move, 1d high & overbought
             & (rsi_3_4h_gt_20 | (aroonu_14_1d_lt_80) | (roc_9_1d < 200.0))
             # 4h down move, 4h & 1d downtrend
@@ -17105,9 +17136,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 4h still high, 1d overbought
             & ((rsi_3_4h_gt_30) | (aroonu_14_4h_lt_50) | (roc_9_1d < 200.0))
             # 4h down move, 4h still not low enough, 1d overbought
-            & ((rsi_3_4h_gt_30) | (stochrsi_k_4h < 20.0) | (roc_9_1d < 60.0))
+            & ((rsi_3_4h_gt_30) | (stochrsi_k_4h_lt_20) | (roc_9_1d < 60.0))
             # 4h down move, 1d high, 1d downtrend
-            & ((rsi_3_4h_gt_35) | (stochrsi_k_1d < 60.0) | (roc_9_1d_gt_neg_30))
+            & ((rsi_3_4h_gt_35) | (stochrsi_k_1d_lt_60) | (roc_9_1d_gt_neg_30))
             # 1h & 4h down move, 1d high & overbought
             & ((rsi_3_1h_gt_45) | (rsi_3_4h_gt_55) | (aroonu_14_1d_lt_80) | (roc_9_1d_lt_50))
             # 4h down move, 1h high, 1d overbought
@@ -17125,7 +17156,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 4h & 1d overbought
             & ((rsi_3_4h_gt_50) | (roc_9_4h_lt_10) | (roc_9_1d_lt_40))
             # 1d down move, 4h still high, 1d downtrend
-            & ((rsi_3_1d_gt_3) | (stochrsi_k_4h < 40.0) | (roc_9_1d > -25.0))
+            & ((rsi_3_1d_gt_3) | (stochrsi_k_4h_lt_40) | (roc_9_1d > -25.0))
             # 1d down move, 1h & 4h high
             & ((rsi_3_1d_gt_10) | (aroonu_14_1h_lt_50) | (aroonu_14_4h_lt_90))
             # 1d down move, 1d high, 1d downtrend
@@ -17139,7 +17170,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1d down move, 1h still high, 4h downtrend
             & ((rsi_3_1d_gt_25) | (stochrsi_k_1h_lt_50) | (roc_9_4h_gt_neg_30))
             # 1d down move, 1h high & overbought
-            & ((rsi_3_1d_gt_35) | (stochrsi_k_1h < 90.0) | (roc_9_1h_lt_10))
+            & ((rsi_3_1d_gt_35) | (stochrsi_k_1h_lt_90) | (roc_9_1h_lt_10))
             # 15m downtrend, 4h & 1d high
             & ((cmf_20_15m > -0.30) | aroonu_14_4h_lt_80 | aroonu_14_1d_lt_100)
             # 15m & 1h high, 1h overbought
@@ -17193,7 +17224,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h high, 4h overbought
             & ((stochrsi_k_1h_lt_80) | (roc_9_4h < 80.0))
             # 1h high, 1h overbought, 4h downtrend
-            & ((stochrsi_k_1h < 90.0) | (roc_9_1h_lt_10) | (roc_9_4h > -15.0))
+            & ((stochrsi_k_1h_lt_90) | (roc_9_1h_lt_10) | (roc_9_4h > -15.0))
             # 4h high, 1h & 4h overbought
             & ((stochrsi_k_4h_lt_90) | (roc_9_1h < 20.0) | (roc_9_4h < 50.0))
             # 1d high, 4h & 1d overbought
@@ -17201,7 +17232,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1d P&D, 4h overbought
             & ((change_pct_1d > -10.0) | (change_pct_1d.shift(288) < 30.0) | (roc_9_4h_lt_10))
             # big drop in the last 20 days, 1d high, 1d downtrend
-            & ((close > (high_max_20_1d * 0.20)) | (stochrsi_k_1d < 70.0) | (roc_9_1d > -15.0))
+            & ((close > (high_max_20_1d * 0.20)) | (stochrsi_k_1d_lt_70) | (roc_9_1d > -15.0))
           )
 
           # Logic
@@ -17217,15 +17248,15 @@ class NostalgiaForInfinityX7(IStrategy):
 
           long_entry_logic.append(
             # 5m & 1h down move, 1d still high
-            ((rsi_3_gt_3) | (rsi_3_1h_gt_3) | (stochrsi_k_1d < 40.0))
+            ((rsi_3_gt_3) | (rsi_3_1h_gt_3) | (stochrsi_k_1d_lt_40))
             # 5m & 1h down move, 1d high
-            & ((rsi_3_gt_3) | (rsi_3_1h_gt_25) | (stochrsi_k_1d < 70.0))
+            & ((rsi_3_gt_3) | (rsi_3_1h_gt_25) | (stochrsi_k_1d_lt_70))
             # 15m & 1h down move, 4h high
             & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_3) | (stochrsi_k_4h_lt_70))
             # 15m & 1h down move, 1h downtrend
             & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_3) | (roc_9_1h > -50.0))
             # 15m & 1h down move, 1d still not low enough
-            & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_5) | (stochrsi_k_1d < 30.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_5) | (stochrsi_k_1d_lt_30))
             # 15m & 1h down move, 4h still high
             & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_10) | (aroonu_14_4h_lt_50))
             # 15m & 1h down move, 1d high
@@ -17233,13 +17264,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 1h high
             & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_15) | (aroonu_14_1h < 60.0))
             # 15m & 4h down move, 4h still high
-            & (rsi_3_15m_gt_3 | (rsi_3_4h_gt_30) | (stochrsi_k_4h < 40.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_4h_gt_30) | (stochrsi_k_4h_lt_40))
             # 15m & 4h down move, 1d still high
             & (rsi_3_15m_gt_3 | (rsi_3_4h_gt_15) | (aroonu_14_1d < 40.0))
             # 15m & 1h down move, 1d downtrend
             & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_15) | (roc_9_1d > -30.0))
             # 15m down move, 4h still high, 1d downtrend
-            & (rsi_3_15m_gt_3 | (stochrsi_k_4h < 40.0) | (roc_9_1d_gt_neg_40))
+            & (rsi_3_15m_gt_3 | (stochrsi_k_4h_lt_40) | (roc_9_1d_gt_neg_40))
             # 15m & 1h & 4h down move
             & ((rsi_3_15m_gt_5) | (rsi_3_1h_gt_5) | rsi_3_4h_gt_20)
             # 15m & 1h down move, 1h still high
@@ -17259,11 +17290,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 1d high
             & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_10) | (aroonu_14_1d < 100.0))
             # 15m & 1h down move, 4h still high
-            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_10) | (stochrsi_k_4h < 40.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_10) | (stochrsi_k_4h_lt_40))
             # 15m & 1h down move, 1d high
             & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_10) | (stochrsi_k_1d_lt_90))
             # 15m & 1h down move, 4h high
-            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_15) | (stochrsi_k_4h < 60.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_15) | (stochrsi_k_4h_lt_60))
             # 15m & 1h down move, 1d downtrend
             & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_15) | (roc_9_1d > -30.0))
             # 15m & 1h down move, 4h high
@@ -17273,25 +17304,25 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 4h down move, 1d high
             & ((rsi_3_15m_gt_10) | (rsi_3_4h_gt_30) | (stochrsi_k_1d_lt_90))
             # 15m & 1d down move, 4h still high
-            & ((rsi_3_15m_gt_10) | (rsi_3_1d_gt_10) | (stochrsi_k_4h < 40.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_1d_gt_10) | (stochrsi_k_4h_lt_40))
             # 15m & 4h down move, 4h still high
-            & ((rsi_3_15m_gt_10) | (rsi_3_4h_gt_10) | (stochrsi_k_4h < 40.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_4h_gt_10) | (stochrsi_k_4h_lt_40))
             # 15m & 4h down move, 1d high
-            & ((rsi_3_15m_gt_10) | rsi_3_4h_gt_20 | (stochrsi_k_1d < 70.0))
+            & ((rsi_3_15m_gt_10) | rsi_3_4h_gt_20 | (stochrsi_k_1d_lt_70))
             # 15m & 4h down move, 4h still not low enough
-            & ((rsi_3_15m_gt_10) | rsi_3_4h_gt_20 | (stochrsi_k_4h < 30.0))
+            & ((rsi_3_15m_gt_10) | rsi_3_4h_gt_20 | (stochrsi_k_4h_lt_30))
             # 15m & 4h down move, 1d high
-            & ((rsi_3_15m_gt_10) | rsi_3_4h_gt_20 | (stochrsi_k_1d < 80.0))
+            & ((rsi_3_15m_gt_10) | rsi_3_4h_gt_20 | (stochrsi_k_1d_lt_80))
             # 15m & 1h down move, 1h high
             & ((rsi_3_15m_gt_15) | (rsi_3_1h_gt_15) | (aroonu_14_1h < 70.0))
             # 15m & 1h down move, 15m still high
-            & ((rsi_3_15m_gt_15) | rsi_3_1h_gt_20 | (stochrsi_k_15m < 50.0))
+            & ((rsi_3_15m_gt_15) | rsi_3_1h_gt_20 | (stochrsi_k_15m_lt_50))
             # 15m & 4h down move, 15m still high
-            & ((rsi_3_15m_gt_15) | (rsi_3_4h_gt_15) | (stochrsi_k_15m < 50.0))
+            & ((rsi_3_15m_gt_15) | (rsi_3_4h_gt_15) | (stochrsi_k_15m_lt_50))
             # 15m & 4h down move, 4h high
             & ((rsi_3_15m_gt_15) | rsi_3_4h_gt_20 | (aroonu_14_4h_lt_60))
             # 15m & 1d down move, 1d high
-            & ((rsi_3_15m_gt_15) | (rsi_3_1d_gt_40) | (stochrsi_k_1d < 70.0))
+            & ((rsi_3_15m_gt_15) | (rsi_3_1d_gt_40) | (stochrsi_k_1d_lt_70))
             # 15m down move, 15m high
             & ((rsi_3_15m_gt_15) | (aroonu_14_15m_lt_70))
             # 15m & 4h down move, 4h high
@@ -17315,21 +17346,21 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 1d still high
             & ((rsi_3_1h_gt_3) | (rsi_3_4h_gt_15) | (aroonu_14_1d < 50.0))
             # 1h & 4h down move, 1d still high
-            & ((rsi_3_1h_gt_3) | (rsi_3_4h_gt_15) | (stochrsi_k_1d < 50.0))
+            & ((rsi_3_1h_gt_3) | (rsi_3_4h_gt_15) | (stochrsi_k_1d_lt_50))
             # 1h & 4h down move, 1h still high
             & ((rsi_3_1h_gt_3) | rsi_3_4h_gt_20 | (aroonu_14_1h < 40.0))
             # 1h & 4h down move, 4h still not low enough
-            & ((rsi_3_1h_gt_3) | rsi_3_4h_gt_20 | (stochrsi_k_4h < 30.0))
+            & ((rsi_3_1h_gt_3) | rsi_3_4h_gt_20 | (stochrsi_k_4h_lt_30))
             # 1h & 4h down move, 4h high
             & ((rsi_3_1h_gt_3) | (rsi_3_4h_gt_25) | aroonu_14_4h_lt_70)
             # 1h & 4h down move, 1d high
             & ((rsi_3_1h_gt_3) | (rsi_3_4h_gt_25) | (aroonu_14_1d_lt_70))
             # 1h & 4h down move, 4h high
-            & ((rsi_3_1h_gt_3) | (rsi_3_4h_gt_25) | (stochrsi_k_4h < 60.0))
+            & ((rsi_3_1h_gt_3) | (rsi_3_4h_gt_25) | (stochrsi_k_4h_lt_60))
             # 1h down move, 1d high, 1d downtrend
             & ((rsi_3_1h_gt_3) | (aroonu_14_1d_lt_70) | (roc_9_1h > -50.0))
             # 1h & 4h down move, 15m still not low enough
-            & ((rsi_3_1h_gt_5) | (rsi_3_4h_gt_5) | (stochrsi_k_15m < 20.0))
+            & ((rsi_3_1h_gt_5) | (rsi_3_4h_gt_5) | (stochrsi_k_15m_lt_20))
             # 1h & 4h down move, 1d downtrend
             & ((rsi_3_1h_gt_5) | (rsi_3_4h_gt_5) | (roc_9_1d_gt_neg_30))
             # 1h & 4h down move, 1d still high
@@ -17337,7 +17368,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 1h high
             & ((rsi_3_1h_gt_5) | (rsi_3_4h_gt_25) | aroonu_14_1h_lt_70)
             # 1h & 4h down move, 1d high
-            & ((rsi_3_1h_gt_5) | (rsi_3_4h_gt_25) | (stochrsi_k_1d < 80.0))
+            & ((rsi_3_1h_gt_5) | (rsi_3_4h_gt_25) | (stochrsi_k_1d_lt_80))
             # 1h & 4h down move, 1d overbought
             & ((rsi_3_1h_gt_5) | (rsi_3_4h_gt_35) | (roc_9_1d_lt_40))
             # 1h & 1d down move, 1h still high
@@ -17347,7 +17378,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 1d high
             & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_10) | (aroonu_14_1d < 75.0))
             # 1h & 4h down move, 1d high
-            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_10) | (stochrsi_k_1d < 80.0))
+            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_10) | (stochrsi_k_1d_lt_80))
             # 1h & 4h down move, 4h downtrend
             & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_10) | (roc_9_4h > -20.0))
             # 1h & 4h down move, 1d downtrend
@@ -17357,7 +17388,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 1d high
             & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_15) | (aroonu_14_1d_lt_80))
             # 1h & 4h down move, 4h still not low enough
-            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_15) | (stochrsi_k_4h < 20.0))
+            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_15) | (stochrsi_k_4h_lt_20))
             # 1h & 4h down move, 1d downtrend
             & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_15) | (roc_9_1d_gt_neg_40))
             # 1h & 4h down move, 1h still high
@@ -17373,7 +17404,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 4h high
             & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_35) | (stochrsi_k_4h_lt_70))
             # 1h & 1d down move, 1d still high
-            & ((rsi_3_1h_gt_10) | (rsi_3_1d_gt_10) | (stochrsi_k_1d < 50.0))
+            & ((rsi_3_1h_gt_10) | (rsi_3_1d_gt_10) | (stochrsi_k_1d_lt_50))
             # 1h & 1d down move, 1d still high
             & ((rsi_3_1h_gt_10) | (rsi_3_1d_gt_25) | (rsi_14_1d < 50.0))
             # 1h & 1d down move, 1h high
@@ -17397,7 +17428,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1d high & overbought
             & ((rsi_3_1h_gt_10) | (aroonu_14_1d_lt_90) | (roc_9_1d_lt_30))
             # 1h down move, 15m high
-            & ((rsi_3_1h_gt_10) | (stochrsi_k_15m < 80.0))
+            & ((rsi_3_1h_gt_10) | (stochrsi_k_15m_lt_80))
             # 1h down move, 4h & 1d downtrend
             & ((rsi_3_1h_gt_10) | (roc_9_4h > -20.0) | (roc_9_1d_gt_neg_40))
             # 1h & 4h down move, 1d still high, 1d downtrend
@@ -17405,21 +17436,21 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 4h still high
             & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_15) | (aroonu_14_4h_lt_50))
             # 1h & 4h down move, 15m still high
-            & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_15) | (stochrsi_k_15m < 40.0))
+            & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_15) | (stochrsi_k_15m_lt_40))
             # 1h & 4h down move, 4h still not low enough
-            & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_15) | (stochrsi_k_4h < 20.0))
+            & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_15) | (stochrsi_k_4h_lt_20))
             # 1h & 4h down move, 1d high
-            & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_15) | (stochrsi_k_1d < 70.0))
+            & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_15) | (stochrsi_k_1d_lt_70))
             # 1h & 4h down move, 1d downtrend
             & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_25) | (roc_9_1d_gt_neg_40))
             # 1h & 4h down move, 4h high
             & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_30) | (aroonu_14_4h_lt_60))
             # 1h & 4h down move, 1d high
-            & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_30) | (stochrsi_k_1d < 80.0))
+            & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_30) | (stochrsi_k_1d_lt_80))
             # 1h & 4h down move, 4h overbought
             & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_35) | (roc_9_4h_lt_10))
             # 1h & 1d down move, 4h high
-            & ((rsi_3_1h_gt_15) | (rsi_3_1d_gt_20) | (stochrsi_k_4h < 60.0))
+            & ((rsi_3_1h_gt_15) | (rsi_3_1d_gt_20) | (stochrsi_k_4h_lt_60))
             # 1h & 1d down move, 1d overbought
             & ((rsi_3_1h_gt_15) | (rsi_3_1d_gt_35) | (roc_9_1d < 10.0))
             # 1h down move, 1h downtrend, 1h high
@@ -17443,15 +17474,15 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 1d overbought
             & ((rsi_3_1h_gt_20) | (rsi_3_4h_gt_20) | (aroonu_14_1d_lt_100))
             # 1h & 4h down move, 15m high
-            & ((rsi_3_1h_gt_20) | (rsi_3_4h_gt_20) | (stochrsi_k_15m < 60.0))
+            & ((rsi_3_1h_gt_20) | (rsi_3_4h_gt_20) | (stochrsi_k_15m_lt_60))
             # 1h & 4h down move, 15m still not low enough, 1d still not low enough
-            & ((rsi_3_1h_gt_20) | (rsi_3_4h_gt_20) | (stochrsi_k_15m < 30.0) | (stochrsi_k_1d < 30.0))
+            & ((rsi_3_1h_gt_20) | (rsi_3_4h_gt_20) | (stochrsi_k_15m_lt_30) | (stochrsi_k_1d_lt_30))
             # 1h & 4h down move, 1d overbought
             & ((rsi_3_1h_gt_20) | (rsi_3_4h_gt_20) | (roc_9_1d_lt_30))
             # 1h & 4h down move, 4h high
             & ((rsi_3_1h_gt_20) | (rsi_3_4h_gt_50) | (stochrsi_k_4h_lt_80))
             # 1h & 1d down move, 1d high
-            & ((rsi_3_1h_gt_20) | (rsi_3_1d_gt_20) | (stochrsi_k_1d < 60.0))
+            & ((rsi_3_1h_gt_20) | (rsi_3_1d_gt_20) | (stochrsi_k_1d_lt_60))
             # 1h & 1d down move, 1d high
             & ((rsi_3_1h_gt_20) | (rsi_3_1d_gt_30) | (aroonu_14_1d_lt_100))
             # 1h & 1d down move, 1d overbought
@@ -17463,15 +17494,15 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1d high & overbought
             & ((rsi_3_1h_gt_20) | (aroonu_14_1d_lt_100) | (roc_9_1d_lt_30))
             # 1h down move, 1d high, 4h downtrend
-            & ((rsi_3_1h_gt_20) | (stochrsi_k_1d < 80.0) | (roc_9_4h_gt_neg_20))
+            & ((rsi_3_1h_gt_20) | (stochrsi_k_1d_lt_80) | (roc_9_4h_gt_neg_20))
             # 1h & 4h down move, 15m high
-            & ((rsi_3_1h_gt_25) | (rsi_3_4h_gt_25) | (stochrsi_k_15m < 70.0))
+            & ((rsi_3_1h_gt_25) | (rsi_3_4h_gt_25) | (stochrsi_k_15m_lt_70))
             # 1h & 4h down move, 4h high
             & ((rsi_3_1h_gt_25) | (rsi_3_4h_gt_40) | aroonu_14_4h_lt_70)
             # 1h & 1d down move, 1h high
             & ((rsi_3_1h_gt_25) | (rsi_3_1d_gt_25) | aroonu_14_1h_lt_80)
             # 1h & 1d down move, 1d high
-            & ((rsi_3_1h_gt_25) | (rsi_3_1d_gt_45) | (stochrsi_k_1d < 80.0))
+            & ((rsi_3_1h_gt_25) | (rsi_3_1d_gt_45) | (stochrsi_k_1d_lt_80))
             # 1h down move, 4h downtrend, 4h high
             & ((rsi_3_1h_gt_25) | (cmf_20_4h > -0.50) | aroonu_14_4h_lt_70)
             # 1h down move, 1h high, 1d overbought
@@ -17487,7 +17518,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h high & overbought
             & ((rsi_3_1h_gt_25) | aroonu_14_1d_lt_100 | (roc_9_1d_lt_20))
             # 1h down move, 4h high & overbought
-            & ((rsi_3_1h_gt_25) | (stochrsi_k_4h < 80.0) | (roc_9_4h_lt_20))
+            & ((rsi_3_1h_gt_25) | (stochrsi_k_4h_lt_80) | (roc_9_4h_lt_20))
             # 1h & 4h down move, 1d downtrend
             & ((rsi_3_1h_gt_30) | (rsi_3_4h_gt_30) | roc_9_1d_gt_neg_50)
             # 1h & 4h down move, 15m high
@@ -17495,7 +17526,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 4h high
             & ((rsi_3_1h_gt_30) | (rsi_3_4h_gt_40) | (aroonu_14_4h < 75.0))
             # 1h & 4h down move, 15m high
-            & ((rsi_3_1h_gt_30) | (rsi_3_4h_gt_40) | (stochrsi_k_15m < 80.0))
+            & ((rsi_3_1h_gt_30) | (rsi_3_4h_gt_40) | (stochrsi_k_15m_lt_80))
             # 1h & 4h down move, 4h high
             & ((rsi_3_1h_gt_30) | (rsi_3_4h_gt_50) | aroonu_14_4h_lt_80)
             # 1h & 1d down move, 1d high
@@ -17509,7 +17540,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1d high, 4h overbought
             & ((rsi_3_1h_gt_30) | aroonu_14_1d_lt_100 | (roc_9_4h_lt_10))
             # 1h down move, 4h still high, 1d downtrend
-            & ((rsi_3_1h_gt_30) | (stochrsi_k_4h < 40.0) | (roc_9_1d > -80.0))
+            & ((rsi_3_1h_gt_30) | (stochrsi_k_4h_lt_40) | (roc_9_1d > -80.0))
             # 1h down move, 4h & 1d overbought
             & ((rsi_3_1h_gt_30) | (roc_9_4h_lt_10) | (roc_9_1d_lt_30))
             # 1h & 4h down move, 15m high
@@ -17533,7 +17564,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 4h high & overbought
             & ((rsi_3_1h_gt_40) | (aroonu_14_4h_lt_90) | (roc_9_4h_lt_20))
             # 1h down move, 4h high, 1d downtrend
-            & ((rsi_3_1h_gt_40) | (stochrsi_k_4h < 60.0) | roc_9_1d_gt_neg_50)
+            & ((rsi_3_1h_gt_40) | (stochrsi_k_4h_lt_60) | roc_9_1d_gt_neg_50)
             # 1h down move, 4h high & overbought
             & ((rsi_3_1h_gt_40) | (stochrsi_k_4h_lt_70) | (roc_9_4h_lt_40))
             # 1h down move, 4h high & overbought
@@ -17547,7 +17578,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h & 1d down move
             & ((rsi_3_4h_gt_3) | (rsi_3_1d_gt_15))
             # 4h & 1d down move, 1d high
-            & ((rsi_3_4h_gt_3) | (rsi_3_1d_gt_25) | (stochrsi_k_1d < 60.0))
+            & ((rsi_3_4h_gt_3) | (rsi_3_1d_gt_25) | (stochrsi_k_1d_lt_60))
             # 4h down move, 1h downtrend, 4h still high
             & ((rsi_3_4h_gt_3) | (cmf_20_1h > -0.30) | (aroonu_14_4h_lt_40))
             # 4h & 1d down move, 4h downtrend
@@ -17557,7 +17588,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h & 1d down move, 1d still high
             & ((rsi_3_4h_gt_5) | (rsi_3_1d_gt_20) | (aroonu_14_1d < 40.0))
             # 4h & 1d down move, 1d still high
-            & ((rsi_3_4h_gt_5) | (rsi_3_1d_gt_20) | (stochrsi_k_1d < 50.0))
+            & ((rsi_3_4h_gt_5) | (rsi_3_1d_gt_20) | (stochrsi_k_1d_lt_50))
             # 4h & 1d down move, 4h still not low enough
             & ((rsi_3_4h_gt_5) | (rsi_3_1d_gt_30) | (aroonu_14_4h < 20.0))
             # 4h & 1d down move, 1d high
@@ -17571,7 +17602,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h & 1d down move, 1d downtrend
             & ((rsi_3_4h_gt_10) | (rsi_3_1d_gt_10) | (roc_9_1d > -20.0))
             # 15m & 1d down move, 15m still high
-            & ((rsi_3_4h_gt_10) | (rsi_3_1d_gt_15) | (stochrsi_k_15m < 50.0))
+            & ((rsi_3_4h_gt_10) | (rsi_3_1d_gt_15) | (stochrsi_k_15m_lt_50))
             # 4h & 1d down move, 4d & 1d downtrend
             & ((rsi_3_4h_gt_10) | (rsi_3_1d_gt_30) | (roc_9_4h > -10.0) | (roc_9_1d > -20.0))
             # 4h & 1d down move, 4h downtrend
@@ -17579,15 +17610,15 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h & 1d down move, 1d overbought
             & ((rsi_3_4h_gt_10) | (rsi_3_1d_gt_45) | (roc_9_1d < 10.0))
             # 4h & 1d down move, 4h still not low enough
-            & ((rsi_3_4h_gt_10) | (rsi_3_1d > 50.0) | (stochrsi_k_4h < 20.0))
+            & ((rsi_3_4h_gt_10) | (rsi_3_1d > 50.0) | (stochrsi_k_4h_lt_20))
             # 4h down move, 15m high, 1h downtrend
-            & ((rsi_3_4h_gt_10) | (stochrsi_k_15m < 60.0) | (roc_9_1h > -10.0))
+            & ((rsi_3_4h_gt_10) | (stochrsi_k_15m_lt_60) | (roc_9_1h > -10.0))
             # 4h down move, 15m high
-            & ((rsi_3_4h_gt_10) | (stochrsi_k_15m < 80.0))
+            & ((rsi_3_4h_gt_10) | (stochrsi_k_15m_lt_80))
             # 4h down move, 4h still not low e nough, 1d downtrend
-            & ((rsi_3_4h_gt_10) | (stochrsi_k_4h < 30.0) | (roc_9_1d > -20.0))
+            & ((rsi_3_4h_gt_10) | (stochrsi_k_4h_lt_30) | (roc_9_1d > -20.0))
             # 4h down move, 4h still high, 1d high
-            & ((rsi_3_4h_gt_10) | (stochrsi_k_4h < 40.0) | (aroonu_14_1d_lt_80))
+            & ((rsi_3_4h_gt_10) | (stochrsi_k_4h_lt_40) | (aroonu_14_1d_lt_80))
             # 4h down move, 4h & 1d downtrend
             & ((rsi_3_4h_gt_10) | (roc_9_4h > -20.0) | (roc_9_1d_gt_neg_40))
             # 4h & 1d down move, 1d downtrend
@@ -17595,7 +17626,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h & 1d down move, 1d still high
             & ((rsi_3_4h_gt_15) | (rsi_3_1d_gt_25) | (aroonu_14_1d < 40.0))
             # 15m & 1d down move, 15m high
-            & ((rsi_3_4h_gt_15) | (rsi_3_1d_gt_30) | (stochrsi_k_15m < 70.0))
+            & ((rsi_3_4h_gt_15) | (rsi_3_1d_gt_30) | (stochrsi_k_15m_lt_70))
             # 4h & 1d down move, 4h still high
             & ((rsi_3_4h_gt_15) | (rsi_3_1d_gt_30) | (stochrsi_k_4h_lt_50))
             # 4h & 1d down move, 1d still high
@@ -17617,9 +17648,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 1h & 4h downtrend
             & ((rsi_3_4h_gt_15) | (roc_9_1h > -40.0) | (roc_9_4h > -40.0))
             # 4h & 1d down move, 1d high
-            & (rsi_3_4h_gt_20 | (rsi_3_1d_gt_20) | (stochrsi_k_1d < 80.0))
+            & (rsi_3_4h_gt_20 | (rsi_3_1d_gt_20) | (stochrsi_k_1d_lt_80))
             # 4h & 1d down move, 15m high
-            & (rsi_3_4h_gt_20 | (rsi_3_1d_gt_30) | (stochrsi_k_15m < 80.0))
+            & (rsi_3_4h_gt_20 | (rsi_3_1d_gt_30) | (stochrsi_k_15m_lt_80))
             # 4h & 1d down move, 1d high
             & (rsi_3_4h_gt_20 | (rsi_3_1d > 50.0) | (stochrsi_k_1d_lt_90))
             # 4h down move, 15m high, 4h downtrend
@@ -17633,13 +17664,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 1d high & overbought
             & (rsi_3_4h_gt_20 | (aroonu_14_1d_lt_90) | (roc_9_1d_lt_40))
             # 4h down move, 15m high
-            & (rsi_3_4h_gt_20 | (stochrsi_k_15m < 70.0))
+            & (rsi_3_4h_gt_20 | (stochrsi_k_15m_lt_70))
             # 4h down move, 4h still not low enough, 1d downtrend
-            & (rsi_3_4h_gt_20 | (stochrsi_k_4h < 30.0) | (roc_9_1d_gt_neg_20))
+            & (rsi_3_4h_gt_20 | (stochrsi_k_4h_lt_30) | (roc_9_1d_gt_neg_20))
             # 4h down move, 4h & 1d downtrend
             & (rsi_3_4h_gt_20 | (roc_9_4h_gt_neg_20) | (roc_9_1d_gt_neg_20))
             # 4h down move, 1d high, 4h downtrend
-            & (rsi_3_4h_gt_20 | (stochrsi_k_1d < 80.0) | (roc_9_4h_gt_neg_20))
+            & (rsi_3_4h_gt_20 | (stochrsi_k_1d_lt_80) | (roc_9_4h_gt_neg_20))
             # 4h & 1d down move, 1h high
             & ((rsi_3_4h_gt_25) | (rsi_3_1d_gt_25) | (aroonu_14_1h_lt_90))
             # 4h & 1d down move, 1d high
@@ -17653,7 +17684,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 1d high, 4h downtrend
             & ((rsi_3_4h_gt_25) | aroonu_14_1d_lt_100 | (roc_9_4h > -20.0))
             # 4h down move, 4h still high, 1d downtrend
-            & ((rsi_3_4h_gt_25) | (stochrsi_k_4h < 40.0) | (roc_9_1d_gt_neg_30))
+            & ((rsi_3_4h_gt_25) | (stochrsi_k_4h_lt_40) | (roc_9_1d_gt_neg_30))
             # 4h down move, 4h high, 1d downtrend
             & ((rsi_3_4h_gt_25) | (stochrsi_k_4h_lt_70) | (roc_9_1d_gt_neg_20))
             # 4h down move, 1d overbought
@@ -17699,7 +17730,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1d down move, 1d high, 1d downtrend
             & ((rsi_3_1d_gt_15) | (aroonu_14_1d_lt_70) | (roc_9_1d_gt_neg_20))
             # 1d down move, 1d still high
-            & ((rsi_3_1d_gt_15) | (stochrsi_k_1d < 40.0))
+            & ((rsi_3_1d_gt_15) | (stochrsi_k_1d_lt_40))
             # 1d down move, 4h & 1d downtrend
             & ((rsi_3_1d_gt_15) | (roc_9_4h > -10.0) | (roc_9_1d_gt_neg_40))
             # 1d down move, 15m high
@@ -17709,7 +17740,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1d down move, 1d high, 1d downtrend
             & ((rsi_3_1d_gt_25) | (aroonu_14_1d_lt_80) | (roc_9_1d_gt_neg_30))
             # 1d down move, 1d still high, 1d downtrend
-            & ((rsi_3_1d_gt_25) | (stochrsi_k_1d < 50.0) | (roc_9_1d_gt_neg_20))
+            & ((rsi_3_1d_gt_25) | (stochrsi_k_1d_lt_50) | (roc_9_1d_gt_neg_20))
             # 1d down move, 4h & 1d high
             & ((rsi_3_1d_gt_30) | (aroonu_14_4h_lt_90) | (aroonu_14_1d_lt_90))
             # 1h & 4h downtrend, 4h high
@@ -17743,23 +17774,23 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1d high, 4h & 1d overbought
             & (aroonu_14_1d_lt_100 | (roc_9_4h_lt_30) | (roc_9_1d < 60.0))
             # 15m still high, 1h & 4h downtrend
-            & ((stochrsi_k_15m < 50.0) | (roc_9_1h > -20.0) | (roc_9_4h_gt_neg_20))
+            & ((stochrsi_k_15m_lt_50) | (roc_9_1h > -20.0) | (roc_9_4h_gt_neg_20))
             # 4h high, 1h & 4h overbought
             & ((stochrsi_k_4h_lt_90) | (roc_9_1h < 20.0) | (roc_9_4h_lt_30))
             # 4h high, 4h & 1d overbought
-            & ((stochrsi_k_4h < 90.0) | (roc_9_4h_lt_20) | (roc_9_1d_lt_80))
+            & ((stochrsi_k_4h_lt_90) | (roc_9_4h_lt_20) | (roc_9_1d_lt_80))
             # 1d still high, 4h & 1d downtrend
-            & ((stochrsi_k_1d < 50.0) | (roc_9_4h_gt_neg_30) | (roc_9_1d_gt_neg_30))
+            & ((stochrsi_k_1d_lt_50) | (roc_9_4h_gt_neg_30) | (roc_9_1d_gt_neg_30))
             # big drop in the last 20 days, 1d high, 1d downtrend
-            & ((close > (high_max_20_1d * 0.20)) | (stochrsi_k_1d < 70.0) | (roc_9_1d > -15.0))
+            & ((close > (high_max_20_1d * 0.20)) | (stochrsi_k_1d_lt_70) | (roc_9_1d > -15.0))
           )
 
           # Logic
           long_entry_logic.append(
             (willr_14 < -50.0)
-            & (stochrsi_k < 20.0)
+            & (stochrsi_k_lt_20)
             & (willr_84_1h < -70.0)
-            & (stochrsi_k_1h < 20.0)
+            & (stochrsi_k_1h_lt_20)
             & (bbb_20_2_0_1h > 16.0)
             & (close_max_48 >= (close * 1.10))
           )
@@ -17776,9 +17807,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 5m & 1h down move, 1h still not low enough
             & ((rsi_3_gt_3) | (rsi_3_1h_gt_10) | (aroonu_14_1h < 30.0))
             # 5m & 1h down move, 1h still not low enough
-            & ((rsi_3_gt_3) | (rsi_3_1h_gt_15) | (stochrsi_k_1h < 30.0))
+            & ((rsi_3_gt_3) | (rsi_3_1h_gt_15) | (stochrsi_k_1h_lt_30))
             # 5m & 1h down move, 4h high
-            & ((rsi_3_gt_3) | (rsi_3_1h_gt_50) | (stochrsi_k_4h < 60.0))
+            & ((rsi_3_gt_3) | (rsi_3_1h_gt_50) | (stochrsi_k_4h_lt_60))
             # 5m & 1d down move, 1d still not low enough
             & ((rsi_3_gt_3) | (rsi_3_1d_gt_15) | (aroonu_14_1d < 30.0))
             # 5m down move, 1h & 4h high
@@ -17786,7 +17817,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 5m down move, 4h high & overbought
             & ((rsi_3_gt_3) | aroonu_14_4h_lt_100 | (roc_9_4h < 20.0))
             # 5m down move, 1h high, 4h overbought
-            & ((rsi_3_gt_3) | (stochrsi_k_1h < 80.0) | (roc_9_4h_lt_20))
+            & ((rsi_3_gt_3) | (stochrsi_k_1h_lt_80) | (roc_9_4h_lt_20))
             # 5m down move, 1d high & overbought
             & ((rsi_3_gt_3) | (stochrsi_k_1d_lt_90) | (roc_9_1d_lt_20))
             # 5m & 1h down move, 1d overbought
@@ -17826,7 +17857,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 1d overbought
             & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_30) | (roc_9_1d < 200.0))
             # 15m & 1h down move, 1h still high
-            & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_35) | (stochrsi_k_1h < 40.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_35) | (stochrsi_k_1h_lt_40))
             # 15m & 1h down move, 4h high
             & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_45) | (aroonu_14_4h_lt_90))
             # 15m & 4h down move, 1d high
@@ -17846,7 +17877,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 1d high & overbought
             & (rsi_3_15m_gt_3 | aroonu_14_1d_lt_100 | (roc_9_1d_lt_40))
             # 15m down move, 1h high, 1d downtrend
-            & (rsi_3_15m_gt_3 | (stochrsi_k_1h < 80.0) | (roc_9_1d_gt_neg_20))
+            & (rsi_3_15m_gt_3 | (stochrsi_k_1h_lt_80) | (roc_9_1d_gt_neg_20))
             # 15m down move, 4h high & overbought
             & (rsi_3_15m_gt_3 | (stochrsi_k_4h_lt_80) | (roc_9_4h_lt_40))
             # 15m down move, 4h high, 1d overbought
@@ -17858,9 +17889,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 4h still high
             & ((rsi_3_15m_gt_5) | (rsi_3_1h_gt_5) | (rsi_14_4h < 40.0))
             # 15m & 1h down move, 1h still not low enough
-            & ((rsi_3_15m_gt_5) | (rsi_3_1h_gt_15) | (stochrsi_k_1h < 20.0))
+            & ((rsi_3_15m_gt_5) | (rsi_3_1h_gt_15) | (stochrsi_k_1h_lt_20))
             # 15m & 1h down move, 1d still high
-            & ((rsi_3_15m_gt_5) | rsi_3_1h_gt_20 | (stochrsi_k_1d < 50.0))
+            & ((rsi_3_15m_gt_5) | rsi_3_1h_gt_20 | (stochrsi_k_1d_lt_50))
             # 15m & 1h down move, 1d overbought
             & ((rsi_3_15m_gt_5) | (rsi_3_1h_gt_25) | (roc_9_1d < 70.0))
             # 15m & 1h down move, 4h high
@@ -17868,11 +17899,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 1h high
             & ((rsi_3_15m_gt_5) | (rsi_3_1h_gt_45) | aroonu_14_1h_lt_80)
             # 15m & 4h down move, 1h still high
-            & ((rsi_3_15m_gt_5) | (rsi_3_4h_gt_10) | (stochrsi_k_1h < 50.0))
+            & ((rsi_3_15m_gt_5) | (rsi_3_4h_gt_10) | (stochrsi_k_1h_lt_50))
             # 15m & 4h down move, 1h downtrend
             & ((rsi_3_15m_gt_5) | (rsi_3_4h_gt_10) | (roc_9_1h > -20.0))
             # 15m & 4h down move, 15m still high
-            & ((rsi_3_15m_gt_5) | (rsi_3_4h_gt_15) | (stochrsi_k_15m < 50.0))
+            & ((rsi_3_15m_gt_5) | (rsi_3_4h_gt_15) | (stochrsi_k_15m_lt_50))
             # 15m & 4h down move, 4h still high
             & ((rsi_3_15m_gt_5) | rsi_3_4h_gt_20 | (aroonu_14_4h_lt_50))
             # 15m & 4h down move, 1d high
@@ -17890,7 +17921,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 4h high & overbought
             & ((rsi_3_15m_gt_5) | aroonu_14_4h_lt_80 | (roc_9_4h < 50.0))
             # 15m down move, 1d still high, 1d downtrend
-            & ((rsi_3_15m_gt_5) | (stochrsi_k_1d < 50.0) | (roc_9_1d_gt_neg_20))
+            & ((rsi_3_15m_gt_5) | (stochrsi_k_1d_lt_50) | (roc_9_1d_gt_neg_20))
             # 15m down move, 1d downtrend
             & ((rsi_3_15m_gt_5) | (roc_9_1d > -60.0))
             # 15m down move, 1h & 1d high
@@ -17898,7 +17929,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 15m high
             & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_10) | (aroonu_14_15m_lt_70))
             # 15m & 1h down move, 1h still high
-            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_15) | (stochrsi_k_1h < 40.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_15) | (stochrsi_k_1h_lt_40))
             # 15m & 1h down move, 1d high
             & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_15) | (stochrsi_k_1d_lt_90))
             # 15m & 1h down move, 4h downtrend
@@ -17920,19 +17951,19 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 4h overbought
             & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_25) | (roc_9_4h_lt_20))
             # 15m & 1h down move, 1h high
-            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_30) | (stochrsi_k_1h < 60.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_30) | (stochrsi_k_1h_lt_60))
             # 15m & 1h down move, 1d high
             & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_40) | (aroonu_14_1d_lt_90))
             # 15m & 1h down move, 1h high
-            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_40) | (stochrsi_k_1h < 90.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_40) | (stochrsi_k_1h_lt_90))
             # 15m & 1h down move, 4h high
             & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_50) | (stochrsi_k_4h_lt_90))
             # 15m & 4h down move, 15m still high
-            & ((rsi_3_15m_gt_10) | (rsi_3_4h_gt_10) | (stochrsi_k_15m < 40.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_4h_gt_10) | (stochrsi_k_15m_lt_40))
             # 15m & 4h down move, 4h still high
-            & ((rsi_3_15m_gt_10) | (rsi_3_4h_gt_10) | (stochrsi_k_4h < 40.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_4h_gt_10) | (stochrsi_k_4h_lt_40))
             # 15m & 4h down move, 1h high
-            & ((rsi_3_15m_gt_10) | (rsi_3_4h_gt_15) | (stochrsi_k_1h < 90.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_4h_gt_15) | (stochrsi_k_1h_lt_90))
             # 15m & 4h down move, 1d downtrend
             & ((rsi_3_15m_gt_10) | (rsi_3_4h_gt_15) | (roc_9_1d > -20.0))
             # 15m & 4h down move, 4h still high
@@ -18010,7 +18041,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 4h high & overbought
             & ((rsi_3_15m_gt_20) | aroonu_14_4h_lt_80 | (roc_9_4h_lt_10))
             # 15m & 1h down move, 15m high
-            & ((rsi_3_15m_gt_25) | (rsi_3_1h_gt_25) | (stochrsi_k_15m < 70.0))
+            & ((rsi_3_15m_gt_25) | (rsi_3_1h_gt_25) | (stochrsi_k_15m_lt_70))
             # 15m & 1h down move, 1h downtrend
             & ((rsi_3_15m_gt_25) | (rsi_3_1h_gt_25) | (roc_9_1h > -30.0))
             # 15m & 4h down move, 15m & 4h high
@@ -18018,7 +18049,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 1d high & overbought
             & ((rsi_3_15m_gt_30) | aroonu_14_1d_lt_100 | roc_9_1d_lt_50)
             # 1h & 4h down move, 1d still high
-            & ((rsi_3_1h_gt_3) | (rsi_3_4h_gt_10) | (stochrsi_k_1d < 40.0))
+            & ((rsi_3_1h_gt_3) | (rsi_3_4h_gt_10) | (stochrsi_k_1d_lt_40))
             # 1h & 4h down move, 4h still high
             & ((rsi_3_1h_gt_3) | (rsi_3_4h_gt_15) | (aroonu_14_4h_lt_40))
             # 1h & 4h down move, 1d still high
@@ -18058,7 +18089,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 1d down move, 4h high
             & ((rsi_3_1h_gt_10) | (rsi_3_1d_gt_15) | (stochrsi_k_4h_lt_70))
             # 1h & 1d down move, 1d still high
-            & ((rsi_3_1h_gt_10) | (rsi_3_1d_gt_30) | (stochrsi_k_1d < 50.0))
+            & ((rsi_3_1h_gt_10) | (rsi_3_1d_gt_30) | (stochrsi_k_1d_lt_50))
             # 1h down move, 15m downtrend, 1d high
             & ((rsi_3_1h_gt_10) | (cmf_20_15m > -0.40) | (aroonu_14_1d_lt_70))
             # 1h down move, 1h high, 4h overbought
@@ -18066,7 +18097,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1d high, 1d downtrend
             & ((rsi_3_1h_gt_10) | (aroonu_14_1d_lt_70) | (roc_9_1d > -20.0))
             # 1h down move, 4h high, 1d downtrend
-            & ((rsi_3_1h_gt_10) | (stochrsi_k_4h < 60.0) | (roc_9_1d > -30.0))
+            & ((rsi_3_1h_gt_10) | (stochrsi_k_4h_lt_60) | (roc_9_1d > -30.0))
             # 1h & 4h down move, 1h still not low enough
             & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_15) | (aroonu_14_1h < 20.0))
             # 1h & 4h down move, 4h high
@@ -18118,7 +18149,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1d high, 4h downtrend
             & ((rsi_3_1h_gt_25) | (aroonu_14_1d_lt_80) | (roc_9_4h > -70.0))
             # 1h down move, 4h high, 1d downtrend
-            & ((rsi_3_1h_gt_25) | (stochrsi_k_4h < 80.0) | (roc_9_1d_gt_neg_30))
+            & ((rsi_3_1h_gt_25) | (stochrsi_k_4h_lt_80) | (roc_9_1d_gt_neg_30))
             # 1h down move, 4h & 1d downtrend
             & ((rsi_3_1h_gt_25) | (roc_9_4h_gt_neg_30) | (roc_9_1d > -60.0))
             # 1h & 4h down move, 1h high
@@ -18146,7 +18177,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1d high & overbought
             & ((rsi_3_1h_gt_35) | (aroonu_14_1d_lt_100) | (roc_9_1d < 200.0))
             # 1h down move, 1h high, 4h downtrend
-            & ((rsi_3_1h_gt_35) | (stochrsi_k_1h < 70.0) | (roc_9_4h_gt_neg_20))
+            & ((rsi_3_1h_gt_35) | (stochrsi_k_1h_lt_70) | (roc_9_4h_gt_neg_20))
             # 1h & 1d down move, 1h high
             & ((rsi_3_1h_gt_40) | (rsi_3_1d_gt_40) | (aroonu_14_1h_lt_90))
             # 1h down move, 1h high, 1d downtrend
@@ -18156,9 +18187,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 4h high & overbought
             & ((rsi_3_1h_gt_40) | (aroonu_14_4h_lt_90) | (roc_9_4h_lt_20))
             # 1h down move, 1h high, 4h overbought
-            & ((rsi_3_1h_gt_40) | (stochrsi_k_1h < 80.0) | (roc_9_4h_lt_20))
+            & ((rsi_3_1h_gt_40) | (stochrsi_k_1h_lt_80) | (roc_9_4h_lt_20))
             # 1h down move, 4h high & overbought
-            & ((rsi_3_1h_gt_40) | (stochrsi_k_4h < 80.0) | (roc_9_4h_lt_20))
+            & ((rsi_3_1h_gt_40) | (stochrsi_k_4h_lt_80) | (roc_9_4h_lt_20))
             # 1h down move, 1d high, 4h overbought
             & ((rsi_3_1h_gt_45) | aroonu_14_1d_lt_100 | (roc_9_4h_lt_40))
             # 1h down move, 1h high, 1d downtrend
@@ -18166,15 +18197,15 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h & 1d high
             & ((rsi_3_1h_gt_50) | aroonu_14_1h_lt_80 | aroonu_14_1d_lt_100)
             # 4h & 1d down move, 15m still high
-            & ((rsi_3_4h_gt_3) | (rsi_3_1d_gt_15) | (stochrsi_k_15m < 40.0))
+            & ((rsi_3_4h_gt_3) | (rsi_3_1d_gt_15) | (stochrsi_k_15m_lt_40))
             # 4h & 1d down move, 1h still not low enough
-            & ((rsi_3_4h_gt_3) | (rsi_3_1d_gt_15) | (stochrsi_k_1h < 30.0))
+            & ((rsi_3_4h_gt_3) | (rsi_3_1d_gt_15) | (stochrsi_k_1h_lt_30))
             # 4h down move, 4h still high
             & ((rsi_3_4h_gt_3) | (aroonu_14_4h_lt_50))
             # 4h down move, 1h still high, 4h downtrend
             & ((rsi_3_4h_gt_3) | (stochrsi_k_1h_lt_50) | (roc_9_4h_gt_neg_30))
             # 4h & 1d down move, 1d still high
-            & ((rsi_3_4h_gt_5) | (rsi_3_1d_gt_30) | (stochrsi_k_1d < 40.0))
+            & ((rsi_3_4h_gt_5) | (rsi_3_1d_gt_30) | (stochrsi_k_1d_lt_40))
             # 4h down move, 1h & 4h downtrend
             & ((rsi_3_4h_gt_5) | (roc_9_1h > -10.0) | (roc_9_4h > -10.0))
             # 4h & 1d down move, 4h downtrend
@@ -18186,13 +18217,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 1d still high, 1d downtrend
             & ((rsi_3_4h_gt_10) | (aroonu_14_1d < 50.0) | (roc_9_1d > -30.0))
             # 4h down move, 4h still not low enough, 1d downtrend
-            & ((rsi_3_4h_gt_10) | (stochrsi_k_4h < 30.0) | (roc_9_1d > -20.0))
+            & ((rsi_3_4h_gt_10) | (stochrsi_k_4h_lt_30) | (roc_9_1d > -20.0))
             # 4h down move, 4h & 1d  downtrend
             & ((rsi_3_4h_gt_10) | (roc_9_4h > -20.0) | (roc_9_1d > -30.0))
             # 4h down move, 1h still high
             & ((rsi_3_4h_gt_15) | (aroonu_14_1h_lt_50))
             # 4h down move, 1h still high, 1d downtrend
-            & ((rsi_3_4h_gt_15) | (stochrsi_k_1h < 50.0) | (roc_9_1d > -30.0))
+            & ((rsi_3_4h_gt_15) | (stochrsi_k_1h_lt_50) | (roc_9_1d > -30.0))
             # 4h down move, 4h still high, 1d downtrend
             & ((rsi_3_4h_gt_15) | (stochrsi_k_4h_lt_50) | (roc_9_1d > -20.0))
             # 4h down move, 4h still high, 1d downtrend
@@ -18204,7 +18235,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 4h still high, 1d downtrend
             & ((rsi_3_4h_gt_30) | (aroonu_14_4h_lt_50) | (roc_9_1d_gt_neg_40))
             # 4h down move, 1d high, 1d downtrend
-            & ((rsi_3_4h_gt_35) | (stochrsi_k_1d < 60.0) | (roc_9_1d_gt_neg_30))
+            & ((rsi_3_4h_gt_35) | (stochrsi_k_1d_lt_60) | (roc_9_1d_gt_neg_30))
             # 4h down move, 1d high, 1d downtrend
             & ((rsi_3_4h_gt_45) | (aroonu_14_1d_lt_80) | (roc_9_1d > -15.0))
             # 4h down move, 4h still high, 1d downtrend
@@ -18212,7 +18243,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1d down move, 4h high, 1d downtrend
             & ((rsi_3_1d_gt_15) | (stochrsi_k_4h_lt_70) | (roc_9_1d > -70.0))
             # 1d down move, 1h high & overbought
-            & ((rsi_3_1d_gt_35) | (stochrsi_k_1h < 90.0) | (roc_9_1h_lt_10))
+            & ((rsi_3_1d_gt_35) | (stochrsi_k_1h_lt_90) | (roc_9_1h_lt_10))
             # 1d down move, 1h high & overbought
             & ((rsi_3_1d_gt_40) | (aroonu_14_1d_lt_70) | (roc_9_1d_lt_80))
             # 4h downtrend, 1h & 4h high
@@ -18260,7 +18291,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h high, 4h overbought
             & ((stochrsi_k_1h_lt_80) | (roc_9_4h < 80.0))
             # 1h high, 4h & 1d downtrend
-            & ((stochrsi_k_1h < 85.0) | (roc_9_4h > -70.0) | (roc_9_1d > -70.0))
+            & ((stochrsi_k_1h_lt_85) | (roc_9_4h > -70.0) | (roc_9_1d > -70.0))
             # 4h high, 1h & 4h overbought
             & ((stochrsi_k_4h_lt_80) | (roc_9_1h < 40.0) | (roc_9_4h < 100.0))
             # 1d high, 4h & 1d overbought
@@ -18272,7 +18303,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # big drop in last hour, 4h high
             & ((close > (close_max_12 * 0.60)) | (aroonu_14_4h_lt_70))
             # big drop in the last 20 days, 1d high, 1d downtrend
-            & ((close > (high_max_20_1d * 0.20)) | (stochrsi_k_1d < 70.0) | (roc_9_1d > -15.0))
+            & ((close > (high_max_20_1d * 0.20)) | (stochrsi_k_1d_lt_70) | (roc_9_1d > -15.0))
           )
 
           # Logic
@@ -18317,7 +18348,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 4h down move, 1h still high
             & ((rsi_3_15m_gt_3) | (rsi_3_4h_gt_15) | (aroonu_14_1h_lt_50))
             # 15m & 4h down move, 1h still high
-            & ((rsi_3_15m_gt_3) | (rsi_3_4h_gt_40) | (stochrsi_k_1h < 40.0))
+            & ((rsi_3_15m_gt_3) | (rsi_3_4h_gt_40) | (stochrsi_k_1h_lt_40))
             # 15m down move, 1h still high, 1d overbought
             & ((rsi_3_15m_gt_3) | (aroonu_14_1h < 40.0) | (roc_9_1d < 70.0))
             # 15m down move, 4h high & overbought
@@ -18331,7 +18362,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 1h downtrend
             & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_10) | (roc_9_1h > -20.0))
             # 15m & 4h down move, 1h still not low enough
-            & ((rsi_3_15m_gt_10) | (rsi_3_4h_gt_10) | (stochrsi_k_1h < 30.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_4h_gt_10) | (stochrsi_k_1h_lt_30))
             # 15m down move, 4h overbought
             & ((rsi_3_15m_gt_10) | (roc_9_4h_lt_30))
             # 15m & 4h down move, 4h high
@@ -18351,11 +18382,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 1d still high
             & ((rsi_3_1h_gt_3) | (rsi_3_4h_gt_10) | (aroonu_14_1d < 50.0))
             # 1h & 4h down move, 1d high
-            & ((rsi_3_1h_gt_3) | (rsi_3_4h_gt_10) | (stochrsi_k_1d < 60.0))
+            & ((rsi_3_1h_gt_3) | (rsi_3_4h_gt_10) | (stochrsi_k_1d_lt_60))
             # 1h & 4h down move, 1d high
             & ((rsi_3_1h_gt_3) | (rsi_3_4h_gt_20) | (aroonu_14_1d < 60.0))
             # 1h & 4h down move, 4h high
-            & ((rsi_3_1h_gt_3) | (rsi_3_4h_gt_20) | (stochrsi_k_4h < 60.0))
+            & ((rsi_3_1h_gt_3) | (rsi_3_4h_gt_20) | (stochrsi_k_4h_lt_60))
             # 1h & 4h down move, 1h & 4h still high
             & ((rsi_3_1h_gt_3) | (rsi_3_4h_gt_35) | (aroonu_14_1h < 40.0) | (aroonu_14_4h_lt_40))
             # 1h down move, 1h & 4h still high
@@ -18435,7 +18466,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 4h overbought
             & ((rsi_3_1h_gt_10) | (roc_9_4h_lt_10))
             # 1h down move, 4h high & overbought
-            & ((rsi_3_1h_gt_10) | (stochrsi_k_4h < 80.0) | (roc_9_4h < 20.0))
+            & ((rsi_3_1h_gt_10) | (stochrsi_k_4h_lt_80) | (roc_9_4h < 20.0))
             # 1h down move, 4h & 1d downtrend
             & ((rsi_3_1h_gt_10) | (roc_9_4h_gt_neg_30) | roc_9_1d_gt_neg_50)
             # 1h & 4h down move, 4h high
@@ -18489,11 +18520,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 4h still high, 1d high
             & ((rsi_3_4h_gt_3) | (aroonu_14_4h_lt_50) | aroonu_14_1d_lt_100)
             # 4h down move, 1d still high, 4h downtrend
-            & ((rsi_3_4h_gt_3) | (stochrsi_k_1d < 50.0) | (roc_9_4h_gt_neg_30))
+            & ((rsi_3_4h_gt_3) | (stochrsi_k_1d_lt_50) | (roc_9_4h_gt_neg_30))
             # 4h down move, 1d overbought
             & ((rsi_3_4h_gt_3) | (roc_9_1d < 200.0))
             # 4h down move, 1h still high
-            & ((rsi_3_4h_gt_5) | (stochrsi_k_1h < 40.0))
+            & ((rsi_3_4h_gt_5) | (stochrsi_k_1h_lt_40))
             # 4h down move, 1h & 4h downtrend
             & ((rsi_3_4h_gt_5) | (roc_9_1h > -15.0) | (roc_9_4h_gt_neg_20))
             # 4h down move, 4h downtrend
@@ -18571,7 +18602,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1d high, 4h & 1d overbought
             & (aroonu_14_1d_lt_100 | (roc_9_4h < 20.0) | (roc_9_1d_lt_80))
             # 1h still high, 4h & 1d downtrend
-            & ((stochrsi_k_1h < 50.0) | (roc_9_4h_gt_neg_20) | roc_9_1d_gt_neg_50)
+            & ((stochrsi_k_1h_lt_50) | (roc_9_4h_gt_neg_20) | roc_9_1d_gt_neg_50)
             # 1h high, 15m downtrend
             & ((stochrsi_k_1h_lt_70) | (roc_9_15m > -30.0))
             # 4h high, 1d downtrend
@@ -18579,13 +18610,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1d high, 1h downtrend
             & ((stochrsi_k_1d_lt_90) | (roc_9_1h > -20.0))
             # 1d high, 1d downtrend
-            & ((stochrsi_k_1d < 60.0) | (roc_9_1d_gt_neg_30))
+            & ((stochrsi_k_1d_lt_60) | (roc_9_1d_gt_neg_30))
             # 15m downtrend, 1d overbought
             & ((roc_9_15m > -60.0) | (roc_9_1d < 200.0))
             # 1h downtrend, 1d overbought
             & ((roc_9_1h > -60.0) | (roc_9_1d < 200.0))
             # big drop in the last 20 days, 1d high, 1d downtrend
-            & ((close > (high_max_20_1d * 0.20)) | (stochrsi_k_1d < 70.0) | (roc_9_1d > -15.0))
+            & ((close > (high_max_20_1d * 0.20)) | (stochrsi_k_1d_lt_70) | (roc_9_1d > -15.0))
           )
 
           # Logic
@@ -18593,7 +18624,7 @@ class NostalgiaForInfinityX7(IStrategy):
             (rsi_3 < 40.0)
             & (rsi_3_15m < 50.0)
             & (aroonu_14_15m < 25.0)
-            & (stochrsi_k_15m < 20.0)
+            & (stochrsi_k_15m_lt_20)
             & (df["EMA_26_15m"] > df["EMA_12_15m"])
             & ((df["EMA_26_15m"] - df["EMA_12_15m"]) > (df["open_15m"] * 0.050))
             & ((df["EMA_26_15m"].shift() - df["EMA_12_15m"].shift()) > (df["open_15m"] / 100.0))
@@ -18608,11 +18639,11 @@ class NostalgiaForInfinityX7(IStrategy):
           # 5m & 15m down move, 4h still high
           long_entry_logic.append((rsi_3_gt_3) | (rsi_3_15m_gt_15) | (stochrsi_k_4h_lt_50))
           # 15m & 1h down move, 1h still high
-          long_entry_logic.append(rsi_3_15m_gt_3 | (rsi_3_1h_gt_25) | (stochrsi_k_1h < 40.0))
+          long_entry_logic.append(rsi_3_15m_gt_3 | (rsi_3_1h_gt_25) | (stochrsi_k_1h_lt_40))
           # 5m & 4h & 1d down move
           long_entry_logic.append((rsi_3_gt_3) | rsi_3_4h_gt_20 | (rsi_3_1d_gt_20))
           # 15m & 1h down move, 4h high
-          long_entry_logic.append(rsi_3_15m_gt_3 | (rsi_3_1h_gt_30) | (stochrsi_k_4h < 60.0))
+          long_entry_logic.append(rsi_3_15m_gt_3 | (rsi_3_1h_gt_30) | (stochrsi_k_4h_lt_60))
           # 15m & 4h down move
           long_entry_logic.append(rsi_3_15m_gt_3 | (rsi_3_4h_gt_10))
           # 15m & 4h down move, 4h still not low enough
@@ -18636,11 +18667,11 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m & 1h down move, 1h high
           long_entry_logic.append((rsi_3_15m_gt_10) | (rsi_3_1h_gt_65) | (stochrsi_k_1h_lt_80))
           # 15m & 4h down move, 4h still not low enough
-          long_entry_logic.append((rsi_3_15m_gt_10) | (rsi_3_4h_gt_10) | (stochrsi_k_4h < 30.0))
+          long_entry_logic.append((rsi_3_15m_gt_10) | (rsi_3_4h_gt_10) | (stochrsi_k_4h_lt_30))
           # 15m & 4h down move, 1d high
-          long_entry_logic.append((rsi_3_15m_gt_10) | (rsi_3_4h_gt_10) | (stochrsi_k_1d < 80.0))
+          long_entry_logic.append((rsi_3_15m_gt_10) | (rsi_3_4h_gt_10) | (stochrsi_k_1d_lt_80))
           # 15m & 4h down move, 4h still high
-          long_entry_logic.append((rsi_3_15m_gt_10) | (rsi_3_4h_gt_30) | (stochrsi_k_4h < 40.0))
+          long_entry_logic.append((rsi_3_15m_gt_10) | (rsi_3_4h_gt_30) | (stochrsi_k_4h_lt_40))
           # 15m down move, 1h & 4h high
           long_entry_logic.append((rsi_3_15m_gt_10) | aroonu_14_1h_lt_70 | aroonu_14_4h_lt_100)
           # 15m down move, 1h high & overbought
@@ -18654,7 +18685,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m & 1h down move, 4h high
           long_entry_logic.append((rsi_3_15m_gt_15) | (rsi_3_1h_gt_15) | aroonu_14_4h_lt_70)
           # 15m down move, 1h & 4h high
-          long_entry_logic.append((rsi_3_15m_gt_15) | aroonu_14_1h_lt_70 | (stochrsi_k_4h < 90.0))
+          long_entry_logic.append((rsi_3_15m_gt_15) | aroonu_14_1h_lt_70 | (stochrsi_k_4h_lt_90))
           # 15m down move, 4h high, 1d overbought
           long_entry_logic.append((rsi_3_15m_gt_15) | aroonu_14_4h_lt_70 | roc_9_1d_lt_50)
           # 15m & 1h down move, 1d overbought
@@ -18670,11 +18701,11 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1h down move, 1h still not low enough
           long_entry_logic.append((rsi_3_1h_gt_5) | (aroonu_14_1h < 30.0))
           # 1h down move, 1h still not low enough
-          long_entry_logic.append((rsi_3_1h_gt_5) | (stochrsi_k_1h < 25.0))
+          long_entry_logic.append((rsi_3_1h_gt_5) | (stochrsi_k_1h_lt_25))
           # 1h & 4h down move
           long_entry_logic.append((rsi_3_1h_gt_10) | (rsi_3_4h_gt_15))
           # 1h & 4h down move, 4h still not low enough
-          long_entry_logic.append((rsi_3_1h_gt_10) | rsi_3_4h_gt_20 | (stochrsi_k_4h < 30.0))
+          long_entry_logic.append((rsi_3_1h_gt_10) | rsi_3_4h_gt_20 | (stochrsi_k_4h_lt_30))
           # 1h & 4h down move, 4h still high
           long_entry_logic.append((rsi_3_1h_gt_10) | (rsi_3_4h_gt_25) | (aroonu_14_4h_lt_50))
           # 1h & 4h down move, 4h still not low enough
@@ -18688,13 +18719,13 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1h & 1d down move, 4h still high
           long_entry_logic.append((rsi_3_1h_gt_10) | (rsi_3_1d_gt_30) | (aroonu_14_4h_lt_50))
           # 15m & 1d down move, 1d high
-          long_entry_logic.append((rsi_3_15m_gt_10) | (rsi_3_1d_gt_30) | (stochrsi_k_1d < 70.0))
+          long_entry_logic.append((rsi_3_15m_gt_10) | (rsi_3_1d_gt_30) | (stochrsi_k_1d_lt_70))
           # 1h & 4h down move, 4h still not low enough
-          long_entry_logic.append((rsi_3_1h_gt_3) | (rsi_3_4h_gt_25) | (stochrsi_k_4h < 30.0))
+          long_entry_logic.append((rsi_3_1h_gt_3) | (rsi_3_4h_gt_25) | (stochrsi_k_4h_lt_30))
           # 1h down move, 1h still not low enough, 1d high
-          long_entry_logic.append((rsi_3_1h_gt_10) | (stochrsi_k_1h < 20.0) | (aroonu_14_1d < 85.0))
+          long_entry_logic.append((rsi_3_1h_gt_10) | (stochrsi_k_1h_lt_20) | (aroonu_14_1d < 85.0))
           # 1h down move, 1h still not low enough
-          long_entry_logic.append((rsi_3_1h_gt_10) | (stochrsi_k_1h < 25.0))
+          long_entry_logic.append((rsi_3_1h_gt_10) | (stochrsi_k_1h_lt_25))
           # 1h down move, 4h high
           long_entry_logic.append((rsi_3_1h_gt_10) | (aroonu_14_4h < 85.0))
           # 1h down move, 1d high & overbought
@@ -18704,7 +18735,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1h & 4h down move, 4h still high
           long_entry_logic.append((rsi_3_1h_gt_15) | (rsi_3_4h_gt_15) | (aroonu_14_4h_lt_40))
           # 1h & 4h down move, 1d high
-          long_entry_logic.append((rsi_3_1h_gt_15) | rsi_3_4h_gt_20 | (stochrsi_k_1d < 70.0))
+          long_entry_logic.append((rsi_3_1h_gt_15) | rsi_3_4h_gt_20 | (stochrsi_k_1d_lt_70))
           # 1h & 4h & 1d down move
           long_entry_logic.append((rsi_3_1h_gt_15) | rsi_3_4h_gt_20 | (rsi_3_1d_gt_30))
           # 1h & 4h down move, 1d high
@@ -18714,7 +18745,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1h down move, 1d high, 4h downtrend
           long_entry_logic.append((rsi_3_1h_gt_15) | (aroonu_14_1d_lt_70) | (roc_9_4h > -20.0))
           # 1h down move, 1h still high
-          long_entry_logic.append((rsi_3_1h_gt_15) | (stochrsi_k_1h < 30.0))
+          long_entry_logic.append((rsi_3_1h_gt_15) | (stochrsi_k_1h_lt_30))
           # 1h & 4h down move, 1d overbought
           long_entry_logic.append(rsi_3_1h_gt_20 | rsi_3_4h_gt_20 | (roc_9_1d_lt_20))
           # 1h down move, 4h high
@@ -18722,7 +18753,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1h down move, 4h still high
           long_entry_logic.append(rsi_3_1h_gt_20 | (stochrsi_k_4h_lt_50))
           # 1h & 4h down move, 1h high
-          long_entry_logic.append((rsi_3_1h_gt_25) | (rsi_3_4h_gt_30) | (stochrsi_k_1h < 60.0))
+          long_entry_logic.append((rsi_3_1h_gt_25) | (rsi_3_4h_gt_30) | (stochrsi_k_1h_lt_60))
           # 1h & 4h down move, 4h high
           long_entry_logic.append((rsi_3_1h_gt_25) | (rsi_3_4h_gt_40) | aroonu_14_4h_lt_70)
           # 1h down move, 1h high
@@ -18740,7 +18771,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1h down move, 4h high
           long_entry_logic.append((rsi_3_1h_gt_30) | (stochrsi_k_4h_lt_80))
           # 1h down move, 4h & 1d high
-          long_entry_logic.append((rsi_3_1h_gt_35) | (stochrsi_k_4h_lt_80) | (stochrsi_k_1d < 80.0))
+          long_entry_logic.append((rsi_3_1h_gt_35) | (stochrsi_k_4h_lt_80) | (stochrsi_k_1d_lt_80))
           # 1h down move, 1h still high, 1d overbought
           long_entry_logic.append((rsi_3_1h_gt_40) | (aroonu_14_1h_lt_50) | roc_9_1d_lt_50)
           # 1h down move, 1h & 4h high
@@ -18750,11 +18781,11 @@ class NostalgiaForInfinityX7(IStrategy):
           # 4h down move, 1d high
           long_entry_logic.append((rsi_3_4h_gt_5) | aroonu_14_1d_lt_100)
           # 4h & 1d down move, 1d still high
-          long_entry_logic.append((rsi_3_4h_gt_10) | (rsi_3_1d_gt_25) | (stochrsi_k_1d < 50.0))
+          long_entry_logic.append((rsi_3_4h_gt_10) | (rsi_3_1d_gt_25) | (stochrsi_k_1d_lt_50))
           # 4h downmove, 4h still high
           long_entry_logic.append((rsi_3_4h_gt_10) | (aroonu_14_4h_lt_40))
           # 4h down move, 1h still high, 1d downtrend
-          long_entry_logic.append((rsi_3_4h_gt_10) | (stochrsi_k_1h < 40.0) | (roc_9_1d > -20.0))
+          long_entry_logic.append((rsi_3_4h_gt_10) | (stochrsi_k_1h_lt_40) | (roc_9_1d > -20.0))
           # 4h down move, 1h & 1d downtrend
           long_entry_logic.append((rsi_3_4h_gt_10) | (roc_9_1h > -20.0) | (roc_9_1d > -20.0))
           # 4h & 1d down move, 1d still high
@@ -18780,13 +18811,13 @@ class NostalgiaForInfinityX7(IStrategy):
           # 4h down move, 4h high
           long_entry_logic.append((rsi_3_4h_gt_60) | (stochrsi_k_4h_lt_80))
           # 1d down move, 1h still not low enough
-          long_entry_logic.append((rsi_3_1d_gt_5) | (stochrsi_k_1h < 30.0))
+          long_entry_logic.append((rsi_3_1d_gt_5) | (stochrsi_k_1h_lt_30))
           # 1d down move, 1h still not low enough
-          long_entry_logic.append((rsi_3_1d_gt_15) | (stochrsi_k_1h < 30.0))
+          long_entry_logic.append((rsi_3_1d_gt_15) | (stochrsi_k_1h_lt_30))
           # 1d down move, 4h still high
           long_entry_logic.append((rsi_3_1d_gt_15) | (stochrsi_k_4h_lt_50))
           # 1d down move, 1h high & overbought
-          long_entry_logic.append((rsi_3_1d_gt_35) | (stochrsi_k_1h < 90.0) | (roc_9_1h_lt_10))
+          long_entry_logic.append((rsi_3_1d_gt_35) | (stochrsi_k_1h_lt_90) | (roc_9_1h_lt_10))
           # 15m still high, 1h & 4h high
           long_entry_logic.append((rsi_14_15m < 40.0) | aroonu_14_1h_lt_80 | (aroonu_14_4h_lt_90))
           # 1h & 4h high, 4h overbought
@@ -18846,14 +18877,14 @@ class NostalgiaForInfinityX7(IStrategy):
           # big drop in the last 20 days, 1h down move
           long_entry_logic.append((close > (high_max_20_1d * 0.10)) | rsi_3_1h_gt_20)
           # big drop in the last 20 days, 1d high, 1d downtrend
-          long_entry_logic.append((close > (high_max_20_1d * 0.20)) | (stochrsi_k_1d < 70.0) | (roc_9_1d > -15.0))
+          long_entry_logic.append((close > (high_max_20_1d * 0.20)) | (stochrsi_k_1d_lt_70) | (roc_9_1d > -15.0))
           # big drop in the last 30 days, 4h down move, 4h still high
           long_entry_logic.append((close > (high_max_30_1d * 0.25)) | (rsi_3_4h_gt_45) | (rsi_14_4h < 40.0))
 
           # Logic
           long_entry_logic.append(rsi_3 < 50.0)
           long_entry_logic.append(aroonu_14_15m < 25.0)
-          long_entry_logic.append(stochrsi_k_15m < 20.0)
+          long_entry_logic.append(stochrsi_k_15m_lt_20)
           long_entry_logic.append(df["close_15m"] < (df["EMA_20_15m"] * 0.924))
 
         # Condition #46 - Quick mode (Long).
@@ -18882,7 +18913,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 1h still high
             & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_20) | (aroonu_14_1h < 40.0))
             # 15m & 1h down move, 4h still high
-            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_25) | (stochrsi_k_4h < 40.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_25) | (stochrsi_k_4h_lt_40))
             # 15m & 4h down move, 1d high
             & ((rsi_3_15m_gt_10) | (rsi_3_4h_gt_15) | (stochrsi_k_1d_lt_90))
             # 15m & 4h down move, 4h downtrend
@@ -18890,7 +18921,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 4h down move, 4h still high
             & ((rsi_3_15m_gt_10) | (rsi_3_4h_gt_20) | (aroonu_14_4h_lt_50))
             # 15m & 4h down move, 4h still not low enough
-            & ((rsi_3_15m_gt_10) | (rsi_3_4h_gt_20) | (stochrsi_k_4h < 30.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_4h_gt_20) | (stochrsi_k_4h_lt_30))
             # 15m & 4h down move, 1d high
             & ((rsi_3_15m_gt_10) | (rsi_3_4h_gt_30) | (stochrsi_k_1d_lt_90))
             # 15m down move, 4h still high, 1d high
@@ -18924,13 +18955,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 4h downtrend
             & ((rsi_3_1h_gt_5) | (rsi_3_4h_gt_15) | (roc_9_4h_gt_neg_30))
             # 1h & 4h down move, 4h still not low enough
-            & ((rsi_3_1h_gt_5) | (rsi_3_4h_gt_30) | (stochrsi_k_4h < 30.0))
+            & ((rsi_3_1h_gt_5) | (rsi_3_4h_gt_30) | (stochrsi_k_4h_lt_30))
             # 1h & 1d down move, 1d high
             & ((rsi_3_1h_gt_5) | (rsi_3_1d_gt_45) | (aroonu_14_1d_lt_80))
             # 1h down move, 4h high
             & ((rsi_3_1h_gt_5) | aroonu_14_4h_lt_70)
             # 1h down move, 1d still high
-            & ((rsi_3_1h_gt_5) | (stochrsi_k_1d < 50.0))
+            & ((rsi_3_1h_gt_5) | (stochrsi_k_1d_lt_50))
             # 1h & 4h down move, 4h still not low enough
             & ((rsi_3_1h_gt_10) | rsi_3_4h_gt_20 | (rsi_14_4h < 30.0))
             # 1h & 4h down move, 4h still not low enough
@@ -18944,9 +18975,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 4h high
             & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_45) | aroonu_14_4h_lt_70)
             # 1h & 4h down move, 4h still high
-            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_50) | (stochrsi_k_4h < 40.0))
+            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_50) | (stochrsi_k_4h_lt_40))
             # 1h & 1d down move, 4h still not low enough
-            & ((rsi_3_1h_gt_10) | (rsi_3_1d_gt_25) | (stochrsi_k_4h < 30.0))
+            & ((rsi_3_1h_gt_10) | (rsi_3_1d_gt_25) | (stochrsi_k_4h_lt_30))
             # 1h & 1d down move, 4h still high
             & ((rsi_3_1h_gt_10) | (rsi_3_1d_gt_30) | (aroonu_14_4h_lt_50))
             # 1h & 1d down move, 4h still high
@@ -18968,7 +18999,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h & 1d down move
             & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_25) | (rsi_3_1d_gt_25))
             # 1h & 4h down move, 1d high
-            & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_30) | (stochrsi_k_1d < 80.0))
+            & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_30) | (stochrsi_k_1d_lt_80))
             # 1h & 4h down move, 1h & 4h still high
             & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_40) | (rsi_14_1h < 40.0) | (rsi_14_4h < 50.0))
             # 1h & 4h down move, 4h still high
@@ -19004,15 +19035,15 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 4h still high, 1d high
             & (rsi_3_4h_gt_20 | (aroonu_14_4h_lt_50) | aroonu_14_1d_lt_100)
             # 1h down move, 4h still high, 1d downtrend
-            & (rsi_3_1h_gt_20 | (stochrsi_k_4h < 40.0) | (roc_9_1d > -25.0))
+            & (rsi_3_1h_gt_20 | (stochrsi_k_4h_lt_40) | (roc_9_1d > -25.0))
             # 1h down move, 4h & 1d high
-            & (rsi_3_1h_gt_20 | (stochrsi_k_4h_lt_50) | (stochrsi_k_1d < 80.0))
+            & (rsi_3_1h_gt_20 | (stochrsi_k_4h_lt_50) | (stochrsi_k_1d_lt_80))
             # 1h & 4h down move, 1h still high
             & ((rsi_3_1h_gt_25) | (rsi_3_4h_gt_35) | (aroonu_14_1h < 40.0))
             # 1h & 4h down move, 4h high
             & ((rsi_3_1h_gt_25) | (rsi_3_4h_gt_40) | aroonu_14_4h_lt_70)
             # 1h down move, 15m still not low enough, 4h high
-            & ((rsi_3_1h_gt_25) | (rsi_14_15m < 30.0) | (stochrsi_k_4h < 60.0))
+            & ((rsi_3_1h_gt_25) | (rsi_14_15m < 30.0) | (stochrsi_k_4h_lt_60))
             # 1h & 4h down move, 4h still high
             & ((rsi_3_1h_gt_25) | (rsi_3_4h_gt_35) | (stochrsi_k_4h_lt_50))
             # 1h down move, 1h high
@@ -19058,7 +19089,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h & 1d down move, 1d overbought
             & (rsi_3_4h_gt_20 | (rsi_3_1d_gt_45) | (roc_9_1d_lt_40))
             # 4h down move, 4h still not low enough, 1d downtrend
-            & (rsi_3_4h_gt_20 | (stochrsi_k_4h < 30.0) | (roc_9_1d_gt_neg_20))
+            & (rsi_3_4h_gt_20 | (stochrsi_k_4h_lt_30) | (roc_9_1d_gt_neg_20))
             # 4h down move, 4h & 1d downtrend
             & (rsi_3_4h_gt_20 | (roc_9_4h_gt_neg_20) | (roc_9_1d_gt_neg_20))
             # 4h down move, 4h high
@@ -19086,7 +19117,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h high, 4h overbought
             & ((stochrsi_k_4h_lt_70) | (roc_9_4h_lt_40))
             # 4h high, 4h overbought, 1d downtrend
-            & ((stochrsi_k_4h < 90.0) | (roc_9_4h_lt_20) | (roc_9_1d_gt_neg_20))
+            & ((stochrsi_k_4h_lt_90) | (roc_9_4h_lt_20) | (roc_9_1d_gt_neg_20))
             # 1d green, 4h down move, 4h still high
             & ((change_pct_1d < 40.0) | (rsi_3_4h_gt_35) | (aroonu_14_4h_lt_40))
             # 4h top wick, 1h down move, 1h still high
@@ -19118,7 +19149,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # big drop in the last 30 days, 4h down move
             & ((close > (high_max_30_1d * 0.40)) | (rsi_3_4h_gt_15))
             # big drop in the last 30 days, 4h still not low enough
-            & ((close > (high_max_30_1d * 0.25)) | (stochrsi_k_4h < 30.0))
+            & ((close > (high_max_30_1d * 0.25)) | (stochrsi_k_4h_lt_30))
           )
 
           # Logic
@@ -19127,9 +19158,9 @@ class NostalgiaForInfinityX7(IStrategy):
             & (rsi_3_15m < 50.0)
             & (df["WILLR_14_15m"] < -50.0)
             & (aroonu_14_15m < 25.0)
-            & (stochrsi_k_15m < 20.0)
+            & (stochrsi_k_15m_lt_20)
             & (willr_84_1h < -70.0)
-            & (stochrsi_k_1h < 20.0)
+            & (stochrsi_k_1h_lt_20)
             & (bbb_20_2_0_1h > 12.0)
             & (close_max_48 >= (close * 1.10))
           )
@@ -19156,7 +19187,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 4h still high
             & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_3) | (aroonu_14_4h_lt_40))
             # 15m & 1h down move, 4h still not low enough
-            & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_5) | (stochrsi_k_4h < 20.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_5) | (stochrsi_k_4h_lt_20))
             # 15m & 1h & 4h down move
             & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_10) | (rsi_3_4h_gt_3))
             # 15m & 1h down move, 1d still high
@@ -19164,7 +19195,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 4h downtrend
             & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_10) | (cmf_20_4h > -0.30))
             # 15m & 1h down move, 1d still high
-            & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_10) | (stochrsi_k_1d < 50.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_10) | (stochrsi_k_1d_lt_50))
             # 15m & 1h down move, 1d overbought
             & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_10) | (roc_9_1d_lt_40))
             # 15m & 1h down move, 1d overbought
@@ -19172,7 +19203,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 1d high
             & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_30) | (aroonu_14_1d_lt_80))
             # 15m & 1h down move, 1h still high
-            & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_30) | (stochrsi_k_1h < 40.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_30) | (stochrsi_k_1h_lt_40))
             # 15m & 1h down move, 1h high
             & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_45) | aroonu_14_1h_lt_80)
             # 15m & 1h down move, 1h high
@@ -19188,7 +19219,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 4h & 1d downtrend
             & (rsi_3_15m_gt_3 | (roc_9_4h_gt_neg_20) | (roc_9_1d_gt_neg_20))
             # 15m & 1h down move, 1h still high
-            & ((rsi_3_15m_gt_5) | rsi_3_1h_gt_20 | (stochrsi_k_1h < 40.0))
+            & ((rsi_3_15m_gt_5) | rsi_3_1h_gt_20 | (stochrsi_k_1h_lt_40))
             # 15m & 1h down move, 1h high
             & ((rsi_3_15m_gt_5) | (rsi_3_1h_gt_30) | (stochrsi_k_1h_lt_80))
             # 15m & 4h down move, 1h downtrend
@@ -19206,7 +19237,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 1h & 1d high
             & ((rsi_3_15m_gt_5) | (roc_9_1h_lt_10) | (roc_9_1d_lt_40))
             # 15m & 1h down move, 1d high
-            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_10) | (stochrsi_k_1d < 70.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_10) | (stochrsi_k_1d_lt_70))
             # 15m & 1h down move, 4h downtrend
             & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_10) | (roc_9_4h > -50.0))
             # 15m & 1h down move, 1d overbought
@@ -19216,7 +19247,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 4h overbought
             & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_30) | (roc_9_4h < 50.0))
             # 15m & 4h down move, 4h still not low enough
-            & ((rsi_3_15m_gt_10) | (rsi_3_4h_gt_10) | (stochrsi_k_4h < 30.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_4h_gt_10) | (stochrsi_k_4h_lt_30))
             # 15m & 4h down move, 4h still high, 1d high & overbought
             & ((rsi_3_15m_gt_10) | (rsi_3_4h_gt_15) | (aroonu_14_4h_lt_40) | (aroonu_14_1d_lt_70) | (roc_9_1d < 10.0))
             # 15m & 4h down move, 4h high
@@ -19232,7 +19263,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 1d high, 1d downtrend
             & ((rsi_3_15m_gt_10) | (aroonu_14_1d < 85.0) | (cmf_20_1d > -0.40))
             # 15m down move, 1h high & overbought
-            & ((rsi_3_15m_gt_10) | (stochrsi_k_1h < 90.0) | (roc_9_1h < 20.0))
+            & ((rsi_3_15m_gt_10) | (stochrsi_k_1h_lt_90) | (roc_9_1h < 20.0))
             # 15m down move, 4h high
             & ((rsi_3_15m_gt_10) | (stochrsi_k_4h_lt_70))
             # 15m down move, 4h & 1d overbought
@@ -19240,7 +19271,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 15m high
             & ((rsi_3_15m_gt_15) | (rsi_3_1h_gt_15) | (aroonu_14_15m < 60.0))
             # 15m & 1h down move, 1h still high
-            & ((rsi_3_15m_gt_15) | (rsi_3_1h_gt_15) | (stochrsi_k_1h < 50.0))
+            & ((rsi_3_15m_gt_15) | (rsi_3_1h_gt_15) | (stochrsi_k_1h_lt_50))
             # 15m & 1h down move, 1h high
             & ((rsi_3_15m_gt_15) | (rsi_3_1h_gt_25) | aroonu_14_1h_lt_80)
             # 15m & 1h down move, 1h high
@@ -19282,11 +19313,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 1h & 4h high
             & ((rsi_3_15m_gt_30) | (stochrsi_k_1h_lt_70) | (stochrsi_k_4h_lt_80))
             # 1h & 4h down move, 4h still not low enough
-            & ((rsi_3_1h_gt_3) | (rsi_3_4h_gt_5) | (stochrsi_k_4h < 20.0))
+            & ((rsi_3_1h_gt_3) | (rsi_3_4h_gt_5) | (stochrsi_k_4h_lt_20))
             # 1h & 4h down move, 15m stil high
-            & ((rsi_3_1h_gt_3) | (rsi_3_4h_gt_10) | (stochrsi_k_15m < 50.0))
+            & ((rsi_3_1h_gt_3) | (rsi_3_4h_gt_10) | (stochrsi_k_15m_lt_50))
             # 1h & 4h down move, 1d still high
-            & ((rsi_3_1h_gt_3) | (rsi_3_4h_gt_10) | (stochrsi_k_1d < 40.0))
+            & ((rsi_3_1h_gt_3) | (rsi_3_4h_gt_10) | (stochrsi_k_1d_lt_40))
             # 1h down move, 1h still not low enough
             & ((rsi_3_1h_gt_3) | (aroonu_14_1h < 20.0))
             # 1h & 4h down move, 1d downtrend
@@ -19296,7 +19327,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 1d high
             & ((rsi_3_1h_gt_5) | (rsi_3_4h_gt_15) | (roc_9_1d_lt_40))
             # 1h & 4h down move, 4h still not low enough
-            & ((rsi_3_1h_gt_5) | rsi_3_4h_gt_20 | (stochrsi_k_4h < 30.0))
+            & ((rsi_3_1h_gt_5) | rsi_3_4h_gt_20 | (stochrsi_k_4h_lt_30))
             # 1h down move, 4h high, 1d overbought
             & ((rsi_3_1h_gt_5) | (aroonu_14_4h_lt_60) | (roc_9_1d < 10.0))
             # 1h down move, 1d high, 4h downtrend
@@ -19304,7 +19335,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1d high, 1d downtrend
             & ((rsi_3_1h_gt_5) | aroonu_14_1d_lt_100 | (roc_9_1d > -20.0))
             # 1h & 4h down move, 1h still not low enough
-            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_10) | (stochrsi_k_1h < 20.0))
+            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_10) | (stochrsi_k_1h_lt_20))
             # 1h & 4h down move, 15m downtrend
             & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_10) | (roc_9_15m > -15.0))
             # 1h & 3h down move, 4h downtrend
@@ -19314,7 +19345,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 1d overbought
             & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_30) | (roc_9_1d_lt_80))
             # 1h down move, 15m still high, 4h high
-            & ((rsi_3_1h_gt_10) | (aroonu_14_15m < 40.0) | (stochrsi_k_4h < 90.0))
+            & ((rsi_3_1h_gt_10) | (aroonu_14_15m < 40.0) | (stochrsi_k_4h_lt_90))
             # 1h down move, 1d high & overbought
             & ((rsi_3_1h_gt_10) | (aroonu_14_1d < 100.0) | (roc_9_1d < 10.0))
             # 1h down move, 4h still high, 4d downtrend
@@ -19326,7 +19357,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 4h high
             & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_40) | (aroonu_14_4h < 80.0))
             # 1h down move, 1d downtrend, 1d high
-            & ((rsi_3_1h_gt_15) | (cmf_20_1d > -0.30) | (stochrsi_k_1d < 80.0))
+            & ((rsi_3_1h_gt_15) | (cmf_20_1d > -0.30) | (stochrsi_k_1d_lt_80))
             # 1h down move, 1h still high
             & ((rsi_3_1h_gt_15) | (aroonu_14_1h_lt_50))
             # 1h down move, 4h high, 1d overbought
@@ -19356,7 +19387,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h still high, 1d overbought
             & ((rsi_3_1h_gt_35) | (stochrsi_k_1h_lt_50) | (roc_9_1d < 200.0))
             # 1h down move, 1h high, 4h downtrend
-            & ((rsi_3_1h_gt_35) | (stochrsi_k_1h < 70.0) | (roc_9_4h_gt_neg_20))
+            & ((rsi_3_1h_gt_35) | (stochrsi_k_1h_lt_70) | (roc_9_4h_gt_neg_20))
             # 1h down move, 4h & 1d overbought
             & ((rsi_3_1h_gt_35) | (roc_9_4h_lt_20) | (roc_9_1d_lt_80))
             # 1h down move, 1h & 4h high
@@ -19364,17 +19395,17 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h high, 1d overbought
             & ((rsi_3_1h_gt_40) | (aroonu_14_1h < 85.0) | (roc_9_1d_lt_80))
             # 1h down move, 1h high, 4h downtrend
-            & ((rsi_3_1h_gt_40) | (stochrsi_k_1h < 80.0) | (roc_9_4h_gt_neg_20))
+            & ((rsi_3_1h_gt_40) | (stochrsi_k_1h_lt_80) | (roc_9_4h_gt_neg_20))
             # 1h down move, 1h high, 1h overbought
             & ((rsi_3_1h_gt_50) | aroonu_14_1h_lt_70 | (roc_9_1h < 25.0))
             # 1h down move, 4h high, 1d downtrend
-            & ((rsi_3_1h_gt_50) | (stochrsi_k_4h < 60.0) | (roc_9_1d > -60.0))
+            & ((rsi_3_1h_gt_50) | (stochrsi_k_4h_lt_60) | (roc_9_1d > -60.0))
             # 1h down move, 4h & 1d overbought
             & ((rsi_3_1h_gt_60) | (roc_9_4h_lt_30) | (roc_9_1d < 60.0))
             # 4h & 1d down move, 15m still high
-            & ((rsi_3_4h_gt_3) | (rsi_3_1d_gt_15) | (stochrsi_k_15m < 40.0))
+            & ((rsi_3_4h_gt_3) | (rsi_3_1d_gt_15) | (stochrsi_k_15m_lt_40))
             # 4h & 1d down move, 1h still not low enough
-            & ((rsi_3_4h_gt_3) | (rsi_3_1d_gt_15) | (stochrsi_k_1h < 30.0))
+            & ((rsi_3_4h_gt_3) | (rsi_3_1d_gt_15) | (stochrsi_k_1h_lt_30))
             # 4h & 1d down move, 1d still not low enough
             & ((rsi_3_4h_gt_3) | (rsi_3_1d_gt_30) | (aroonu_14_1d < 30.0))
             # 4h down move, 1d high
@@ -19388,13 +19419,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 1d overbought
             & ((rsi_3_4h_gt_3) | (roc_9_1d_lt_40))
             # 4h & 1d down move, 1d still high
-            & ((rsi_3_4h_gt_5) | (rsi_3_1d_gt_30) | (stochrsi_k_1d < 40.0))
+            & ((rsi_3_4h_gt_5) | (rsi_3_1d_gt_30) | (stochrsi_k_1d_lt_40))
             # 4h down move, 4h downtrend, 4h still high
             & ((rsi_3_4h_gt_5) | (cmf_20_4h > -0.20) | (aroonu_14_4h_lt_40))
             # 4h & 1d down move, 1d downtrend
             & ((rsi_3_4h_gt_10) | (rsi_3_1d_gt_10) | (roc_9_1d_gt_neg_40))
             # 4h down move, 1h high, 1d downtrend
-            & ((rsi_3_4h_gt_10) | (stochrsi_k_1h < 60.0) | (roc_9_1d_gt_neg_40))
+            & ((rsi_3_4h_gt_10) | (stochrsi_k_1h_lt_60) | (roc_9_1d_gt_neg_40))
             # 4h & 1d down move, 1d high
             & ((rsi_3_4h_gt_15) | (rsi_3_1d_gt_20) | (aroonu_14_1d < 60.0))
             # 4h down move, 4h high, 1h downtrend
@@ -19404,9 +19435,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 1d high & overbought
             & (rsi_3_4h_gt_20 | (aroonu_14_1d_lt_80) | roc_9_1d_lt_50)
             # 4h down move, 1h still not low enough, 1d downtrend
-            & ((rsi_3_4h_gt_15) | (stochrsi_k_1h < 20.0) | (roc_9_1d > -20.0))
+            & ((rsi_3_4h_gt_15) | (stochrsi_k_1h_lt_20) | (roc_9_1d > -20.0))
             # 4h down move, 4h still high, 1d downtrend
-            & (rsi_3_4h_gt_20 | (stochrsi_k_4h < 40.0) | (roc_9_1d_gt_neg_20))
+            & (rsi_3_4h_gt_20 | (stochrsi_k_4h_lt_40) | (roc_9_1d_gt_neg_20))
             # 4h down move, 4h still high, 1d downtrend
             & ((rsi_3_4h_gt_25) | (aroonu_14_4h_lt_50) | (roc_9_1d_gt_neg_40))
             # 4h down move, 4h still high, 1d downtrend
@@ -19424,13 +19455,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 4h still high, 1d downtrend
             & ((rsi_3_4h_gt_50) | (stochrsi_k_4h_lt_50) | (roc_9_1d_gt_neg_30))
             # 1d down move, 1h still high, 1d downtrend
-            & ((rsi_3_1d_gt_5) | (stochrsi_k_1h < 50.0) | (roc_9_1d_gt_neg_30))
+            & ((rsi_3_1d_gt_5) | (stochrsi_k_1h_lt_50) | (roc_9_1d_gt_neg_30))
             # 1d down move, 1h high, 1d downtrend
             & ((rsi_3_1d_gt_10) | aroonu_14_1h_lt_80 | (roc_9_1d > -10.0))
             # 1d down move, 1d high, 1d downtrend
             & ((rsi_3_1d_gt_10) | (aroonu_14_1d_lt_70) | (roc_9_1d_gt_neg_40))
             # 1d down move, 1h high & overbought
-            & ((rsi_3_1d_gt_35) | (stochrsi_k_1h < 90.0) | (roc_9_1h_lt_10))
+            & ((rsi_3_1d_gt_35) | (stochrsi_k_1h_lt_90) | (roc_9_1h_lt_10))
             # 1d downtrend, 1d high & overbought
             & ((cmf_20_1d > -0.30) | (aroonu_14_1d < 85.0) | (roc_9_1d_lt_100))
             # 15m high, 1h high & overbought
@@ -19466,14 +19497,14 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h overbought
             & ((roc_9_1h < 100.0) | (roc_9_4h < 100.0))
             # big drop in the last 20 days, 1d high, 1d downtrend
-            & ((close > (high_max_20_1d * 0.20)) | (stochrsi_k_1d < 70.0) | (roc_9_1d > -15.0))
+            & ((close > (high_max_20_1d * 0.20)) | (stochrsi_k_1d_lt_70) | (roc_9_1d > -15.0))
           )
 
           # Logic
           long_entry_logic.append(
             (rsi_3 < 50.0)
             & (aroonu_14 < 25.0)
-            & (stochrsi_k < 30.0)
+            & (stochrsi_k_lt_30)
             & (ema_26 > ema_12)
             & ((ema_26 - ema_12) > (open_rate * 0.030))
             & ((ema_26.shift() - ema_12.shift()) > (open_rate / 100.0))
@@ -19489,11 +19520,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 5m & 4h down move, 1d high
             ((rsi_3_gt_3) | (rsi_3_4h_gt_10) | (aroonu_14_1d_lt_90))
             # 5m & 1d down move, 15m still high
-            & ((rsi_3_gt_3) | (rsi_3_1d_gt_20) | (stochrsi_k_15m < 40.0))
+            & ((rsi_3_gt_3) | (rsi_3_1d_gt_20) | (stochrsi_k_15m_lt_40))
             # 5m & 4h down move, 15m still high
-            & ((rsi_3_gt_5) | (rsi_3_4h_gt_25) | (stochrsi_k_15m < 50.0))
+            & ((rsi_3_gt_5) | (rsi_3_4h_gt_25) | (stochrsi_k_15m_lt_50))
             # 5m & 4h down move, 4h still not low enough
-            & ((rsi_3_gt_5) | (rsi_3_4h_gt_15) | (stochrsi_k_4h < 20.0))
+            & ((rsi_3_gt_5) | (rsi_3_4h_gt_15) | (stochrsi_k_4h_lt_20))
             # 15m & 1h down move, 1h still not low enough
             & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_10) | (aroonu_14_1h < 20.0))
             # 15m & 1h down move, 4h still not low enough
@@ -19501,7 +19532,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 4h still high
             & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_15) | (rsi_14_4h < 50.0))
             # 15m & 1h down move, 4h still high
-            & (rsi_3_15m_gt_3 | rsi_3_1h_gt_20 | (stochrsi_k_4h < 40.0))
+            & (rsi_3_15m_gt_3 | rsi_3_1h_gt_20 | (stochrsi_k_4h_lt_40))
             # 15m & 1h down move, 4h still high
             & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_25) | (aroonu_14_4h_lt_50))
             # 15m & 4h down move, 4h still not low enough
@@ -19509,13 +19540,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 4h down move, 4h still high
             & (rsi_3_15m_gt_3 | rsi_3_4h_gt_20 | (aroonu_14_4h_lt_40))
             # 15m & 1h down move, 1h still not low enough
-            & ((rsi_3_15m_gt_5) | (rsi_3_1h_gt_10) | (stochrsi_k_1h < 20.0))
+            & ((rsi_3_15m_gt_5) | (rsi_3_1h_gt_10) | (stochrsi_k_1h_lt_20))
             # 15m & 1h down move, 15m still not low enough
-            & ((rsi_3_15m_gt_5) | (rsi_3_1h_gt_10) | (stochrsi_k_15m < 20.0))
+            & ((rsi_3_15m_gt_5) | (rsi_3_1h_gt_10) | (stochrsi_k_15m_lt_20))
             # 15m & 1h down move, 4h still high
             & ((rsi_3_15m_gt_5) | (rsi_3_1h_gt_10) | (aroonu_14_4h_lt_40))
             # 15m & 4h down move, 15m still not low enough
-            & ((rsi_3_15m_gt_5) | (rsi_3_4h_gt_10) | (stochrsi_k_15m < 30.0))
+            & ((rsi_3_15m_gt_5) | (rsi_3_4h_gt_10) | (stochrsi_k_15m_lt_30))
             # 15m & 4h down move, 1h downtrend
             & ((rsi_3_15m_gt_5) | (rsi_3_4h_gt_10) | (roc_9_1h > -20.0))
             # 15m & 4h down move, 1d overbought
@@ -19523,7 +19554,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 4h down move, 4h still high
             & ((rsi_3_15m_gt_5) | (rsi_3_4h_gt_15) | (rsi_14_4h < 40.0))
             # 15m & 1h down move, 4h still high
-            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_10) | (stochrsi_k_4h < 40.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_10) | (stochrsi_k_4h_lt_40))
             # 15m & 1h down move, 1d downtrend
             & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_10) | (roc_9_1d > -20.0))
             # 15m & 1h down move, 15m high
@@ -19543,9 +19574,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 4h down move, 1d high
             & ((rsi_3_15m_gt_10) | rsi_3_4h_gt_20 | (stochrsi_k_1d_lt_90))
             # 15m & 4h down move, 4h still not low enough
-            & ((rsi_3_15m_gt_10) | rsi_3_4h_gt_20 | (stochrsi_k_4h < 30.0))
+            & ((rsi_3_15m_gt_10) | rsi_3_4h_gt_20 | (stochrsi_k_4h_lt_30))
             # 15m & 4h down move, 1d high
-            & ((rsi_3_15m_gt_10) | rsi_3_4h_gt_20 | (stochrsi_k_1d < 70.0))
+            & ((rsi_3_15m_gt_10) | rsi_3_4h_gt_20 | (stochrsi_k_1d_lt_70))
             # 15m & 4h down move, 4h downtrend
             & ((rsi_3_15m_gt_10) | (rsi_3_4h_gt_25) | (cmf_20_4h > -0.30))
             # 15m & 4h down move, 1d high
@@ -19563,7 +19594,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 4h down move, 4h high
             & ((rsi_3_15m_gt_15) | rsi_3_4h_gt_20 | (aroonu_14_4h_lt_60))
             # 15m & 4h down move, 4h still high
-            & ((rsi_3_15m_gt_15) | (rsi_3_4h_gt_25) | (stochrsi_k_4h < 40.0))
+            & ((rsi_3_15m_gt_15) | (rsi_3_4h_gt_25) | (stochrsi_k_4h_lt_40))
             # 15m down move, 15m downtrend, 4h high
             & ((rsi_3_15m_gt_15) | (cmf_20_15m > -0.30) | (aroonu_14_4h_lt_50))
             # 15m down move, 15m still high, 4h overbought
@@ -19573,9 +19604,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 1h & 4h high
             & ((rsi_3_15m_gt_20) | aroonu_14_1h_lt_70 | aroonu_14_4h_lt_100)
             # 15m down move, 15m still not low enough, 1d overbought
-            & ((rsi_3_15m_gt_20) | (stochrsi_k_15m < 30.0) | (roc_9_1d_lt_80))
+            & ((rsi_3_15m_gt_20) | (stochrsi_k_15m_lt_30) | (roc_9_1d_lt_80))
             # 15m & 4h down move, 15m stil high
-            & ((rsi_3_15m_gt_25) | (rsi_3_4h_gt_30) | (stochrsi_k_15m < 40.0))
+            & ((rsi_3_15m_gt_25) | (rsi_3_4h_gt_30) | (stochrsi_k_15m_lt_40))
             # 15m down move, 15m still not low enough, 1d downtrend
             & ((rsi_3_15m_gt_25) | (aroonu_14_15m < 25.0) | roc_9_1d_gt_neg_50)
             # 15m down move, 15m still high, 4h high
@@ -19587,19 +19618,19 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 15m still high, 4h high
             & ((rsi_3_15m_gt_35) | (aroonu_14_15m_lt_50) | aroonu_14_4h_lt_80)
             # 1h & 4h down move, 1d still high
-            & ((rsi_3_1h_gt_3) | (rsi_3_4h_gt_10) | (stochrsi_k_1d < 40.0))
+            & ((rsi_3_1h_gt_3) | (rsi_3_4h_gt_10) | (stochrsi_k_1d_lt_40))
             # 1h & 4h down move, 4h still high
             & ((rsi_3_1h_gt_3) | (rsi_3_4h_gt_40) | (stochrsi_k_4h_lt_50))
             # 1h & 4h down move, 4h high
             & ((rsi_3_1h_gt_3) | (rsi_3_4h_gt_50) | aroonu_14_4h_lt_70)
             # 1h down move, 15m still not low enough
-            & ((rsi_3_1h_gt_3) | (stochrsi_k_15m < 20.0))
+            & ((rsi_3_1h_gt_3) | (stochrsi_k_15m_lt_20))
             # 1h down move, 4h still high, 1d downtrend
             & ((rsi_3_1h_gt_3) | (stochrsi_k_4h_lt_50) | (roc_9_1d_gt_neg_20))
             # 1h & 4h down move, 15m still not low enough
-            & ((rsi_3_1h_gt_5) | (rsi_3_4h_gt_5) | (stochrsi_k_15m < 30.0))
+            & ((rsi_3_1h_gt_5) | (rsi_3_4h_gt_5) | (stochrsi_k_15m_lt_30))
             # 1h & 4h down move, 4h still not low enough
-            & ((rsi_3_1h_gt_5) | (rsi_3_4h_gt_5) | (stochrsi_k_4h < 30.0))
+            & ((rsi_3_1h_gt_5) | (rsi_3_4h_gt_5) | (stochrsi_k_4h_lt_30))
             # 1h & 4h down move, 4h still not low enough
             & ((rsi_3_1h_gt_5) | (rsi_3_4h_gt_10) | (aroonu_14_4h < 20.0))
             # 1h & 4h down move, 4h downtrend
@@ -19611,7 +19642,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h & 1d down move
             & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_10) | (rsi_3_1d_gt_15))
             # 1h & 4h down move, 15m high
-            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_10) | (stochrsi_k_15m < 60.0))
+            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_10) | (stochrsi_k_15m_lt_60))
             # 1h & 4h down move, 4h still not low enough
             & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_10) | (aroonu_14_4h < 30.0))
             # 1h & 4h down move, 1h downtrend
@@ -19625,7 +19656,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 4h high
             & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_25) | (aroonu_14_4h_lt_60))
             # 1h & 4h down move, 4h still high
-            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_25) | (stochrsi_k_4h < 40.0))
+            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_25) | (stochrsi_k_4h_lt_40))
             # 1h & 4h down move, 1h still not low enough
             & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_35) | (aroonu_14_1h < 30.0))
             # 1h& 1d down move, 1h still high
@@ -19637,25 +19668,25 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 4h still high
             & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_15) | (aroonu_14_4h_lt_40))
             # 1h & 4h down move, 1d high
-            & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_15) | (stochrsi_k_1d < 70.0))
+            & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_15) | (stochrsi_k_1d_lt_70))
             # 1h & 4h down move, 4h still high
-            & ((rsi_3_1h_gt_15) | rsi_3_4h_gt_20 | (stochrsi_k_4h < 40.0))
+            & ((rsi_3_1h_gt_15) | rsi_3_4h_gt_20 | (stochrsi_k_4h_lt_40))
             # 1h & 4h down move, 1d high
             & ((rsi_3_1h_gt_15) | rsi_3_4h_gt_20 | (stochrsi_k_1d_lt_90))
             # 1h & 4h down move, 1d high
-            & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_30) | (stochrsi_k_1d < 80.0))
+            & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_30) | (stochrsi_k_1d_lt_80))
             # 1h & 4h down move, 1d downtrend
             & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_45) | (roc_9_1d_gt_neg_40))
             # 1h & 1d down move, 4h high
-            & ((rsi_3_1h_gt_15) | (rsi_3_1d_gt_15) | (stochrsi_k_4h < 80.0))
+            & ((rsi_3_1h_gt_15) | (rsi_3_1d_gt_15) | (stochrsi_k_4h_lt_80))
             # 1h down move, 4h high, 1d overbought
             & ((rsi_3_1h_gt_15) | aroonu_14_4h_lt_70 | (roc_9_1d < 100.0))
             # 1h down move, 1d high, 4h downtrend
             & ((rsi_3_1h_gt_15) | (aroonu_14_1d_lt_90) | (roc_9_4h > -20.0))
             # 1h & 4h down move, 4h & 1d still not low enough, 15m still not low enough
-            & (rsi_3_1h_gt_20 | (rsi_3_4h_gt_20) | (rsi_14_4h < 30.0) | (rsi_14_1d < 30.0) | (stochrsi_k_15m < 30.0))
+            & (rsi_3_1h_gt_20 | (rsi_3_4h_gt_20) | (rsi_14_4h < 30.0) | (rsi_14_1d < 30.0) | (stochrsi_k_15m_lt_30))
             # 1h & 4h down move, 1d high
-            & (rsi_3_1h_gt_20 | (rsi_3_4h_gt_25) | (stochrsi_k_1d < 70.0))
+            & (rsi_3_1h_gt_20 | (rsi_3_4h_gt_25) | (stochrsi_k_1d_lt_70))
             # 1h & 4h down move, 4h high
             & (rsi_3_1h_gt_20 | (rsi_3_4h_gt_40) | (stochrsi_k_4h_lt_70))
             # 1h & 4h down move, 4h overbought
@@ -19671,15 +19702,15 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 4h high
             & (rsi_3_1h_gt_20 | (aroonu_14_4h < 85.0))
             # 1h down move, 1h still not low enough, 4h stil high
-            & (rsi_3_1h_gt_20 | (stochrsi_k_1h < 20.0) | (aroonu_14_4h_lt_40))
+            & (rsi_3_1h_gt_20 | (stochrsi_k_1h_lt_20) | (aroonu_14_4h_lt_40))
             # 1h down move, 4h still high, 1d downtrend
-            & (rsi_3_1h_gt_20 | (stochrsi_k_4h < 40.0) | (roc_9_1d_gt_neg_40))
+            & (rsi_3_1h_gt_20 | (stochrsi_k_4h_lt_40) | (roc_9_1d_gt_neg_40))
             # 1h down move, 1d high, 4h downtrend
-            & (rsi_3_1h_gt_20 | (stochrsi_k_1d < 80.0) | (roc_9_4h_gt_neg_20))
+            & (rsi_3_1h_gt_20 | (stochrsi_k_1d_lt_80) | (roc_9_4h_gt_neg_20))
             # 1h down move, 4h high
             & (rsi_3_1h_gt_20 | (stochrsi_k_4h_lt_80))
             # 1h & 4h down move, 1h still not low enough
-            & ((rsi_3_1h_gt_25) | (rsi_3_4h_gt_25) | (stochrsi_k_1h < 20.0))
+            & ((rsi_3_1h_gt_25) | (rsi_3_4h_gt_25) | (stochrsi_k_1h_lt_20))
             # 1h & 4h down move, 1d overbought
             & ((rsi_3_1h_gt_25) | (rsi_3_4h_gt_25) | roc_9_1d_lt_50)
             # 1h & 4h down move, 4h high
@@ -19691,7 +19722,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 4h high & overbought
             & ((rsi_3_1h_gt_25) | aroonu_14_4h_lt_70 | (roc_9_4h_lt_10))
             # 1h down move, 15m still high, 1d overbought
-            & ((rsi_3_1h_gt_25) | (stochrsi_k_15m < 50.0) | (roc_9_1d_lt_30))
+            & ((rsi_3_1h_gt_25) | (stochrsi_k_15m_lt_50) | (roc_9_1d_lt_30))
             # 1h & 4h down move, 4h still high
             & ((rsi_3_1h_gt_30) | (rsi_3_4h_gt_30) | (stochrsi_k_4h_lt_50))
             # 1h & 4h down move, 1d overbought
@@ -19709,9 +19740,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1d high, 4h overbought
             & ((rsi_3_1h_gt_30) | aroonu_14_1d_lt_100 | (roc_9_4h < 20.0))
             # 1h down move, 4h still high, 1d downtrend
-            & ((rsi_3_1h_gt_30) | (stochrsi_k_4h < 40.0) | (roc_9_1d > -80.0))
+            & ((rsi_3_1h_gt_30) | (stochrsi_k_4h_lt_40) | (roc_9_1d > -80.0))
             # 1h down move, 4h high & overbought
-            & ((rsi_3_1h_gt_30) | (stochrsi_k_4h < 90.0) | (roc_9_4h_lt_20))
+            & ((rsi_3_1h_gt_30) | (stochrsi_k_4h_lt_90) | (roc_9_4h_lt_20))
             # 1h down move, 4h & 1d overbought
             & ((rsi_3_1h_gt_30) | (roc_9_4h_lt_10) | (roc_9_1d_lt_30))
             # 1h & 4h down move, 1h still high
@@ -19743,7 +19774,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h & 1d down move, 1d still not low enough
             & ((rsi_3_4h_gt_10) | (rsi_3_1d_gt_15) | (aroonu_14_1d < 30.0))
             # 4h down move, 15m still high
-            & ((rsi_3_4h_gt_10) | (stochrsi_k_15m < 40.0))
+            & ((rsi_3_4h_gt_10) | (stochrsi_k_15m_lt_40))
             # 4h down move, 1d still high, 1d downtrend
             & ((rsi_3_4h_gt_15) | (rsi_14_1d < 40.0) | (roc_9_1d > -15.0))
             # 4h down move, 1h downtrend, 1d downtrend
@@ -19753,7 +19784,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 4h still high, 4h downtrend
             & ((rsi_3_4h_gt_15) | (aroonu_14_4h_lt_40) | (roc_9_4h > -20.0))
             # 4h down move, 15m still not low enough, 1d downtrend
-            & ((rsi_3_4h_gt_15) | (stochrsi_k_15m < 30.0) | (roc_9_1d > -20.0))
+            & ((rsi_3_4h_gt_15) | (stochrsi_k_15m_lt_30) | (roc_9_1d > -20.0))
             # 4h down move, 1d high & overbought
             & ((rsi_3_4h_gt_15) | (stochrsi_k_1d_lt_90) | (roc_9_1d_lt_20))
             # 4h & 1d down move, 1d overbought
@@ -19771,17 +19802,17 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 4h still high, 4h downtrend
             & ((rsi_3_4h_gt_25) | (aroonu_14_4h_lt_50) | (cmf_20_4h > -0.40))
             # 4h down move, 4h high, 1d high
-            & ((rsi_3_4h_gt_30) | aroonu_14_4h_lt_70 | (stochrsi_k_1d < 80.0))
+            & ((rsi_3_4h_gt_30) | aroonu_14_4h_lt_70 | (stochrsi_k_1d_lt_80))
             # 4h down move, 1d still high, 1d downtrend
             & ((rsi_3_4h_gt_30) | (aroonu_14_1d < 40.0) | (roc_9_1d_gt_neg_20))
             # 4h down move, 1d high & overbought
             & ((rsi_3_4h_gt_30) | aroonu_14_1d_lt_100 | (roc_9_1d_lt_20))
             # 4h down move, 4h still not low enough, 1d overbought
-            & ((rsi_3_4h_gt_30) | (stochrsi_k_4h < 20.0) | (roc_9_1d_lt_40))
+            & ((rsi_3_4h_gt_30) | (stochrsi_k_4h_lt_20) | (roc_9_1d_lt_40))
             # 4h down move, 1h high
             & ((rsi_3_4h_gt_35) | aroonu_14_1h_lt_70)
             # 4h down move, 15m & 4h still high
-            & ((rsi_3_4h_gt_40) | (stochrsi_k_15m < 50.0) | (stochrsi_k_4h_lt_50))
+            & ((rsi_3_4h_gt_40) | (stochrsi_k_15m_lt_50) | (stochrsi_k_4h_lt_50))
             # 4h down move, 1d high & overbought
             & ((rsi_3_4h_gt_40) | (stochrsi_k_1d_lt_90) | (roc_9_1d < 200.0))
             # 4h down move, 4h high
@@ -19817,7 +19848,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h high, 1h & 4h overbought
             & ((stochrsi_k_4h_lt_70) | (roc_9_1h < 40.0) | (roc_9_4h_lt_40))
             # 4h high, 4h & 1d overbought
-            & ((stochrsi_k_4h < 80.0) | (roc_9_4h_lt_20) | (roc_9_1d_lt_20))
+            & ((stochrsi_k_4h_lt_80) | (roc_9_4h_lt_20) | (roc_9_1d_lt_20))
             # 1d green, 4h down move, 4h still high
             & ((change_pct_1d < 40.0) | (rsi_3_4h_gt_35) | (aroonu_14_4h_lt_40))
           )
@@ -19826,10 +19857,10 @@ class NostalgiaForInfinityX7(IStrategy):
           long_entry_logic.append(
             (rsi_3 < 40.0)
             & (aroonu_14 < 30.0)
-            & (stochrsi_k < 20.0)
-            & (stochrsi_k_15m < 70.0)
+            & (stochrsi_k_lt_20)
+            & (stochrsi_k_15m_lt_70)
             & (willr_84_1h < -70.0)
-            & (stochrsi_k_1h < 30.0)
+            & (stochrsi_k_1h_lt_30)
             & (bbb_20_2_0_1h > 12.0)
             & (close_max_48 >= (close * 1.10))
           )
@@ -19847,15 +19878,15 @@ class NostalgiaForInfinityX7(IStrategy):
             # 5m & 1d down move, 1d downtrend
             & ((rsi_3_gt_3) | (rsi_3_1d_gt_15) | (cmf_20_1d > -0.25))
             # 5m down move, 1h high, 4h overbought
-            & ((rsi_3_gt_3) | (stochrsi_k_1h < 80.0) | (roc_9_4h_lt_20))
+            & ((rsi_3_gt_3) | (stochrsi_k_1h_lt_80) | (roc_9_4h_lt_20))
             # 5m down move, 1d high & overbought
             & ((rsi_3_gt_3) | (stochrsi_k_1d_lt_90) | (roc_9_1d_lt_20))
             # 15m & 1h down move, 1h still not low enough
-            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_15) | (stochrsi_k_1h < 30.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_15) | (stochrsi_k_1h_lt_30))
             # 15m & 1h down move, 4h still high
             & ((rsi_3_15m_gt_10) | rsi_3_1h_gt_20 | (stochrsi_k_4h_lt_50))
             # 15m & 1h down move 1h still high
-            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_25) | (stochrsi_k_1h < 40.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_25) | (stochrsi_k_1h_lt_40))
             # 15m & 1h down move, 15m still high
             & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_30) | (aroonu_14_15m_lt_50))
             # 15m & 1h down move 1h still high
@@ -19863,13 +19894,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 4h overbought
             & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_30) | (roc_9_4h_lt_10))
             # 15m & 1h down move, 1h high
-            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_50) | (stochrsi_k_1h < 90.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_50) | (stochrsi_k_1h_lt_90))
             # 15m & 4h down move, 4h still not low enough
-            & ((rsi_3_15m_gt_10) | (rsi_3_4h_gt_10) | (stochrsi_k_4h < 30.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_4h_gt_10) | (stochrsi_k_4h_lt_30))
             # 15m & 4h down move, 1d high
-            & ((rsi_3_15m_gt_10) | (rsi_3_4h_gt_10) | (stochrsi_k_1d < 80.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_4h_gt_10) | (stochrsi_k_1d_lt_80))
             # 15m & 4h down move, 4h still not low enough
-            & ((rsi_3_15m_gt_10) | (rsi_3_4h_gt_15) | (stochrsi_k_4h < 30.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_4h_gt_15) | (stochrsi_k_4h_lt_30))
             # 15m & 4h down move, 1d downtrend
             & ((rsi_3_15m_gt_10) | (rsi_3_4h_gt_15) | (roc_9_1d > -20.0))
             # 1h & 4h down move, 15m still high
@@ -19911,7 +19942,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 4h & 1d high
             & ((rsi_3_15m_gt_15) | (aroonu_14_4h < 75.0) | aroonu_14_1d_lt_100)
             # 15m down move, 15m still not low enough, 1h still high
-            & ((rsi_3_15m_gt_15) | (stochrsi_k_15m < 30.0) | (stochrsi_k_1h_lt_50))
+            & ((rsi_3_15m_gt_15) | (stochrsi_k_15m_lt_30) | (stochrsi_k_1h_lt_50))
             # 15m down move, 4h & 1d overbought
             & ((rsi_3_15m_gt_15) | (roc_9_4h_lt_20) | (roc_9_1d < 60.0))
             # 15m & 1h down move, 1h high
@@ -19923,7 +19954,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 1d high & overbought
             & ((rsi_3_15m_gt_20) | (aroonu_14_1d_lt_90) | (roc_9_1d_lt_80))
             # 15m down move, 15m high, 4h downtrend
-            & ((rsi_3_15m_gt_20) | (stochrsi_k_15m < 60.0) | (roc_9_4h > -50.0))
+            & ((rsi_3_15m_gt_20) | (stochrsi_k_15m_lt_60) | (roc_9_4h > -50.0))
             # 15m down move, 4h overbought
             & ((rsi_3_15m_gt_20) | (roc_9_4h_lt_40))
             # 15m & 1h down move, 1h high
@@ -19931,7 +19962,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 1d overbought
             & ((rsi_3_15m_gt_25) | (rsi_3_1h_gt_40) | (roc_9_1d_lt_80))
             # 15m & 4h down move, 4h high
-            & ((rsi_3_15m_gt_25) | (rsi_3_4h_gt_25) | (stochrsi_k_4h < 60.0))
+            & ((rsi_3_15m_gt_25) | (rsi_3_4h_gt_25) | (stochrsi_k_4h_lt_60))
             # 15m down move, 1d high, 4h overbought
             & ((rsi_3_15m_gt_25) | (aroonu_14_1d_lt_80) | (roc_9_4h_lt_10))
             # 15m down move, 4h & 1d overbought
@@ -19943,7 +19974,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 15m downtrend, 4h high
             & ((rsi_3_15m_gt_30) | (cmf_20_15m > -0.30) | aroonu_14_4h_lt_100)
             # 15m down move, 15m still high, 1d high
-            & ((rsi_3_15m_gt_30) | (aroonu_14_15m_lt_50) | (stochrsi_k_1d < 70.0))
+            & ((rsi_3_15m_gt_30) | (aroonu_14_15m_lt_50) | (stochrsi_k_1d_lt_70))
             # 15m down move, 15m high, 4h high
             & ((rsi_3_15m_gt_30) | (aroonu_14_15m < 60.0) | (stochrsi_k_4h_lt_70))
             # 15m down move, 4h high, 1h downtrend
@@ -19967,33 +19998,33 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 4h still not low enough
             & ((rsi_3_1h > 2.0) | (rsi_3_4h_gt_15) | (rsi_14_4h < 30.0))
             # 1h & 4h down move, 15m still not low enough
-            & ((rsi_3_1h_gt_3) | (rsi_3_4h_gt_3) | (stochrsi_k_15m < 30.0))
+            & ((rsi_3_1h_gt_3) | (rsi_3_4h_gt_3) | (stochrsi_k_15m_lt_30))
             # 1h & 4h down move, 15m downtrend
             & ((rsi_3_1h_gt_3) | (rsi_3_4h_gt_3) | (roc_9_15m > -30.0))
             # 1h & 4h down move, 4h still high
-            & ((rsi_3_1h_gt_3) | (rsi_3_4h_gt_10) | (stochrsi_k_4h < 40.0))
+            & ((rsi_3_1h_gt_3) | (rsi_3_4h_gt_10) | (stochrsi_k_4h_lt_40))
             # 1h & 4h down move, 1d still high
-            & ((rsi_3_1h_gt_3) | (rsi_3_4h_gt_10) | (stochrsi_k_1d < 40.0))
+            & ((rsi_3_1h_gt_3) | (rsi_3_4h_gt_10) | (stochrsi_k_1d_lt_40))
             # 1h & 4h down move, 4h stil high
             & ((rsi_3_1h_gt_3) | rsi_3_4h_gt_20 | (rsi_14_4h < 40.0))
             # 1h ^ 4h down move, 1d downtrend
             & ((rsi_3_1h_gt_3) | (rsi_3_4h_gt_25) | roc_9_1d_gt_neg_50)
             # 1h & 1d down move, 4h still high
-            & ((rsi_3_1h_gt_3) | (rsi_3_1d_gt_10) | (stochrsi_k_4h < 40.0))
+            & ((rsi_3_1h_gt_3) | (rsi_3_1d_gt_10) | (stochrsi_k_4h_lt_40))
             # 1h & 1d down move, 1h downtrend
             & ((rsi_3_1h_gt_3) | (rsi_3_1d_gt_15) | (roc_9_1h > -40.0))
             # 1h down move, 15m downtrend, 1h still high
             & ((rsi_3_1h_gt_3) | (cmf_20_15m > -0.40) | (aroonu_14_1h < 40.0))
             # 1h down move, 15m still not low enough, 4h still high
-            & ((rsi_3_1h_gt_3) | (aroonu_14_15m < 30.0) | (stochrsi_k_4h < 40.0))
+            & ((rsi_3_1h_gt_3) | (aroonu_14_15m < 30.0) | (stochrsi_k_4h_lt_40))
             # 1h down move, 1h still not low enough
-            & ((rsi_3_1h_gt_3) | (stochrsi_k_1h < 30.0))
+            & ((rsi_3_1h_gt_3) | (stochrsi_k_1h_lt_30))
             # 1h down move, 4h still high, 1d downtrend
             & ((rsi_3_1h_gt_3) | (stochrsi_k_4h_lt_50) | (roc_9_1d_gt_neg_20))
             # 1h down move, 4h high
             & ((rsi_3_1h_gt_3) | (stochrsi_k_4h_lt_70))
             # 1h & 4h down move, 1d high
-            & ((rsi_3_1h_gt_5) | (rsi_3_4h_gt_5) | (stochrsi_k_1d < 60.0))
+            & ((rsi_3_1h_gt_5) | (rsi_3_4h_gt_5) | (stochrsi_k_1d_lt_60))
             # 1h & 4h down move, 4h still not low enough
             & ((rsi_3_1h_gt_5) | (rsi_3_4h_gt_10) | (aroonu_14_4h < 20.0))
             # 1h & 4h down move, 4h downtrend
@@ -20001,7 +20032,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 4h still not low enough
             & ((rsi_3_1h_gt_5) | (rsi_3_4h_gt_15) | (aroonu_14_4h < 30.0))
             # 15m & 4h down move, 4h still not low enough, 15m still not low enough
-            & ((rsi_3_1h_gt_5) | (rsi_3_4h_gt_20) | (aroonu_14_4h < 20.0) | (stochrsi_k_15m < 20.0))
+            & ((rsi_3_1h_gt_5) | (rsi_3_4h_gt_20) | (aroonu_14_4h < 20.0) | (stochrsi_k_15m_lt_20))
             # 1h & 4h down move, 4h still high
             & ((rsi_3_1h_gt_5) | (rsi_3_4h_gt_35) | (rsi_14_4h < 40.0))
             # 1h down move, 1d high, 4h downtrend
@@ -20015,11 +20046,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 4h still not low enough
             & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_10) | (aroonu_14_4h < 30.0))
             # 1h & 4h down move, 15m still high
-            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_10) | (stochrsi_k_15m < 50.0))
+            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_10) | (stochrsi_k_15m_lt_50))
             # 1h & 4h down move, 15m still not low enough
             & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_15) | (aroonu_14_15m < 30.0))
             # 1h & 4h down move, 1h still not low enough
-            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_15) | (stochrsi_k_1h < 20.0))
+            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_15) | (stochrsi_k_1h_lt_20))
             # 1h & 4h down move, 1d high
             & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_25) | (aroonu_14_1d_lt_80))
             # 1h & 4h down move, 1d downtrend
@@ -20029,7 +20060,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 1d overbought
             & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_35) | (roc_9_1d < 70.0))
             # 1h & 1d down move, 1h still high
-            & ((rsi_3_1h_gt_10) | (rsi_3_1d_gt_10) | (stochrsi_k_1h < 40.0))
+            & ((rsi_3_1h_gt_10) | (rsi_3_1d_gt_10) | (stochrsi_k_1h_lt_40))
             # 1h & 1d down move, 4h high
             & ((rsi_3_1h_gt_10) | (rsi_3_1d_gt_15) | (stochrsi_k_4h_lt_70))
             # 1h & 1d downtrend, 1d overbought
@@ -20037,25 +20068,25 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h downtrend, 1h still not low enough
             & ((rsi_3_1h_gt_10) | (cmf_20_1h > -0.20) | (aroonu_14_1h < 30.0))
             # 1h down move, 1h downtrend, 1h still not low enough
-            & ((rsi_3_1h_gt_10) | (cmf_20_1h > -0.20) | (stochrsi_k_1h < 30.0))
+            & ((rsi_3_1h_gt_10) | (cmf_20_1h > -0.20) | (stochrsi_k_1h_lt_30))
             # 1h down move, 1h downtrend
             & ((rsi_3_1h_gt_10) | (cmf_20_1h > -0.30))
             # 1h down move, 1d high & overbought
             & ((rsi_3_1h_gt_10) | (aroonu_14_1d_lt_70) | roc_9_1d_lt_50)
             # 1h & 4h down move, 4h still not low enough
-            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_10) | (stochrsi_k_4h < 20.0))
+            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_10) | (stochrsi_k_4h_lt_20))
             # 1h down move, 1d overbought
             & ((rsi_3_1h_gt_10) | (roc_9_1d < 100.0))
             # 1h & 4h down move, 1h still not low enough
-            & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_15) | (stochrsi_k_1h < 30.0))
+            & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_15) | (stochrsi_k_1h_lt_30))
             # 1h & 4h down move, 15m high
-            & ((rsi_3_1h_gt_15) | rsi_3_4h_gt_20 | (stochrsi_k_15m < 90.0))
+            & ((rsi_3_1h_gt_15) | rsi_3_4h_gt_20 | (stochrsi_k_15m_lt_90))
             # 1h & 4h down move, 1d downtrend
             & ((rsi_3_1h_gt_15) | rsi_3_4h_gt_20 | (roc_9_1d_gt_neg_40))
             # 1h & 4h down mov, 1d overbought
             & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_30) | (roc_9_1d < 100.0))
             # 1h down move, 1d downtrend, 1d high
-            & ((rsi_3_1h_gt_15) | (cmf_20_1d > -0.30) | (stochrsi_k_1d < 80.0))
+            & ((rsi_3_1h_gt_15) | (cmf_20_1d > -0.30) | (stochrsi_k_1d_lt_80))
             # 1h down move, 1h still high
             & ((rsi_3_1h_gt_15) | (aroonu_14_1h_lt_50))
             # 1h down move, 1d high, 4h downtrend
@@ -20065,7 +20096,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1d high & overbought
             & ((rsi_3_1h_gt_15) | (aroonu_14_1d_lt_90) | (roc_9_1d_lt_30))
             # 1h down move, 1h still high
-            & ((rsi_3_1h_gt_15) | (stochrsi_k_1h < 40.0))
+            & ((rsi_3_1h_gt_15) | (stochrsi_k_1h_lt_40))
             # 1h & 4h down move, 1d high
             & (rsi_3_1h_gt_20 | (rsi_3_4h_gt_25) | (aroonu_14_1d_lt_80))
             # 1h & 4h down move, 1h high
@@ -20077,7 +20108,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 4h still high
             & (rsi_3_1h_gt_20 | (aroonu_14_4h_lt_40))
             # 1h down move, 4h still high, 1d downtrend
-            & (rsi_3_1h_gt_20 | (stochrsi_k_4h < 40.0) | (roc_9_1d > -25.0))
+            & (rsi_3_1h_gt_20 | (stochrsi_k_4h_lt_40) | (roc_9_1d > -25.0))
             # 1h down move, 4h high & overbought
             & (rsi_3_1h_gt_20 | (stochrsi_k_4h_lt_70) | (roc_9_4h_lt_10))
             # 1h down move, 1h & 1d high
@@ -20087,7 +20118,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 1d overbought
             & ((rsi_3_1h_gt_25) | (rsi_3_4h_gt_50) | (roc_9_1d_lt_100))
             # 1h down move, 1h still not low enough, 4h still high
-            & ((rsi_3_1h_gt_25) | (stochrsi_k_1h < 30.0) | (stochrsi_k_4h_lt_50))
+            & ((rsi_3_1h_gt_25) | (stochrsi_k_1h_lt_30) | (stochrsi_k_4h_lt_50))
             # 1h down move, 4h high, 1d downtrend
             & ((rsi_3_1h_gt_25) | (stochrsi_k_4h_lt_80) | (roc_9_1d_gt_neg_40))
             # 1h down move, 1h still high, 1h downtrend
@@ -20097,11 +20128,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h still high, 1d overbought
             & ((rsi_3_1h_gt_25) | (stochrsi_k_1h_lt_50) | (roc_9_1d_lt_40))
             # 1h down move, 4h high & overbought
-            & ((rsi_3_1h_gt_25) | (stochrsi_k_4h < 80.0) | (roc_9_4h_lt_20))
+            & ((rsi_3_1h_gt_25) | (stochrsi_k_4h_lt_80) | (roc_9_4h_lt_20))
             # 1h down move, 4h high, 1d overbought
             & ((rsi_3_1h_gt_25) | (stochrsi_k_4h_lt_80) | (roc_9_1d < 70.0))
             # 1h & 4h down move, 1h high
-            & ((rsi_3_1h_gt_30) | (rsi_3_4h_gt_30) | (stochrsi_k_1h < 60.0))
+            & ((rsi_3_1h_gt_30) | (rsi_3_4h_gt_30) | (stochrsi_k_1h_lt_60))
             # 1h & 4h down move, 4h still high
             & ((rsi_3_1h_gt_30) | (rsi_3_4h_gt_30) | (aroonu_14_4h_lt_50))
             # 1h & 4h down move, 1h high
@@ -20121,9 +20152,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1d high, 4h overbought
             & ((rsi_3_1h_gt_30) | aroonu_14_1d_lt_100 | (roc_9_4h < 80.0))
             # 1h down move, 1h & 4h still high
-            & ((rsi_3_1h_gt_30) | (stochrsi_k_1h < 40.0) | (stochrsi_k_4h_lt_50))
+            & ((rsi_3_1h_gt_30) | (stochrsi_k_1h_lt_40) | (stochrsi_k_4h_lt_50))
             # 1h down move, 1h highm 1d overbought
-            & ((rsi_3_1h_gt_30) | (stochrsi_k_1h < 60.0) | (roc_9_1d_lt_30))
+            & ((rsi_3_1h_gt_30) | (stochrsi_k_1h_lt_60) | (roc_9_1d_lt_30))
             # 1h down move, 4h overbought
             & ((rsi_3_1h_gt_30) | (roc_9_4h < 50.0))
             # 4h down move, 1d downtrend
@@ -20149,7 +20180,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h high, 1d overbought
             & ((rsi_3_1h_gt_40) | aroonu_14_1h_lt_80 | (roc_9_1d_lt_80))
             # 1h down move, 1h high, 4h overbought
-            & ((rsi_3_1h_gt_40) | (stochrsi_k_1h < 80.0) | (roc_9_4h_lt_20))
+            & ((rsi_3_1h_gt_40) | (stochrsi_k_1h_lt_80) | (roc_9_4h_lt_20))
             # 1h down move, 1h & 4h overbought
             & ((rsi_3_1h_gt_40) | (roc_9_1h_lt_10) | (roc_9_4h_lt_10))
             # 1h & 4h down move, 1d overbought
@@ -20163,13 +20194,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 4h high & overbought
             & ((rsi_3_1h_gt_50) | aroonu_14_4h_lt_100 | (roc_9_4h < 100.0))
             # 1h down move, 4h high, 1d downtrend
-            & ((rsi_3_1h_gt_50) | (stochrsi_k_4h < 60.0) | (roc_9_1d > -60.0))
+            & ((rsi_3_1h_gt_50) | (stochrsi_k_4h_lt_60) | (roc_9_1d > -60.0))
             # 1h down move, 15m high, 1h high
             & ((rsi_3_1h_gt_55) | (aroonu_14_15m < 60.0) | (stochrsi_k_1h_lt_80))
             # 1h down move, 1h high & overbought
             & ((rsi_3_1h_gt_55) | (aroonu_14_1h_lt_90) | (roc_9_1h_lt_10))
             # 4h down move, 1h still not low enough, 4h downtrend
-            & ((rsi_3_4h_gt_3) | (stochrsi_k_1h < 20.0) | (roc_9_4h_gt_neg_30))
+            & ((rsi_3_4h_gt_3) | (stochrsi_k_1h_lt_20) | (roc_9_4h_gt_neg_30))
             # 4h down move, 1h & 4h downtrend
             & ((rsi_3_4h_gt_3) | (roc_9_1h > -30.0) | (roc_9_4h_gt_neg_30))
             # 4h down move, 1d high, 4h downtrend
@@ -20185,13 +20216,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 1d high, 4h downtrend
             & ((rsi_3_4h_gt_10) | (aroonu_14_1d < 85.0) | (roc_9_4h > -20.0))
             # 4h down move, 15m high, 15m downtrend
-            & ((rsi_3_4h_gt_10) | (stochrsi_k_15m < 60.0) | (roc_9_15m > -10.0))
+            & ((rsi_3_4h_gt_10) | (stochrsi_k_15m_lt_60) | (roc_9_15m > -10.0))
             # 4h down move, 1h still high, 1d downtrend
-            & ((rsi_3_4h_gt_10) | (stochrsi_k_1h < 40.0) | (roc_9_1d > -20.0))
+            & ((rsi_3_4h_gt_10) | (stochrsi_k_1h_lt_40) | (roc_9_1d > -20.0))
             # 4h down move, 1h high
-            & ((rsi_3_4h_gt_10) | (stochrsi_k_1h < 70.0))
+            & ((rsi_3_4h_gt_10) | (stochrsi_k_1h_lt_70))
             # 4h down move, 4h still high, 1d downtrend
-            & ((rsi_3_4h_gt_10) | (stochrsi_k_4h < 40.0) | (roc_9_1d > -20.0))
+            & ((rsi_3_4h_gt_10) | (stochrsi_k_4h_lt_40) | (roc_9_1d > -20.0))
             # 4h down move, 4h downtrend, 1d overbought
             & ((rsi_3_4h_gt_10) | (roc_9_4h_gt_neg_30) | (roc_9_1d_lt_40))
             # 4h & 1d down move, 1d high
@@ -20201,7 +20232,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 1h high
             & ((rsi_3_4h_gt_15) | (aroonu_14_1h_lt_50))
             # 4h down move, 1h still high, 1d downtrend
-            & ((rsi_3_4h_gt_15) | (stochrsi_k_1h < 50.0) | (roc_9_1d > -30.0))
+            & ((rsi_3_4h_gt_15) | (stochrsi_k_1h_lt_50) | (roc_9_1d > -30.0))
             # 4h down move, 1d high & overbought
             & ((rsi_3_4h_gt_15) | (stochrsi_k_1d_lt_90) | (roc_9_1d_lt_20))
             # 4h down move, 15m still high
@@ -20215,9 +20246,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 15m still high, 4h high
             & ((rsi_3_4h_gt_25) | (aroonu_14_15m < 40.0) | aroonu_14_4h_lt_70)
             # 4h down move, 1h & 4h still high
-            & ((rsi_3_4h_gt_25) | (stochrsi_k_1h < 40.0) | (stochrsi_k_4h < 40.0))
+            & ((rsi_3_4h_gt_25) | (stochrsi_k_1h_lt_40) | (stochrsi_k_4h_lt_40))
             # 4h dowqn move, 4h still high, 1d downtrend
-            & ((rsi_3_4h_gt_25) | (stochrsi_k_4h < 30.0) | (roc_9_1d_gt_neg_30))
+            & ((rsi_3_4h_gt_25) | (stochrsi_k_4h_lt_30) | (roc_9_1d_gt_neg_30))
             # 4h down move, 4h high, 1d overbought
             & ((rsi_3_4h_gt_30) | aroonu_14_4h_lt_80 | roc_9_1d_lt_50)
             # 4h down move, 1h high, 4h downtrend
@@ -20227,7 +20258,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 1d high & overbought
             & ((rsi_3_4h_gt_40) | (aroonu_14_1d_lt_90) | (roc_9_1d_lt_80))
             # 4h down move, 1h high, 1d downtrend
-            & ((rsi_3_4h_gt_40) | (stochrsi_k_1h < 80.0) | (roc_9_1d_gt_neg_20))
+            & ((rsi_3_4h_gt_40) | (stochrsi_k_1h_lt_80) | (roc_9_1d_gt_neg_20))
             # 4h down move, 4h & 1d overbought
             & ((rsi_3_4h_gt_40) | (roc_9_4h_lt_10) | roc_9_1d_lt_50)
             # 4h down move, 4h still high, 1d downtrend
@@ -20237,13 +20268,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 4h still high, 1d downtrend
             & ((rsi_3_4h_gt_50) | (stochrsi_k_4h_lt_50) | (roc_9_1d_gt_neg_30))
             # 4h down move, 1h high, 1d overbought
-            & ((rsi_3_4h_gt_60) | (stochrsi_k_1h < 90.0) | (roc_9_1d_lt_30))
+            & ((rsi_3_4h_gt_60) | (stochrsi_k_1h_lt_90) | (roc_9_1d_lt_30))
             # 4h down move, 4h high & overbought
             & ((rsi_3_4h_gt_60) | (stochrsi_k_4h_lt_70) | (roc_9_4h_lt_20))
             # 1d down move, 1h & 4h still not low enough
-            & ((rsi_3_1d_gt_5) | (stochrsi_k_1h < 20.0) | (stochrsi_k_4h < 20.0))
+            & ((rsi_3_1d_gt_5) | (stochrsi_k_1h_lt_20) | (stochrsi_k_4h_lt_20))
             # 1d down move, 1h high & overbought
-            & ((rsi_3_1d_gt_35) | (stochrsi_k_1h < 90.0) | (roc_9_1h_lt_10))
+            & ((rsi_3_1d_gt_35) | (stochrsi_k_1h_lt_90) | (roc_9_1h_lt_10))
             # 1d down move, 1h high & overbought
             & ((rsi_3_1d_gt_40) | (aroonu_14_1d_lt_70) | (roc_9_1d_lt_80))
             # 1d down move, 4h high & overbought
@@ -20251,7 +20282,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h downtrend, 1h high
             & ((cmf_20_1h > -0.20) | aroonu_14_1h_lt_80)
             # 4h & 1d downtrend, 1d high
-            & ((cmf_20_4h > -0.30) | (cmf_20_1d > -0.30) | (stochrsi_k_1d < 60.0))
+            & ((cmf_20_4h > -0.30) | (cmf_20_1d > -0.30) | (stochrsi_k_1d_lt_60))
             # 1d downtrend, 1d high & overbought
             & ((cmf_20_1d > -0.30) | (aroonu_14_1d < 85.0) | (roc_9_1d_lt_100))
             # 1d downtrend, 1d high & overbought
@@ -20301,9 +20332,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1d high, 4h & 1d overbought
             & (aroonu_14_1d_lt_100 | (roc_9_4h < 20.0) | (roc_9_1d_lt_30))
             # 1h high, 4h & 1d overbought
-            & ((stochrsi_k_1h < 90.0) | (roc_9_4h_lt_20) | (roc_9_1d_lt_100))
+            & ((stochrsi_k_1h_lt_90) | (roc_9_4h_lt_20) | (roc_9_1d_lt_100))
             # 4h still high, 4h & 1d downtrend
-            & ((stochrsi_k_4h < 40.0) | (roc_9_4h_gt_neg_20) | (roc_9_1d_gt_neg_40))
+            & ((stochrsi_k_4h_lt_40) | (roc_9_4h_gt_neg_20) | (roc_9_1d_gt_neg_40))
             # 4h high, 1h & 1d downtrend
             & ((stochrsi_k_4h_lt_70) | (roc_9_1h > -20.0) | (roc_9_1d_gt_neg_20))
             # 4h high, 4h & 1d overbought
@@ -20327,7 +20358,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # drop in last 20 days, 1h high, 1d downtrend
             & ((close > (high_max_20_1d * 0.20)) | aroonu_14_1h_lt_70 | (roc_9_1d > -70.0))
             # drop in last 20 days, 1d high, 1d downtrend
-            & ((close > (high_max_20_1d * 0.20)) | (stochrsi_k_1d < 70.0) | (roc_9_1d > -15.0))
+            & ((close > (high_max_20_1d * 0.20)) | (stochrsi_k_1d_lt_70) | (roc_9_1d > -15.0))
           )
 
           # Logic
@@ -20355,15 +20386,15 @@ class NostalgiaForInfinityX7(IStrategy):
             # 5m & 4h down move, 1d downtrend
             & ((rsi_3_gt_5) | (rsi_3_4h_gt_10) | (roc_9_1d > -20.0))
             # 5m & 4h down move, 15m still high
-            & ((rsi_3_gt_5) | (rsi_3_4h_gt_25) | (stochrsi_k_15m < 50.0))
+            & ((rsi_3_gt_5) | (rsi_3_4h_gt_25) | (stochrsi_k_15m_lt_50))
             # 5 & 15m down move, 1h high
-            & ((rsi_3_gt_10) | (rsi_3_15m_gt_40) | (stochrsi_k_1h < 90.0))
+            & ((rsi_3_gt_10) | (rsi_3_15m_gt_40) | (stochrsi_k_1h_lt_90))
             # 5m down move, 1h & 4h high
             & ((rsi_3_gt_10) | (aroonu_14_1h < 85.0) | (aroonu_14_4h_lt_90))
             # 15m & 1h & 4h & 1d down move, 1d still high
             & ((rsi_3_15m_gt_3) | (rsi_3_1h_gt_3) | (rsi_3_4h_gt_15) | (rsi_3_1d_gt_50) | (rsi_14_1d < 40.0))
             # 15m & 1h down move, 4h still not low enough
-            & ((rsi_3_15m_gt_3) | (rsi_3_1h_gt_5) | (stochrsi_k_4h < 30.0))
+            & ((rsi_3_15m_gt_3) | (rsi_3_1h_gt_5) | (stochrsi_k_4h_lt_30))
             # 15m & 1h down move, 1d still high
             & ((rsi_3_15m_gt_3) | (rsi_3_1h_gt_5) | (aroonu_14_1d < 40.0))
             # 15m & 1h & 4h down move, 4h still not low enough, 1d still high
@@ -20373,17 +20404,17 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 4h down move, 4h high
             & ((rsi_3_15m_gt_3) | (rsi_3_1h_gt_30) | (aroonu_14_4h < 75.0))
             # 15m & 1h down move, 1h still not low enough
-            & ((rsi_3_15m_gt_3) | (rsi_3_1h_gt_35) | (stochrsi_k_1h < 30.0))
+            & ((rsi_3_15m_gt_3) | (rsi_3_1h_gt_35) | (stochrsi_k_1h_lt_30))
             # 15m & 4h down move, 4h still not low enough
-            & ((rsi_3_15m_gt_3) | (rsi_3_4h_gt_10) | (stochrsi_k_4h < 20.0))
+            & ((rsi_3_15m_gt_3) | (rsi_3_4h_gt_10) | (stochrsi_k_4h_lt_20))
             # 15m & 4h down move, 1d downtrend
             & ((rsi_3_15m_gt_3) | (rsi_3_4h_gt_10) | (roc_9_1d > -20.0))
             # 15m & 4h down move, 4h still not low enough
             & ((rsi_3_15m_gt_3) | (rsi_3_4h_gt_25) | (aroonu_14_4h < 30.0))
             # 15m & 4h down move, 4h still not low enough
-            & ((rsi_3_15m_gt_3) | (rsi_3_4h_gt_25) | (stochrsi_k_4h < 30.0))
+            & ((rsi_3_15m_gt_3) | (rsi_3_4h_gt_25) | (stochrsi_k_4h_lt_30))
             # 15m down move, 15m still not low enough, 1h high
-            & ((rsi_3_15m_gt_3) | (aroonu_14_15m < 20.0) | (stochrsi_k_1h < 60.0))
+            & ((rsi_3_15m_gt_3) | (aroonu_14_15m < 20.0) | (stochrsi_k_1h_lt_60))
             # 15m down move, 15m still not low enough, 4h high
             & ((rsi_3_15m_gt_3) | (aroonu_14_15m < 30.0) | (stochrsi_k_4h_lt_70))
             # 15m down move, 4h high, 1d overbought
@@ -20391,9 +20422,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h & 1d down move
             & ((rsi_3_15m_gt_5) | (rsi_3_1h_gt_10) | (rsi_3_1d_gt_20))
             # 15m down move, 1h still not low enough, 1d high
-            & ((rsi_3_15m_gt_5) | (stochrsi_k_1h < 30.0) | (aroonu_14_1d_lt_90))
+            & ((rsi_3_15m_gt_5) | (stochrsi_k_1h_lt_30) | (aroonu_14_1d_lt_90))
             # 15m & 1h down move, 1h still not low enough
-            & ((rsi_3_15m_gt_5) | (rsi_3_1h_gt_30) | (stochrsi_k_1h < 30.0))
+            & ((rsi_3_15m_gt_5) | (rsi_3_1h_gt_30) | (stochrsi_k_1h_lt_30))
             # 15m & 1h down move, 4h high
             & ((rsi_3_15m_gt_5) | (rsi_3_1h_gt_30) | (stochrsi_k_4h_lt_80))
             # 15m & 1h down move, 4h high
@@ -20403,13 +20434,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 4h high
             & ((rsi_3_15m_gt_5) | (rsi_3_1h_gt_50) | (stochrsi_k_4h_lt_90))
             # 15m & 4h down move, 1d still high
-            & ((rsi_3_15m_gt_5) | (rsi_3_4h_gt_5) | (stochrsi_k_1d < 40.0))
+            & ((rsi_3_15m_gt_5) | (rsi_3_4h_gt_5) | (stochrsi_k_1d_lt_40))
             # 15m & 4h down move, 4h still high
             & ((rsi_3_15m_gt_5) | (rsi_3_4h_gt_40) | (stochrsi_k_4h_lt_50))
             # 15m & 1d down move
             & ((rsi_3_15m_gt_5) | (rsi_3_1d_gt_5))
             # 15m & 1d down move, 4h still not low enough
-            & ((rsi_3_15m_gt_5) | (rsi_3_1d_gt_30) | (stochrsi_k_4h < 30.0))
+            & ((rsi_3_15m_gt_5) | (rsi_3_1d_gt_30) | (stochrsi_k_4h_lt_30))
             # 15m down move, 1h still high, 4h high
             & ((rsi_3_15m_gt_5) | (aroonu_14_1h_lt_50) | (stochrsi_k_4h_lt_90))
             # 15m down move, 1h high & overbought
@@ -20419,11 +20450,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 4h still high
             & ((rsi_3_15m_gt_10) | rsi_3_1h_gt_20 | (stochrsi_k_4h_lt_50))
             # 15m & 1h & 4h down move, 1d high
-            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_25) | (rsi_3_4h_gt_25) | (stochrsi_k_1d < 70.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_25) | (rsi_3_4h_gt_25) | (stochrsi_k_1d_lt_70))
             # 15m & 1h down move, 1h still not low enough
             & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_25) | (aroonu_14_1h < 25.0))
             # 15m & 1h down move, 1h still high
-            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_30) | (stochrsi_k_1h < 40.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_30) | (stochrsi_k_1h_lt_40))
             # 15m & 1h down move, 4h still high
             & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_30) | (stochrsi_k_4h_lt_50))
             # 15m & 1h down move, 1h still high
@@ -20451,11 +20482,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 1h & 4h high
             & ((rsi_3_15m_gt_10) | (stochrsi_k_1h_lt_70) | (stochrsi_k_4h < 75.0))
             # 15m & 1h down move, 15m still not low enough
-            & ((rsi_3_15m_gt_15) | (rsi_3_1h_gt_15) | (stochrsi_k_15m < 30.0))
+            & ((rsi_3_15m_gt_15) | (rsi_3_1h_gt_15) | (stochrsi_k_15m_lt_30))
             # 15m & 1h down move, 4h high
             & ((rsi_3_15m_gt_15) | rsi_3_1h_gt_20 | (stochrsi_k_4h_lt_90))
             # 15m & 1h down move, 1h still high
-            & ((rsi_3_15m_gt_15) | (rsi_3_1h_gt_25) | (stochrsi_k_1h < 40.0))
+            & ((rsi_3_15m_gt_15) | (rsi_3_1h_gt_25) | (stochrsi_k_1h_lt_40))
             # 15m & 1h down move, 1h still high
             & ((rsi_3_15m_gt_15) | (rsi_3_1h_gt_40) | (aroonu_14_1h_lt_50))
             # 15m & 1h down move, 4h high & overbought
@@ -20463,7 +20494,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 4h & 1d down move
             & ((rsi_3_15m_gt_15) | (rsi_3_4h_gt_15) | (rsi_3_1d_gt_15))
             # 15m & 4h down move, 1h high
-            & ((rsi_3_15m_gt_15) | (rsi_3_4h_gt_15) | (stochrsi_k_1h < 80.0))
+            & ((rsi_3_15m_gt_15) | (rsi_3_4h_gt_15) | (stochrsi_k_1h_lt_80))
             # 15m & 4h down move, 1h still high
             & ((rsi_3_15m_gt_15) | rsi_3_4h_gt_20 | (stochrsi_k_1h_lt_50))
             # 15m & 4h down move, 15m still not low enough
@@ -20485,17 +20516,17 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 1d high & overbought
             & ((rsi_3_15m_gt_20) | aroonu_14_1d_lt_100 | (roc_9_1d_lt_20))
             # 15m down move, 1h high, 1d downtrend
-            & ((rsi_3_15m_gt_20) | (stochrsi_k_1h < 80.0) | (roc_9_1d_gt_neg_20))
+            & ((rsi_3_15m_gt_20) | (stochrsi_k_1h_lt_80) | (roc_9_1d_gt_neg_20))
             # 15m down move, 1d high & overbought
             & ((rsi_3_15m_gt_20) | (stochrsi_k_1h_lt_80) | (roc_9_1d_lt_20))
             # 15m & 1h down move, 1h high
-            & ((rsi_3_15m_gt_25) | (rsi_3_1h_gt_25) | (stochrsi_k_1h < 60.0))
+            & ((rsi_3_15m_gt_25) | (rsi_3_1h_gt_25) | (stochrsi_k_1h_lt_60))
             # 15m & 1h down move, 1h high
             & ((rsi_3_15m_gt_25) | (rsi_3_1h_gt_60) | (aroonu_14_1h < 85.0))
             # 15m down move, 15m still not low enough, 4h high
             & ((rsi_3_15m_gt_25) | (aroonu_14_15m < 25.0) | (aroonu_14_4h_lt_60))
             # 15m down move, 15m still not low enough, 1h high
-            & ((rsi_3_15m_gt_25) | (stochrsi_k_15m < 30.0) | aroonu_14_1h_lt_80)
+            & ((rsi_3_15m_gt_25) | (stochrsi_k_15m_lt_30) | aroonu_14_1h_lt_80)
             # 15m & 1h down move, 1h high
             & ((rsi_3_15m_gt_30) | (rsi_3_1h_gt_45) | aroonu_14_1h_lt_70)
             # 1h & 4h down move, 15m downtrend
@@ -20509,13 +20540,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 4h downtrend
             & ((rsi_3_1h_gt_5) | (rsi_3_4h_gt_15) | (roc_9_4h_gt_neg_30))
             # 1h & 4h down move, 4h still not low enough
-            & ((rsi_3_1h_gt_5) | rsi_3_4h_gt_20 | (stochrsi_k_4h < 20.0))
+            & ((rsi_3_1h_gt_5) | rsi_3_4h_gt_20 | (stochrsi_k_4h_lt_20))
             # 1h & 4h down move, 1d low
             & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_10) | (cmf_20_1d > -0.2))
             # 1h & 4h down move, 4h still not low enough
             & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_15) | (aroonu_14_4h < 20.0))
             # 1h & 4h down move, 4h still not low enough
-            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_25) | (stochrsi_k_4h < 30.0))
+            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_25) | (stochrsi_k_4h_lt_30))
             # 1h & 1d down move, 5m moving down
             & ((rsi_3_1h_gt_10) | (rsi_3_1d_gt_15) | (roc_2 > -0.0))
             # 1h down move, 4h downtrend
@@ -20525,19 +20556,19 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h & 1d down move
             & ((rsi_3_1h_gt_15) | rsi_3_4h_gt_20 | (rsi_3_1d_gt_30))
             # 1h & 4h down move, 1h still high
-            & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_30) | (stochrsi_k_1h < 40.0))
+            & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_30) | (stochrsi_k_1h_lt_40))
             # 1h & 4h down move, 1h still not low enough
-            & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_40) | (stochrsi_k_1h < 30.0))
+            & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_40) | (stochrsi_k_1h_lt_30))
             # 1h & 4h down move, 1h still high
             & ((rsi_3_1h_gt_15) | (rsi_3_1d_gt_10) | (aroonu_14_1h < 40.0))
             # 1h down move, 1d high & overbought
             & (rsi_3_1h_gt_20 | (aroonu_14_1d_lt_90) | (roc_9_1d_lt_30))
             # 1h down move, 1h still not low enough, 4h high
-            & (rsi_3_1h_gt_20 | (stochrsi_k_1h < 20.0) | aroonu_14_4h_lt_80)
+            & (rsi_3_1h_gt_20 | (stochrsi_k_1h_lt_20) | aroonu_14_4h_lt_80)
             # 1h & 4h down move, 1h still high
             & ((rsi_3_1h_gt_25) | (rsi_3_4h_gt_25) | (stochrsi_k_1h_lt_50))
             # 1h & 4h down move, 1d high
-            & ((rsi_3_1h_gt_25) | (rsi_3_4h_gt_30) | (stochrsi_k_1d < 80.0))
+            & ((rsi_3_1h_gt_25) | (rsi_3_4h_gt_30) | (stochrsi_k_1d_lt_80))
             # 1h & 4h down move, 1h high
             & ((rsi_3_1h_gt_25) | (rsi_3_4h_gt_60) | (stochrsi_k_4h_lt_80))
             # 1h & 4h down move, 1h still high
@@ -20547,23 +20578,23 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 4h & 1d high
             & ((rsi_3_1h_gt_30) | aroonu_14_4h_lt_80 | aroonu_14_1d_lt_100)
             # 1h down move, 15m high
-            & ((rsi_3_1h_gt_35) | (stochrsi_k_15m < 80.0))
+            & ((rsi_3_1h_gt_35) | (stochrsi_k_15m_lt_80))
             # 1h down move, 1h high, 1d overbought
             & ((rsi_3_1h_gt_35) | aroonu_14_1h_lt_70 | (roc_9_1d_lt_20))
             # 1h down move, 1h & 4h high
             & ((rsi_3_1h_gt_40) | aroonu_14_1h_lt_80 | aroonu_14_4h_lt_100)
             # 1h down move, 1h high, 1d high & overbought
-            & ((rsi_3_1h_gt_45) | (stochrsi_k_1h < 60.0) | (stochrsi_k_1d < 70.0) | (roc_9_1d < 40.0))
+            & ((rsi_3_1h_gt_45) | (stochrsi_k_1h_lt_60) | (stochrsi_k_1d_lt_70) | (roc_9_1d < 40.0))
             # 1h down move, 1h high & overbought
             & ((rsi_3_1h_gt_55) | (stochrsi_k_1h_lt_80) | (roc_9_1h_lt_10))
             # 1h down move, 4h high
             & ((rsi_3_1h_gt_60) | (aroonu_14_4h_lt_90))
             # 4h down move, 15m still high
-            & ((rsi_3_4h_gt_5) | (stochrsi_k_15m < 40.0))
+            & ((rsi_3_4h_gt_5) | (stochrsi_k_15m_lt_40))
             # 4h down move, 1d still high, 1d downtrend
             & ((rsi_3_4h_gt_10) | (aroonu_14_1d < 40.0) | (roc_9_1d > -20.0))
             # 4h down move, 15m 4h still high
-            & ((rsi_3_4h_gt_10) | (stochrsi_k_15m < 40.0) | (aroonu_14_4h_lt_50))
+            & ((rsi_3_4h_gt_10) | (stochrsi_k_15m_lt_40) | (aroonu_14_4h_lt_50))
             # 4h & 1d down move, 4h high
             & ((rsi_3_4h_gt_15) | (rsi_3_1d_gt_25) | aroonu_14_4h_lt_70)
             # 4h down move, 1h still high
@@ -20585,13 +20616,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 4h high, 1d downtrend
             & ((rsi_3_4h_gt_40) | (stochrsi_k_4h_lt_70) | (roc_9_1d > -60.0))
             # 4h down move, 4h still high
-            & ((rsi_3_4h_gt_60) | (stochrsi_k_4h < 40.0))
+            & ((rsi_3_4h_gt_60) | (stochrsi_k_4h_lt_40))
             # 4h down move, 4h overbought
             & ((rsi_3_4h_gt_60) | (roc_9_4h_lt_20))
             # 1d down move, 1h still high, 4h high
             & ((rsi_3_1d_gt_20) | (aroonu_14_1h_lt_50) | (aroonu_14_4h < 85.0))
             # 1d down move, 1h high & overbought
-            & ((rsi_3_1d_gt_35) | (stochrsi_k_1h < 90.0) | (roc_9_1h_lt_10))
+            & ((rsi_3_1d_gt_35) | (stochrsi_k_1h_lt_90) | (roc_9_1h_lt_10))
             # 1d down move, 4h high, 1d overbought
             & ((rsi_3_1d_gt_45) | (stochrsi_k_4h_lt_90) | (roc_9_1d < 10.0))
             # 4h still high, 4h moving lower, 4h overbought
@@ -20603,13 +20634,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1d high, 4h & 1d overbought
             & (aroonu_14_1d_lt_100 | (roc_9_4h_lt_10) | (roc_9_1d_lt_20))
             # 1h high, 4h downtrend
-            & ((stochrsi_k_1h < 80.0) | (roc_9_4h_gt_neg_20))
+            & ((stochrsi_k_1h_lt_80) | (roc_9_4h_gt_neg_20))
             # 1h high, 4h overbought
             & ((stochrsi_k_1h_lt_80) | (roc_9_4h < 80.0))
             # 4h high, 4h & 1d overbought
             & ((stochrsi_k_4h_lt_80) | (roc_9_4h_lt_30) | (roc_9_1d_lt_30))
             # 1d high, 4h & 1d overbought
-            & ((stochrsi_k_1d < 80.0) | (roc_9_4h < 60.0) | (roc_9_1d < 60.0))
+            & ((stochrsi_k_1d_lt_80) | (roc_9_4h < 60.0) | (roc_9_1d < 60.0))
             # 1d red, 4h down move, 1h still high
             & ((change_pct_1d > -30.0) | (rsi_3_4h_gt_30) | (stochrsi_k_1h_lt_50))
             # pump, drop but not yet near the previous lows
@@ -20629,7 +20660,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # big drop in last 6 hours, 1d overbought
             & ((close > (df["high_max_6_1h"] * 0.65)) | roc_9_1d_lt_50)
             # big drop in last 4 hours, 4h still not low enough
-            & ((close > (high_max_24_4h * 0.50)) | (stochrsi_k_4h < 30.0))
+            & ((close > (high_max_24_4h * 0.50)) | (stochrsi_k_4h_lt_30))
             # big drop in the last 4 days, 4h down move
             & ((close > (high_max_24_4h * 0.20)) | rsi_3_4h_gt_20)
             # big drop in the last 6 days, 1d down move
@@ -20641,7 +20672,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # big drop in the last 20 days, 1h still high
             & ((close > (high_max_20_1d * 0.05)) | (aroonu_14_1h_lt_50))
             # big drop in the last 20 days, 1d high, 1d downtrend
-            & ((close > (high_max_20_1d * 0.20)) | (stochrsi_k_1d < 70.0) | (roc_9_1d > -15.0))
+            & ((close > (high_max_20_1d * 0.20)) | (stochrsi_k_1d_lt_70) | (roc_9_1d > -15.0))
             # big drop in the last 30 days, 1h down move
             & ((close > (high_max_30_1d * 0.25)) | (rsi_3_1h_gt_15))
           )
@@ -20651,7 +20682,7 @@ class NostalgiaForInfinityX7(IStrategy):
             (rsi_3_gt_3)
             & (rsi_14 < 36.0)
             & (aroonu_14 < 25.0)
-            & (stochrsi_k < 20.0)
+            & (stochrsi_k_lt_20)
             & (close < (sma_16 * 0.946))
             & (aroonu_14_15m_lt_50)
           )
@@ -20672,21 +20703,21 @@ class NostalgiaForInfinityX7(IStrategy):
             # 5m & 15m down move, 15m still high
             & ((rsi_3_gt_3) | (rsi_3_15m_gt_20) | (aroonu_14_15m < 40.0))
             # 5m & 15m down move, 1h still high
-            & ((rsi_3_gt_3) | (rsi_3_15m_gt_25) | (stochrsi_k_1h < 40.0))
+            & ((rsi_3_gt_3) | (rsi_3_15m_gt_25) | (stochrsi_k_1h_lt_40))
             # 5m & 1h down move, 4h still high
             & ((rsi_3_gt_3) | (rsi_3_1h_gt_25) | (aroonu_14_4h_lt_50))
             # 5m & 4h & 1d down move
             & ((rsi_3_gt_3) | rsi_3_4h_gt_20 | (rsi_3_1d_gt_20))
             # 5m & 1d down move, 15m still high
-            & ((rsi_3_gt_3) | (rsi_3_1d_gt_10) | (stochrsi_k_15m < 40.0))
+            & ((rsi_3_gt_3) | (rsi_3_1d_gt_10) | (stochrsi_k_15m_lt_40))
             # 5m down move, 15m high
             & ((rsi_3_gt_3) | (aroonu_14_15m_lt_70))
             # 5m down move, 15m & 1h still high
-            & ((rsi_3_gt_3) | (stochrsi_k_15m < 40.0) | (aroonu_14_1h < 40.0))
+            & ((rsi_3_gt_3) | (stochrsi_k_15m_lt_40) | (aroonu_14_1h < 40.0))
             # 5m down move, 1h high
-            & ((rsi_3_gt_3) | aroonu_14_1h_lt_70 | (stochrsi_k_1h < 50.0))
+            & ((rsi_3_gt_3) | aroonu_14_1h_lt_70 | (stochrsi_k_1h_lt_50))
             # 5m & 1h down move, 1h high
-            & ((rsi_3_gt_5) | (rsi_3_1h_gt_40) | (stochrsi_k_1h < 60.0))
+            & ((rsi_3_gt_5) | (rsi_3_1h_gt_40) | (stochrsi_k_1h_lt_60))
             # 5m & 4h down move, 4h high
             & ((rsi_3_gt_5) | (rsi_3_4h_gt_50) | aroonu_14_4h_lt_70)
             # 5m down move, 15m still high, 1h high
@@ -20694,13 +20725,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 5m down move, 15m still high, 1h high
             & ((rsi_3_gt_5) | (aroonu_14_15m < 40.0) | (stochrsi_k_1h_lt_50))
             # 5m down move, 15m & 4h high
-            & ((rsi_3_gt_5) | (stochrsi_k_15m < 70.0) | (stochrsi_k_4h_lt_90))
+            & ((rsi_3_gt_5) | (stochrsi_k_15m_lt_70) | (stochrsi_k_4h_lt_90))
             # 5m & 15m down move, 4h high
             & ((rsi_3_gt_10) | (rsi_3_15m_gt_20) | (aroonu_14_4h_lt_90))
             # 5m & 15m down move, 1d high
-            & ((rsi_3_gt_10) | (rsi_3_15m_gt_20) | (stochrsi_k_1d < 80.0))
+            & ((rsi_3_gt_10) | (rsi_3_15m_gt_20) | (stochrsi_k_1d_lt_80))
             # 5m & 15m down move, 1h high
-            & ((rsi_3_gt_10) | (rsi_3_15m_gt_25) | (stochrsi_k_1h < 90.0))
+            & ((rsi_3_gt_10) | (rsi_3_15m_gt_25) | (stochrsi_k_1h_lt_90))
             # 5m & 1h down move, 4h still high
             & ((rsi_3_gt_10) | (rsi_3_1h_gt_30) | (stochrsi_k_4h_lt_50))
             # 5m down move, 1h & 4h high
@@ -20708,17 +20739,17 @@ class NostalgiaForInfinityX7(IStrategy):
             # 5m down move, 4h high, 1d high
             & ((rsi_3_gt_10) | (aroonu_14_4h_lt_60) | (stochrsi_k_1d_lt_90))
             # 5m down move, 15m still high, 1h high
-            & ((rsi_3_gt_15) | (rsi_14_15m < 40.0) | (stochrsi_k_1h < 90.0))
+            & ((rsi_3_gt_15) | (rsi_14_15m < 40.0) | (stochrsi_k_1h_lt_90))
             # 5m down move, 15m still high, 4h high
             & ((rsi_3_gt_15) | (rsi_14_15m < 40.0) | (stochrsi_k_4h_lt_90))
             # 15m down move, 15m still not low enough, 1h high
-            & (rsi_3_15m_gt_3 | (aroonu_14_15m < 20.0) | (stochrsi_k_1h < 60.0))
+            & (rsi_3_15m_gt_3 | (aroonu_14_15m < 20.0) | (stochrsi_k_1h_lt_60))
             # 15m & 1h down move, 1d high
             & ((rsi_3_15m_gt_10) | rsi_3_1h_gt_20 | (aroonu_14_1d_lt_70))
             # 15m & 1h down move, 1h still not low enough
-            & ((rsi_3_15m_gt_10) | rsi_3_1h_gt_20 | (stochrsi_k_1h < 20.0))
+            & ((rsi_3_15m_gt_10) | rsi_3_1h_gt_20 | (stochrsi_k_1h_lt_20))
             # 15m & 1h & 4h down move, 1d high
-            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_25) | (rsi_3_4h_gt_25) | (stochrsi_k_1d < 70.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_25) | (rsi_3_4h_gt_25) | (stochrsi_k_1d_lt_70))
             # 15m & 1h down move, 1h still not low enough
             & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_25) | (aroonu_14_1h < 30.0))
             # 15m & 1h down move, 1h still high
@@ -20730,17 +20761,17 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 4h down move, 4h still not low enough
             & ((rsi_3_15m_gt_10) | (rsi_3_4h_gt_15) | (aroonu_14_4h < 30.0))
             # 15m& 4h down move, 15m still high
-            & ((rsi_3_15m_gt_10) | (rsi_3_4h_gt_15) | (stochrsi_k_15m < 40.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_4h_gt_15) | (stochrsi_k_15m_lt_40))
             # 15m & 4h down move, 15m still high
             & ((rsi_3_15m_gt_10) | rsi_3_4h_gt_20 | (aroonu_14_15m_lt_50))
             # 15m & 4h down move, 4h still not low enough
-            & ((rsi_3_15m_gt_10) | rsi_3_4h_gt_20 | (stochrsi_k_4h < 30.0))
+            & ((rsi_3_15m_gt_10) | rsi_3_4h_gt_20 | (stochrsi_k_4h_lt_30))
             # 15m & 4h down move, 4h still high
             & ((rsi_3_15m_gt_10) | (rsi_3_4h_gt_25) | (aroonu_14_4h_lt_50))
             # 15m & 4h down move, 4h still high
-            & ((rsi_3_15m_gt_10) | (rsi_3_4h_gt_30) | (stochrsi_k_4h < 40.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_4h_gt_30) | (stochrsi_k_4h_lt_40))
             # 15m & 4h down move, 1h still high
-            & ((rsi_3_15m_gt_10) | rsi_3_4h_gt_20 | (stochrsi_k_1h < 40.0))
+            & ((rsi_3_15m_gt_10) | rsi_3_4h_gt_20 | (stochrsi_k_1h_lt_40))
             # 15m & 4h down move, 1d high
             & ((rsi_3_15m_gt_10) | (rsi_3_4h_gt_25) | (aroonu_14_1d < 85.0))
             # 15m & 4h down move, 1h still high
@@ -20758,7 +20789,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 1h still high
             & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_30) | (aroonu_14_1h < 40.0))
             # 15m & 1h & 4h & 1d down move, 1d high
-            & ((rsi_3_15m_gt_15) | (rsi_3_1h_gt_30) | (rsi_3_4h_gt_40) | (rsi_3_1d_gt_50) | (stochrsi_k_1d < 70.0))
+            & ((rsi_3_15m_gt_15) | (rsi_3_1h_gt_30) | (rsi_3_4h_gt_40) | (rsi_3_1d_gt_50) | (stochrsi_k_1d_lt_70))
             # 15m & 1h down move, 1h still high
             & ((rsi_3_15m_gt_15) | (rsi_3_1h_gt_40) | (aroonu_14_1h_lt_50))
             # 15m & 1h down move, 1h still high
@@ -20766,7 +20797,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 4h high
             & ((rsi_3_15m_gt_15) | (rsi_3_1h_gt_45) | (aroonu_14_4h_lt_80))
             # 15m & 1h down move, 15m still not low enough
-            & ((rsi_3_15m_gt_15) | (rsi_3_1h_gt_45) | (stochrsi_k_15m < 50.0))
+            & ((rsi_3_15m_gt_15) | (rsi_3_1h_gt_45) | (stochrsi_k_15m_lt_50))
             # 15m & 4h & 1d down move
             & ((rsi_3_15m_gt_15) | (rsi_3_4h_gt_15) | (rsi_3_1d_gt_15))
             # 15m & 4h down move, 4h still high
@@ -20786,9 +20817,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 15m & 4h still high
             & ((rsi_3_15m_gt_15) | (aroonu_14_15m_lt_50) | (aroonu_14_4h_lt_50))
             # 15m down move, 15m still high, 1h high
-            & ((rsi_3_15m_gt_15) | (stochrsi_k_15m < 40.0) | (stochrsi_k_1h_lt_70))
+            & ((rsi_3_15m_gt_15) | (stochrsi_k_15m_lt_40) | (stochrsi_k_1h_lt_70))
             # 15m down move, 1h still high, 4h high
-            & ((rsi_3_15m_gt_15) | (stochrsi_k_1h_lt_50) | (stochrsi_k_4h < 60.0))
+            & ((rsi_3_15m_gt_15) | (stochrsi_k_1h_lt_50) | (stochrsi_k_4h_lt_60))
             # 15m down move, 4h still high 1d overbought
             & ((rsi_3_15m_gt_15) | (aroonu_14_4h_lt_50) | roc_9_1d_lt_50)
             # 15m & 1h down move, 15m still not low enough
@@ -20798,7 +20829,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 15m high
             & ((rsi_3_15m_gt_20) | (rsi_3_1h_gt_40) | (aroonu_14_15m < 60.0))
             # 15m & 4h down move, 1h high
-            & ((rsi_3_15m_gt_20) | rsi_3_4h_gt_20 | (stochrsi_k_1h < 60.0))
+            & ((rsi_3_15m_gt_20) | rsi_3_4h_gt_20 | (stochrsi_k_1h_lt_60))
             # 15m & 4h down move, 4h high
             & ((rsi_3_15m_gt_20) | (rsi_3_4h_gt_60) | aroonu_14_4h_lt_80)
             # 15m & 1d down move, 4h high
@@ -20812,9 +20843,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 15m still high, 4d downtrend
             & ((rsi_3_15m_gt_20) | (aroonu_14_15m < 40.0) | (roc_9_4h_gt_neg_20))
             # 15m down move, 15m still not low enough, 1h still high
-            & ((rsi_3_15m_gt_20) | (stochrsi_k_15m < 30.0) | (aroonu_14_1h_lt_50))
+            & ((rsi_3_15m_gt_20) | (stochrsi_k_15m_lt_30) | (aroonu_14_1h_lt_50))
             # 15m down move, 15m & 1h still high
-            & ((rsi_3_15m_gt_20) | (aroonu_14_15m_lt_50) | (stochrsi_k_1h < 40.0))
+            & ((rsi_3_15m_gt_20) | (aroonu_14_15m_lt_50) | (stochrsi_k_1h_lt_40))
             # 15m down move, 1h & 4h high
             & ((rsi_3_15m_gt_20) | aroonu_14_1h_lt_70 | (aroonu_14_4h_lt_90))
             # 15m & 1h down move, 1h high
@@ -20850,9 +20881,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 15m high, 4h still high
             & ((rsi_3_15m_gt_30) | (aroonu_14_15m_lt_70) | (aroonu_14_4h_lt_50))
             # 15m down move, 15m still not low enough, 1h high
-            & ((rsi_3_15m_gt_30) | (stochrsi_k_15m < 30.0) | (stochrsi_k_1h_lt_80))
+            & ((rsi_3_15m_gt_30) | (stochrsi_k_15m_lt_30) | (stochrsi_k_1h_lt_80))
             # 15m down move, 15m still high, 1d high, 1d downtrend
-            & ((rsi_3_15m_gt_30) | (aroonu_14_15m_lt_50) | (stochrsi_k_1d < 70.0) | (roc_9_1d > -15.0))
+            & ((rsi_3_15m_gt_30) | (aroonu_14_15m_lt_50) | (stochrsi_k_1d_lt_70) | (roc_9_1d > -15.0))
             # 15m down move, 1h still high, 4h high
             & ((rsi_3_15m_gt_30) | (aroonu_14_1h_lt_50) | (aroonu_14_4h_lt_90))
             # 15m down move, 15m & 1h high
@@ -20872,7 +20903,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 4h still high
             & ((rsi_3_1h_gt_15) | rsi_3_4h_gt_20 | (rsi_14_4h < 40.0))
             # 1h & 4h down move, 1h still high
-            & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_30) | (stochrsi_k_1h < 50.0))
+            & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_30) | (stochrsi_k_1h_lt_50))
             # 1h & 4h down move, 4h still high
             & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_30) | (aroonu_14_4h_lt_40))
             # 1h & 1d down move, 4h downtrend
@@ -20884,9 +20915,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 4h high
             & ((rsi_3_1h_gt_25) | (rsi_3_4h_gt_40) | aroonu_14_4h_lt_70)
             # 1h down move, 1h still not low enough, 4h high
-            & ((rsi_3_1h_gt_25) | (stochrsi_k_1h < 30.0) | (stochrsi_k_4h_lt_70))
+            & ((rsi_3_1h_gt_25) | (stochrsi_k_1h_lt_30) | (stochrsi_k_4h_lt_70))
             # 1h down move, 1d still high, 1d downtrend
-            & ((rsi_3_1h_gt_25) | (stochrsi_k_1d < 50.0) | (roc_9_1d_gt_neg_20))
+            & ((rsi_3_1h_gt_25) | (stochrsi_k_1d_lt_50) | (roc_9_1d_gt_neg_20))
             # 1h down move, 4h high & overbought
             & ((rsi_3_1h_gt_30) | aroonu_14_4h_lt_70 | (roc_9_4h_lt_10))
             # 1h down move, 4h high, 1d downtrend
@@ -20914,11 +20945,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 4h still not low enough, 1d overbought
             & ((rsi_3_4h_gt_15) | (aroonu_14_4h < 30.0) | (roc_9_1d < 100.0))
             # 4h down move, 15m still high, 1d downtrend
-            & ((rsi_3_4h_gt_15) | (stochrsi_k_15m < 50.0) | (roc_9_1d > -20.0))
+            & ((rsi_3_4h_gt_15) | (stochrsi_k_15m_lt_50) | (roc_9_1d > -20.0))
             # 4h & 1d down move, 15m still not low enough
-            & (rsi_3_4h_gt_20 | (rsi_3_1d_gt_20) | (stochrsi_k_15m < 30.0))
+            & (rsi_3_4h_gt_20 | (rsi_3_1d_gt_20) | (stochrsi_k_15m_lt_30))
             # 4h down move, 4h still not low enough, 1d downtrend
-            & (rsi_3_4h_gt_20 | (stochrsi_k_4h < 30.0) | (roc_9_1d_gt_neg_20))
+            & (rsi_3_4h_gt_20 | (stochrsi_k_4h_lt_30) | (roc_9_1d_gt_neg_20))
             # 4h down move, 1d high, 4h downtrend
             & ((rsi_3_4h_gt_30) | (stochrsi_k_1d_lt_90) | (roc_9_4h_gt_neg_20))
             # 4h & 1d down move, 4h still high, 1d high
@@ -20928,19 +20959,19 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h & 1d down move, 1d high
             & ((rsi_3_4h_gt_40) | (rsi_3_1d_gt_60) | aroonu_14_1d_lt_100)
             # 4h down move, 4h high, 1d downtrend
-            & ((rsi_3_4h_gt_60) | (stochrsi_k_4h < 80.0) | (roc_9_1d_gt_neg_20))
+            & ((rsi_3_4h_gt_60) | (stochrsi_k_4h_lt_80) | (roc_9_1d_gt_neg_20))
             # 4h down move, 15m high, 4h overbought
-            & ((rsi_3_4h_gt_60) | (stochrsi_k_15m < 80.0) | (roc_9_4h_lt_20))
+            & ((rsi_3_4h_gt_60) | (stochrsi_k_15m_lt_80) | (roc_9_4h_lt_20))
             # 4h down move, 4h & 1d overbought
             & ((rsi_3_4h_gt_60) | (roc_9_4h_lt_20) | (roc_9_1d_lt_20))
             # 1d down move, 1h & 4h still not low enough
-            & ((rsi_3_1d_gt_5) | (stochrsi_k_1h < 20.0) | (stochrsi_k_4h < 20.0))
+            & ((rsi_3_1d_gt_5) | (stochrsi_k_1h_lt_20) | (stochrsi_k_4h_lt_20))
             # 1d down move, 1h high, 1d downtrend
             & ((rsi_3_1d_gt_10) | (aroonu_14_1h < 85.0) | (roc_9_1d_gt_neg_30))
             # 1d down move, 15m still not low enough, 1h still high
             & ((rsi_3_1d_gt_15) | (aroonu_14_15m < 30.0) | (stochrsi_k_1h_lt_50))
             # 15m still not low enough, 1h high, 1d overbought
-            & ((aroonu_14_15m < 30.0) | (stochrsi_k_1h < 80.0) | (roc_9_1d_lt_100))
+            & ((aroonu_14_15m < 30.0) | (stochrsi_k_1h_lt_80) | (roc_9_1d_lt_100))
             # 15m still high, 4h high & overbought
             & ((aroonu_14_15m < 40.0) | (stochrsi_k_4h_lt_80) | (roc_9_4h_lt_30))
             # 15m & 1h & 4h high
@@ -20950,7 +20981,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1d high, 1d overbought
             & ((aroonu_14_15m_lt_70) | (aroonu_14_1d_lt_90) | (roc_9_1d_lt_100))
             # 15m high
-            & ((aroonu_14_15m < 80.0) | (stochrsi_k_15m < 60.0))
+            & ((aroonu_14_15m < 80.0) | (stochrsi_k_15m_lt_60))
             # 15m & 4h high
             & ((aroonu_14_15m < 80.0) | (stochrsi_k_4h_lt_70))
             # 15m high, 1d overbought
@@ -20998,7 +21029,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # big drop in the last 4 days, 4h down move
             & ((close > (high_max_24_4h * 0.20)) | rsi_3_4h_gt_20)
             # big drop in the last 12 days, 1h high
-            & ((close > (high_max_12_1d * 0.30)) | (stochrsi_k_1h < 90.0))
+            & ((close > (high_max_12_1d * 0.30)) | (stochrsi_k_1h_lt_90))
             # big drop in the last 20 days, 1d down move
             & ((close > (high_max_20_1d * 0.40)) | (rsi_3_1d_gt_30))
             # big drop in the last 30 days, 4h down move, 4h still high
@@ -21032,7 +21063,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m & 1h down move, 15m high
           long_entry_logic.append((rsi_3_15m_gt_20) | (rsi_3_1h_gt_45) | (aroonu_14_15m_lt_70))
           # 15m & 4h down move, 15m still high
-          long_entry_logic.append((rsi_3_15m_gt_20) | rsi_3_4h_gt_20 | (stochrsi_k_15m < 50.0))
+          long_entry_logic.append((rsi_3_15m_gt_20) | rsi_3_4h_gt_20 | (stochrsi_k_15m_lt_50))
           # 15m down move, 15m still high, 1h high
           long_entry_logic.append((rsi_3_15m_gt_20) | (rsi_14_15m < 40.0) | (stochrsi_k_1h_lt_70))
           # 15m down move, 15m still high, 4h high
@@ -21044,7 +21075,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m down move, 15m high, 4h still high
           long_entry_logic.append((rsi_3_15m_gt_20) | (aroonu_14_15m_lt_70) | (aroonu_14_4h_lt_50))
           # 15m down move, 15m & 1h still high
-          long_entry_logic.append((rsi_3_15m_gt_20) | (stochrsi_k_15m < 50.0) | (stochrsi_k_1h_lt_50))
+          long_entry_logic.append((rsi_3_15m_gt_20) | (stochrsi_k_15m_lt_50) | (stochrsi_k_1h_lt_50))
           # 15m down move, 4h overbought
           long_entry_logic.append((rsi_3_15m_gt_20) | (roc_9_4h < 70.0))
           # 15m down move, 15m still high, 1h high
@@ -21072,7 +21103,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1h & 4h down move, 1h still high
           long_entry_logic.append((rsi_3_1h_gt_10) | rsi_3_4h_gt_20 | (aroonu_14_1h < 40.0))
           # 1h & 4h down move, 15m still not low enough
-          long_entry_logic.append((rsi_3_1h_gt_10) | rsi_3_4h_gt_20 | (stochrsi_k_15m < 20.0))
+          long_entry_logic.append((rsi_3_1h_gt_10) | rsi_3_4h_gt_20 | (stochrsi_k_15m_lt_20))
           # 1h down move, 1d high & overbought
           long_entry_logic.append((rsi_3_1h_gt_10) | (aroonu_14_1d_lt_90) | (roc_9_1d < 10.0))
           # 1h & 4h down move, 4h still high
@@ -21082,7 +21113,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1h down move, 15m still not low enough, 4h high
           long_entry_logic.append(rsi_3_1h_gt_20 | (aroonu_14_15m < 25.0) | aroonu_14_4h_lt_80)
           # 1h down move, 4h & 1d high
-          long_entry_logic.append((rsi_3_1h_gt_30) | aroonu_14_4h_lt_70 | (stochrsi_k_1d < 80.0))
+          long_entry_logic.append((rsi_3_1h_gt_30) | aroonu_14_4h_lt_70 | (stochrsi_k_1d_lt_80))
           # 1h down move, 4h high & overbought
           long_entry_logic.append((rsi_3_1h_gt_30) | aroonu_14_4h_lt_70 | (roc_9_4h_lt_10))
           # 1h down move, 4h high, 1d overbought
@@ -21110,13 +21141,13 @@ class NostalgiaForInfinityX7(IStrategy):
           # 4h down move, 1h & 4h downtrend
           long_entry_logic.append((rsi_3_4h_gt_5) | (roc_9_1h > -30.0) | (roc_9_4h_gt_neg_30))
           # 1h down move, 4h high & overbought
-          long_entry_logic.append((rsi_3_1h_gt_50) | (stochrsi_k_4h < 90.0) | (roc_9_4h_lt_20))
+          long_entry_logic.append((rsi_3_1h_gt_50) | (stochrsi_k_4h_lt_90) | (roc_9_4h_lt_20))
           # 4h down move, 4h still high, 1d downtrend
           long_entry_logic.append(rsi_3_4h_gt_20 | (aroonu_14_4h_lt_50) | (roc_9_1d_gt_neg_40))
           # 1h down move, 15m & 1h still high
-          long_entry_logic.append(rsi_3_4h_gt_20 | (stochrsi_k_15m < 40.0) | (stochrsi_k_1h_lt_50))
+          long_entry_logic.append(rsi_3_4h_gt_20 | (stochrsi_k_15m_lt_40) | (stochrsi_k_1h_lt_50))
           # 4h down move, 15m still high, 4h high
-          long_entry_logic.append((rsi_3_4h_gt_25) | (stochrsi_k_15m < 50.0) | aroonu_14_4h_lt_70)
+          long_entry_logic.append((rsi_3_4h_gt_25) | (stochrsi_k_15m_lt_50) | aroonu_14_4h_lt_70)
           # 4h down move, 15m still not low enough, 4h high
           long_entry_logic.append((rsi_3_4h_gt_35) | (aroonu_14_15m < 30.0) | aroonu_14_4h_lt_70)
           # 4h down move, 1h high, 4h downtrend
@@ -21130,7 +21161,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 4h down move, 15m still high, 1h high
           long_entry_logic.append((rsi_3_4h_gt_60) | (aroonu_14_15m_lt_50) | (aroonu_14_1h_lt_90))
           # 4h down move, 1h high, 1d overbought
-          long_entry_logic.append((rsi_3_4h_gt_60) | (stochrsi_k_1h < 90.0) | (roc_9_1d_lt_30))
+          long_entry_logic.append((rsi_3_4h_gt_60) | (stochrsi_k_1h_lt_90) | (roc_9_1d_lt_30))
           # 1d down move, 1h high, 1d downtrend
           long_entry_logic.append((rsi_3_1d_gt_10) | aroonu_14_1h_lt_80 | (roc_9_1d > -10.0))
           # 1d down move, 4h high
@@ -21166,11 +21197,11 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1d high, 4h & 1d overbought
           long_entry_logic.append(aroonu_14_1d_lt_100 | (roc_9_4h_lt_10) | roc_9_1d_lt_50)
           # 15m still high, 1h high
-          long_entry_logic.append((stochrsi_k_15m < 40.0) | (aroonu_14_1h_lt_90) | (stochrsi_k_1h < 90.0))
+          long_entry_logic.append((stochrsi_k_15m_lt_40) | (aroonu_14_1h_lt_90) | (stochrsi_k_1h_lt_90))
           # 15m still high, 1d high
-          long_entry_logic.append((stochrsi_k_15m < 50.0) | (stochrsi_k_1d_lt_90))
+          long_entry_logic.append((stochrsi_k_15m_lt_50) | (stochrsi_k_1d_lt_90))
           # 4h high, 4h & 1d overbought
-          long_entry_logic.append((stochrsi_k_4h < 80.0) | (roc_9_4h_lt_40) | (roc_9_1d_lt_100))
+          long_entry_logic.append((stochrsi_k_4h_lt_80) | (roc_9_4h_lt_40) | (roc_9_1d_lt_100))
           # 1d green, 4h down move, 4h still high
           long_entry_logic.append((change_pct_1d < 40.0) | (rsi_3_4h_gt_35) | (aroonu_14_4h_lt_40))
           # 1d top wick, 4h high
@@ -21186,13 +21217,13 @@ class NostalgiaForInfinityX7(IStrategy):
             | (close < (low_min_24_4h * 1.25))
           )
           # pump, 1h high
-          long_entry_logic.append((((high_max_24_4h - low_min_24_4h) / low_min_24_4h) < 4.0) | (stochrsi_k_1h < 90.0))
+          long_entry_logic.append((((high_max_24_4h - low_min_24_4h) / low_min_24_4h) < 4.0) | (stochrsi_k_1h_lt_90))
           # big drop in the last 2 days, 1d down move
           long_entry_logic.append((close > (high_max_12_4h * 0.30)) | (rsi_3_1d_gt_30))
           # big drop in the last 12 days, 1h still high
           long_entry_logic.append((close > (high_max_12_1d * 0.25)) | (aroonu_14_1h_lt_50))
           # big drop in the last 12 days, 1h still not low enough
-          long_entry_logic.append((close > (high_max_12_1d * 0.10)) | (stochrsi_k_1h < 30.0))
+          long_entry_logic.append((close > (high_max_12_1d * 0.10)) | (stochrsi_k_1h_lt_30))
           # big drop in the last 12 days, 15m still high
           long_entry_logic.append((close > (high_max_12_1d * 0.20)) | (aroonu_14_15m_lt_50))
           # big drop in the last 20 days, 4h down move
@@ -21226,7 +21257,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m & 1h down move, 1d still high
           long_entry_logic.append(rsi_3_15m_gt_3 | (rsi_3_1h_gt_10) | (aroonu_14_1d < 50.0))
           # 15m & 1h down move, 1h still not low enough
-          long_entry_logic.append(rsi_3_15m_gt_3 | (rsi_3_1h_gt_15) | (stochrsi_k_1h < 30.0))
+          long_entry_logic.append(rsi_3_15m_gt_3 | (rsi_3_1h_gt_15) | (stochrsi_k_1h_lt_30))
           # 15m & 4h down move, 4h still high
           long_entry_logic.append(rsi_3_15m_gt_3 | (rsi_3_4h_gt_30) | (rsi_14_4h < 40.0))
           # 15m & 1h & 4h down move
@@ -21242,7 +21273,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m & 1h down move, 15m & 1h downtrend
           long_entry_logic.append((rsi_3_15m_gt_10) | (rsi_3_1h_gt_10) | (cmf_20_15m > -0.40) | (cmf_20_1h > -0.40))
           # 15m & 1h down move, 1h still not low enough
-          long_entry_logic.append((rsi_3_15m_gt_10) | (rsi_3_1h_gt_10) | (stochrsi_k_1h < 20.0))
+          long_entry_logic.append((rsi_3_15m_gt_10) | (rsi_3_1h_gt_10) | (stochrsi_k_1h_lt_20))
           # 15m & 1h down move, 4h still high
           long_entry_logic.append((rsi_3_15m_gt_10) | rsi_3_1h_gt_20 | (stochrsi_k_4h_lt_50))
           # 15m & 1h down move, 4h overbought
@@ -21252,7 +21283,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m & 4h down move, 1h & 4h downtrend
           long_entry_logic.append((rsi_3_15m_gt_10) | (rsi_3_4h_gt_10) | (cmf_20_1h > -0.20) | (cmf_20_4h > -0.20))
           # 15m & 4h down move, 4h still not low enough
-          long_entry_logic.append((rsi_3_15m_gt_10) | (rsi_3_4h_gt_10) | (stochrsi_k_4h < 30.0))
+          long_entry_logic.append((rsi_3_15m_gt_10) | (rsi_3_4h_gt_10) | (stochrsi_k_4h_lt_30))
           # 15m & 4h down move, 4h still high
           long_entry_logic.append((rsi_3_15m_gt_10) | (rsi_3_4h_gt_10) | (aroonu_14_4h_lt_40))
           # 15m & 4h down move, 1d high
@@ -21260,11 +21291,11 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m & 4h down move, 1h high
           long_entry_logic.append((rsi_3_15m_gt_10) | rsi_3_4h_gt_20 | (stochrsi_k_1h_lt_70))
           # 15m & 4h down move, 4h still high
-          long_entry_logic.append((rsi_3_15m_gt_10) | rsi_3_4h_gt_20 | (stochrsi_k_4h < 40.0))
+          long_entry_logic.append((rsi_3_15m_gt_10) | rsi_3_4h_gt_20 | (stochrsi_k_4h_lt_40))
           # 15m & 4h down move, 1d downtrend
           long_entry_logic.append((rsi_3_15m_gt_10) | rsi_3_4h_gt_20 | (roc_9_1d > -25.0))
           # 15m & 4h down move, 15m still not low enough
-          long_entry_logic.append((rsi_3_15m_gt_10) | (rsi_3_4h_gt_25) | (stochrsi_k_15m < 20.0))
+          long_entry_logic.append((rsi_3_15m_gt_10) | (rsi_3_4h_gt_25) | (stochrsi_k_15m_lt_20))
           # 15m & 4h down move, 4h high
           long_entry_logic.append((rsi_3_15m_gt_10) | (rsi_3_4h_gt_40) | aroonu_14_4h_lt_80)
           # 15m & 1h down move, 4h still high
@@ -21272,7 +21303,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m & 1h down move, 4h high
           long_entry_logic.append((rsi_3_15m_gt_15) | (rsi_3_1h_gt_25) | aroonu_14_4h_lt_70)
           # 15m & 1h down move, 1h high
-          long_entry_logic.append((rsi_3_15m_gt_15) | (rsi_3_1h_gt_25) | (stochrsi_k_1h < 60.0))
+          long_entry_logic.append((rsi_3_15m_gt_15) | (rsi_3_1h_gt_25) | (stochrsi_k_1h_lt_60))
           # 15m & 1h down move, 1h still high
           long_entry_logic.append((rsi_3_15m_gt_15) | (rsi_3_1h_gt_30) | (aroonu_14_1h < 40.0))
           # 15m down move, 4h still high, 4h downtrend
@@ -21280,17 +21311,17 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m down move, 1d high, 4h overbought
           long_entry_logic.append((rsi_3_15m_gt_15) | aroonu_14_1d_lt_100 | (roc_9_4h < 50.0))
           # 15m & 3h down move, 15m still not low enough
-          long_entry_logic.append((rsi_3_15m_gt_20) | rsi_3_4h_gt_20 | (stochrsi_k_15m < 20.0))
+          long_entry_logic.append((rsi_3_15m_gt_20) | rsi_3_4h_gt_20 | (stochrsi_k_15m_lt_20))
           # 15m & 1h down move, 1h still high
           long_entry_logic.append((rsi_3_15m_gt_25) | (rsi_3_1h_gt_25) | (rsi_14_1h < 40.0))
           # 15m & 4h down move, 4h high
           long_entry_logic.append((rsi_3_15m_gt_25) | (rsi_3_4h_gt_25) | aroonu_14_4h_lt_70)
           # 15m down move, 15m still not low enough, 1d overbought
-          long_entry_logic.append((rsi_3_15m_gt_25) | (stochrsi_k_15m < 20.0) | (roc_9_1d_lt_80))
+          long_entry_logic.append((rsi_3_15m_gt_25) | (stochrsi_k_15m_lt_20) | (roc_9_1d_lt_80))
           # 1h & 4h down move
           long_entry_logic.append((rsi_3_1h_gt_3) | (rsi_3_4h_gt_10))
           # 1h & 4h down move, 4h still not low enough
-          long_entry_logic.append((rsi_3_1h_gt_3) | (rsi_3_4h_gt_25) | (stochrsi_k_4h < 30.0))
+          long_entry_logic.append((rsi_3_1h_gt_3) | (rsi_3_4h_gt_25) | (stochrsi_k_4h_lt_30))
           # 1h & 4h down move, 4h high
           long_entry_logic.append((rsi_3_1h_gt_3) | (rsi_3_4h_gt_50) | aroonu_14_4h_lt_70)
           # 1h & 4h down move
@@ -21304,9 +21335,9 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1h & 4h down move
           long_entry_logic.append((rsi_3_1h_gt_10) | (rsi_3_4h_gt_10))
           # 1h & 4h down move, 4h still not low enough
-          long_entry_logic.append((rsi_3_1h_gt_10) | (rsi_3_4h_gt_15) | (stochrsi_k_4h < 30.0))
+          long_entry_logic.append((rsi_3_1h_gt_10) | (rsi_3_4h_gt_15) | (stochrsi_k_4h_lt_30))
           # 1h & 4h down move, 1d still high
-          long_entry_logic.append((rsi_3_1h_gt_10) | (rsi_3_4h_gt_15) | (stochrsi_k_1d < 50.0))
+          long_entry_logic.append((rsi_3_1h_gt_10) | (rsi_3_4h_gt_15) | (stochrsi_k_1d_lt_50))
           # 1h & 1d down move, 1h still moving lower
           long_entry_logic.append((rsi_3_1h_gt_10) | (rsi_3_1d_gt_15) | (cci_20_change_pct_1h > -0.0))
           # 1h down move, 1d high, 4h downtrend
@@ -21316,9 +21347,9 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1h & 4h & 1d down move
           long_entry_logic.append((rsi_3_1h_gt_15) | rsi_3_4h_gt_20 | (rsi_3_1d_gt_30))
           # 1h & 4h down move, 1h still not low enough
-          long_entry_logic.append((rsi_3_1h_gt_15) | rsi_3_4h_gt_20 | (stochrsi_k_1h < 20.0))
+          long_entry_logic.append((rsi_3_1h_gt_15) | rsi_3_4h_gt_20 | (stochrsi_k_1h_lt_20))
           # 1h & 4h down move, 4h still not low enough
-          long_entry_logic.append((rsi_3_1h_gt_15) | rsi_3_4h_gt_20 | (stochrsi_k_4h < 30.0))
+          long_entry_logic.append((rsi_3_1h_gt_15) | rsi_3_4h_gt_20 | (stochrsi_k_4h_lt_30))
           # 1h & 4h & 1d down move
           long_entry_logic.append((rsi_3_1h_gt_15) | (rsi_3_4h_gt_25) | (rsi_3_1d_gt_25))
           # 1h & 4h down move, 1h high
@@ -21326,7 +21357,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1h & 1d down move, 1d high
           long_entry_logic.append((rsi_3_1h_gt_15) | (rsi_3_1d_gt_25) | (aroonu_14_1d_lt_70))
           # 1h & 1d down move, 1d high
-          long_entry_logic.append((rsi_3_1h_gt_15) | (rsi_3_1d_gt_25) | (stochrsi_k_1d < 70.0))
+          long_entry_logic.append((rsi_3_1h_gt_15) | (rsi_3_1d_gt_25) | (stochrsi_k_1d_lt_70))
           # 1h down move, 1h & 4h high
           long_entry_logic.append((rsi_3_1h_gt_15) | (aroonu_14_1h < 60.0) | (aroonu_14_4h_lt_60))
           # 1h & 4h down move, 1d overbought
@@ -21354,7 +21385,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1h down move, 4h still not low enough, 1d overbought
           long_entry_logic.append((rsi_3_1h_gt_30) | (aroonu_14_4h < 30.0) | roc_9_1d_lt_50)
           # 1h down move, 1h still not low enough, 4h downtrend
-          long_entry_logic.append((rsi_3_1h_gt_35) | (stochrsi_k_1h < 30.0) | (roc_9_4h_gt_neg_20))
+          long_entry_logic.append((rsi_3_1h_gt_35) | (stochrsi_k_1h_lt_30) | (roc_9_4h_gt_neg_20))
           # 1h down move, 4h still high, 1d downtrend
           long_entry_logic.append((rsi_3_1h_gt_35) | (stochrsi_k_4h_lt_50) | (roc_9_1d_gt_neg_20))
           # 1h down move, 4h & 1d overbought
@@ -21362,33 +21393,33 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1h down move, 4h high & overbought
           long_entry_logic.append((rsi_3_1h_gt_50) | (aroonu_14_4h_lt_90) | (roc_9_4h_lt_20))
           # 1h down move, 4h high & overbought
-          long_entry_logic.append((rsi_3_1h_gt_50) | (stochrsi_k_4h < 80.0) | (roc_9_4h_lt_20))
+          long_entry_logic.append((rsi_3_1h_gt_50) | (stochrsi_k_4h_lt_80) | (roc_9_4h_lt_20))
           # 4h down move, 15m not low enough, 1h still high
-          long_entry_logic.append((rsi_3_4h_gt_3) | (stochrsi_k_15m < 20.0) | (stochrsi_k_1h < 40.0))
+          long_entry_logic.append((rsi_3_4h_gt_3) | (stochrsi_k_15m_lt_20) | (stochrsi_k_1h_lt_40))
           # 4h & 1d down move, 4h downtrend
           long_entry_logic.append((rsi_3_4h_gt_5) | (rsi_3_1d_gt_20) | (roc_9_4h_gt_neg_20))
           # 4h & 1d down move, 1d high
           long_entry_logic.append((rsi_3_4h_gt_5) | (rsi_3_1d_gt_30) | (aroonu_14_1d_lt_70))
           # 4h down move, 4h still high, 1d downtrend
-          long_entry_logic.append((rsi_3_4h_gt_5) | (stochrsi_k_4h < 40.0) | (roc_9_1d_gt_neg_20))
+          long_entry_logic.append((rsi_3_4h_gt_5) | (stochrsi_k_4h_lt_40) | (roc_9_1d_gt_neg_20))
           # 4h down move, 1d still not low enough, 1d downtrend
-          long_entry_logic.append((rsi_3_4h_gt_5) | (stochrsi_k_1d < 30.0) | (roc_9_1d_gt_neg_20))
+          long_entry_logic.append((rsi_3_4h_gt_5) | (stochrsi_k_1d_lt_30) | (roc_9_1d_gt_neg_20))
           # 4h down move, 1h downtrend, 1h still not low enough
           long_entry_logic.append((rsi_3_4h_gt_10) | (cmf_20_1h > -0.25) | (aroonu_14_1h < 30.0))
           # 4h down move, 1h & 1d downtrend
           long_entry_logic.append((rsi_3_4h_gt_10) | (roc_9_1h > -20.0) | (roc_9_1d > -20.0))
           # 4h & 1d down move, 4h still high
-          long_entry_logic.append((rsi_3_4h_gt_15) | (rsi_3_1d_gt_45) | (stochrsi_k_4h < 40.0))
+          long_entry_logic.append((rsi_3_4h_gt_15) | (rsi_3_1d_gt_45) | (stochrsi_k_4h_lt_40))
           # 4h & 1d down move, 1d high
-          long_entry_logic.append(rsi_3_4h_gt_20 | (rsi_3_1d_gt_25) | (stochrsi_k_1d < 60.0))
+          long_entry_logic.append(rsi_3_4h_gt_20 | (rsi_3_1d_gt_25) | (stochrsi_k_1d_lt_60))
           # 4h down move, 1d high & overbought
           long_entry_logic.append(rsi_3_4h_gt_20 | (aroonu_14_1d_lt_70) | roc_9_1d_lt_50)
           # 4h down move, 1h still high, 1d downtrend
-          long_entry_logic.append(rsi_3_4h_gt_20 | (stochrsi_k_1h < 50.0) | (roc_9_1d_gt_neg_20))
+          long_entry_logic.append(rsi_3_4h_gt_20 | (stochrsi_k_1h_lt_50) | (roc_9_1d_gt_neg_20))
           # 4h down move, 1h high
           long_entry_logic.append(rsi_3_4h_gt_20 | (stochrsi_k_1h_lt_80))
           # 4h down move, 1d high, 1h downtrend
-          long_entry_logic.append(rsi_3_4h_gt_20 | (stochrsi_k_1d < 70.0) | (roc_9_1h > -10.0))
+          long_entry_logic.append(rsi_3_4h_gt_20 | (stochrsi_k_1d_lt_70) | (roc_9_1h > -10.0))
           # 4h down move, 4h still high, 1d overbought
           long_entry_logic.append((rsi_3_4h_gt_30) | (aroonu_14_4h_lt_40) | (roc_9_1d_lt_100))
           # 4h down move, 4h high, 1h downtrend
@@ -21400,7 +21431,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 4h down move, 4h & 1d overbought
           long_entry_logic.append((rsi_3_4h_gt_40) | (roc_9_4h_lt_10) | roc_9_1d_lt_50)
           # 1d down move, 1h still not low enough
-          long_entry_logic.append((rsi_3_1d_gt_5) | (stochrsi_k_1h < 20.0))
+          long_entry_logic.append((rsi_3_1d_gt_5) | (stochrsi_k_1h_lt_20))
           # 1h & 4h high, 4h overbought
           long_entry_logic.append((aroonu_14_1h < 60.0) | aroonu_14_4h_lt_100 | (roc_9_4h_lt_30))
           # 4h & 1d high, 4h overbought
@@ -21437,9 +21468,9 @@ class NostalgiaForInfinityX7(IStrategy):
           # Logic
           long_entry_logic.append(rsi_3 < 40.0)
           long_entry_logic.append(aroonu_14 < 25.0)
-          long_entry_logic.append(stochrsi_k < 20.0)
+          long_entry_logic.append(stochrsi_k_lt_20)
           long_entry_logic.append(aroonu_14_15m < 25.0)
-          long_entry_logic.append(stochrsi_k_15m < 30.0)
+          long_entry_logic.append(stochrsi_k_15m_lt_30)
           long_entry_logic.append(close < df["EMA_16"] * 0.975)
           long_entry_logic.append(((df["EMA_50"] - df["EMA_200"]) / close * 100.0) < -5.5)
 
@@ -21464,7 +21495,7 @@ class NostalgiaForInfinityX7(IStrategy):
 
           # Logic
           long_entry_logic.append(
-            (stochrsi_k < 20.0) & (willr_14 < -80.0) & (aroonu_14 < 25.0) & (close < (ema_20 * 0.978))
+            (stochrsi_k_lt_20) & (willr_14 < -80.0) & (aroonu_14 < 25.0) & (close < (ema_20 * 0.978))
           )
 
         # Condition #141 - Top Coins mode (Long).
@@ -21488,19 +21519,19 @@ class NostalgiaForInfinityX7(IStrategy):
             # 5m & 4h down move, 15m still high
             & ((rsi_3_gt_3) | (rsi_3_4h_gt_5) | (aroonu_14_15m < 40.0))
             # 5m & 4h down move, 15m still high
-            & ((rsi_3_gt_3) | (rsi_3_4h_gt_5) | (stochrsi_k_15m < 40.0))
+            & ((rsi_3_gt_3) | (rsi_3_4h_gt_5) | (stochrsi_k_15m_lt_40))
             # 5m & 4h down move, 15m still high
-            & ((rsi_3_gt_3) | rsi_3_4h_gt_20 | (stochrsi_k_15m < 50.0))
+            & ((rsi_3_gt_3) | rsi_3_4h_gt_20 | (stochrsi_k_15m_lt_50))
             # 5m & 4h down move, 1h high
             & ((rsi_3_gt_3) | (rsi_3_4h_gt_45) | (stochrsi_k_1h_lt_80))
             # 5m & 1d down move, 15m high
             & ((rsi_3_gt_3) | (rsi_3_1d_gt_10) | (aroonu_14_15m_lt_70))
             # 5m & 1d down move, 15m stil high
-            & ((rsi_3_gt_3) | (rsi_3_1d_gt_10) | (stochrsi_k_15m < 40.0))
+            & ((rsi_3_gt_3) | (rsi_3_1d_gt_10) | (stochrsi_k_15m_lt_40))
             # 5m & 1d down move, 4h still high
-            & ((rsi_3_gt_3) | (rsi_3_1d_gt_10) | (stochrsi_k_4h < 40.0))
+            & ((rsi_3_gt_3) | (rsi_3_1d_gt_10) | (stochrsi_k_4h_lt_40))
             # 5m down move, 1h high
-            & ((rsi_3_gt_3) | (stochrsi_k_1h < 90.0))
+            & ((rsi_3_gt_3) | (stochrsi_k_1h_lt_90))
             # 5m down move, 15m & 1d high
             & ((rsi_3_gt_5) | (aroonu_14_15m < 60.0) | aroonu_14_1d_lt_100)
             # 5m down move, 1h & 1d high
@@ -21508,15 +21539,15 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 1d overbought
             & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_10) | (roc_9_1d < 100.0))
             # 15m & 1h down move, 1h still not low enough
-            & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_10) | (stochrsi_k_1h < 20.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_10) | (stochrsi_k_1h_lt_20))
             # 15m & 1h down move, 1d overbought
             & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_10) | (roc_9_1d < 60.0))
             # 15m & 1h down move, 4h still high
             & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_15) | (aroonu_14_4h_lt_40))
             # 15m & 1h down move, 4h high
-            & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_15) | (stochrsi_k_4h < 90.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_15) | (stochrsi_k_4h_lt_90))
             # 15m & 1h down move, 1d still high
-            & (rsi_3_15m_gt_3 | rsi_3_1h_gt_20 | (stochrsi_k_1d < 50.0))
+            & (rsi_3_15m_gt_3 | rsi_3_1h_gt_20 | (stochrsi_k_1d_lt_50))
             # 15m & 1h & 4h down move, 1d downtrend
             & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_25) | (rsi_14_4h < 40.0) | (roc_9_1d > -10.0))
             # 15m & 1h down move, 15m still high
@@ -21530,7 +21561,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 1h high
             & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_45) | (stochrsi_k_1h_lt_80))
             # 15m & 1h down move, 1d high
-            & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_45) | (stochrsi_k_1d < 80.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_45) | (stochrsi_k_1d_lt_80))
             # 15m & 4h down move, 15m downtrend
             & (rsi_3_15m_gt_3 | (rsi_3_4h_gt_3) | (cmf_20_15m > -0.30))
             # 15m & 4h down move, 4h still high
@@ -21544,9 +21575,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 1h still high
             & ((rsi_3_15m_gt_5) | (rsi_3_1h_gt_25) | (stochrsi_k_1h_lt_50))
             # 15m & 1h & 4h down move, 15m still not low enough, 1h still not low enough
-            & (
-              (rsi_3_15m_gt_5) | (rsi_3_1h_gt_30) | (rsi_3_4h_gt_30) | (aroonu_14_15m < 30.0) | (stochrsi_k_1h < 30.0)
-            )
+            & ((rsi_3_15m_gt_5) | (rsi_3_1h_gt_30) | (rsi_3_4h_gt_30) | (aroonu_14_15m < 30.0) | (stochrsi_k_1h_lt_30))
             # 15m & 1h down move, 1h high
             & ((rsi_3_15m_gt_5) | (rsi_3_1h_gt_30) | (stochrsi_k_1h_lt_80))
             # 15m & 4h down move, 1d high
@@ -21564,11 +21593,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 1d high
             & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_10) | (aroonu_14_1d < 85.0))
             # 15m & 1h down move, 15m still high
-            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_15) | (stochrsi_k_15m < 50.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_15) | (stochrsi_k_15m_lt_50))
             # 15m & 1h down move, 1h still high
-            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_15) | (stochrsi_k_1h < 50.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_15) | (stochrsi_k_1h_lt_50))
             # 15m & 1h down move, 1d still high
-            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_15) | (stochrsi_k_1d < 50.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_15) | (stochrsi_k_1d_lt_50))
             # 15m & 1h down move, 15m high
             & ((rsi_3_15m_gt_10) | rsi_3_1h_gt_20 | (aroonu_14_15m < 60.0))
             # 15m & 1h down move, 1h high
@@ -21596,7 +21625,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 4h down move, 1h high
             & ((rsi_3_15m_gt_10) | rsi_3_4h_gt_20 | (stochrsi_k_1h_lt_70))
             # 15m & 4h down move, 1d high
-            & ((rsi_3_15m_gt_10) | rsi_3_4h_gt_20 | (stochrsi_k_1d < 80.0))
+            & ((rsi_3_15m_gt_10) | rsi_3_4h_gt_20 | (stochrsi_k_1d_lt_80))
             # 15m & 4h down move, 1d overbought
             & ((rsi_3_15m_gt_10) | rsi_3_4h_gt_20 | roc_9_1d_lt_50)
             # 15m & 4h down move, 1d high
@@ -21606,11 +21635,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 4h down move, 4h high
             & ((rsi_3_15m_gt_10) | (rsi_3_4h_gt_45) | aroonu_14_4h_lt_70)
             # 15m down move, 1h high
-            & ((rsi_3_15m_gt_10) | (stochrsi_k_1h < 90.0))
+            & ((rsi_3_15m_gt_10) | (stochrsi_k_1h_lt_90))
             # 15m & 1d down move, 1h still high
             & ((rsi_3_15m_gt_10) | (rsi_3_1d_gt_10) | (stochrsi_k_1h_lt_50))
             # 15m & 1d down move, 1d high
-            & ((rsi_3_15m_gt_10) | (rsi_3_1d_gt_30) | (stochrsi_k_1d < 60.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_1d_gt_30) | (stochrsi_k_1d_lt_60))
             # 15m down move, 15m & 1h high
             & ((rsi_3_15m_gt_10) | (aroonu_14_15m < 60.0) | (aroonu_14_1h_lt_100))
             # 15m down move, 15m & 4h high
@@ -21628,23 +21657,23 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 4h high
             & ((rsi_3_15m_gt_15) | (rsi_3_1h_gt_15) | (aroonu_14_4h < 80.0))
             # 15m & 1h & 1d down move, 1h high
-            & ((rsi_3_15m_gt_15) | (rsi_3_1h_gt_25) | (rsi_3_1d_gt_25) | (stochrsi_k_1h < 60.0))
+            & ((rsi_3_15m_gt_15) | (rsi_3_1h_gt_25) | (rsi_3_1d_gt_25) | (stochrsi_k_1h_lt_60))
             # 15m & 1h down move, 1h high
             & ((rsi_3_15m_gt_15) | (rsi_3_1h_gt_40) | (aroonu_14_1h_lt_90))
             # 15m & 4h down move, 15m high
             & ((rsi_3_15m_gt_15) | (rsi_3_4h_gt_15) | (aroonu_14_15m_lt_50))
             # 15m & 4h down move, 1h high
-            & ((rsi_3_15m_gt_15) | (rsi_3_4h_gt_15) | (stochrsi_k_1h < 70.0))
+            & ((rsi_3_15m_gt_15) | (rsi_3_4h_gt_15) | (stochrsi_k_1h_lt_70))
             # 15m & 4h down move, 15m high
             & ((rsi_3_15m_gt_15) | (rsi_3_4h_gt_20) | (aroonu_14_15m_lt_70))
             # 15m & 4h down move, 4h high
             & ((rsi_3_15m_gt_15) | (rsi_3_4h_gt_25) | (aroonu_14_4h_lt_60))
             # 15m & 4h down move, 4h still high
-            & ((rsi_3_15m_gt_15) | (rsi_3_4h_gt_25) | (stochrsi_k_4h < 40.0))
+            & ((rsi_3_15m_gt_15) | (rsi_3_4h_gt_25) | (stochrsi_k_4h_lt_40))
             # 15m & 4h down move, 1h high
             & ((rsi_3_15m_gt_15) | (rsi_3_4h_gt_35) | (aroonu_14_1h_lt_90))
             # 15m & 1d down move, 1h still high
-            & ((rsi_3_15m_gt_15) | (rsi_3_1d_gt_15) | (stochrsi_k_1h < 30.0))
+            & ((rsi_3_15m_gt_15) | (rsi_3_1d_gt_15) | (stochrsi_k_1h_lt_30))
             # 15m down move, 15m downtrend, 1h high
             & ((rsi_3_15m_gt_15) | (cmf_20_15m > -0.40) | (aroonu_14_1h < 60.0))
             # 15m down move, 15m still high, 4h high
@@ -21662,13 +21691,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 1h high, 1d overbought
             & ((rsi_3_15m_gt_20) | (aroonu_14_1h_lt_80) | (roc_9_1d < 10.0))
             # 15m down move, 1h high, 1d downtrend
-            & ((rsi_3_15m_gt_20) | (stochrsi_k_1h < 80.0) | (roc_9_1d_gt_neg_20))
+            & ((rsi_3_15m_gt_20) | (stochrsi_k_1h_lt_80) | (roc_9_1d_gt_neg_20))
             # 15m down move, 4h high, 1d downtrend
-            & ((rsi_3_15m_gt_20) | (stochrsi_k_4h < 80.0) | (roc_9_1d_gt_neg_30))
+            & ((rsi_3_15m_gt_20) | (stochrsi_k_4h_lt_80) | (roc_9_1d_gt_neg_30))
             # 15m & 1h & 4h down move, 4h high
             & ((rsi_3_15m_gt_25) | (rsi_3_1h_gt_30) | (rsi_3_4h_gt_50) | (aroonu_14_4h_lt_70))
             # 15m & 4h down move, 15m high
-            & ((rsi_3_15m_gt_25) | (rsi_3_4h_gt_30) | (stochrsi_k_15m < 70.0))
+            & ((rsi_3_15m_gt_25) | (rsi_3_4h_gt_30) | (stochrsi_k_15m_lt_70))
             # 15m down move, 15m & 1h high
             & ((rsi_3_15m_gt_25) | (aroonu_14_15m_lt_70) | (aroonu_14_1h_lt_100))
             # 15m & 4h down mve, 1h high
@@ -21684,29 +21713,29 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 15m & 4h high
             & ((rsi_3_15m_gt_35) | (aroonu_14_15m_lt_70) | (aroonu_14_4h_lt_90))
             # 1h & 4h down move, 4h still not low enough
-            & ((rsi_3_1h_gt_3) | (rsi_3_4h_gt_10) | (stochrsi_k_4h < 10.0))
+            & ((rsi_3_1h_gt_3) | (rsi_3_4h_gt_10) | (stochrsi_k_4h_lt_10))
             # 1h & 4h down move, 1d still high
-            & ((rsi_3_1h_gt_3) | (rsi_3_4h_gt_10) | (stochrsi_k_1d < 40.0))
+            & ((rsi_3_1h_gt_3) | (rsi_3_4h_gt_10) | (stochrsi_k_1d_lt_40))
             # 1h & 4h down move, 1d overbought
             & ((rsi_3_1h_gt_3) | (rsi_3_4h_gt_25) | (roc_9_1d < 10.0))
             # 1h & 1d down move, 1d still high
-            & ((rsi_3_1h_gt_3) | (rsi_3_1d_gt_25) | (stochrsi_k_1d < 40.0))
+            & ((rsi_3_1h_gt_3) | (rsi_3_1d_gt_25) | (stochrsi_k_1d_lt_40))
             # 1h & 4h down move, 15m still not low enough
-            & ((rsi_3_1h_gt_5) | (rsi_3_4h_gt_5) | (stochrsi_k_15m < 20.0))
+            & ((rsi_3_1h_gt_5) | (rsi_3_4h_gt_5) | (stochrsi_k_15m_lt_20))
             # 1h & 4h down move, 4h downtrend
             & ((rsi_3_1h_gt_5) | (rsi_3_4h_gt_10) | (roc_9_4h > -10.0))
             # 1h & 4h down move, 15m high
-            & ((rsi_3_1h_gt_5) | (rsi_3_4h_gt_25) | (stochrsi_k_15m < 60.0))
+            & ((rsi_3_1h_gt_5) | (rsi_3_4h_gt_25) | (stochrsi_k_15m_lt_60))
             # 1h & 4h down move, 1d still high
             & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_10) | (aroonu_14_1d < 50.0))
             # 1h & 4h down move, 15m still high
-            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_10) | (stochrsi_k_15m < 70.0))
+            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_10) | (stochrsi_k_15m_lt_70))
             # 1h & 4h down move, 4h still not low enough
             & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_15) | (aroonu_14_4h < 30.0))
             # 1h & 4h down move, 4h still high
             & ((rsi_3_1h_gt_10) | rsi_3_4h_gt_20 | (aroonu_14_4h_lt_40))
             # 1h & 4h down move, 4h high
-            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_25) | (stochrsi_k_4h < 60.0))
+            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_25) | (stochrsi_k_4h_lt_60))
             # 1h & 4h down move, 4h high
             & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_40) | aroonu_14_4h_lt_70)
             # 1h & 1d down move, 1h still not low enough
@@ -21716,11 +21745,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 15m downtrend, 1d high
             & ((rsi_3_1h_gt_10) | (cmf_20_15m > -0.40) | (aroonu_14_1d_lt_70))
             # 1h down move, 1h high, 4h high
-            & ((rsi_3_1h_gt_10) | (aroonu_14_1h < 70.0) | (stochrsi_k_4h < 80.0))
+            & ((rsi_3_1h_gt_10) | (aroonu_14_1h < 70.0) | (stochrsi_k_4h_lt_80))
             # 1h & 4h down move, 1h still high
             & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_15) | (aroonu_14_1h < 40.0))
             # 1h & 4h down move, 1h still high
-            & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_15) | (stochrsi_k_1h < 50.0))
+            & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_15) | (stochrsi_k_1h_lt_50))
             # 1h & 4h down move, 1d downtrend
             & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_15) | (roc_9_1d > -30.0))
             # 1h & 1d down move, 4h downtrend
@@ -21730,7 +21759,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 1d down move, 1d high
             & ((rsi_3_1h_gt_15) | (rsi_3_1d_gt_35) | (aroonu_14_1d_lt_70))
             # 1h down move, 1h still high, 1d high
-            & ((rsi_3_1h_gt_15) | (aroonu_14_1h_lt_50) | (stochrsi_k_1d < 80.0))
+            & ((rsi_3_1h_gt_15) | (aroonu_14_1h_lt_50) | (stochrsi_k_1d_lt_80))
             # 1h down move, 1h still high, 4h overbought
             & ((rsi_3_1h_gt_15) | (aroonu_14_1h_lt_50) | (roc_9_4h_lt_10))
             # 1h down move, 1h still high, 1d downtrend
@@ -21754,7 +21783,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h high, 1d overbought
             & (rsi_3_1h_gt_20 | (aroonu_14_1h < 60.0) | (roc_9_1d < 10.0))
             # 1h & 4h down move, 15m high
-            & ((rsi_3_1h_gt_25) | (rsi_3_4h_gt_25) | (stochrsi_k_15m < 70.0))
+            & ((rsi_3_1h_gt_25) | (rsi_3_4h_gt_25) | (stochrsi_k_15m_lt_70))
             # 1h & 4h down move, 1h high
             & ((rsi_3_1h_gt_25) | (rsi_3_4h_gt_30) | aroonu_14_1h_lt_80)
             # 1h & 4h down move, 4h high
@@ -21764,7 +21793,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1d high & overbought
             & ((rsi_3_1h_gt_30) | (aroonu_14_1d < 85.0) | (roc_9_1d_lt_40))
             # 1h down move, 1d high & overbought
-            & ((rsi_3_1h_gt_30) | (stochrsi_k_1d < 80.0) | (roc_9_1d_lt_20))
+            & ((rsi_3_1h_gt_30) | (stochrsi_k_1d_lt_80) | (roc_9_1d_lt_20))
             # 1h down move, 15m still high, 1h high
             & ((rsi_3_1h_gt_30) | (aroonu_14_15m_lt_50) | (aroonu_14_1h < 85.0))
             # 1h down move, 4h high, 1d overbought
@@ -21782,7 +21811,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h & 4h high
             & ((rsi_3_1h_gt_45) | (aroonu_14_1h < 75.0) | aroonu_14_4h_lt_100)
             # 1h down move, 1h high, 1d high & overbought
-            & ((rsi_3_1h_gt_45) | (stochrsi_k_1h < 60.0) | (stochrsi_k_1d < 70.0) | (roc_9_1d < 40.0))
+            & ((rsi_3_1h_gt_45) | (stochrsi_k_1h_lt_60) | (stochrsi_k_1d_lt_70) | (roc_9_1d < 40.0))
             # 1h down move, 4h high & overbought
             & ((rsi_3_1h_gt_50) | (stochrsi_k_4h_lt_90) | (roc_9_4h < 25.0))
             # 1h & 1d down move, 1h high
@@ -21792,13 +21821,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 1h still not low enough, 4h downtrend
             & ((rsi_3_4h_gt_3) | (aroonu_14_1h < 20.0) | (roc_9_4h > -10.0))
             # 4h & 1d down move, 1d still high
-            & ((rsi_3_4h_gt_5) | (rsi_3_1d_gt_30) | (stochrsi_k_1d < 40.0))
+            & ((rsi_3_4h_gt_5) | (rsi_3_1d_gt_30) | (stochrsi_k_1d_lt_40))
             # 4h down move, 1h high
-            & ((rsi_3_4h_gt_5) | (stochrsi_k_1h < 90.0))
+            & ((rsi_3_4h_gt_5) | (stochrsi_k_1h_lt_90))
             # 4h down move, 4h & 1d downtrend
             & ((rsi_3_4h_gt_5) | (roc_9_4h > -10.0) | (roc_9_1d > -10.0))
             # 4h & 1d down move, 1h high
-            & ((rsi_3_4h_gt_10) | (rsi_3_1d_gt_10) | (stochrsi_k_1h < 60.0))
+            & ((rsi_3_4h_gt_10) | (rsi_3_1d_gt_10) | (stochrsi_k_1h_lt_60))
             # 4h & 1d down move, 4h downtrend
             & ((rsi_3_4h_gt_10) | (rsi_3_1d_gt_10) | (roc_9_4h > -20.0))
             # 4h & 1d down move, 1d still high
@@ -21808,17 +21837,17 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h & 1d down move, 1h high
             & ((rsi_3_4h_gt_10) | (rsi_3_1d_gt_30) | (aroonu_14_1h_lt_100))
             # 4h down move, 15m still high, 1h still high
-            & ((rsi_3_4h_gt_10) | (aroonu_14_15m < 40.0) | (stochrsi_k_1h < 50.0))
+            & ((rsi_3_4h_gt_10) | (aroonu_14_15m < 40.0) | (stochrsi_k_1h_lt_50))
             # 4h down move, 4h still high, 4h downtrend
             & ((rsi_3_4h_gt_10) | (aroonu_14_4h_lt_40) | (roc_9_4h > -20.0))
             # 4h down move, 15m high
-            & ((rsi_3_4h_gt_10) | (stochrsi_k_15m < 80.0))
+            & ((rsi_3_4h_gt_10) | (stochrsi_k_15m_lt_80))
             # 4h down move, 1h still not low enough, 4h downtrend
-            & ((rsi_3_4h_gt_10) | (stochrsi_k_1h < 20.0) | (roc_9_4h > -20.0))
+            & ((rsi_3_4h_gt_10) | (stochrsi_k_1h_lt_20) | (roc_9_4h > -20.0))
             # 4h & 1d down move, 15m still high
-            & ((rsi_3_4h_gt_15) | (rsi_3_1d_gt_15) | (stochrsi_k_15m < 50.0))
+            & ((rsi_3_4h_gt_15) | (rsi_3_1d_gt_15) | (stochrsi_k_15m_lt_50))
             # 4h & 1d down move, 1h still high
-            & ((rsi_3_4h_gt_15) | (rsi_3_1d_gt_15) | (stochrsi_k_1h < 40.0))
+            & ((rsi_3_4h_gt_15) | (rsi_3_1d_gt_15) | (stochrsi_k_1h_lt_40))
             # 4h & 1d down move, 1d high
             & ((rsi_3_4h_gt_15) | (rsi_3_1d_gt_20) | (aroonu_14_1d < 60.0))
             # 4h & 1d down move, 4h high
@@ -21828,15 +21857,15 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h & 1d down move, 1d high
             & ((rsi_3_4h_gt_15) | (rsi_3_1d_gt_40) | (aroonu_14_1d_lt_70))
             # 4h & 1d down move, 4h still high
-            & ((rsi_3_4h_gt_15) | (rsi_3_1d > 50.0) | (stochrsi_k_4h < 40.0))
+            & ((rsi_3_4h_gt_15) | (rsi_3_1d > 50.0) | (stochrsi_k_4h_lt_40))
             # 4h down move, 1d still high, 4h still not low enough
-            & ((rsi_3_4h_gt_15) | (rsi_14_1d < 40.0) | (stochrsi_k_4h < 30.0))
+            & ((rsi_3_4h_gt_15) | (rsi_14_1d < 40.0) | (stochrsi_k_4h_lt_30))
             # 4h down move, 4h still high, 4h downtrend
             & ((rsi_3_4h_gt_15) | (aroonu_14_4h_lt_50) | (roc_9_4h > -10.0))
             # 4h down move, 1d still high, 1d downtrend
             & ((rsi_3_4h_gt_15) | (aroonu_14_1d < 50.0) | (roc_9_1d > -20.0))
             # 4h down move, 4h still not low enough, 1d downtrend
-            & ((rsi_3_4h_gt_15) | (stochrsi_k_4h < 20.0) | (roc_9_1d > -20.0))
+            & ((rsi_3_4h_gt_15) | (stochrsi_k_4h_lt_20) | (roc_9_1d > -20.0))
             # 4h down move, 1h downtrend, 1d overbought
             & ((rsi_3_4h_gt_15) | (roc_9_1h > -10.0) | (roc_9_1d < 200.0))
             # 4h down move, 4h high, 4h downtrend
@@ -21846,7 +21875,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 4h & 1d downtrend
             & ((rsi_3_4h_gt_25) | (roc_9_4h > -10.0) | (roc_9_1d > -10.0))
             # 1h down move, 4h still not low enough, 1d downtrend
-            & (rsi_3_4h_gt_20 | (stochrsi_k_4h < 30.0) | (roc_9_1d_gt_neg_20))
+            & (rsi_3_4h_gt_20 | (stochrsi_k_4h_lt_30) | (roc_9_1d_gt_neg_20))
             # 4h & 1d down move, 1h high
             & ((rsi_3_4h_gt_25) | (rsi_3_1d_gt_25) | (stochrsi_k_1h_lt_80))
             # 4h down move, 1h high
@@ -21864,9 +21893,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 4h & 1d downtrend
             & ((rsi_3_4h_gt_30) | (roc_9_4h_gt_neg_20) | (roc_9_1d_gt_neg_40))
             # 4h down move, 4h still high, 1d downtrend
-            & ((rsi_3_4h_gt_35) | (stochrsi_k_4h < 40.0) | (roc_9_1d_gt_neg_30))
+            & ((rsi_3_4h_gt_35) | (stochrsi_k_4h_lt_40) | (roc_9_1d_gt_neg_30))
             # 4h down move, 1d high & overbought
-            & ((rsi_3_4h_gt_35) | (stochrsi_k_1d < 80.0) | (roc_9_1d_lt_20))
+            & ((rsi_3_4h_gt_35) | (stochrsi_k_1d_lt_80) | (roc_9_1d_lt_20))
             # 4h down move, 15m still high, 1h high
             & ((rsi_3_4h_gt_35) | (aroonu_14_15m_lt_50) | (aroonu_14_1h_lt_100))
             # 4h down move, 1h high
@@ -21882,7 +21911,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1d down move, 4h high, 1d overbought
             & ((rsi_3_1d_gt_45) | (stochrsi_k_4h_lt_90) | (roc_9_1d < 10.0))
             # 1d down move, 1d high & overbought
-            & ((rsi_3_1d_gt_55) | (stochrsi_k_1d < 80.0) | (roc_9_1d < 10.0))
+            & ((rsi_3_1d_gt_55) | (stochrsi_k_1d_lt_80) | (roc_9_1d < 10.0))
             # 1d down move, 1d overbought
             & ((rsi_3_1d_gt_60) | (roc_9_1d < 200.0))
             # 15m & 1h high, 4h overbought
@@ -21896,7 +21925,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m high, 1d high & overbought
             & ((aroonu_14_15m_lt_70) | aroonu_14_1d_lt_100 | (roc_9_1d_lt_20))
             # 15m high, 1h high, 1d downtrend
-            & ((aroonu_14_15m_lt_70) | (stochrsi_k_1h < 80.0) | (roc_9_1d_gt_neg_20))
+            & ((aroonu_14_15m_lt_70) | (stochrsi_k_1h_lt_80) | (roc_9_1d_gt_neg_20))
             # 1h & 4h high, 4h overbought
             & ((aroonu_14_1h_lt_90) | (aroonu_14_4h_lt_90) | (roc_9_4h_lt_10))
             # 1h & 4h high, 1d overbought
@@ -21908,7 +21937,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h & 1d high, 1d overbought
             & ((aroonu_14_4h_lt_90) | aroonu_14_1d_lt_100 | roc_9_1d_lt_50)
             # 1h high, 1h & 4h overbought
-            & ((stochrsi_k_1h < 80.0) | (roc_9_1h < 20.0) | (roc_9_4h_lt_20))
+            & ((stochrsi_k_1h_lt_80) | (roc_9_1h < 20.0) | (roc_9_4h_lt_20))
             # 4h & 1d overbought
             & ((roc_9_4h < 100.0) | (roc_9_1d < 200.0))
           )
@@ -21941,7 +21970,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 1d high
             & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_10) | (aroonu_14_1d_lt_70))
             # 15m & 1h down move, 1h still high
-            & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_10) | (stochrsi_k_1h < 40.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_10) | (stochrsi_k_1h_lt_40))
             # 15m & 1h down move, 1d overbought
             & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_10) | (roc_9_1d < 60.0))
             # 15m & 1h down move, 1h still high
@@ -21949,7 +21978,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 4h still high
             & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_15) | (aroonu_14_4h_lt_40))
             # 15m & 1h down move, 4h high
-            & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_15) | (stochrsi_k_4h < 90.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_15) | (stochrsi_k_4h_lt_90))
             # 15m & 1h down move, 15m high
             & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_30) | (aroonu_14_15m_lt_70))
             # 15m & 1h down move, 1h high
@@ -21963,13 +21992,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 4h high
             & (rsi_3_15m_gt_3 | (aroonu_14_4h_lt_90))
             # 15m down move, 1h high, 1d overbought
-            & (rsi_3_15m_gt_3 | (stochrsi_k_1h < 60.0) | (roc_9_1d_lt_20))
+            & (rsi_3_15m_gt_3 | (stochrsi_k_1h_lt_60) | (roc_9_1d_lt_20))
             # 15m down move, 4h high
             & (rsi_3_15m_gt_3 | (stochrsi_k_4h_lt_80))
             # 15m & 1d down move, 1d still high
             & ((rsi_3_15m_gt_5) | (rsi_3_1h_gt_5) | (aroonu_14_1d < 40.0))
             # 15m & 1h down move, 15m still not low enough
-            & ((rsi_3_15m_gt_5) | (rsi_3_1h_gt_5) | (stochrsi_k_15m < 30.0))
+            & ((rsi_3_15m_gt_5) | (rsi_3_1h_gt_5) | (stochrsi_k_15m_lt_30))
             # 15m & 1h down move, 4h still high
             & ((rsi_3_15m_gt_5) | (rsi_3_1h_gt_10) | (stochrsi_k_4h_lt_50))
             # 15m & 4h down move, 1d high
@@ -21979,11 +22008,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 4h high
             & ((rsi_3_15m_gt_5) | (rsi_3_1h_gt_15) | (aroonu_14_4h < 85.0))
             # 15m & 1h down move, 4h high
-            & ((rsi_3_15m_gt_5) | (rsi_3_1h_gt_15) | (stochrsi_k_4h < 60.0))
+            & ((rsi_3_15m_gt_5) | (rsi_3_1h_gt_15) | (stochrsi_k_4h_lt_60))
             # 15m & 1h & 4h down move, 15m still not low enough, 1h still high
-            & (
-              (rsi_3_15m_gt_5) | (rsi_3_1h_gt_30) | (rsi_3_4h_gt_30) | (aroonu_14_15m < 30.0) | (stochrsi_k_1h < 40.0)
-            )
+            & ((rsi_3_15m_gt_5) | (rsi_3_1h_gt_30) | (rsi_3_4h_gt_30) | (aroonu_14_15m < 30.0) | (stochrsi_k_1h_lt_40))
             # 15m & 4h down move, 1d high
             & ((rsi_3_15m_gt_5) | rsi_3_4h_gt_20 | (aroonu_14_1d_lt_80))
             # 15m down move, 4h high, 1h overbought
@@ -21993,11 +22020,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 4h high
             & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_10) | (aroonu_14_4h < 85.0))
             # 15m & 1h down move, 1h still high
-            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_10) | (stochrsi_k_1h < 40.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_10) | (stochrsi_k_1h_lt_40))
             # 15m & 1h down move, 4h high
-            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_10) | (stochrsi_k_4h < 60.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_10) | (stochrsi_k_4h_lt_60))
             # 15m & 1h down move, 1h still high
-            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_15) | (stochrsi_k_1h < 50.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_15) | (stochrsi_k_1h_lt_50))
             # 15m & 1h down move, 15m high
             & ((rsi_3_15m_gt_10) | rsi_3_1h_gt_20 | (aroonu_14_15m < 60.0))
             # 15m & 1h down move, 15m still high
@@ -22023,7 +22050,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 4h down move, 1h high
             & ((rsi_3_15m_gt_10) | rsi_3_4h_gt_20 | (stochrsi_k_1h_lt_70))
             # 15m & 4h down move, 1d high
-            & ((rsi_3_15m_gt_10) | rsi_3_4h_gt_20 | (stochrsi_k_1d < 80.0))
+            & ((rsi_3_15m_gt_10) | rsi_3_4h_gt_20 | (stochrsi_k_1d_lt_80))
             # 15m & 4h down move, 1d overbought
             & ((rsi_3_15m_gt_10) | rsi_3_4h_gt_20 | roc_9_1d_lt_50)
             # 15m & 4h down move, 15m high
@@ -22075,21 +22102,21 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 1d high & overbought
             & ((rsi_3_15m_gt_15) | (aroonu_14_1d_lt_100) | (roc_9_1d_lt_80))
             # 15m & 1h down move, 1h high
-            & ((rsi_3_15m_gt_20) | (rsi_3_1h_gt_20) | (stochrsi_k_1h < 60.0))
+            & ((rsi_3_15m_gt_20) | (rsi_3_1h_gt_20) | (stochrsi_k_1h_lt_60))
             # 15m & 1h & 1d down move, 4h still high, 4h downtrend
             & ((rsi_3_15m_gt_20) | (rsi_3_1h_gt_25) | (rsi_3_1d_gt_25) | (aroonu_14_4h_lt_40) | (roc_9_4h_gt_neg_20))
             # 15m & 4h down move, 15m high
             & ((rsi_3_15m_gt_20) | (rsi_3_4h_gt_20) | (aroonu_14_15m_lt_70))
             # 15m & 4h down move, 15m still high
-            & ((rsi_3_15m_gt_20) | (rsi_3_4h_gt_20) | (stochrsi_k_15m < 50.0))
+            & ((rsi_3_15m_gt_20) | (rsi_3_4h_gt_20) | (stochrsi_k_15m_lt_50))
             # 15m down move, 15m & 1h high
             & ((rsi_3_15m_gt_20) | (aroonu_14_15m_lt_70) | (aroonu_14_1h_lt_100))
             # 15m down move, 15m high, 1d high
             & ((rsi_3_15m_gt_20) | (aroonu_14_15m < 90.0) | aroonu_14_1d_lt_100)
             # 15m down move, 1h high, 1d downtrend
-            & ((rsi_3_15m_gt_20) | (stochrsi_k_1h < 80.0) | (roc_9_1d_gt_neg_20))
+            & ((rsi_3_15m_gt_20) | (stochrsi_k_1h_lt_80) | (roc_9_1d_gt_neg_20))
             # 15m down move, 1h high & overbought
-            & ((rsi_3_15m_gt_20) | (stochrsi_k_1h < 90.0) | (roc_9_1h_lt_10))
+            & ((rsi_3_15m_gt_20) | (stochrsi_k_1h_lt_90) | (roc_9_1h_lt_10))
             # 15m & 1h & 4h down move, 4h high
             & ((rsi_3_15m_gt_25) | (rsi_3_1h_gt_30) | (rsi_3_4h_gt_50) | aroonu_14_4h_lt_70)
             # 15m down move, 15m still high, 4h high
@@ -22107,7 +22134,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 15m high, 1d overbought
             & ((rsi_3_15m_gt_35) | (aroonu_14_15m < 80.0) | roc_9_1d_lt_50)
             # 15m down move, 1d high, 1h overbought
-            & ((rsi_3_15m_gt_40) | (stochrsi_k_1d < 80.0) | (roc_9_1h < 20.0))
+            & ((rsi_3_15m_gt_40) | (stochrsi_k_1d_lt_80) | (roc_9_1h < 20.0))
             # 1h & 4h down move, 1d still high
             & ((rsi_3_1h_gt_3) | (rsi_3_4h_gt_10) | (aroonu_14_1d < 50.0))
             # 1h & 4h down move, 1d overbought
@@ -22117,13 +22144,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h & 1d down move
             & ((rsi_3_1h_gt_5) | rsi_3_4h_gt_20 | (rsi_3_1d_gt_25))
             # 1h & 4h down move, 15m high
-            & ((rsi_3_1h_gt_5) | (rsi_3_4h_gt_25) | (stochrsi_k_15m < 60.0))
+            & ((rsi_3_1h_gt_5) | (rsi_3_4h_gt_25) | (stochrsi_k_15m_lt_60))
             # 1h & 4h & 1d down move
             & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_10) | (rsi_3_1d_gt_15))
             # 1h & 4h down move, 1d still not low enough
-            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_10) | (stochrsi_k_1d < 20.0))
+            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_10) | (stochrsi_k_1d_lt_20))
             # 1h & 4h down move, 15m still high
-            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_15) | (stochrsi_k_15m < 50.0))
+            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_15) | (stochrsi_k_15m_lt_50))
             # 1h & 4h down move, 1h still not low enough
             & ((rsi_3_1h_gt_10) | rsi_3_4h_gt_20 | (aroonu_14_1h < 30.0))
             # 1h & 4h down move, 1d overbought
@@ -22137,13 +22164,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 1d still high
             & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_15) | (aroonu_14_1d < 50.0))
             # 1h & 4h down move, 1h still not low enough
-            & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_15) | (stochrsi_k_1h < 30.0))
+            & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_15) | (stochrsi_k_1h_lt_30))
             # 1h & 4h down move, 15m still not low enough
-            & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_15) | (stochrsi_k_15m < 30.0))
+            & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_15) | (stochrsi_k_15m_lt_30))
             # 1h & 4h down move, 4h still high
-            & ((rsi_3_1h_gt_15) | rsi_3_4h_gt_20 | (stochrsi_k_4h < 40.0))
+            & ((rsi_3_1h_gt_15) | rsi_3_4h_gt_20 | (stochrsi_k_4h_lt_40))
             # 1h & 1d down move, 1d still high
-            & ((rsi_3_1h_gt_15) | (rsi_3_1d_gt_20) | (stochrsi_k_1d < 40.0))
+            & ((rsi_3_1h_gt_15) | (rsi_3_1d_gt_20) | (stochrsi_k_1d_lt_40))
             # 1h & 1d down move, 1d high
             & ((rsi_3_1h_gt_15) | (rsi_3_1d_gt_35) | (aroonu_14_1d_lt_70))
             # 1h down move, 15m & 1d high
@@ -22169,15 +22196,15 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 4h high & overbought, 1d downtrend
             & ((rsi_3_1h_gt_20) | (stochrsi_k_4h_lt_80) | (roc_9_4h_lt_10) | (roc_9_1d_gt_neg_20))
             # 1h & 4h down move, 15m high
-            & ((rsi_3_1h_gt_25) | (rsi_3_4h_gt_25) | (stochrsi_k_15m < 70.0))
+            & ((rsi_3_1h_gt_25) | (rsi_3_4h_gt_25) | (stochrsi_k_15m_lt_70))
             # 1h & 4h down move, 4h high
             & ((rsi_3_1h_gt_25) | (rsi_3_4h_gt_30) | (aroonu_14_4h_lt_60))
             # 1h down move, 4h & 1d overbought
             & ((rsi_3_1h_gt_25) | (roc_9_4h_lt_30) | (roc_9_1d < 60.0))
             # 1h & 1d down move, 1d still high
-            & ((rsi_3_1h_gt_25) | (rsi_3_1d_gt_25) | (stochrsi_k_1d < 50.0))
+            & ((rsi_3_1h_gt_25) | (rsi_3_1d_gt_25) | (stochrsi_k_1d_lt_50))
             # 1h & 4h down move, 1h high
-            & ((rsi_3_1h_gt_30) | (rsi_3_4h_gt_30) | (stochrsi_k_1h < 60.0))
+            & ((rsi_3_1h_gt_30) | (rsi_3_4h_gt_30) | (stochrsi_k_1h_lt_60))
             # 1h & 4g down move, 4h still high
             & ((rsi_3_1h_gt_30) | (rsi_3_4h_gt_30) | (stochrsi_k_4h_lt_50))
             # 1h down move, 15m still high, 1h high
@@ -22187,13 +22214,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 4h & 1d high
             & ((rsi_3_1h_gt_35) | aroonu_14_4h_lt_100 | aroonu_14_1d_lt_100)
             # 1h down move, 1h still high, 1d downtrend
-            & ((rsi_3_1h_gt_35) | (stochrsi_k_1h < 50.0) | (roc_9_1d_gt_neg_30))
+            & ((rsi_3_1h_gt_35) | (stochrsi_k_1h_lt_50) | (roc_9_1d_gt_neg_30))
             # 1h & 1d down move, 1h high
             & ((rsi_3_1h_gt_45) | (rsi_3_1d_gt_45) | aroonu_14_1h_lt_80)
             # 1h down move, 1h & 4h high
             & ((rsi_3_1h_gt_45) | (aroonu_14_1h < 75.0) | aroonu_14_4h_lt_100)
             # 1h down move, 1h high, 1d high & overbought
-            & ((rsi_3_1h_gt_45) | (stochrsi_k_1h < 60.0) | (stochrsi_k_1d < 70.0) | (roc_9_1d < 40.0))
+            & ((rsi_3_1h_gt_45) | (stochrsi_k_1h_lt_60) | (stochrsi_k_1d_lt_70) | (roc_9_1d < 40.0))
             # 1h down move, 4h high & overbought
             & ((rsi_3_1h_gt_50) | (stochrsi_k_4h_lt_90) | (roc_9_4h < 25.0))
             # 4h & 1d down move, 1d downtrend
@@ -22205,23 +22232,23 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 4h still high, 4h downtrend
             & ((rsi_3_4h_gt_5) | (aroonu_14_4h_lt_40) | (roc_9_4h > -10.0))
             # 4h down move, 1h high
-            & ((rsi_3_4h_gt_5) | (stochrsi_k_1h < 90.0))
+            & ((rsi_3_4h_gt_5) | (stochrsi_k_1h_lt_90))
             # 4h & 1d down move, 1h still high
-            & ((rsi_3_4h_gt_10) | (rsi_3_1d_gt_10) | (stochrsi_k_1h < 50.0))
+            & ((rsi_3_4h_gt_10) | (rsi_3_1d_gt_10) | (stochrsi_k_1h_lt_50))
             # 4h & 1d down move, 1h high
-            & ((rsi_3_4h_gt_10) | (rsi_3_1d_gt_15) | (stochrsi_k_1h < 70.0))
+            & ((rsi_3_4h_gt_10) | (rsi_3_1d_gt_15) | (stochrsi_k_1h_lt_70))
             # 4h down move, 15m still high, 1h still high
-            & ((rsi_3_4h_gt_10) | (aroonu_14_15m < 40.0) | (stochrsi_k_1h < 50.0))
+            & ((rsi_3_4h_gt_10) | (aroonu_14_15m < 40.0) | (stochrsi_k_1h_lt_50))
             # 4h down move, 1d still high, 1d downtrend
             & ((rsi_3_4h_gt_10) | (aroonu_14_1d < 50.0) | (roc_9_1d > -30.0))
             # 4h down move, 15m high
-            & ((rsi_3_4h_gt_10) | (stochrsi_k_15m < 80.0))
+            & ((rsi_3_4h_gt_10) | (stochrsi_k_15m_lt_80))
             # 4h down move, 15m still high, 1d downtrend
-            & ((rsi_3_4h_gt_10) | (stochrsi_k_15m < 50.0) | (roc_9_1d > -30.0))
+            & ((rsi_3_4h_gt_10) | (stochrsi_k_15m_lt_50) | (roc_9_1d > -30.0))
             # 4h down move, 1h still high, 1d downtrend
-            & ((rsi_3_4h_gt_10) | (stochrsi_k_1h < 50.0) | (roc_9_1d > -30.0))
+            & ((rsi_3_4h_gt_10) | (stochrsi_k_1h_lt_50) | (roc_9_1d > -30.0))
             # 4h down move, 1h high, 4h downtrend
-            & ((rsi_3_4h_gt_10) | (stochrsi_k_1h < 70.0) | (roc_9_4h > -20.0))
+            & ((rsi_3_4h_gt_10) | (stochrsi_k_1h_lt_70) | (roc_9_4h > -20.0))
             # 4h down move, 4h & 1d downtrend
             & ((rsi_3_4h_gt_10) | (roc_9_4h > -15.0) | (roc_9_1d > -20.0))
             # 4h & 1d down move, 1d still high
@@ -22231,17 +22258,17 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h & 1d down move, 4h high
             & ((rsi_3_4h_gt_15) | (rsi_3_1d_gt_25) | aroonu_14_4h_lt_70)
             # 4h & 1d down move, 15m high
-            & ((rsi_3_4h_gt_15) | (rsi_3_1d_gt_30) | (stochrsi_k_15m < 80.0))
+            & ((rsi_3_4h_gt_15) | (rsi_3_1d_gt_30) | (stochrsi_k_15m_lt_80))
             # 4h & 1d down move, 4h still high
-            & ((rsi_3_4h_gt_15) | (rsi_3_1d > 50.0) | (stochrsi_k_4h < 40.0))
+            & ((rsi_3_4h_gt_15) | (rsi_3_1d > 50.0) | (stochrsi_k_4h_lt_40))
             # 4h down move, 1d still high, 4h still not low enough
-            & ((rsi_3_4h_gt_15) | (rsi_14_1d < 40.0) | (stochrsi_k_4h < 30.0))
+            & ((rsi_3_4h_gt_15) | (rsi_14_1d < 40.0) | (stochrsi_k_4h_lt_30))
             # 4h down move, 15m still not low enough, 1d high
             & ((rsi_3_4h_gt_15) | (aroonu_14_15m < 30.0) | (aroonu_14_1d_lt_70))
             # 4h down move, 4h still high, 4h downtrend
             & ((rsi_3_4h_gt_15) | (aroonu_14_4h_lt_50) | (roc_9_4h > -10.0))
             # 4h down move, 4h still not low enough, 1d downtrend
-            & ((rsi_3_4h_gt_15) | (stochrsi_k_4h < 20.0) | (roc_9_1d > -20.0))
+            & ((rsi_3_4h_gt_15) | (stochrsi_k_4h_lt_20) | (roc_9_1d > -20.0))
             # 4h down move, 4h & 1d high
             & ((rsi_3_4h_gt_20) | (aroonu_14_4h_lt_70) | (aroonu_14_1d_lt_70))
             # 4h down move, 4h high
@@ -22259,7 +22286,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h & 1d down move, 1d overbought
             & ((rsi_3_4h_gt_25) | (rsi_3_1d_gt_45) | (roc_9_1d < 10.0))
             # 4h down move, 15m still not low enough, 4h still high
-            & ((rsi_3_4h_gt_25) | (aroonu_14_15m < 30.0) | (stochrsi_k_4h < 40.0))
+            & ((rsi_3_4h_gt_25) | (aroonu_14_15m < 30.0) | (stochrsi_k_4h_lt_40))
             # 4h down move, 1d high, 4h overbought
             & ((rsi_3_4h_gt_25) | (aroonu_14_1d_lt_80) | (roc_9_4h < 5.0))
             # 4h & 1d down move, 4h still high
@@ -22267,7 +22294,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h & 1d down move, 1d high
             & ((rsi_3_4h_gt_30) | (rsi_3_1d_gt_60) | (aroonu_14_1d_lt_90))
             # 4h down move, 4h high, 1d high
-            & ((rsi_3_4h_gt_30) | (aroonu_14_4h_lt_70) | (stochrsi_k_1d < 80.0))
+            & ((rsi_3_4h_gt_30) | (aroonu_14_4h_lt_70) | (stochrsi_k_1d_lt_80))
             # 4h down move, 1d stil high, 1d downtrend
             & ((rsi_3_4h_gt_30) | (aroonu_14_1d < 40.0) | (roc_9_1d_gt_neg_30))
             # 4h down move, 1h high, 1d downtrend
@@ -22277,15 +22304,15 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 15m still high, 1h high
             & ((rsi_3_4h_gt_35) | (aroonu_14_15m_lt_50) | (aroonu_14_1h_lt_100))
             # 4h down move, 4h still high, 1d downtrend
-            & ((rsi_3_4h_gt_35) | (stochrsi_k_4h < 40.0) | (roc_9_1d_gt_neg_30))
+            & ((rsi_3_4h_gt_35) | (stochrsi_k_4h_lt_40) | (roc_9_1d_gt_neg_30))
             # 4h down move, 1d high & overbought
-            & ((rsi_3_4h_gt_35) | (stochrsi_k_1d < 80.0) | (roc_9_1d_lt_20))
+            & ((rsi_3_4h_gt_35) | (stochrsi_k_1d_lt_80) | (roc_9_1d_lt_20))
             # 4h down move, 1h high
             & ((rsi_3_4h_gt_40) | (aroonu_14_1h_lt_80))
             # 4h down move, 1d high & overbought
             & ((rsi_3_4h_gt_45) | (aroonu_14_1d_lt_70) | (roc_9_1d_lt_20))
             # 4h down move, 4h high, 1d downtrend
-            & ((rsi_3_4h_gt_45) | (stochrsi_k_4h < 40.0) | (roc_9_1d > -25.0))
+            & ((rsi_3_4h_gt_45) | (stochrsi_k_4h_lt_40) | (roc_9_1d > -25.0))
             # 4h down move, 1d high & overbought
             & ((rsi_3_4h_gt_50) | (aroonu_14_1d < 85.0) | (roc_9_1d < 200.0))
             # 4h down move, 4h high & overbought
@@ -22337,20 +22364,20 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1d high, 4h & 1d overbought
             & (aroonu_14_1d_lt_100 | (roc_9_4h < 60.0) | (roc_9_1d < 100.0))
             # 15m high, 4h & 1d overbought
-            & ((stochrsi_k_15m < 70.0) | (roc_9_4h_lt_20) | (roc_9_1d_lt_20))
+            & ((stochrsi_k_15m_lt_70) | (roc_9_4h_lt_20) | (roc_9_1d_lt_20))
             # 1h high, 1h & 1d overbought
-            & ((stochrsi_k_1h < 80.0) | (roc_9_1h < 20.0) | (roc_9_1d_lt_100))
+            & ((stochrsi_k_1h_lt_80) | (roc_9_1h < 20.0) | (roc_9_1d_lt_100))
             # 4h high, 4h overbought, 1d downtrend
-            & ((stochrsi_k_4h < 90.0) | (roc_9_4h_lt_20) | (roc_9_1d_gt_neg_20))
+            & ((stochrsi_k_4h_lt_90) | (roc_9_4h_lt_20) | (roc_9_1d_gt_neg_20))
             # 1d high, 1h & 4h overbought
-            & ((stochrsi_k_1d < 80.0) | (roc_9_1h < 20.0) | (roc_9_4h_lt_20))
+            & ((stochrsi_k_1d_lt_80) | (roc_9_1h < 20.0) | (roc_9_4h_lt_20))
           )
 
           # Logic
           long_entry_logic.append(
             (rsi_3_gt_5)
             & (rsi_4 < 46.0)
-            # & (stochrsi_k < 20.0)
+            # & (stochrsi_k_lt_20)
             & (rsi_20 < rsi_20.shift(1))
             & (close < sma_16 * 0.960)
           )
@@ -22378,9 +22405,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 4h still high
             & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_15) | (aroonu_14_4h_lt_40))
             # 15m & 1h down move, 1h still high
-            & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_15) | (stochrsi_k_1h < 50.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_15) | (stochrsi_k_1h_lt_50))
             # 15m & 1h down move, 4h high
-            & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_15) | (stochrsi_k_4h < 90.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_15) | (stochrsi_k_4h_lt_90))
             # 15m & 1h down move, 15m high
             & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_30) | (aroonu_14_15m_lt_70))
             # 15m & 1h down move, 1d downtrend
@@ -22404,7 +22431,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 4h down move, 4h high
             & ((rsi_3_15m_gt_5) | (rsi_3_4h_gt_10) | (aroonu_14_4h < 80.0))
             # 15m & 4h down move, 1h still high
-            & ((rsi_3_15m_gt_5) | (rsi_3_4h_gt_10) | (stochrsi_k_1h < 40.0))
+            & ((rsi_3_15m_gt_5) | (rsi_3_4h_gt_10) | (stochrsi_k_1h_lt_40))
             # 15m & 4h down move, 1d downtrend
             & ((rsi_3_15m_gt_5) | (rsi_3_4h_gt_10) | (roc_9_1d > -20.0))
             # 15m & 1d down move, 1h still high
@@ -22434,7 +22461,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 1h high
             & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_30) | (stochrsi_k_1h_lt_70))
             # 15m & 4h down move, 1h still high
-            & ((rsi_3_15m_gt_10) | (rsi_3_4h_gt_10) | (stochrsi_k_1h < 50.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_4h_gt_10) | (stochrsi_k_1h_lt_50))
             # 15m & 4h down move, 4h still high, 1d high & overbought
             & ((rsi_3_15m_gt_10) | (rsi_3_4h_gt_15) | (aroonu_14_4h_lt_40) | (aroonu_14_1d_lt_70) | (roc_9_1d < 10.0))
             # 15m & 4h down move, 1h high
@@ -22444,7 +22471,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1d down move, 1h high
             & ((rsi_3_15m_gt_10) | (rsi_3_1d_gt_10) | (stochrsi_k_1h_lt_70))
             # 15m & 1d down move, 4h still high
-            & ((rsi_3_15m_gt_10) | (rsi_3_1d_gt_10) | (stochrsi_k_4h < 40.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_1d_gt_10) | (stochrsi_k_4h_lt_40))
             # 15m & 4h down move, 15m high
             & ((rsi_3_15m_gt_10) | (rsi_3_4h_gt_40) | (aroonu_14_15m_lt_70))
             # 15m down move, 15m high, 1d high
@@ -22454,7 +22481,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 4h high, 1d overbought
             & ((rsi_3_15m_gt_10) | (aroonu_14_4h_lt_70) | (roc_9_1d_lt_100))
             # 15m down move, 1h still high, 1d downtrend
-            & ((rsi_3_15m_gt_10) | (stochrsi_k_1h < 50.0) | (roc_9_1d_gt_neg_20))
+            & ((rsi_3_15m_gt_10) | (stochrsi_k_1h_lt_50) | (roc_9_1d_gt_neg_20))
             # 15m & 1h down move, 1h high, 1d high & overbought
             & ((rsi_3_15m_gt_15) | (rsi_3_1h_gt_15) | (aroonu_14_1h_lt_70) | (aroonu_14_1d_lt_100) | (roc_9_1d < 10.0))
             # 15m & 4h down move, 1h high
@@ -22462,7 +22489,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h & 1d down move, 4h still high, 4h downtrend
             & ((rsi_3_15m_gt_20) | (rsi_3_1h_gt_25) | (rsi_3_1d_gt_25) | (aroonu_14_4h_lt_40) | (roc_9_4h_gt_neg_20))
             # 1h & 1d down move, 1d still high
-            & ((rsi_3_1h_gt_3) | (rsi_3_1d_gt_25) | (stochrsi_k_1d < 40.0))
+            & ((rsi_3_1h_gt_3) | (rsi_3_1d_gt_25) | (stochrsi_k_1d_lt_40))
             # 1h & 4h down move, 1d downtrend
             & ((rsi_3_1h_gt_5) | (rsi_3_4h_gt_5) | (roc_9_1d_gt_neg_30))
             # 1h & 4h down move, 1d still high
@@ -22474,15 +22501,15 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 4h & 1d downtrend
             & ((rsi_3_1h_gt_5) | (roc_9_4h > -10.0) | (roc_9_1d_gt_neg_20))
             # 1h & 4h down move, 1d still not low enough
-            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_10) | (stochrsi_k_1d < 20.0))
+            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_10) | (stochrsi_k_1d_lt_20))
             # 1h & 4h down move, 15m still not low enough
-            & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_3) | (stochrsi_k_15m < 30.0))
+            & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_3) | (stochrsi_k_15m_lt_30))
             # 1h & 4h down move, 4h high
             & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_15) | (aroonu_14_4h_lt_60))
             # 1h down move, 1h still not low enough, 1d overbought
-            & ((rsi_3_1h_gt_15) | (stochrsi_k_1h < 30.0) | roc_9_1d_lt_50)
+            & ((rsi_3_1h_gt_15) | (stochrsi_k_1h_lt_30) | roc_9_1d_lt_50)
             # 1h down move, 1h still high, 1d downtrend
-            & ((rsi_3_1h_gt_15) | (stochrsi_k_1h < 40.0) | (roc_9_1d > -20.0))
+            & ((rsi_3_1h_gt_15) | (stochrsi_k_1h_lt_40) | (roc_9_1d > -20.0))
             # 1h down move, 1d high & overbought
             & ((rsi_3_1h_gt_15) | (stochrsi_k_1d_lt_90) | (roc_9_1d_lt_40))
             # 1h & 4h down move, 1h high
@@ -22506,7 +22533,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 4h & 1d overbought
             & ((rsi_3_1h_gt_25) | (roc_9_4h_lt_20) | (roc_9_1d_lt_30))
             # 1h & 4h down move, 1h high
-            & ((rsi_3_1h_gt_30) | (rsi_3_4h_gt_30) | (stochrsi_k_1h < 60.0))
+            & ((rsi_3_1h_gt_30) | (rsi_3_4h_gt_30) | (stochrsi_k_1h_lt_60))
             # 1h down move, 15m still high, 1h high
             & ((rsi_3_1h_gt_30) | (aroonu_14_15m_lt_50) | (aroonu_14_1h < 85.0))
             # 1h & 1d down move, 1h high
@@ -22520,31 +22547,31 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h & 1d down move, 1h still high
             & ((rsi_3_4h_gt_5) | (rsi_3_1d_gt_10) | (stochrsi_k_1h_lt_50))
             # 4h down move, 4h still high, 1d downtrend
-            & ((rsi_3_4h_gt_5) | (stochrsi_k_4h < 40.0) | (roc_9_1d_gt_neg_20))
+            & ((rsi_3_4h_gt_5) | (stochrsi_k_4h_lt_40) | (roc_9_1d_gt_neg_20))
             # 4h & 1d down move, 1d high
             & ((rsi_3_4h_gt_10) | (rsi_3_1d_gt_15) | (aroonu_14_1d_lt_70))
             # 4h & 1d down move, 15m still high
-            & ((rsi_3_4h_gt_10) | (rsi_3_1d_gt_20) | (stochrsi_k_15m < 40.0))
+            & ((rsi_3_4h_gt_10) | (rsi_3_1d_gt_20) | (stochrsi_k_15m_lt_40))
             # 4h down move, 1d high & overbought
             & ((rsi_3_4h_gt_10) | (aroonu_14_1d < 100.0) | (roc_9_1d < 10.0))
             # 4h down move, 1h high, 1d downtrend
-            & ((rsi_3_4h_gt_10) | (stochrsi_k_1h < 50.0) | (roc_9_1d > -30.0))
+            & ((rsi_3_4h_gt_10) | (stochrsi_k_1h_lt_50) | (roc_9_1d > -30.0))
             # 4h down move, 4h & 1d downtrend
             & ((rsi_3_4h_gt_10) | (roc_9_4h > -20.0) | (roc_9_1d_gt_neg_40))
             # 4h & 1d down move, 1d high
             & ((rsi_3_4h_gt_15) | (rsi_3_1d_gt_20) | (aroonu_14_1d < 60.0))
             # 4h & 1d down move, 4h high
-            & ((rsi_3_4h_gt_15) | (rsi_3_1d_gt_30) | (stochrsi_k_4h < 60.0))
+            & ((rsi_3_4h_gt_15) | (rsi_3_1d_gt_30) | (stochrsi_k_4h_lt_60))
             # 4h down move, 1d still high, 4h still not low enough
-            & ((rsi_3_4h_gt_15) | (rsi_14_1d < 40.0) | (stochrsi_k_4h < 30.0))
+            & ((rsi_3_4h_gt_15) | (rsi_14_1d < 40.0) | (stochrsi_k_4h_lt_30))
             # 1h down move, 1h still high, 1d downtrend
             & ((rsi_3_1h_gt_15) | (aroonu_14_1h_lt_50) | (roc_9_1d > -30.0))
             # 4h down move, 4h & 1d high
             & ((rsi_3_4h_gt_15) | aroonu_14_4h_lt_70 | (aroonu_14_1d_lt_70))
             # 4h down move, 1h still not low enough, 1d downtrend
-            & ((rsi_3_4h_gt_15) | (stochrsi_k_1h < 20.0) | (roc_9_1d > -20.0))
+            & ((rsi_3_4h_gt_15) | (stochrsi_k_1h_lt_20) | (roc_9_1d > -20.0))
             # 4h down move, 1h high
-            & ((rsi_3_4h_gt_15) | (stochrsi_k_1h < 80.0))
+            & ((rsi_3_4h_gt_15) | (stochrsi_k_1h_lt_80))
             # 4h down move, 1h downtrend, 1d overbought
             & ((rsi_3_4h_gt_15) | (roc_9_1h > -10.0) | (roc_9_1d < 200.0))
             # 4h & 1d down move, 1d still high
@@ -22554,17 +22581,17 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 1d high & overbought
             & (rsi_3_4h_gt_20 | (aroonu_14_1d_lt_80) | (roc_9_1d < 70.0))
             # 4h down move, 4h high, 1d downtrend
-            & (rsi_3_4h_gt_20 | (stochrsi_k_4h < 60.0) | (roc_9_1d_gt_neg_20))
+            & (rsi_3_4h_gt_20 | (stochrsi_k_4h_lt_60) | (roc_9_1d_gt_neg_20))
             # 4h & 1d down move, 1d overbought
             & ((rsi_3_4h_gt_25) | (rsi_3_1d_gt_40) | (roc_9_1d_lt_30))
             # 4h down move, 1h high, 1d downtrend
-            & ((rsi_3_4h_gt_25) | (stochrsi_k_1h < 60.0) | (roc_9_1d_gt_neg_20))
+            & ((rsi_3_4h_gt_25) | (stochrsi_k_1h_lt_60) | (roc_9_1d_gt_neg_20))
             # 4h down move, 15m still high, 1h high
             & ((rsi_3_4h_gt_35) | (aroonu_14_15m_lt_50) | (aroonu_14_1h_lt_100))
             # 4h down move, 1h high
             & ((rsi_3_4h_gt_40) | aroonu_14_1h_lt_80)
             # 4h down move, 4h high, 1d downtrend
-            & ((rsi_3_4h_gt_45) | (stochrsi_k_4h < 80.0) | (roc_9_1d_gt_neg_20))
+            & ((rsi_3_4h_gt_45) | (stochrsi_k_4h_lt_80) | (roc_9_1d_gt_neg_20))
             # 1h high, 4h & 1d overbought
             & (aroonu_14_1h_lt_70 | (roc_9_4h_lt_40) | (roc_9_1d_lt_80))
             # 1h & 4h high, 1d overbought
@@ -22572,13 +22599,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1d high, 4h & 1d downtrend
             & ((aroonu_14_1d < 60.0) | (roc_9_4h_gt_neg_20) | (roc_9_1d_gt_neg_30))
             # 4h high, 4h & 1d overbought
-            & ((stochrsi_k_4h < 90.0) | (roc_9_4h_lt_20) | (roc_9_1d_lt_20))
+            & ((stochrsi_k_4h_lt_90) | (roc_9_4h_lt_20) | (roc_9_1d_lt_20))
           )
 
           # Logic
           long_entry_logic.append(
             (rsi_3 < 40.0)
-            & (stochrsi_k < 20.0)
+            & (stochrsi_k_lt_20)
             & (ema_26 > ema_12)
             & ((ema_26 - ema_12) > (open_rate * 0.020))
             & ((ema_26.shift() - ema_12.shift()) > (open_rate / 100.0))
@@ -22615,15 +22642,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 1d high
             & ((rsi_3_15m_gt_5) | (rsi_3_1h_gt_10) | (aroonu_14_1d < 100.0))
             # 15m & 1h & 4h down move, 15m still not low enough, 1h still not low enough
-            & (
-              (rsi_3_15m_gt_5) | (rsi_3_1h_gt_30) | (rsi_3_4h_gt_30) | (aroonu_14_15m < 30.0) | (stochrsi_k_1h < 30.0)
-            )
+            & ((rsi_3_15m_gt_5) | (rsi_3_1h_gt_30) | (rsi_3_4h_gt_30) | (aroonu_14_15m < 30.0) | (stochrsi_k_1h_lt_30))
             # 15m & 1h down move, 1d overbought
             & ((rsi_3_15m_gt_5) | (rsi_3_1h_gt_30) | (roc_9_1d_lt_30))
             # 15m & 4h down move, 4h downtrend
             & ((rsi_3_15m_gt_5) | (rsi_3_4h_gt_5) | (roc_9_4h_gt_neg_20))
             # 15m & 4h down move, 4h still high
-            & ((rsi_3_15m_gt_5) | (rsi_3_4h_gt_30) | (stochrsi_k_4h < 40.0))
+            & ((rsi_3_15m_gt_5) | (rsi_3_4h_gt_30) | (stochrsi_k_4h_lt_40))
             # 15m down move, 1d high & overbought
             & ((rsi_3_15m_gt_5) | (aroonu_14_1d_lt_100) | (roc_9_1d_lt_40))
             # 15m & 4h down move, 4h still not low enough
@@ -22633,7 +22658,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 4h high, 1d overbought
             & ((rsi_3_15m_gt_10) | (aroonu_14_4h_lt_80) | (roc_9_1d_lt_50))
             # 15m & 1h down move, 15m still high
-            & ((rsi_3_15m_gt_15) | (rsi_3_1h_gt_15) | (stochrsi_k_15m < 50.0))
+            & ((rsi_3_15m_gt_15) | (rsi_3_1h_gt_15) | (stochrsi_k_15m_lt_50))
             # 15m & 1h down move, 1d overbought
             & ((rsi_3_15m_gt_15) | (rsi_3_1h_gt_20) | (roc_9_1d_lt_30))
             # 15m & 1h down move, 4h high
@@ -22649,9 +22674,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 4h & 1d high, 4h overbought
             & ((rsi_3_15m_gt_25) | (aroonu_14_4h_lt_80) | (aroonu_14_1d_lt_100) | (roc_9_4h < 30.0))
             # 15m down move, 4h high, 1d downtrend
-            & ((rsi_3_15m_gt_25) | (stochrsi_k_4h < 80.0) | (roc_9_1d_gt_neg_30))
+            & ((rsi_3_15m_gt_25) | (stochrsi_k_4h_lt_80) | (roc_9_1d_gt_neg_30))
             # 15m & 1h down move, 15m high
-            & ((rsi_3_15m_gt_45) | (rsi_3_1h_gt_45) | (stochrsi_k_15m < 70.0))
+            & ((rsi_3_15m_gt_45) | (rsi_3_1h_gt_45) | (stochrsi_k_15m_lt_70))
             # 15m down move, 4h high, 1d overbought
             & ((rsi_3_15m_gt_10) | aroonu_14_4h_lt_70 | (roc_9_1d_lt_100))
             # 15m & 4h down move, 1d downtrend
@@ -22663,9 +22688,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 15m still high, 4h high
             & ((rsi_3_15m_gt_25) | (aroonu_14_15m_lt_50) | aroonu_14_4h_lt_80)
             # 15m down move, 4h high & overbought
-            & ((rsi_3_15m_gt_25) | (stochrsi_k_4h < 80.0) | (roc_9_4h_lt_20))
+            & ((rsi_3_15m_gt_25) | (stochrsi_k_4h_lt_80) | (roc_9_4h_lt_20))
             # 15m down move, 4h high, 1d downtrend
-            & ((rsi_3_15m_gt_25) | (stochrsi_k_4h < 90.0) | (roc_9_1d_gt_neg_30))
+            & ((rsi_3_15m_gt_25) | (stochrsi_k_4h_lt_90) | (roc_9_1d_gt_neg_30))
             # 15m down move, 1h & 4h overbought
             & ((rsi_3_15m_gt_25) | (roc_9_1h_lt_10) | (roc_9_4h_lt_30))
             # 15m down move, 1h & 4h high
@@ -22675,17 +22700,17 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 1h downtrend
             & ((rsi_3_1h_gt_3) | (rsi_3_4h_gt_10) | (cmf_20_1h > -0.20))
             # 1h & 4h down move, 1d still high
-            & ((rsi_3_1h_gt_3) | (rsi_3_4h_gt_10) | (stochrsi_k_1d < 40.0))
+            & ((rsi_3_1h_gt_3) | (rsi_3_4h_gt_10) | (stochrsi_k_1d_lt_40))
             # 1h & 4h down move, 4h still high
-            & ((rsi_3_1h_gt_3) | rsi_3_4h_gt_20 | (stochrsi_k_4h < 40.0))
+            & ((rsi_3_1h_gt_3) | rsi_3_4h_gt_20 | (stochrsi_k_4h_lt_40))
             # 1h & 4h down move, 15m still high
-            & ((rsi_3_1h_gt_3) | (rsi_3_4h_gt_30) | (stochrsi_k_15m < 50.0))
+            & ((rsi_3_1h_gt_3) | (rsi_3_4h_gt_30) | (stochrsi_k_15m_lt_50))
             # 1h & 4h down move, 15m still not low enough
-            & ((rsi_3_1h_gt_5) | (rsi_3_4h_gt_5) | (stochrsi_k_15m < 20.0))
+            & ((rsi_3_1h_gt_5) | (rsi_3_4h_gt_5) | (stochrsi_k_15m_lt_20))
             # 1h & 4h down move, 1d still high
             & ((rsi_3_1h_gt_5) | rsi_3_4h_gt_20 | (aroonu_14_1d < 50.0))
             # 1h & 4h down move, 4h still not low enough
-            & ((rsi_3_1h_gt_5) | (rsi_3_4h_gt_40) | (stochrsi_k_4h < 30.0))
+            & ((rsi_3_1h_gt_5) | (rsi_3_4h_gt_40) | (stochrsi_k_4h_lt_30))
             # 1h & 1d down move, 1h still high
             & ((rsi_3_1h_gt_5) | (rsi_3_1d_gt_5) | (aroonu_14_1h < 40.0))
             # 1h down move, 1d high & overbought
@@ -22693,9 +22718,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h & 1d down move, 4h downtrend, 1d still high
             & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_15) | (rsi_3_1d_gt_25) | (rsi_14_4h > 30.0) | (aroonu_14_1d < 40.0))
             # 1h & 4h down move, 4h still not low enough
-            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_15) | (stochrsi_k_4h < 30.0))
+            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_15) | (stochrsi_k_4h_lt_30))
             # 1h & 4h down move, 15m still high
-            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_15) | (stochrsi_k_15m < 50.0))
+            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_15) | (stochrsi_k_15m_lt_50))
             # 1h & 4h down move, 1d downtrend
             & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_15) | (roc_9_1d > -20.0))
             # 1h & 4h down move, 4h still high
@@ -22707,7 +22732,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1d high, 1h downtrend
             & ((rsi_3_1h_gt_10) | (aroonu_14_1d_lt_70) | (roc_9_1h > -10.0))
             # 1h & 4h down move, 15m still not low enough
-            & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_3) | (stochrsi_k_15m < 30.0))
+            & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_3) | (stochrsi_k_15m_lt_30))
             # 1h & 4h down move, 1h high
             & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_25) | (aroonu_14_1h < 70.0))
             # 1h & 4h down move, 4h high
@@ -22723,9 +22748,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1d high & overbought
             & ((rsi_3_1h_gt_15) | (aroonu_14_1d_lt_80) | (roc_9_1d < 10.0))
             # 1h down move, 4h high & overbought
-            & ((rsi_3_1h_gt_15) | (stochrsi_k_4h < 80.0) | (roc_9_4h < 20.0))
+            & ((rsi_3_1h_gt_15) | (stochrsi_k_4h_lt_80) | (roc_9_4h < 20.0))
             # 1h down move, 4h high, 1d downtrend
-            & ((rsi_3_1h_gt_15) | (stochrsi_k_4h < 80.0) | (roc_9_1d > -30.0))
+            & ((rsi_3_1h_gt_15) | (stochrsi_k_4h_lt_80) | (roc_9_1d > -30.0))
             # 1h & 4h down move, 4h still high
             & (rsi_3_1h_gt_20 | (rsi_3_4h_gt_20) | (aroonu_14_4h_lt_40))
             # 1h & 4h down move, 1d high
@@ -22741,17 +22766,17 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 4h high & overbought
             & (rsi_3_1h_gt_20 | (aroonu_14_4h_lt_80) | (roc_9_4h < 70.0))
             # 1h down move, 1h high, 1h still not low enough
-            & (rsi_3_1h_gt_20 | (aroonu_14_1d_lt_80) | (stochrsi_k_1h < 20.0))
+            & (rsi_3_1h_gt_20 | (aroonu_14_1d_lt_80) | (stochrsi_k_1h_lt_20))
             # 1h down move, 1d high & overbought
             & (rsi_3_1h_gt_20 | (aroonu_14_1d_lt_100) | (roc_9_1d_lt_20))
             # 1h down move, 4h still high, 1d downtrend
-            & (rsi_3_1h_gt_20 | (stochrsi_k_4h < 40.0) | (roc_9_1d_gt_neg_40))
+            & (rsi_3_1h_gt_20 | (stochrsi_k_4h_lt_40) | (roc_9_1d_gt_neg_40))
             # 1h down move, 4h high & overbought, 1d downtrend
             & ((rsi_3_1h_gt_20) | (stochrsi_k_4h_lt_80) | (roc_9_4h_lt_10) | (roc_9_1d_gt_neg_20))
             # 1h & 4h down move, 15m high
-            & ((rsi_3_1h_gt_25) | (rsi_3_4h_gt_25) | (stochrsi_k_15m < 70.0))
+            & ((rsi_3_1h_gt_25) | (rsi_3_4h_gt_25) | (stochrsi_k_15m_lt_70))
             # 1h & 4h down move, 4h still not low enough
-            & ((rsi_3_1h_gt_25) | (rsi_3_4h_gt_25) | (stochrsi_k_4h < 30.0))
+            & ((rsi_3_1h_gt_25) | (rsi_3_4h_gt_25) | (stochrsi_k_4h_lt_30))
             # 1h & 4h down move, 1d overbought
             & ((rsi_3_1h_gt_25) | (rsi_3_4h_gt_25) | (roc_9_1d_lt_100))
             # 1h & 4h down move, 4h high
@@ -22765,23 +22790,23 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h & 4h high
             & ((rsi_3_1h_gt_30) | aroonu_14_1h_lt_70 | aroonu_14_4h_lt_100)
             # 1h down move, 1h high, 4h high
-            & ((rsi_3_1h_gt_30) | aroonu_14_1h_lt_80 | (stochrsi_k_4h < 80.0))
+            & ((rsi_3_1h_gt_30) | aroonu_14_1h_lt_80 | (stochrsi_k_4h_lt_80))
             # 1h down move, 4h high, 1h overbought
             & ((rsi_3_1h_gt_40) | aroonu_14_4h_lt_80 | (roc_9_1h_lt_10))
             # 1h down move, 1h high, 15m high
-            & ((rsi_3_1h_gt_50) | aroonu_14_1h_lt_70 | (stochrsi_k_15m < 70.0))
+            & ((rsi_3_1h_gt_50) | aroonu_14_1h_lt_70 | (stochrsi_k_15m_lt_70))
             # 4h & 1d down move, 15m still not low enough
             & ((rsi_3_4h_gt_3) | (rsi_3_1d_gt_15) | (aroonu_14_15m < 20.0))
             # 4h & 1d down move, 1d still high
-            & ((rsi_3_4h_gt_3) | (rsi_3_1d_gt_20) | (stochrsi_k_1d < 40.0))
+            & ((rsi_3_4h_gt_3) | (rsi_3_1d_gt_20) | (stochrsi_k_1d_lt_40))
             # 4h & 1d down move, 1d high
             & ((rsi_3_4h_gt_3) | (rsi_3_1d_gt_25) | (aroonu_14_1d_lt_70))
             # 4h down move, 15m high
-            & ((rsi_3_4h_gt_3) | (stochrsi_k_15m < 60.0))
+            & ((rsi_3_4h_gt_3) | (stochrsi_k_15m_lt_60))
             # 4h down move, 15m still high, 4h still not low enough
-            & ((rsi_3_4h_gt_5) | (stochrsi_k_15m < 50.0) | (aroonu_14_4h < 30.0))
+            & ((rsi_3_4h_gt_5) | (stochrsi_k_15m_lt_50) | (aroonu_14_4h < 30.0))
             # 4h & 1d down move, 15m still high
-            & ((rsi_3_4h_gt_10) | (rsi_3_1d_gt_15) | (stochrsi_k_15m < 40.0))
+            & ((rsi_3_4h_gt_10) | (rsi_3_1d_gt_15) | (stochrsi_k_15m_lt_40))
             # 4h down move, 4h still not low enough, 1d downtrend
             & ((rsi_3_4h_gt_10) | (aroonu_14_4h < 20.0) | (roc_9_1d > -10.0))
             # 4h down move, 4h still high, 4h downtrend
@@ -22789,7 +22814,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 1d still high, 1d downtrend
             & ((rsi_3_4h_gt_10) | (aroonu_14_1d < 40.0) | (roc_9_1d > -30.0))
             # 4h down move, 1d high, 15m high
-            & ((rsi_3_4h_gt_10) | (aroonu_14_1d_lt_80) | (stochrsi_k_15m < 60.0))
+            & ((rsi_3_4h_gt_10) | (aroonu_14_1d_lt_80) | (stochrsi_k_15m_lt_60))
             # 4h down move, 1d high, 4h downtrend
             & ((rsi_3_4h_gt_10) | (aroonu_14_1d < 100.0) | (roc_9_4h > -10.0))
             # 4h down move, 4h & 1d downtrend
@@ -22799,13 +22824,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h & 1d down move, 4h still high
             & ((rsi_3_4h_gt_15) | (rsi_3_1d_gt_30) | (stochrsi_k_4h_lt_50))
             # 4h & 1d down move, 4h still high
-            & ((rsi_3_4h_gt_15) | (rsi_3_1d_gt_45) | (stochrsi_k_4h < 40.0))
+            & ((rsi_3_4h_gt_15) | (rsi_3_1d_gt_45) | (stochrsi_k_4h_lt_40))
             # 4h down move, 4h still not low enough, 1d high
             & ((rsi_3_4h_gt_15) | (aroonu_14_4h < 30.0) | (aroonu_14_1d_lt_70))
             # 4h down move, 1d high & overbought
             & ((rsi_3_4h_gt_15) | (aroonu_14_1d < 100.0) | (roc_9_1d_lt_30))
             # 4h down move, 15m high
-            & ((rsi_3_4h_gt_15) | (stochrsi_k_15m < 70.0))
+            & ((rsi_3_4h_gt_15) | (stochrsi_k_15m_lt_70))
             # 4h & 1d down move, 1d downtrend
             & (rsi_3_4h_gt_20 | (rsi_3_1d_gt_25) | (roc_9_1d_gt_neg_30))
             # 4h down move, 1d high & overbought
@@ -22817,19 +22842,19 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h & 1d down move, 1d overbought
             & ((rsi_3_4h_gt_30) | (rsi_3_1d > 70.0) | (roc_9_1d_lt_20))
             # 4h down move, 4h high, 1d high
-            & ((rsi_3_4h_gt_30) | (aroonu_14_4h_lt_70) | (stochrsi_k_1d < 80.0))
+            & ((rsi_3_4h_gt_30) | (aroonu_14_4h_lt_70) | (stochrsi_k_1d_lt_80))
             # 4h down move, 1d stil high, 1d downtrend
             & ((rsi_3_4h_gt_30) | (aroonu_14_1d < 40.0) | (roc_9_1d_gt_neg_30))
             # 4h down move, 4h still high, 4h downtrend
-            & ((rsi_3_4h_gt_30) | (stochrsi_k_4h < 40.0) | (roc_9_4h > -15.0))
+            & ((rsi_3_4h_gt_30) | (stochrsi_k_4h_lt_40) | (roc_9_4h > -15.0))
             # 4h & 1d down move, 4h still high, 1d high
             & ((rsi_3_4h_gt_35) | (rsi_3_1d_gt_35) | (stochrsi_k_4h_lt_50) | (aroonu_14_1d < 60.0))
             # 4h down move, 4h still high, 1d downtrend
-            & ((rsi_3_4h_gt_35) | (stochrsi_k_4h < 40.0) | (roc_9_1d_gt_neg_20))
+            & ((rsi_3_4h_gt_35) | (stochrsi_k_4h_lt_40) | (roc_9_1d_gt_neg_20))
             # 4h down move, 1d high & overbought
             & ((rsi_3_4h_gt_55) | (stochrsi_k_1d_lt_90) | (roc_9_1d_lt_100))
             # 1d down move, 4h still not low enough, 4h downtrend
-            & ((rsi_3_1d_gt_10) | (stochrsi_k_4h < 30.0) | (roc_9_4h > -15.0))
+            & ((rsi_3_1d_gt_10) | (stochrsi_k_4h_lt_30) | (roc_9_4h > -15.0))
             # 1d down move, 4h & 1d downtrend
             & ((rsi_3_1d_gt_10) | (roc_9_4h_gt_neg_20) | (roc_9_1d_gt_neg_20))
             # 1d down move, 1d high, 4h downtrend
@@ -22845,9 +22870,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h high, 4h & 1d overbought
             & ((aroonu_14_4h_lt_90) | (roc_9_4h_lt_30) | (roc_9_1d < 60.0))
             # 15m high, 4h & 1d overbought
-            & ((stochrsi_k_15m < 80.0) | (roc_9_4h_lt_20) | (roc_9_1d_lt_20))
+            & ((stochrsi_k_15m_lt_80) | (roc_9_4h_lt_20) | (roc_9_1d_lt_20))
             # 15m still high, 4h & 1d overbought
-            & ((stochrsi_k_15m < 50.0) | (roc_9_4h_lt_40) | (roc_9_1d_lt_100))
+            & ((stochrsi_k_15m_lt_50) | (roc_9_4h_lt_40) | (roc_9_1d_lt_100))
             # 4h high, 4h & 1d overbought
             & ((stochrsi_k_4h_lt_90) | (roc_9_4h_lt_30) | (roc_9_1d < 60.0))
             # 1d high, 4h & 1d overbought
@@ -22861,9 +22886,9 @@ class NostalgiaForInfinityX7(IStrategy):
           # Logic
           long_entry_logic.append(
             (willr_14 < -50.0)
-            & (stochrsi_k < 30.0)
+            & (stochrsi_k_lt_30)
             # & (df["STOCHRSIk_14_14_3_3_15m"] < 40.0)
-            & (stochrsi_k_1h < 40.0)
+            & (stochrsi_k_1h_lt_40)
             & (bbb_20_2_0_1h > 12.0)
             & (close_max_48 >= (close * 1.10))
           )
@@ -22885,7 +22910,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 1h downtrend
             & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_3) | (roc_9_1h > -20.0))
             # 15m & 1h down move, 1h still not low enough
-            & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_10) | (stochrsi_k_1h < 20.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_10) | (stochrsi_k_1h_lt_20))
             # 15m & 1h down move, 4h high
             & ((rsi_3_15m_gt_5) | (rsi_3_1h_gt_10) | aroonu_14_4h_lt_70)
             # 15m & 1h down move, 1h high
@@ -22903,19 +22928,19 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 15m downtrend, 1h high
             & ((rsi_3_15m_gt_15) | (cmf_20_15m > -0.40) | (aroonu_14_1h < 60.0))
             # 15m down move, 15m still high, 4h high
-            & ((rsi_3_15m_gt_15) | (aroonu_14_15m < 40.0) | (stochrsi_k_4h < 60.0))
+            & ((rsi_3_15m_gt_15) | (aroonu_14_15m < 40.0) | (stochrsi_k_4h_lt_60))
             # 15m down move, 1h high, 1d downtrend
             & ((rsi_3_15m_gt_15) | (aroonu_14_1h_lt_90) | (roc_9_1d_gt_neg_30))
             # 15m & 1h down move, 1d downtrend
             & ((rsi_3_15m_gt_20) | rsi_3_1h_gt_20 | (roc_9_1d_gt_neg_30))
             # 15m & 4h down move, 15m still high
-            & ((rsi_3_15m_gt_20) | rsi_3_4h_gt_20 | (stochrsi_k_15m < 50.0))
+            & ((rsi_3_15m_gt_20) | rsi_3_4h_gt_20 | (stochrsi_k_15m_lt_50))
             # 15m down move, 15m & 1h high
             & ((rsi_3_15m_gt_20) | (aroonu_14_15m_lt_70) | (aroonu_14_1h_lt_100))
             # 15m & 1h down move, 15m still high
-            & ((rsi_3_15m_gt_25) | (rsi_3_1h_gt_35) | (stochrsi_k_15m < 50.0))
+            & ((rsi_3_15m_gt_25) | (rsi_3_1h_gt_35) | (stochrsi_k_15m_lt_50))
             # 15m down move, 15m still high, 1d overbought
-            & ((rsi_3_15m_gt_25) | (stochrsi_k_15m < 50.0) | (roc_9_1d_lt_30))
+            & ((rsi_3_15m_gt_25) | (stochrsi_k_15m_lt_50) | (roc_9_1d_lt_30))
             # 15m & 4h down move, 1h high
             & ((rsi_3_15m_gt_30) | (rsi_3_4h_gt_30) | (stochrsi_k_1h_lt_70))
             # 15m down move, 15m & 4h high
@@ -22945,7 +22970,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 1d downtrend
             & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_10) | (roc_9_1d > -30.0))
             # 1h & 4h down move, 15m high
-            & ((rsi_3_1h_gt_10) | rsi_3_4h_gt_20 | (stochrsi_k_15m < 80.0))
+            & ((rsi_3_1h_gt_10) | rsi_3_4h_gt_20 | (stochrsi_k_15m_lt_80))
             # 1h & 4h down move, 1d downtrend
             & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_25) | roc_9_1d_gt_neg_50)
             # 1h & 4h down move, 4h high
@@ -22961,7 +22986,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h & 1d down move
             & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_15) | (rsi_3_1d_gt_20))
             # 1h & 4h down move, 15m still not low enough
-            & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_15) | (stochrsi_k_15m < 30.0))
+            & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_15) | (stochrsi_k_15m_lt_30))
             # 1h & 4h down move, 15m still high
             & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_15) | (aroonu_14_15m_lt_50))
             # 1h & 4h & 1d down move, 1d still high
@@ -22993,7 +23018,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 4h high & overbought
             & ((rsi_3_1h_gt_20) | (aroonu_14_4h_lt_80) | (roc_9_4h < 60.0))
             # 1h down move, 1h still not low enough, 1d downtrend
-            & ((rsi_3_1h_gt_20) | (stochrsi_k_1h < 30.0) | (roc_9_1d_gt_neg_30))
+            & ((rsi_3_1h_gt_20) | (stochrsi_k_1h_lt_30) | (roc_9_1d_gt_neg_30))
             # 1h & 4h down move, 1h high
             & ((rsi_3_1h_gt_25) | (rsi_3_4h_gt_35) | (aroonu_14_1h_lt_70))
             # 1h & 4h down move, 1d overbought
@@ -23003,7 +23028,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h high, 1d overbought
             & ((rsi_3_1h_gt_25) | aroonu_14_1h_lt_80 | (roc_9_1d_lt_30))
             # 1h down move, 1h still high, 4h downtrend
-            & ((rsi_3_1h_gt_25) | (stochrsi_k_1h < 50.0) | (roc_9_4h_gt_neg_20))
+            & ((rsi_3_1h_gt_25) | (stochrsi_k_1h_lt_50) | (roc_9_4h_gt_neg_20))
             # 1h down move, 1d overbought
             & ((rsi_3_1h_gt_25) | (roc_9_1d_lt_80))
             # 1h down move, 1h high, 1d overbought
@@ -23015,11 +23040,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 4h high & overbought
             & ((rsi_3_1h_gt_35) | (aroonu_14_4h_lt_90) | (roc_9_4h < 60.0))
             # 1h down move, 4h high, 1d downtrend
-            & ((rsi_3_1h_gt_35) | (stochrsi_k_4h < 90.0) | (roc_9_1d_gt_neg_20))
+            & ((rsi_3_1h_gt_35) | (stochrsi_k_4h_lt_90) | (roc_9_1d_gt_neg_20))
             # 1h down move, 1h high, 1d downtrend
             & ((rsi_3_1h_gt_40) | aroonu_14_1h_lt_70 | (roc_9_1d > -30.0))
             # 1h down move, 1h high, 1d downtrend
-            & ((rsi_3_1h_gt_40) | (stochrsi_k_1h < 70.0) | (roc_9_1d_gt_neg_30))
+            & ((rsi_3_1h_gt_40) | (stochrsi_k_1h_lt_70) | (roc_9_1d_gt_neg_30))
             # 1h down move, 1h & 4h high
             & ((rsi_3_1h_gt_45) | aroonu_14_1h_lt_80 | aroonu_14_4h_lt_100)
             # 1h down move, 1h high, 4h overbought
@@ -23029,27 +23054,27 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 4h & 1d downtrend
             & ((rsi_3_4h_gt_5) | (roc_9_4h > -15.0) | (roc_9_1d_gt_neg_20))
             # 4h & 1d down move, 1d still high
-            & ((rsi_3_4h_gt_10) | (rsi_3_1d_gt_30) | (stochrsi_k_1d < 50.0))
+            & ((rsi_3_4h_gt_10) | (rsi_3_1d_gt_30) | (stochrsi_k_1d_lt_50))
             # 4h down move, 4h & 1d high
             & ((rsi_3_4h_gt_10) | (aroonu_14_4h_lt_60) | (aroonu_14_1d_lt_70))
             # 4h down move, 1d still high, 1d downtrend
             & ((rsi_3_4h_gt_10) | (aroonu_14_1d < 50.0) | (roc_9_1d > -30.0))
             # 4h down move, 15m & 1h still not low enough
-            & ((rsi_3_4h_gt_10) | (stochrsi_k_15m < 30.0) | (stochrsi_k_1h < 30.0))
+            & ((rsi_3_4h_gt_10) | (stochrsi_k_15m_lt_30) | (stochrsi_k_1h_lt_30))
             # 4h down move, 15m stil high, 4h downtrend
-            & ((rsi_3_4h_gt_10) | (stochrsi_k_15m < 50.0) | (roc_9_4h > -20.0))
+            & ((rsi_3_4h_gt_10) | (stochrsi_k_15m_lt_50) | (roc_9_4h > -20.0))
             # 4h & 1d down move, 1d downtrend
             & ((rsi_3_4h_gt_15) | (rsi_3_1d_gt_25) | (roc_9_1d > -30.0))
             # 4h & 1d down move, 1h still high
-            & ((rsi_3_4h_gt_15) | (rsi_3_1d_gt_30) | (stochrsi_k_1h < 50.0))
+            & ((rsi_3_4h_gt_15) | (rsi_3_1d_gt_30) | (stochrsi_k_1h_lt_50))
             # 4h & 1d down move, 4h high
             & ((rsi_3_4h_gt_15) | (rsi_3_1d_gt_35) | (stochrsi_k_4h_lt_70))
             # 4h down move, 4h high
-            & ((rsi_3_4h_gt_15) | (stochrsi_k_4h < 60.0))
+            & ((rsi_3_4h_gt_15) | (stochrsi_k_4h_lt_60))
             # 4h down move, 4h & 1d high
             & (rsi_3_4h_gt_20 | aroonu_14_4h_lt_70 | (aroonu_14_1d_lt_70))
             # 4h down move, 15m high
-            & (rsi_3_4h_gt_20 | (stochrsi_k_15m < 90.0))
+            & (rsi_3_4h_gt_20 | (stochrsi_k_15m_lt_90))
             # 4h down move, 1d high & overbought
             & (rsi_3_4h_gt_20 | (aroonu_14_1d_lt_90) | (roc_9_1d_lt_30))
             # 4h & 1d down move, 1d overbought
@@ -23057,9 +23082,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h & 1d down move, 1d high
             & ((rsi_3_4h_gt_25) | (rsi_3_1d_gt_45) | (aroonu_14_1d_lt_80))
             # 4h down move, 15m high, 1d overbought
-            & ((rsi_3_4h_gt_30) | (stochrsi_k_15m < 90.0) | (roc_9_1d < 10.0))
+            & ((rsi_3_4h_gt_30) | (stochrsi_k_15m_lt_90) | (roc_9_1d < 10.0))
             # 4h down move, 4h still high, 1d downtrend
-            & ((rsi_3_4h_gt_35) | (stochrsi_k_4h < 40.0) | (roc_9_1d_gt_neg_30))
+            & ((rsi_3_4h_gt_35) | (stochrsi_k_4h_lt_40) | (roc_9_1d_gt_neg_30))
             # 4h down move, 4h high, 1d overbought
             & ((rsi_3_4h_gt_40) | (aroonu_14_4h_lt_60) | (roc_9_1d_lt_40))
             # 4h & 1d down move, 1h high
@@ -23071,7 +23096,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1d down move, 1h high
             & ((rsi_3_1d_gt_20) | (stochrsi_k_1h_lt_70))
             # 1d down move, 1h high, 1d downtrend
-            & ((rsi_3_1d_gt_25) | (stochrsi_k_1h < 60.0) | (roc_9_1d_gt_neg_30))
+            & ((rsi_3_1d_gt_25) | (stochrsi_k_1h_lt_60) | (roc_9_1d_gt_neg_30))
             # 1d down move, 1d high, 4h downtrend
             & ((rsi_3_1d_gt_35) | (aroonu_14_1d_lt_70) | (roc_9_4h > -10.0))
             # 1d down move, 4h high, 1d overbought
@@ -23123,7 +23148,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m & 4h & 1d down move, 15m high
           long_entry_logic.append((rsi_3_15m_gt_30) | (rsi_3_4h_gt_50) | (rsi_3_1d_gt_60) | (aroonu_14_15m_lt_70))
           # 15m down move, 15m & 4h still high
-          long_entry_logic.append((rsi_3_15m_gt_30) | (stochrsi_k_15m < 50.0) | (stochrsi_k_4h_lt_50))
+          long_entry_logic.append((rsi_3_15m_gt_30) | (stochrsi_k_15m_lt_50) | (stochrsi_k_4h_lt_50))
           # 15m & 4h down move, 4h high
           long_entry_logic.append((rsi_3_15m_gt_35) | (rsi_3_4h_gt_60) | aroonu_14_4h_lt_80)
           # 15m & 1h down move, 1h high
@@ -23133,50 +23158,50 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m & 1h down move, 4h high
           long_entry_logic.append((rsi_3_15m_gt_40) | (rsi_3_1h_gt_60) | aroonu_14_4h_lt_80)
           # 15m & 4h down move, 15m high
-          long_entry_logic.append((rsi_3_15m_gt_40) | (rsi_3_4h_gt_40) | (stochrsi_k_15m < 50.0))
+          long_entry_logic.append((rsi_3_15m_gt_40) | (rsi_3_4h_gt_40) | (stochrsi_k_15m_lt_50))
           # 15m & 4h down move, 15m high
-          long_entry_logic.append((rsi_3_15m_gt_40) | (rsi_3_4h_gt_60) | (stochrsi_k_15m < 70.0))
+          long_entry_logic.append((rsi_3_15m_gt_40) | (rsi_3_4h_gt_60) | (stochrsi_k_15m_lt_70))
           # 15m down move, 15m & 1h still high
           long_entry_logic.append((rsi_3_15m_gt_40) | (aroonu_14_15m_lt_50) | (stochrsi_k_1h_lt_50))
           # 15m down move, 15m & 1h still high
-          long_entry_logic.append((rsi_3_15m_gt_40) | (stochrsi_k_15m < 50.0) | (stochrsi_k_1h_lt_50))
+          long_entry_logic.append((rsi_3_15m_gt_40) | (stochrsi_k_15m_lt_50) | (stochrsi_k_1h_lt_50))
           # 15m down move, 4h still high, 1d overbought
           long_entry_logic.append((rsi_3_15m_gt_40) | (aroonu_14_4h_lt_50) | (roc_9_1d_lt_100))
           # 15m & 1h down move, 1h still high
-          long_entry_logic.append((rsi_3_15m_gt_45) | (rsi_3_1h_gt_45) | (stochrsi_k_1h < 40.0))
+          long_entry_logic.append((rsi_3_15m_gt_45) | (rsi_3_1h_gt_45) | (stochrsi_k_1h_lt_40))
           # 15m down move, 15m high, 1d overbought
           long_entry_logic.append((rsi_3_15m_gt_45) | (aroonu_14_15m < 60.0) | roc_9_1d_lt_50)
           # 15m down move, 15m high, 4h still high
           long_entry_logic.append((rsi_3_15m_gt_45) | (aroonu_14_15m_lt_70) | (stochrsi_k_4h_lt_50))
           # 15m down move, 15m still not low enough, 4h still high
-          long_entry_logic.append((rsi_3_15m_gt_45) | (stochrsi_k_15m < 30.0) | (stochrsi_k_4h_lt_50))
+          long_entry_logic.append((rsi_3_15m_gt_45) | (stochrsi_k_15m_lt_30) | (stochrsi_k_4h_lt_50))
           # 15m down move, 15m & 1h still high
-          long_entry_logic.append((rsi_3_15m_gt_45) | (stochrsi_k_15m < 45.0) | (stochrsi_k_1h < 40.0))
+          long_entry_logic.append((rsi_3_15m_gt_45) | (stochrsi_k_15m < 45.0) | (stochrsi_k_1h_lt_40))
           # 15m down move, 15m still not low enough, 4h high
-          long_entry_logic.append((rsi_3_15m_gt_50) | (stochrsi_k_15m < 30.0) | (stochrsi_k_4h_lt_90))
+          long_entry_logic.append((rsi_3_15m_gt_50) | (stochrsi_k_15m_lt_30) | (stochrsi_k_4h_lt_90))
           # 15m down move, 15m still high, 1d overbought
           long_entry_logic.append((rsi_3_15m_gt_50) | (aroonu_14_15m_lt_50) | roc_9_1d_lt_50)
           # 15m down move, 15m still high, 1h high
-          long_entry_logic.append((rsi_3_15m_gt_55) | (stochrsi_k_15m < 40.0) | (stochrsi_k_1h_lt_70))
+          long_entry_logic.append((rsi_3_15m_gt_55) | (stochrsi_k_15m_lt_40) | (stochrsi_k_1h_lt_70))
           # 15m down move, 15m still high, 4h high
-          long_entry_logic.append((rsi_3_15m_gt_55) | (stochrsi_k_15m < 50.0) | (aroonu_14_4h < 85.0))
+          long_entry_logic.append((rsi_3_15m_gt_55) | (stochrsi_k_15m_lt_50) | (aroonu_14_4h < 85.0))
           # 15m down move, 15m & 1h still high
-          long_entry_logic.append((rsi_3_15m_gt_55) | (stochrsi_k_15m < 50.0) | (stochrsi_k_1h_lt_50))
+          long_entry_logic.append((rsi_3_15m_gt_55) | (stochrsi_k_15m_lt_50) | (stochrsi_k_1h_lt_50))
           # 1h down move, 4h still high, 1d high
           long_entry_logic.append((rsi_3_1h_gt_25) | (aroonu_14_4h_lt_50) | (stochrsi_k_1d_lt_90))
           # 1h & 4h down move, 1h still high
           long_entry_logic.append((rsi_3_1h_gt_30) | (rsi_3_4h_gt_65) | (aroonu_14_1h_lt_50))
-          long_entry_logic.append((rsi_3_1h_gt_30) | (stochrsi_k_1h < 40.0) | (stochrsi_k_1d_lt_90))
+          long_entry_logic.append((rsi_3_1h_gt_30) | (stochrsi_k_1h_lt_40) | (stochrsi_k_1d_lt_90))
           # 1h & 4h down move, 4h still high
           long_entry_logic.append((rsi_3_1h_gt_35) | (rsi_3_4h_gt_55) | (stochrsi_k_4h_lt_50))
           # 1h & 4h down move, 4h high
           long_entry_logic.append((rsi_3_1h_gt_35) | (rsi_3_4h_gt_60) | (stochrsi_k_4h_lt_80))
           # 1h down move, 15m & 1h still high
-          long_entry_logic.append((rsi_3_1h_gt_40) | (stochrsi_k_15m < 50.0) | (stochrsi_k_1h_lt_50))
+          long_entry_logic.append((rsi_3_1h_gt_40) | (stochrsi_k_15m_lt_50) | (stochrsi_k_1h_lt_50))
           # 1h down move, 1h still high, 4h high
           long_entry_logic.append((rsi_3_1h_gt_40) | (stochrsi_k_1h_lt_50) | (stochrsi_k_4h_lt_70))
           # 1h down move, 1h high
-          long_entry_logic.append((rsi_3_1h_gt_40) | (stochrsi_k_1h < 60.0))
+          long_entry_logic.append((rsi_3_1h_gt_40) | (stochrsi_k_1h_lt_60))
           # 1h down move, 4h & 1d high
           long_entry_logic.append((rsi_3_1h_gt_40) | (aroonu_14_4h < 85.0) | (aroonu_14_1d_lt_90))
           # 1h down move, 1h still high, 4h high
@@ -23184,19 +23209,19 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1h down move, 1h still high, 1d high
           long_entry_logic.append((rsi_3_1h_gt_45) | (aroonu_14_1h_lt_50) | (aroonu_14_1d_lt_90))
           # 1h down move, 1h high
-          long_entry_logic.append((rsi_3_1h_gt_45) | (stochrsi_k_1h < 60.0))
+          long_entry_logic.append((rsi_3_1h_gt_45) | (stochrsi_k_1h_lt_60))
           # 1h & 4h down move, 15m high
           long_entry_logic.append((rsi_3_1h_gt_50) | (rsi_3_4h_gt_60) | (aroonu_14_15m_lt_70))
           # 1h down move, 15m still high, 4h high
           long_entry_logic.append((rsi_3_1h_gt_50) | (aroonu_14_15m_lt_50) | aroonu_14_4h_lt_80)
           # 1h down move, 15m high, 1h still high
-          long_entry_logic.append((rsi_3_1h_gt_50) | (aroonu_14_15m_lt_70) | (stochrsi_k_1h < 40.0))
+          long_entry_logic.append((rsi_3_1h_gt_50) | (aroonu_14_15m_lt_70) | (stochrsi_k_1h_lt_40))
           # 1h down move, 15m still high, 4h high
-          long_entry_logic.append((rsi_3_1h_gt_50) | (stochrsi_k_15m < 50.0) | (stochrsi_k_4h_lt_80))
+          long_entry_logic.append((rsi_3_1h_gt_50) | (stochrsi_k_15m_lt_50) | (stochrsi_k_4h_lt_80))
           # 1h down move, 15m & 1h high
-          long_entry_logic.append((rsi_3_1h_gt_50) | (stochrsi_k_15m < 60.0) | (aroonu_14_1h < 60.0))
+          long_entry_logic.append((rsi_3_1h_gt_50) | (stochrsi_k_15m_lt_60) | (aroonu_14_1h < 60.0))
           # 1h down move, 1h & 1d high
-          long_entry_logic.append((rsi_3_1h_gt_50) | aroonu_14_1h_lt_70 | (stochrsi_k_1d < 80.0))
+          long_entry_logic.append((rsi_3_1h_gt_50) | aroonu_14_1h_lt_70 | (stochrsi_k_1d_lt_80))
           # 1h down move, 4h still high, 1d high
           long_entry_logic.append((rsi_3_1h_gt_50) | (stochrsi_k_4h_lt_50) | (stochrsi_k_1d_lt_90))
           # 1h down move, 1h still high, 1d high
@@ -23210,11 +23235,11 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1h down move, 15m still not low enough, 4h high
           long_entry_logic.append((rsi_3_1h_gt_60) | (aroonu_14_15m_lt_70) | (stochrsi_k_4h_lt_90))
           # 1h down move, 15m still not low enough, 1h high
-          long_entry_logic.append((rsi_3_1h_gt_60) | (stochrsi_k_15m < 30.0) | aroonu_14_1h_lt_70)
+          long_entry_logic.append((rsi_3_1h_gt_60) | (stochrsi_k_15m_lt_30) | aroonu_14_1h_lt_70)
           # 1h down move, 15m still not low enough, 1h high
-          long_entry_logic.append((rsi_3_1h_gt_60) | (stochrsi_k_15m < 30.0) | (stochrsi_k_1h < 60.0))
+          long_entry_logic.append((rsi_3_1h_gt_60) | (stochrsi_k_15m_lt_30) | (stochrsi_k_1h_lt_60))
           # 1h down move, 15m & 4h still high
-          long_entry_logic.append((rsi_3_1h_gt_60) | (stochrsi_k_15m < 50.0) | (stochrsi_k_4h_lt_50))
+          long_entry_logic.append((rsi_3_1h_gt_60) | (stochrsi_k_15m_lt_50) | (stochrsi_k_4h_lt_50))
           # 1h down move, 15m & 1h high
           long_entry_logic.append((rsi_3_1h_gt_60) | (aroonu_14_15m_lt_70) | (aroonu_14_1h_lt_90))
           # 1h down move, 1h still high, 4h high
@@ -23222,7 +23247,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1h down move, 1h high, 4h still high
           long_entry_logic.append((rsi_3_1h_gt_60) | aroonu_14_1h_lt_80 | (aroonu_14_4h_lt_40))
           # 1h down move, 1h still high, 4h high
-          long_entry_logic.append((rsi_3_1h_gt_60) | (stochrsi_k_1h < 40.0) | aroonu_14_4h_lt_70)
+          long_entry_logic.append((rsi_3_1h_gt_60) | (stochrsi_k_1h_lt_40) | aroonu_14_4h_lt_70)
           # 1h down move, 1h & 1d high
           long_entry_logic.append((rsi_3_1h_gt_60) | (stochrsi_k_1h_lt_70) | (aroonu_14_1d_lt_90))
           # 1h down move, 4h & 1d high
@@ -23236,33 +23261,33 @@ class NostalgiaForInfinityX7(IStrategy):
           # 4h down move, 15m & 4h still high
           long_entry_logic.append((rsi_3_4h_gt_30) | (aroonu_14_15m_lt_50) | (aroonu_14_4h_lt_50))
           # 4h down move, 15m still high, 1d overbought
-          long_entry_logic.append((rsi_3_4h_gt_30) | (stochrsi_k_15m < 50.0) | (roc_9_1d < 10.0))
+          long_entry_logic.append((rsi_3_4h_gt_30) | (stochrsi_k_15m_lt_50) | (roc_9_1d < 10.0))
           # 4h down move, 1h & 4h still high
           long_entry_logic.append((rsi_3_4h_gt_35) | (stochrsi_k_1h_lt_50) | (aroonu_14_4h_lt_50))
           # 4h down move, 1d high & overbought
-          long_entry_logic.append((rsi_3_4h_gt_35) | (stochrsi_k_1d < 80.0) | (roc_9_1d_lt_40))
+          long_entry_logic.append((rsi_3_4h_gt_35) | (stochrsi_k_1d_lt_80) | (roc_9_1d_lt_40))
           # 4h down move, 15m & 1h high
           long_entry_logic.append((rsi_3_4h_gt_40) | (aroonu_14_15m < 80.0) | (stochrsi_k_1h_lt_70))
           # 4h down move, 1d high & overbought
           long_entry_logic.append((rsi_3_4h_gt_40) | (aroonu_14_1d_lt_80) | (roc_9_1d_lt_20))
           # 4h down move, 15m still high, 1h high
-          long_entry_logic.append((rsi_3_4h_gt_40) | (stochrsi_k_15m < 40.0) | (stochrsi_k_1h_lt_80))
+          long_entry_logic.append((rsi_3_4h_gt_40) | (stochrsi_k_15m_lt_40) | (stochrsi_k_1h_lt_80))
           # 4h down move, 1h & 4h still high
           long_entry_logic.append((rsi_3_4h_gt_40) | (stochrsi_k_1h_lt_50) | (rsi_14_4h < 50.0))
           # 4h down move, 1h still high, 4h still moving down
           long_entry_logic.append((rsi_3_4h_gt_40) | (stochrsi_k_1h_lt_50) | (cci_20_change_pct_4h > -0.0))
           # 4h down move, 1d high & overbought
-          long_entry_logic.append((rsi_3_4h_gt_40) | (stochrsi_k_1d < 80.0) | (roc_9_1d < 10.0))
+          long_entry_logic.append((rsi_3_4h_gt_40) | (stochrsi_k_1d_lt_80) | (roc_9_1d < 10.0))
           # 4h down move, 1h high, 4h still high
           long_entry_logic.append((rsi_3_4h_gt_45) | aroonu_14_1h_lt_70 | (aroonu_14_4h_lt_50))
           # 4h down move, 15m high, 4h still high
-          long_entry_logic.append((rsi_3_4h_gt_50) | (aroonu_14_15m_lt_70) | (stochrsi_k_4h < 40.0))
+          long_entry_logic.append((rsi_3_4h_gt_50) | (aroonu_14_15m_lt_70) | (stochrsi_k_4h_lt_40))
           # 4h down move, 15m still high, 1h high
-          long_entry_logic.append((rsi_3_4h_gt_50) | (stochrsi_k_15m < 40.0) | (stochrsi_k_1h_lt_70))
+          long_entry_logic.append((rsi_3_4h_gt_50) | (stochrsi_k_15m_lt_40) | (stochrsi_k_1h_lt_70))
           # 4h down move, 15m & 4h still high
-          long_entry_logic.append((rsi_3_4h_gt_50) | (stochrsi_k_15m < 50.0) | (aroonu_14_4h_lt_50))
+          long_entry_logic.append((rsi_3_4h_gt_50) | (stochrsi_k_15m_lt_50) | (aroonu_14_4h_lt_50))
           # 4h down move, 15m high, 4h still not low enough
-          long_entry_logic.append((rsi_3_4h_gt_50) | (stochrsi_k_15m < 70.0) | (stochrsi_k_4h < 30.0))
+          long_entry_logic.append((rsi_3_4h_gt_50) | (stochrsi_k_15m_lt_70) | (stochrsi_k_4h_lt_30))
           # 4h down move, 1h still high, 4h high
           long_entry_logic.append((rsi_3_4h_gt_50) | (stochrsi_k_1h_lt_50) | aroonu_14_4h_lt_70)
           # 4h down move, 15m & 1d high
@@ -23274,15 +23299,15 @@ class NostalgiaForInfinityX7(IStrategy):
           # 4h down move, 15m high, 4h still high
           long_entry_logic.append((rsi_3_4h_gt_60) | (aroonu_14_15m < 80.0) | (aroonu_14_4h_lt_40))
           # 4h down move, 15m still high, 1h high
-          long_entry_logic.append((rsi_3_4h_gt_60) | (stochrsi_k_15m < 50.0) | aroonu_14_1h_lt_70)
+          long_entry_logic.append((rsi_3_4h_gt_60) | (stochrsi_k_15m_lt_50) | aroonu_14_1h_lt_70)
           # 4h down move, 15m still high, 4h high
-          long_entry_logic.append((rsi_3_4h_gt_60) | (stochrsi_k_15m < 50.0) | (stochrsi_k_4h_lt_70))
+          long_entry_logic.append((rsi_3_4h_gt_60) | (stochrsi_k_15m_lt_50) | (stochrsi_k_4h_lt_70))
           # 4h down move, 15m & 4h high
-          long_entry_logic.append((rsi_3_4h_gt_60) | (stochrsi_k_15m < 70.0) | (stochrsi_k_4h < 60.0))
+          long_entry_logic.append((rsi_3_4h_gt_60) | (stochrsi_k_15m_lt_70) | (stochrsi_k_4h_lt_60))
           # 4h down move, 1h & 4h high
           long_entry_logic.append((rsi_3_4h_gt_60) | (stochrsi_k_1h_lt_70) | aroonu_14_4h_lt_70)
           # 4h down move, 4h still high, 1d high
-          long_entry_logic.append((rsi_3_4h_gt_60) | (stochrsi_k_4h_lt_50) | (stochrsi_k_1d < 80.0))
+          long_entry_logic.append((rsi_3_4h_gt_60) | (stochrsi_k_4h_lt_50) | (stochrsi_k_1d_lt_80))
           # 15m still high, 1d high & overbought
           long_entry_logic.append((aroonu_14_15m_lt_50) | aroonu_14_1d_lt_100 | (roc_9_1d < 100.0))
           # 15m high, 4h high
@@ -23304,15 +23329,15 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1d high & overbought
           long_entry_logic.append(aroonu_14_1d_lt_100 | (roc_9_1d < 200.0))
           # 15m high, 1h still high
-          long_entry_logic.append((stochrsi_k_15m < 70.0) | (stochrsi_k_1h < 40.0))
+          long_entry_logic.append((stochrsi_k_15m_lt_70) | (stochrsi_k_1h_lt_40))
           # 15m & 4h high
-          long_entry_logic.append((stochrsi_k_15m < 70.0) | aroonu_14_4h_lt_70)
+          long_entry_logic.append((stochrsi_k_15m_lt_70) | aroonu_14_4h_lt_70)
           # 15m high, 1d overbought
-          long_entry_logic.append((stochrsi_k_15m < 70.0) | (roc_9_1d < 10.0))
+          long_entry_logic.append((stochrsi_k_15m_lt_70) | (roc_9_1d < 10.0))
           # 15m high, 1h still not low enough
-          long_entry_logic.append((stochrsi_k_15m < 80.0) | (stochrsi_k_1h < 30.0))
+          long_entry_logic.append((stochrsi_k_15m_lt_80) | (stochrsi_k_1h_lt_30))
           # 1d high, 4h overbought
-          long_entry_logic.append((stochrsi_k_1d < 80.0) | (roc_9_4h_lt_40))
+          long_entry_logic.append((stochrsi_k_1d_lt_80) | (roc_9_4h_lt_40))
           # 1d high & overbought
           long_entry_logic.append((stochrsi_k_1d_lt_90) | (roc_9_1d_lt_30))
           # 4h & 1d overbought
@@ -23323,7 +23348,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # Logic
           long_entry_logic.append(rsi_14 < 50.0)
           long_entry_logic.append(aroonu_14_15m < 90.0)
-          long_entry_logic.append(stochrsi_k_15m < 90.0)
+          long_entry_logic.append(stochrsi_k_15m_lt_90)
           long_entry_logic.append(
             (sma_21.shift(1) < sma_200.shift(1).infer_objects(copy=False).fillna(value=np.nan))
             & sma_200.shift(1).notna()
@@ -23364,7 +23389,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 1d high, 1d downtrend
             & ((rsi_3_15m_gt_10) | (aroonu_14_1d < 85.0) | (cmf_20_1d > -0.40))
             # 15m & 1h down move, 15m still not low enough
-            & ((rsi_3_15m_gt_15) | rsi_3_1h_gt_20 | (stochrsi_k_15m < 30.0))
+            & ((rsi_3_15m_gt_15) | rsi_3_1h_gt_20 | (stochrsi_k_15m_lt_30))
             # 15m & 1h down nove, 1h still high
             & ((rsi_3_15m_gt_15) | rsi_3_1h_gt_20 | (stochrsi_k_1h_lt_50))
             # 15m & 1h down move, 4h high
@@ -23384,11 +23409,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 15m high, 1d overbought
             & ((rsi_3_15m_gt_25) | (aroonu_14_15m < 60.0) | (roc_9_1d < 150.0))
             # 15m down move, 15m still high, 1d high, 1d downtrend
-            & ((rsi_3_15m_gt_30) | (aroonu_14_15m_lt_50) | (stochrsi_k_1d < 70.0) | (roc_9_1d > -15.0))
+            & ((rsi_3_15m_gt_30) | (aroonu_14_15m_lt_50) | (stochrsi_k_1d_lt_70) | (roc_9_1d > -15.0))
             # 15m down move, 1h & 4h high
             & ((rsi_3_15m_gt_35) | aroonu_14_1h_lt_80 | (rsi_14_4h < 80.0))
             # 1h & 4h down move, 15m stil high
-            & ((rsi_3_1h_gt_3) | (rsi_3_4h_gt_10) | (stochrsi_k_15m < 50.0))
+            & ((rsi_3_1h_gt_3) | (rsi_3_4h_gt_10) | (stochrsi_k_15m_lt_50))
             # 1h & 4h down move, 1h still high
             & ((rsi_3_1h_gt_3) | (rsi_3_4h_gt_25) | (aroonu_14_1h < 40.0))
             # 1h & 4h down move, 4h high
@@ -23432,7 +23457,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 4h high & overbought
             & ((rsi_3_1h_gt_35) | (stochrsi_k_4h_lt_80) | (roc_9_4h_lt_30))
             # 1h down move, 1h high, 4h downtrend
-            & ((rsi_3_1h_gt_40) | (stochrsi_k_1h < 80.0) | (roc_9_4h_gt_neg_20))
+            & ((rsi_3_1h_gt_40) | (stochrsi_k_1h_lt_80) | (roc_9_4h_gt_neg_20))
             # 1h down move, 15m still high, 1d overbought
             & ((rsi_3_1h_gt_45) | (aroonu_14_15m_lt_50) | (roc_9_1d_lt_50))
             # 1h down move, 4h & 1d overbought
@@ -23442,7 +23467,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 1d high
             & ((rsi_3_4h_gt_3) | (aroonu_14_1d_lt_90))
             # 4h down move, 15m still high
-            & ((rsi_3_4h_gt_3) | (stochrsi_k_15m < 50.0))
+            & ((rsi_3_4h_gt_3) | (stochrsi_k_15m_lt_50))
             # 4h down move, 1d high
             & ((rsi_3_4h_gt_3) | (stochrsi_k_1d_lt_90))
             # 4h down move, 1d overbought
@@ -23454,7 +23479,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 1h & 4h downtrend
             & ((rsi_3_4h_gt_10) | (roc_9_1h > -40.0) | (roc_9_4h > -40.0))
             # 4h & 1d down move, 4h still not low enough
-            & (rsi_3_4h_gt_20 | (rsi_3_1d_gt_20) | (stochrsi_k_4h < 30.0))
+            & (rsi_3_4h_gt_20 | (rsi_3_1d_gt_20) | (stochrsi_k_4h_lt_30))
             # 4h down move, 4h still high, 1d downtrend
             & ((rsi_3_4h_gt_30) | (aroonu_14_4h_lt_50) | (roc_9_1d_gt_neg_40))
             # 4h down move, 15m still high, 1d overbought
@@ -23520,7 +23545,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # big drop in the last 20 days, 1d down move
             & ((close > (high_max_20_1d * 0.05)) | (rsi_3_1d_gt_20))
             # big drop in the last 20 days, 1h still high
-            & ((close > (high_max_20_1d * 0.05)) | (stochrsi_k_1h < 45.0))
+            & ((close > (high_max_20_1d * 0.05)) | (stochrsi_k_1h_lt_45))
             # big drop in the last 20 days, 4h high
             & ((close > (high_max_20_1d * 0.05)) | (stochrsi_k_4h_lt_70))
           )
@@ -23529,7 +23554,7 @@ class NostalgiaForInfinityX7(IStrategy):
           long_entry_logic.append(
             (aroonu_14 < 25.0)
             & (aroond_14 > 75.0)
-            & (stochrsi_k < 30.0)
+            & (stochrsi_k_lt_30)
             & (ema_26 > ema_12)
             & ((ema_26 - ema_12) > (open_rate * 0.030))
             & ((ema_26.shift() - ema_12.shift()) > (open_rate / 100.0))
@@ -23586,13 +23611,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 15m high
             & ((rsi_3_15m_gt_15) | (rsi_3_1h_gt_35) | (aroonu_14_15m_lt_70))
             # 15m & 1h down move, 1h high
-            & ((rsi_3_15m_gt_15) | (rsi_3_1h_gt_35) | (stochrsi_k_1h < 85.0))
+            & ((rsi_3_15m_gt_15) | (rsi_3_1h_gt_35) | (stochrsi_k_1h_lt_85))
             # 15m & 1h down move, 15m still not low enough, 1h & 4h high
             & ((rsi_3_15m_gt_15) | (rsi_3_1h_gt_40) | (aroonu_14_15m < 30.0) | aroonu_14_1h_lt_80 | aroonu_14_4h_lt_80)
             # 15m & 1h down move, 4h high & overbought
             & ((rsi_3_15m_gt_15) | (rsi_3_1h_gt_45) | (rsi_14_4h < 70.0) | (roc_9_4h < 50.0))
             # 15m & 1h down move, 1h high
-            & ((rsi_3_15m_gt_15) | (rsi_3_1h_gt_50) | (stochrsi_k_1h < 90.0))
+            & ((rsi_3_15m_gt_15) | (rsi_3_1h_gt_50) | (stochrsi_k_1h_lt_90))
             # 15m & 4h down move, 15m high
             & ((rsi_3_15m_gt_15) | (rsi_3_4h_gt_30) | (aroonu_14_15m < 60.0))
             # 15m & 4h down move, 4h high
@@ -23602,7 +23627,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 4h down move, 1d high
             & ((rsi_3_15m_gt_15) | (rsi_3_4h_gt_35) | (stochrsi_k_1d_lt_90))
             # 15m & 4h down move, 1h high
-            & ((rsi_3_15m_gt_15) | (rsi_3_4h_gt_35) | (stochrsi_k_1h < 60.0))
+            & ((rsi_3_15m_gt_15) | (rsi_3_4h_gt_35) | (stochrsi_k_1h_lt_60))
             # 15m & 4h down move, 1h high
             & ((rsi_3_15m_gt_15) | (rsi_3_4h_gt_50) | (stochrsi_k_1h_lt_80))
             # 15m down move, 4h & 1d up move, 1d downtrend
@@ -23620,7 +23645,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1d down move, 1d high
             & ((rsi_3_15m_gt_15) | (rsi_3_1d > 50.0) | (aroonu_14_1d_lt_70))
             # 15m & 1d down move, 1d high
-            & ((rsi_3_15m_gt_15) | (rsi_3_1d_gt_60) | (stochrsi_k_1d < 80.0))
+            & ((rsi_3_15m_gt_15) | (rsi_3_1d_gt_60) | (stochrsi_k_1d_lt_80))
             # 15m down move, 15m & 4h high
             & ((rsi_3_15m_gt_15) | (aroonu_14_15m_lt_70) | (aroonu_14_4h_lt_80))
             # 15m down move, 15m & 1h high
@@ -23634,9 +23659,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 1d high & overbought
             & ((rsi_3_15m_gt_15) | (aroonu_14_1d_lt_100) | (roc_9_1d < 100.0))
             # 15m down move, 15m still not low enough, 4h high
-            & ((rsi_3_15m_gt_15) | (stochrsi_k_15m < 30.0) | (stochrsi_k_4h_lt_50))
+            & ((rsi_3_15m_gt_15) | (stochrsi_k_15m_lt_30) | (stochrsi_k_4h_lt_50))
             # 15m down move, 15m & 1h high
-            & ((rsi_3_15m_gt_15) | (stochrsi_k_15m < 50.0) | (stochrsi_k_1h_lt_50))
+            & ((rsi_3_15m_gt_15) | (stochrsi_k_15m_lt_50) | (stochrsi_k_1h_lt_50))
             # 15m down move, 1h high, 1d overbought
             & ((rsi_3_15m_gt_15) | (stochrsi_k_1h_lt_70) | (roc_9_1d_lt_30))
             # 15m down move, 1h high, 1d overbought
@@ -23644,7 +23669,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 1h high & overbought
             & ((rsi_3_15m_gt_15) | (stochrsi_k_1h_lt_80) | (roc_9_1h < 20.0))
             # 15m down move, 1h high, 1d overbought
-            & ((rsi_3_15m_gt_15) | (stochrsi_k_1h < 80.0) | (roc_9_1d_lt_100))
+            & ((rsi_3_15m_gt_15) | (stochrsi_k_1h_lt_80) | (roc_9_1d_lt_100))
             # 15m down move, 4h high, 1d overbought
             & ((rsi_3_15m_gt_15) | (stochrsi_k_4h_lt_80) | (roc_9_1d < 25.0))
             # 15m down move, 4h high & overbought
@@ -23658,7 +23683,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 4h & 1d downtrend
             & ((rsi_3_15m_gt_15) | (roc_9_4h_gt_neg_20) | (roc_9_1d_gt_neg_20))
             # 16m & 1h down move, 1h still high
-            & ((rsi_3_15m_gt_20) | (rsi_3_1h_gt_25) | (stochrsi_k_1h < 40.0))
+            & ((rsi_3_15m_gt_20) | (rsi_3_1h_gt_25) | (stochrsi_k_1h_lt_40))
             # 15m & 1h down move, 1h downtrend, 1h downtrend, 15m still high, 1h high
             & (
               (rsi_3_15m_gt_20)
@@ -23694,7 +23719,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1d down move, 1d high
             & ((rsi_3_15m_gt_25) | (rsi_3_1d_gt_40) | (aroonu_14_1d_lt_80))
             # 15m down move, 4h high, 1d downtrend
-            & ((rsi_3_15m_gt_25) | (stochrsi_k_4h < 90.0) | (roc_9_1d_gt_neg_30))
+            & ((rsi_3_15m_gt_25) | (stochrsi_k_4h_lt_90) | (roc_9_1d_gt_neg_30))
             # 15m & 1h down move, 15m still not low enough, 1h & 4h high
             & (
               (rsi_3_15m_gt_30)
@@ -23711,7 +23736,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 4h down move, 4h high
             & ((rsi_3_15m_gt_35) | (rsi_3_4h_gt_35) | (stochrsi_k_4h_lt_80))
             # 1h & 4h down move, 1d high
-            & ((rsi_3_1h_gt_25) | (rsi_3_4h_gt_30) | (stochrsi_k_1d < 80.0))
+            & ((rsi_3_1h_gt_25) | (rsi_3_4h_gt_30) | (stochrsi_k_1d_lt_80))
             # 1h & 4h down move, 4h high
             & ((rsi_3_1h_gt_25) | (rsi_3_4h_gt_40) | aroonu_14_4h_lt_70)
             # 1h & 4h down move, 4h high
@@ -23733,7 +23758,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 4h high & overbought
             & ((rsi_3_1h_gt_25) | (aroonu_14_4h_lt_90) | (roc_9_4h_lt_20))
             # 1h down move, 1h still not low enough, 1d downtrend
-            & ((rsi_3_1h_gt_25) | (stochrsi_k_1h < 30.0) | (roc_9_1d_gt_neg_40))
+            & ((rsi_3_1h_gt_25) | (stochrsi_k_1h_lt_30) | (roc_9_1d_gt_neg_40))
             # 1h down move, 4h high, 1d overbought
             & ((rsi_3_1h_gt_25) | (stochrsi_k_4h_lt_90) | (roc_9_1d < 25.0))
             # 1h & 4h & 1d down move, 1d high & overbought
@@ -23803,7 +23828,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 15m & 1h high, 1d downtrend
             & ((rsi_3_1h_gt_60) | (aroonu_14_15m < 65.0) | (stochrsi_k_1h_lt_80) | (cmf_20_1d > -0.0))
             # 1h down move, 1h high, 1d downtrend
-            & ((rsi_3_1h_gt_60) | (stochrsi_k_1h < 90.0) | (roc_9_1d_gt_neg_20))
+            & ((rsi_3_1h_gt_60) | (stochrsi_k_1h_lt_90) | (roc_9_1d_gt_neg_20))
             # 4h down move, 15m high
             & ((rsi_3_4h_gt_3) | (aroonu_14_15m_lt_50))
             # 4h & 1d down move, 1d high
@@ -23811,11 +23836,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 15m still not low enough, 4h downtrend
             & ((rsi_3_4h_gt_10) | (aroonu_14_15m < 30.0) | (cmf_20_4h > -0.30))
             # 4h down move, 15m & 1h still not low enough
-            & ((rsi_3_4h_gt_10) | (aroonu_14_15m < 30.0) | (stochrsi_k_1h < 25.0))
+            & ((rsi_3_4h_gt_10) | (aroonu_14_15m < 30.0) | (stochrsi_k_1h_lt_25))
             # 4h down move, 4h still high
             & ((rsi_3_4h_gt_10) | (aroonu_14_4h_lt_40))
             # 4h down move, 1h still high, 4h downtrend
-            & ((rsi_3_4h_gt_10) | (stochrsi_k_1h < 50.0) | (cmf_20_4h > -0.3))
+            & ((rsi_3_4h_gt_10) | (stochrsi_k_1h_lt_50) | (cmf_20_4h > -0.3))
             # 4h down move, 1d still high, 1d downtrend
             & ((rsi_3_4h_gt_15) | (rsi_14_1d < 40.0) | (roc_9_1d > -10.0))
             # 4h down move, 4h high
@@ -23829,7 +23854,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 4h still high 1d downtrend
             & ((rsi_3_4h_gt_25) | (aroonu_14_4h_lt_50) | (roc_9_1d_gt_neg_20))
             # 4h down move, 1d high & overbought
-            & ((rsi_3_4h_gt_25) | (stochrsi_k_1d < 80.0) | (roc_9_1d < 25.0))
+            & ((rsi_3_4h_gt_25) | (stochrsi_k_1d_lt_80) | (roc_9_1d < 25.0))
             # 4h down move, 4h & 1d high
             & ((rsi_3_4h_gt_35) | aroonu_14_4h_lt_70 | aroonu_14_1d_lt_100)
             # 4h down move, 15m still high, 1d overbought
@@ -23837,7 +23862,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 4h high, 1d overbought
             & ((rsi_3_4h_gt_40) | aroonu_14_4h_lt_80 | (roc_9_1d_lt_20))
             # 4h down move, 1h high, 1d downtrend
-            & ((rsi_3_4h_gt_40) | (stochrsi_k_1h < 80.0) | (roc_9_1d_gt_neg_20))
+            & ((rsi_3_4h_gt_40) | (stochrsi_k_1h_lt_80) | (roc_9_1d_gt_neg_20))
             # 4h down move, 4h & 1d overbought
             & ((rsi_3_4h_gt_40) | (roc_9_4h_lt_10) | roc_9_1d_lt_50)
             # 4h down move, 4h high, 1d overbought
@@ -23855,7 +23880,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 4h & 1d high
             & ((rsi_3_4h > 70.0) | (aroonu_14_4h_lt_90) | aroonu_14_1d_lt_100)
             # 1d down move, 4h high
-            & ((rsi_3_1d_gt_3) | (stochrsi_k_4h < 60.0))
+            & ((rsi_3_1d_gt_3) | (stochrsi_k_4h_lt_60))
             # 1d down move, 1h high
             & ((rsi_3_1d_gt_5) | (stochrsi_k_1h_lt_80))
             # 1d down move, 15m & 1h still high
@@ -23863,7 +23888,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1d down move, 1h & 4h high
             & ((rsi_3_1d_gt_10) | aroonu_14_1h_lt_80 | (aroonu_14_4h_lt_90))
             # 1d down move, 1h & 4h still high
-            & ((rsi_3_1d_gt_10) | (stochrsi_k_1h < 40.0) | (aroonu_14_4h_lt_40))
+            & ((rsi_3_1d_gt_10) | (stochrsi_k_1h_lt_40) | (aroonu_14_4h_lt_40))
             # 1d down move, 1h high & overbought
             & ((rsi_3_1d_gt_20) | (stochrsi_k_1h_lt_80) | (roc_9_1h < 20.0))
             # 1d down move, 1d high & overbought
@@ -23885,7 +23910,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 1h high
             & ((rsi_14_15m > 25.0) | (stochrsi_k_1h_lt_80))
             # 15m down move, 4h & 1d high
-            & ((rsi_14_15m > 30.0) | (stochrsi_k_4h_lt_90) | (stochrsi_k_1d < 70.0))
+            & ((rsi_14_15m > 30.0) | (stochrsi_k_4h_lt_90) | (stochrsi_k_1d_lt_70))
             # 1h downtrend, 4h high, 1d downtrend
             & ((cmf_20_1h > -0.2) | (stochrsi_k_4h_lt_90) | (cmf_20_1d > -0.25))
             # 15m & 1h high, 1d overbought
@@ -23927,9 +23952,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # big drop in the last 12 days, 1h down move, 1h high
             & ((close > (high_max_12_1d * 0.35)) | (rsi_3_1h_gt_35) | aroonu_14_1h_lt_70)
             # big drop in the last 20 days, 1h down move, 1h high
-            & ((close > (high_max_20_1d * 0.30)) | (rsi_3_1h_gt_30) | (stochrsi_k_1h < 75.0))
+            & ((close > (high_max_20_1d * 0.30)) | (rsi_3_1h_gt_30) | (stochrsi_k_1h_lt_75))
             # big drop in the last 20 days, 1d high, 1d downtrend
-            & ((close > (high_max_20_1d * 0.20)) | (stochrsi_k_1d < 70.0) | (roc_9_1d > -15.0))
+            & ((close > (high_max_20_1d * 0.20)) | (stochrsi_k_1d_lt_70) | (roc_9_1d > -15.0))
           )
 
           # Logic
@@ -23937,7 +23962,7 @@ class NostalgiaForInfinityX7(IStrategy):
             (rsi_14 < 30.0)
             & (aroonu_14 < 25.0)
             & (aroond_14 > 75.0)
-            & (stochrsi_k < 20.0)
+            & (stochrsi_k_lt_20)
             & (ema_9 < (ema_26 * 0.982))
             & (close < df["SMA_9"])
           )
@@ -24523,7 +24548,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1h & 4h down move, 4h still high
           short_entry_logic.append((rsi_3_1h_lt_90) | (rsi_3_change_pct_4h < 65.0) | (stochrsi_k_4h_gt_50))
           # 1h & 4h down move, 4h still high
-          short_entry_logic.append((rsi_3_1h_lt_90) | (rsi_3_4h_lt_85) | (stochrsi_k_4h < 10.0))
+          short_entry_logic.append((rsi_3_1h_lt_90) | (rsi_3_4h_lt_85) | (stochrsi_k_4h_lt_10))
           # 1h down move, 4h still not low enough, 1d overbought
           short_entry_logic.append((rsi_3_1h_lt_90) | (aroond_14_4h < 25.0) | (roc_9_1d > -120.0))
           # 1h down move, 1h still not low enough, 4h still not low


### PR DESCRIPTION
## Summary
- Add ordered `STOCHRSI` comparison masks in `populate_entry_trend()` for repeated threshold checks.
- Reuse those masks where the same `STOCHRSI` Series comparisons were repeated inline.
- Independent on latest upstream `main`.

## Safety
- Behavior is preserved: each replacement keeps the same Series, comparison operator, and threshold value.
- No indicator formulas, candle selection, order classification, profit arithmetic, thresholds, condition order, return values, or signal logic are changed.
- Touched function: `populate_entry_trend()`.
- No v3 grind-entry code is touched.

## Backtest scope
- A full backtest was not required for this patch because it only reuses already-read `STOCHRSI` Series comparisons inside the same `populate_entry_trend()` call.
- The trading conditions are textually equivalent at the comparison level; validation focused on static checks, merge simulation, and targeted diff review.

## Checks
- `python3 ~/.codex/skills/nfi-upstream-pr/scripts/validate_nfi_pr.py --base origin/main`
- `git merge-tree` conflict simulation against `origin/main`
- targeted `git diff origin/main...HEAD -- NostalgiaForInfinityX7.py` review
- `git diff --check`
- `ruff format --check NostalgiaForInfinityX7.py`
- `ruff check NostalgiaForInfinityX7.py`
- `PYTHONDONTWRITEBYTECODE=1 python3 -m py_compile NostalgiaForInfinityX7.py`
