### PR TITLE
Reuse X7 entry STOCHRSI 4h masks

### DIFF
--- a/NostalgiaForInfinityX7.py
+++ b/NostalgiaForInfinityX7.py
@@ -13089,7 +13089,12 @@ class NostalgiaForInfinityX7(IStrategy):
     stochrsi_k_1h_lt_50 = stochrsi_k_1h < 50.0
     stochrsi_k_1h_lt_70 = stochrsi_k_1h < 70.0
     stochrsi_k_1h_lt_80 = stochrsi_k_1h < 80.0
+    stochrsi_k_4h_lt_10 = stochrsi_k_4h < 10.0
+    stochrsi_k_4h_lt_20 = stochrsi_k_4h < 20.0
+    stochrsi_k_4h_lt_30 = stochrsi_k_4h < 30.0
+    stochrsi_k_4h_lt_40 = stochrsi_k_4h < 40.0
     stochrsi_k_4h_lt_50 = stochrsi_k_4h < 50.0
+    stochrsi_k_4h_lt_60 = stochrsi_k_4h < 60.0
     stochrsi_k_4h_lt_70 = stochrsi_k_4h < 70.0
     stochrsi_k_4h_lt_80 = stochrsi_k_4h < 80.0
     stochrsi_k_4h_lt_90 = stochrsi_k_4h < 90.0
@@ -13458,7 +13463,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 1h high, 1d downtrend
             & ((rsi_3_4h_gt_10) | (stochrsi_k_1h < 60.0) | (roc_9_1d_gt_neg_40))
             # 4h down move, 4h still not low enough, 1d downtrend
-            & ((rsi_3_4h_gt_10) | (stochrsi_k_4h < 30.0) | (roc_9_1d > -20.0))
+            & ((rsi_3_4h_gt_10) | (stochrsi_k_4h_lt_30) | (roc_9_1d > -20.0))
             # 4h down move, 1h & 4h downtrend
             & ((rsi_3_4h_gt_10) | (roc_9_1h > -30.0) | (roc_9_4h_gt_neg_30))
             # 4h down move, 4h & 1d downtrend
@@ -13609,7 +13614,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 5m & 4h down move, 1d downtrend
             & ((rsi_3_gt_5) | (rsi_3_4h_gt_10) | (roc_9_1d > -20.0))
             # 5m & 4h down move, 4h still not low enough
-            & ((rsi_3_gt_5) | (rsi_3_4h_gt_15) | (stochrsi_k_4h < 20.0))
+            & ((rsi_3_gt_5) | (rsi_3_4h_gt_15) | (stochrsi_k_4h_lt_20))
             # 5m down move, 4h high, 1h overbought
             & ((rsi_3_gt_10) | aroonu_14_4h_lt_100 | (roc_9_1h < 30.0))
             # 15m & 1h down move, 1h still high
@@ -13643,7 +13648,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 1h still high
             & ((rsi_3_15m_gt_3) | (rsi_3_1h_gt_20) | (stochrsi_k_1h_lt_50))
             # 15m & 1h down move, 4h high
-            & ((rsi_3_15m_gt_3) | (rsi_3_1h_gt_20) | (stochrsi_k_4h < 60.0))
+            & ((rsi_3_15m_gt_3) | (rsi_3_1h_gt_20) | (stochrsi_k_4h_lt_60))
             # 15m & 1h down move, 1h high
             & ((rsi_3_15m_gt_3) | (rsi_3_1h_gt_30) | (aroonu_14_1h_lt_60))
             # 15m & 1h down move, 1h high
@@ -13669,7 +13674,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 4h down move, 1d downtrend
             & ((rsi_3_15m_gt_3) | (rsi_3_4h_gt_10) | (roc_9_1d > -20.0))
             # 15m & 4h down move, 4h still high
-            & ((rsi_3_15m_gt_3) | (rsi_3_4h_gt_30) | (stochrsi_k_4h < 40.0))
+            & ((rsi_3_15m_gt_3) | (rsi_3_4h_gt_30) | (stochrsi_k_4h_lt_40))
             # 15m & 4h down move, 4h still high
             & ((rsi_3_15m_gt_3) | (rsi_3_4h_gt_35) | (stochrsi_k_4h_lt_50))
             # 15m down move, 15m still not low enough, 1h high
@@ -13693,7 +13698,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 4h high
             & ((rsi_3_15m_gt_5) | (rsi_3_1h_gt_10) | (aroonu_14_4h_lt_100))
             # 15m & 1h down move, 4h high
-            & ((rsi_3_15m_gt_5) | (rsi_3_1h_gt_15) | (stochrsi_k_4h < 60.0))
+            & ((rsi_3_15m_gt_5) | (rsi_3_1h_gt_15) | (stochrsi_k_4h_lt_60))
             # 15m & 1h & 4h & 1d down move, 1d high
             & ((rsi_3_15m_gt_5) | (rsi_3_1h_gt_20) | (rsi_3_4h_gt_20) | (rsi_3_1d_gt_25) | (aroonu_14_1d_lt_70))
             # 15m & 1h down move, 1h high
@@ -13721,7 +13726,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1d down move, 1h high
             & ((rsi_3_15m_gt_5) | (rsi_3_1d_gt_40) | (stochrsi_k_1h < 90.0))
             # 15m down move, 15m downtrend, 4h still not low enough
-            & ((rsi_3_15m_gt_5) | (cmf_20_15m > -0.30) | (stochrsi_k_4h < 30.0))
+            & ((rsi_3_15m_gt_5) | (cmf_20_15m > -0.30) | (stochrsi_k_4h_lt_30))
             # 15m down move, 15m still not low enough, 4h high
             & ((rsi_3_15m_gt_5) | (aroonu_14_15m_lt_20) | (stochrsi_k_4h_lt_70))
             # 15m down move, 15m stil high, 1h still high
@@ -13773,13 +13778,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 1h high
             & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_40) | (aroonu_14_1h_lt_70))
             # 15m & 4h down move, 4h still not low enough
-            & ((rsi_3_15m_gt_10) | (rsi_3_4h_gt_10) | (stochrsi_k_4h < 30.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_4h_gt_10) | (stochrsi_k_4h_lt_30))
             # 15m & 4h down move, 1d high
             & ((rsi_3_15m_gt_10) | (rsi_3_4h_gt_10) | (stochrsi_k_1d < 80.0))
             # 15m & 4h down move, 1d overbought
             & ((rsi_3_15m_gt_10) | (rsi_3_4h_gt_10) | (roc_9_1d_lt_20))
             # 15m & 4h down move, 4h still not low enough
-            & ((rsi_3_15m_gt_10) | rsi_3_4h_gt_20 | (stochrsi_k_4h < 30.0))
+            & ((rsi_3_15m_gt_10) | rsi_3_4h_gt_20 | (stochrsi_k_4h_lt_30))
             # 15m & 4h down move, 1d high
             & ((rsi_3_15m_gt_10) | (rsi_3_4h_gt_30) | (aroonu_14_1d_lt_90))
             # 15m & 4h down move, 1d high
@@ -13811,7 +13816,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 15m sill high, 4h high
             & ((rsi_3_15m_gt_10) | (stochrsi_k_15m < 40.0) | (aroonu_14_4h_lt_60))
             # 15m down move, 4h high, 1d downtrend
-            & ((rsi_3_15m_gt_10) | (stochrsi_k_4h < 80.0) | (roc_9_1d_gt_neg_30))
+            & ((rsi_3_15m_gt_10) | (stochrsi_k_4h_lt_80) | (roc_9_1d_gt_neg_30))
             # 15m & 1h down move, 4h downtrend
             & ((rsi_3_15m_gt_15) | (rsi_3_1h_gt_15) | (roc_9_4h > -20.0))
             # 15m & 1h down move, 1h downtrend
@@ -13943,7 +13948,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 1d down move, 15m still high
             & ((rsi_3_1h_gt_3) | (rsi_3_1d_gt_10) | (stochrsi_k_15m < 50.0))
             # 1h & 4h down move, 4h high
-            & ((rsi_3_1h_gt_5) | (rsi_3_4h_gt_5) | (stochrsi_k_4h < 40.0))
+            & ((rsi_3_1h_gt_5) | (rsi_3_4h_gt_5) | (stochrsi_k_4h_lt_40))
             # 1h & 4h down move, 1d still high
             & ((rsi_3_1h_gt_5) | (rsi_3_4h_gt_5) | (stochrsi_k_1d < 50.0))
             # 1h & 4h down move, 1d downtrend
@@ -13993,7 +13998,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 4h still high
             & ((rsi_3_1h_gt_15) | rsi_3_4h_gt_20 | (rsi_14_4h < 40.0))
             # 1h & 4h down move, 4h still not low enough
-            & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_25) | (stochrsi_k_4h < 30.0))
+            & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_25) | (stochrsi_k_4h_lt_30))
             # 1h & 4h down move, 1d high
             & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_30) | (stochrsi_k_1d < 80.0))
             # 1h & 4h down move, 4h downtrend
@@ -14013,7 +14018,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 4h high, 1d overbought
             & ((rsi_3_1h_gt_15) | (aroonu_14_4h_lt_60) | roc_9_1d_lt_50)
             # 1h down move, 4h high & overbought
-            & ((rsi_3_1h_gt_15) | (stochrsi_k_4h < 60.0) | (roc_9_4h_lt_10))
+            & ((rsi_3_1h_gt_15) | (stochrsi_k_4h_lt_60) | (roc_9_4h_lt_10))
             # 1h down move, 1d high & overbought
             & ((rsi_3_1h_gt_15) | (stochrsi_k_1d_lt_90) | (roc_9_1d_lt_40))
             # 1h down move, 4h & 1d downtrend
@@ -14099,7 +14104,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 4h high, 1h overbought
             & ((rsi_3_1h_gt_50) | (aroonu_14_4h_lt_85) | (roc_9_1h < 20.0))
             # 1h down move, 4h high, 1d downtrend
-            & ((rsi_3_1h_gt_50) | (stochrsi_k_4h < 60.0) | (roc_9_1d > -60.0))
+            & ((rsi_3_1h_gt_50) | (stochrsi_k_4h_lt_60) | (roc_9_1d > -60.0))
             # 1h down move, 4h high & overbought
             & ((rsi_3_1h_gt_50) | (stochrsi_k_4h_lt_80) | (roc_9_4h < 100.0))
             # 1h down move, 1h & 4h overbought
@@ -14137,13 +14142,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 1d high & overbought
             & ((rsi_3_4h_gt_10) | (aroonu_14_1d_lt_90) | (roc_9_1d_lt_40))
             # 4h down move, 4h still high, 1d downtrend
-            & ((rsi_3_4h_gt_10) | (stochrsi_k_4h < 40.0) | (roc_9_1d > -20.0))
+            & ((rsi_3_4h_gt_10) | (stochrsi_k_4h_lt_40) | (roc_9_1d > -20.0))
             # 4h & 1d down move, 1d high
             & ((rsi_3_4h_gt_15) | (rsi_3_1d_gt_20) | (aroonu_14_1d_lt_60))
             # 4h down move, 4h still high, 1d downtrend
             & ((rsi_3_4h_gt_15) | (aroonu_14_4h_lt_50) | (roc_9_1d > -20.0))
             # 4h & 1d down move, 4h still high
-            & ((rsi_3_4h_gt_20) | (rsi_3_1d_gt_20) | (stochrsi_k_4h < 40.0))
+            & ((rsi_3_4h_gt_20) | (rsi_3_1d_gt_20) | (stochrsi_k_4h_lt_40))
             # 4h & 1d down move, 1d high
             & ((rsi_3_4h_gt_20) | (rsi_3_1d_gt_20) | (stochrsi_k_1d < 80.0))
             # 4h down move, 1h high, 1d downtrend
@@ -14173,7 +14178,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 4h & 1d downtrend
             & ((rsi_3_4h_gt_40) | aroonu_14_4h_lt_80 | aroonu_14_1d_lt_100)
             # 4h down move, 4h still high, 1d overbought
-            & ((rsi_3_4h_gt_40) | (stochrsi_k_4h < 40.0) | roc_9_1d_lt_50)
+            & ((rsi_3_4h_gt_40) | (stochrsi_k_4h_lt_40) | roc_9_1d_lt_50)
             # 4h down move, 4h high, 1d downtrend
             & ((rsi_3_4h_gt_40) | (stochrsi_k_4h_lt_70) | (roc_9_1d > -60.0))
             # 4h down move, 1d high & overbought
@@ -14199,7 +14204,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1d down move, 1d high, 1d downtrend
             & ((rsi_3_1d_gt_5) | (aroonu_14_1d_lt_80) | (roc_9_1d_gt_neg_20))
             # 1d down move, 1h & 4h still not low enough
-            & ((rsi_3_1d_gt_5) | (stochrsi_k_1h < 20.0) | (stochrsi_k_4h < 20.0))
+            & ((rsi_3_1d_gt_5) | (stochrsi_k_1h < 20.0) | (stochrsi_k_4h_lt_20))
             # 1d down move, 1h & 4h high
             & ((rsi_3_1d_gt_10) | (aroonu_14_1h_lt_50) | (aroonu_14_4h_lt_90))
             # 1d down move, 1h high
@@ -14271,7 +14276,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h high, 4h overbought
             & ((stochrsi_k_1h_lt_80) | (roc_9_4h < 80.0))
             # 4h high, 1h & 4h overbought
-            & ((stochrsi_k_4h < 80.0) | (roc_9_1h_lt_10) | (roc_9_4h_lt_20))
+            & ((stochrsi_k_4h_lt_80) | (roc_9_1h_lt_10) | (roc_9_4h_lt_20))
             # 1d high, 1h & 1d overbought
             & ((stochrsi_k_1d < 80.0) | (roc_9_1h_lt_10) | (roc_9_1d_lt_80))
             # 1d high, 4h & 1d overbought
@@ -14336,7 +14341,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 15m high, 1d overbought
             & ((rsi_3_15m_gt_10) | (aroonu_14_15m_lt_60) | roc_9_1d_lt_50)
             # 15m down move, 4h high, 1d downtrend
-            & ((rsi_3_15m_gt_10) | (stochrsi_k_4h < 80.0) | (roc_9_1d_gt_neg_20))
+            & ((rsi_3_15m_gt_10) | (stochrsi_k_4h_lt_80) | (roc_9_1d_gt_neg_20))
             # 15m & 1h down move, 4h still high
             & ((rsi_3_15m_gt_15) | (rsi_3_1h_gt_35) | (aroonu_14_4h_lt_50))
             # 15m & 1h down move, 1h high
@@ -14438,9 +14443,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 1h high
             & ((rsi_3_15m_gt_20) | (stochrsi_k_1h < 90.0))
             # 15m down move, 4h still high, 1d downtrend
-            & ((rsi_3_15m_gt_20) | (stochrsi_k_4h < 40.0) | (roc_9_1d_gt_neg_20))
+            & ((rsi_3_15m_gt_20) | (stochrsi_k_4h_lt_40) | (roc_9_1d_gt_neg_20))
             # 15m down move, 4h high, 1d downtrend
-            & ((rsi_3_15m_gt_20) | (stochrsi_k_4h < 80.0) | (roc_9_1d_gt_neg_30))
+            & ((rsi_3_15m_gt_20) | (stochrsi_k_4h_lt_80) | (roc_9_1d_gt_neg_30))
             # 15m down move, 4h & 1d overbought
             & ((rsi_3_15m_gt_20) | (roc_9_4h < 25.0) | (roc_9_1d_lt_100))
             # 15m & 1h down move, 15m high
@@ -14514,7 +14519,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 1h high, 1d downtrend
             & ((rsi_3_15m_gt_35) | (stochrsi_k_1h < 90.0) | roc_9_1d_gt_neg_50)
             # 15m down move, 4h high & overbought
-            & ((rsi_3_15m_gt_35) | (stochrsi_k_4h < 90.0) | (roc_9_4h_lt_20))
+            & ((rsi_3_15m_gt_35) | (stochrsi_k_4h_lt_90) | (roc_9_4h_lt_20))
             # 15m down move, 15m high, 1h downtrend
             & ((rsi_3_15m_gt_40) | (aroonu_14_15m_lt_70) | (roc_9_1h > -20.0))
             # 15m down move, 15m & 4h high
@@ -14556,7 +14561,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1d high & overbought
             & ((rsi_3_1h_gt_25) | (aroonu_14_1d_lt_80) | (roc_9_1d_lt_20))
             # 1h down move, 4h high, 1d downtrend
-            & ((rsi_3_1h_gt_25) | (stochrsi_k_4h < 60.0) | (roc_9_1d_gt_neg_20))
+            & ((rsi_3_1h_gt_25) | (stochrsi_k_4h_lt_60) | (roc_9_1d_gt_neg_20))
             # 1h down move, 4h downtrend, 1d overbought
             & ((rsi_3_1h_gt_25) | (roc_9_4h > -40.0) | roc_9_1d_lt_50)
             # 1h down move, 15m & 1h still high
@@ -14568,7 +14573,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h high, 1d overbought
             & ((rsi_3_1h_gt_30) | aroonu_14_1h_lt_70 | (roc_9_1d_lt_30))
             # 1h down move, 4h high & overbought
-            & ((rsi_3_1h_gt_30) | (stochrsi_k_4h < 60.0) | (roc_9_4h_lt_20))
+            & ((rsi_3_1h_gt_30) | (stochrsi_k_4h_lt_60) | (roc_9_4h_lt_20))
             # 1h down move, 4h & 1h overbought
             & ((rsi_3_1h_gt_30) | (roc_9_4h_lt_30) | (roc_9_1d_lt_40))
             # 1h & 1d down move, 1h high
@@ -14582,7 +14587,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 15m & 1d high
             & ((rsi_3_1h_gt_35) | (aroonu_14_15m_lt_60) | (aroonu_14_1d_lt_80))
             # 1h down move, 1h & 4h high
-            & ((rsi_3_1h_gt_35) | aroonu_14_1h_lt_70 | (stochrsi_k_4h < 90.0))
+            & ((rsi_3_1h_gt_35) | aroonu_14_1h_lt_70 | (stochrsi_k_4h_lt_90))
             # 1h down move, 1h & 1d high
             & ((rsi_3_1h_gt_35) | aroonu_14_1h_lt_80 | (aroonu_14_1d_lt_90))
             # 1h down move, 1h downtrend, 4h overbought
@@ -14596,7 +14601,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 1h high
             & ((rsi_3_1h_gt_40) | (rsi_3_4h_gt_50) | (stochrsi_k_1h_lt_70))
             # 1h & 4h down move, 4h high
-            & ((rsi_3_1h_gt_40) | (rsi_3_4h_gt_50) | (stochrsi_k_4h < 60.0))
+            & ((rsi_3_1h_gt_40) | (rsi_3_4h_gt_50) | (stochrsi_k_4h_lt_60))
             # 1h down move, 15m still high, 4h downtrend
             & ((rsi_3_1h_gt_40) | (stochrsi_k_15m < 40.0) | (roc_9_4h > -15.0))
             # 1h down move, 15m still high, 1d overbought
@@ -14666,7 +14671,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 15m high
             & ((rsi_3_4h_gt_5) | (stochrsi_k_15m < 70.0))
             # 4h down move, 4h still high, 1d downtrend
-            & ((rsi_3_4h_gt_5) | (stochrsi_k_4h < 40.0) | (roc_9_1d_gt_neg_20))
+            & ((rsi_3_4h_gt_5) | (stochrsi_k_4h_lt_40) | (roc_9_1d_gt_neg_20))
             # 4h & 1d down move, 1d still high
             & ((rsi_3_4h_gt_10) | (rsi_3_1d_gt_20) | (stochrsi_k_1d < 50.0))
             # 4h & 1d down move, 1d downtrend
@@ -14716,9 +14721,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 1h high, 1d downtrend
             & (rsi_3_4h_gt_20 | (stochrsi_k_1h < 60.0) | (roc_9_1d_gt_neg_40))
             # 4h down move, 4h still not low enough, 4h downtrend
-            & (rsi_3_4h_gt_20 | (stochrsi_k_4h < 30.0) | (roc_9_4h > -10.0))
+            & (rsi_3_4h_gt_20 | (stochrsi_k_4h_lt_30) | (roc_9_4h > -10.0))
             # 4h down move, 4h high, 1d downtrend
-            & (rsi_3_4h_gt_20 | (stochrsi_k_4h < 60.0) | (roc_9_1d > -60.0))
+            & (rsi_3_4h_gt_20 | (stochrsi_k_4h_lt_60) | (roc_9_1d > -60.0))
             # 4h & 1d down move, 1d overbought
             & ((rsi_3_4h_gt_25) | (rsi_3_1d_gt_40) | (roc_9_1d_lt_30))
             # 4h & 1d down move, 1d high
@@ -14816,7 +14821,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 1d high, 4h overbought
             & ((rsi_3_4h_gt_50) | (aroonu_14_1d_lt_90) | (roc_9_4h_lt_10))
             # 4h down move, 4h high, 1d downtrend
-            & ((rsi_3_4h_gt_50) | (stochrsi_k_4h < 60.0) | (roc_9_1d_gt_neg_20))
+            & ((rsi_3_4h_gt_50) | (stochrsi_k_4h_lt_60) | (roc_9_1d_gt_neg_20))
             # 4h down move, 4h downtrend, 1d overbought
             & ((rsi_3_4h_gt_50) | (roc_9_4h_gt_neg_20) | (roc_9_1d_lt_20))
             # 4h down move, 1h high, 4h overbought
@@ -14938,7 +14943,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h high, 1d downtrend
             & ((stochrsi_k_1h < 70.0) | (roc_9_1d_gt_neg_20))
             # 4h high, 4h overbought, 1d downtrend
-            & ((stochrsi_k_4h < 90.0) | (roc_9_4h_lt_20) | (roc_9_1d_gt_neg_20))
+            & ((stochrsi_k_4h_lt_90) | (roc_9_4h_lt_20) | (roc_9_1d_gt_neg_20))
             # 1d still high, 4h & 1d downtrend
             & ((stochrsi_k_1d < 50.0) | (roc_9_4h_gt_neg_30) | (roc_9_1d_gt_neg_30))
             # 1d P&D, 4h downtrend
@@ -15077,7 +15082,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 1d high
             & ((rsi_3_1h_gt_3) | rsi_3_4h_gt_20 | (stochrsi_k_1d < 70.0))
             # 1h down move, 1h high, 4h high
-            & ((rsi_3_1h_gt_3) | aroonu_14_1h_lt_70 | (stochrsi_k_4h < 80.0))
+            & ((rsi_3_1h_gt_3) | aroonu_14_1h_lt_70 | (stochrsi_k_4h_lt_80))
             # 1h down move, 15m still high
             & ((rsi_3_1h_gt_3) | (stochrsi_k_15m < 50.0))
             # 1h down move, 1h still high, 4h overbought
@@ -15121,7 +15126,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 1h still not low enough
             & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_15) | (aroonu_14_1h_lt_20))
             # 1h & 4h down move, 4h still not low enough
-            & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_25) | (stochrsi_k_4h < 30.0))
+            & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_25) | (stochrsi_k_4h_lt_30))
             # 1h & 1d down move, 1d still high
             & ((rsi_3_1h_gt_15) | (rsi_3_1d_gt_20) | (stochrsi_k_1d < 40.0))
             # 1h & 1d down move, 1d high
@@ -15173,7 +15178,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h & 4h high
             & ((rsi_3_1h_gt_45) | aroonu_14_1h_lt_70 | aroonu_14_4h_lt_100)
             # 1h down move, 4h high, 1d downtrend
-            & ((rsi_3_1h_gt_50) | (stochrsi_k_4h < 60.0) | (roc_9_1d > -60.0))
+            & ((rsi_3_1h_gt_50) | (stochrsi_k_4h_lt_60) | (roc_9_1d > -60.0))
             # 1h down move, 4h high & overbought
             & ((rsi_3_1h_gt_50) | (stochrsi_k_4h_lt_90) | (roc_9_4h_lt_40))
             # 1h down move, 1h high & overbought
@@ -15280,7 +15285,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 5m & 4h down move, 15m still high
             & ((rsi_3_gt_3) | (rsi_3_4h_gt_3) | (stochrsi_k_15m < 40.0))
             # 15m & 1h down move, 4h high
-            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_30) | (stochrsi_k_4h < 60.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_30) | (stochrsi_k_4h_lt_60))
             # 15m & 1h down move, 1h still high
             & ((rsi_3_15m_gt_25) | (rsi_3_1h_gt_25) | (stochrsi_k_1h_lt_50))
             # 1h & 4h down move, 4h high
@@ -15358,11 +15363,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 1d overbought
             & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_30) | (roc_9_1d < 100.0))
             # 1h & 4h down move, 4h still high
-            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_45) | (stochrsi_k_4h < 40.0))
+            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_45) | (stochrsi_k_4h_lt_40))
             # 1h down move, 4h downtrend. 4h still not low enough
             & ((rsi_3_1h_gt_10) | (roc_9_4h > -20.0) | (aroonu_14_4h_lt_30))
             # 1h down move, 15m still high, 4h high
-            & ((rsi_3_1h_gt_10) | (aroonu_14_15m_lt_40) | (stochrsi_k_4h < 90.0))
+            & ((rsi_3_1h_gt_10) | (aroonu_14_15m_lt_40) | (stochrsi_k_4h_lt_90))
             # 1h down move, 15m high, 4h downtrend
             & ((rsi_3_1h_gt_10) | (aroonu_14_15m_lt_70) | (roc_9_4h > -10.0))
             # 1h down move, 1h still high, 15m downtrend
@@ -15382,7 +15387,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 4h high
             & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_50) | (aroonu_14_4h_lt_100))
             # 1h & 1d down move, 4h high
-            & ((rsi_3_1h_gt_15) | (rsi_3_1d_gt_15) | (stochrsi_k_4h < 80.0))
+            & ((rsi_3_1h_gt_15) | (rsi_3_1d_gt_15) | (stochrsi_k_4h_lt_80))
             # 1h down move, 4h high, 1d overbought
             & ((rsi_3_1h_gt_15) | (aroonu_14_4h_lt_60) | roc_9_1d_lt_50)
             # 1h down move, 4h high, 1d high
@@ -15410,7 +15415,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1d high & overbought
             & ((rsi_3_1h_gt_25) | (aroonu_14_1d_lt_90) | (roc_9_1d_lt_30))
             # 1h down move, 4h high, 1d downtrend
-            & ((rsi_3_1h_gt_25) | (stochrsi_k_4h < 80.0) | (roc_9_1d_gt_neg_30))
+            & ((rsi_3_1h_gt_25) | (stochrsi_k_4h_lt_80) | (roc_9_1d_gt_neg_30))
             # 1h & 4h down move, 4h high
             & ((rsi_3_1h_gt_30) | (rsi_3_4h_gt_50) | (aroonu_14_4h_lt_85))
             # 1h down move, 1h & 4h high
@@ -15468,7 +15473,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 4h & 1d high
             & ((rsi_3_1h_gt_50) | aroonu_14_4h_lt_100 | aroonu_14_1d_lt_100)
             # 1h down move, 4h high, 1d downtrend
-            & ((rsi_3_1h_gt_50) | (stochrsi_k_4h < 60.0) | (roc_9_1d > -60.0))
+            & ((rsi_3_1h_gt_50) | (stochrsi_k_4h_lt_60) | (roc_9_1d > -60.0))
             # 1h down move, 4h & 1d overbought
             & ((rsi_3_1h_gt_50) | (roc_9_4h_lt_20) | (roc_9_1d_lt_80))
             # 1h down move, 15m high, 1h high
@@ -15500,7 +15505,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 1h high, 1d downtrend
             & ((rsi_3_4h_gt_10) | (stochrsi_k_1h < 70.0) | (roc_9_1d > -20.0))
             # 4h down move, 4h still high, 1d downtrend
-            & ((rsi_3_4h_gt_10) | (stochrsi_k_4h < 40.0) | (roc_9_1d > -20.0))
+            & ((rsi_3_4h_gt_10) | (stochrsi_k_4h_lt_40) | (roc_9_1d > -20.0))
             # 4h down move, 4h downtrend, 1d overbought
             & ((rsi_3_4h_gt_10) | (roc_9_4h > -20.0) | (roc_9_1d_lt_40))
             # 4h & 1d down move, 4h downtrend
@@ -15522,7 +15527,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 4h still high. 4h downtrend
             & ((rsi_3_4h_gt_25) | (aroonu_14_4h_lt_50) | (cmf_20_4h > -0.40))
             # 4h down move, 4h high, 1d downtrend
-            & ((rsi_3_4h_gt_25) | (stochrsi_k_4h < 60.0) | (roc_9_1d > -70.0))
+            & ((rsi_3_4h_gt_25) | (stochrsi_k_4h_lt_60) | (roc_9_1d > -70.0))
             # 4h down move, 1h high, 4h downtrend
             & ((rsi_3_4h_gt_30) | aroonu_14_1h_lt_70 | (roc_9_4h > -10.0))
             # 4h down move, 1h high, 1d downtrend
@@ -15584,7 +15589,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h high, 1h overbought, 1d downtrend
             & ((stochrsi_k_4h_lt_80) | (roc_9_1h < 40.0) | (roc_9_1d > -70.0))
             # 4h high, 4h & 1d overbought
-            & ((stochrsi_k_4h < 80.0) | (roc_9_4h < 80.0) | (roc_9_1d_lt_100))
+            & ((stochrsi_k_4h_lt_80) | (roc_9_4h < 80.0) | (roc_9_1d_lt_100))
             # 4h high, 1h & 4h overbought
             & ((stochrsi_k_4h_lt_90) | (roc_9_1h_lt_10) | (roc_9_4h < 80.0))
             # 4h high, 1h & 4h overbought
@@ -15675,7 +15680,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 1h still not low enough
             & ((rsi_3_15m_gt_3) | (rsi_3_1h_gt_25) | (aroonu_14_1h_lt_20))
             # 15m & 1h down move, 4h still high
-            & ((rsi_3_15m_gt_3) | (rsi_3_1h_gt_25) | (stochrsi_k_4h < 40.0))
+            & ((rsi_3_15m_gt_3) | (rsi_3_1h_gt_25) | (stochrsi_k_4h_lt_40))
             # 15m & 1h down move, 4h high
             & ((rsi_3_15m_gt_3) | (rsi_3_1h_gt_40) | aroonu_14_4h_lt_70)
             # 15m & 4h down move, 1h still not low enough
@@ -15701,7 +15706,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 1h still high
             & ((rsi_3_15m_gt_5) | (rsi_3_1h_gt_25) | (stochrsi_k_1h < 40.0))
             # 15m & 1h down move, 4h still high
-            & ((rsi_3_15m_gt_5) | (rsi_3_1h_gt_25) | (stochrsi_k_4h < 30.0))
+            & ((rsi_3_15m_gt_5) | (rsi_3_1h_gt_25) | (stochrsi_k_4h_lt_30))
             # 15m & 1h down move, 4h high
             & ((rsi_3_15m_gt_5) | (rsi_3_1h_gt_30) | (aroonu_14_4h_lt_90))
             # 15m & 1h & 4h down move, 15m downtrend
@@ -15713,7 +15718,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 4h down move, 15m still not low enough
             & ((rsi_3_15m_gt_5) | (rsi_3_4h_gt_20) | (aroonu_14_15m_lt_30))
             # 15m & 4h down move, 4h high
-            & ((rsi_3_15m_gt_5) | (rsi_3_4h_gt_35) | (stochrsi_k_4h < 60.0))
+            & ((rsi_3_15m_gt_5) | (rsi_3_4h_gt_35) | (stochrsi_k_4h_lt_60))
             # 15m down move, 15m still high, 1h still high
             & ((rsi_3_15m_gt_5) | (aroonu_14_15m_lt_30) | (stochrsi_k_1h_lt_50))
             # 15m down move, 1h still high, 1d high
@@ -15727,9 +15732,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 4h still high
             & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_20) | (aroonu_14_4h_lt_40))
             # 15m & 1h down move, 4h high
-            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_20) | (stochrsi_k_4h < 60.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_20) | (stochrsi_k_4h_lt_60))
             # 15m & 1h & 4h down move, 4h still not low enough
-            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_25) | (rsi_3_4h_gt_25) | (stochrsi_k_4h < 30.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_25) | (rsi_3_4h_gt_25) | (stochrsi_k_4h_lt_30))
             # 15m & 1h & 4h down move, 1d high
             & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_25) | (rsi_3_4h_gt_25) | (stochrsi_k_1d < 70.0))
             # 15m & 1h down move, 4h still high
@@ -15737,7 +15742,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 4h high
             & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_30) | (stochrsi_k_4h_lt_70))
             # 15m & 1h down move, 4h high
-            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_30) | (stochrsi_k_4h < 60.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_30) | (stochrsi_k_4h_lt_60))
             # 15m & 1h down move, 1d overbought
             & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_30) | (roc_9_1d_lt_30))
             # 15m & 1h down move, 1d downtrend
@@ -15757,7 +15762,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 4h down move, 1d high
             & ((rsi_3_15m_gt_10) | (rsi_3_4h_gt_10) | (aroonu_14_1d_lt_80))
             # 15m & 4h down move, 4h still not low enough
-            & ((rsi_3_15m_gt_10) | (rsi_3_4h_gt_10) | (stochrsi_k_4h < 30.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_4h_gt_10) | (stochrsi_k_4h_lt_30))
             # 15m & 4h down move, 1d high
             & ((rsi_3_15m_gt_10) | (rsi_3_4h_gt_10) | (stochrsi_k_1d < 70.0))
             # 15m & 4h down move, 1d high
@@ -15769,7 +15774,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 4h down move, 1h still high
             & ((rsi_3_15m_gt_10) | (rsi_3_4h_gt_20) | (stochrsi_k_1h_lt_50))
             # 15m & 4h down move, 4h still high
-            & ((rsi_3_15m_gt_10) | (rsi_3_4h_gt_20) | (stochrsi_k_4h < 40.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_4h_gt_20) | (stochrsi_k_4h_lt_40))
             # 15m & 4h down move, 1d high
             & ((rsi_3_15m_gt_10) | (rsi_3_4h_gt_20) | (stochrsi_k_1d_lt_90))
             # 15m & 4h down move, 1d overbought
@@ -15795,7 +15800,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 15m downtrend, 4h still high
             & ((rsi_3_15m_gt_10) | (cmf_20_15m > -0.40) | (stochrsi_k_4h_lt_50))
             # 15m down move, 1h downtrend, 4h still high
-            & ((rsi_3_15m_gt_10) | (cmf_20_1h > -0.30) | (stochrsi_k_4h < 40.0))
+            & ((rsi_3_15m_gt_10) | (cmf_20_1h > -0.30) | (stochrsi_k_4h_lt_40))
             # 15m down move, 15m still not low enough, 4h high
             & ((rsi_3_15m_gt_10) | (aroonu_14_15m_lt_30) | (aroonu_14_4h_lt_60))
             # 15m down move, 15m still high, 1h still high
@@ -15883,7 +15888,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 1h high, 4h downtrend
             & ((rsi_3_15m_gt_15) | (stochrsi_k_1h < 80.0) | (roc_9_4h_gt_neg_20))
             # 15m down move, 4h high & overbought
-            & ((rsi_3_15m_gt_15) | (stochrsi_k_4h < 90.0) | (roc_9_4h_lt_20))
+            & ((rsi_3_15m_gt_15) | (stochrsi_k_4h_lt_90) | (roc_9_4h_lt_20))
             # 15m & 1h down move, 1h still high
             & ((rsi_3_15m_gt_20) | rsi_3_1h_gt_20 | (stochrsi_k_1h < 20.0))
             # 15m & 1h down move, 1d downtrend
@@ -16033,7 +16038,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 1d high
             & ((rsi_3_1h_gt_3) | (rsi_3_4h_gt_15) | (stochrsi_k_1d < 70.0))
             # 1h & 4h down move, 4h high
-            & ((rsi_3_1h_gt_5) | (rsi_3_4h_gt_5) | (stochrsi_k_4h < 40.0))
+            & ((rsi_3_1h_gt_5) | (rsi_3_4h_gt_5) | (stochrsi_k_4h_lt_40))
             # 1h & 4h down move, 4h high
             & ((rsi_3_1h_gt_5) | (rsi_3_4h_gt_30) | aroonu_14_4h_lt_70)
             # 1h & 4h down move, 4h still high
@@ -16053,7 +16058,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 15m high
             & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_15) | (stochrsi_k_15m < 70.0))
             # 1h & 4h down move, 4h still not low enough
-            & ((rsi_3_1h_gt_15) | rsi_3_4h_gt_20 | (stochrsi_k_4h < 30.0))
+            & ((rsi_3_1h_gt_15) | rsi_3_4h_gt_20 | (stochrsi_k_4h_lt_30))
             # 1h & 4h down move, 1d downtrend
             & ((rsi_3_1h_gt_15) | rsi_3_4h_gt_20 | (roc_9_1d > -30.0))
             # 1h & 4h down move, 1h high
@@ -16205,17 +16210,17 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h & 1d down move, 1d downtrend
             & ((rsi_3_4h_gt_15) | (rsi_3_1d_gt_25) | (roc_9_1d > -15.0))
             # 4h & 1d down move, 4h still high
-            & ((rsi_3_4h_gt_15) | (rsi_3_1d > 50.0) | (stochrsi_k_4h < 40.0))
+            & ((rsi_3_4h_gt_15) | (rsi_3_1d > 50.0) | (stochrsi_k_4h_lt_40))
             # 4h down move, 1d still high, 4h still not low enough
-            & ((rsi_3_4h_gt_15) | (rsi_14_1d < 40.0) | (stochrsi_k_4h < 30.0))
+            & ((rsi_3_4h_gt_15) | (rsi_14_1d < 40.0) | (stochrsi_k_4h_lt_30))
             # 4h down move, 4h still not low enough, 1d downtrend
-            & ((rsi_3_4h_gt_15) | (stochrsi_k_4h < 20.0) | (roc_9_1d > -20.0))
+            & ((rsi_3_4h_gt_15) | (stochrsi_k_4h_lt_20) | (roc_9_1d > -20.0))
             # 4h down move, 1h & 4h downtrend
             & ((rsi_3_4h_gt_15) | (roc_9_1h > -30.0) | (roc_9_4h_gt_neg_30))
             # 4h & 1d down move, 1d high
             & (rsi_3_4h_gt_20 | (rsi_3_1d_gt_20) | (aroonu_14_1d_lt_60))
             # 4h & 1d down move, 4h still high
-            & (rsi_3_4h_gt_20 | (rsi_3_1d_gt_20) | (stochrsi_k_4h < 40.0))
+            & (rsi_3_4h_gt_20 | (rsi_3_1d_gt_20) | (stochrsi_k_4h_lt_40))
             # 4h & 1d down move, 1d overbought
             & (rsi_3_4h_gt_20 | (rsi_3_1d_gt_45) | (roc_9_1d_lt_40))
             # 4h down move, 15m high
@@ -16247,7 +16252,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 1d high & overbought
             & ((rsi_3_4h_gt_45) | (aroonu_14_1d_lt_70) | (roc_9_1d_lt_20))
             # 4h down move, 4h high & overbought
-            & ((rsi_3_4h_gt_45) | (stochrsi_k_4h < 60.0) | (roc_9_4h_lt_20))
+            & ((rsi_3_4h_gt_45) | (stochrsi_k_4h_lt_60) | (roc_9_4h_lt_20))
             # 4h down move, 4h high, 1d overbought
             & ((rsi_3_4h_gt_45) | (stochrsi_k_4h_lt_80) | (roc_9_1d < 10.0))
             # 4h down move, 4h high & overbought
@@ -16277,7 +16282,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1d down move, 15m still high
             & ((rsi_3_1d_gt_5) | (stochrsi_k_15m < 40.0))
             # 1d down move, 1h & 4h still not low enough
-            & ((rsi_3_1d_gt_5) | (stochrsi_k_1h < 20.0) | (stochrsi_k_4h < 20.0))
+            & ((rsi_3_1d_gt_5) | (stochrsi_k_1h < 20.0) | (stochrsi_k_4h_lt_20))
             # 1d down move, 1h high
             & ((rsi_3_1d_gt_10) | aroonu_14_1h_lt_70)
             # 1d down move, 4h downtrend, 4h high
@@ -16556,7 +16561,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 1d high, 4h overbought
             & ((aroonu_14_1h_lt_90) | (aroonu_14_1d_lt_90) | (roc_9_4h_lt_30))
             # 1h & 4h high, 1h overbought
-            & (aroonu_14_1h_lt_80 | (stochrsi_k_4h < 90.0) | (roc_9_1h_lt_10))
+            & (aroonu_14_1h_lt_80 | (stochrsi_k_4h_lt_90) | (roc_9_1h_lt_10))
             # 1h high & overbought
             & (aroonu_14_1h_lt_80 | (roc_9_1h < 80.0))
             # 1h high, 1h & 4h overbought
@@ -16594,9 +16599,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h high, 4h overbought. 1d downtrend
             & ((stochrsi_k_1h_lt_80) | (roc_9_4h_lt_40) | (cmf_20_1d > -0.25))
             # 4h high, 1h & 4h overbought
-            & ((stochrsi_k_4h < 90.0) | (roc_9_1h_lt_10) | (roc_9_4h_lt_20))
+            & ((stochrsi_k_4h_lt_90) | (roc_9_1h_lt_10) | (roc_9_4h_lt_20))
             # 4h high & 4h & 1d overbought
-            & ((stochrsi_k_4h < 90.0) | (roc_9_4h_lt_20) | (roc_9_1d_lt_20))
+            & ((stochrsi_k_4h_lt_90) | (roc_9_4h_lt_20) | (roc_9_1d_lt_20))
             # 1d high, 1h & 4h overbought
             & ((stochrsi_k_1d < 80.0) | (roc_9_1h_lt_10) | (roc_9_4h_lt_20))
             # 1d hihg, 1h & 1d overbought
@@ -16636,7 +16641,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 1h still high
             & ((rsi_3_15m_gt_3) | (rsi_3_1h_gt_10) | (stochrsi_k_1h < 40.0))
             # 15m & 1h down move, 4h high
-            & ((rsi_3_15m_gt_3) | (rsi_3_1h_gt_10) | (stochrsi_k_4h < 60.0))
+            & ((rsi_3_15m_gt_3) | (rsi_3_1h_gt_10) | (stochrsi_k_4h_lt_60))
             # 15m & 1h down move, 1d downtrend
             & ((rsi_3_15m_gt_3) | (rsi_3_1h_gt_15) | (roc_9_1d > -20.0))
             # 15m & 1h down move, 1h still high
@@ -16682,7 +16687,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 1d high
             & ((rsi_3_15m_gt_5) | (rsi_3_1h_gt_10) | (aroonu_14_1d_lt_80))
             # 15m & 1h down move, 4h high
-            & ((rsi_3_15m_gt_5) | (rsi_3_1h_gt_10) | (stochrsi_k_4h < 80.0))
+            & ((rsi_3_15m_gt_5) | (rsi_3_1h_gt_10) | (stochrsi_k_4h_lt_80))
             # 15m & 1h down move, 1h high
             & ((rsi_3_15m_gt_5) | (rsi_3_1h_gt_30) | aroonu_14_1h_lt_70)
             # 15m & 1h down move, 4h high
@@ -16760,7 +16765,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 1h high, 1d overbought
             & ((rsi_3_15m_gt_10) | (stochrsi_k_1h < 90.0) | (roc_9_1d_lt_30))
             # 15m down move, 4h high & overbought
-            & ((rsi_3_15m_gt_10) | (stochrsi_k_4h < 90.0) | (roc_9_4h_lt_20))
+            & ((rsi_3_15m_gt_10) | (stochrsi_k_4h_lt_90) | (roc_9_4h_lt_20))
             # 15m & 1h down move, 1d overbought
             & ((rsi_3_15m_gt_15) | (rsi_3_1h_gt_15) | (roc_9_1d_lt_30))
             # 15m & 1h down move, 1d high
@@ -16818,7 +16823,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 4h high, 1d overbought
             & ((rsi_3_15m_gt_20) | aroonu_14_4h_lt_80 | (roc_9_1d < 60.0))
             # 15m & 4h down move, 4h high
-            & ((rsi_3_15m_gt_25) | (rsi_3_4h_gt_25) | (stochrsi_k_4h < 60.0))
+            & ((rsi_3_15m_gt_25) | (rsi_3_4h_gt_25) | (stochrsi_k_4h_lt_60))
             # 15m & 1d down move, 1h high
             & ((rsi_3_15m_gt_25) | (rsi_3_1d_gt_25) | (aroonu_14_1h_lt_90))
             # 15m down move, 15m high, 1h high
@@ -16922,7 +16927,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 1d down move, 1h downtrend
             & ((rsi_3_1h_gt_10) | (rsi_3_1d_gt_30) | (cmf_20_1h > -0.40))
             # 1h down move, 1d downtrend, 4h high
-            & ((rsi_3_1h_gt_10) | (cmf_20_1d > -0.30) | (stochrsi_k_4h < 90.0))
+            & ((rsi_3_1h_gt_10) | (cmf_20_1d > -0.30) | (stochrsi_k_4h_lt_90))
             # 1h down move, 1h still high, 4h overbought
             & ((rsi_3_1h_gt_10) | (aroonu_14_1h_lt_50) | (roc_9_4h < 20.0))
             # 1h down move, 1h & 4h high
@@ -16968,9 +16973,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1d high, 4h overbought
             & ((rsi_3_1h_gt_15) | (aroonu_14_1d_lt_100) | (roc_9_4h_lt_10))
             # 1h down move, 4h still not low enough, 1d downtrend
-            & ((rsi_3_1h_gt_15) | (stochrsi_k_4h < 30.0) | (roc_9_1d > -30.0))
+            & ((rsi_3_1h_gt_15) | (stochrsi_k_4h_lt_30) | (roc_9_1d > -30.0))
             # 1h down move, 4h high & overbought
-            & ((rsi_3_1h_gt_15) | (stochrsi_k_4h < 80.0) | (roc_9_4h < 100.0))
+            & ((rsi_3_1h_gt_15) | (stochrsi_k_4h_lt_80) | (roc_9_4h < 100.0))
             # 1h down move, 1h downtrend, 1d overbought
             & ((rsi_3_1h_gt_15) | (roc_9_1h > -30.0) | (roc_9_1d < 35.0))
             # 1h down move, 4h downtrend, 1d overbought
@@ -17090,7 +17095,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h high, 1d overbought
             & ((rsi_3_1h_gt_50) | (stochrsi_k_1h < 70.0) | (roc_9_1d_lt_100))
             # 1h down move, 4h high, 1d downtrend
-            & ((rsi_3_1h_gt_50) | (stochrsi_k_4h < 60.0) | (roc_9_1d > -60.0))
+            & ((rsi_3_1h_gt_50) | (stochrsi_k_4h_lt_60) | (roc_9_1d > -60.0))
             # 1h down move, 1h high
             & ((rsi_3_1h_gt_60) | (stochrsi_k_1h_lt_80))
             # 1h down move, 1h overbought
@@ -17138,7 +17143,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 4h still high, 1d overbought
             & ((rsi_3_4h_gt_30) | (aroonu_14_4h_lt_50) | (roc_9_1d < 200.0))
             # 4h down move, 4h still not low enough, 1d overbought
-            & ((rsi_3_4h_gt_30) | (stochrsi_k_4h < 20.0) | (roc_9_1d < 60.0))
+            & ((rsi_3_4h_gt_30) | (stochrsi_k_4h_lt_20) | (roc_9_1d < 60.0))
             # 4h down move, 1d high, 1d downtrend
             & ((rsi_3_4h_gt_35) | (stochrsi_k_1d < 60.0) | (roc_9_1d_gt_neg_30))
             # 1h & 4h down move, 1d high & overbought
@@ -17158,7 +17163,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 4h & 1d overbought
             & ((rsi_3_4h_gt_50) | (roc_9_4h_lt_10) | (roc_9_1d_lt_40))
             # 1d down move, 4h still high, 1d downtrend
-            & ((rsi_3_1d_gt_3) | (stochrsi_k_4h < 40.0) | (roc_9_1d > -25.0))
+            & ((rsi_3_1d_gt_3) | (stochrsi_k_4h_lt_40) | (roc_9_1d > -25.0))
             # 1d down move, 1h & 4h high
             & ((rsi_3_1d_gt_10) | (aroonu_14_1h_lt_50) | (aroonu_14_4h_lt_90))
             # 1d down move, 1d high, 1d downtrend
@@ -17266,13 +17271,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 1h high
             & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_15) | (aroonu_14_1h_lt_60))
             # 15m & 4h down move, 4h still high
-            & (rsi_3_15m_gt_3 | (rsi_3_4h_gt_30) | (stochrsi_k_4h < 40.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_4h_gt_30) | (stochrsi_k_4h_lt_40))
             # 15m & 4h down move, 1d still high
             & (rsi_3_15m_gt_3 | (rsi_3_4h_gt_15) | (aroonu_14_1d_lt_40))
             # 15m & 1h down move, 1d downtrend
             & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_15) | (roc_9_1d > -30.0))
             # 15m down move, 4h still high, 1d downtrend
-            & (rsi_3_15m_gt_3 | (stochrsi_k_4h < 40.0) | (roc_9_1d_gt_neg_40))
+            & (rsi_3_15m_gt_3 | (stochrsi_k_4h_lt_40) | (roc_9_1d_gt_neg_40))
             # 15m & 1h & 4h down move
             & ((rsi_3_15m_gt_5) | (rsi_3_1h_gt_5) | rsi_3_4h_gt_20)
             # 15m & 1h down move, 1h still high
@@ -17292,11 +17297,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 1d high
             & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_10) | (aroonu_14_1d_lt_100))
             # 15m & 1h down move, 4h still high
-            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_10) | (stochrsi_k_4h < 40.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_10) | (stochrsi_k_4h_lt_40))
             # 15m & 1h down move, 1d high
             & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_10) | (stochrsi_k_1d_lt_90))
             # 15m & 1h down move, 4h high
-            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_15) | (stochrsi_k_4h < 60.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_15) | (stochrsi_k_4h_lt_60))
             # 15m & 1h down move, 1d downtrend
             & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_15) | (roc_9_1d > -30.0))
             # 15m & 1h down move, 4h high
@@ -17306,13 +17311,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 4h down move, 1d high
             & ((rsi_3_15m_gt_10) | (rsi_3_4h_gt_30) | (stochrsi_k_1d_lt_90))
             # 15m & 1d down move, 4h still high
-            & ((rsi_3_15m_gt_10) | (rsi_3_1d_gt_10) | (stochrsi_k_4h < 40.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_1d_gt_10) | (stochrsi_k_4h_lt_40))
             # 15m & 4h down move, 4h still high
-            & ((rsi_3_15m_gt_10) | (rsi_3_4h_gt_10) | (stochrsi_k_4h < 40.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_4h_gt_10) | (stochrsi_k_4h_lt_40))
             # 15m & 4h down move, 1d high
             & ((rsi_3_15m_gt_10) | rsi_3_4h_gt_20 | (stochrsi_k_1d < 70.0))
             # 15m & 4h down move, 4h still not low enough
-            & ((rsi_3_15m_gt_10) | rsi_3_4h_gt_20 | (stochrsi_k_4h < 30.0))
+            & ((rsi_3_15m_gt_10) | rsi_3_4h_gt_20 | (stochrsi_k_4h_lt_30))
             # 15m & 4h down move, 1d high
             & ((rsi_3_15m_gt_10) | rsi_3_4h_gt_20 | (stochrsi_k_1d < 80.0))
             # 15m & 1h down move, 1h high
@@ -17352,13 +17357,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 1h still high
             & ((rsi_3_1h_gt_3) | rsi_3_4h_gt_20 | (aroonu_14_1h_lt_40))
             # 1h & 4h down move, 4h still not low enough
-            & ((rsi_3_1h_gt_3) | rsi_3_4h_gt_20 | (stochrsi_k_4h < 30.0))
+            & ((rsi_3_1h_gt_3) | rsi_3_4h_gt_20 | (stochrsi_k_4h_lt_30))
             # 1h & 4h down move, 4h high
             & ((rsi_3_1h_gt_3) | (rsi_3_4h_gt_25) | aroonu_14_4h_lt_70)
             # 1h & 4h down move, 1d high
             & ((rsi_3_1h_gt_3) | (rsi_3_4h_gt_25) | (aroonu_14_1d_lt_70))
             # 1h & 4h down move, 4h high
-            & ((rsi_3_1h_gt_3) | (rsi_3_4h_gt_25) | (stochrsi_k_4h < 60.0))
+            & ((rsi_3_1h_gt_3) | (rsi_3_4h_gt_25) | (stochrsi_k_4h_lt_60))
             # 1h down move, 1d high, 1d downtrend
             & ((rsi_3_1h_gt_3) | (aroonu_14_1d_lt_70) | (roc_9_1h > -50.0))
             # 1h & 4h down move, 15m still not low enough
@@ -17390,7 +17395,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 1d high
             & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_15) | (aroonu_14_1d_lt_80))
             # 1h & 4h down move, 4h still not low enough
-            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_15) | (stochrsi_k_4h < 20.0))
+            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_15) | (stochrsi_k_4h_lt_20))
             # 1h & 4h down move, 1d downtrend
             & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_15) | (roc_9_1d_gt_neg_40))
             # 1h & 4h down move, 1h still high
@@ -17440,7 +17445,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 15m still high
             & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_15) | (stochrsi_k_15m < 40.0))
             # 1h & 4h down move, 4h still not low enough
-            & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_15) | (stochrsi_k_4h < 20.0))
+            & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_15) | (stochrsi_k_4h_lt_20))
             # 1h & 4h down move, 1d high
             & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_15) | (stochrsi_k_1d < 70.0))
             # 1h & 4h down move, 1d downtrend
@@ -17452,7 +17457,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 4h overbought
             & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_35) | (roc_9_4h_lt_10))
             # 1h & 1d down move, 4h high
-            & ((rsi_3_1h_gt_15) | (rsi_3_1d_gt_20) | (stochrsi_k_4h < 60.0))
+            & ((rsi_3_1h_gt_15) | (rsi_3_1d_gt_20) | (stochrsi_k_4h_lt_60))
             # 1h & 1d down move, 1d overbought
             & ((rsi_3_1h_gt_15) | (rsi_3_1d_gt_35) | (roc_9_1d < 10.0))
             # 1h down move, 1h downtrend, 1h high
@@ -17520,7 +17525,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h high & overbought
             & ((rsi_3_1h_gt_25) | aroonu_14_1d_lt_100 | (roc_9_1d_lt_20))
             # 1h down move, 4h high & overbought
-            & ((rsi_3_1h_gt_25) | (stochrsi_k_4h < 80.0) | (roc_9_4h_lt_20))
+            & ((rsi_3_1h_gt_25) | (stochrsi_k_4h_lt_80) | (roc_9_4h_lt_20))
             # 1h & 4h down move, 1d downtrend
             & ((rsi_3_1h_gt_30) | (rsi_3_4h_gt_30) | roc_9_1d_gt_neg_50)
             # 1h & 4h down move, 15m high
@@ -17542,7 +17547,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1d high, 4h overbought
             & ((rsi_3_1h_gt_30) | aroonu_14_1d_lt_100 | (roc_9_4h_lt_10))
             # 1h down move, 4h still high, 1d downtrend
-            & ((rsi_3_1h_gt_30) | (stochrsi_k_4h < 40.0) | (roc_9_1d > -80.0))
+            & ((rsi_3_1h_gt_30) | (stochrsi_k_4h_lt_40) | (roc_9_1d > -80.0))
             # 1h down move, 4h & 1d overbought
             & ((rsi_3_1h_gt_30) | (roc_9_4h_lt_10) | (roc_9_1d_lt_30))
             # 1h & 4h down move, 15m high
@@ -17566,7 +17571,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 4h high & overbought
             & ((rsi_3_1h_gt_40) | (aroonu_14_4h_lt_90) | (roc_9_4h_lt_20))
             # 1h down move, 4h high, 1d downtrend
-            & ((rsi_3_1h_gt_40) | (stochrsi_k_4h < 60.0) | roc_9_1d_gt_neg_50)
+            & ((rsi_3_1h_gt_40) | (stochrsi_k_4h_lt_60) | roc_9_1d_gt_neg_50)
             # 1h down move, 4h high & overbought
             & ((rsi_3_1h_gt_40) | (stochrsi_k_4h_lt_70) | (roc_9_4h_lt_40))
             # 1h down move, 4h high & overbought
@@ -17612,15 +17617,15 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h & 1d down move, 1d overbought
             & ((rsi_3_4h_gt_10) | (rsi_3_1d_gt_45) | (roc_9_1d < 10.0))
             # 4h & 1d down move, 4h still not low enough
-            & ((rsi_3_4h_gt_10) | (rsi_3_1d > 50.0) | (stochrsi_k_4h < 20.0))
+            & ((rsi_3_4h_gt_10) | (rsi_3_1d > 50.0) | (stochrsi_k_4h_lt_20))
             # 4h down move, 15m high, 1h downtrend
             & ((rsi_3_4h_gt_10) | (stochrsi_k_15m < 60.0) | (roc_9_1h > -10.0))
             # 4h down move, 15m high
             & ((rsi_3_4h_gt_10) | (stochrsi_k_15m < 80.0))
             # 4h down move, 4h still not low e nough, 1d downtrend
-            & ((rsi_3_4h_gt_10) | (stochrsi_k_4h < 30.0) | (roc_9_1d > -20.0))
+            & ((rsi_3_4h_gt_10) | (stochrsi_k_4h_lt_30) | (roc_9_1d > -20.0))
             # 4h down move, 4h still high, 1d high
-            & ((rsi_3_4h_gt_10) | (stochrsi_k_4h < 40.0) | (aroonu_14_1d_lt_80))
+            & ((rsi_3_4h_gt_10) | (stochrsi_k_4h_lt_40) | (aroonu_14_1d_lt_80))
             # 4h down move, 4h & 1d downtrend
             & ((rsi_3_4h_gt_10) | (roc_9_4h > -20.0) | (roc_9_1d_gt_neg_40))
             # 4h & 1d down move, 1d downtrend
@@ -17668,7 +17673,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 15m high
             & (rsi_3_4h_gt_20 | (stochrsi_k_15m < 70.0))
             # 4h down move, 4h still not low enough, 1d downtrend
-            & (rsi_3_4h_gt_20 | (stochrsi_k_4h < 30.0) | (roc_9_1d_gt_neg_20))
+            & (rsi_3_4h_gt_20 | (stochrsi_k_4h_lt_30) | (roc_9_1d_gt_neg_20))
             # 4h down move, 4h & 1d downtrend
             & (rsi_3_4h_gt_20 | (roc_9_4h_gt_neg_20) | (roc_9_1d_gt_neg_20))
             # 4h down move, 1d high, 4h downtrend
@@ -17686,7 +17691,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 1d high, 4h downtrend
             & ((rsi_3_4h_gt_25) | aroonu_14_1d_lt_100 | (roc_9_4h > -20.0))
             # 4h down move, 4h still high, 1d downtrend
-            & ((rsi_3_4h_gt_25) | (stochrsi_k_4h < 40.0) | (roc_9_1d_gt_neg_30))
+            & ((rsi_3_4h_gt_25) | (stochrsi_k_4h_lt_40) | (roc_9_1d_gt_neg_30))
             # 4h down move, 4h high, 1d downtrend
             & ((rsi_3_4h_gt_25) | (stochrsi_k_4h_lt_70) | (roc_9_1d_gt_neg_20))
             # 4h down move, 1d overbought
@@ -17780,7 +17785,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h high, 1h & 4h overbought
             & ((stochrsi_k_4h_lt_90) | (roc_9_1h < 20.0) | (roc_9_4h_lt_30))
             # 4h high, 4h & 1d overbought
-            & ((stochrsi_k_4h < 90.0) | (roc_9_4h_lt_20) | (roc_9_1d_lt_80))
+            & ((stochrsi_k_4h_lt_90) | (roc_9_4h_lt_20) | (roc_9_1d_lt_80))
             # 1d still high, 4h & 1d downtrend
             & ((stochrsi_k_1d < 50.0) | (roc_9_4h_gt_neg_30) | (roc_9_1d_gt_neg_30))
             # big drop in the last 20 days, 1d high, 1d downtrend
@@ -17811,7 +17816,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 5m & 1h down move, 1h still not low enough
             & ((rsi_3_gt_3) | (rsi_3_1h_gt_15) | (stochrsi_k_1h < 30.0))
             # 5m & 1h down move, 4h high
-            & ((rsi_3_gt_3) | (rsi_3_1h_gt_50) | (stochrsi_k_4h < 60.0))
+            & ((rsi_3_gt_3) | (rsi_3_1h_gt_50) | (stochrsi_k_4h_lt_60))
             # 5m & 1d down move, 1d still not low enough
             & ((rsi_3_gt_3) | (rsi_3_1d_gt_15) | (aroonu_14_1d_lt_30))
             # 5m down move, 1h & 4h high
@@ -17963,7 +17968,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 4h down move, 15m still high
             & ((rsi_3_15m_gt_10) | (rsi_3_4h_gt_10) | (stochrsi_k_15m < 40.0))
             # 15m & 4h down move, 4h still high
-            & ((rsi_3_15m_gt_10) | (rsi_3_4h_gt_10) | (stochrsi_k_4h < 40.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_4h_gt_10) | (stochrsi_k_4h_lt_40))
             # 15m & 4h down move, 1h high
             & ((rsi_3_15m_gt_10) | (rsi_3_4h_gt_15) | (stochrsi_k_1h < 90.0))
             # 15m & 4h down move, 1d downtrend
@@ -18099,7 +18104,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1d high, 1d downtrend
             & ((rsi_3_1h_gt_10) | (aroonu_14_1d_lt_70) | (roc_9_1d > -20.0))
             # 1h down move, 4h high, 1d downtrend
-            & ((rsi_3_1h_gt_10) | (stochrsi_k_4h < 60.0) | (roc_9_1d > -30.0))
+            & ((rsi_3_1h_gt_10) | (stochrsi_k_4h_lt_60) | (roc_9_1d > -30.0))
             # 1h & 4h down move, 1h still not low enough
             & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_15) | (aroonu_14_1h_lt_20))
             # 1h & 4h down move, 4h high
@@ -18151,7 +18156,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1d high, 4h downtrend
             & ((rsi_3_1h_gt_25) | (aroonu_14_1d_lt_80) | (roc_9_4h > -70.0))
             # 1h down move, 4h high, 1d downtrend
-            & ((rsi_3_1h_gt_25) | (stochrsi_k_4h < 80.0) | (roc_9_1d_gt_neg_30))
+            & ((rsi_3_1h_gt_25) | (stochrsi_k_4h_lt_80) | (roc_9_1d_gt_neg_30))
             # 1h down move, 4h & 1d downtrend
             & ((rsi_3_1h_gt_25) | (roc_9_4h_gt_neg_30) | (roc_9_1d > -60.0))
             # 1h & 4h down move, 1h high
@@ -18191,7 +18196,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h high, 4h overbought
             & ((rsi_3_1h_gt_40) | (stochrsi_k_1h < 80.0) | (roc_9_4h_lt_20))
             # 1h down move, 4h high & overbought
-            & ((rsi_3_1h_gt_40) | (stochrsi_k_4h < 80.0) | (roc_9_4h_lt_20))
+            & ((rsi_3_1h_gt_40) | (stochrsi_k_4h_lt_80) | (roc_9_4h_lt_20))
             # 1h down move, 1d high, 4h overbought
             & ((rsi_3_1h_gt_45) | aroonu_14_1d_lt_100 | (roc_9_4h_lt_40))
             # 1h down move, 1h high, 1d downtrend
@@ -18219,7 +18224,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 1d still high, 1d downtrend
             & ((rsi_3_4h_gt_10) | (aroonu_14_1d_lt_50) | (roc_9_1d > -30.0))
             # 4h down move, 4h still not low enough, 1d downtrend
-            & ((rsi_3_4h_gt_10) | (stochrsi_k_4h < 30.0) | (roc_9_1d > -20.0))
+            & ((rsi_3_4h_gt_10) | (stochrsi_k_4h_lt_30) | (roc_9_1d > -20.0))
             # 4h down move, 4h & 1d  downtrend
             & ((rsi_3_4h_gt_10) | (roc_9_4h > -20.0) | (roc_9_1d > -30.0))
             # 4h down move, 1h still high
@@ -18388,7 +18393,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 1d high
             & ((rsi_3_1h_gt_3) | (rsi_3_4h_gt_20) | (aroonu_14_1d_lt_60))
             # 1h & 4h down move, 4h high
-            & ((rsi_3_1h_gt_3) | (rsi_3_4h_gt_20) | (stochrsi_k_4h < 60.0))
+            & ((rsi_3_1h_gt_3) | (rsi_3_4h_gt_20) | (stochrsi_k_4h_lt_60))
             # 1h & 4h down move, 1h & 4h still high
             & ((rsi_3_1h_gt_3) | (rsi_3_4h_gt_35) | (aroonu_14_1h_lt_40) | (aroonu_14_4h_lt_40))
             # 1h down move, 1h & 4h still high
@@ -18468,7 +18473,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 4h overbought
             & ((rsi_3_1h_gt_10) | (roc_9_4h_lt_10))
             # 1h down move, 4h high & overbought
-            & ((rsi_3_1h_gt_10) | (stochrsi_k_4h < 80.0) | (roc_9_4h < 20.0))
+            & ((rsi_3_1h_gt_10) | (stochrsi_k_4h_lt_80) | (roc_9_4h < 20.0))
             # 1h down move, 4h & 1d downtrend
             & ((rsi_3_1h_gt_10) | (roc_9_4h_gt_neg_30) | roc_9_1d_gt_neg_50)
             # 1h & 4h down move, 4h high
@@ -18645,7 +18650,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 5m & 4h & 1d down move
           long_entry_logic.append((rsi_3_gt_3) | rsi_3_4h_gt_20 | (rsi_3_1d_gt_20))
           # 15m & 1h down move, 4h high
-          long_entry_logic.append(rsi_3_15m_gt_3 | (rsi_3_1h_gt_30) | (stochrsi_k_4h < 60.0))
+          long_entry_logic.append(rsi_3_15m_gt_3 | (rsi_3_1h_gt_30) | (stochrsi_k_4h_lt_60))
           # 15m & 4h down move
           long_entry_logic.append(rsi_3_15m_gt_3 | (rsi_3_4h_gt_10))
           # 15m & 4h down move, 4h still not low enough
@@ -18669,11 +18674,11 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m & 1h down move, 1h high
           long_entry_logic.append((rsi_3_15m_gt_10) | (rsi_3_1h_gt_65) | (stochrsi_k_1h_lt_80))
           # 15m & 4h down move, 4h still not low enough
-          long_entry_logic.append((rsi_3_15m_gt_10) | (rsi_3_4h_gt_10) | (stochrsi_k_4h < 30.0))
+          long_entry_logic.append((rsi_3_15m_gt_10) | (rsi_3_4h_gt_10) | (stochrsi_k_4h_lt_30))
           # 15m & 4h down move, 1d high
           long_entry_logic.append((rsi_3_15m_gt_10) | (rsi_3_4h_gt_10) | (stochrsi_k_1d < 80.0))
           # 15m & 4h down move, 4h still high
-          long_entry_logic.append((rsi_3_15m_gt_10) | (rsi_3_4h_gt_30) | (stochrsi_k_4h < 40.0))
+          long_entry_logic.append((rsi_3_15m_gt_10) | (rsi_3_4h_gt_30) | (stochrsi_k_4h_lt_40))
           # 15m down move, 1h & 4h high
           long_entry_logic.append((rsi_3_15m_gt_10) | aroonu_14_1h_lt_70 | aroonu_14_4h_lt_100)
           # 15m down move, 1h high & overbought
@@ -18687,7 +18692,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m & 1h down move, 4h high
           long_entry_logic.append((rsi_3_15m_gt_15) | (rsi_3_1h_gt_15) | aroonu_14_4h_lt_70)
           # 15m down move, 1h & 4h high
-          long_entry_logic.append((rsi_3_15m_gt_15) | aroonu_14_1h_lt_70 | (stochrsi_k_4h < 90.0))
+          long_entry_logic.append((rsi_3_15m_gt_15) | aroonu_14_1h_lt_70 | (stochrsi_k_4h_lt_90))
           # 15m down move, 4h high, 1d overbought
           long_entry_logic.append((rsi_3_15m_gt_15) | aroonu_14_4h_lt_70 | roc_9_1d_lt_50)
           # 15m & 1h down move, 1d overbought
@@ -18707,7 +18712,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1h & 4h down move
           long_entry_logic.append((rsi_3_1h_gt_10) | (rsi_3_4h_gt_15))
           # 1h & 4h down move, 4h still not low enough
-          long_entry_logic.append((rsi_3_1h_gt_10) | rsi_3_4h_gt_20 | (stochrsi_k_4h < 30.0))
+          long_entry_logic.append((rsi_3_1h_gt_10) | rsi_3_4h_gt_20 | (stochrsi_k_4h_lt_30))
           # 1h & 4h down move, 4h still high
           long_entry_logic.append((rsi_3_1h_gt_10) | (rsi_3_4h_gt_25) | (aroonu_14_4h_lt_50))
           # 1h & 4h down move, 4h still not low enough
@@ -18723,7 +18728,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m & 1d down move, 1d high
           long_entry_logic.append((rsi_3_15m_gt_10) | (rsi_3_1d_gt_30) | (stochrsi_k_1d < 70.0))
           # 1h & 4h down move, 4h still not low enough
-          long_entry_logic.append((rsi_3_1h_gt_3) | (rsi_3_4h_gt_25) | (stochrsi_k_4h < 30.0))
+          long_entry_logic.append((rsi_3_1h_gt_3) | (rsi_3_4h_gt_25) | (stochrsi_k_4h_lt_30))
           # 1h down move, 1h still not low enough, 1d high
           long_entry_logic.append((rsi_3_1h_gt_10) | (stochrsi_k_1h < 20.0) | (aroonu_14_1d_lt_85))
           # 1h down move, 1h still not low enough
@@ -18915,7 +18920,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 1h still high
             & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_20) | (aroonu_14_1h_lt_40))
             # 15m & 1h down move, 4h still high
-            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_25) | (stochrsi_k_4h < 40.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_25) | (stochrsi_k_4h_lt_40))
             # 15m & 4h down move, 1d high
             & ((rsi_3_15m_gt_10) | (rsi_3_4h_gt_15) | (stochrsi_k_1d_lt_90))
             # 15m & 4h down move, 4h downtrend
@@ -18923,7 +18928,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 4h down move, 4h still high
             & ((rsi_3_15m_gt_10) | (rsi_3_4h_gt_20) | (aroonu_14_4h_lt_50))
             # 15m & 4h down move, 4h still not low enough
-            & ((rsi_3_15m_gt_10) | (rsi_3_4h_gt_20) | (stochrsi_k_4h < 30.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_4h_gt_20) | (stochrsi_k_4h_lt_30))
             # 15m & 4h down move, 1d high
             & ((rsi_3_15m_gt_10) | (rsi_3_4h_gt_30) | (stochrsi_k_1d_lt_90))
             # 15m down move, 4h still high, 1d high
@@ -18957,7 +18962,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 4h downtrend
             & ((rsi_3_1h_gt_5) | (rsi_3_4h_gt_15) | (roc_9_4h_gt_neg_30))
             # 1h & 4h down move, 4h still not low enough
-            & ((rsi_3_1h_gt_5) | (rsi_3_4h_gt_30) | (stochrsi_k_4h < 30.0))
+            & ((rsi_3_1h_gt_5) | (rsi_3_4h_gt_30) | (stochrsi_k_4h_lt_30))
             # 1h & 1d down move, 1d high
             & ((rsi_3_1h_gt_5) | (rsi_3_1d_gt_45) | (aroonu_14_1d_lt_80))
             # 1h down move, 4h high
@@ -18977,9 +18982,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 4h high
             & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_45) | aroonu_14_4h_lt_70)
             # 1h & 4h down move, 4h still high
-            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_50) | (stochrsi_k_4h < 40.0))
+            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_50) | (stochrsi_k_4h_lt_40))
             # 1h & 1d down move, 4h still not low enough
-            & ((rsi_3_1h_gt_10) | (rsi_3_1d_gt_25) | (stochrsi_k_4h < 30.0))
+            & ((rsi_3_1h_gt_10) | (rsi_3_1d_gt_25) | (stochrsi_k_4h_lt_30))
             # 1h & 1d down move, 4h still high
             & ((rsi_3_1h_gt_10) | (rsi_3_1d_gt_30) | (aroonu_14_4h_lt_50))
             # 1h & 1d down move, 4h still high
@@ -19037,7 +19042,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 4h still high, 1d high
             & (rsi_3_4h_gt_20 | (aroonu_14_4h_lt_50) | aroonu_14_1d_lt_100)
             # 1h down move, 4h still high, 1d downtrend
-            & (rsi_3_1h_gt_20 | (stochrsi_k_4h < 40.0) | (roc_9_1d > -25.0))
+            & (rsi_3_1h_gt_20 | (stochrsi_k_4h_lt_40) | (roc_9_1d > -25.0))
             # 1h down move, 4h & 1d high
             & (rsi_3_1h_gt_20 | (stochrsi_k_4h_lt_50) | (stochrsi_k_1d < 80.0))
             # 1h & 4h down move, 1h still high
@@ -19045,7 +19050,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 4h high
             & ((rsi_3_1h_gt_25) | (rsi_3_4h_gt_40) | aroonu_14_4h_lt_70)
             # 1h down move, 15m still not low enough, 4h high
-            & ((rsi_3_1h_gt_25) | (rsi_14_15m < 30.0) | (stochrsi_k_4h < 60.0))
+            & ((rsi_3_1h_gt_25) | (rsi_14_15m < 30.0) | (stochrsi_k_4h_lt_60))
             # 1h & 4h down move, 4h still high
             & ((rsi_3_1h_gt_25) | (rsi_3_4h_gt_35) | (stochrsi_k_4h_lt_50))
             # 1h down move, 1h high
@@ -19091,7 +19096,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h & 1d down move, 1d overbought
             & (rsi_3_4h_gt_20 | (rsi_3_1d_gt_45) | (roc_9_1d_lt_40))
             # 4h down move, 4h still not low enough, 1d downtrend
-            & (rsi_3_4h_gt_20 | (stochrsi_k_4h < 30.0) | (roc_9_1d_gt_neg_20))
+            & (rsi_3_4h_gt_20 | (stochrsi_k_4h_lt_30) | (roc_9_1d_gt_neg_20))
             # 4h down move, 4h & 1d downtrend
             & (rsi_3_4h_gt_20 | (roc_9_4h_gt_neg_20) | (roc_9_1d_gt_neg_20))
             # 4h down move, 4h high
@@ -19119,7 +19124,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h high, 4h overbought
             & ((stochrsi_k_4h_lt_70) | (roc_9_4h_lt_40))
             # 4h high, 4h overbought, 1d downtrend
-            & ((stochrsi_k_4h < 90.0) | (roc_9_4h_lt_20) | (roc_9_1d_gt_neg_20))
+            & ((stochrsi_k_4h_lt_90) | (roc_9_4h_lt_20) | (roc_9_1d_gt_neg_20))
             # 1d green, 4h down move, 4h still high
             & ((change_pct_1d < 40.0) | (rsi_3_4h_gt_35) | (aroonu_14_4h_lt_40))
             # 4h top wick, 1h down move, 1h still high
@@ -19151,7 +19156,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # big drop in the last 30 days, 4h down move
             & ((close > (high_max_30_1d * 0.40)) | (rsi_3_4h_gt_15))
             # big drop in the last 30 days, 4h still not low enough
-            & ((close > (high_max_30_1d * 0.25)) | (stochrsi_k_4h < 30.0))
+            & ((close > (high_max_30_1d * 0.25)) | (stochrsi_k_4h_lt_30))
           )
 
           # Logic
@@ -19189,7 +19194,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 4h still high
             & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_3) | (aroonu_14_4h_lt_40))
             # 15m & 1h down move, 4h still not low enough
-            & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_5) | (stochrsi_k_4h < 20.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_5) | (stochrsi_k_4h_lt_20))
             # 15m & 1h & 4h down move
             & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_10) | (rsi_3_4h_gt_3))
             # 15m & 1h down move, 1d still high
@@ -19249,7 +19254,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 4h overbought
             & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_30) | (roc_9_4h < 50.0))
             # 15m & 4h down move, 4h still not low enough
-            & ((rsi_3_15m_gt_10) | (rsi_3_4h_gt_10) | (stochrsi_k_4h < 30.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_4h_gt_10) | (stochrsi_k_4h_lt_30))
             # 15m & 4h down move, 4h still high, 1d high & overbought
             & ((rsi_3_15m_gt_10) | (rsi_3_4h_gt_15) | (aroonu_14_4h_lt_40) | (aroonu_14_1d_lt_70) | (roc_9_1d < 10.0))
             # 15m & 4h down move, 4h high
@@ -19315,7 +19320,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 1h & 4h high
             & ((rsi_3_15m_gt_30) | (stochrsi_k_1h_lt_70) | (stochrsi_k_4h_lt_80))
             # 1h & 4h down move, 4h still not low enough
-            & ((rsi_3_1h_gt_3) | (rsi_3_4h_gt_5) | (stochrsi_k_4h < 20.0))
+            & ((rsi_3_1h_gt_3) | (rsi_3_4h_gt_5) | (stochrsi_k_4h_lt_20))
             # 1h & 4h down move, 15m stil high
             & ((rsi_3_1h_gt_3) | (rsi_3_4h_gt_10) | (stochrsi_k_15m < 50.0))
             # 1h & 4h down move, 1d still high
@@ -19329,7 +19334,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 1d high
             & ((rsi_3_1h_gt_5) | (rsi_3_4h_gt_15) | (roc_9_1d_lt_40))
             # 1h & 4h down move, 4h still not low enough
-            & ((rsi_3_1h_gt_5) | rsi_3_4h_gt_20 | (stochrsi_k_4h < 30.0))
+            & ((rsi_3_1h_gt_5) | rsi_3_4h_gt_20 | (stochrsi_k_4h_lt_30))
             # 1h down move, 4h high, 1d overbought
             & ((rsi_3_1h_gt_5) | (aroonu_14_4h_lt_60) | (roc_9_1d < 10.0))
             # 1h down move, 1d high, 4h downtrend
@@ -19347,7 +19352,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 1d overbought
             & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_30) | (roc_9_1d_lt_80))
             # 1h down move, 15m still high, 4h high
-            & ((rsi_3_1h_gt_10) | (aroonu_14_15m_lt_40) | (stochrsi_k_4h < 90.0))
+            & ((rsi_3_1h_gt_10) | (aroonu_14_15m_lt_40) | (stochrsi_k_4h_lt_90))
             # 1h down move, 1d high & overbought
             & ((rsi_3_1h_gt_10) | (aroonu_14_1d_lt_100) | (roc_9_1d < 10.0))
             # 1h down move, 4h still high, 4d downtrend
@@ -19401,7 +19406,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h high, 1h overbought
             & ((rsi_3_1h_gt_50) | aroonu_14_1h_lt_70 | (roc_9_1h < 25.0))
             # 1h down move, 4h high, 1d downtrend
-            & ((rsi_3_1h_gt_50) | (stochrsi_k_4h < 60.0) | (roc_9_1d > -60.0))
+            & ((rsi_3_1h_gt_50) | (stochrsi_k_4h_lt_60) | (roc_9_1d > -60.0))
             # 1h down move, 4h & 1d overbought
             & ((rsi_3_1h_gt_60) | (roc_9_4h_lt_30) | (roc_9_1d < 60.0))
             # 4h & 1d down move, 15m still high
@@ -19439,7 +19444,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 1h still not low enough, 1d downtrend
             & ((rsi_3_4h_gt_15) | (stochrsi_k_1h < 20.0) | (roc_9_1d > -20.0))
             # 4h down move, 4h still high, 1d downtrend
-            & (rsi_3_4h_gt_20 | (stochrsi_k_4h < 40.0) | (roc_9_1d_gt_neg_20))
+            & (rsi_3_4h_gt_20 | (stochrsi_k_4h_lt_40) | (roc_9_1d_gt_neg_20))
             # 4h down move, 4h still high, 1d downtrend
             & ((rsi_3_4h_gt_25) | (aroonu_14_4h_lt_50) | (roc_9_1d_gt_neg_40))
             # 4h down move, 4h still high, 1d downtrend
@@ -19526,7 +19531,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 5m & 4h down move, 15m still high
             & ((rsi_3_gt_5) | (rsi_3_4h_gt_25) | (stochrsi_k_15m < 50.0))
             # 5m & 4h down move, 4h still not low enough
-            & ((rsi_3_gt_5) | (rsi_3_4h_gt_15) | (stochrsi_k_4h < 20.0))
+            & ((rsi_3_gt_5) | (rsi_3_4h_gt_15) | (stochrsi_k_4h_lt_20))
             # 15m & 1h down move, 1h still not low enough
             & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_10) | (aroonu_14_1h_lt_20))
             # 15m & 1h down move, 4h still not low enough
@@ -19534,7 +19539,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 4h still high
             & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_15) | (rsi_14_4h < 50.0))
             # 15m & 1h down move, 4h still high
-            & (rsi_3_15m_gt_3 | rsi_3_1h_gt_20 | (stochrsi_k_4h < 40.0))
+            & (rsi_3_15m_gt_3 | rsi_3_1h_gt_20 | (stochrsi_k_4h_lt_40))
             # 15m & 1h down move, 4h still high
             & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_25) | (aroonu_14_4h_lt_50))
             # 15m & 4h down move, 4h still not low enough
@@ -19556,7 +19561,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 4h down move, 4h still high
             & ((rsi_3_15m_gt_5) | (rsi_3_4h_gt_15) | (rsi_14_4h < 40.0))
             # 15m & 1h down move, 4h still high
-            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_10) | (stochrsi_k_4h < 40.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_10) | (stochrsi_k_4h_lt_40))
             # 15m & 1h down move, 1d downtrend
             & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_10) | (roc_9_1d > -20.0))
             # 15m & 1h down move, 15m high
@@ -19576,7 +19581,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 4h down move, 1d high
             & ((rsi_3_15m_gt_10) | rsi_3_4h_gt_20 | (stochrsi_k_1d_lt_90))
             # 15m & 4h down move, 4h still not low enough
-            & ((rsi_3_15m_gt_10) | rsi_3_4h_gt_20 | (stochrsi_k_4h < 30.0))
+            & ((rsi_3_15m_gt_10) | rsi_3_4h_gt_20 | (stochrsi_k_4h_lt_30))
             # 15m & 4h down move, 1d high
             & ((rsi_3_15m_gt_10) | rsi_3_4h_gt_20 | (stochrsi_k_1d < 70.0))
             # 15m & 4h down move, 4h downtrend
@@ -19596,7 +19601,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 4h down move, 4h high
             & ((rsi_3_15m_gt_15) | rsi_3_4h_gt_20 | (aroonu_14_4h_lt_60))
             # 15m & 4h down move, 4h still high
-            & ((rsi_3_15m_gt_15) | (rsi_3_4h_gt_25) | (stochrsi_k_4h < 40.0))
+            & ((rsi_3_15m_gt_15) | (rsi_3_4h_gt_25) | (stochrsi_k_4h_lt_40))
             # 15m down move, 15m downtrend, 4h high
             & ((rsi_3_15m_gt_15) | (cmf_20_15m > -0.30) | (aroonu_14_4h_lt_50))
             # 15m down move, 15m still high, 4h overbought
@@ -19632,7 +19637,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 15m still not low enough
             & ((rsi_3_1h_gt_5) | (rsi_3_4h_gt_5) | (stochrsi_k_15m < 30.0))
             # 1h & 4h down move, 4h still not low enough
-            & ((rsi_3_1h_gt_5) | (rsi_3_4h_gt_5) | (stochrsi_k_4h < 30.0))
+            & ((rsi_3_1h_gt_5) | (rsi_3_4h_gt_5) | (stochrsi_k_4h_lt_30))
             # 1h & 4h down move, 4h still not low enough
             & ((rsi_3_1h_gt_5) | (rsi_3_4h_gt_10) | (aroonu_14_4h_lt_20))
             # 1h & 4h down move, 4h downtrend
@@ -19658,7 +19663,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 4h high
             & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_25) | (aroonu_14_4h_lt_60))
             # 1h & 4h down move, 4h still high
-            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_25) | (stochrsi_k_4h < 40.0))
+            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_25) | (stochrsi_k_4h_lt_40))
             # 1h & 4h down move, 1h still not low enough
             & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_35) | (aroonu_14_1h_lt_30))
             # 1h& 1d down move, 1h still high
@@ -19672,7 +19677,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 1d high
             & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_15) | (stochrsi_k_1d < 70.0))
             # 1h & 4h down move, 4h still high
-            & ((rsi_3_1h_gt_15) | rsi_3_4h_gt_20 | (stochrsi_k_4h < 40.0))
+            & ((rsi_3_1h_gt_15) | rsi_3_4h_gt_20 | (stochrsi_k_4h_lt_40))
             # 1h & 4h down move, 1d high
             & ((rsi_3_1h_gt_15) | rsi_3_4h_gt_20 | (stochrsi_k_1d_lt_90))
             # 1h & 4h down move, 1d high
@@ -19680,7 +19685,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 1d downtrend
             & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_45) | (roc_9_1d_gt_neg_40))
             # 1h & 1d down move, 4h high
-            & ((rsi_3_1h_gt_15) | (rsi_3_1d_gt_15) | (stochrsi_k_4h < 80.0))
+            & ((rsi_3_1h_gt_15) | (rsi_3_1d_gt_15) | (stochrsi_k_4h_lt_80))
             # 1h down move, 4h high, 1d overbought
             & ((rsi_3_1h_gt_15) | aroonu_14_4h_lt_70 | (roc_9_1d < 100.0))
             # 1h down move, 1d high, 4h downtrend
@@ -19706,7 +19711,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h still not low enough, 4h stil high
             & (rsi_3_1h_gt_20 | (stochrsi_k_1h < 20.0) | (aroonu_14_4h_lt_40))
             # 1h down move, 4h still high, 1d downtrend
-            & (rsi_3_1h_gt_20 | (stochrsi_k_4h < 40.0) | (roc_9_1d_gt_neg_40))
+            & (rsi_3_1h_gt_20 | (stochrsi_k_4h_lt_40) | (roc_9_1d_gt_neg_40))
             # 1h down move, 1d high, 4h downtrend
             & (rsi_3_1h_gt_20 | (stochrsi_k_1d < 80.0) | (roc_9_4h_gt_neg_20))
             # 1h down move, 4h high
@@ -19742,9 +19747,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1d high, 4h overbought
             & ((rsi_3_1h_gt_30) | aroonu_14_1d_lt_100 | (roc_9_4h < 20.0))
             # 1h down move, 4h still high, 1d downtrend
-            & ((rsi_3_1h_gt_30) | (stochrsi_k_4h < 40.0) | (roc_9_1d > -80.0))
+            & ((rsi_3_1h_gt_30) | (stochrsi_k_4h_lt_40) | (roc_9_1d > -80.0))
             # 1h down move, 4h high & overbought
-            & ((rsi_3_1h_gt_30) | (stochrsi_k_4h < 90.0) | (roc_9_4h_lt_20))
+            & ((rsi_3_1h_gt_30) | (stochrsi_k_4h_lt_90) | (roc_9_4h_lt_20))
             # 1h down move, 4h & 1d overbought
             & ((rsi_3_1h_gt_30) | (roc_9_4h_lt_10) | (roc_9_1d_lt_30))
             # 1h & 4h down move, 1h still high
@@ -19810,7 +19815,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 1d high & overbought
             & ((rsi_3_4h_gt_30) | aroonu_14_1d_lt_100 | (roc_9_1d_lt_20))
             # 4h down move, 4h still not low enough, 1d overbought
-            & ((rsi_3_4h_gt_30) | (stochrsi_k_4h < 20.0) | (roc_9_1d_lt_40))
+            & ((rsi_3_4h_gt_30) | (stochrsi_k_4h_lt_20) | (roc_9_1d_lt_40))
             # 4h down move, 1h high
             & ((rsi_3_4h_gt_35) | aroonu_14_1h_lt_70)
             # 4h down move, 15m & 4h still high
@@ -19850,7 +19855,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h high, 1h & 4h overbought
             & ((stochrsi_k_4h_lt_70) | (roc_9_1h < 40.0) | (roc_9_4h_lt_40))
             # 4h high, 4h & 1d overbought
-            & ((stochrsi_k_4h < 80.0) | (roc_9_4h_lt_20) | (roc_9_1d_lt_20))
+            & ((stochrsi_k_4h_lt_80) | (roc_9_4h_lt_20) | (roc_9_1d_lt_20))
             # 1d green, 4h down move, 4h still high
             & ((change_pct_1d < 40.0) | (rsi_3_4h_gt_35) | (aroonu_14_4h_lt_40))
           )
@@ -19898,11 +19903,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 1h high
             & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_50) | (stochrsi_k_1h < 90.0))
             # 15m & 4h down move, 4h still not low enough
-            & ((rsi_3_15m_gt_10) | (rsi_3_4h_gt_10) | (stochrsi_k_4h < 30.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_4h_gt_10) | (stochrsi_k_4h_lt_30))
             # 15m & 4h down move, 1d high
             & ((rsi_3_15m_gt_10) | (rsi_3_4h_gt_10) | (stochrsi_k_1d < 80.0))
             # 15m & 4h down move, 4h still not low enough
-            & ((rsi_3_15m_gt_10) | (rsi_3_4h_gt_15) | (stochrsi_k_4h < 30.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_4h_gt_15) | (stochrsi_k_4h_lt_30))
             # 15m & 4h down move, 1d downtrend
             & ((rsi_3_15m_gt_10) | (rsi_3_4h_gt_15) | (roc_9_1d > -20.0))
             # 1h & 4h down move, 15m still high
@@ -19964,7 +19969,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 1d overbought
             & ((rsi_3_15m_gt_25) | (rsi_3_1h_gt_40) | (roc_9_1d_lt_80))
             # 15m & 4h down move, 4h high
-            & ((rsi_3_15m_gt_25) | (rsi_3_4h_gt_25) | (stochrsi_k_4h < 60.0))
+            & ((rsi_3_15m_gt_25) | (rsi_3_4h_gt_25) | (stochrsi_k_4h_lt_60))
             # 15m down move, 1d high, 4h overbought
             & ((rsi_3_15m_gt_25) | (aroonu_14_1d_lt_80) | (roc_9_4h_lt_10))
             # 15m down move, 4h & 1d overbought
@@ -20004,7 +20009,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 15m downtrend
             & ((rsi_3_1h_gt_3) | (rsi_3_4h_gt_3) | (roc_9_15m > -30.0))
             # 1h & 4h down move, 4h still high
-            & ((rsi_3_1h_gt_3) | (rsi_3_4h_gt_10) | (stochrsi_k_4h < 40.0))
+            & ((rsi_3_1h_gt_3) | (rsi_3_4h_gt_10) | (stochrsi_k_4h_lt_40))
             # 1h & 4h down move, 1d still high
             & ((rsi_3_1h_gt_3) | (rsi_3_4h_gt_10) | (stochrsi_k_1d < 40.0))
             # 1h & 4h down move, 4h stil high
@@ -20012,13 +20017,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h ^ 4h down move, 1d downtrend
             & ((rsi_3_1h_gt_3) | (rsi_3_4h_gt_25) | roc_9_1d_gt_neg_50)
             # 1h & 1d down move, 4h still high
-            & ((rsi_3_1h_gt_3) | (rsi_3_1d_gt_10) | (stochrsi_k_4h < 40.0))
+            & ((rsi_3_1h_gt_3) | (rsi_3_1d_gt_10) | (stochrsi_k_4h_lt_40))
             # 1h & 1d down move, 1h downtrend
             & ((rsi_3_1h_gt_3) | (rsi_3_1d_gt_15) | (roc_9_1h > -40.0))
             # 1h down move, 15m downtrend, 1h still high
             & ((rsi_3_1h_gt_3) | (cmf_20_15m > -0.40) | (aroonu_14_1h_lt_40))
             # 1h down move, 15m still not low enough, 4h still high
-            & ((rsi_3_1h_gt_3) | (aroonu_14_15m_lt_30) | (stochrsi_k_4h < 40.0))
+            & ((rsi_3_1h_gt_3) | (aroonu_14_15m_lt_30) | (stochrsi_k_4h_lt_40))
             # 1h down move, 1h still not low enough
             & ((rsi_3_1h_gt_3) | (stochrsi_k_1h < 30.0))
             # 1h down move, 4h still high, 1d downtrend
@@ -20076,7 +20081,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1d high & overbought
             & ((rsi_3_1h_gt_10) | (aroonu_14_1d_lt_70) | roc_9_1d_lt_50)
             # 1h & 4h down move, 4h still not low enough
-            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_10) | (stochrsi_k_4h < 20.0))
+            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_10) | (stochrsi_k_4h_lt_20))
             # 1h down move, 1d overbought
             & ((rsi_3_1h_gt_10) | (roc_9_1d < 100.0))
             # 1h & 4h down move, 1h still not low enough
@@ -20110,7 +20115,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 4h still high
             & (rsi_3_1h_gt_20 | (aroonu_14_4h_lt_40))
             # 1h down move, 4h still high, 1d downtrend
-            & (rsi_3_1h_gt_20 | (stochrsi_k_4h < 40.0) | (roc_9_1d > -25.0))
+            & (rsi_3_1h_gt_20 | (stochrsi_k_4h_lt_40) | (roc_9_1d > -25.0))
             # 1h down move, 4h high & overbought
             & (rsi_3_1h_gt_20 | (stochrsi_k_4h_lt_70) | (roc_9_4h_lt_10))
             # 1h down move, 1h & 1d high
@@ -20130,7 +20135,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h still high, 1d overbought
             & ((rsi_3_1h_gt_25) | (stochrsi_k_1h_lt_50) | (roc_9_1d_lt_40))
             # 1h down move, 4h high & overbought
-            & ((rsi_3_1h_gt_25) | (stochrsi_k_4h < 80.0) | (roc_9_4h_lt_20))
+            & ((rsi_3_1h_gt_25) | (stochrsi_k_4h_lt_80) | (roc_9_4h_lt_20))
             # 1h down move, 4h high, 1d overbought
             & ((rsi_3_1h_gt_25) | (stochrsi_k_4h_lt_80) | (roc_9_1d < 70.0))
             # 1h & 4h down move, 1h high
@@ -20196,7 +20201,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 4h high & overbought
             & ((rsi_3_1h_gt_50) | aroonu_14_4h_lt_100 | (roc_9_4h < 100.0))
             # 1h down move, 4h high, 1d downtrend
-            & ((rsi_3_1h_gt_50) | (stochrsi_k_4h < 60.0) | (roc_9_1d > -60.0))
+            & ((rsi_3_1h_gt_50) | (stochrsi_k_4h_lt_60) | (roc_9_1d > -60.0))
             # 1h down move, 15m high, 1h high
             & ((rsi_3_1h_gt_55) | (aroonu_14_15m_lt_60) | (stochrsi_k_1h_lt_80))
             # 1h down move, 1h high & overbought
@@ -20226,7 +20231,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 1h high
             & ((rsi_3_4h_gt_10) | (stochrsi_k_1h < 70.0))
             # 4h down move, 4h still high, 1d downtrend
-            & ((rsi_3_4h_gt_10) | (stochrsi_k_4h < 40.0) | (roc_9_1d > -20.0))
+            & ((rsi_3_4h_gt_10) | (stochrsi_k_4h_lt_40) | (roc_9_1d > -20.0))
             # 4h down move, 4h downtrend, 1d overbought
             & ((rsi_3_4h_gt_10) | (roc_9_4h_gt_neg_30) | (roc_9_1d_lt_40))
             # 4h & 1d down move, 1d high
@@ -20250,9 +20255,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 15m still high, 4h high
             & ((rsi_3_4h_gt_25) | (aroonu_14_15m_lt_40) | aroonu_14_4h_lt_70)
             # 4h down move, 1h & 4h still high
-            & ((rsi_3_4h_gt_25) | (stochrsi_k_1h < 40.0) | (stochrsi_k_4h < 40.0))
+            & ((rsi_3_4h_gt_25) | (stochrsi_k_1h < 40.0) | (stochrsi_k_4h_lt_40))
             # 4h dowqn move, 4h still high, 1d downtrend
-            & ((rsi_3_4h_gt_25) | (stochrsi_k_4h < 30.0) | (roc_9_1d_gt_neg_30))
+            & ((rsi_3_4h_gt_25) | (stochrsi_k_4h_lt_30) | (roc_9_1d_gt_neg_30))
             # 4h down move, 4h high, 1d overbought
             & ((rsi_3_4h_gt_30) | aroonu_14_4h_lt_80 | roc_9_1d_lt_50)
             # 4h down move, 1h high, 4h downtrend
@@ -20276,7 +20281,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 4h high & overbought
             & ((rsi_3_4h_gt_60) | (stochrsi_k_4h_lt_70) | (roc_9_4h_lt_20))
             # 1d down move, 1h & 4h still not low enough
-            & ((rsi_3_1d_gt_5) | (stochrsi_k_1h < 20.0) | (stochrsi_k_4h < 20.0))
+            & ((rsi_3_1d_gt_5) | (stochrsi_k_1h < 20.0) | (stochrsi_k_4h_lt_20))
             # 1d down move, 1h high & overbought
             & ((rsi_3_1d_gt_35) | (stochrsi_k_1h < 90.0) | (roc_9_1h_lt_10))
             # 1d down move, 1h high & overbought
@@ -20338,7 +20343,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h high, 4h & 1d overbought
             & ((stochrsi_k_1h < 90.0) | (roc_9_4h_lt_20) | (roc_9_1d_lt_100))
             # 4h still high, 4h & 1d downtrend
-            & ((stochrsi_k_4h < 40.0) | (roc_9_4h_gt_neg_20) | (roc_9_1d_gt_neg_40))
+            & ((stochrsi_k_4h_lt_40) | (roc_9_4h_gt_neg_20) | (roc_9_1d_gt_neg_40))
             # 4h high, 1h & 1d downtrend
             & ((stochrsi_k_4h_lt_70) | (roc_9_1h > -20.0) | (roc_9_1d_gt_neg_20))
             # 4h high, 4h & 1d overbought
@@ -20398,7 +20403,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h & 4h & 1d down move, 1d still high
             & ((rsi_3_15m_gt_3) | (rsi_3_1h_gt_3) | (rsi_3_4h_gt_15) | (rsi_3_1d_gt_50) | (rsi_14_1d < 40.0))
             # 15m & 1h down move, 4h still not low enough
-            & ((rsi_3_15m_gt_3) | (rsi_3_1h_gt_5) | (stochrsi_k_4h < 30.0))
+            & ((rsi_3_15m_gt_3) | (rsi_3_1h_gt_5) | (stochrsi_k_4h_lt_30))
             # 15m & 1h down move, 1d still high
             & ((rsi_3_15m_gt_3) | (rsi_3_1h_gt_5) | (aroonu_14_1d_lt_40))
             # 15m & 1h & 4h down move, 4h still not low enough, 1d still high
@@ -20410,13 +20415,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 1h still not low enough
             & ((rsi_3_15m_gt_3) | (rsi_3_1h_gt_35) | (stochrsi_k_1h < 30.0))
             # 15m & 4h down move, 4h still not low enough
-            & ((rsi_3_15m_gt_3) | (rsi_3_4h_gt_10) | (stochrsi_k_4h < 20.0))
+            & ((rsi_3_15m_gt_3) | (rsi_3_4h_gt_10) | (stochrsi_k_4h_lt_20))
             # 15m & 4h down move, 1d downtrend
             & ((rsi_3_15m_gt_3) | (rsi_3_4h_gt_10) | (roc_9_1d > -20.0))
             # 15m & 4h down move, 4h still not low enough
             & ((rsi_3_15m_gt_3) | (rsi_3_4h_gt_25) | (aroonu_14_4h_lt_30))
             # 15m & 4h down move, 4h still not low enough
-            & ((rsi_3_15m_gt_3) | (rsi_3_4h_gt_25) | (stochrsi_k_4h < 30.0))
+            & ((rsi_3_15m_gt_3) | (rsi_3_4h_gt_25) | (stochrsi_k_4h_lt_30))
             # 15m down move, 15m still not low enough, 1h high
             & ((rsi_3_15m_gt_3) | (aroonu_14_15m_lt_20) | (stochrsi_k_1h < 60.0))
             # 15m down move, 15m still not low enough, 4h high
@@ -20444,7 +20449,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1d down move
             & ((rsi_3_15m_gt_5) | (rsi_3_1d_gt_5))
             # 15m & 1d down move, 4h still not low enough
-            & ((rsi_3_15m_gt_5) | (rsi_3_1d_gt_30) | (stochrsi_k_4h < 30.0))
+            & ((rsi_3_15m_gt_5) | (rsi_3_1d_gt_30) | (stochrsi_k_4h_lt_30))
             # 15m down move, 1h still high, 4h high
             & ((rsi_3_15m_gt_5) | (aroonu_14_1h_lt_50) | (stochrsi_k_4h_lt_90))
             # 15m down move, 1h high & overbought
@@ -20544,13 +20549,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 4h downtrend
             & ((rsi_3_1h_gt_5) | (rsi_3_4h_gt_15) | (roc_9_4h_gt_neg_30))
             # 1h & 4h down move, 4h still not low enough
-            & ((rsi_3_1h_gt_5) | rsi_3_4h_gt_20 | (stochrsi_k_4h < 20.0))
+            & ((rsi_3_1h_gt_5) | rsi_3_4h_gt_20 | (stochrsi_k_4h_lt_20))
             # 1h & 4h down move, 1d low
             & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_10) | (cmf_20_1d > -0.2))
             # 1h & 4h down move, 4h still not low enough
             & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_15) | (aroonu_14_4h_lt_20))
             # 1h & 4h down move, 4h still not low enough
-            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_25) | (stochrsi_k_4h < 30.0))
+            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_25) | (stochrsi_k_4h_lt_30))
             # 1h & 1d down move, 5m moving down
             & ((rsi_3_1h_gt_10) | (rsi_3_1d_gt_15) | (roc_2 > -0.0))
             # 1h down move, 4h downtrend
@@ -20620,7 +20625,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 4h high, 1d downtrend
             & ((rsi_3_4h_gt_40) | (stochrsi_k_4h_lt_70) | (roc_9_1d > -60.0))
             # 4h down move, 4h still high
-            & ((rsi_3_4h_gt_60) | (stochrsi_k_4h < 40.0))
+            & ((rsi_3_4h_gt_60) | (stochrsi_k_4h_lt_40))
             # 4h down move, 4h overbought
             & ((rsi_3_4h_gt_60) | (roc_9_4h_lt_20))
             # 1d down move, 1h still high, 4h high
@@ -20664,7 +20669,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # big drop in last 6 hours, 1d overbought
             & ((close > (df["high_max_6_1h"] * 0.65)) | roc_9_1d_lt_50)
             # big drop in last 4 hours, 4h still not low enough
-            & ((close > (high_max_24_4h * 0.50)) | (stochrsi_k_4h < 30.0))
+            & ((close > (high_max_24_4h * 0.50)) | (stochrsi_k_4h_lt_30))
             # big drop in the last 4 days, 4h down move
             & ((close > (high_max_24_4h * 0.20)) | rsi_3_4h_gt_20)
             # big drop in the last 6 days, 1d down move
@@ -20769,11 +20774,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 4h down move, 15m still high
             & ((rsi_3_15m_gt_10) | rsi_3_4h_gt_20 | (aroonu_14_15m_lt_50))
             # 15m & 4h down move, 4h still not low enough
-            & ((rsi_3_15m_gt_10) | rsi_3_4h_gt_20 | (stochrsi_k_4h < 30.0))
+            & ((rsi_3_15m_gt_10) | rsi_3_4h_gt_20 | (stochrsi_k_4h_lt_30))
             # 15m & 4h down move, 4h still high
             & ((rsi_3_15m_gt_10) | (rsi_3_4h_gt_25) | (aroonu_14_4h_lt_50))
             # 15m & 4h down move, 4h still high
-            & ((rsi_3_15m_gt_10) | (rsi_3_4h_gt_30) | (stochrsi_k_4h < 40.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_4h_gt_30) | (stochrsi_k_4h_lt_40))
             # 15m & 4h down move, 1h still high
             & ((rsi_3_15m_gt_10) | rsi_3_4h_gt_20 | (stochrsi_k_1h < 40.0))
             # 15m & 4h down move, 1d high
@@ -20823,7 +20828,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 15m still high, 1h high
             & ((rsi_3_15m_gt_15) | (stochrsi_k_15m < 40.0) | (stochrsi_k_1h_lt_70))
             # 15m down move, 1h still high, 4h high
-            & ((rsi_3_15m_gt_15) | (stochrsi_k_1h_lt_50) | (stochrsi_k_4h < 60.0))
+            & ((rsi_3_15m_gt_15) | (stochrsi_k_1h_lt_50) | (stochrsi_k_4h_lt_60))
             # 15m down move, 4h still high 1d overbought
             & ((rsi_3_15m_gt_15) | (aroonu_14_4h_lt_50) | roc_9_1d_lt_50)
             # 15m & 1h down move, 15m still not low enough
@@ -20953,7 +20958,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h & 1d down move, 15m still not low enough
             & (rsi_3_4h_gt_20 | (rsi_3_1d_gt_20) | (stochrsi_k_15m < 30.0))
             # 4h down move, 4h still not low enough, 1d downtrend
-            & (rsi_3_4h_gt_20 | (stochrsi_k_4h < 30.0) | (roc_9_1d_gt_neg_20))
+            & (rsi_3_4h_gt_20 | (stochrsi_k_4h_lt_30) | (roc_9_1d_gt_neg_20))
             # 4h down move, 1d high, 4h downtrend
             & ((rsi_3_4h_gt_30) | (stochrsi_k_1d_lt_90) | (roc_9_4h_gt_neg_20))
             # 4h & 1d down move, 4h still high, 1d high
@@ -20963,13 +20968,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h & 1d down move, 1d high
             & ((rsi_3_4h_gt_40) | (rsi_3_1d_gt_60) | aroonu_14_1d_lt_100)
             # 4h down move, 4h high, 1d downtrend
-            & ((rsi_3_4h_gt_60) | (stochrsi_k_4h < 80.0) | (roc_9_1d_gt_neg_20))
+            & ((rsi_3_4h_gt_60) | (stochrsi_k_4h_lt_80) | (roc_9_1d_gt_neg_20))
             # 4h down move, 15m high, 4h overbought
             & ((rsi_3_4h_gt_60) | (stochrsi_k_15m < 80.0) | (roc_9_4h_lt_20))
             # 4h down move, 4h & 1d overbought
             & ((rsi_3_4h_gt_60) | (roc_9_4h_lt_20) | (roc_9_1d_lt_20))
             # 1d down move, 1h & 4h still not low enough
-            & ((rsi_3_1d_gt_5) | (stochrsi_k_1h < 20.0) | (stochrsi_k_4h < 20.0))
+            & ((rsi_3_1d_gt_5) | (stochrsi_k_1h < 20.0) | (stochrsi_k_4h_lt_20))
             # 1d down move, 1h high, 1d downtrend
             & ((rsi_3_1d_gt_10) | (aroonu_14_1h_lt_85) | (roc_9_1d_gt_neg_30))
             # 1d down move, 15m still not low enough, 1h still high
@@ -21145,7 +21150,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 4h down move, 1h & 4h downtrend
           long_entry_logic.append((rsi_3_4h_gt_5) | (roc_9_1h > -30.0) | (roc_9_4h_gt_neg_30))
           # 1h down move, 4h high & overbought
-          long_entry_logic.append((rsi_3_1h_gt_50) | (stochrsi_k_4h < 90.0) | (roc_9_4h_lt_20))
+          long_entry_logic.append((rsi_3_1h_gt_50) | (stochrsi_k_4h_lt_90) | (roc_9_4h_lt_20))
           # 4h down move, 4h still high, 1d downtrend
           long_entry_logic.append(rsi_3_4h_gt_20 | (aroonu_14_4h_lt_50) | (roc_9_1d_gt_neg_40))
           # 1h down move, 15m & 1h still high
@@ -21205,7 +21210,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m still high, 1d high
           long_entry_logic.append((stochrsi_k_15m < 50.0) | (stochrsi_k_1d_lt_90))
           # 4h high, 4h & 1d overbought
-          long_entry_logic.append((stochrsi_k_4h < 80.0) | (roc_9_4h_lt_40) | (roc_9_1d_lt_100))
+          long_entry_logic.append((stochrsi_k_4h_lt_80) | (roc_9_4h_lt_40) | (roc_9_1d_lt_100))
           # 1d green, 4h down move, 4h still high
           long_entry_logic.append((change_pct_1d < 40.0) | (rsi_3_4h_gt_35) | (aroonu_14_4h_lt_40))
           # 1d top wick, 4h high
@@ -21287,7 +21292,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m & 4h down move, 1h & 4h downtrend
           long_entry_logic.append((rsi_3_15m_gt_10) | (rsi_3_4h_gt_10) | (cmf_20_1h > -0.20) | (cmf_20_4h > -0.20))
           # 15m & 4h down move, 4h still not low enough
-          long_entry_logic.append((rsi_3_15m_gt_10) | (rsi_3_4h_gt_10) | (stochrsi_k_4h < 30.0))
+          long_entry_logic.append((rsi_3_15m_gt_10) | (rsi_3_4h_gt_10) | (stochrsi_k_4h_lt_30))
           # 15m & 4h down move, 4h still high
           long_entry_logic.append((rsi_3_15m_gt_10) | (rsi_3_4h_gt_10) | (aroonu_14_4h_lt_40))
           # 15m & 4h down move, 1d high
@@ -21295,7 +21300,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m & 4h down move, 1h high
           long_entry_logic.append((rsi_3_15m_gt_10) | rsi_3_4h_gt_20 | (stochrsi_k_1h_lt_70))
           # 15m & 4h down move, 4h still high
-          long_entry_logic.append((rsi_3_15m_gt_10) | rsi_3_4h_gt_20 | (stochrsi_k_4h < 40.0))
+          long_entry_logic.append((rsi_3_15m_gt_10) | rsi_3_4h_gt_20 | (stochrsi_k_4h_lt_40))
           # 15m & 4h down move, 1d downtrend
           long_entry_logic.append((rsi_3_15m_gt_10) | rsi_3_4h_gt_20 | (roc_9_1d > -25.0))
           # 15m & 4h down move, 15m still not low enough
@@ -21325,7 +21330,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1h & 4h down move
           long_entry_logic.append((rsi_3_1h_gt_3) | (rsi_3_4h_gt_10))
           # 1h & 4h down move, 4h still not low enough
-          long_entry_logic.append((rsi_3_1h_gt_3) | (rsi_3_4h_gt_25) | (stochrsi_k_4h < 30.0))
+          long_entry_logic.append((rsi_3_1h_gt_3) | (rsi_3_4h_gt_25) | (stochrsi_k_4h_lt_30))
           # 1h & 4h down move, 4h high
           long_entry_logic.append((rsi_3_1h_gt_3) | (rsi_3_4h_gt_50) | aroonu_14_4h_lt_70)
           # 1h & 4h down move
@@ -21339,7 +21344,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1h & 4h down move
           long_entry_logic.append((rsi_3_1h_gt_10) | (rsi_3_4h_gt_10))
           # 1h & 4h down move, 4h still not low enough
-          long_entry_logic.append((rsi_3_1h_gt_10) | (rsi_3_4h_gt_15) | (stochrsi_k_4h < 30.0))
+          long_entry_logic.append((rsi_3_1h_gt_10) | (rsi_3_4h_gt_15) | (stochrsi_k_4h_lt_30))
           # 1h & 4h down move, 1d still high
           long_entry_logic.append((rsi_3_1h_gt_10) | (rsi_3_4h_gt_15) | (stochrsi_k_1d < 50.0))
           # 1h & 1d down move, 1h still moving lower
@@ -21353,7 +21358,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1h & 4h down move, 1h still not low enough
           long_entry_logic.append((rsi_3_1h_gt_15) | rsi_3_4h_gt_20 | (stochrsi_k_1h < 20.0))
           # 1h & 4h down move, 4h still not low enough
-          long_entry_logic.append((rsi_3_1h_gt_15) | rsi_3_4h_gt_20 | (stochrsi_k_4h < 30.0))
+          long_entry_logic.append((rsi_3_1h_gt_15) | rsi_3_4h_gt_20 | (stochrsi_k_4h_lt_30))
           # 1h & 4h & 1d down move
           long_entry_logic.append((rsi_3_1h_gt_15) | (rsi_3_4h_gt_25) | (rsi_3_1d_gt_25))
           # 1h & 4h down move, 1h high
@@ -21397,7 +21402,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1h down move, 4h high & overbought
           long_entry_logic.append((rsi_3_1h_gt_50) | (aroonu_14_4h_lt_90) | (roc_9_4h_lt_20))
           # 1h down move, 4h high & overbought
-          long_entry_logic.append((rsi_3_1h_gt_50) | (stochrsi_k_4h < 80.0) | (roc_9_4h_lt_20))
+          long_entry_logic.append((rsi_3_1h_gt_50) | (stochrsi_k_4h_lt_80) | (roc_9_4h_lt_20))
           # 4h down move, 15m not low enough, 1h still high
           long_entry_logic.append((rsi_3_4h_gt_3) | (stochrsi_k_15m < 20.0) | (stochrsi_k_1h < 40.0))
           # 4h & 1d down move, 4h downtrend
@@ -21405,7 +21410,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 4h & 1d down move, 1d high
           long_entry_logic.append((rsi_3_4h_gt_5) | (rsi_3_1d_gt_30) | (aroonu_14_1d_lt_70))
           # 4h down move, 4h still high, 1d downtrend
-          long_entry_logic.append((rsi_3_4h_gt_5) | (stochrsi_k_4h < 40.0) | (roc_9_1d_gt_neg_20))
+          long_entry_logic.append((rsi_3_4h_gt_5) | (stochrsi_k_4h_lt_40) | (roc_9_1d_gt_neg_20))
           # 4h down move, 1d still not low enough, 1d downtrend
           long_entry_logic.append((rsi_3_4h_gt_5) | (stochrsi_k_1d < 30.0) | (roc_9_1d_gt_neg_20))
           # 4h down move, 1h downtrend, 1h still not low enough
@@ -21413,7 +21418,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 4h down move, 1h & 1d downtrend
           long_entry_logic.append((rsi_3_4h_gt_10) | (roc_9_1h > -20.0) | (roc_9_1d > -20.0))
           # 4h & 1d down move, 4h still high
-          long_entry_logic.append((rsi_3_4h_gt_15) | (rsi_3_1d_gt_45) | (stochrsi_k_4h < 40.0))
+          long_entry_logic.append((rsi_3_4h_gt_15) | (rsi_3_1d_gt_45) | (stochrsi_k_4h_lt_40))
           # 4h & 1d down move, 1d high
           long_entry_logic.append(rsi_3_4h_gt_20 | (rsi_3_1d_gt_25) | (stochrsi_k_1d < 60.0))
           # 4h down move, 1d high & overbought
@@ -21533,7 +21538,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 5m & 1d down move, 15m stil high
             & ((rsi_3_gt_3) | (rsi_3_1d_gt_10) | (stochrsi_k_15m < 40.0))
             # 5m & 1d down move, 4h still high
-            & ((rsi_3_gt_3) | (rsi_3_1d_gt_10) | (stochrsi_k_4h < 40.0))
+            & ((rsi_3_gt_3) | (rsi_3_1d_gt_10) | (stochrsi_k_4h_lt_40))
             # 5m down move, 1h high
             & ((rsi_3_gt_3) | (stochrsi_k_1h < 90.0))
             # 5m down move, 15m & 1d high
@@ -21549,7 +21554,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 4h still high
             & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_15) | (aroonu_14_4h_lt_40))
             # 15m & 1h down move, 4h high
-            & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_15) | (stochrsi_k_4h < 90.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_15) | (stochrsi_k_4h_lt_90))
             # 15m & 1h down move, 1d still high
             & (rsi_3_15m_gt_3 | rsi_3_1h_gt_20 | (stochrsi_k_1d < 50.0))
             # 15m & 1h & 4h down move, 1d downtrend
@@ -21673,7 +21678,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 4h down move, 4h high
             & ((rsi_3_15m_gt_15) | (rsi_3_4h_gt_25) | (aroonu_14_4h_lt_60))
             # 15m & 4h down move, 4h still high
-            & ((rsi_3_15m_gt_15) | (rsi_3_4h_gt_25) | (stochrsi_k_4h < 40.0))
+            & ((rsi_3_15m_gt_15) | (rsi_3_4h_gt_25) | (stochrsi_k_4h_lt_40))
             # 15m & 4h down move, 1h high
             & ((rsi_3_15m_gt_15) | (rsi_3_4h_gt_35) | (aroonu_14_1h_lt_90))
             # 15m & 1d down move, 1h still high
@@ -21697,7 +21702,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 1h high, 1d downtrend
             & ((rsi_3_15m_gt_20) | (stochrsi_k_1h < 80.0) | (roc_9_1d_gt_neg_20))
             # 15m down move, 4h high, 1d downtrend
-            & ((rsi_3_15m_gt_20) | (stochrsi_k_4h < 80.0) | (roc_9_1d_gt_neg_30))
+            & ((rsi_3_15m_gt_20) | (stochrsi_k_4h_lt_80) | (roc_9_1d_gt_neg_30))
             # 15m & 1h & 4h down move, 4h high
             & ((rsi_3_15m_gt_25) | (rsi_3_1h_gt_30) | (rsi_3_4h_gt_50) | (aroonu_14_4h_lt_70))
             # 15m & 4h down move, 15m high
@@ -21717,7 +21722,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 15m & 4h high
             & ((rsi_3_15m_gt_35) | (aroonu_14_15m_lt_70) | (aroonu_14_4h_lt_90))
             # 1h & 4h down move, 4h still not low enough
-            & ((rsi_3_1h_gt_3) | (rsi_3_4h_gt_10) | (stochrsi_k_4h < 10.0))
+            & ((rsi_3_1h_gt_3) | (rsi_3_4h_gt_10) | (stochrsi_k_4h_lt_10))
             # 1h & 4h down move, 1d still high
             & ((rsi_3_1h_gt_3) | (rsi_3_4h_gt_10) | (stochrsi_k_1d < 40.0))
             # 1h & 4h down move, 1d overbought
@@ -21739,7 +21744,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 4h still high
             & ((rsi_3_1h_gt_10) | rsi_3_4h_gt_20 | (aroonu_14_4h_lt_40))
             # 1h & 4h down move, 4h high
-            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_25) | (stochrsi_k_4h < 60.0))
+            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_25) | (stochrsi_k_4h_lt_60))
             # 1h & 4h down move, 4h high
             & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_40) | aroonu_14_4h_lt_70)
             # 1h & 1d down move, 1h still not low enough
@@ -21749,7 +21754,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 15m downtrend, 1d high
             & ((rsi_3_1h_gt_10) | (cmf_20_15m > -0.40) | (aroonu_14_1d_lt_70))
             # 1h down move, 1h high, 4h high
-            & ((rsi_3_1h_gt_10) | (aroonu_14_1h_lt_70) | (stochrsi_k_4h < 80.0))
+            & ((rsi_3_1h_gt_10) | (aroonu_14_1h_lt_70) | (stochrsi_k_4h_lt_80))
             # 1h & 4h down move, 1h still high
             & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_15) | (aroonu_14_1h_lt_40))
             # 1h & 4h down move, 1h still high
@@ -21861,15 +21866,15 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h & 1d down move, 1d high
             & ((rsi_3_4h_gt_15) | (rsi_3_1d_gt_40) | (aroonu_14_1d_lt_70))
             # 4h & 1d down move, 4h still high
-            & ((rsi_3_4h_gt_15) | (rsi_3_1d > 50.0) | (stochrsi_k_4h < 40.0))
+            & ((rsi_3_4h_gt_15) | (rsi_3_1d > 50.0) | (stochrsi_k_4h_lt_40))
             # 4h down move, 1d still high, 4h still not low enough
-            & ((rsi_3_4h_gt_15) | (rsi_14_1d < 40.0) | (stochrsi_k_4h < 30.0))
+            & ((rsi_3_4h_gt_15) | (rsi_14_1d < 40.0) | (stochrsi_k_4h_lt_30))
             # 4h down move, 4h still high, 4h downtrend
             & ((rsi_3_4h_gt_15) | (aroonu_14_4h_lt_50) | (roc_9_4h > -10.0))
             # 4h down move, 1d still high, 1d downtrend
             & ((rsi_3_4h_gt_15) | (aroonu_14_1d_lt_50) | (roc_9_1d > -20.0))
             # 4h down move, 4h still not low enough, 1d downtrend
-            & ((rsi_3_4h_gt_15) | (stochrsi_k_4h < 20.0) | (roc_9_1d > -20.0))
+            & ((rsi_3_4h_gt_15) | (stochrsi_k_4h_lt_20) | (roc_9_1d > -20.0))
             # 4h down move, 1h downtrend, 1d overbought
             & ((rsi_3_4h_gt_15) | (roc_9_1h > -10.0) | (roc_9_1d < 200.0))
             # 4h down move, 4h high, 4h downtrend
@@ -21879,7 +21884,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 4h & 1d downtrend
             & ((rsi_3_4h_gt_25) | (roc_9_4h > -10.0) | (roc_9_1d > -10.0))
             # 1h down move, 4h still not low enough, 1d downtrend
-            & (rsi_3_4h_gt_20 | (stochrsi_k_4h < 30.0) | (roc_9_1d_gt_neg_20))
+            & (rsi_3_4h_gt_20 | (stochrsi_k_4h_lt_30) | (roc_9_1d_gt_neg_20))
             # 4h & 1d down move, 1h high
             & ((rsi_3_4h_gt_25) | (rsi_3_1d_gt_25) | (stochrsi_k_1h_lt_80))
             # 4h down move, 1h high
@@ -21897,7 +21902,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 4h & 1d downtrend
             & ((rsi_3_4h_gt_30) | (roc_9_4h_gt_neg_20) | (roc_9_1d_gt_neg_40))
             # 4h down move, 4h still high, 1d downtrend
-            & ((rsi_3_4h_gt_35) | (stochrsi_k_4h < 40.0) | (roc_9_1d_gt_neg_30))
+            & ((rsi_3_4h_gt_35) | (stochrsi_k_4h_lt_40) | (roc_9_1d_gt_neg_30))
             # 4h down move, 1d high & overbought
             & ((rsi_3_4h_gt_35) | (stochrsi_k_1d < 80.0) | (roc_9_1d_lt_20))
             # 4h down move, 15m still high, 1h high
@@ -21982,7 +21987,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 4h still high
             & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_15) | (aroonu_14_4h_lt_40))
             # 15m & 1h down move, 4h high
-            & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_15) | (stochrsi_k_4h < 90.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_15) | (stochrsi_k_4h_lt_90))
             # 15m & 1h down move, 15m high
             & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_30) | (aroonu_14_15m_lt_70))
             # 15m & 1h down move, 1h high
@@ -22012,7 +22017,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 4h high
             & ((rsi_3_15m_gt_5) | (rsi_3_1h_gt_15) | (aroonu_14_4h_lt_85))
             # 15m & 1h down move, 4h high
-            & ((rsi_3_15m_gt_5) | (rsi_3_1h_gt_15) | (stochrsi_k_4h < 60.0))
+            & ((rsi_3_15m_gt_5) | (rsi_3_1h_gt_15) | (stochrsi_k_4h_lt_60))
             # 15m & 1h & 4h down move, 15m still not low enough, 1h still high
             & ((rsi_3_15m_gt_5) | (rsi_3_1h_gt_30) | (rsi_3_4h_gt_30) | (aroonu_14_15m_lt_30) | (stochrsi_k_1h < 40.0))
             # 15m & 4h down move, 1d high
@@ -22026,7 +22031,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 1h still high
             & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_10) | (stochrsi_k_1h < 40.0))
             # 15m & 1h down move, 4h high
-            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_10) | (stochrsi_k_4h < 60.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_10) | (stochrsi_k_4h_lt_60))
             # 15m & 1h down move, 1h still high
             & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_15) | (stochrsi_k_1h < 50.0))
             # 15m & 1h down move, 15m high
@@ -22172,7 +22177,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 15m still not low enough
             & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_15) | (stochrsi_k_15m < 30.0))
             # 1h & 4h down move, 4h still high
-            & ((rsi_3_1h_gt_15) | rsi_3_4h_gt_20 | (stochrsi_k_4h < 40.0))
+            & ((rsi_3_1h_gt_15) | rsi_3_4h_gt_20 | (stochrsi_k_4h_lt_40))
             # 1h & 1d down move, 1d still high
             & ((rsi_3_1h_gt_15) | (rsi_3_1d_gt_20) | (stochrsi_k_1d < 40.0))
             # 1h & 1d down move, 1d high
@@ -22264,15 +22269,15 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h & 1d down move, 15m high
             & ((rsi_3_4h_gt_15) | (rsi_3_1d_gt_30) | (stochrsi_k_15m < 80.0))
             # 4h & 1d down move, 4h still high
-            & ((rsi_3_4h_gt_15) | (rsi_3_1d > 50.0) | (stochrsi_k_4h < 40.0))
+            & ((rsi_3_4h_gt_15) | (rsi_3_1d > 50.0) | (stochrsi_k_4h_lt_40))
             # 4h down move, 1d still high, 4h still not low enough
-            & ((rsi_3_4h_gt_15) | (rsi_14_1d < 40.0) | (stochrsi_k_4h < 30.0))
+            & ((rsi_3_4h_gt_15) | (rsi_14_1d < 40.0) | (stochrsi_k_4h_lt_30))
             # 4h down move, 15m still not low enough, 1d high
             & ((rsi_3_4h_gt_15) | (aroonu_14_15m_lt_30) | (aroonu_14_1d_lt_70))
             # 4h down move, 4h still high, 4h downtrend
             & ((rsi_3_4h_gt_15) | (aroonu_14_4h_lt_50) | (roc_9_4h > -10.0))
             # 4h down move, 4h still not low enough, 1d downtrend
-            & ((rsi_3_4h_gt_15) | (stochrsi_k_4h < 20.0) | (roc_9_1d > -20.0))
+            & ((rsi_3_4h_gt_15) | (stochrsi_k_4h_lt_20) | (roc_9_1d > -20.0))
             # 4h down move, 4h & 1d high
             & ((rsi_3_4h_gt_20) | (aroonu_14_4h_lt_70) | (aroonu_14_1d_lt_70))
             # 4h down move, 4h high
@@ -22290,7 +22295,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h & 1d down move, 1d overbought
             & ((rsi_3_4h_gt_25) | (rsi_3_1d_gt_45) | (roc_9_1d < 10.0))
             # 4h down move, 15m still not low enough, 4h still high
-            & ((rsi_3_4h_gt_25) | (aroonu_14_15m_lt_30) | (stochrsi_k_4h < 40.0))
+            & ((rsi_3_4h_gt_25) | (aroonu_14_15m_lt_30) | (stochrsi_k_4h_lt_40))
             # 4h down move, 1d high, 4h overbought
             & ((rsi_3_4h_gt_25) | (aroonu_14_1d_lt_80) | (roc_9_4h < 5.0))
             # 4h & 1d down move, 4h still high
@@ -22308,7 +22313,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 15m still high, 1h high
             & ((rsi_3_4h_gt_35) | (aroonu_14_15m_lt_50) | (aroonu_14_1h_lt_100))
             # 4h down move, 4h still high, 1d downtrend
-            & ((rsi_3_4h_gt_35) | (stochrsi_k_4h < 40.0) | (roc_9_1d_gt_neg_30))
+            & ((rsi_3_4h_gt_35) | (stochrsi_k_4h_lt_40) | (roc_9_1d_gt_neg_30))
             # 4h down move, 1d high & overbought
             & ((rsi_3_4h_gt_35) | (stochrsi_k_1d < 80.0) | (roc_9_1d_lt_20))
             # 4h down move, 1h high
@@ -22316,7 +22321,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 1d high & overbought
             & ((rsi_3_4h_gt_45) | (aroonu_14_1d_lt_70) | (roc_9_1d_lt_20))
             # 4h down move, 4h high, 1d downtrend
-            & ((rsi_3_4h_gt_45) | (stochrsi_k_4h < 40.0) | (roc_9_1d > -25.0))
+            & ((rsi_3_4h_gt_45) | (stochrsi_k_4h_lt_40) | (roc_9_1d > -25.0))
             # 4h down move, 1d high & overbought
             & ((rsi_3_4h_gt_50) | (aroonu_14_1d_lt_85) | (roc_9_1d < 200.0))
             # 4h down move, 4h high & overbought
@@ -22372,7 +22377,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h high, 1h & 1d overbought
             & ((stochrsi_k_1h < 80.0) | (roc_9_1h < 20.0) | (roc_9_1d_lt_100))
             # 4h high, 4h overbought, 1d downtrend
-            & ((stochrsi_k_4h < 90.0) | (roc_9_4h_lt_20) | (roc_9_1d_gt_neg_20))
+            & ((stochrsi_k_4h_lt_90) | (roc_9_4h_lt_20) | (roc_9_1d_gt_neg_20))
             # 1d high, 1h & 4h overbought
             & ((stochrsi_k_1d < 80.0) | (roc_9_1h < 20.0) | (roc_9_4h_lt_20))
           )
@@ -22411,7 +22416,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 1h still high
             & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_15) | (stochrsi_k_1h < 50.0))
             # 15m & 1h down move, 4h high
-            & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_15) | (stochrsi_k_4h < 90.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_15) | (stochrsi_k_4h_lt_90))
             # 15m & 1h down move, 15m high
             & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_30) | (aroonu_14_15m_lt_70))
             # 15m & 1h down move, 1d downtrend
@@ -22475,7 +22480,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1d down move, 1h high
             & ((rsi_3_15m_gt_10) | (rsi_3_1d_gt_10) | (stochrsi_k_1h_lt_70))
             # 15m & 1d down move, 4h still high
-            & ((rsi_3_15m_gt_10) | (rsi_3_1d_gt_10) | (stochrsi_k_4h < 40.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_1d_gt_10) | (stochrsi_k_4h_lt_40))
             # 15m & 4h down move, 15m high
             & ((rsi_3_15m_gt_10) | (rsi_3_4h_gt_40) | (aroonu_14_15m_lt_70))
             # 15m down move, 15m high, 1d high
@@ -22551,7 +22556,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h & 1d down move, 1h still high
             & ((rsi_3_4h_gt_5) | (rsi_3_1d_gt_10) | (stochrsi_k_1h_lt_50))
             # 4h down move, 4h still high, 1d downtrend
-            & ((rsi_3_4h_gt_5) | (stochrsi_k_4h < 40.0) | (roc_9_1d_gt_neg_20))
+            & ((rsi_3_4h_gt_5) | (stochrsi_k_4h_lt_40) | (roc_9_1d_gt_neg_20))
             # 4h & 1d down move, 1d high
             & ((rsi_3_4h_gt_10) | (rsi_3_1d_gt_15) | (aroonu_14_1d_lt_70))
             # 4h & 1d down move, 15m still high
@@ -22565,9 +22570,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h & 1d down move, 1d high
             & ((rsi_3_4h_gt_15) | (rsi_3_1d_gt_20) | (aroonu_14_1d_lt_60))
             # 4h & 1d down move, 4h high
-            & ((rsi_3_4h_gt_15) | (rsi_3_1d_gt_30) | (stochrsi_k_4h < 60.0))
+            & ((rsi_3_4h_gt_15) | (rsi_3_1d_gt_30) | (stochrsi_k_4h_lt_60))
             # 4h down move, 1d still high, 4h still not low enough
-            & ((rsi_3_4h_gt_15) | (rsi_14_1d < 40.0) | (stochrsi_k_4h < 30.0))
+            & ((rsi_3_4h_gt_15) | (rsi_14_1d < 40.0) | (stochrsi_k_4h_lt_30))
             # 1h down move, 1h still high, 1d downtrend
             & ((rsi_3_1h_gt_15) | (aroonu_14_1h_lt_50) | (roc_9_1d > -30.0))
             # 4h down move, 4h & 1d high
@@ -22585,7 +22590,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 1d high & overbought
             & (rsi_3_4h_gt_20 | (aroonu_14_1d_lt_80) | (roc_9_1d < 70.0))
             # 4h down move, 4h high, 1d downtrend
-            & (rsi_3_4h_gt_20 | (stochrsi_k_4h < 60.0) | (roc_9_1d_gt_neg_20))
+            & (rsi_3_4h_gt_20 | (stochrsi_k_4h_lt_60) | (roc_9_1d_gt_neg_20))
             # 4h & 1d down move, 1d overbought
             & ((rsi_3_4h_gt_25) | (rsi_3_1d_gt_40) | (roc_9_1d_lt_30))
             # 4h down move, 1h high, 1d downtrend
@@ -22595,7 +22600,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 1h high
             & ((rsi_3_4h_gt_40) | aroonu_14_1h_lt_80)
             # 4h down move, 4h high, 1d downtrend
-            & ((rsi_3_4h_gt_45) | (stochrsi_k_4h < 80.0) | (roc_9_1d_gt_neg_20))
+            & ((rsi_3_4h_gt_45) | (stochrsi_k_4h_lt_80) | (roc_9_1d_gt_neg_20))
             # 1h high, 4h & 1d overbought
             & (aroonu_14_1h_lt_70 | (roc_9_4h_lt_40) | (roc_9_1d_lt_80))
             # 1h & 4h high, 1d overbought
@@ -22603,7 +22608,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1d high, 4h & 1d downtrend
             & ((aroonu_14_1d_lt_60) | (roc_9_4h_gt_neg_20) | (roc_9_1d_gt_neg_30))
             # 4h high, 4h & 1d overbought
-            & ((stochrsi_k_4h < 90.0) | (roc_9_4h_lt_20) | (roc_9_1d_lt_20))
+            & ((stochrsi_k_4h_lt_90) | (roc_9_4h_lt_20) | (roc_9_1d_lt_20))
           )
 
           # Logic
@@ -22652,7 +22657,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 4h down move, 4h downtrend
             & ((rsi_3_15m_gt_5) | (rsi_3_4h_gt_5) | (roc_9_4h_gt_neg_20))
             # 15m & 4h down move, 4h still high
-            & ((rsi_3_15m_gt_5) | (rsi_3_4h_gt_30) | (stochrsi_k_4h < 40.0))
+            & ((rsi_3_15m_gt_5) | (rsi_3_4h_gt_30) | (stochrsi_k_4h_lt_40))
             # 15m down move, 1d high & overbought
             & ((rsi_3_15m_gt_5) | (aroonu_14_1d_lt_100) | (roc_9_1d_lt_40))
             # 15m & 4h down move, 4h still not low enough
@@ -22678,7 +22683,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 4h & 1d high, 4h overbought
             & ((rsi_3_15m_gt_25) | (aroonu_14_4h_lt_80) | (aroonu_14_1d_lt_100) | (roc_9_4h < 30.0))
             # 15m down move, 4h high, 1d downtrend
-            & ((rsi_3_15m_gt_25) | (stochrsi_k_4h < 80.0) | (roc_9_1d_gt_neg_30))
+            & ((rsi_3_15m_gt_25) | (stochrsi_k_4h_lt_80) | (roc_9_1d_gt_neg_30))
             # 15m & 1h down move, 15m high
             & ((rsi_3_15m_gt_45) | (rsi_3_1h_gt_45) | (stochrsi_k_15m < 70.0))
             # 15m down move, 4h high, 1d overbought
@@ -22692,9 +22697,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 15m still high, 4h high
             & ((rsi_3_15m_gt_25) | (aroonu_14_15m_lt_50) | aroonu_14_4h_lt_80)
             # 15m down move, 4h high & overbought
-            & ((rsi_3_15m_gt_25) | (stochrsi_k_4h < 80.0) | (roc_9_4h_lt_20))
+            & ((rsi_3_15m_gt_25) | (stochrsi_k_4h_lt_80) | (roc_9_4h_lt_20))
             # 15m down move, 4h high, 1d downtrend
-            & ((rsi_3_15m_gt_25) | (stochrsi_k_4h < 90.0) | (roc_9_1d_gt_neg_30))
+            & ((rsi_3_15m_gt_25) | (stochrsi_k_4h_lt_90) | (roc_9_1d_gt_neg_30))
             # 15m down move, 1h & 4h overbought
             & ((rsi_3_15m_gt_25) | (roc_9_1h_lt_10) | (roc_9_4h_lt_30))
             # 15m down move, 1h & 4h high
@@ -22706,7 +22711,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 1d still high
             & ((rsi_3_1h_gt_3) | (rsi_3_4h_gt_10) | (stochrsi_k_1d < 40.0))
             # 1h & 4h down move, 4h still high
-            & ((rsi_3_1h_gt_3) | rsi_3_4h_gt_20 | (stochrsi_k_4h < 40.0))
+            & ((rsi_3_1h_gt_3) | rsi_3_4h_gt_20 | (stochrsi_k_4h_lt_40))
             # 1h & 4h down move, 15m still high
             & ((rsi_3_1h_gt_3) | (rsi_3_4h_gt_30) | (stochrsi_k_15m < 50.0))
             # 1h & 4h down move, 15m still not low enough
@@ -22714,7 +22719,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 1d still high
             & ((rsi_3_1h_gt_5) | rsi_3_4h_gt_20 | (aroonu_14_1d_lt_50))
             # 1h & 4h down move, 4h still not low enough
-            & ((rsi_3_1h_gt_5) | (rsi_3_4h_gt_40) | (stochrsi_k_4h < 30.0))
+            & ((rsi_3_1h_gt_5) | (rsi_3_4h_gt_40) | (stochrsi_k_4h_lt_30))
             # 1h & 1d down move, 1h still high
             & ((rsi_3_1h_gt_5) | (rsi_3_1d_gt_5) | (aroonu_14_1h_lt_40))
             # 1h down move, 1d high & overbought
@@ -22722,7 +22727,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h & 1d down move, 4h downtrend, 1d still high
             & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_15) | (rsi_3_1d_gt_25) | (rsi_14_4h > 30.0) | (aroonu_14_1d_lt_40))
             # 1h & 4h down move, 4h still not low enough
-            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_15) | (stochrsi_k_4h < 30.0))
+            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_15) | (stochrsi_k_4h_lt_30))
             # 1h & 4h down move, 15m still high
             & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_15) | (stochrsi_k_15m < 50.0))
             # 1h & 4h down move, 1d downtrend
@@ -22752,9 +22757,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1d high & overbought
             & ((rsi_3_1h_gt_15) | (aroonu_14_1d_lt_80) | (roc_9_1d < 10.0))
             # 1h down move, 4h high & overbought
-            & ((rsi_3_1h_gt_15) | (stochrsi_k_4h < 80.0) | (roc_9_4h < 20.0))
+            & ((rsi_3_1h_gt_15) | (stochrsi_k_4h_lt_80) | (roc_9_4h < 20.0))
             # 1h down move, 4h high, 1d downtrend
-            & ((rsi_3_1h_gt_15) | (stochrsi_k_4h < 80.0) | (roc_9_1d > -30.0))
+            & ((rsi_3_1h_gt_15) | (stochrsi_k_4h_lt_80) | (roc_9_1d > -30.0))
             # 1h & 4h down move, 4h still high
             & (rsi_3_1h_gt_20 | (rsi_3_4h_gt_20) | (aroonu_14_4h_lt_40))
             # 1h & 4h down move, 1d high
@@ -22774,13 +22779,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1d high & overbought
             & (rsi_3_1h_gt_20 | (aroonu_14_1d_lt_100) | (roc_9_1d_lt_20))
             # 1h down move, 4h still high, 1d downtrend
-            & (rsi_3_1h_gt_20 | (stochrsi_k_4h < 40.0) | (roc_9_1d_gt_neg_40))
+            & (rsi_3_1h_gt_20 | (stochrsi_k_4h_lt_40) | (roc_9_1d_gt_neg_40))
             # 1h down move, 4h high & overbought, 1d downtrend
             & ((rsi_3_1h_gt_20) | (stochrsi_k_4h_lt_80) | (roc_9_4h_lt_10) | (roc_9_1d_gt_neg_20))
             # 1h & 4h down move, 15m high
             & ((rsi_3_1h_gt_25) | (rsi_3_4h_gt_25) | (stochrsi_k_15m < 70.0))
             # 1h & 4h down move, 4h still not low enough
-            & ((rsi_3_1h_gt_25) | (rsi_3_4h_gt_25) | (stochrsi_k_4h < 30.0))
+            & ((rsi_3_1h_gt_25) | (rsi_3_4h_gt_25) | (stochrsi_k_4h_lt_30))
             # 1h & 4h down move, 1d overbought
             & ((rsi_3_1h_gt_25) | (rsi_3_4h_gt_25) | (roc_9_1d_lt_100))
             # 1h & 4h down move, 4h high
@@ -22794,7 +22799,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h & 4h high
             & ((rsi_3_1h_gt_30) | aroonu_14_1h_lt_70 | aroonu_14_4h_lt_100)
             # 1h down move, 1h high, 4h high
-            & ((rsi_3_1h_gt_30) | aroonu_14_1h_lt_80 | (stochrsi_k_4h < 80.0))
+            & ((rsi_3_1h_gt_30) | aroonu_14_1h_lt_80 | (stochrsi_k_4h_lt_80))
             # 1h down move, 4h high, 1h overbought
             & ((rsi_3_1h_gt_40) | aroonu_14_4h_lt_80 | (roc_9_1h_lt_10))
             # 1h down move, 1h high, 15m high
@@ -22828,7 +22833,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h & 1d down move, 4h still high
             & ((rsi_3_4h_gt_15) | (rsi_3_1d_gt_30) | (stochrsi_k_4h_lt_50))
             # 4h & 1d down move, 4h still high
-            & ((rsi_3_4h_gt_15) | (rsi_3_1d_gt_45) | (stochrsi_k_4h < 40.0))
+            & ((rsi_3_4h_gt_15) | (rsi_3_1d_gt_45) | (stochrsi_k_4h_lt_40))
             # 4h down move, 4h still not low enough, 1d high
             & ((rsi_3_4h_gt_15) | (aroonu_14_4h_lt_30) | (aroonu_14_1d_lt_70))
             # 4h down move, 1d high & overbought
@@ -22850,15 +22855,15 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 1d stil high, 1d downtrend
             & ((rsi_3_4h_gt_30) | (aroonu_14_1d_lt_40) | (roc_9_1d_gt_neg_30))
             # 4h down move, 4h still high, 4h downtrend
-            & ((rsi_3_4h_gt_30) | (stochrsi_k_4h < 40.0) | (roc_9_4h > -15.0))
+            & ((rsi_3_4h_gt_30) | (stochrsi_k_4h_lt_40) | (roc_9_4h > -15.0))
             # 4h & 1d down move, 4h still high, 1d high
             & ((rsi_3_4h_gt_35) | (rsi_3_1d_gt_35) | (stochrsi_k_4h_lt_50) | (aroonu_14_1d_lt_60))
             # 4h down move, 4h still high, 1d downtrend
-            & ((rsi_3_4h_gt_35) | (stochrsi_k_4h < 40.0) | (roc_9_1d_gt_neg_20))
+            & ((rsi_3_4h_gt_35) | (stochrsi_k_4h_lt_40) | (roc_9_1d_gt_neg_20))
             # 4h down move, 1d high & overbought
             & ((rsi_3_4h_gt_55) | (stochrsi_k_1d_lt_90) | (roc_9_1d_lt_100))
             # 1d down move, 4h still not low enough, 4h downtrend
-            & ((rsi_3_1d_gt_10) | (stochrsi_k_4h < 30.0) | (roc_9_4h > -15.0))
+            & ((rsi_3_1d_gt_10) | (stochrsi_k_4h_lt_30) | (roc_9_4h > -15.0))
             # 1d down move, 4h & 1d downtrend
             & ((rsi_3_1d_gt_10) | (roc_9_4h_gt_neg_20) | (roc_9_1d_gt_neg_20))
             # 1d down move, 1d high, 4h downtrend
@@ -22932,7 +22937,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 15m downtrend, 1h high
             & ((rsi_3_15m_gt_15) | (cmf_20_15m > -0.40) | (aroonu_14_1h_lt_60))
             # 15m down move, 15m still high, 4h high
-            & ((rsi_3_15m_gt_15) | (aroonu_14_15m_lt_40) | (stochrsi_k_4h < 60.0))
+            & ((rsi_3_15m_gt_15) | (aroonu_14_15m_lt_40) | (stochrsi_k_4h_lt_60))
             # 15m down move, 1h high, 1d downtrend
             & ((rsi_3_15m_gt_15) | (aroonu_14_1h_lt_90) | (roc_9_1d_gt_neg_30))
             # 15m & 1h down move, 1d downtrend
@@ -23044,7 +23049,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 4h high & overbought
             & ((rsi_3_1h_gt_35) | (aroonu_14_4h_lt_90) | (roc_9_4h < 60.0))
             # 1h down move, 4h high, 1d downtrend
-            & ((rsi_3_1h_gt_35) | (stochrsi_k_4h < 90.0) | (roc_9_1d_gt_neg_20))
+            & ((rsi_3_1h_gt_35) | (stochrsi_k_4h_lt_90) | (roc_9_1d_gt_neg_20))
             # 1h down move, 1h high, 1d downtrend
             & ((rsi_3_1h_gt_40) | aroonu_14_1h_lt_70 | (roc_9_1d > -30.0))
             # 1h down move, 1h high, 1d downtrend
@@ -23074,7 +23079,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h & 1d down move, 4h high
             & ((rsi_3_4h_gt_15) | (rsi_3_1d_gt_35) | (stochrsi_k_4h_lt_70))
             # 4h down move, 4h high
-            & ((rsi_3_4h_gt_15) | (stochrsi_k_4h < 60.0))
+            & ((rsi_3_4h_gt_15) | (stochrsi_k_4h_lt_60))
             # 4h down move, 4h & 1d high
             & (rsi_3_4h_gt_20 | aroonu_14_4h_lt_70 | (aroonu_14_1d_lt_70))
             # 4h down move, 15m high
@@ -23088,7 +23093,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 15m high, 1d overbought
             & ((rsi_3_4h_gt_30) | (stochrsi_k_15m < 90.0) | (roc_9_1d < 10.0))
             # 4h down move, 4h still high, 1d downtrend
-            & ((rsi_3_4h_gt_35) | (stochrsi_k_4h < 40.0) | (roc_9_1d_gt_neg_30))
+            & ((rsi_3_4h_gt_35) | (stochrsi_k_4h_lt_40) | (roc_9_1d_gt_neg_30))
             # 4h down move, 4h high, 1d overbought
             & ((rsi_3_4h_gt_40) | (aroonu_14_4h_lt_60) | (roc_9_1d_lt_40))
             # 4h & 1d down move, 1h high
@@ -23285,13 +23290,13 @@ class NostalgiaForInfinityX7(IStrategy):
           # 4h down move, 1h high, 4h still high
           long_entry_logic.append((rsi_3_4h_gt_45) | aroonu_14_1h_lt_70 | (aroonu_14_4h_lt_50))
           # 4h down move, 15m high, 4h still high
-          long_entry_logic.append((rsi_3_4h_gt_50) | (aroonu_14_15m_lt_70) | (stochrsi_k_4h < 40.0))
+          long_entry_logic.append((rsi_3_4h_gt_50) | (aroonu_14_15m_lt_70) | (stochrsi_k_4h_lt_40))
           # 4h down move, 15m still high, 1h high
           long_entry_logic.append((rsi_3_4h_gt_50) | (stochrsi_k_15m < 40.0) | (stochrsi_k_1h_lt_70))
           # 4h down move, 15m & 4h still high
           long_entry_logic.append((rsi_3_4h_gt_50) | (stochrsi_k_15m < 50.0) | (aroonu_14_4h_lt_50))
           # 4h down move, 15m high, 4h still not low enough
-          long_entry_logic.append((rsi_3_4h_gt_50) | (stochrsi_k_15m < 70.0) | (stochrsi_k_4h < 30.0))
+          long_entry_logic.append((rsi_3_4h_gt_50) | (stochrsi_k_15m < 70.0) | (stochrsi_k_4h_lt_30))
           # 4h down move, 1h still high, 4h high
           long_entry_logic.append((rsi_3_4h_gt_50) | (stochrsi_k_1h_lt_50) | aroonu_14_4h_lt_70)
           # 4h down move, 15m & 1d high
@@ -23307,7 +23312,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 4h down move, 15m still high, 4h high
           long_entry_logic.append((rsi_3_4h_gt_60) | (stochrsi_k_15m < 50.0) | (stochrsi_k_4h_lt_70))
           # 4h down move, 15m & 4h high
-          long_entry_logic.append((rsi_3_4h_gt_60) | (stochrsi_k_15m < 70.0) | (stochrsi_k_4h < 60.0))
+          long_entry_logic.append((rsi_3_4h_gt_60) | (stochrsi_k_15m < 70.0) | (stochrsi_k_4h_lt_60))
           # 4h down move, 1h & 4h high
           long_entry_logic.append((rsi_3_4h_gt_60) | (stochrsi_k_1h_lt_70) | aroonu_14_4h_lt_70)
           # 4h down move, 4h still high, 1d high
@@ -23483,7 +23488,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 1h & 4h downtrend
             & ((rsi_3_4h_gt_10) | (roc_9_1h > -40.0) | (roc_9_4h > -40.0))
             # 4h & 1d down move, 4h still not low enough
-            & (rsi_3_4h_gt_20 | (rsi_3_1d_gt_20) | (stochrsi_k_4h < 30.0))
+            & (rsi_3_4h_gt_20 | (rsi_3_1d_gt_20) | (stochrsi_k_4h_lt_30))
             # 4h down move, 4h still high, 1d downtrend
             & ((rsi_3_4h_gt_30) | (aroonu_14_4h_lt_50) | (roc_9_1d_gt_neg_40))
             # 4h down move, 15m still high, 1d overbought
@@ -23719,7 +23724,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1d down move, 1d high
             & ((rsi_3_15m_gt_25) | (rsi_3_1d_gt_40) | (aroonu_14_1d_lt_80))
             # 15m down move, 4h high, 1d downtrend
-            & ((rsi_3_15m_gt_25) | (stochrsi_k_4h < 90.0) | (roc_9_1d_gt_neg_30))
+            & ((rsi_3_15m_gt_25) | (stochrsi_k_4h_lt_90) | (roc_9_1d_gt_neg_30))
             # 15m & 1h down move, 15m still not low enough, 1h & 4h high
             & (
               (rsi_3_15m_gt_30)
@@ -23880,7 +23885,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 4h & 1d high
             & ((rsi_3_4h > 70.0) | (aroonu_14_4h_lt_90) | aroonu_14_1d_lt_100)
             # 1d down move, 4h high
-            & ((rsi_3_1d_gt_3) | (stochrsi_k_4h < 60.0))
+            & ((rsi_3_1d_gt_3) | (stochrsi_k_4h_lt_60))
             # 1d down move, 1h high
             & ((rsi_3_1d_gt_5) | (stochrsi_k_1h_lt_80))
             # 1d down move, 15m & 1h still high
@@ -24548,7 +24553,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1h & 4h down move, 4h still high
           short_entry_logic.append((rsi_3_1h_lt_90) | (rsi_3_change_pct_4h < 65.0) | (stochrsi_k_4h_gt_50))
           # 1h & 4h down move, 4h still high
-          short_entry_logic.append((rsi_3_1h_lt_90) | (rsi_3_4h_lt_85) | (stochrsi_k_4h < 10.0))
+          short_entry_logic.append((rsi_3_1h_lt_90) | (rsi_3_4h_lt_85) | (stochrsi_k_4h_lt_10))
           # 1h down move, 4h still not low enough, 1d overbought
           short_entry_logic.append((rsi_3_1h_lt_90) | (aroond_14_4h < 25.0) | (roc_9_1d > -120.0))
           # 1h down move, 1h still not low enough, 4h still not low


### PR DESCRIPTION
## Summary
- Adds ordered `stochrsi_k_4h` entry comparison masks for repeated `<` thresholds in `populate_entry_trend()`.
- Reuses those masks in the existing entry condition ladder.
- Independent on latest upstream `main`.

## Safety
- This is a behavior-preserving Series mask reuse patch.
- The same `stochrsi_k_4h` Series, comparison operators, and threshold values are used.
- Indicator formulas, candle selection, thresholds, condition order, profit arithmetic, order/stake logic, return values, and signal behavior are unchanged.
- Touched function: `populate_entry_trend()` only.
- No v3 grind-entry code is touched.

## Backtest scope
- Full backtesting was not required because this patch only aliases repeated `stochrsi_k_4h < value` Series comparisons already used by the same `populate_entry_trend()` condition ladder.
- The trading conditions remain textually equivalent at the comparison level; only repeated Series comparisons are replaced with same-scope local masks.

## Checks
- `python3 ~/.codex/skills/nfi-upstream-pr/scripts/validate_nfi_pr.py --base origin/main`
- `git merge-tree $(git merge-base origin/main HEAD) origin/main HEAD` conflict simulation: `NO_CONFLICT`
- targeted `git diff origin/main...HEAD -- NostalgiaForInfinityX7.py` review
- confirmed no raw `stochrsi_k_4h < ...` comparisons remain in the condition ladder after the mask block
- `git diff --check`
- `ruff format --check NostalgiaForInfinityX7.py`
- `ruff check NostalgiaForInfinityX7.py`
- `PYTHONDONTWRITEBYTECODE=1 python3 -m py_compile NostalgiaForInfinityX7.py`
