### PR TITLE
Reuse X7 entry STOCHRSI 15m masks

### DIFF
--- a/NostalgiaForInfinityX7.py
+++ b/NostalgiaForInfinityX7.py
@@ -13086,6 +13086,13 @@ class NostalgiaForInfinityX7(IStrategy):
     aroonu_14_1d_lt_90 = aroonu_14_1d < 90.0
     aroonu_14_1d_lt_100 = aroonu_14_1d < 100.0
 
+    stochrsi_k_15m_lt_20 = stochrsi_k_15m < 20.0
+    stochrsi_k_15m_lt_30 = stochrsi_k_15m < 30.0
+    stochrsi_k_15m_lt_40 = stochrsi_k_15m < 40.0
+    stochrsi_k_15m_lt_50 = stochrsi_k_15m < 50.0
+    stochrsi_k_15m_lt_60 = stochrsi_k_15m < 60.0
+    stochrsi_k_15m_lt_70 = stochrsi_k_15m < 70.0
+    stochrsi_k_15m_lt_80 = stochrsi_k_15m < 80.0
     stochrsi_k_1h_lt_50 = stochrsi_k_1h < 50.0
     stochrsi_k_1h_lt_70 = stochrsi_k_1h < 70.0
     stochrsi_k_1h_lt_80 = stochrsi_k_1h < 80.0
@@ -13263,7 +13270,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 4h down move, 1d high
             & ((rsi_3_15m_gt_5) | (rsi_3_4h_gt_15) | (stochrsi_k_1d < 60.0))
             # 15m & 4h down move, 15m still high
-            & ((rsi_3_15m_gt_5) | (rsi_3_4h_gt_30) | (stochrsi_k_15m < 50.0))
+            & ((rsi_3_15m_gt_5) | (rsi_3_4h_gt_30) | (stochrsi_k_15m_lt_50))
             # 15m down move, 15m & 4h still high
             & ((rsi_3_15m_gt_5) | (aroonu_14_15m_lt_50) | (aroonu_14_4h_lt_60))
             # 15m down move, 15m still high, 1d overbought
@@ -13289,7 +13296,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 4h down move, 1h high
             & ((rsi_3_15m_gt_10) | (rsi_3_4h_gt_10) | (aroonu_14_1h_lt_75))
             # 15m & 4h down move, 15m still high
-            & ((rsi_3_15m_gt_10) | (rsi_3_4h_gt_10) | (stochrsi_k_15m < 50.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_4h_gt_10) | (stochrsi_k_15m_lt_50))
             # 15m & 4h down move, 1h still high
             & ((rsi_3_15m_gt_10) | (rsi_3_4h_gt_10) | (stochrsi_k_1h < 40.0))
             # 15m & 4h down move, 4h downtrend
@@ -13341,7 +13348,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 1d overbought
             & ((rsi_3_15m_gt_30) | (roc_9_1d_lt_80))
             # 15m & 4h down move, 15m high
-            & ((rsi_3_15m_gt_40) | (rsi_3_4h_gt_45) | (stochrsi_k_15m < 70.0))
+            & ((rsi_3_15m_gt_40) | (rsi_3_4h_gt_45) | (stochrsi_k_15m_lt_70))
             # 1h & 4h down move, 4h downtrend
             & ((rsi_3_1h_gt_3) | (rsi_3_4h_gt_10) | (roc_9_4h > -10.0))
             # 1h & 4h down move, 1h still high
@@ -13582,13 +13589,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 5m & 1h down move, 1d high
             & ((rsi_3_gt_3) | (rsi_3_1h_gt_35) | aroonu_14_1d_lt_100)
             # 5m & 4h down move, 15m still not low enough
-            & ((rsi_3_gt_3) | (rsi_3_4h_gt_3) | (stochrsi_k_15m < 30.0))
+            & ((rsi_3_gt_3) | (rsi_3_4h_gt_3) | (stochrsi_k_15m_lt_30))
             # 5m & 4h down move, 1d downtrend
             & ((rsi_3_gt_3) | (rsi_3_4h_gt_15) | (roc_9_1d > -30.0))
             # 5m & 4h down move, 4h high
             & ((rsi_3_gt_3) | (rsi_3_4h_gt_45) | (stochrsi_k_4h_lt_80))
             # 5m & 4h down move, 15m still high
-            & ((rsi_3_gt_5) | (rsi_3_4h_gt_25) | (stochrsi_k_15m < 50.0))
+            & ((rsi_3_gt_5) | (rsi_3_4h_gt_25) | (stochrsi_k_15m_lt_50))
             # 5m & 1d down move, 1h still high
             & ((rsi_3_gt_3) | (rsi_3_1d_gt_10) | (aroonu_14_1h_lt_40))
             # 5m & 1d down move, 1h still high
@@ -13596,7 +13603,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 5m & 1d down move, 1d downtrend
             & ((rsi_3_gt_3) | (rsi_3_1d_gt_15) | (cmf_20_1d > -0.25))
             # 5m & 1d down move, 15m still high
-            & ((rsi_3_gt_3) | (rsi_3_1d_gt_20) | (stochrsi_k_15m < 40.0))
+            & ((rsi_3_gt_3) | (rsi_3_1d_gt_20) | (stochrsi_k_15m_lt_40))
             # 5m down move, 1h high
             & ((rsi_3_gt_3) | aroonu_14_1h_lt_80)
             # 5m down move, 4h high, 1d overbought
@@ -13608,7 +13615,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 5m down move, 1d downtrend
             & ((rsi_3_gt_3) | (roc_9_1d_gt_neg_40))
             # 5m & 15m down move, 15m still high
-            & ((rsi_3_gt_5) | (rsi_3_15m_gt_10) | (stochrsi_k_15m < 40.0))
+            & ((rsi_3_gt_5) | (rsi_3_15m_gt_10) | (stochrsi_k_15m_lt_40))
             # 5m & 15m down move, 1h high
             & ((rsi_3_gt_5) | (rsi_3_15m_gt_30) | (stochrsi_k_1h_lt_80))
             # 5m & 4h down move, 1d downtrend
@@ -13708,7 +13715,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 4h down move, 1d still high
             & ((rsi_3_15m_gt_5) | (rsi_3_4h_gt_5) | (stochrsi_k_1d < 40.0))
             # 15m & 4h down move, 15m still not low enough
-            & ((rsi_3_15m_gt_5) | (rsi_3_4h_gt_10) | (stochrsi_k_15m < 30.0))
+            & ((rsi_3_15m_gt_5) | (rsi_3_4h_gt_10) | (stochrsi_k_15m_lt_30))
             # 15m & 4h down move, 1d high
             & ((rsi_3_15m_gt_5) | (rsi_3_4h_gt_10) | (stochrsi_k_1d < 70.0))
             # 15m & 4h down move, 15m still high
@@ -13734,13 +13741,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 1d high & overbought
             & ((rsi_3_15m_gt_5) | (aroonu_14_1d_lt_80) | (roc_9_1d_lt_20))
             # 15m down move, 15m still not low enough, 1h still high
-            & ((rsi_3_15m_gt_5) | (stochrsi_k_15m < 20.0) | (stochrsi_k_1h_lt_50))
+            & ((rsi_3_15m_gt_5) | (stochrsi_k_15m_lt_20) | (stochrsi_k_1h_lt_50))
             # 15m down move, 1h still high, 4h overbought
             & ((rsi_3_15m_gt_5) | (stochrsi_k_1h_lt_50) | (roc_9_4h_lt_30))
             # 15m down move, 1h high & overbought
             & ((rsi_3_15m_gt_5) | (stochrsi_k_1h_lt_80) | (roc_9_1h < 20.0))
             # 15m & 1h down move, 15m high
-            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_10) | (stochrsi_k_15m < 50.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_10) | (stochrsi_k_15m_lt_50))
             # 15m & 1h down move, 1h still high
             & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_10) | (aroonu_14_1h_lt_50))
             # 15m & 1h down move, 4h high
@@ -13812,9 +13819,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 4h high & overbought
             & ((rsi_3_15m_gt_10) | (aroonu_14_4h_lt_70) | (roc_9_4h_lt_10))
             # 15m down move, 15m still not low enough, 4h high
-            & ((rsi_3_15m_gt_10) | (stochrsi_k_15m < 20.0) | (aroonu_14_4h_lt_70))
+            & ((rsi_3_15m_gt_10) | (stochrsi_k_15m_lt_20) | (aroonu_14_4h_lt_70))
             # 15m down move, 15m sill high, 4h high
-            & ((rsi_3_15m_gt_10) | (stochrsi_k_15m < 40.0) | (aroonu_14_4h_lt_60))
+            & ((rsi_3_15m_gt_10) | (stochrsi_k_15m_lt_40) | (aroonu_14_4h_lt_60))
             # 15m down move, 4h high, 1d downtrend
             & ((rsi_3_15m_gt_10) | (stochrsi_k_4h_lt_80) | (roc_9_1d_gt_neg_30))
             # 15m & 1h down move, 4h downtrend
@@ -13862,7 +13869,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 4h high & overbought
             & ((rsi_3_15m_gt_15) | aroonu_14_4h_lt_80 | (roc_9_4h_lt_10))
             # 15m down move, 15m still high, 1d overbought
-            & ((rsi_3_15m_gt_15) | (stochrsi_k_15m < 50.0) | (roc_9_1d_lt_100))
+            & ((rsi_3_15m_gt_15) | (stochrsi_k_15m_lt_50) | (roc_9_1d_lt_100))
             # 15m down move, 1h high & overbought
             & ((rsi_3_15m_gt_15) | (stochrsi_k_1h < 90.0) | (roc_9_1h_lt_10))
             # 15m down move, 4h high, 1d overbought
@@ -13872,7 +13879,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 4h overbought
             & ((rsi_3_15m_gt_20) | (rsi_3_1h_gt_20) | (roc_9_4h < 50.0))
             # 15m & 1h down move, 15m high
-            & ((rsi_3_15m_gt_20) | (rsi_3_1h_gt_25) | (stochrsi_k_15m < 80.0))
+            & ((rsi_3_15m_gt_20) | (rsi_3_1h_gt_25) | (stochrsi_k_15m_lt_80))
             # 15m & 1h down move, 4h high
             & ((rsi_3_15m_gt_20) | (rsi_3_1h_gt_25) | (stochrsi_k_4h_lt_80))
             # 15m & 1h down move, 1h high
@@ -13946,7 +13953,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 4h high
             & ((rsi_3_1h_gt_3) | (rsi_3_4h_gt_50) | aroonu_14_4h_lt_70)
             # 1h & 1d down move, 15m still high
-            & ((rsi_3_1h_gt_3) | (rsi_3_1d_gt_10) | (stochrsi_k_15m < 50.0))
+            & ((rsi_3_1h_gt_3) | (rsi_3_1d_gt_10) | (stochrsi_k_15m_lt_50))
             # 1h & 4h down move, 4h high
             & ((rsi_3_1h_gt_5) | (rsi_3_4h_gt_5) | (stochrsi_k_4h_lt_40))
             # 1h & 4h down move, 1d still high
@@ -13958,7 +13965,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 4h still high
             & ((rsi_3_1h_gt_5) | (rsi_3_4h_gt_60) | (stochrsi_k_4h_lt_50))
             # 1h & 4h down move, 15m high
-            & ((rsi_3_1h_gt_5) | (rsi_3_4h_gt_10) | (stochrsi_k_15m < 70.0))
+            & ((rsi_3_1h_gt_5) | (rsi_3_4h_gt_10) | (stochrsi_k_15m_lt_70))
             # 1h & 4h down move, 1h still high
             & ((rsi_3_1h_gt_5) | (rsi_3_4h_gt_15) | (aroonu_14_1h_lt_50))
             # 1h & 4h down move, 4h downtrend
@@ -13976,13 +13983,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h & 1d down move, 4h downtrend, 1d still high
             & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_15) | (rsi_3_1d_gt_25) | (rsi_14_4h > 30.0) | (aroonu_14_1d_lt_40))
             # 1h & 4h down move, 15m high
-            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_15) | (stochrsi_k_15m < 70.0))
+            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_15) | (stochrsi_k_15m_lt_70))
             # 1h & 4h down move, 1d downtrend
             & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_15) | (roc_9_1d_gt_neg_40))
             # 1h & 4h down move, 4h still high
             & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_30) | (stochrsi_k_4h_lt_50))
             # 1h & 1d down move, 15m still high
-            & ((rsi_3_1h_gt_10) | (rsi_3_1d_gt_15) | (stochrsi_k_15m < 40.0))
+            & ((rsi_3_1h_gt_10) | (rsi_3_1d_gt_15) | (stochrsi_k_15m_lt_40))
             # 1h & 4h down move, 4h still high
             & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_35) | (rsi_14_4h < 40.0))
             # 1h down move, 1h still not low enough 1d overbought
@@ -13992,7 +13999,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 1h still not low enough
             & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_15) | (aroonu_14_1h_lt_20))
             # 1h & 4h down move, 15m still high
-            & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_15) | (stochrsi_k_15m < 50.0))
+            & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_15) | (stochrsi_k_15m_lt_50))
             # 1h & 4h down move, 4h downtrend
             & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_15) | (roc_9_4h > -20.0))
             # 1h & 4h down move, 4h still high
@@ -14126,7 +14133,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 4h still high, 1d high
             & ((rsi_3_4h_gt_5) | (aroonu_14_4h_lt_50) | (aroonu_14_1d_lt_100))
             # 4h down move, 15m still high
-            & ((rsi_3_4h_gt_5) | (stochrsi_k_15m < 50.0))
+            & ((rsi_3_4h_gt_5) | (stochrsi_k_15m_lt_50))
             # 4h & 1d down move, 1h still not low enough
             & ((rsi_3_4h_gt_10) | (rsi_3_1d_gt_10) | (stochrsi_k_1h < 20.0))
             # 4h & 1d down move, 1d still high
@@ -14266,7 +14273,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1d high, 1h & 4h down move
             & (aroonu_14_1d_lt_100 | (roc_9_1h < 25.0) | (roc_9_4h < 60.0))
             # 15m high, 1d overbought
-            & ((stochrsi_k_15m < 70.0) | (roc_9_1d < 60.0))
+            & ((stochrsi_k_15m_lt_70) | (roc_9_1d < 60.0))
             # 1h high, 1d downtrend
             & ((stochrsi_k_1h_lt_70) | roc_9_1d_gt_neg_50)
             # 1h high, 1d overbought
@@ -14311,7 +14318,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 5m down move, 15m high, 1d overbought
             & ((rsi_3_gt_5) | (aroonu_14_15m_lt_70) | (roc_9_1d_lt_40))
             # 5m down move, 15m still high, 1d downtrend
-            & ((rsi_3_gt_5) | (stochrsi_k_15m < 50.0) | (roc_9_1d_gt_neg_20))
+            & ((rsi_3_gt_5) | (stochrsi_k_15m_lt_50) | (roc_9_1d_gt_neg_20))
             # 5m down move, 1h still high, 4h downtrend
             & ((rsi_3_gt_5) | (stochrsi_k_1h_lt_50) | (roc_9_4h > -10.0))
             # 5m down move, 1h high. 1d downtrend
@@ -14355,7 +14362,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 4h down move, 1d downtrend
             & ((rsi_3_15m_gt_15) | (rsi_3_4h_gt_15) | (roc_9_1d > -30.0))
             # 15m & 4h down move, 15m still high
-            & ((rsi_3_15m_gt_15) | (rsi_3_4h_gt_15) | (stochrsi_k_15m < 50.0))
+            & ((rsi_3_15m_gt_15) | (rsi_3_4h_gt_15) | (stochrsi_k_15m_lt_50))
             # 15m & 4h down move, 1d high
             & ((rsi_3_15m_gt_15) | rsi_3_4h_gt_20 | aroonu_14_1d_lt_100)
             # 15m & 1d down move, 15m high
@@ -14403,7 +14410,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 4h down move, 4h high
             & ((rsi_3_15m_gt_20) | (rsi_3_4h_gt_60) | aroonu_14_4h_lt_70)
             # 15m & 1h down move, 15m still high
-            & ((rsi_3_15m_gt_20) | (rsi_3_1d_gt_25) | (stochrsi_k_15m < 50.0))
+            & ((rsi_3_15m_gt_20) | (rsi_3_1d_gt_25) | (stochrsi_k_15m_lt_50))
             # 15m & 1d down move, 1h still high
             & ((rsi_3_15m_gt_20) | (rsi_3_1d_gt_25) | (stochrsi_k_1h_lt_50))
             # 15m & 1d down move, 1h high
@@ -14479,7 +14486,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 4h high & overbought
             & ((rsi_3_15m_gt_25) | aroonu_14_4h_lt_80 | (roc_9_4h_lt_10))
             # 15m down move, 15m still high, 1h still high
-            & ((rsi_3_15m_gt_25) | (stochrsi_k_15m < 50.0) | (aroonu_14_1h_lt_50))
+            & ((rsi_3_15m_gt_25) | (stochrsi_k_15m_lt_50) | (aroonu_14_1h_lt_50))
             # 15m down move, 1h high, 4h high
             & ((rsi_3_15m_gt_25) | (stochrsi_k_1h < 70.0) | (aroonu_14_4h_lt_100))
             # 15m down move, 4h & 1d overbought
@@ -14503,7 +14510,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 4h high & overbought
             & ((rsi_3_15m_gt_30) | (aroonu_14_4h_lt_70) | (roc_9_4h < 60.0))
             # 15m down move, 15m high, 4h overbought
-            & ((rsi_3_15m_gt_30) | (stochrsi_k_15m < 70.0) | (roc_9_4h < 70.0))
+            & ((rsi_3_15m_gt_30) | (stochrsi_k_15m_lt_70) | (roc_9_4h < 70.0))
             # 15m down move, 1h high, 1d overbought
             & ((rsi_3_15m_gt_30) | (stochrsi_k_1h < 90.0) | (roc_9_1d_lt_50))
             # 15m & 1h down move, 15m still high, 1h high
@@ -14527,7 +14534,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 4h high & overbought
             & ((rsi_3_15m_gt_40) | (stochrsi_k_4h_lt_80) | (roc_9_4h_lt_30))
             # 1h & 4h down move, 15m still high
-            & ((rsi_3_1h_gt_5) | (rsi_3_4h_gt_10) | (stochrsi_k_15m < 50.0))
+            & ((rsi_3_1h_gt_5) | (rsi_3_4h_gt_10) | (stochrsi_k_15m_lt_50))
             # 1h & 4h down move, 4h still high
             & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_10) | (aroonu_14_4h_lt_50))
             # 1h down move, 4h still high, 4h downtrend
@@ -14603,7 +14610,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 4h high
             & ((rsi_3_1h_gt_40) | (rsi_3_4h_gt_50) | (stochrsi_k_4h_lt_60))
             # 1h down move, 15m still high, 4h downtrend
-            & ((rsi_3_1h_gt_40) | (stochrsi_k_15m < 40.0) | (roc_9_4h > -15.0))
+            & ((rsi_3_1h_gt_40) | (stochrsi_k_15m_lt_40) | (roc_9_4h > -15.0))
             # 1h down move, 15m still high, 1d overbought
             & ((rsi_3_1h_gt_40) | (aroonu_14_15m_lt_50) | roc_9_1d_lt_50)
             # 1h down move, 15m & 4h high
@@ -14669,7 +14676,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 15m high, 1h still high
             & ((rsi_3_4h_gt_5) | (aroonu_14_15m_lt_70) | (stochrsi_k_1h_lt_50))
             # 4h down move, 15m high
-            & ((rsi_3_4h_gt_5) | (stochrsi_k_15m < 70.0))
+            & ((rsi_3_4h_gt_5) | (stochrsi_k_15m_lt_70))
             # 4h down move, 4h still high, 1d downtrend
             & ((rsi_3_4h_gt_5) | (stochrsi_k_4h_lt_40) | (roc_9_1d_gt_neg_20))
             # 4h & 1d down move, 1d still high
@@ -14681,13 +14688,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h & 1d down move, 1d still high
             & ((rsi_3_4h_gt_10) | (rsi_3_1d_gt_35) | (stochrsi_k_1d < 40.0))
             # 4h down move, 15m still not low enough, 1d downtrend
-            & ((rsi_3_4h_gt_10) | (stochrsi_k_15m < 30.0) | (roc_9_1d_gt_neg_40))
+            & ((rsi_3_4h_gt_10) | (stochrsi_k_15m_lt_30) | (roc_9_1d_gt_neg_40))
             # 4h down move, 15m high, 4h downtrend
-            & ((rsi_3_4h_gt_10) | (stochrsi_k_15m < 60.0) | (roc_9_4h > -50.0))
+            & ((rsi_3_4h_gt_10) | (stochrsi_k_15m_lt_60) | (roc_9_4h > -50.0))
             # 4h down move, 15m high
-            & ((rsi_3_4h_gt_10) | (stochrsi_k_15m < 70.0))
+            & ((rsi_3_4h_gt_10) | (stochrsi_k_15m_lt_70))
             # 4h & 1d down move, 15m high
-            & ((rsi_3_4h_gt_15) | (rsi_3_1d_gt_35) | (stochrsi_k_15m < 70.0))
+            & ((rsi_3_4h_gt_15) | (rsi_3_1d_gt_35) | (stochrsi_k_15m_lt_70))
             # 4h & 1d down move, 4h high
             & ((rsi_3_4h_gt_15) | (rsi_3_1d_gt_35) | (stochrsi_k_4h_lt_70))
             # 4h & 1d down move, 1d high
@@ -14697,7 +14704,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 15m & 1d high
             & ((rsi_3_4h_gt_15) | (aroonu_14_15m_lt_70) | (aroonu_14_1d_lt_80))
             # 4h down move, 15m high
-            & ((rsi_3_4h_gt_15) | (stochrsi_k_15m < 80.0))
+            & ((rsi_3_4h_gt_15) | (stochrsi_k_15m_lt_80))
             # 4h down move, 1d high
             & ((rsi_3_4h_gt_15) | (stochrsi_k_1d < 80.0))
             # 4h down move, 1h & 4h downtrend
@@ -14705,7 +14712,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h & 1d down move, 1h still high
             & (rsi_3_4h_gt_20 | (rsi_3_1d_gt_20) | (aroonu_14_1h_lt_40))
             # 4h & 1d down move, 15m high
-            & (rsi_3_4h_gt_20 | (rsi_3_1d_gt_25) | (stochrsi_k_15m < 70.0))
+            & (rsi_3_4h_gt_20 | (rsi_3_1d_gt_25) | (stochrsi_k_15m_lt_70))
             # 4h & 1d down move, 1d overbought
             & (rsi_3_4h_gt_20 | (rsi_3_1d_gt_55) | roc_9_1d_lt_50)
             # 4h down move, 15m & 4h still high
@@ -14717,7 +14724,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 1d high & overbought
             & (rsi_3_4h_gt_20 | (aroonu_14_1d_lt_90) | (roc_9_1d < 10.0))
             # 4h down move, 15m high, 4h downtrend
-            & (rsi_3_4h_gt_20 | (stochrsi_k_15m < 80.0) | (roc_9_4h > -50.0))
+            & (rsi_3_4h_gt_20 | (stochrsi_k_15m_lt_80) | (roc_9_4h > -50.0))
             # 4h down move, 1h high, 1d downtrend
             & (rsi_3_4h_gt_20 | (stochrsi_k_1h < 60.0) | (roc_9_1d_gt_neg_40))
             # 4h down move, 4h still not low enough, 4h downtrend
@@ -14785,7 +14792,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 1d high & overbought
             & ((rsi_3_4h_gt_40) | aroonu_14_1d_lt_100 | (roc_9_1d_lt_20))
             # 4h down move, 15m high, 1h high
-            & ((rsi_3_4h_gt_40) | (stochrsi_k_15m < 70.0) | (aroonu_14_1h_lt_100))
+            & ((rsi_3_4h_gt_40) | (stochrsi_k_15m_lt_70) | (aroonu_14_1h_lt_100))
             # 4h down move, 1h high, 1d overbought
             & ((rsi_3_4h_gt_40) | (stochrsi_k_1h_lt_70) | (roc_9_1d < 60.0))
             # 4h down move, 4h & 1d overbought
@@ -14933,7 +14940,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1d high, 4h & 1d overbought
             & (aroonu_14_1d_lt_100 | (roc_9_4h_lt_30) | (roc_9_1d_lt_40))
             # 15m & 1h high, 1d overbought
-            & ((stochrsi_k_15m < 70.0) | (stochrsi_k_1h_lt_70) | roc_9_1d_lt_50)
+            & ((stochrsi_k_15m_lt_70) | (stochrsi_k_1h_lt_70) | roc_9_1d_lt_50)
             # 15m & 1d high
             & ((stochrsi_k_15m < 90.0) | (stochrsi_k_1d_lt_90))
             # 1h high, 4h & 1d downtrend
@@ -15004,11 +15011,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 5m & 4h down move, 4h high
             & ((rsi_3_gt_3) | (rsi_3_4h_gt_25) | aroonu_14_4h_lt_70)
             # 5m & 1d down move, 15m still high
-            & ((rsi_3_gt_3) | (rsi_3_1d_gt_20) | (stochrsi_k_15m < 40.0))
+            & ((rsi_3_gt_3) | (rsi_3_1d_gt_20) | (stochrsi_k_15m_lt_40))
             # 5m down move, 1h high, 4h overbought
             & ((rsi_3_gt_3) | (stochrsi_k_1h < 80.0) | (roc_9_4h_lt_20))
             # 5m & 4h down move, 15m still high
-            & ((rsi_3_gt_5) | (rsi_3_4h_gt_25) | (stochrsi_k_15m < 50.0))
+            & ((rsi_3_gt_5) | (rsi_3_4h_gt_25) | (stochrsi_k_15m_lt_50))
             # 5m down move, 4h high, 1h overbought
             & ((rsi_3_gt_10) | aroonu_14_4h_lt_100 | (roc_9_1h < 30.0))
             # 15m & 1h down move, 1d still high
@@ -15030,7 +15037,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 1h & 1d high
             & ((rsi_3_15m_gt_5) | (roc_9_1h_lt_10) | (roc_9_1d_lt_40))
             # 15m & 1h down move, 15m stil high
-            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_10) | (stochrsi_k_15m < 50.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_10) | (stochrsi_k_15m_lt_50))
             # 15m & 1h down move, 4h downtrend
             & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_10) | (roc_9_4h > -40.0))
             # 15m & 1h down move, 1h still high
@@ -15084,7 +15091,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h high, 4h high
             & ((rsi_3_1h_gt_3) | aroonu_14_1h_lt_70 | (stochrsi_k_4h_lt_80))
             # 1h down move, 15m still high
-            & ((rsi_3_1h_gt_3) | (stochrsi_k_15m < 50.0))
+            & ((rsi_3_1h_gt_3) | (stochrsi_k_15m_lt_50))
             # 1h down move, 1h still high, 4h overbought
             & ((rsi_3_1h_gt_3) | (stochrsi_k_1h < 50.0) | (roc_9_4h_lt_20))
             # 1h & 4h & 1d down move
@@ -15154,11 +15161,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 1d overbought
             & ((rsi_3_1h_gt_30) | (rsi_3_4h_gt_30) | (roc_9_1d_lt_40))
             # 1h & 4h down move, 15m high
-            & ((rsi_3_1h_gt_30) | (rsi_3_4h_gt_40) | (stochrsi_k_15m < 80.0))
+            & ((rsi_3_1h_gt_30) | (rsi_3_4h_gt_40) | (stochrsi_k_15m_lt_80))
             # 1h & 4h down move, 1h high
             & ((rsi_3_1h_gt_30) | (rsi_3_4h_gt_50) | (stochrsi_k_1h_lt_70))
             # 1h down move, 15m still high, 1h high
-            & ((rsi_3_1h_gt_30) | (stochrsi_k_15m < 40.0) | (aroonu_14_1h_lt_60))
+            & ((rsi_3_1h_gt_30) | (stochrsi_k_15m_lt_40) | (aroonu_14_1h_lt_60))
             # 1h down move, 1h still high, 4h high
             & ((rsi_3_1h_gt_30) | (stochrsi_k_1h < 40.0) | (stochrsi_k_4h_lt_70))
             # 1h down move, 4h & 1d downtrend
@@ -15283,7 +15290,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 5m & 1h down move, 1h still high
             & ((rsi_3_gt_3) | (rsi_3_1h_gt_30) | (stochrsi_k_1h_lt_50))
             # 5m & 4h down move, 15m still high
-            & ((rsi_3_gt_3) | (rsi_3_4h_gt_3) | (stochrsi_k_15m < 40.0))
+            & ((rsi_3_gt_3) | (rsi_3_4h_gt_3) | (stochrsi_k_15m_lt_40))
             # 15m & 1h down move, 4h high
             & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_30) | (stochrsi_k_4h_lt_60))
             # 15m & 1h down move, 1h still high
@@ -15351,13 +15358,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 4h still high
             & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_10) | (aroonu_14_4h_lt_50))
             # 1h & 4h down move, 15m still high
-            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_10) | (stochrsi_k_15m < 50.0))
+            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_10) | (stochrsi_k_15m_lt_50))
             # 1h & 4h down move, 1h downtrend
             & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_10) | (roc_9_1h > -20.0))
             # 1h & 4h & 1d down move
             & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_15) | (rsi_3_1d_gt_15))
             # 1h & 4h down move, 15m high
-            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_15) | (stochrsi_k_15m < 70.0))
+            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_15) | (stochrsi_k_15m_lt_70))
             # 1h & 4h down move, 4h high
             & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_15) | (aroonu_14_4h_lt_60))
             # 1h & 4h down move, 1d overbought
@@ -15427,7 +15434,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 4h high & overbought
             & ((rsi_3_1h_gt_30) | (aroonu_14_4h_lt_90) | (roc_9_4h < 100.0))
             # 1h down move, 15m still high, 1h high
-            & ((rsi_3_1h_gt_30) | (stochrsi_k_15m < 40.0) | (aroonu_14_1h_lt_60))
+            & ((rsi_3_1h_gt_30) | (stochrsi_k_15m_lt_40) | (aroonu_14_1h_lt_60))
             # 1h down move, 1h high, 1d downtrend
             & ((rsi_3_1h_gt_30) | (stochrsi_k_1h_lt_70) | (roc_9_1d_gt_neg_40))
             # 1h down move, 4h high, 1d downtrend
@@ -15491,7 +15498,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 1d high, 4h downtrend
             & ((rsi_3_4h_gt_5) | (aroonu_14_1d_lt_80) | (roc_9_4h > -10.0))
             # 4h & 1d down move, 15m high
-            & ((rsi_3_4h_gt_10) | (rsi_3_1d_gt_15) | (stochrsi_k_15m < 80.0))
+            & ((rsi_3_4h_gt_10) | (rsi_3_1d_gt_15) | (stochrsi_k_15m_lt_80))
             # 4h & 1d down move, 1d downtrend
             & ((rsi_3_4h_gt_10) | (rsi_3_1d_gt_15) | (roc_9_1d > -15.0))
             # 4h & 1d down move, 1d still high
@@ -15499,9 +15506,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 15m downtrend, 1d high
             & ((rsi_3_4h_gt_10) | (cmf_20_15m > -0.30) | (aroonu_14_1d_lt_80))
             # 4h down move, 15m still high, 1d downtrend
-            & ((rsi_3_4h_gt_10) | (stochrsi_k_15m < 50.0) | (roc_9_1d > -25.0))
+            & ((rsi_3_4h_gt_10) | (stochrsi_k_15m_lt_50) | (roc_9_1d > -25.0))
             # 4h down move, 15m high
-            & ((rsi_3_4h_gt_10) | (stochrsi_k_15m < 80.0))
+            & ((rsi_3_4h_gt_10) | (stochrsi_k_15m_lt_80))
             # 4h down move, 1h high, 1d downtrend
             & ((rsi_3_4h_gt_10) | (stochrsi_k_1h < 70.0) | (roc_9_1d > -20.0))
             # 4h down move, 4h still high, 1d downtrend
@@ -15583,7 +15590,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1d high, 4h & 1d overbought
             & (aroonu_14_1d_lt_100 | (roc_9_4h < 20.0) | (roc_9_1d_lt_80))
             # 15m high, 4h & 1d downtrend
-            & ((stochrsi_k_15m < 70.0) | (roc_9_4h_gt_neg_30) | (roc_9_1d_gt_neg_30))
+            & ((stochrsi_k_15m_lt_70) | (roc_9_4h_gt_neg_30) | (roc_9_1d_gt_neg_30))
             # 1h high, 4h & 1d overbought
             & ((stochrsi_k_1h < 90.0) | (roc_9_4h_lt_20) | (roc_9_1d_lt_100))
             # 4h high, 1h overbought, 1d downtrend
@@ -15624,7 +15631,7 @@ class NostalgiaForInfinityX7(IStrategy):
 
           long_entry_logic.append(
             # 5m & 15m down move, 15m still high
-            ((rsi_3_gt_3) | (rsi_3_15m_gt_10) | (stochrsi_k_15m < 40.0))
+            ((rsi_3_gt_3) | (rsi_3_15m_gt_10) | (stochrsi_k_15m_lt_40))
             # 5m & 15m down move, 15m still high
             & ((rsi_3_gt_3) | (rsi_3_15m_gt_15) | (aroonu_14_15m_lt_40))
             # 5m & 15m down move, 1d downtrend
@@ -15644,7 +15651,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 5m & 4h down move, 4h still high
             & ((rsi_3_gt_3) | (rsi_3_4h_gt_55) | (aroonu_14_4h_lt_50))
             # 5m & 1d down move, 15m still high
-            & ((rsi_3_gt_3) | (rsi_3_1d_gt_20) | (stochrsi_k_15m < 40.0))
+            & ((rsi_3_gt_3) | (rsi_3_1d_gt_20) | (stochrsi_k_15m_lt_40))
             # 5m down move, 4h & 1d overbought
             & ((rsi_3_gt_3) | (roc_9_4h_lt_20) | (roc_9_1d_lt_40))
             # 5m & 1h down move, 4h high
@@ -15656,7 +15663,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 5m & 4h down move, 4h still high
             & ((rsi_3_gt_5) | (rsi_3_4h_gt_15) | (aroonu_14_4h_lt_40))
             # 5m & 4h down move, 15m still high
-            & ((rsi_3_gt_5) | (rsi_3_4h_gt_25) | (stochrsi_k_15m < 50.0))
+            & ((rsi_3_gt_5) | (rsi_3_4h_gt_25) | (stochrsi_k_15m_lt_50))
             # 5m & 4h down move, 1d overbought
             & ((rsi_3_gt_5) | (rsi_3_4h_gt_30) | (roc_9_1d < 60.0))
             # 5m & 4h down move, 4h high
@@ -15726,7 +15733,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 1h & 4h high
             & ((rsi_3_15m_gt_5) | (aroonu_14_1h_lt_70) | (aroonu_14_4h_lt_90))
             # 15m down move, 15m & 1h still not low enough
-            & ((rsi_3_15m_gt_5) | (stochrsi_k_15m < 30.0) | (stochrsi_k_1h < 30.0))
+            & ((rsi_3_15m_gt_5) | (stochrsi_k_15m_lt_30) | (stochrsi_k_1h < 30.0))
             # 15m & 1h down move, 1h still high
             & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_20) | (stochrsi_k_1h_lt_50))
             # 15m & 1h down move, 4h still high
@@ -15838,7 +15845,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 4h down move, 1d high
             & ((rsi_3_15m_gt_15) | rsi_3_4h_gt_20 | (aroonu_14_1d_lt_90))
             # 15m & 4h down move, 15m still high
-            & ((rsi_3_15m_gt_15) | rsi_3_4h_gt_20 | (stochrsi_k_15m < 50.0))
+            & ((rsi_3_15m_gt_15) | rsi_3_4h_gt_20 | (stochrsi_k_15m_lt_50))
             # 15m & 4h down move, 1h high
             & ((rsi_3_15m_gt_15) | (rsi_3_4h_gt_30) | (stochrsi_k_1h < 60.0))
             # 15m & 4h down move, 4h high
@@ -15918,7 +15925,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1d down move, 1h high
             & ((rsi_3_15m_gt_20) | (rsi_3_1d_gt_20) | aroonu_14_1h_lt_70)
             # 15m & 1d down move, 15m still high
-            & ((rsi_3_15m_gt_20) | (rsi_3_1d_gt_30) | (stochrsi_k_15m < 50.0))
+            & ((rsi_3_15m_gt_20) | (rsi_3_1d_gt_30) | (stochrsi_k_15m_lt_50))
             # 15m down move, 15m still not low enough, 1h high
             & ((rsi_3_15m_gt_20) | (aroonu_14_15m_lt_25) | (stochrsi_k_1h < 90.0))
             # 15m down move, 15m still high, 1h high
@@ -15940,13 +15947,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 1d high, 1d overbought
             & ((rsi_3_15m_gt_20) | aroonu_14_1d_lt_100 | (roc_9_1d_lt_20))
             # 15m down move, 15m high, 4h downtrend
-            & ((rsi_3_15m_gt_20) | (stochrsi_k_15m < 60.0) | (roc_9_4h > -50.0))
+            & ((rsi_3_15m_gt_20) | (stochrsi_k_15m_lt_60) | (roc_9_4h > -50.0))
             # 15 down move, 1h high, 1d overbought
             & ((rsi_3_15m_gt_20) | (stochrsi_k_1h_lt_70) | (roc_9_1d < 10.0))
             # 15m down move, 4h high, 15m downtrend
             & ((rsi_3_15m_gt_20) | (stochrsi_k_4h_lt_70) | (cmf_20_15m > -0.40))
             # 15m & 1h down move, 15m high
-            & ((rsi_3_15m_gt_25) | (rsi_3_1h_gt_25) | (stochrsi_k_15m < 70.0))
+            & ((rsi_3_15m_gt_25) | (rsi_3_1h_gt_25) | (stochrsi_k_15m_lt_70))
             # 15m & 1h & 4h down move, 4h still high
             & ((rsi_3_15m_gt_25) | (rsi_3_1h_gt_30) | (rsi_3_4h_gt_45) | (stochrsi_k_4h_lt_50))
             # 15m & 1h & 4h down move, 4h high
@@ -15998,7 +16005,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 1h high
             & ((rsi_3_15m_gt_30) | (rsi_3_1h_gt_55) | (stochrsi_k_1h_lt_80))
             # 15m & 4h down move, 15m high
-            & ((rsi_3_15m_gt_30) | (rsi_3_4h_gt_30) | (stochrsi_k_15m < 70.0))
+            & ((rsi_3_15m_gt_30) | (rsi_3_4h_gt_30) | (stochrsi_k_15m_lt_70))
             # 15m down move, 1h high & overbought
             & ((rsi_3_15m_gt_30) | (aroonu_14_1h_lt_90) | (roc_9_1h_lt_10))
             # 15m down move, 15m still high, 4h high
@@ -16030,7 +16037,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 4h down move, 1h high
             & ((rsi_3_15m_gt_40) | (rsi_3_4h_gt_45) | (stochrsi_k_1h < 90.0))
             # 15m down move, 15m still high, 1d high
-            & ((rsi_3_15m_gt_40) | (stochrsi_k_15m < 40.0) | (roc_9_1d_lt_100))
+            & ((rsi_3_15m_gt_40) | (stochrsi_k_15m_lt_40) | (roc_9_1d_lt_100))
             # 15m down move, 4h high & overbought
             & ((rsi_3_15m_gt_40) | aroonu_14_4h_lt_100 | (roc_9_4h_lt_40))
             # 15m down move, 1h high, 4h overbought
@@ -16050,13 +16057,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 1h still high
             & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_30) | (aroonu_14_1h_lt_50))
             # 1h & 4h down move, 15m still not low enough
-            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_40) | (stochrsi_k_15m < 30.0))
+            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_40) | (stochrsi_k_15m_lt_30))
             # 1h down move, 1d high, 1d downtrend
             & ((rsi_3_1h_gt_10) | (aroonu_14_1d_lt_70) | (roc_9_1d > -20.0))
             # 1h down move, 4h high, 1d downtrend
             & ((rsi_3_1h_gt_10) | (stochrsi_k_4h_lt_50) | (roc_9_1d_gt_neg_40))
             # 1h & 4h down move, 15m high
-            & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_15) | (stochrsi_k_15m < 70.0))
+            & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_15) | (stochrsi_k_15m_lt_70))
             # 1h & 4h down move, 4h still not low enough
             & ((rsi_3_1h_gt_15) | rsi_3_4h_gt_20 | (stochrsi_k_4h_lt_30))
             # 1h & 4h down move, 1d downtrend
@@ -16084,7 +16091,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 1h still high
             & ((rsi_3_1h_gt_25) | (rsi_3_4h_gt_10) | (stochrsi_k_1h < 40.0))
             # 1h & 4h down move, 15m high
-            & ((rsi_3_1h_gt_25) | (rsi_3_4h_gt_30) | (stochrsi_k_15m < 70.0))
+            & ((rsi_3_1h_gt_25) | (rsi_3_4h_gt_30) | (stochrsi_k_15m_lt_70))
             # 1h down move, 4h downtrend, 4h high
             & ((rsi_3_1h_gt_25) | (cmf_20_4h > -0.50) | aroonu_14_4h_lt_70)
             # 1h down move, 1h still high, 1d high
@@ -16188,7 +16195,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 4h & 1d downtrend
             & ((rsi_3_4h_gt_3) | (roc_9_4h > -10.0) | (roc_9_1d > -10.0))
             # 4h & 1d down move, 15m still high
-            & ((rsi_3_4h_gt_5) | (rsi_3_1d_gt_25) | (stochrsi_k_15m < 40.0))
+            & ((rsi_3_4h_gt_5) | (rsi_3_1d_gt_25) | (stochrsi_k_15m_lt_40))
             # 4h & 1d down move, 1h still not low enough
             & ((rsi_3_4h_gt_10) | (rsi_3_1d_gt_10) | (stochrsi_k_1h < 20.0))
             # 4h & 1d down move, 1d downtrend
@@ -16200,7 +16207,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h & 1d down move, 1d overbought
             & ((rsi_3_4h_gt_10) | (rsi_3_1d_gt_45) | (roc_9_1d < 10.0))
             # 4h down move, 15m high
-            & ((rsi_3_4h_gt_10) | (stochrsi_k_15m < 70.0))
+            & ((rsi_3_4h_gt_10) | (stochrsi_k_15m_lt_70))
             # 4h & 1d down move, 4h high
             & ((rsi_3_4h_gt_15) | (rsi_3_1d_gt_25) | aroonu_14_4h_lt_70)
             # 4h & 1d down move, 1h still high
@@ -16224,7 +16231,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h & 1d down move, 1d overbought
             & (rsi_3_4h_gt_20 | (rsi_3_1d_gt_45) | (roc_9_1d_lt_40))
             # 4h down move, 15m high
-            & (rsi_3_4h_gt_20 | (stochrsi_k_15m < 80.0))
+            & (rsi_3_4h_gt_20 | (stochrsi_k_15m_lt_80))
             # 4h down move, 1h high, 4h downtrend
             & (rsi_3_4h_gt_20 | (stochrsi_k_1h < 70.0) | (roc_9_4h_gt_neg_20))
             # 4h down move, 4h still high, 4h downtrend
@@ -16280,7 +16287,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1d down move, 1d still not low enough, 1d downtrend
             & ((rsi_3_1d_gt_5) | (aroonu_14_1d < 20.0) | (roc_9_1d_gt_neg_20))
             # 1d down move, 15m still high
-            & ((rsi_3_1d_gt_5) | (stochrsi_k_15m < 40.0))
+            & ((rsi_3_1d_gt_5) | (stochrsi_k_15m_lt_40))
             # 1d down move, 1h & 4h still not low enough
             & ((rsi_3_1d_gt_5) | (stochrsi_k_1h < 20.0) | (stochrsi_k_4h_lt_20))
             # 1d down move, 1h high
@@ -16344,9 +16351,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1d high, 4h & 1d overbought
             & (aroonu_14_1d_lt_100 | (roc_9_4h_lt_10) | (roc_9_1d_lt_20))
             # 15m still not low enough, 4h high, 1d overbought
-            & ((stochrsi_k_15m < 30.0) | aroonu_14_4h_lt_100 | (roc_9_1d_lt_30))
+            & ((stochrsi_k_15m_lt_30) | aroonu_14_4h_lt_100 | (roc_9_1d_lt_30))
             # 15m still high, 4h high & overbought
-            & ((stochrsi_k_15m < 40.0) | (stochrsi_k_4h_lt_80) | (roc_9_4h_lt_30))
+            & ((stochrsi_k_15m_lt_40) | (stochrsi_k_4h_lt_80) | (roc_9_4h_lt_30))
             # 1h high, 1d overbought
             & ((stochrsi_k_1h_lt_70) | (roc_9_1d_lt_40))
             # 1h high, 1h overbought, 4h downtrend
@@ -17323,9 +17330,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 1h high
             & ((rsi_3_15m_gt_15) | (rsi_3_1h_gt_15) | (aroonu_14_1h_lt_70))
             # 15m & 1h down move, 15m still high
-            & ((rsi_3_15m_gt_15) | rsi_3_1h_gt_20 | (stochrsi_k_15m < 50.0))
+            & ((rsi_3_15m_gt_15) | rsi_3_1h_gt_20 | (stochrsi_k_15m_lt_50))
             # 15m & 4h down move, 15m still high
-            & ((rsi_3_15m_gt_15) | (rsi_3_4h_gt_15) | (stochrsi_k_15m < 50.0))
+            & ((rsi_3_15m_gt_15) | (rsi_3_4h_gt_15) | (stochrsi_k_15m_lt_50))
             # 15m & 4h down move, 4h high
             & ((rsi_3_15m_gt_15) | rsi_3_4h_gt_20 | (aroonu_14_4h_lt_60))
             # 15m & 1d down move, 1d high
@@ -17367,7 +17374,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1d high, 1d downtrend
             & ((rsi_3_1h_gt_3) | (aroonu_14_1d_lt_70) | (roc_9_1h > -50.0))
             # 1h & 4h down move, 15m still not low enough
-            & ((rsi_3_1h_gt_5) | (rsi_3_4h_gt_5) | (stochrsi_k_15m < 20.0))
+            & ((rsi_3_1h_gt_5) | (rsi_3_4h_gt_5) | (stochrsi_k_15m_lt_20))
             # 1h & 4h down move, 1d downtrend
             & ((rsi_3_1h_gt_5) | (rsi_3_4h_gt_5) | (roc_9_1d_gt_neg_30))
             # 1h & 4h down move, 1d still high
@@ -17435,7 +17442,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1d high & overbought
             & ((rsi_3_1h_gt_10) | (aroonu_14_1d_lt_90) | (roc_9_1d_lt_30))
             # 1h down move, 15m high
-            & ((rsi_3_1h_gt_10) | (stochrsi_k_15m < 80.0))
+            & ((rsi_3_1h_gt_10) | (stochrsi_k_15m_lt_80))
             # 1h down move, 4h & 1d downtrend
             & ((rsi_3_1h_gt_10) | (roc_9_4h > -20.0) | (roc_9_1d_gt_neg_40))
             # 1h & 4h down move, 1d still high, 1d downtrend
@@ -17443,7 +17450,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 4h still high
             & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_15) | (aroonu_14_4h_lt_50))
             # 1h & 4h down move, 15m still high
-            & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_15) | (stochrsi_k_15m < 40.0))
+            & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_15) | (stochrsi_k_15m_lt_40))
             # 1h & 4h down move, 4h still not low enough
             & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_15) | (stochrsi_k_4h_lt_20))
             # 1h & 4h down move, 1d high
@@ -17481,9 +17488,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 1d overbought
             & ((rsi_3_1h_gt_20) | (rsi_3_4h_gt_20) | (aroonu_14_1d_lt_100))
             # 1h & 4h down move, 15m high
-            & ((rsi_3_1h_gt_20) | (rsi_3_4h_gt_20) | (stochrsi_k_15m < 60.0))
+            & ((rsi_3_1h_gt_20) | (rsi_3_4h_gt_20) | (stochrsi_k_15m_lt_60))
             # 1h & 4h down move, 15m still not low enough, 1d still not low enough
-            & ((rsi_3_1h_gt_20) | (rsi_3_4h_gt_20) | (stochrsi_k_15m < 30.0) | (stochrsi_k_1d < 30.0))
+            & ((rsi_3_1h_gt_20) | (rsi_3_4h_gt_20) | (stochrsi_k_15m_lt_30) | (stochrsi_k_1d < 30.0))
             # 1h & 4h down move, 1d overbought
             & ((rsi_3_1h_gt_20) | (rsi_3_4h_gt_20) | (roc_9_1d_lt_30))
             # 1h & 4h down move, 4h high
@@ -17503,7 +17510,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1d high, 4h downtrend
             & ((rsi_3_1h_gt_20) | (stochrsi_k_1d < 80.0) | (roc_9_4h_gt_neg_20))
             # 1h & 4h down move, 15m high
-            & ((rsi_3_1h_gt_25) | (rsi_3_4h_gt_25) | (stochrsi_k_15m < 70.0))
+            & ((rsi_3_1h_gt_25) | (rsi_3_4h_gt_25) | (stochrsi_k_15m_lt_70))
             # 1h & 4h down move, 4h high
             & ((rsi_3_1h_gt_25) | (rsi_3_4h_gt_40) | aroonu_14_4h_lt_70)
             # 1h & 1d down move, 1h high
@@ -17533,7 +17540,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 4h high
             & ((rsi_3_1h_gt_30) | (rsi_3_4h_gt_40) | (aroonu_14_4h_lt_75))
             # 1h & 4h down move, 15m high
-            & ((rsi_3_1h_gt_30) | (rsi_3_4h_gt_40) | (stochrsi_k_15m < 80.0))
+            & ((rsi_3_1h_gt_30) | (rsi_3_4h_gt_40) | (stochrsi_k_15m_lt_80))
             # 1h & 4h down move, 4h high
             & ((rsi_3_1h_gt_30) | (rsi_3_4h_gt_50) | aroonu_14_4h_lt_80)
             # 1h & 1d down move, 1d high
@@ -17609,7 +17616,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h & 1d down move, 1d downtrend
             & ((rsi_3_4h_gt_10) | (rsi_3_1d_gt_10) | (roc_9_1d > -20.0))
             # 15m & 1d down move, 15m still high
-            & ((rsi_3_4h_gt_10) | (rsi_3_1d_gt_15) | (stochrsi_k_15m < 50.0))
+            & ((rsi_3_4h_gt_10) | (rsi_3_1d_gt_15) | (stochrsi_k_15m_lt_50))
             # 4h & 1d down move, 4d & 1d downtrend
             & ((rsi_3_4h_gt_10) | (rsi_3_1d_gt_30) | (roc_9_4h > -10.0) | (roc_9_1d > -20.0))
             # 4h & 1d down move, 4h downtrend
@@ -17619,9 +17626,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h & 1d down move, 4h still not low enough
             & ((rsi_3_4h_gt_10) | (rsi_3_1d > 50.0) | (stochrsi_k_4h_lt_20))
             # 4h down move, 15m high, 1h downtrend
-            & ((rsi_3_4h_gt_10) | (stochrsi_k_15m < 60.0) | (roc_9_1h > -10.0))
+            & ((rsi_3_4h_gt_10) | (stochrsi_k_15m_lt_60) | (roc_9_1h > -10.0))
             # 4h down move, 15m high
-            & ((rsi_3_4h_gt_10) | (stochrsi_k_15m < 80.0))
+            & ((rsi_3_4h_gt_10) | (stochrsi_k_15m_lt_80))
             # 4h down move, 4h still not low e nough, 1d downtrend
             & ((rsi_3_4h_gt_10) | (stochrsi_k_4h_lt_30) | (roc_9_1d > -20.0))
             # 4h down move, 4h still high, 1d high
@@ -17633,7 +17640,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h & 1d down move, 1d still high
             & ((rsi_3_4h_gt_15) | (rsi_3_1d_gt_25) | (aroonu_14_1d_lt_40))
             # 15m & 1d down move, 15m high
-            & ((rsi_3_4h_gt_15) | (rsi_3_1d_gt_30) | (stochrsi_k_15m < 70.0))
+            & ((rsi_3_4h_gt_15) | (rsi_3_1d_gt_30) | (stochrsi_k_15m_lt_70))
             # 4h & 1d down move, 4h still high
             & ((rsi_3_4h_gt_15) | (rsi_3_1d_gt_30) | (stochrsi_k_4h_lt_50))
             # 4h & 1d down move, 1d still high
@@ -17657,7 +17664,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h & 1d down move, 1d high
             & (rsi_3_4h_gt_20 | (rsi_3_1d_gt_20) | (stochrsi_k_1d < 80.0))
             # 4h & 1d down move, 15m high
-            & (rsi_3_4h_gt_20 | (rsi_3_1d_gt_30) | (stochrsi_k_15m < 80.0))
+            & (rsi_3_4h_gt_20 | (rsi_3_1d_gt_30) | (stochrsi_k_15m_lt_80))
             # 4h & 1d down move, 1d high
             & (rsi_3_4h_gt_20 | (rsi_3_1d > 50.0) | (stochrsi_k_1d_lt_90))
             # 4h down move, 15m high, 4h downtrend
@@ -17671,7 +17678,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 1d high & overbought
             & (rsi_3_4h_gt_20 | (aroonu_14_1d_lt_90) | (roc_9_1d_lt_40))
             # 4h down move, 15m high
-            & (rsi_3_4h_gt_20 | (stochrsi_k_15m < 70.0))
+            & (rsi_3_4h_gt_20 | (stochrsi_k_15m_lt_70))
             # 4h down move, 4h still not low enough, 1d downtrend
             & (rsi_3_4h_gt_20 | (stochrsi_k_4h_lt_30) | (roc_9_1d_gt_neg_20))
             # 4h down move, 4h & 1d downtrend
@@ -17781,7 +17788,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1d high, 4h & 1d overbought
             & (aroonu_14_1d_lt_100 | (roc_9_4h_lt_30) | (roc_9_1d < 60.0))
             # 15m still high, 1h & 4h downtrend
-            & ((stochrsi_k_15m < 50.0) | (roc_9_1h > -20.0) | (roc_9_4h_gt_neg_20))
+            & ((stochrsi_k_15m_lt_50) | (roc_9_1h > -20.0) | (roc_9_4h_gt_neg_20))
             # 4h high, 1h & 4h overbought
             & ((stochrsi_k_4h_lt_90) | (roc_9_1h < 20.0) | (roc_9_4h_lt_30))
             # 4h high, 4h & 1d overbought
@@ -17910,7 +17917,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 4h down move, 1h downtrend
             & ((rsi_3_15m_gt_5) | (rsi_3_4h_gt_10) | (roc_9_1h > -20.0))
             # 15m & 4h down move, 15m still high
-            & ((rsi_3_15m_gt_5) | (rsi_3_4h_gt_15) | (stochrsi_k_15m < 50.0))
+            & ((rsi_3_15m_gt_5) | (rsi_3_4h_gt_15) | (stochrsi_k_15m_lt_50))
             # 15m & 4h down move, 4h still high
             & ((rsi_3_15m_gt_5) | rsi_3_4h_gt_20 | (aroonu_14_4h_lt_50))
             # 15m & 4h down move, 1d high
@@ -17966,7 +17973,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 4h high
             & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_50) | (stochrsi_k_4h_lt_90))
             # 15m & 4h down move, 15m still high
-            & ((rsi_3_15m_gt_10) | (rsi_3_4h_gt_10) | (stochrsi_k_15m < 40.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_4h_gt_10) | (stochrsi_k_15m_lt_40))
             # 15m & 4h down move, 4h still high
             & ((rsi_3_15m_gt_10) | (rsi_3_4h_gt_10) | (stochrsi_k_4h_lt_40))
             # 15m & 4h down move, 1h high
@@ -18048,7 +18055,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 4h high & overbought
             & ((rsi_3_15m_gt_20) | aroonu_14_4h_lt_80 | (roc_9_4h_lt_10))
             # 15m & 1h down move, 15m high
-            & ((rsi_3_15m_gt_25) | (rsi_3_1h_gt_25) | (stochrsi_k_15m < 70.0))
+            & ((rsi_3_15m_gt_25) | (rsi_3_1h_gt_25) | (stochrsi_k_15m_lt_70))
             # 15m & 1h down move, 1h downtrend
             & ((rsi_3_15m_gt_25) | (rsi_3_1h_gt_25) | (roc_9_1h > -30.0))
             # 15m & 4h down move, 15m & 4h high
@@ -18204,7 +18211,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h & 1d high
             & ((rsi_3_1h_gt_50) | aroonu_14_1h_lt_80 | aroonu_14_1d_lt_100)
             # 4h & 1d down move, 15m still high
-            & ((rsi_3_4h_gt_3) | (rsi_3_1d_gt_15) | (stochrsi_k_15m < 40.0))
+            & ((rsi_3_4h_gt_3) | (rsi_3_1d_gt_15) | (stochrsi_k_15m_lt_40))
             # 4h & 1d down move, 1h still not low enough
             & ((rsi_3_4h_gt_3) | (rsi_3_1d_gt_15) | (stochrsi_k_1h < 30.0))
             # 4h down move, 4h still high
@@ -18631,7 +18638,7 @@ class NostalgiaForInfinityX7(IStrategy):
             (rsi_3 < 40.0)
             & (rsi_3_15m < 50.0)
             & (aroonu_14_15m_lt_25)
-            & (stochrsi_k_15m < 20.0)
+            & (stochrsi_k_15m_lt_20)
             & (df["EMA_26_15m"] > df["EMA_12_15m"])
             & ((df["EMA_26_15m"] - df["EMA_12_15m"]) > (df["open_15m"] * 0.050))
             & ((df["EMA_26_15m"].shift() - df["EMA_12_15m"].shift()) > (df["open_15m"] / 100.0))
@@ -18891,7 +18898,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # Logic
           long_entry_logic.append(rsi_3 < 50.0)
           long_entry_logic.append(aroonu_14_15m_lt_25)
-          long_entry_logic.append(stochrsi_k_15m < 20.0)
+          long_entry_logic.append(stochrsi_k_15m_lt_20)
           long_entry_logic.append(df["close_15m"] < (df["EMA_20_15m"] * 0.924))
 
         # Condition #46 - Quick mode (Long).
@@ -19165,7 +19172,7 @@ class NostalgiaForInfinityX7(IStrategy):
             & (rsi_3_15m < 50.0)
             & (df["WILLR_14_15m"] < -50.0)
             & (aroonu_14_15m_lt_25)
-            & (stochrsi_k_15m < 20.0)
+            & (stochrsi_k_15m_lt_20)
             & (willr_84_1h < -70.0)
             & (stochrsi_k_1h < 20.0)
             & (bbb_20_2_0_1h > 12.0)
@@ -19322,7 +19329,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 4h still not low enough
             & ((rsi_3_1h_gt_3) | (rsi_3_4h_gt_5) | (stochrsi_k_4h_lt_20))
             # 1h & 4h down move, 15m stil high
-            & ((rsi_3_1h_gt_3) | (rsi_3_4h_gt_10) | (stochrsi_k_15m < 50.0))
+            & ((rsi_3_1h_gt_3) | (rsi_3_4h_gt_10) | (stochrsi_k_15m_lt_50))
             # 1h & 4h down move, 1d still high
             & ((rsi_3_1h_gt_3) | (rsi_3_4h_gt_10) | (stochrsi_k_1d < 40.0))
             # 1h down move, 1h still not low enough
@@ -19410,7 +19417,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 4h & 1d overbought
             & ((rsi_3_1h_gt_60) | (roc_9_4h_lt_30) | (roc_9_1d < 60.0))
             # 4h & 1d down move, 15m still high
-            & ((rsi_3_4h_gt_3) | (rsi_3_1d_gt_15) | (stochrsi_k_15m < 40.0))
+            & ((rsi_3_4h_gt_3) | (rsi_3_1d_gt_15) | (stochrsi_k_15m_lt_40))
             # 4h & 1d down move, 1h still not low enough
             & ((rsi_3_4h_gt_3) | (rsi_3_1d_gt_15) | (stochrsi_k_1h < 30.0))
             # 4h & 1d down move, 1d still not low enough
@@ -19527,9 +19534,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 5m & 4h down move, 1d high
             ((rsi_3_gt_3) | (rsi_3_4h_gt_10) | (aroonu_14_1d_lt_90))
             # 5m & 1d down move, 15m still high
-            & ((rsi_3_gt_3) | (rsi_3_1d_gt_20) | (stochrsi_k_15m < 40.0))
+            & ((rsi_3_gt_3) | (rsi_3_1d_gt_20) | (stochrsi_k_15m_lt_40))
             # 5m & 4h down move, 15m still high
-            & ((rsi_3_gt_5) | (rsi_3_4h_gt_25) | (stochrsi_k_15m < 50.0))
+            & ((rsi_3_gt_5) | (rsi_3_4h_gt_25) | (stochrsi_k_15m_lt_50))
             # 5m & 4h down move, 4h still not low enough
             & ((rsi_3_gt_5) | (rsi_3_4h_gt_15) | (stochrsi_k_4h_lt_20))
             # 15m & 1h down move, 1h still not low enough
@@ -19549,11 +19556,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 1h still not low enough
             & ((rsi_3_15m_gt_5) | (rsi_3_1h_gt_10) | (stochrsi_k_1h < 20.0))
             # 15m & 1h down move, 15m still not low enough
-            & ((rsi_3_15m_gt_5) | (rsi_3_1h_gt_10) | (stochrsi_k_15m < 20.0))
+            & ((rsi_3_15m_gt_5) | (rsi_3_1h_gt_10) | (stochrsi_k_15m_lt_20))
             # 15m & 1h down move, 4h still high
             & ((rsi_3_15m_gt_5) | (rsi_3_1h_gt_10) | (aroonu_14_4h_lt_40))
             # 15m & 4h down move, 15m still not low enough
-            & ((rsi_3_15m_gt_5) | (rsi_3_4h_gt_10) | (stochrsi_k_15m < 30.0))
+            & ((rsi_3_15m_gt_5) | (rsi_3_4h_gt_10) | (stochrsi_k_15m_lt_30))
             # 15m & 4h down move, 1h downtrend
             & ((rsi_3_15m_gt_5) | (rsi_3_4h_gt_10) | (roc_9_1h > -20.0))
             # 15m & 4h down move, 1d overbought
@@ -19611,9 +19618,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 1h & 4h high
             & ((rsi_3_15m_gt_20) | aroonu_14_1h_lt_70 | aroonu_14_4h_lt_100)
             # 15m down move, 15m still not low enough, 1d overbought
-            & ((rsi_3_15m_gt_20) | (stochrsi_k_15m < 30.0) | (roc_9_1d_lt_80))
+            & ((rsi_3_15m_gt_20) | (stochrsi_k_15m_lt_30) | (roc_9_1d_lt_80))
             # 15m & 4h down move, 15m stil high
-            & ((rsi_3_15m_gt_25) | (rsi_3_4h_gt_30) | (stochrsi_k_15m < 40.0))
+            & ((rsi_3_15m_gt_25) | (rsi_3_4h_gt_30) | (stochrsi_k_15m_lt_40))
             # 15m down move, 15m still not low enough, 1d downtrend
             & ((rsi_3_15m_gt_25) | (aroonu_14_15m_lt_25) | roc_9_1d_gt_neg_50)
             # 15m down move, 15m still high, 4h high
@@ -19631,11 +19638,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 4h high
             & ((rsi_3_1h_gt_3) | (rsi_3_4h_gt_50) | aroonu_14_4h_lt_70)
             # 1h down move, 15m still not low enough
-            & ((rsi_3_1h_gt_3) | (stochrsi_k_15m < 20.0))
+            & ((rsi_3_1h_gt_3) | (stochrsi_k_15m_lt_20))
             # 1h down move, 4h still high, 1d downtrend
             & ((rsi_3_1h_gt_3) | (stochrsi_k_4h_lt_50) | (roc_9_1d_gt_neg_20))
             # 1h & 4h down move, 15m still not low enough
-            & ((rsi_3_1h_gt_5) | (rsi_3_4h_gt_5) | (stochrsi_k_15m < 30.0))
+            & ((rsi_3_1h_gt_5) | (rsi_3_4h_gt_5) | (stochrsi_k_15m_lt_30))
             # 1h & 4h down move, 4h still not low enough
             & ((rsi_3_1h_gt_5) | (rsi_3_4h_gt_5) | (stochrsi_k_4h_lt_30))
             # 1h & 4h down move, 4h still not low enough
@@ -19649,7 +19656,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h & 1d down move
             & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_10) | (rsi_3_1d_gt_15))
             # 1h & 4h down move, 15m high
-            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_10) | (stochrsi_k_15m < 60.0))
+            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_10) | (stochrsi_k_15m_lt_60))
             # 1h & 4h down move, 4h still not low enough
             & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_10) | (aroonu_14_4h_lt_30))
             # 1h & 4h down move, 1h downtrend
@@ -19691,7 +19698,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1d high, 4h downtrend
             & ((rsi_3_1h_gt_15) | (aroonu_14_1d_lt_90) | (roc_9_4h > -20.0))
             # 1h & 4h down move, 4h & 1d still not low enough, 15m still not low enough
-            & (rsi_3_1h_gt_20 | (rsi_3_4h_gt_20) | (rsi_14_4h < 30.0) | (rsi_14_1d < 30.0) | (stochrsi_k_15m < 30.0))
+            & (rsi_3_1h_gt_20 | (rsi_3_4h_gt_20) | (rsi_14_4h < 30.0) | (rsi_14_1d < 30.0) | (stochrsi_k_15m_lt_30))
             # 1h & 4h down move, 1d high
             & (rsi_3_1h_gt_20 | (rsi_3_4h_gt_25) | (stochrsi_k_1d < 70.0))
             # 1h & 4h down move, 4h high
@@ -19729,7 +19736,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 4h high & overbought
             & ((rsi_3_1h_gt_25) | aroonu_14_4h_lt_70 | (roc_9_4h_lt_10))
             # 1h down move, 15m still high, 1d overbought
-            & ((rsi_3_1h_gt_25) | (stochrsi_k_15m < 50.0) | (roc_9_1d_lt_30))
+            & ((rsi_3_1h_gt_25) | (stochrsi_k_15m_lt_50) | (roc_9_1d_lt_30))
             # 1h & 4h down move, 4h still high
             & ((rsi_3_1h_gt_30) | (rsi_3_4h_gt_30) | (stochrsi_k_4h_lt_50))
             # 1h & 4h down move, 1d overbought
@@ -19781,7 +19788,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h & 1d down move, 1d still not low enough
             & ((rsi_3_4h_gt_10) | (rsi_3_1d_gt_15) | (aroonu_14_1d_lt_30))
             # 4h down move, 15m still high
-            & ((rsi_3_4h_gt_10) | (stochrsi_k_15m < 40.0))
+            & ((rsi_3_4h_gt_10) | (stochrsi_k_15m_lt_40))
             # 4h down move, 1d still high, 1d downtrend
             & ((rsi_3_4h_gt_15) | (rsi_14_1d < 40.0) | (roc_9_1d > -15.0))
             # 4h down move, 1h downtrend, 1d downtrend
@@ -19791,7 +19798,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 4h still high, 4h downtrend
             & ((rsi_3_4h_gt_15) | (aroonu_14_4h_lt_40) | (roc_9_4h > -20.0))
             # 4h down move, 15m still not low enough, 1d downtrend
-            & ((rsi_3_4h_gt_15) | (stochrsi_k_15m < 30.0) | (roc_9_1d > -20.0))
+            & ((rsi_3_4h_gt_15) | (stochrsi_k_15m_lt_30) | (roc_9_1d > -20.0))
             # 4h down move, 1d high & overbought
             & ((rsi_3_4h_gt_15) | (stochrsi_k_1d_lt_90) | (roc_9_1d_lt_20))
             # 4h & 1d down move, 1d overbought
@@ -19819,7 +19826,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 1h high
             & ((rsi_3_4h_gt_35) | aroonu_14_1h_lt_70)
             # 4h down move, 15m & 4h still high
-            & ((rsi_3_4h_gt_40) | (stochrsi_k_15m < 50.0) | (stochrsi_k_4h_lt_50))
+            & ((rsi_3_4h_gt_40) | (stochrsi_k_15m_lt_50) | (stochrsi_k_4h_lt_50))
             # 4h down move, 1d high & overbought
             & ((rsi_3_4h_gt_40) | (stochrsi_k_1d_lt_90) | (roc_9_1d < 200.0))
             # 4h down move, 4h high
@@ -19865,7 +19872,7 @@ class NostalgiaForInfinityX7(IStrategy):
             (rsi_3 < 40.0)
             & (aroonu_14_lt_30)
             & (stochrsi_k < 20.0)
-            & (stochrsi_k_15m < 70.0)
+            & (stochrsi_k_15m_lt_70)
             & (willr_84_1h < -70.0)
             & (stochrsi_k_1h < 30.0)
             & (bbb_20_2_0_1h > 12.0)
@@ -19949,7 +19956,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 4h & 1d high
             & ((rsi_3_15m_gt_15) | (aroonu_14_4h_lt_75) | aroonu_14_1d_lt_100)
             # 15m down move, 15m still not low enough, 1h still high
-            & ((rsi_3_15m_gt_15) | (stochrsi_k_15m < 30.0) | (stochrsi_k_1h_lt_50))
+            & ((rsi_3_15m_gt_15) | (stochrsi_k_15m_lt_30) | (stochrsi_k_1h_lt_50))
             # 15m down move, 4h & 1d overbought
             & ((rsi_3_15m_gt_15) | (roc_9_4h_lt_20) | (roc_9_1d < 60.0))
             # 15m & 1h down move, 1h high
@@ -19961,7 +19968,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 1d high & overbought
             & ((rsi_3_15m_gt_20) | (aroonu_14_1d_lt_90) | (roc_9_1d_lt_80))
             # 15m down move, 15m high, 4h downtrend
-            & ((rsi_3_15m_gt_20) | (stochrsi_k_15m < 60.0) | (roc_9_4h > -50.0))
+            & ((rsi_3_15m_gt_20) | (stochrsi_k_15m_lt_60) | (roc_9_4h > -50.0))
             # 15m down move, 4h overbought
             & ((rsi_3_15m_gt_20) | (roc_9_4h_lt_40))
             # 15m & 1h down move, 1h high
@@ -20005,7 +20012,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 4h still not low enough
             & ((rsi_3_1h > 2.0) | (rsi_3_4h_gt_15) | (rsi_14_4h < 30.0))
             # 1h & 4h down move, 15m still not low enough
-            & ((rsi_3_1h_gt_3) | (rsi_3_4h_gt_3) | (stochrsi_k_15m < 30.0))
+            & ((rsi_3_1h_gt_3) | (rsi_3_4h_gt_3) | (stochrsi_k_15m_lt_30))
             # 1h & 4h down move, 15m downtrend
             & ((rsi_3_1h_gt_3) | (rsi_3_4h_gt_3) | (roc_9_15m > -30.0))
             # 1h & 4h down move, 4h still high
@@ -20039,7 +20046,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 4h still not low enough
             & ((rsi_3_1h_gt_5) | (rsi_3_4h_gt_15) | (aroonu_14_4h_lt_30))
             # 15m & 4h down move, 4h still not low enough, 15m still not low enough
-            & ((rsi_3_1h_gt_5) | (rsi_3_4h_gt_20) | (aroonu_14_4h_lt_20) | (stochrsi_k_15m < 20.0))
+            & ((rsi_3_1h_gt_5) | (rsi_3_4h_gt_20) | (aroonu_14_4h_lt_20) | (stochrsi_k_15m_lt_20))
             # 1h & 4h down move, 4h still high
             & ((rsi_3_1h_gt_5) | (rsi_3_4h_gt_35) | (rsi_14_4h < 40.0))
             # 1h down move, 1d high, 4h downtrend
@@ -20053,7 +20060,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 4h still not low enough
             & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_10) | (aroonu_14_4h_lt_30))
             # 1h & 4h down move, 15m still high
-            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_10) | (stochrsi_k_15m < 50.0))
+            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_10) | (stochrsi_k_15m_lt_50))
             # 1h & 4h down move, 15m still not low enough
             & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_15) | (aroonu_14_15m_lt_30))
             # 1h & 4h down move, 1h still not low enough
@@ -20225,7 +20232,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 1d high, 4h downtrend
             & ((rsi_3_4h_gt_10) | (aroonu_14_1d_lt_85) | (roc_9_4h > -20.0))
             # 4h down move, 15m high, 15m downtrend
-            & ((rsi_3_4h_gt_10) | (stochrsi_k_15m < 60.0) | (roc_9_15m > -10.0))
+            & ((rsi_3_4h_gt_10) | (stochrsi_k_15m_lt_60) | (roc_9_15m > -10.0))
             # 4h down move, 1h still high, 1d downtrend
             & ((rsi_3_4h_gt_10) | (stochrsi_k_1h < 40.0) | (roc_9_1d > -20.0))
             # 4h down move, 1h high
@@ -20395,7 +20402,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 5m & 4h down move, 1d downtrend
             & ((rsi_3_gt_5) | (rsi_3_4h_gt_10) | (roc_9_1d > -20.0))
             # 5m & 4h down move, 15m still high
-            & ((rsi_3_gt_5) | (rsi_3_4h_gt_25) | (stochrsi_k_15m < 50.0))
+            & ((rsi_3_gt_5) | (rsi_3_4h_gt_25) | (stochrsi_k_15m_lt_50))
             # 5 & 15m down move, 1h high
             & ((rsi_3_gt_10) | (rsi_3_15m_gt_40) | (stochrsi_k_1h < 90.0))
             # 5m down move, 1h & 4h high
@@ -20491,7 +20498,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 1h & 4h high
             & ((rsi_3_15m_gt_10) | (stochrsi_k_1h_lt_70) | (stochrsi_k_4h < 75.0))
             # 15m & 1h down move, 15m still not low enough
-            & ((rsi_3_15m_gt_15) | (rsi_3_1h_gt_15) | (stochrsi_k_15m < 30.0))
+            & ((rsi_3_15m_gt_15) | (rsi_3_1h_gt_15) | (stochrsi_k_15m_lt_30))
             # 15m & 1h down move, 4h high
             & ((rsi_3_15m_gt_15) | rsi_3_1h_gt_20 | (stochrsi_k_4h_lt_90))
             # 15m & 1h down move, 1h still high
@@ -20535,7 +20542,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 15m still not low enough, 4h high
             & ((rsi_3_15m_gt_25) | (aroonu_14_15m_lt_25) | (aroonu_14_4h_lt_60))
             # 15m down move, 15m still not low enough, 1h high
-            & ((rsi_3_15m_gt_25) | (stochrsi_k_15m < 30.0) | aroonu_14_1h_lt_80)
+            & ((rsi_3_15m_gt_25) | (stochrsi_k_15m_lt_30) | aroonu_14_1h_lt_80)
             # 15m & 1h down move, 1h high
             & ((rsi_3_15m_gt_30) | (rsi_3_1h_gt_45) | aroonu_14_1h_lt_70)
             # 1h & 4h down move, 15m downtrend
@@ -20587,7 +20594,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 4h & 1d high
             & ((rsi_3_1h_gt_30) | aroonu_14_4h_lt_80 | aroonu_14_1d_lt_100)
             # 1h down move, 15m high
-            & ((rsi_3_1h_gt_35) | (stochrsi_k_15m < 80.0))
+            & ((rsi_3_1h_gt_35) | (stochrsi_k_15m_lt_80))
             # 1h down move, 1h high, 1d overbought
             & ((rsi_3_1h_gt_35) | aroonu_14_1h_lt_70 | (roc_9_1d_lt_20))
             # 1h down move, 1h & 4h high
@@ -20599,11 +20606,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 4h high
             & ((rsi_3_1h_gt_60) | (aroonu_14_4h_lt_90))
             # 4h down move, 15m still high
-            & ((rsi_3_4h_gt_5) | (stochrsi_k_15m < 40.0))
+            & ((rsi_3_4h_gt_5) | (stochrsi_k_15m_lt_40))
             # 4h down move, 1d still high, 1d downtrend
             & ((rsi_3_4h_gt_10) | (aroonu_14_1d_lt_40) | (roc_9_1d > -20.0))
             # 4h down move, 15m 4h still high
-            & ((rsi_3_4h_gt_10) | (stochrsi_k_15m < 40.0) | (aroonu_14_4h_lt_50))
+            & ((rsi_3_4h_gt_10) | (stochrsi_k_15m_lt_40) | (aroonu_14_4h_lt_50))
             # 4h & 1d down move, 4h high
             & ((rsi_3_4h_gt_15) | (rsi_3_1d_gt_25) | aroonu_14_4h_lt_70)
             # 4h down move, 1h still high
@@ -20718,11 +20725,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 5m & 4h & 1d down move
             & ((rsi_3_gt_3) | rsi_3_4h_gt_20 | (rsi_3_1d_gt_20))
             # 5m & 1d down move, 15m still high
-            & ((rsi_3_gt_3) | (rsi_3_1d_gt_10) | (stochrsi_k_15m < 40.0))
+            & ((rsi_3_gt_3) | (rsi_3_1d_gt_10) | (stochrsi_k_15m_lt_40))
             # 5m down move, 15m high
             & ((rsi_3_gt_3) | (aroonu_14_15m_lt_70))
             # 5m down move, 15m & 1h still high
-            & ((rsi_3_gt_3) | (stochrsi_k_15m < 40.0) | (aroonu_14_1h_lt_40))
+            & ((rsi_3_gt_3) | (stochrsi_k_15m_lt_40) | (aroonu_14_1h_lt_40))
             # 5m down move, 1h high
             & ((rsi_3_gt_3) | aroonu_14_1h_lt_70 | (stochrsi_k_1h < 50.0))
             # 5m & 1h down move, 1h high
@@ -20734,7 +20741,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 5m down move, 15m still high, 1h high
             & ((rsi_3_gt_5) | (aroonu_14_15m_lt_40) | (stochrsi_k_1h_lt_50))
             # 5m down move, 15m & 4h high
-            & ((rsi_3_gt_5) | (stochrsi_k_15m < 70.0) | (stochrsi_k_4h_lt_90))
+            & ((rsi_3_gt_5) | (stochrsi_k_15m_lt_70) | (stochrsi_k_4h_lt_90))
             # 5m & 15m down move, 4h high
             & ((rsi_3_gt_10) | (rsi_3_15m_gt_20) | (aroonu_14_4h_lt_90))
             # 5m & 15m down move, 1d high
@@ -20770,7 +20777,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 4h down move, 4h still not low enough
             & ((rsi_3_15m_gt_10) | (rsi_3_4h_gt_15) | (aroonu_14_4h_lt_30))
             # 15m& 4h down move, 15m still high
-            & ((rsi_3_15m_gt_10) | (rsi_3_4h_gt_15) | (stochrsi_k_15m < 40.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_4h_gt_15) | (stochrsi_k_15m_lt_40))
             # 15m & 4h down move, 15m still high
             & ((rsi_3_15m_gt_10) | rsi_3_4h_gt_20 | (aroonu_14_15m_lt_50))
             # 15m & 4h down move, 4h still not low enough
@@ -20806,7 +20813,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 4h high
             & ((rsi_3_15m_gt_15) | (rsi_3_1h_gt_45) | (aroonu_14_4h_lt_80))
             # 15m & 1h down move, 15m still not low enough
-            & ((rsi_3_15m_gt_15) | (rsi_3_1h_gt_45) | (stochrsi_k_15m < 50.0))
+            & ((rsi_3_15m_gt_15) | (rsi_3_1h_gt_45) | (stochrsi_k_15m_lt_50))
             # 15m & 4h & 1d down move
             & ((rsi_3_15m_gt_15) | (rsi_3_4h_gt_15) | (rsi_3_1d_gt_15))
             # 15m & 4h down move, 4h still high
@@ -20826,7 +20833,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 15m & 4h still high
             & ((rsi_3_15m_gt_15) | (aroonu_14_15m_lt_50) | (aroonu_14_4h_lt_50))
             # 15m down move, 15m still high, 1h high
-            & ((rsi_3_15m_gt_15) | (stochrsi_k_15m < 40.0) | (stochrsi_k_1h_lt_70))
+            & ((rsi_3_15m_gt_15) | (stochrsi_k_15m_lt_40) | (stochrsi_k_1h_lt_70))
             # 15m down move, 1h still high, 4h high
             & ((rsi_3_15m_gt_15) | (stochrsi_k_1h_lt_50) | (stochrsi_k_4h_lt_60))
             # 15m down move, 4h still high 1d overbought
@@ -20852,7 +20859,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 15m still high, 4d downtrend
             & ((rsi_3_15m_gt_20) | (aroonu_14_15m_lt_40) | (roc_9_4h_gt_neg_20))
             # 15m down move, 15m still not low enough, 1h still high
-            & ((rsi_3_15m_gt_20) | (stochrsi_k_15m < 30.0) | (aroonu_14_1h_lt_50))
+            & ((rsi_3_15m_gt_20) | (stochrsi_k_15m_lt_30) | (aroonu_14_1h_lt_50))
             # 15m down move, 15m & 1h still high
             & ((rsi_3_15m_gt_20) | (aroonu_14_15m_lt_50) | (stochrsi_k_1h < 40.0))
             # 15m down move, 1h & 4h high
@@ -20890,7 +20897,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 15m high, 4h still high
             & ((rsi_3_15m_gt_30) | (aroonu_14_15m_lt_70) | (aroonu_14_4h_lt_50))
             # 15m down move, 15m still not low enough, 1h high
-            & ((rsi_3_15m_gt_30) | (stochrsi_k_15m < 30.0) | (stochrsi_k_1h_lt_80))
+            & ((rsi_3_15m_gt_30) | (stochrsi_k_15m_lt_30) | (stochrsi_k_1h_lt_80))
             # 15m down move, 15m still high, 1d high, 1d downtrend
             & ((rsi_3_15m_gt_30) | (aroonu_14_15m_lt_50) | (stochrsi_k_1d < 70.0) | (roc_9_1d > -15.0))
             # 15m down move, 1h still high, 4h high
@@ -20954,9 +20961,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 4h still not low enough, 1d overbought
             & ((rsi_3_4h_gt_15) | (aroonu_14_4h_lt_30) | (roc_9_1d < 100.0))
             # 4h down move, 15m still high, 1d downtrend
-            & ((rsi_3_4h_gt_15) | (stochrsi_k_15m < 50.0) | (roc_9_1d > -20.0))
+            & ((rsi_3_4h_gt_15) | (stochrsi_k_15m_lt_50) | (roc_9_1d > -20.0))
             # 4h & 1d down move, 15m still not low enough
-            & (rsi_3_4h_gt_20 | (rsi_3_1d_gt_20) | (stochrsi_k_15m < 30.0))
+            & (rsi_3_4h_gt_20 | (rsi_3_1d_gt_20) | (stochrsi_k_15m_lt_30))
             # 4h down move, 4h still not low enough, 1d downtrend
             & (rsi_3_4h_gt_20 | (stochrsi_k_4h_lt_30) | (roc_9_1d_gt_neg_20))
             # 4h down move, 1d high, 4h downtrend
@@ -20970,7 +20977,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 4h high, 1d downtrend
             & ((rsi_3_4h_gt_60) | (stochrsi_k_4h_lt_80) | (roc_9_1d_gt_neg_20))
             # 4h down move, 15m high, 4h overbought
-            & ((rsi_3_4h_gt_60) | (stochrsi_k_15m < 80.0) | (roc_9_4h_lt_20))
+            & ((rsi_3_4h_gt_60) | (stochrsi_k_15m_lt_80) | (roc_9_4h_lt_20))
             # 4h down move, 4h & 1d overbought
             & ((rsi_3_4h_gt_60) | (roc_9_4h_lt_20) | (roc_9_1d_lt_20))
             # 1d down move, 1h & 4h still not low enough
@@ -20990,7 +20997,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1d high, 1d overbought
             & ((aroonu_14_15m_lt_70) | (aroonu_14_1d_lt_90) | (roc_9_1d_lt_100))
             # 15m high
-            & ((aroonu_14_15m_lt_80) | (stochrsi_k_15m < 60.0))
+            & ((aroonu_14_15m_lt_80) | (stochrsi_k_15m_lt_60))
             # 15m & 4h high
             & ((aroonu_14_15m_lt_80) | (stochrsi_k_4h_lt_70))
             # 15m high, 1d overbought
@@ -21072,7 +21079,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m & 1h down move, 15m high
           long_entry_logic.append((rsi_3_15m_gt_20) | (rsi_3_1h_gt_45) | (aroonu_14_15m_lt_70))
           # 15m & 4h down move, 15m still high
-          long_entry_logic.append((rsi_3_15m_gt_20) | rsi_3_4h_gt_20 | (stochrsi_k_15m < 50.0))
+          long_entry_logic.append((rsi_3_15m_gt_20) | rsi_3_4h_gt_20 | (stochrsi_k_15m_lt_50))
           # 15m down move, 15m still high, 1h high
           long_entry_logic.append((rsi_3_15m_gt_20) | (rsi_14_15m < 40.0) | (stochrsi_k_1h_lt_70))
           # 15m down move, 15m still high, 4h high
@@ -21084,7 +21091,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m down move, 15m high, 4h still high
           long_entry_logic.append((rsi_3_15m_gt_20) | (aroonu_14_15m_lt_70) | (aroonu_14_4h_lt_50))
           # 15m down move, 15m & 1h still high
-          long_entry_logic.append((rsi_3_15m_gt_20) | (stochrsi_k_15m < 50.0) | (stochrsi_k_1h_lt_50))
+          long_entry_logic.append((rsi_3_15m_gt_20) | (stochrsi_k_15m_lt_50) | (stochrsi_k_1h_lt_50))
           # 15m down move, 4h overbought
           long_entry_logic.append((rsi_3_15m_gt_20) | (roc_9_4h < 70.0))
           # 15m down move, 15m still high, 1h high
@@ -21112,7 +21119,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1h & 4h down move, 1h still high
           long_entry_logic.append((rsi_3_1h_gt_10) | rsi_3_4h_gt_20 | (aroonu_14_1h_lt_40))
           # 1h & 4h down move, 15m still not low enough
-          long_entry_logic.append((rsi_3_1h_gt_10) | rsi_3_4h_gt_20 | (stochrsi_k_15m < 20.0))
+          long_entry_logic.append((rsi_3_1h_gt_10) | rsi_3_4h_gt_20 | (stochrsi_k_15m_lt_20))
           # 1h down move, 1d high & overbought
           long_entry_logic.append((rsi_3_1h_gt_10) | (aroonu_14_1d_lt_90) | (roc_9_1d < 10.0))
           # 1h & 4h down move, 4h still high
@@ -21154,9 +21161,9 @@ class NostalgiaForInfinityX7(IStrategy):
           # 4h down move, 4h still high, 1d downtrend
           long_entry_logic.append(rsi_3_4h_gt_20 | (aroonu_14_4h_lt_50) | (roc_9_1d_gt_neg_40))
           # 1h down move, 15m & 1h still high
-          long_entry_logic.append(rsi_3_4h_gt_20 | (stochrsi_k_15m < 40.0) | (stochrsi_k_1h_lt_50))
+          long_entry_logic.append(rsi_3_4h_gt_20 | (stochrsi_k_15m_lt_40) | (stochrsi_k_1h_lt_50))
           # 4h down move, 15m still high, 4h high
-          long_entry_logic.append((rsi_3_4h_gt_25) | (stochrsi_k_15m < 50.0) | aroonu_14_4h_lt_70)
+          long_entry_logic.append((rsi_3_4h_gt_25) | (stochrsi_k_15m_lt_50) | aroonu_14_4h_lt_70)
           # 4h down move, 15m still not low enough, 4h high
           long_entry_logic.append((rsi_3_4h_gt_35) | (aroonu_14_15m_lt_30) | aroonu_14_4h_lt_70)
           # 4h down move, 1h high, 4h downtrend
@@ -21206,9 +21213,9 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1d high, 4h & 1d overbought
           long_entry_logic.append(aroonu_14_1d_lt_100 | (roc_9_4h_lt_10) | roc_9_1d_lt_50)
           # 15m still high, 1h high
-          long_entry_logic.append((stochrsi_k_15m < 40.0) | (aroonu_14_1h_lt_90) | (stochrsi_k_1h < 90.0))
+          long_entry_logic.append((stochrsi_k_15m_lt_40) | (aroonu_14_1h_lt_90) | (stochrsi_k_1h < 90.0))
           # 15m still high, 1d high
-          long_entry_logic.append((stochrsi_k_15m < 50.0) | (stochrsi_k_1d_lt_90))
+          long_entry_logic.append((stochrsi_k_15m_lt_50) | (stochrsi_k_1d_lt_90))
           # 4h high, 4h & 1d overbought
           long_entry_logic.append((stochrsi_k_4h_lt_80) | (roc_9_4h_lt_40) | (roc_9_1d_lt_100))
           # 1d green, 4h down move, 4h still high
@@ -21304,7 +21311,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m & 4h down move, 1d downtrend
           long_entry_logic.append((rsi_3_15m_gt_10) | rsi_3_4h_gt_20 | (roc_9_1d > -25.0))
           # 15m & 4h down move, 15m still not low enough
-          long_entry_logic.append((rsi_3_15m_gt_10) | (rsi_3_4h_gt_25) | (stochrsi_k_15m < 20.0))
+          long_entry_logic.append((rsi_3_15m_gt_10) | (rsi_3_4h_gt_25) | (stochrsi_k_15m_lt_20))
           # 15m & 4h down move, 4h high
           long_entry_logic.append((rsi_3_15m_gt_10) | (rsi_3_4h_gt_40) | aroonu_14_4h_lt_80)
           # 15m & 1h down move, 4h still high
@@ -21320,13 +21327,13 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m down move, 1d high, 4h overbought
           long_entry_logic.append((rsi_3_15m_gt_15) | aroonu_14_1d_lt_100 | (roc_9_4h < 50.0))
           # 15m & 3h down move, 15m still not low enough
-          long_entry_logic.append((rsi_3_15m_gt_20) | rsi_3_4h_gt_20 | (stochrsi_k_15m < 20.0))
+          long_entry_logic.append((rsi_3_15m_gt_20) | rsi_3_4h_gt_20 | (stochrsi_k_15m_lt_20))
           # 15m & 1h down move, 1h still high
           long_entry_logic.append((rsi_3_15m_gt_25) | (rsi_3_1h_gt_25) | (rsi_14_1h < 40.0))
           # 15m & 4h down move, 4h high
           long_entry_logic.append((rsi_3_15m_gt_25) | (rsi_3_4h_gt_25) | aroonu_14_4h_lt_70)
           # 15m down move, 15m still not low enough, 1d overbought
-          long_entry_logic.append((rsi_3_15m_gt_25) | (stochrsi_k_15m < 20.0) | (roc_9_1d_lt_80))
+          long_entry_logic.append((rsi_3_15m_gt_25) | (stochrsi_k_15m_lt_20) | (roc_9_1d_lt_80))
           # 1h & 4h down move
           long_entry_logic.append((rsi_3_1h_gt_3) | (rsi_3_4h_gt_10))
           # 1h & 4h down move, 4h still not low enough
@@ -21404,7 +21411,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1h down move, 4h high & overbought
           long_entry_logic.append((rsi_3_1h_gt_50) | (stochrsi_k_4h_lt_80) | (roc_9_4h_lt_20))
           # 4h down move, 15m not low enough, 1h still high
-          long_entry_logic.append((rsi_3_4h_gt_3) | (stochrsi_k_15m < 20.0) | (stochrsi_k_1h < 40.0))
+          long_entry_logic.append((rsi_3_4h_gt_3) | (stochrsi_k_15m_lt_20) | (stochrsi_k_1h < 40.0))
           # 4h & 1d down move, 4h downtrend
           long_entry_logic.append((rsi_3_4h_gt_5) | (rsi_3_1d_gt_20) | (roc_9_4h_gt_neg_20))
           # 4h & 1d down move, 1d high
@@ -21479,7 +21486,7 @@ class NostalgiaForInfinityX7(IStrategy):
           long_entry_logic.append(aroonu_14_lt_25)
           long_entry_logic.append(stochrsi_k < 20.0)
           long_entry_logic.append(aroonu_14_15m_lt_25)
-          long_entry_logic.append(stochrsi_k_15m < 30.0)
+          long_entry_logic.append(stochrsi_k_15m_lt_30)
           long_entry_logic.append(close < df["EMA_16"] * 0.975)
           long_entry_logic.append(((df["EMA_50"] - df["EMA_200"]) / close * 100.0) < -5.5)
 
@@ -21528,15 +21535,15 @@ class NostalgiaForInfinityX7(IStrategy):
             # 5m & 4h down move, 15m still high
             & ((rsi_3_gt_3) | (rsi_3_4h_gt_5) | (aroonu_14_15m_lt_40))
             # 5m & 4h down move, 15m still high
-            & ((rsi_3_gt_3) | (rsi_3_4h_gt_5) | (stochrsi_k_15m < 40.0))
+            & ((rsi_3_gt_3) | (rsi_3_4h_gt_5) | (stochrsi_k_15m_lt_40))
             # 5m & 4h down move, 15m still high
-            & ((rsi_3_gt_3) | rsi_3_4h_gt_20 | (stochrsi_k_15m < 50.0))
+            & ((rsi_3_gt_3) | rsi_3_4h_gt_20 | (stochrsi_k_15m_lt_50))
             # 5m & 4h down move, 1h high
             & ((rsi_3_gt_3) | (rsi_3_4h_gt_45) | (stochrsi_k_1h_lt_80))
             # 5m & 1d down move, 15m high
             & ((rsi_3_gt_3) | (rsi_3_1d_gt_10) | (aroonu_14_15m_lt_70))
             # 5m & 1d down move, 15m stil high
-            & ((rsi_3_gt_3) | (rsi_3_1d_gt_10) | (stochrsi_k_15m < 40.0))
+            & ((rsi_3_gt_3) | (rsi_3_1d_gt_10) | (stochrsi_k_15m_lt_40))
             # 5m & 1d down move, 4h still high
             & ((rsi_3_gt_3) | (rsi_3_1d_gt_10) | (stochrsi_k_4h_lt_40))
             # 5m down move, 1h high
@@ -21602,7 +21609,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 1d high
             & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_10) | (aroonu_14_1d_lt_85))
             # 15m & 1h down move, 15m still high
-            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_15) | (stochrsi_k_15m < 50.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_15) | (stochrsi_k_15m_lt_50))
             # 15m & 1h down move, 1h still high
             & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_15) | (stochrsi_k_1h < 50.0))
             # 15m & 1h down move, 1d still high
@@ -21706,7 +21713,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h & 4h down move, 4h high
             & ((rsi_3_15m_gt_25) | (rsi_3_1h_gt_30) | (rsi_3_4h_gt_50) | (aroonu_14_4h_lt_70))
             # 15m & 4h down move, 15m high
-            & ((rsi_3_15m_gt_25) | (rsi_3_4h_gt_30) | (stochrsi_k_15m < 70.0))
+            & ((rsi_3_15m_gt_25) | (rsi_3_4h_gt_30) | (stochrsi_k_15m_lt_70))
             # 15m down move, 15m & 1h high
             & ((rsi_3_15m_gt_25) | (aroonu_14_15m_lt_70) | (aroonu_14_1h_lt_100))
             # 15m & 4h down mve, 1h high
@@ -21730,15 +21737,15 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 1d down move, 1d still high
             & ((rsi_3_1h_gt_3) | (rsi_3_1d_gt_25) | (stochrsi_k_1d < 40.0))
             # 1h & 4h down move, 15m still not low enough
-            & ((rsi_3_1h_gt_5) | (rsi_3_4h_gt_5) | (stochrsi_k_15m < 20.0))
+            & ((rsi_3_1h_gt_5) | (rsi_3_4h_gt_5) | (stochrsi_k_15m_lt_20))
             # 1h & 4h down move, 4h downtrend
             & ((rsi_3_1h_gt_5) | (rsi_3_4h_gt_10) | (roc_9_4h > -10.0))
             # 1h & 4h down move, 15m high
-            & ((rsi_3_1h_gt_5) | (rsi_3_4h_gt_25) | (stochrsi_k_15m < 60.0))
+            & ((rsi_3_1h_gt_5) | (rsi_3_4h_gt_25) | (stochrsi_k_15m_lt_60))
             # 1h & 4h down move, 1d still high
             & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_10) | (aroonu_14_1d_lt_50))
             # 1h & 4h down move, 15m still high
-            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_10) | (stochrsi_k_15m < 70.0))
+            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_10) | (stochrsi_k_15m_lt_70))
             # 1h & 4h down move, 4h still not low enough
             & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_15) | (aroonu_14_4h_lt_30))
             # 1h & 4h down move, 4h still high
@@ -21792,7 +21799,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h high, 1d overbought
             & (rsi_3_1h_gt_20 | (aroonu_14_1h_lt_60) | (roc_9_1d < 10.0))
             # 1h & 4h down move, 15m high
-            & ((rsi_3_1h_gt_25) | (rsi_3_4h_gt_25) | (stochrsi_k_15m < 70.0))
+            & ((rsi_3_1h_gt_25) | (rsi_3_4h_gt_25) | (stochrsi_k_15m_lt_70))
             # 1h & 4h down move, 1h high
             & ((rsi_3_1h_gt_25) | (rsi_3_4h_gt_30) | aroonu_14_1h_lt_80)
             # 1h & 4h down move, 4h high
@@ -21850,11 +21857,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 4h still high, 4h downtrend
             & ((rsi_3_4h_gt_10) | (aroonu_14_4h_lt_40) | (roc_9_4h > -20.0))
             # 4h down move, 15m high
-            & ((rsi_3_4h_gt_10) | (stochrsi_k_15m < 80.0))
+            & ((rsi_3_4h_gt_10) | (stochrsi_k_15m_lt_80))
             # 4h down move, 1h still not low enough, 4h downtrend
             & ((rsi_3_4h_gt_10) | (stochrsi_k_1h < 20.0) | (roc_9_4h > -20.0))
             # 4h & 1d down move, 15m still high
-            & ((rsi_3_4h_gt_15) | (rsi_3_1d_gt_15) | (stochrsi_k_15m < 50.0))
+            & ((rsi_3_4h_gt_15) | (rsi_3_1d_gt_15) | (stochrsi_k_15m_lt_50))
             # 4h & 1d down move, 1h still high
             & ((rsi_3_4h_gt_15) | (rsi_3_1d_gt_15) | (stochrsi_k_1h < 40.0))
             # 4h & 1d down move, 1d high
@@ -22007,7 +22014,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1d down move, 1d still high
             & ((rsi_3_15m_gt_5) | (rsi_3_1h_gt_5) | (aroonu_14_1d_lt_40))
             # 15m & 1h down move, 15m still not low enough
-            & ((rsi_3_15m_gt_5) | (rsi_3_1h_gt_5) | (stochrsi_k_15m < 30.0))
+            & ((rsi_3_15m_gt_5) | (rsi_3_1h_gt_5) | (stochrsi_k_15m_lt_30))
             # 15m & 1h down move, 4h still high
             & ((rsi_3_15m_gt_5) | (rsi_3_1h_gt_10) | (stochrsi_k_4h_lt_50))
             # 15m & 4h down move, 1d high
@@ -22117,7 +22124,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 4h down move, 15m high
             & ((rsi_3_15m_gt_20) | (rsi_3_4h_gt_20) | (aroonu_14_15m_lt_70))
             # 15m & 4h down move, 15m still high
-            & ((rsi_3_15m_gt_20) | (rsi_3_4h_gt_20) | (stochrsi_k_15m < 50.0))
+            & ((rsi_3_15m_gt_20) | (rsi_3_4h_gt_20) | (stochrsi_k_15m_lt_50))
             # 15m down move, 15m & 1h high
             & ((rsi_3_15m_gt_20) | (aroonu_14_15m_lt_70) | (aroonu_14_1h_lt_100))
             # 15m down move, 15m high, 1d high
@@ -22153,13 +22160,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h & 1d down move
             & ((rsi_3_1h_gt_5) | rsi_3_4h_gt_20 | (rsi_3_1d_gt_25))
             # 1h & 4h down move, 15m high
-            & ((rsi_3_1h_gt_5) | (rsi_3_4h_gt_25) | (stochrsi_k_15m < 60.0))
+            & ((rsi_3_1h_gt_5) | (rsi_3_4h_gt_25) | (stochrsi_k_15m_lt_60))
             # 1h & 4h & 1d down move
             & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_10) | (rsi_3_1d_gt_15))
             # 1h & 4h down move, 1d still not low enough
             & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_10) | (stochrsi_k_1d < 20.0))
             # 1h & 4h down move, 15m still high
-            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_15) | (stochrsi_k_15m < 50.0))
+            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_15) | (stochrsi_k_15m_lt_50))
             # 1h & 4h down move, 1h still not low enough
             & ((rsi_3_1h_gt_10) | rsi_3_4h_gt_20 | (aroonu_14_1h_lt_30))
             # 1h & 4h down move, 1d overbought
@@ -22175,7 +22182,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 1h still not low enough
             & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_15) | (stochrsi_k_1h < 30.0))
             # 1h & 4h down move, 15m still not low enough
-            & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_15) | (stochrsi_k_15m < 30.0))
+            & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_15) | (stochrsi_k_15m_lt_30))
             # 1h & 4h down move, 4h still high
             & ((rsi_3_1h_gt_15) | rsi_3_4h_gt_20 | (stochrsi_k_4h_lt_40))
             # 1h & 1d down move, 1d still high
@@ -22205,7 +22212,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 4h high & overbought, 1d downtrend
             & ((rsi_3_1h_gt_20) | (stochrsi_k_4h_lt_80) | (roc_9_4h_lt_10) | (roc_9_1d_gt_neg_20))
             # 1h & 4h down move, 15m high
-            & ((rsi_3_1h_gt_25) | (rsi_3_4h_gt_25) | (stochrsi_k_15m < 70.0))
+            & ((rsi_3_1h_gt_25) | (rsi_3_4h_gt_25) | (stochrsi_k_15m_lt_70))
             # 1h & 4h down move, 4h high
             & ((rsi_3_1h_gt_25) | (rsi_3_4h_gt_30) | (aroonu_14_4h_lt_60))
             # 1h down move, 4h & 1d overbought
@@ -22251,9 +22258,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 1d still high, 1d downtrend
             & ((rsi_3_4h_gt_10) | (aroonu_14_1d_lt_50) | (roc_9_1d > -30.0))
             # 4h down move, 15m high
-            & ((rsi_3_4h_gt_10) | (stochrsi_k_15m < 80.0))
+            & ((rsi_3_4h_gt_10) | (stochrsi_k_15m_lt_80))
             # 4h down move, 15m still high, 1d downtrend
-            & ((rsi_3_4h_gt_10) | (stochrsi_k_15m < 50.0) | (roc_9_1d > -30.0))
+            & ((rsi_3_4h_gt_10) | (stochrsi_k_15m_lt_50) | (roc_9_1d > -30.0))
             # 4h down move, 1h still high, 1d downtrend
             & ((rsi_3_4h_gt_10) | (stochrsi_k_1h < 50.0) | (roc_9_1d > -30.0))
             # 4h down move, 1h high, 4h downtrend
@@ -22267,7 +22274,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h & 1d down move, 4h high
             & ((rsi_3_4h_gt_15) | (rsi_3_1d_gt_25) | aroonu_14_4h_lt_70)
             # 4h & 1d down move, 15m high
-            & ((rsi_3_4h_gt_15) | (rsi_3_1d_gt_30) | (stochrsi_k_15m < 80.0))
+            & ((rsi_3_4h_gt_15) | (rsi_3_1d_gt_30) | (stochrsi_k_15m_lt_80))
             # 4h & 1d down move, 4h still high
             & ((rsi_3_4h_gt_15) | (rsi_3_1d > 50.0) | (stochrsi_k_4h_lt_40))
             # 4h down move, 1d still high, 4h still not low enough
@@ -22373,7 +22380,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1d high, 4h & 1d overbought
             & (aroonu_14_1d_lt_100 | (roc_9_4h < 60.0) | (roc_9_1d < 100.0))
             # 15m high, 4h & 1d overbought
-            & ((stochrsi_k_15m < 70.0) | (roc_9_4h_lt_20) | (roc_9_1d_lt_20))
+            & ((stochrsi_k_15m_lt_70) | (roc_9_4h_lt_20) | (roc_9_1d_lt_20))
             # 1h high, 1h & 1d overbought
             & ((stochrsi_k_1h < 80.0) | (roc_9_1h < 20.0) | (roc_9_1d_lt_100))
             # 4h high, 4h overbought, 1d downtrend
@@ -22512,7 +22519,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 1d still not low enough
             & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_10) | (stochrsi_k_1d < 20.0))
             # 1h & 4h down move, 15m still not low enough
-            & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_3) | (stochrsi_k_15m < 30.0))
+            & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_3) | (stochrsi_k_15m_lt_30))
             # 1h & 4h down move, 4h high
             & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_15) | (aroonu_14_4h_lt_60))
             # 1h down move, 1h still not low enough, 1d overbought
@@ -22560,7 +22567,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h & 1d down move, 1d high
             & ((rsi_3_4h_gt_10) | (rsi_3_1d_gt_15) | (aroonu_14_1d_lt_70))
             # 4h & 1d down move, 15m still high
-            & ((rsi_3_4h_gt_10) | (rsi_3_1d_gt_20) | (stochrsi_k_15m < 40.0))
+            & ((rsi_3_4h_gt_10) | (rsi_3_1d_gt_20) | (stochrsi_k_15m_lt_40))
             # 4h down move, 1d high & overbought
             & ((rsi_3_4h_gt_10) | (aroonu_14_1d_lt_100) | (roc_9_1d < 10.0))
             # 4h down move, 1h high, 1d downtrend
@@ -22667,7 +22674,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 4h high, 1d overbought
             & ((rsi_3_15m_gt_10) | (aroonu_14_4h_lt_80) | (roc_9_1d_lt_50))
             # 15m & 1h down move, 15m still high
-            & ((rsi_3_15m_gt_15) | (rsi_3_1h_gt_15) | (stochrsi_k_15m < 50.0))
+            & ((rsi_3_15m_gt_15) | (rsi_3_1h_gt_15) | (stochrsi_k_15m_lt_50))
             # 15m & 1h down move, 1d overbought
             & ((rsi_3_15m_gt_15) | (rsi_3_1h_gt_20) | (roc_9_1d_lt_30))
             # 15m & 1h down move, 4h high
@@ -22685,7 +22692,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 4h high, 1d downtrend
             & ((rsi_3_15m_gt_25) | (stochrsi_k_4h_lt_80) | (roc_9_1d_gt_neg_30))
             # 15m & 1h down move, 15m high
-            & ((rsi_3_15m_gt_45) | (rsi_3_1h_gt_45) | (stochrsi_k_15m < 70.0))
+            & ((rsi_3_15m_gt_45) | (rsi_3_1h_gt_45) | (stochrsi_k_15m_lt_70))
             # 15m down move, 4h high, 1d overbought
             & ((rsi_3_15m_gt_10) | aroonu_14_4h_lt_70 | (roc_9_1d_lt_100))
             # 15m & 4h down move, 1d downtrend
@@ -22713,9 +22720,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 4h still high
             & ((rsi_3_1h_gt_3) | rsi_3_4h_gt_20 | (stochrsi_k_4h_lt_40))
             # 1h & 4h down move, 15m still high
-            & ((rsi_3_1h_gt_3) | (rsi_3_4h_gt_30) | (stochrsi_k_15m < 50.0))
+            & ((rsi_3_1h_gt_3) | (rsi_3_4h_gt_30) | (stochrsi_k_15m_lt_50))
             # 1h & 4h down move, 15m still not low enough
-            & ((rsi_3_1h_gt_5) | (rsi_3_4h_gt_5) | (stochrsi_k_15m < 20.0))
+            & ((rsi_3_1h_gt_5) | (rsi_3_4h_gt_5) | (stochrsi_k_15m_lt_20))
             # 1h & 4h down move, 1d still high
             & ((rsi_3_1h_gt_5) | rsi_3_4h_gt_20 | (aroonu_14_1d_lt_50))
             # 1h & 4h down move, 4h still not low enough
@@ -22729,7 +22736,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 4h still not low enough
             & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_15) | (stochrsi_k_4h_lt_30))
             # 1h & 4h down move, 15m still high
-            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_15) | (stochrsi_k_15m < 50.0))
+            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_15) | (stochrsi_k_15m_lt_50))
             # 1h & 4h down move, 1d downtrend
             & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_15) | (roc_9_1d > -20.0))
             # 1h & 4h down move, 4h still high
@@ -22741,7 +22748,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1d high, 1h downtrend
             & ((rsi_3_1h_gt_10) | (aroonu_14_1d_lt_70) | (roc_9_1h > -10.0))
             # 1h & 4h down move, 15m still not low enough
-            & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_3) | (stochrsi_k_15m < 30.0))
+            & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_3) | (stochrsi_k_15m_lt_30))
             # 1h & 4h down move, 1h high
             & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_25) | (aroonu_14_1h_lt_70))
             # 1h & 4h down move, 4h high
@@ -22783,7 +22790,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 4h high & overbought, 1d downtrend
             & ((rsi_3_1h_gt_20) | (stochrsi_k_4h_lt_80) | (roc_9_4h_lt_10) | (roc_9_1d_gt_neg_20))
             # 1h & 4h down move, 15m high
-            & ((rsi_3_1h_gt_25) | (rsi_3_4h_gt_25) | (stochrsi_k_15m < 70.0))
+            & ((rsi_3_1h_gt_25) | (rsi_3_4h_gt_25) | (stochrsi_k_15m_lt_70))
             # 1h & 4h down move, 4h still not low enough
             & ((rsi_3_1h_gt_25) | (rsi_3_4h_gt_25) | (stochrsi_k_4h_lt_30))
             # 1h & 4h down move, 1d overbought
@@ -22803,7 +22810,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 4h high, 1h overbought
             & ((rsi_3_1h_gt_40) | aroonu_14_4h_lt_80 | (roc_9_1h_lt_10))
             # 1h down move, 1h high, 15m high
-            & ((rsi_3_1h_gt_50) | aroonu_14_1h_lt_70 | (stochrsi_k_15m < 70.0))
+            & ((rsi_3_1h_gt_50) | aroonu_14_1h_lt_70 | (stochrsi_k_15m_lt_70))
             # 4h & 1d down move, 15m still not low enough
             & ((rsi_3_4h_gt_3) | (rsi_3_1d_gt_15) | (aroonu_14_15m_lt_20))
             # 4h & 1d down move, 1d still high
@@ -22811,11 +22818,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h & 1d down move, 1d high
             & ((rsi_3_4h_gt_3) | (rsi_3_1d_gt_25) | (aroonu_14_1d_lt_70))
             # 4h down move, 15m high
-            & ((rsi_3_4h_gt_3) | (stochrsi_k_15m < 60.0))
+            & ((rsi_3_4h_gt_3) | (stochrsi_k_15m_lt_60))
             # 4h down move, 15m still high, 4h still not low enough
-            & ((rsi_3_4h_gt_5) | (stochrsi_k_15m < 50.0) | (aroonu_14_4h_lt_30))
+            & ((rsi_3_4h_gt_5) | (stochrsi_k_15m_lt_50) | (aroonu_14_4h_lt_30))
             # 4h & 1d down move, 15m still high
-            & ((rsi_3_4h_gt_10) | (rsi_3_1d_gt_15) | (stochrsi_k_15m < 40.0))
+            & ((rsi_3_4h_gt_10) | (rsi_3_1d_gt_15) | (stochrsi_k_15m_lt_40))
             # 4h down move, 4h still not low enough, 1d downtrend
             & ((rsi_3_4h_gt_10) | (aroonu_14_4h_lt_20) | (roc_9_1d > -10.0))
             # 4h down move, 4h still high, 4h downtrend
@@ -22823,7 +22830,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 1d still high, 1d downtrend
             & ((rsi_3_4h_gt_10) | (aroonu_14_1d_lt_40) | (roc_9_1d > -30.0))
             # 4h down move, 1d high, 15m high
-            & ((rsi_3_4h_gt_10) | (aroonu_14_1d_lt_80) | (stochrsi_k_15m < 60.0))
+            & ((rsi_3_4h_gt_10) | (aroonu_14_1d_lt_80) | (stochrsi_k_15m_lt_60))
             # 4h down move, 1d high, 4h downtrend
             & ((rsi_3_4h_gt_10) | (aroonu_14_1d_lt_100) | (roc_9_4h > -10.0))
             # 4h down move, 4h & 1d downtrend
@@ -22839,7 +22846,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 1d high & overbought
             & ((rsi_3_4h_gt_15) | (aroonu_14_1d_lt_100) | (roc_9_1d_lt_30))
             # 4h down move, 15m high
-            & ((rsi_3_4h_gt_15) | (stochrsi_k_15m < 70.0))
+            & ((rsi_3_4h_gt_15) | (stochrsi_k_15m_lt_70))
             # 4h & 1d down move, 1d downtrend
             & (rsi_3_4h_gt_20 | (rsi_3_1d_gt_25) | (roc_9_1d_gt_neg_30))
             # 4h down move, 1d high & overbought
@@ -22879,9 +22886,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h high, 4h & 1d overbought
             & ((aroonu_14_4h_lt_90) | (roc_9_4h_lt_30) | (roc_9_1d < 60.0))
             # 15m high, 4h & 1d overbought
-            & ((stochrsi_k_15m < 80.0) | (roc_9_4h_lt_20) | (roc_9_1d_lt_20))
+            & ((stochrsi_k_15m_lt_80) | (roc_9_4h_lt_20) | (roc_9_1d_lt_20))
             # 15m still high, 4h & 1d overbought
-            & ((stochrsi_k_15m < 50.0) | (roc_9_4h_lt_40) | (roc_9_1d_lt_100))
+            & ((stochrsi_k_15m_lt_50) | (roc_9_4h_lt_40) | (roc_9_1d_lt_100))
             # 4h high, 4h & 1d overbought
             & ((stochrsi_k_4h_lt_90) | (roc_9_4h_lt_30) | (roc_9_1d < 60.0))
             # 1d high, 4h & 1d overbought
@@ -22943,13 +22950,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 1d downtrend
             & ((rsi_3_15m_gt_20) | rsi_3_1h_gt_20 | (roc_9_1d_gt_neg_30))
             # 15m & 4h down move, 15m still high
-            & ((rsi_3_15m_gt_20) | rsi_3_4h_gt_20 | (stochrsi_k_15m < 50.0))
+            & ((rsi_3_15m_gt_20) | rsi_3_4h_gt_20 | (stochrsi_k_15m_lt_50))
             # 15m down move, 15m & 1h high
             & ((rsi_3_15m_gt_20) | (aroonu_14_15m_lt_70) | (aroonu_14_1h_lt_100))
             # 15m & 1h down move, 15m still high
-            & ((rsi_3_15m_gt_25) | (rsi_3_1h_gt_35) | (stochrsi_k_15m < 50.0))
+            & ((rsi_3_15m_gt_25) | (rsi_3_1h_gt_35) | (stochrsi_k_15m_lt_50))
             # 15m down move, 15m still high, 1d overbought
-            & ((rsi_3_15m_gt_25) | (stochrsi_k_15m < 50.0) | (roc_9_1d_lt_30))
+            & ((rsi_3_15m_gt_25) | (stochrsi_k_15m_lt_50) | (roc_9_1d_lt_30))
             # 15m & 4h down move, 1h high
             & ((rsi_3_15m_gt_30) | (rsi_3_4h_gt_30) | (stochrsi_k_1h_lt_70))
             # 15m down move, 15m & 4h high
@@ -22979,7 +22986,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 1d downtrend
             & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_10) | (roc_9_1d > -30.0))
             # 1h & 4h down move, 15m high
-            & ((rsi_3_1h_gt_10) | rsi_3_4h_gt_20 | (stochrsi_k_15m < 80.0))
+            & ((rsi_3_1h_gt_10) | rsi_3_4h_gt_20 | (stochrsi_k_15m_lt_80))
             # 1h & 4h down move, 1d downtrend
             & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_25) | roc_9_1d_gt_neg_50)
             # 1h & 4h down move, 4h high
@@ -22995,7 +23002,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h & 1d down move
             & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_15) | (rsi_3_1d_gt_20))
             # 1h & 4h down move, 15m still not low enough
-            & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_15) | (stochrsi_k_15m < 30.0))
+            & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_15) | (stochrsi_k_15m_lt_30))
             # 1h & 4h down move, 15m still high
             & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_15) | (aroonu_14_15m_lt_50))
             # 1h & 4h & 1d down move, 1d still high
@@ -23069,9 +23076,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 1d still high, 1d downtrend
             & ((rsi_3_4h_gt_10) | (aroonu_14_1d_lt_50) | (roc_9_1d > -30.0))
             # 4h down move, 15m & 1h still not low enough
-            & ((rsi_3_4h_gt_10) | (stochrsi_k_15m < 30.0) | (stochrsi_k_1h < 30.0))
+            & ((rsi_3_4h_gt_10) | (stochrsi_k_15m_lt_30) | (stochrsi_k_1h < 30.0))
             # 4h down move, 15m stil high, 4h downtrend
-            & ((rsi_3_4h_gt_10) | (stochrsi_k_15m < 50.0) | (roc_9_4h > -20.0))
+            & ((rsi_3_4h_gt_10) | (stochrsi_k_15m_lt_50) | (roc_9_4h > -20.0))
             # 4h & 1d down move, 1d downtrend
             & ((rsi_3_4h_gt_15) | (rsi_3_1d_gt_25) | (roc_9_1d > -30.0))
             # 4h & 1d down move, 1h still high
@@ -23157,7 +23164,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m & 4h & 1d down move, 15m high
           long_entry_logic.append((rsi_3_15m_gt_30) | (rsi_3_4h_gt_50) | (rsi_3_1d_gt_60) | (aroonu_14_15m_lt_70))
           # 15m down move, 15m & 4h still high
-          long_entry_logic.append((rsi_3_15m_gt_30) | (stochrsi_k_15m < 50.0) | (stochrsi_k_4h_lt_50))
+          long_entry_logic.append((rsi_3_15m_gt_30) | (stochrsi_k_15m_lt_50) | (stochrsi_k_4h_lt_50))
           # 15m & 4h down move, 4h high
           long_entry_logic.append((rsi_3_15m_gt_35) | (rsi_3_4h_gt_60) | aroonu_14_4h_lt_80)
           # 15m & 1h down move, 1h high
@@ -23167,13 +23174,13 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m & 1h down move, 4h high
           long_entry_logic.append((rsi_3_15m_gt_40) | (rsi_3_1h_gt_60) | aroonu_14_4h_lt_80)
           # 15m & 4h down move, 15m high
-          long_entry_logic.append((rsi_3_15m_gt_40) | (rsi_3_4h_gt_40) | (stochrsi_k_15m < 50.0))
+          long_entry_logic.append((rsi_3_15m_gt_40) | (rsi_3_4h_gt_40) | (stochrsi_k_15m_lt_50))
           # 15m & 4h down move, 15m high
-          long_entry_logic.append((rsi_3_15m_gt_40) | (rsi_3_4h_gt_60) | (stochrsi_k_15m < 70.0))
+          long_entry_logic.append((rsi_3_15m_gt_40) | (rsi_3_4h_gt_60) | (stochrsi_k_15m_lt_70))
           # 15m down move, 15m & 1h still high
           long_entry_logic.append((rsi_3_15m_gt_40) | (aroonu_14_15m_lt_50) | (stochrsi_k_1h_lt_50))
           # 15m down move, 15m & 1h still high
-          long_entry_logic.append((rsi_3_15m_gt_40) | (stochrsi_k_15m < 50.0) | (stochrsi_k_1h_lt_50))
+          long_entry_logic.append((rsi_3_15m_gt_40) | (stochrsi_k_15m_lt_50) | (stochrsi_k_1h_lt_50))
           # 15m down move, 4h still high, 1d overbought
           long_entry_logic.append((rsi_3_15m_gt_40) | (aroonu_14_4h_lt_50) | (roc_9_1d_lt_100))
           # 15m & 1h down move, 1h still high
@@ -23183,19 +23190,19 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m down move, 15m high, 4h still high
           long_entry_logic.append((rsi_3_15m_gt_45) | (aroonu_14_15m_lt_70) | (stochrsi_k_4h_lt_50))
           # 15m down move, 15m still not low enough, 4h still high
-          long_entry_logic.append((rsi_3_15m_gt_45) | (stochrsi_k_15m < 30.0) | (stochrsi_k_4h_lt_50))
+          long_entry_logic.append((rsi_3_15m_gt_45) | (stochrsi_k_15m_lt_30) | (stochrsi_k_4h_lt_50))
           # 15m down move, 15m & 1h still high
           long_entry_logic.append((rsi_3_15m_gt_45) | (stochrsi_k_15m < 45.0) | (stochrsi_k_1h < 40.0))
           # 15m down move, 15m still not low enough, 4h high
-          long_entry_logic.append((rsi_3_15m_gt_50) | (stochrsi_k_15m < 30.0) | (stochrsi_k_4h_lt_90))
+          long_entry_logic.append((rsi_3_15m_gt_50) | (stochrsi_k_15m_lt_30) | (stochrsi_k_4h_lt_90))
           # 15m down move, 15m still high, 1d overbought
           long_entry_logic.append((rsi_3_15m_gt_50) | (aroonu_14_15m_lt_50) | roc_9_1d_lt_50)
           # 15m down move, 15m still high, 1h high
-          long_entry_logic.append((rsi_3_15m_gt_55) | (stochrsi_k_15m < 40.0) | (stochrsi_k_1h_lt_70))
+          long_entry_logic.append((rsi_3_15m_gt_55) | (stochrsi_k_15m_lt_40) | (stochrsi_k_1h_lt_70))
           # 15m down move, 15m still high, 4h high
-          long_entry_logic.append((rsi_3_15m_gt_55) | (stochrsi_k_15m < 50.0) | (aroonu_14_4h_lt_85))
+          long_entry_logic.append((rsi_3_15m_gt_55) | (stochrsi_k_15m_lt_50) | (aroonu_14_4h_lt_85))
           # 15m down move, 15m & 1h still high
-          long_entry_logic.append((rsi_3_15m_gt_55) | (stochrsi_k_15m < 50.0) | (stochrsi_k_1h_lt_50))
+          long_entry_logic.append((rsi_3_15m_gt_55) | (stochrsi_k_15m_lt_50) | (stochrsi_k_1h_lt_50))
           # 1h down move, 4h still high, 1d high
           long_entry_logic.append((rsi_3_1h_gt_25) | (aroonu_14_4h_lt_50) | (stochrsi_k_1d_lt_90))
           # 1h & 4h down move, 1h still high
@@ -23206,7 +23213,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1h & 4h down move, 4h high
           long_entry_logic.append((rsi_3_1h_gt_35) | (rsi_3_4h_gt_60) | (stochrsi_k_4h_lt_80))
           # 1h down move, 15m & 1h still high
-          long_entry_logic.append((rsi_3_1h_gt_40) | (stochrsi_k_15m < 50.0) | (stochrsi_k_1h_lt_50))
+          long_entry_logic.append((rsi_3_1h_gt_40) | (stochrsi_k_15m_lt_50) | (stochrsi_k_1h_lt_50))
           # 1h down move, 1h still high, 4h high
           long_entry_logic.append((rsi_3_1h_gt_40) | (stochrsi_k_1h_lt_50) | (stochrsi_k_4h_lt_70))
           # 1h down move, 1h high
@@ -23226,9 +23233,9 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1h down move, 15m high, 1h still high
           long_entry_logic.append((rsi_3_1h_gt_50) | (aroonu_14_15m_lt_70) | (stochrsi_k_1h < 40.0))
           # 1h down move, 15m still high, 4h high
-          long_entry_logic.append((rsi_3_1h_gt_50) | (stochrsi_k_15m < 50.0) | (stochrsi_k_4h_lt_80))
+          long_entry_logic.append((rsi_3_1h_gt_50) | (stochrsi_k_15m_lt_50) | (stochrsi_k_4h_lt_80))
           # 1h down move, 15m & 1h high
-          long_entry_logic.append((rsi_3_1h_gt_50) | (stochrsi_k_15m < 60.0) | (aroonu_14_1h_lt_60))
+          long_entry_logic.append((rsi_3_1h_gt_50) | (stochrsi_k_15m_lt_60) | (aroonu_14_1h_lt_60))
           # 1h down move, 1h & 1d high
           long_entry_logic.append((rsi_3_1h_gt_50) | aroonu_14_1h_lt_70 | (stochrsi_k_1d < 80.0))
           # 1h down move, 4h still high, 1d high
@@ -23244,11 +23251,11 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1h down move, 15m still not low enough, 4h high
           long_entry_logic.append((rsi_3_1h_gt_60) | (aroonu_14_15m_lt_70) | (stochrsi_k_4h_lt_90))
           # 1h down move, 15m still not low enough, 1h high
-          long_entry_logic.append((rsi_3_1h_gt_60) | (stochrsi_k_15m < 30.0) | aroonu_14_1h_lt_70)
+          long_entry_logic.append((rsi_3_1h_gt_60) | (stochrsi_k_15m_lt_30) | aroonu_14_1h_lt_70)
           # 1h down move, 15m still not low enough, 1h high
-          long_entry_logic.append((rsi_3_1h_gt_60) | (stochrsi_k_15m < 30.0) | (stochrsi_k_1h < 60.0))
+          long_entry_logic.append((rsi_3_1h_gt_60) | (stochrsi_k_15m_lt_30) | (stochrsi_k_1h < 60.0))
           # 1h down move, 15m & 4h still high
-          long_entry_logic.append((rsi_3_1h_gt_60) | (stochrsi_k_15m < 50.0) | (stochrsi_k_4h_lt_50))
+          long_entry_logic.append((rsi_3_1h_gt_60) | (stochrsi_k_15m_lt_50) | (stochrsi_k_4h_lt_50))
           # 1h down move, 15m & 1h high
           long_entry_logic.append((rsi_3_1h_gt_60) | (aroonu_14_15m_lt_70) | (aroonu_14_1h_lt_90))
           # 1h down move, 1h still high, 4h high
@@ -23270,7 +23277,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 4h down move, 15m & 4h still high
           long_entry_logic.append((rsi_3_4h_gt_30) | (aroonu_14_15m_lt_50) | (aroonu_14_4h_lt_50))
           # 4h down move, 15m still high, 1d overbought
-          long_entry_logic.append((rsi_3_4h_gt_30) | (stochrsi_k_15m < 50.0) | (roc_9_1d < 10.0))
+          long_entry_logic.append((rsi_3_4h_gt_30) | (stochrsi_k_15m_lt_50) | (roc_9_1d < 10.0))
           # 4h down move, 1h & 4h still high
           long_entry_logic.append((rsi_3_4h_gt_35) | (stochrsi_k_1h_lt_50) | (aroonu_14_4h_lt_50))
           # 4h down move, 1d high & overbought
@@ -23280,7 +23287,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 4h down move, 1d high & overbought
           long_entry_logic.append((rsi_3_4h_gt_40) | (aroonu_14_1d_lt_80) | (roc_9_1d_lt_20))
           # 4h down move, 15m still high, 1h high
-          long_entry_logic.append((rsi_3_4h_gt_40) | (stochrsi_k_15m < 40.0) | (stochrsi_k_1h_lt_80))
+          long_entry_logic.append((rsi_3_4h_gt_40) | (stochrsi_k_15m_lt_40) | (stochrsi_k_1h_lt_80))
           # 4h down move, 1h & 4h still high
           long_entry_logic.append((rsi_3_4h_gt_40) | (stochrsi_k_1h_lt_50) | (rsi_14_4h < 50.0))
           # 4h down move, 1h still high, 4h still moving down
@@ -23292,11 +23299,11 @@ class NostalgiaForInfinityX7(IStrategy):
           # 4h down move, 15m high, 4h still high
           long_entry_logic.append((rsi_3_4h_gt_50) | (aroonu_14_15m_lt_70) | (stochrsi_k_4h_lt_40))
           # 4h down move, 15m still high, 1h high
-          long_entry_logic.append((rsi_3_4h_gt_50) | (stochrsi_k_15m < 40.0) | (stochrsi_k_1h_lt_70))
+          long_entry_logic.append((rsi_3_4h_gt_50) | (stochrsi_k_15m_lt_40) | (stochrsi_k_1h_lt_70))
           # 4h down move, 15m & 4h still high
-          long_entry_logic.append((rsi_3_4h_gt_50) | (stochrsi_k_15m < 50.0) | (aroonu_14_4h_lt_50))
+          long_entry_logic.append((rsi_3_4h_gt_50) | (stochrsi_k_15m_lt_50) | (aroonu_14_4h_lt_50))
           # 4h down move, 15m high, 4h still not low enough
-          long_entry_logic.append((rsi_3_4h_gt_50) | (stochrsi_k_15m < 70.0) | (stochrsi_k_4h_lt_30))
+          long_entry_logic.append((rsi_3_4h_gt_50) | (stochrsi_k_15m_lt_70) | (stochrsi_k_4h_lt_30))
           # 4h down move, 1h still high, 4h high
           long_entry_logic.append((rsi_3_4h_gt_50) | (stochrsi_k_1h_lt_50) | aroonu_14_4h_lt_70)
           # 4h down move, 15m & 1d high
@@ -23308,11 +23315,11 @@ class NostalgiaForInfinityX7(IStrategy):
           # 4h down move, 15m high, 4h still high
           long_entry_logic.append((rsi_3_4h_gt_60) | (aroonu_14_15m_lt_80) | (aroonu_14_4h_lt_40))
           # 4h down move, 15m still high, 1h high
-          long_entry_logic.append((rsi_3_4h_gt_60) | (stochrsi_k_15m < 50.0) | aroonu_14_1h_lt_70)
+          long_entry_logic.append((rsi_3_4h_gt_60) | (stochrsi_k_15m_lt_50) | aroonu_14_1h_lt_70)
           # 4h down move, 15m still high, 4h high
-          long_entry_logic.append((rsi_3_4h_gt_60) | (stochrsi_k_15m < 50.0) | (stochrsi_k_4h_lt_70))
+          long_entry_logic.append((rsi_3_4h_gt_60) | (stochrsi_k_15m_lt_50) | (stochrsi_k_4h_lt_70))
           # 4h down move, 15m & 4h high
-          long_entry_logic.append((rsi_3_4h_gt_60) | (stochrsi_k_15m < 70.0) | (stochrsi_k_4h_lt_60))
+          long_entry_logic.append((rsi_3_4h_gt_60) | (stochrsi_k_15m_lt_70) | (stochrsi_k_4h_lt_60))
           # 4h down move, 1h & 4h high
           long_entry_logic.append((rsi_3_4h_gt_60) | (stochrsi_k_1h_lt_70) | aroonu_14_4h_lt_70)
           # 4h down move, 4h still high, 1d high
@@ -23338,13 +23345,13 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1d high & overbought
           long_entry_logic.append(aroonu_14_1d_lt_100 | (roc_9_1d < 200.0))
           # 15m high, 1h still high
-          long_entry_logic.append((stochrsi_k_15m < 70.0) | (stochrsi_k_1h < 40.0))
+          long_entry_logic.append((stochrsi_k_15m_lt_70) | (stochrsi_k_1h < 40.0))
           # 15m & 4h high
-          long_entry_logic.append((stochrsi_k_15m < 70.0) | aroonu_14_4h_lt_70)
+          long_entry_logic.append((stochrsi_k_15m_lt_70) | aroonu_14_4h_lt_70)
           # 15m high, 1d overbought
-          long_entry_logic.append((stochrsi_k_15m < 70.0) | (roc_9_1d < 10.0))
+          long_entry_logic.append((stochrsi_k_15m_lt_70) | (roc_9_1d < 10.0))
           # 15m high, 1h still not low enough
-          long_entry_logic.append((stochrsi_k_15m < 80.0) | (stochrsi_k_1h < 30.0))
+          long_entry_logic.append((stochrsi_k_15m_lt_80) | (stochrsi_k_1h < 30.0))
           # 1d high, 4h overbought
           long_entry_logic.append((stochrsi_k_1d < 80.0) | (roc_9_4h_lt_40))
           # 1d high & overbought
@@ -23398,7 +23405,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 1d high, 1d downtrend
             & ((rsi_3_15m_gt_10) | (aroonu_14_1d_lt_85) | (cmf_20_1d > -0.40))
             # 15m & 1h down move, 15m still not low enough
-            & ((rsi_3_15m_gt_15) | rsi_3_1h_gt_20 | (stochrsi_k_15m < 30.0))
+            & ((rsi_3_15m_gt_15) | rsi_3_1h_gt_20 | (stochrsi_k_15m_lt_30))
             # 15m & 1h down nove, 1h still high
             & ((rsi_3_15m_gt_15) | rsi_3_1h_gt_20 | (stochrsi_k_1h_lt_50))
             # 15m & 1h down move, 4h high
@@ -23422,7 +23429,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 1h & 4h high
             & ((rsi_3_15m_gt_35) | aroonu_14_1h_lt_80 | (rsi_14_4h < 80.0))
             # 1h & 4h down move, 15m stil high
-            & ((rsi_3_1h_gt_3) | (rsi_3_4h_gt_10) | (stochrsi_k_15m < 50.0))
+            & ((rsi_3_1h_gt_3) | (rsi_3_4h_gt_10) | (stochrsi_k_15m_lt_50))
             # 1h & 4h down move, 1h still high
             & ((rsi_3_1h_gt_3) | (rsi_3_4h_gt_25) | (aroonu_14_1h_lt_40))
             # 1h & 4h down move, 4h high
@@ -23476,7 +23483,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 1d high
             & ((rsi_3_4h_gt_3) | (aroonu_14_1d_lt_90))
             # 4h down move, 15m still high
-            & ((rsi_3_4h_gt_3) | (stochrsi_k_15m < 50.0))
+            & ((rsi_3_4h_gt_3) | (stochrsi_k_15m_lt_50))
             # 4h down move, 1d high
             & ((rsi_3_4h_gt_3) | (stochrsi_k_1d_lt_90))
             # 4h down move, 1d overbought
@@ -23668,9 +23675,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 1d high & overbought
             & ((rsi_3_15m_gt_15) | (aroonu_14_1d_lt_100) | (roc_9_1d < 100.0))
             # 15m down move, 15m still not low enough, 4h high
-            & ((rsi_3_15m_gt_15) | (stochrsi_k_15m < 30.0) | (stochrsi_k_4h_lt_50))
+            & ((rsi_3_15m_gt_15) | (stochrsi_k_15m_lt_30) | (stochrsi_k_4h_lt_50))
             # 15m down move, 15m & 1h high
-            & ((rsi_3_15m_gt_15) | (stochrsi_k_15m < 50.0) | (stochrsi_k_1h_lt_50))
+            & ((rsi_3_15m_gt_15) | (stochrsi_k_15m_lt_50) | (stochrsi_k_1h_lt_50))
             # 15m down move, 1h high, 1d overbought
             & ((rsi_3_15m_gt_15) | (stochrsi_k_1h_lt_70) | (roc_9_1d_lt_30))
             # 15m down move, 1h high, 1d overbought


### PR DESCRIPTION
## Summary
- Reuse repeated `stochrsi_k_15m < ...` comparison masks inside X7 `populate_entry_trend()`.
- Adds the 15m STOCHRSI masks next to the existing entry-trend mask definitions, independent on latest upstream `main`.

## Safety
- Behavior is preserved: this only reuses already-read local Series comparisons inside the same call.
- No indicator formulas, candle selection, order classification, profit arithmetic, thresholds, condition order, return values, or signal behavior are changed.
- Touched function: `populate_entry_trend()`.
- No v3 grind-entry code is touched.

## Backtest scope
- Full backtesting was not required for this patch because it only replaces repeated inline comparisons with equivalent local masks from the same `stochrsi_k_15m` Series.
- Validation focused on static safety, mergeability, and targeted diff review for unchanged thresholds and condition order.

## Checks
- `python3 ~/.codex/skills/nfi-upstream-pr/scripts/validate_nfi_pr.py --base origin/main`
- `git merge-tree` conflict simulation against `origin/main`
- targeted `git diff origin/main...HEAD -- NostalgiaForInfinityX7.py` review
- `git diff --check origin/main...HEAD`
- `ruff format --check NostalgiaForInfinityX7.py`
- `ruff check NostalgiaForInfinityX7.py`
- `PYTHONDONTWRITEBYTECODE=1 python3 -m py_compile NostalgiaForInfinityX7.py`
