### PR TITLE
Reuse X7 entry STOCHRSI 1h masks

### DIFF
--- a/NostalgiaForInfinityX7.py
+++ b/NostalgiaForInfinityX7.py
@@ -13093,9 +13093,21 @@ class NostalgiaForInfinityX7(IStrategy):
     stochrsi_k_15m_lt_60 = stochrsi_k_15m < 60.0
     stochrsi_k_15m_lt_70 = stochrsi_k_15m < 70.0
     stochrsi_k_15m_lt_80 = stochrsi_k_15m < 80.0
+    stochrsi_k_1h_gt_10 = stochrsi_k_1h > 10.0
+    stochrsi_k_1h_gt_20 = stochrsi_k_1h > 20.0
+    stochrsi_k_1h_gt_40 = stochrsi_k_1h > 40.0
+    stochrsi_k_1h_gt_60 = stochrsi_k_1h > 60.0
+    stochrsi_k_1h_gt_75 = stochrsi_k_1h > 75.0
+    stochrsi_k_1h_gt_80 = stochrsi_k_1h > 80.0
+    stochrsi_k_1h_gt_90 = stochrsi_k_1h > 90.0
+    stochrsi_k_1h_lt_20 = stochrsi_k_1h < 20.0
+    stochrsi_k_1h_lt_30 = stochrsi_k_1h < 30.0
+    stochrsi_k_1h_lt_40 = stochrsi_k_1h < 40.0
     stochrsi_k_1h_lt_50 = stochrsi_k_1h < 50.0
+    stochrsi_k_1h_lt_60 = stochrsi_k_1h < 60.0
     stochrsi_k_1h_lt_70 = stochrsi_k_1h < 70.0
     stochrsi_k_1h_lt_80 = stochrsi_k_1h < 80.0
+    stochrsi_k_1h_lt_90 = stochrsi_k_1h < 90.0
     stochrsi_k_4h_lt_10 = stochrsi_k_4h < 10.0
     stochrsi_k_4h_lt_20 = stochrsi_k_4h < 20.0
     stochrsi_k_4h_lt_30 = stochrsi_k_4h < 30.0
@@ -13202,7 +13214,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 5m down move, 15m high
             & ((rsi_3_gt_3) | (aroonu_14_15m_lt_80))
             # 5m down move, 1h high, 4h overbought
-            & ((rsi_3_gt_3) | (stochrsi_k_1h < 80.0) | (roc_9_4h_lt_20))
+            & ((rsi_3_gt_3) | (stochrsi_k_1h_lt_80) | (roc_9_4h_lt_20))
             # 5m & 4h down move, 4h high
             & ((rsi_3_gt_5) | (rsi_3_4h_gt_35) | aroonu_14_4h_lt_70)
             # 15m down move, 1h downtrend, 1h high
@@ -13214,7 +13226,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 1d high
             & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_10) | (aroonu_14_1d_lt_100))
             # 15m & 1h down move, 1h still high
-            & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_10) | (stochrsi_k_1h < 40.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_10) | (stochrsi_k_1h_lt_40))
             # 15m & 1h & 4h & 1d down move
             & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_15) | (rsi_3_4h_gt_15) | (rsi_3_1d_gt_15))
             # 15m & 1h down move, 15m still high
@@ -13248,7 +13260,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 4h high, 1d overbought
             & (rsi_3_15m_gt_3 | (aroonu_14_4h_lt_85) | (roc_9_1d_lt_100))
             # 15m down move, 1h high, 4h overbought
-            & (rsi_3_15m_gt_3 | (stochrsi_k_1h < 90.0) | (roc_9_4h_lt_10))
+            & (rsi_3_15m_gt_3 | (stochrsi_k_1h_lt_90) | (roc_9_4h_lt_10))
             # 15m down move, 4h high & overbought
             & (rsi_3_15m_gt_3 | (stochrsi_k_4h_lt_80) | (roc_9_4h_lt_30))
             # 15m down move, drop in last half hour, 15m downtrend
@@ -13266,7 +13278,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 4h down move, 1d downtrend
             & ((rsi_3_15m_gt_5) | (rsi_3_4h_gt_5) | (roc_9_1d_gt_neg_20))
             # 15m & 4h down move, 1h still high
-            & ((rsi_3_15m_gt_5) | (rsi_3_4h_gt_10) | (stochrsi_k_1h < 50.0))
+            & ((rsi_3_15m_gt_5) | (rsi_3_4h_gt_10) | (stochrsi_k_1h_lt_50))
             # 15m & 4h down move, 1d high
             & ((rsi_3_15m_gt_5) | (rsi_3_4h_gt_15) | (stochrsi_k_1d < 60.0))
             # 15m & 4h down move, 15m still high
@@ -13280,11 +13292,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 4h high, 1d overbought
             & ((rsi_3_15m_gt_5) | (aroonu_14_4h_lt_60) | (roc_9_1d_lt_80))
             # 15m & 1h down move, 1h still high
-            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_10) | (stochrsi_k_1h < 40.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_10) | (stochrsi_k_1h_lt_40))
             # 15m & 1h down move, 4h high
             & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_10) | (stochrsi_k_4h_lt_70))
             # 15m & 1h down move, 1h still high
-            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_15) | (stochrsi_k_1h < 50.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_15) | (stochrsi_k_1h_lt_50))
             # 15m & 1h down move, 1d downtrend
             & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_15) | (roc_9_1d_gt_neg_40))
             # 15m & 1h down move, 4h high
@@ -13298,7 +13310,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 4h down move, 15m still high
             & ((rsi_3_15m_gt_10) | (rsi_3_4h_gt_10) | (stochrsi_k_15m_lt_50))
             # 15m & 4h down move, 1h still high
-            & ((rsi_3_15m_gt_10) | (rsi_3_4h_gt_10) | (stochrsi_k_1h < 40.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_4h_gt_10) | (stochrsi_k_1h_lt_40))
             # 15m & 4h down move, 4h downtrend
             & ((rsi_3_15m_gt_10) | (rsi_3_4h_gt_10) | (roc_9_4h > -20.0))
             # 15m & 4h down move, 1d overbought
@@ -13324,7 +13336,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 1h high, 1d downtrend
             & ((rsi_3_15m_gt_10) | (stochrsi_k_1h_lt_70) | roc_9_1d_gt_neg_50)
             # 15m down move, 1h high & overbought
-            & ((rsi_3_15m_gt_10) | (stochrsi_k_1h < 90.0) | (roc_9_1h < 20.0))
+            & ((rsi_3_15m_gt_10) | (stochrsi_k_1h_lt_90) | (roc_9_1h < 20.0))
             # 15m down move, 1h & 1d overbought
             & ((rsi_3_15m_gt_10) | (roc_9_1h_lt_10) | (roc_9_1d_lt_80))
             # 15m down move, 4h high
@@ -13382,7 +13394,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 15m still not low enough
             & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_10) | (aroonu_14_15m_lt_30))
             # 1h & 4h down move, 1h still high
-            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_10) | (stochrsi_k_1h < 50.0))
+            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_10) | (stochrsi_k_1h_lt_50))
             # 1h & 4h & 1d down move, 4h downtrend, 1d still high
             & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_15) | (rsi_3_1d_gt_25) | (rsi_14_4h > 30.0) | (aroonu_14_1d_lt_40))
             # 1h & 1d down move, 4h high
@@ -13448,7 +13460,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h high, 1d overbought
             & ((rsi_3_1h_gt_40) | aroonu_14_1h_lt_80 | (roc_9_1d < 100.0))
             # 1h down move, 1h high, 4h overbought
-            & ((rsi_3_1h_gt_40) | (stochrsi_k_1h < 80.0) | (roc_9_4h_lt_20))
+            & ((rsi_3_1h_gt_40) | (stochrsi_k_1h_lt_80) | (roc_9_4h_lt_20))
             # 1h down move, 1h & 4h high
             & ((rsi_3_1h_gt_45) | aroonu_14_1h_lt_80 | aroonu_14_4h_lt_100)
             # 1h down move, 1h high & overbought
@@ -13468,7 +13480,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 1d high
             & ((rsi_3_4h_gt_10) | (aroonu_14_1d_lt_100))
             # 4h down move, 1h high, 1d downtrend
-            & ((rsi_3_4h_gt_10) | (stochrsi_k_1h < 60.0) | (roc_9_1d_gt_neg_40))
+            & ((rsi_3_4h_gt_10) | (stochrsi_k_1h_lt_60) | (roc_9_1d_gt_neg_40))
             # 4h down move, 4h still not low enough, 1d downtrend
             & ((rsi_3_4h_gt_10) | (stochrsi_k_4h_lt_30) | (roc_9_1d > -20.0))
             # 4h down move, 1h & 4h downtrend
@@ -13486,9 +13498,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 4h high, 1d overbought
             & ((rsi_3_4h_gt_50) | aroonu_14_4h_lt_70 | (roc_9_1d_lt_40))
             # 4h down move, 1h high, 1d overbought
-            & ((rsi_3_4h_gt_60) | (stochrsi_k_1h < 90.0) | (roc_9_1d < 60.0))
+            & ((rsi_3_4h_gt_60) | (stochrsi_k_1h_lt_90) | (roc_9_1d < 60.0))
             # 1d down move, 1h high, 1d downtrend
-            & ((rsi_3_1d_gt_5) | (stochrsi_k_1h < 90.0) | (roc_9_1d_gt_neg_20))
+            & ((rsi_3_1d_gt_5) | (stochrsi_k_1h_lt_90) | (roc_9_1d_gt_neg_20))
             # 1d down move, 1h still high, 4h high
             & ((rsi_3_1d_gt_20) | (aroonu_14_1h_lt_50) | (aroonu_14_4h_lt_90))
             # 1d down move, 1h & 4h high
@@ -13625,7 +13637,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 5m down move, 4h high, 1h overbought
             & ((rsi_3_gt_10) | aroonu_14_4h_lt_100 | (roc_9_1h < 30.0))
             # 15m & 1h down move, 1h still high
-            & ((rsi_3_15m > 1.0) | (rsi_3_1h_gt_25) | (stochrsi_k_1h < 40.0))
+            & ((rsi_3_15m > 1.0) | (rsi_3_1h_gt_25) | (stochrsi_k_1h_lt_40))
             # 15m & 1h & 4h down move
             & ((rsi_3_15m_gt_3) | (rsi_3_1h_gt_3) | (rsi_3_4h_gt_15))
             # 15m & 1h down move, 4h still high
@@ -13637,13 +13649,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 1h still not low enough
             & ((rsi_3_15m_gt_3) | (rsi_3_1h_gt_5) | (aroonu_14_1h_lt_25))
             # 15m & 1h down move, 1h still not low enough
-            & ((rsi_3_15m_gt_3) | (rsi_3_1h_gt_5) | (stochrsi_k_1h < 30.0))
+            & ((rsi_3_15m_gt_3) | (rsi_3_1h_gt_5) | (stochrsi_k_1h_lt_30))
             # 15m & 1h & 4h down move
             & ((rsi_3_15m_gt_3) | (rsi_3_1h_gt_10) | (rsi_3_4h_gt_10))
             # 15m & 1h & 4h down move, 4h still not low enough, 1d still high
             & ((rsi_3_15m_gt_3) | (rsi_3_1h_gt_10) | (rsi_3_4h_gt_20) | (aroonu_14_4h_lt_20) | (rsi_14_1d < 50.0))
             # 15m & 1h down move, 1h high
-            & ((rsi_3_15m_gt_3) | (rsi_3_1h_gt_10) | (stochrsi_k_1h < 30.0))
+            & ((rsi_3_15m_gt_3) | (rsi_3_1h_gt_10) | (stochrsi_k_1h_lt_30))
             # 15m & 1h down move, 1d downtrend
             & ((rsi_3_15m_gt_3) | (rsi_3_1h_gt_10) | (roc_9_1d_gt_neg_40))
             # 15m & 1h down move, 15m downtrend
@@ -13685,7 +13697,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 4h down move, 4h still high
             & ((rsi_3_15m_gt_3) | (rsi_3_4h_gt_35) | (stochrsi_k_4h_lt_50))
             # 15m down move, 15m still not low enough, 1h high
-            & ((rsi_3_15m_gt_3) | (aroonu_14_15m_lt_20) | (stochrsi_k_1h < 60.0))
+            & ((rsi_3_15m_gt_3) | (aroonu_14_15m_lt_20) | (stochrsi_k_1h_lt_60))
             # 15m down move, 15m still not low enough, 1h still high
             & ((rsi_3_15m_gt_3) | (aroonu_14_15m_lt_30) | (stochrsi_k_1h_lt_50))
             # 15m down move, 1h high, 1d overbought
@@ -13723,7 +13735,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 4h down move, 15m still high
             & ((rsi_3_15m_gt_5) | (rsi_3_4h_gt_15) | (aroonu_14_15m_lt_40))
             # 15m & 4h down move, 1h still high
-            & ((rsi_3_15m_gt_5) | (rsi_3_4h_gt_15) | (stochrsi_k_1h < 50.0))
+            & ((rsi_3_15m_gt_5) | (rsi_3_4h_gt_15) | (stochrsi_k_1h_lt_50))
             # 15m & 4h down move, 4h still high
             & ((rsi_3_15m_gt_5) | (rsi_3_4h_gt_15) | (stochrsi_k_4h_lt_50))
             # 15m & 4h down move, 1d overbought
@@ -13733,7 +13745,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1d down move, 15m still not low enough
             & ((rsi_3_15m_gt_5) | (rsi_3_1d_gt_10) | (aroonu_14_15m_lt_30))
             # 15m & 1d down move, 1h high
-            & ((rsi_3_15m_gt_5) | (rsi_3_1d_gt_40) | (stochrsi_k_1h < 90.0))
+            & ((rsi_3_15m_gt_5) | (rsi_3_1d_gt_40) | (stochrsi_k_1h_lt_90))
             # 15m down move, 15m downtrend, 4h still not low enough
             & ((rsi_3_15m_gt_5) | (cmf_20_15m > -0.30) | (stochrsi_k_4h < 30.0))
             # 15m down move, 15m still not low enough, 4h high
@@ -13773,7 +13785,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 4h still high
             & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_35) | (rsi_14_4h < 50.0))
             # 15m & 1h down move, 1h high
-            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_35) | (stochrsi_k_1h < 60.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_35) | (stochrsi_k_1h_lt_60))
             # 15m & 1h down move, 4h high
             & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_40) | (stochrsi_k_4h_lt_80))
             # 15m & 1h down move, 1h high
@@ -13805,7 +13817,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1d down move, 1d still high
             & ((rsi_3_15m_gt_10) | (rsi_3_1d_gt_10) | (rsi_14_1d < 40.0))
             # 15m & 1d down move, 1h high
-            & ((rsi_3_15m_gt_10) | (rsi_3_1d_gt_10) | (stochrsi_k_1h < 90.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_1d_gt_10) | (stochrsi_k_1h_lt_90))
             # 15m & 1d down move, 4h high
             & ((rsi_3_15m_gt_10) | (rsi_3_1d_gt_15) | (stochrsi_k_4h_lt_90))
             # 15m & 1d down move, 1h high
@@ -13873,7 +13885,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 15m still high, 1d overbought
             & ((rsi_3_15m_gt_15) | (stochrsi_k_15m_lt_50) | (roc_9_1d_lt_100))
             # 15m down move, 1h high & overbought
-            & ((rsi_3_15m_gt_15) | (stochrsi_k_1h < 90.0) | (roc_9_1h_lt_10))
+            & ((rsi_3_15m_gt_15) | (stochrsi_k_1h_lt_90) | (roc_9_1h_lt_10))
             # 15m down move, 4h high, 1d overbought
             & ((rsi_3_15m_gt_15) | (stochrsi_k_4h_lt_70) | (roc_9_1d < 10.0))
             # 15m & 1h down move, 15m still not low enough
@@ -13899,17 +13911,17 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 1h high, 1d downtrend
             & ((rsi_3_15m_gt_20) | (aroonu_14_1h_lt_90) | (roc_9_1d_gt_neg_30))
             # 15m down move, 1h high, 1d overbought
-            & ((rsi_3_15m_gt_20) | (stochrsi_k_1h < 70.0) | (roc_9_1d_lt_100))
+            & ((rsi_3_15m_gt_20) | (stochrsi_k_1h_lt_70) | (roc_9_1d_lt_100))
             # 15m down move, 1h high, 1d downtrend
-            & ((rsi_3_15m_gt_20) | (stochrsi_k_1h < 80.0) | (roc_9_1d_gt_neg_20))
+            & ((rsi_3_15m_gt_20) | (stochrsi_k_1h_lt_80) | (roc_9_1d_gt_neg_20))
             # 15m down move, 1h high & overbought
-            & ((rsi_3_15m_gt_20) | (stochrsi_k_1h < 90.0) | (roc_9_1h_lt_10))
+            & ((rsi_3_15m_gt_20) | (stochrsi_k_1h_lt_90) | (roc_9_1h_lt_10))
             # 15m & 1h down move, 1d overbought
             & ((rsi_3_15m_gt_25) | (rsi_3_1h_gt_40) | (roc_9_1d_lt_80))
             # 15m & 4h down move, 1h overbought
             & ((rsi_3_15m_gt_25) | (rsi_3_4h_gt_35) | (roc_9_1h < 100.0))
             # 15m down move, 15m still not low enough, 1h high
-            & ((rsi_3_15m_gt_25) | (aroonu_14_15m_lt_20) | (stochrsi_k_1h < 90.0))
+            & ((rsi_3_15m_gt_25) | (aroonu_14_15m_lt_20) | (stochrsi_k_1h_lt_90))
             # 15m down move, 1h & 4h high
             & ((rsi_3_15m_gt_25) | (aroonu_14_1h_lt_70) | (aroonu_14_4h_lt_100))
             # 15m down move, 1h high, 1d overbought
@@ -13921,7 +13933,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 4h high & overbought
             & ((rsi_3_15m_gt_30) | (aroonu_14_4h_lt_70) | (roc_9_4h < 50.0))
             # 15m down move, 1h high, 1d downtrend
-            & ((rsi_3_15m_gt_30) | (stochrsi_k_1h < 80.0) | (roc_9_1d_gt_neg_20))
+            & ((rsi_3_15m_gt_30) | (stochrsi_k_1h_lt_80) | (roc_9_1d_gt_neg_20))
             # 15m down move, 4h high & overbought
             & ((rsi_3_15m_gt_30) | (stochrsi_k_4h_lt_80) | (roc_9_4h_lt_30))
             # 15m down move, 1h high, 4h overbought
@@ -13979,7 +13991,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 1d still high
             & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_10) | (aroonu_14_1d_lt_40))
             # 1h & 4h down move, 1h still not low enough
-            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_10) | (stochrsi_k_1h < 20.0))
+            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_10) | (stochrsi_k_1h_lt_20))
             # 1h & 4h down move, 1d downtrend
             & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_10) | (roc_9_1d > -20.0))
             # 1h & 4h & 1d down move, 4h downtrend, 1d still high
@@ -14045,7 +14057,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h high, 4h overbought
             & (rsi_3_1h_gt_20 | aroonu_14_1h_lt_70 | (roc_9_4h_lt_10))
             # 1h down move, 1h high, 1h still not low enough
-            & (rsi_3_1h_gt_20 | (aroonu_14_1d_lt_80) | (stochrsi_k_1h < 20.0))
+            & (rsi_3_1h_gt_20 | (aroonu_14_1d_lt_80) | (stochrsi_k_1h_lt_20))
             # 1h down move, 1d high & overbought
             & (rsi_3_1h_gt_20 | aroonu_14_1d_lt_100 | (roc_9_1d_lt_20))
             # 1h down move, 1d high, 4h downtrend
@@ -14079,7 +14091,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 4h & 1d downtrend
             & ((rsi_3_1h_gt_30) | (roc_9_4h > -25.0) | (roc_9_1d > -60.0))
             # 1h & 4h down move, 1h still high
-            & ((rsi_3_1h_gt_35) | (rsi_3_4h_gt_35) | (stochrsi_k_1h < 40.0))
+            & ((rsi_3_1h_gt_35) | (rsi_3_4h_gt_35) | (stochrsi_k_1h_lt_40))
             # 1h down move, 1h still high, 4h downtrend
             & ((rsi_3_1h_gt_35) | (aroonu_14_1h_lt_50) | (roc_9_4h_gt_neg_20))
             # 1h down move, 1h high, 1d downtrend
@@ -14107,7 +14119,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 1d overbought
             & ((rsi_3_1h_gt_45) | (rsi_3_4h_gt_65) | (roc_9_1d < 200.0))
             # 1h down move, 1h high, 1d high & overbought
-            & ((rsi_3_1h_gt_45) | (stochrsi_k_1h < 60.0) | (stochrsi_k_1d < 70.0) | (roc_9_1d < 40.0))
+            & ((rsi_3_1h_gt_45) | (stochrsi_k_1h_lt_60) | (stochrsi_k_1d < 70.0) | (roc_9_1d < 40.0))
             # 1h down move, 1h high & overbought
             & ((rsi_3_1h_gt_50) | aroonu_14_1h_lt_80 | (roc_9_1h_lt_10))
             # 1h down move, 4h high, 1h overbought
@@ -14137,7 +14149,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 15m still high
             & ((rsi_3_4h_gt_5) | (stochrsi_k_15m_lt_50))
             # 4h & 1d down move, 1h still not low enough
-            & ((rsi_3_4h_gt_10) | (rsi_3_1d_gt_10) | (stochrsi_k_1h < 20.0))
+            & ((rsi_3_4h_gt_10) | (rsi_3_1d_gt_10) | (stochrsi_k_1h_lt_20))
             # 4h & 1d down move, 1d still high
             & ((rsi_3_4h_gt_10) | (rsi_3_1d_gt_15) | (stochrsi_k_1d < 40.0))
             # 4h & 1d down move, 1d downtrend
@@ -14213,17 +14225,17 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1d down move, 1d high, 1d downtrend
             & ((rsi_3_1d_gt_5) | (aroonu_14_1d_lt_80) | (roc_9_1d_gt_neg_20))
             # 1d down move, 1h & 4h still not low enough
-            & ((rsi_3_1d_gt_5) | (stochrsi_k_1h < 20.0) | (stochrsi_k_4h < 20.0))
+            & ((rsi_3_1d_gt_5) | (stochrsi_k_1h_lt_20) | (stochrsi_k_4h < 20.0))
             # 1d down move, 1h & 4h high
             & ((rsi_3_1d_gt_10) | (aroonu_14_1h_lt_50) | (aroonu_14_4h_lt_90))
             # 1d down move, 1h high
             & ((rsi_3_1d_gt_10) | aroonu_14_1h_lt_70)
             # 1d down move, 1h high, 1d downtrend
-            & ((rsi_3_1d_gt_10) | (stochrsi_k_1h < 80.0) | (roc_9_1d_gt_neg_20))
+            & ((rsi_3_1d_gt_10) | (stochrsi_k_1h_lt_80) | (roc_9_1d_gt_neg_20))
             # 1d down move, 1h overbought, 1d downtrend
             & ((rsi_3_1d_gt_15) | (roc_9_1h < 20.0) | roc_9_1d_gt_neg_50)
             # 1d down move, 1h high, 1d downtrend
-            & ((rsi_3_1d_gt_20) | (stochrsi_k_1h < 90.0) | (roc_9_1d > -10.0))
+            & ((rsi_3_1d_gt_20) | (stochrsi_k_1h_lt_90) | (roc_9_1d > -10.0))
             # 1d down move, 1h high, 1d overbought
             & ((rsi_3_1d_gt_25) | aroonu_14_1h_lt_70 | (roc_9_1d < 25.0))
             # 1d down move, 1d still high, 1d downtrend
@@ -14281,7 +14293,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h high, 1d overbought
             & ((stochrsi_k_1h_lt_70) | (roc_9_1d_lt_40))
             # 1h high, 4h downtrend
-            & ((stochrsi_k_1h < 80.0) | (roc_9_4h_gt_neg_20))
+            & ((stochrsi_k_1h_lt_80) | (roc_9_4h_gt_neg_20))
             # 1h high, 4h overbought
             & ((stochrsi_k_1h_lt_80) | (roc_9_4h < 80.0))
             # 4h high, 1h & 4h overbought
@@ -14316,7 +14328,7 @@ class NostalgiaForInfinityX7(IStrategy):
 
           long_entry_logic.append(
             # 5m & 4h down move, 1h still high
-            ((rsi_3_gt_5) | (rsi_3_4h_gt_15) | (stochrsi_k_1h < 50.0))
+            ((rsi_3_gt_5) | (rsi_3_4h_gt_15) | (stochrsi_k_1h_lt_50))
             # 5m down move, 15m high, 1d overbought
             & ((rsi_3_gt_5) | (aroonu_14_15m_lt_70) | (roc_9_1d_lt_40))
             # 5m down move, 15m still high, 1d downtrend
@@ -14324,7 +14336,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 5m down move, 1h still high, 4h downtrend
             & ((rsi_3_gt_5) | (stochrsi_k_1h_lt_50) | (roc_9_4h > -10.0))
             # 5m down move, 1h high. 1d downtrend
-            & ((rsi_3_gt_5) | (stochrsi_k_1h < 80.0) | (roc_9_1d_gt_neg_30))
+            & ((rsi_3_gt_5) | (stochrsi_k_1h_lt_80) | (roc_9_1d_gt_neg_30))
             # 5m down move, 15m & 1h high
             & ((rsi_3_gt_10) | (aroonu_14_15m_lt_70) | (aroonu_14_1h_lt_100))
             # 5m down move, 15m & 1d high
@@ -14334,15 +14346,15 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h dowbn move, 1d high
             & ((rsi_3_15m_gt_5) | (rsi_3_1h_gt_25) | (stochrsi_k_1d_lt_90))
             # 15m & 1d down move, 1h high
-            & ((rsi_3_15m_gt_5) | (rsi_3_1d_gt_15) | (stochrsi_k_1h < 60.0))
+            & ((rsi_3_15m_gt_5) | (rsi_3_1d_gt_15) | (stochrsi_k_1h_lt_60))
             # 15m & 1h down move, 15m still high
             & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_35) | (aroonu_14_15m_lt_50))
             # 15m & 1h down move, 1h still high
-            & ((rsi_3_15m_gt_10) | (rsi_3_4h_gt_10) | (stochrsi_k_1h < 40.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_4h_gt_10) | (stochrsi_k_1h_lt_40))
             # 15m & 4h down move, 15m still high
             & ((rsi_3_15m_gt_10) | rsi_3_4h_gt_20 | (aroonu_14_15m_lt_50))
             # 15m down move, 15m still high, 1h high
-            & ((rsi_3_15m_gt_10) | (aroonu_14_15m_lt_40) | (stochrsi_k_1h < 90.0))
+            & ((rsi_3_15m_gt_10) | (aroonu_14_15m_lt_40) | (stochrsi_k_1h_lt_90))
             # 15m down move, 15m still high, 1h high
             & ((rsi_3_15m_gt_10) | (aroonu_14_15m_lt_50) | (stochrsi_k_1h_lt_80))
             # 15m down move, 15m still high, 1d overbought
@@ -14354,7 +14366,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 4h still high
             & ((rsi_3_15m_gt_15) | (rsi_3_1h_gt_35) | (aroonu_14_4h_lt_50))
             # 15m & 1h down move, 1h high
-            & ((rsi_3_15m_gt_15) | (rsi_3_1h_gt_35) | (stochrsi_k_1h < 60.0))
+            & ((rsi_3_15m_gt_15) | (rsi_3_1h_gt_35) | (stochrsi_k_1h_lt_60))
             # 15m & 1h down move, 1h high
             & ((rsi_3_15m_gt_15) | (rsi_3_1h_gt_45) | (stochrsi_k_1h_lt_80))
             # 15m & 1h down move, 1h high
@@ -14446,11 +14458,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 4h high & overbought
             & ((rsi_3_15m_gt_20) | aroonu_14_4h_lt_70 | (roc_9_4h < 50.0))
             # 15m down move, 1h high, 4h downtrend
-            & ((rsi_3_15m_gt_20) | (stochrsi_k_1h < 60.0) | (roc_9_4h_gt_neg_20))
+            & ((rsi_3_15m_gt_20) | (stochrsi_k_1h_lt_60) | (roc_9_4h_gt_neg_20))
             # 15m down move, 1h high, 1d overbought
             & ((rsi_3_15m_gt_20) | (stochrsi_k_1h_lt_80) | (roc_9_1d_lt_30))
             # 15m down move, 1h high
-            & ((rsi_3_15m_gt_20) | (stochrsi_k_1h < 90.0))
+            & ((rsi_3_15m_gt_20) | (stochrsi_k_1h_lt_90))
             # 15m down move, 4h still high, 1d downtrend
             & ((rsi_3_15m_gt_20) | (stochrsi_k_4h_lt_40) | (roc_9_1d_gt_neg_20))
             # 15m down move, 4h high, 1d downtrend
@@ -14490,7 +14502,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 15m still high, 1h still high
             & ((rsi_3_15m_gt_25) | (stochrsi_k_15m_lt_50) | (aroonu_14_1h_lt_50))
             # 15m down move, 1h high, 4h high
-            & ((rsi_3_15m_gt_25) | (stochrsi_k_1h < 70.0) | (aroonu_14_4h_lt_100))
+            & ((rsi_3_15m_gt_25) | (stochrsi_k_1h_lt_70) | (aroonu_14_4h_lt_100))
             # 15m down move, 4h & 1d overbought
             & ((rsi_3_15m_gt_25) | (roc_9_4h < 50.0) | (roc_9_1d_lt_50))
             # 15m & 1h down move, 1h high
@@ -14514,7 +14526,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 15m high, 4h overbought
             & ((rsi_3_15m_gt_30) | (stochrsi_k_15m_lt_70) | (roc_9_4h < 70.0))
             # 15m down move, 1h high, 1d overbought
-            & ((rsi_3_15m_gt_30) | (stochrsi_k_1h < 90.0) | (roc_9_1d_lt_50))
+            & ((rsi_3_15m_gt_30) | (stochrsi_k_1h_lt_90) | (roc_9_1d_lt_50))
             # 15m & 1h down move, 15m still high, 1h high
             & ((rsi_3_15m_gt_35) | (rsi_3_1h_gt_40) | (aroonu_14_15m_lt_50) | (aroonu_14_1h_lt_90))
             # 15m down move, 15m high, 4h high
@@ -14526,7 +14538,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 4h high, 1d overbought
             & ((rsi_3_15m_gt_35) | (aroonu_14_4h_lt_80) | (roc_9_1d < 200.0))
             # 15m down move, 1h high, 1d downtrend
-            & ((rsi_3_15m_gt_35) | (stochrsi_k_1h < 90.0) | roc_9_1d_gt_neg_50)
+            & ((rsi_3_15m_gt_35) | (stochrsi_k_1h_lt_90) | roc_9_1d_gt_neg_50)
             # 15m down move, 4h high & overbought
             & ((rsi_3_15m_gt_35) | (stochrsi_k_4h_lt_90) | (roc_9_4h_lt_20))
             # 15m down move, 15m high, 1h downtrend
@@ -14554,7 +14566,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 1d down move, 1d overbought
             & ((rsi_3_1h_gt_15) | (rsi_3_1d_gt_60) | (roc_9_1d_lt_40))
             # 1h down move, 1h still not low enough, 1d downtrend
-            & ((rsi_3_1h_gt_15) | (stochrsi_k_1h < 30.0) | (roc_9_1d > -30.0))
+            & ((rsi_3_1h_gt_15) | (stochrsi_k_1h_lt_30) | (roc_9_1d > -30.0))
             # 1h & 4h down move, 1d high
             & (rsi_3_1h_gt_20 | (rsi_3_4h_gt_25) | (aroonu_14_1d_lt_80))
             # 1h & 4h down move, 1d overbought
@@ -14642,7 +14654,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1d high & overbought
             & ((rsi_3_1h_gt_45) | aroonu_14_1d_lt_100 | (roc_9_1d_lt_30))
             # 1h down move, 1h still high, 1d overbought
-            & ((rsi_3_1h_gt_45) | (stochrsi_k_1h < 40.0) | (roc_9_1d < 200.0))
+            & ((rsi_3_1h_gt_45) | (stochrsi_k_1h_lt_40) | (roc_9_1d < 200.0))
             # 1h down move, 1d high & overbought
             & ((rsi_3_1h_gt_45) | (stochrsi_k_1d < 80.0) | (roc_9_1d < 10.0))
             # 1h down move, 15m & 1h high
@@ -14654,23 +14666,23 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 4h high & overbought
             & ((rsi_3_1h_gt_50) | aroonu_14_4h_lt_100 | (roc_9_4h < 50.0))
             # 1h down move, 1h & 4h high
-            & ((rsi_3_1h_gt_50) | (stochrsi_k_1h < 80.0) | aroonu_14_4h_lt_100)
+            & ((rsi_3_1h_gt_50) | (stochrsi_k_1h_lt_80) | aroonu_14_4h_lt_100)
             # 1h down move, 4h high & overbought
             & ((rsi_3_1h_gt_50) | (stochrsi_k_4h_lt_70) | (roc_9_4h_lt_10))
             # 1h down move, 1h high, 1d high
-            & ((rsi_3_1h_gt_55) | (stochrsi_k_1h < 70.0) | aroonu_14_1d_lt_100)
+            & ((rsi_3_1h_gt_55) | (stochrsi_k_1h_lt_70) | aroonu_14_1d_lt_100)
             # 1h down move, 1h high, 1d downtrend
-            & ((rsi_3_1h_gt_55) | (stochrsi_k_1h < 80.0) | (roc_9_1d_gt_neg_30))
+            & ((rsi_3_1h_gt_55) | (stochrsi_k_1h_lt_80) | (roc_9_1d_gt_neg_30))
             # 1h down move, 4h high & overbought
             & ((rsi_3_1h_gt_55) | (stochrsi_k_4h_lt_80) | (roc_9_4h < 100.0))
             # 1h down move, 1h high, 1d overbought
-            & ((rsi_3_1h_gt_60) | (stochrsi_k_1h < 80.0) | (roc_9_1d_lt_100))
+            & ((rsi_3_1h_gt_60) | (stochrsi_k_1h_lt_80) | (roc_9_1d_lt_100))
             # 1h down move, 15m & 1h high
             & ((rsi_3_1h_gt_65) | (aroonu_14_15m_lt_70) | (aroonu_14_1h_lt_100))
             # 1h down move, 1h high & overbought
             & ((rsi_3_1h_gt_65) | (stochrsi_k_1h_lt_80) | (roc_9_1h_lt_10))
             # 4h down move, 1h still high, 1d downtrend
-            & ((rsi_3_4h_gt_3) | (stochrsi_k_1h < 40.0) | (roc_9_1d_gt_neg_30))
+            & ((rsi_3_4h_gt_3) | (stochrsi_k_1h_lt_40) | (roc_9_1d_gt_neg_30))
             # 4h down move, 1h still high, 4h downtrend
             & ((rsi_3_4h_gt_3) | (stochrsi_k_1h_lt_50) | (roc_9_4h_gt_neg_30))
             # 4h down move, 4h & 1d downtrend
@@ -14702,7 +14714,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h & 1d down move, 1d high
             & ((rsi_3_4h_gt_15) | (rsi_3_1d_gt_40) | (aroonu_14_1d_lt_70))
             # 4h down move, 15m still high, 1h high
-            & ((rsi_3_4h_gt_15) | (aroonu_14_15m_lt_50) | (stochrsi_k_1h < 60.0))
+            & ((rsi_3_4h_gt_15) | (aroonu_14_15m_lt_50) | (stochrsi_k_1h_lt_60))
             # 4h down move, 15m & 1d high
             & ((rsi_3_4h_gt_15) | (aroonu_14_15m_lt_70) | (aroonu_14_1d_lt_80))
             # 4h down move, 15m high
@@ -14728,7 +14740,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 15m high, 4h downtrend
             & (rsi_3_4h_gt_20 | (stochrsi_k_15m_lt_80) | (roc_9_4h > -50.0))
             # 4h down move, 1h high, 1d downtrend
-            & (rsi_3_4h_gt_20 | (stochrsi_k_1h < 60.0) | (roc_9_1d_gt_neg_40))
+            & (rsi_3_4h_gt_20 | (stochrsi_k_1h_lt_60) | (roc_9_1d_gt_neg_40))
             # 4h down move, 4h still not low enough, 4h downtrend
             & (rsi_3_4h_gt_20 | (stochrsi_k_4h_lt_30) | (roc_9_4h > -10.0))
             # 4h down move, 4h high, 1d downtrend
@@ -14754,7 +14766,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 4h high, 1d overbought
             & ((rsi_3_4h_gt_25) | aroonu_14_4h_lt_70 | (roc_9_1d_lt_40))
             # 4h down move, 1h still high, 1d overbought
-            & ((rsi_3_4h_gt_25) | (stochrsi_k_1h < 50.0) | (roc_9_1d_lt_100))
+            & ((rsi_3_4h_gt_25) | (stochrsi_k_1h_lt_50) | (roc_9_1d_lt_100))
             # 4h down move, 4h high, 1d downtrend
             & ((rsi_3_4h_gt_25) | (stochrsi_k_4h_lt_80) | roc_9_1d_gt_neg_50)
             # 4h down move, 1h high, 1h downtrend
@@ -14770,11 +14782,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 1h high, 1d downtrend
             & ((rsi_3_4h_gt_30) | (stochrsi_k_1h_lt_80) | (roc_9_1d_gt_neg_40))
             # 4h down move, 1h high, 1d overbought
-            & ((rsi_3_4h_gt_30) | (stochrsi_k_1h < 90.0) | roc_9_1d_lt_50)
+            & ((rsi_3_4h_gt_30) | (stochrsi_k_1h_lt_90) | roc_9_1d_lt_50)
             # 4h down move, 1d high & overbought
             & ((rsi_3_4h_gt_30) | (stochrsi_k_1d < 80.0) | (roc_9_1d < 10.0))
             # 4h down move, 15m still high, 1h high
-            & ((rsi_3_4h_gt_35) | (aroonu_14_15m_lt_40) | (stochrsi_k_1h < 90.0))
+            & ((rsi_3_4h_gt_35) | (aroonu_14_15m_lt_40) | (stochrsi_k_1h_lt_90))
             # 4h down move, 15m still high, 4h high
             & ((rsi_3_4h_gt_35) | (aroonu_14_15m_lt_50) | aroonu_14_4h_lt_80)
             # 4h down move, 15m high, 1h high
@@ -14842,7 +14854,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 4h high & overbought
             & ((rsi_3_4h_gt_55) | (stochrsi_k_4h_lt_80) | (roc_9_4h_lt_10))
             # 4h down move, 15m high, 1h high
-            & ((rsi_3_4h_gt_60) | (aroonu_14_15m_lt_60) | (stochrsi_k_1h < 90.0))
+            & ((rsi_3_4h_gt_60) | (aroonu_14_15m_lt_60) | (stochrsi_k_1h_lt_90))
             # 4h down move, 4h high & overbought
             & ((rsi_3_4h_gt_60) | aroonu_14_4h_lt_70 | (roc_9_4h_lt_30))
             # 4h down move, 4h still high, 1d downtrend
@@ -14946,11 +14958,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1d high
             & ((stochrsi_k_15m < 90.0) | (stochrsi_k_1d_lt_90))
             # 1h high, 4h & 1d downtrend
-            & ((stochrsi_k_1h < 60.0) | (roc_9_4h_gt_neg_30) | (roc_9_1d_gt_neg_30))
+            & ((stochrsi_k_1h_lt_60) | (roc_9_4h_gt_neg_30) | (roc_9_1d_gt_neg_30))
             # 1h high, 4h downtrend
             & ((stochrsi_k_1h_lt_70) | (roc_9_4h_gt_neg_30))
             # 1h high, 1d downtrend
-            & ((stochrsi_k_1h < 70.0) | (roc_9_1d_gt_neg_20))
+            & ((stochrsi_k_1h_lt_70) | (roc_9_1d_gt_neg_20))
             # 4h high, 4h overbought, 1d downtrend
             & ((stochrsi_k_4h_lt_90) | (roc_9_4h_lt_20) | (roc_9_1d_gt_neg_20))
             # 1d still high, 4h & 1d downtrend
@@ -15015,7 +15027,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 5m & 1d down move, 15m still high
             & ((rsi_3_gt_3) | (rsi_3_1d_gt_20) | (stochrsi_k_15m_lt_40))
             # 5m down move, 1h high, 4h overbought
-            & ((rsi_3_gt_3) | (stochrsi_k_1h < 80.0) | (roc_9_4h_lt_20))
+            & ((rsi_3_gt_3) | (stochrsi_k_1h_lt_80) | (roc_9_4h_lt_20))
             # 5m & 4h down move, 15m still high
             & ((rsi_3_gt_5) | (rsi_3_4h_gt_25) | (stochrsi_k_15m_lt_50))
             # 5m down move, 4h high, 1h overbought
@@ -15025,7 +15037,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 1d still high
             & ((rsi_3_15m_gt_5) | (rsi_3_1h_gt_10) | (aroonu_14_1d_lt_50))
             # 15m & 1h down move, 1h still high
-            & ((rsi_3_15m_gt_5) | (rsi_3_1h_gt_30) | (stochrsi_k_1h < 40.0))
+            & ((rsi_3_15m_gt_5) | (rsi_3_1h_gt_30) | (stochrsi_k_1h_lt_40))
             # 15m & 1h down move, 1d overbought
             & ((rsi_3_15m_gt_5) | (rsi_3_1h_gt_30) | roc_9_1d_lt_50)
             # 15m & 1h down move, 4h high
@@ -15043,7 +15055,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 4h downtrend
             & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_10) | (roc_9_4h > -40.0))
             # 15m & 1h down move, 1h still high
-            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_15) | (stochrsi_k_1h < 50.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_15) | (stochrsi_k_1h_lt_50))
             # 15m & 1h down move, 4h high
             & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_15) | aroonu_14_4h_lt_70)
             # 15m & 1h down move, 1d overbought
@@ -15059,7 +15071,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 1h high
             & ((rsi_3_15m_gt_10) | (stochrsi_k_1h_lt_80))
             # 15m & 1h down move, 1h still high
-            & ((rsi_3_15m_gt_15) | (rsi_3_1h_gt_25) | (stochrsi_k_1h < 40.0))
+            & ((rsi_3_15m_gt_15) | (rsi_3_1h_gt_25) | (stochrsi_k_1h_lt_40))
             # 15m & 4h down move, 1d high
             & ((rsi_3_15m_gt_15) | (rsi_3_4h_gt_15) | (stochrsi_k_1d < 80.0))
             # 15m down move, 4h high & overbought
@@ -15075,7 +15087,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 4h high, 1h overbought
             & ((rsi_3_15m_gt_20) | aroonu_14_4h_lt_100 | (roc_9_1h < 30.0))
             # 15m down move, 1h high & overbought
-            & ((rsi_3_15m_gt_20) | (stochrsi_k_1h < 90.0) | (roc_9_1h_lt_10))
+            & ((rsi_3_15m_gt_20) | (stochrsi_k_1h_lt_90) | (roc_9_1h_lt_10))
             # 15m & 4h down move, 4h high
             & ((rsi_3_15m_gt_25) | (rsi_3_4h_gt_50) | (stochrsi_k_4h_lt_80))
             # 15m down move, 4h high, 4h overbought
@@ -15095,7 +15107,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 15m still high
             & ((rsi_3_1h_gt_3) | (stochrsi_k_15m_lt_50))
             # 1h down move, 1h still high, 4h overbought
-            & ((rsi_3_1h_gt_3) | (stochrsi_k_1h < 50.0) | (roc_9_4h_lt_20))
+            & ((rsi_3_1h_gt_3) | (stochrsi_k_1h_lt_50) | (roc_9_4h_lt_20))
             # 1h & 4h & 1d down move
             & ((rsi_3_1h_gt_5) | (rsi_3_4h_gt_5) | (rsi_3_1d_gt_10))
             # 1h & 4h down move, 1h downtrend
@@ -15169,7 +15181,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 15m still high, 1h high
             & ((rsi_3_1h_gt_30) | (stochrsi_k_15m_lt_40) | (aroonu_14_1h_lt_60))
             # 1h down move, 1h still high, 4h high
-            & ((rsi_3_1h_gt_30) | (stochrsi_k_1h < 40.0) | (stochrsi_k_4h_lt_70))
+            & ((rsi_3_1h_gt_30) | (stochrsi_k_1h_lt_40) | (stochrsi_k_4h_lt_70))
             # 1h down move, 4h & 1d downtrend
             & ((rsi_3_1h_gt_30) | (roc_9_4h > -25.0) | (roc_9_1d > -60.0))
             # 1h down move, 4h & 1d overbought
@@ -15181,9 +15193,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h still high, 1d overbought
             & ((rsi_3_1h_gt_35) | (stochrsi_k_1h_lt_50) | (roc_9_1d < 200.0))
             # 1h down move, 1h high, 4h downtrend
-            & ((rsi_3_1h_gt_35) | (stochrsi_k_1h < 70.0) | (roc_9_4h_gt_neg_20))
+            & ((rsi_3_1h_gt_35) | (stochrsi_k_1h_lt_70) | (roc_9_4h_gt_neg_20))
             # 1h down move, 1h high, 4h overbought
-            & ((rsi_3_1h_gt_40) | (stochrsi_k_1h < 80.0) | (roc_9_4h_lt_20))
+            & ((rsi_3_1h_gt_40) | (stochrsi_k_1h_lt_80) | (roc_9_4h_lt_20))
             # 1h down move, 1h & 4h high
             & ((rsi_3_1h_gt_45) | aroonu_14_1h_lt_70 | aroonu_14_4h_lt_100)
             # 1h down move, 4h high, 1d downtrend
@@ -15199,7 +15211,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 4h high, 4h downtrend
             & ((rsi_3_4h_gt_3) | (aroonu_14_4h_lt_50) | (roc_9_4h > -40.0))
             # 4h & 1d down move, 1h still not low enough
-            & ((rsi_3_4h_gt_5) | (rsi_3_1d_gt_10) | (stochrsi_k_1h < 30.0))
+            & ((rsi_3_4h_gt_5) | (rsi_3_1d_gt_10) | (stochrsi_k_1h_lt_30))
             # 4h & 1d down move, 1d high
             & ((rsi_3_4h_gt_5) | (rsi_3_1d_gt_45) | (aroonu_14_1d_lt_70))
             # 4h down move, 4h & 1d downtrend
@@ -15207,7 +15219,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h & 1d down move, 1h still high
             & ((rsi_3_4h_gt_10) | (rsi_3_1d_gt_10) | (aroonu_14_1h_lt_40))
             # 4h & 1d down move, 1h high
-            & ((rsi_3_4h_gt_10) | (rsi_3_1d_gt_15) | (stochrsi_k_1h < 70.0))
+            & ((rsi_3_4h_gt_10) | (rsi_3_1d_gt_15) | (stochrsi_k_1h_lt_70))
             # 4h & 1d down move, 1d still high
             & ((rsi_3_4h_gt_10) | (rsi_3_1d_gt_25) | (aroonu_14_1d_lt_40))
             # 4h & 1d down move, 1d still high
@@ -15384,13 +15396,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1d high, 4h overbought
             & ((rsi_3_1h_gt_10) | (aroonu_14_1d_lt_100) | (roc_9_4h < 20.0))
             # 1h down move, 1h still high, 1d downtrend
-            & ((rsi_3_1h_gt_10) | (stochrsi_k_1h < 50.0) | (roc_9_1d_gt_neg_40))
+            & ((rsi_3_1h_gt_10) | (stochrsi_k_1h_lt_50) | (roc_9_1d_gt_neg_40))
             # 1h down move, 1d high & overbought
             & ((rsi_3_1h_gt_10) | (stochrsi_k_1d < 80.0) | (roc_9_1d_lt_30))
             # 1h & 4h down move, 1h still high
             & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_15) | (aroonu_14_1h_lt_50))
             # 1h & 4h down move, 1h still not low enough
-            & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_15) | (stochrsi_k_1h < 30.0))
+            & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_15) | (stochrsi_k_1h_lt_30))
             # 1h & 4h down move, 1d downtrend
             & ((rsi_3_1h_gt_15) | rsi_3_4h_gt_20 | (roc_9_1d_gt_neg_40))
             # 1h & 4h down move, 4h high
@@ -15488,7 +15500,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 15m high, 1h high
             & ((rsi_3_1h_gt_55) | (aroonu_14_15m_lt_60) | (stochrsi_k_1h_lt_80))
             # 1h down move, 1h high & overbought
-            & ((rsi_3_1h_gt_55) | (stochrsi_k_1h < 60.0) | (roc_9_1d < 10.0))
+            & ((rsi_3_1h_gt_55) | (stochrsi_k_1h_lt_60) | (roc_9_1d < 10.0))
             # 1h down move, 4h & 1d overbought
             & ((rsi_3_1h_gt_60) | (roc_9_4h_lt_10) | (roc_9_1d_lt_40))
             # 1h down move, 4h high, 1d overbought
@@ -15496,7 +15508,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h & 1d down move, 4h downtrend
             & ((rsi_3_4h_gt_3) | (rsi_3_1d_gt_10) | (roc_9_4h_gt_neg_20))
             # 4h & 1d down move, 1h still not low enough
-            & ((rsi_3_4h_gt_5) | (rsi_3_1d_gt_10) | (stochrsi_k_1h < 30.0))
+            & ((rsi_3_4h_gt_5) | (rsi_3_1d_gt_10) | (stochrsi_k_1h_lt_30))
             # 4h down move, 1d high, 4h downtrend
             & ((rsi_3_4h_gt_5) | (aroonu_14_1d_lt_80) | (roc_9_4h > -10.0))
             # 4h & 1d down move, 15m high
@@ -15512,7 +15524,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 15m high
             & ((rsi_3_4h_gt_10) | (stochrsi_k_15m_lt_80))
             # 4h down move, 1h high, 1d downtrend
-            & ((rsi_3_4h_gt_10) | (stochrsi_k_1h < 70.0) | (roc_9_1d > -20.0))
+            & ((rsi_3_4h_gt_10) | (stochrsi_k_1h_lt_70) | (roc_9_1d > -20.0))
             # 4h down move, 4h still high, 1d downtrend
             & ((rsi_3_4h_gt_10) | (stochrsi_k_4h_lt_40) | (roc_9_1d > -20.0))
             # 4h down move, 4h downtrend, 1d overbought
@@ -15540,7 +15552,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 1h high, 4h downtrend
             & ((rsi_3_4h_gt_30) | aroonu_14_1h_lt_70 | (roc_9_4h > -10.0))
             # 4h down move, 1h high, 1d downtrend
-            & ((rsi_3_4h_gt_30) | (stochrsi_k_1h < 60.0) | (roc_9_1d_gt_neg_40))
+            & ((rsi_3_4h_gt_30) | (stochrsi_k_1h_lt_60) | (roc_9_1d_gt_neg_40))
             # 4h down move, 4h & 1d high
             & ((rsi_3_4h_gt_35) | aroonu_14_4h_lt_70 | aroonu_14_1d_lt_100)
             # 4h down move, 4h high & overbought
@@ -15552,7 +15564,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1d down move, 1d high, 1d downtrend
             & ((rsi_3_1d_gt_10) | (aroonu_14_1d_lt_70) | (roc_9_1d > -10.0))
             # 1d down move, 1h high, 4h downtrend
-            & ((rsi_3_1d_gt_30) | (stochrsi_k_1h < 90.0) | (roc_9_4h_gt_neg_30))
+            & ((rsi_3_1d_gt_30) | (stochrsi_k_1h_lt_90) | (roc_9_4h_gt_neg_30))
             # 15m & 1h & 4h downtrend
             & ((cmf_20_15m > -0.30) | (cmf_20_1h > -0.30) | (cmf_20_4h > -0.30))
             # 1d downtrend, 1d high & overbought
@@ -15594,7 +15606,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m high, 4h & 1d downtrend
             & ((stochrsi_k_15m_lt_70) | (roc_9_4h_gt_neg_30) | (roc_9_1d_gt_neg_30))
             # 1h high, 4h & 1d overbought
-            & ((stochrsi_k_1h < 90.0) | (roc_9_4h_lt_20) | (roc_9_1d_lt_100))
+            & ((stochrsi_k_1h_lt_90) | (roc_9_4h_lt_20) | (roc_9_1d_lt_100))
             # 4h high, 1h overbought, 1d downtrend
             & ((stochrsi_k_4h_lt_80) | (roc_9_1h < 40.0) | (roc_9_1d > -70.0))
             # 4h high, 4h & 1d overbought
@@ -15693,7 +15705,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 4h high
             & ((rsi_3_15m_gt_3) | (rsi_3_1h_gt_40) | aroonu_14_4h_lt_70)
             # 15m & 4h down move, 1h still not low enough
-            & ((rsi_3_15m_gt_3) | (rsi_3_4h_gt_10) | (stochrsi_k_1h < 30.0))
+            & ((rsi_3_15m_gt_3) | (rsi_3_4h_gt_10) | (stochrsi_k_1h_lt_30))
             # 15m & 4h down move, 1d downtrend
             & ((rsi_3_15m_gt_3) | (rsi_3_4h_gt_15) | (roc_9_1d > -10.0))
             # 15m & 4h down move, 4h still not low enough
@@ -15701,9 +15713,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 4h down move, 15m still not low enough
             & ((rsi_3_15m_gt_3) | (rsi_3_4h_gt_30) | (aroonu_14_15m_lt_25))
             # 15m & 4h down move, 1h still high
-            & ((rsi_3_15m_gt_3) | (rsi_3_4h_gt_30) | (stochrsi_k_1h < 40.0))
+            & ((rsi_3_15m_gt_3) | (rsi_3_4h_gt_30) | (stochrsi_k_1h_lt_40))
             # 15m & 4h down move, 1h high
-            & ((rsi_3_15m_gt_3) | (rsi_3_4h_gt_45) | (stochrsi_k_1h < 60.0))
+            & ((rsi_3_15m_gt_3) | (rsi_3_4h_gt_45) | (stochrsi_k_1h_lt_60))
             # 15m & 1d down move, 15m still not low enough
             & ((rsi_3_15m_gt_3) | (rsi_3_1d_gt_10) | (aroonu_14_15m_lt_30))
             # 15m & 1d down move, 4h high
@@ -15713,7 +15725,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 1h high
             & ((rsi_3_15m_gt_5) | (rsi_3_1h_gt_25) | (aroonu_14_1h_lt_60))
             # 15m & 1h down move, 1h still high
-            & ((rsi_3_15m_gt_5) | (rsi_3_1h_gt_25) | (stochrsi_k_1h < 40.0))
+            & ((rsi_3_15m_gt_5) | (rsi_3_1h_gt_25) | (stochrsi_k_1h_lt_40))
             # 15m & 1h down move, 4h still high
             & ((rsi_3_15m_gt_5) | (rsi_3_1h_gt_25) | (stochrsi_k_4h_lt_30))
             # 15m & 1h down move, 4h high
@@ -15731,11 +15743,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 15m still high, 1h still high
             & ((rsi_3_15m_gt_5) | (aroonu_14_15m_lt_30) | (stochrsi_k_1h_lt_50))
             # 15m down move, 1h still high, 1d high
-            & ((rsi_3_15m_gt_5) | (stochrsi_k_1h < 40.0) | (aroonu_14_1d_lt_70))
+            & ((rsi_3_15m_gt_5) | (stochrsi_k_1h_lt_40) | (aroonu_14_1d_lt_70))
             # 15m down move, 1h & 4h high
             & ((rsi_3_15m_gt_5) | (aroonu_14_1h_lt_70) | (aroonu_14_4h_lt_90))
             # 15m down move, 15m & 1h still not low enough
-            & ((rsi_3_15m_gt_5) | (stochrsi_k_15m_lt_30) | (stochrsi_k_1h < 30.0))
+            & ((rsi_3_15m_gt_5) | (stochrsi_k_15m_lt_30) | (stochrsi_k_1h_lt_30))
             # 15m & 1h down move, 1h still high
             & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_20) | (stochrsi_k_1h_lt_50))
             # 15m & 1h down move, 4h still high
@@ -15757,15 +15769,15 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 1d downtrend
             & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_30) | (roc_9_1d_gt_neg_40))
             # 15m & 1h down move, 1h still high
-            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_35) | (stochrsi_k_1h < 40.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_35) | (stochrsi_k_1h_lt_40))
             # 15m & 1h down move, 1h still high
-            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_45) | (stochrsi_k_1h < 40.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_45) | (stochrsi_k_1h_lt_40))
             # 15m & 1h down move, 1d overbought
             & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_45) | (roc_9_1d < 150.0))
             # 15m & 1h down move, 4h high
             & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_50) | (stochrsi_k_4h_lt_80))
             # 15m & 1h down move, 1h high
-            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_55) | (stochrsi_k_1h < 60.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_55) | (stochrsi_k_1h_lt_60))
             # 15m & 1h down move, 1h high
             & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_65) | aroonu_14_1h_lt_80)
             # 15m & 4h down move, 1d high
@@ -15801,7 +15813,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 4h down move, 4h high
             & ((rsi_3_15m_gt_10) | (rsi_3_4h_gt_60) | (stochrsi_k_4h_lt_80))
             # 15m & 1d down move, 1h still high
-            & ((rsi_3_15m_gt_10) | (rsi_3_1d_gt_10) | (stochrsi_k_1h < 40.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_1d_gt_10) | (stochrsi_k_1h_lt_40))
             # 15m & 1d down move, 1d high
             & ((rsi_3_15m_gt_10) | (rsi_3_1d_gt_20) | (aroonu_14_1d_lt_75))
             # 15m & 1d down move, 1d overbought
@@ -15817,9 +15829,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 4h high & overbought
             & ((rsi_3_15m_gt_10) | (aroonu_14_4h_lt_90) | (roc_9_4h_lt_20))
             # 15m down move, 1h still not low enough, 1d overbought
-            & ((rsi_3_15m_gt_10) | (stochrsi_k_1h < 30.0) | (roc_9_1d_lt_100))
+            & ((rsi_3_15m_gt_10) | (stochrsi_k_1h_lt_30) | (roc_9_1d_lt_100))
             # 15m down move, 1h still high, 4h downtrend
-            & ((rsi_3_15m_gt_10) | (stochrsi_k_1h < 50.0) | (roc_9_4h_gt_neg_20))
+            & ((rsi_3_15m_gt_10) | (stochrsi_k_1h_lt_50) | (roc_9_4h_gt_neg_20))
             # 15m down move, 4h high & overbought
             & ((rsi_3_15m_gt_10) | (stochrsi_k_4h_lt_70) | (roc_9_4h_lt_10))
             # 15m down move, 4h high, 1d overbought
@@ -15835,7 +15847,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 4h high
             & ((rsi_3_15m_gt_15) | (rsi_3_1h_gt_25) | aroonu_14_4h_lt_70)
             # 15m & 1h down move, 1h still high
-            & ((rsi_3_15m_gt_15) | (rsi_3_1h_gt_25) | (stochrsi_k_1h < 40.0))
+            & ((rsi_3_15m_gt_15) | (rsi_3_1h_gt_25) | (stochrsi_k_1h_lt_40))
             # 15m & 1h down move, 1d overbought
             & ((rsi_3_15m_gt_15) | (rsi_3_1h_gt_25) | (roc_9_1d_lt_100))
             # 15m & 1h down move, 1d high
@@ -15849,7 +15861,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 4h down move, 15m still high
             & ((rsi_3_15m_gt_15) | rsi_3_4h_gt_20 | (stochrsi_k_15m_lt_50))
             # 15m & 4h down move, 1h high
-            & ((rsi_3_15m_gt_15) | (rsi_3_4h_gt_30) | (stochrsi_k_1h < 60.0))
+            & ((rsi_3_15m_gt_15) | (rsi_3_4h_gt_30) | (stochrsi_k_1h_lt_60))
             # 15m & 4h down move, 4h high
             & ((rsi_3_15m_gt_15) | (rsi_3_4h_gt_35) | (aroonu_14_4h_lt_60))
             # 15m & 4h down move, 4h high
@@ -15863,7 +15875,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 4h down move, 4h high
             & ((rsi_3_15m_gt_15) | (rsi_3_4h_gt_55) | (stochrsi_k_4h_lt_70))
             # 15m & 1d down move, 1h still high
-            & ((rsi_3_15m_gt_15) | (rsi_3_1d_gt_15) | (stochrsi_k_1h < 30.0))
+            & ((rsi_3_15m_gt_15) | (rsi_3_1d_gt_15) | (stochrsi_k_1h_lt_30))
             # 15m & 1d down move, 1h still high
             & ((rsi_3_15m_gt_15) | (rsi_3_1d_gt_20) | (stochrsi_k_1h_lt_50))
             # 15m & 1d down move, 1d overbought
@@ -15895,17 +15907,17 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 1h still high, 4h overbought
             & ((rsi_3_15m_gt_15) | (stochrsi_k_1h_lt_50) | (roc_9_4h_lt_10))
             # 15m down move, 1h high, 4h downtrend
-            & ((rsi_3_15m_gt_15) | (stochrsi_k_1h < 80.0) | (roc_9_4h_gt_neg_20))
+            & ((rsi_3_15m_gt_15) | (stochrsi_k_1h_lt_80) | (roc_9_4h_gt_neg_20))
             # 15m down move, 4h high & overbought
             & ((rsi_3_15m_gt_15) | (stochrsi_k_4h_lt_90) | (roc_9_4h_lt_20))
             # 15m & 1h down move, 1h still high
-            & ((rsi_3_15m_gt_20) | rsi_3_1h_gt_20 | (stochrsi_k_1h < 20.0))
+            & ((rsi_3_15m_gt_20) | rsi_3_1h_gt_20 | (stochrsi_k_1h_lt_20))
             # 15m & 1h down move, 1d downtrend
             & ((rsi_3_15m_gt_20) | (rsi_3_1h_gt_30) | (roc_9_1d_gt_neg_30))
             # 15m & 1h down move, 1h overbought
             & ((rsi_3_15m_gt_20) | (rsi_3_1h_gt_50) | (roc_9_1h_lt_10))
             # 15m & 1h & 4h down move, 1h still not low enough
-            & ((rsi_3_15m_gt_20) | (rsi_3_1h_gt_25) | (rsi_3_4h_gt_30) | (stochrsi_k_1h < 30.0))
+            & ((rsi_3_15m_gt_20) | (rsi_3_1h_gt_25) | (rsi_3_4h_gt_30) | (stochrsi_k_1h_lt_30))
             # 15m & 1h down move, 4h high
             & ((rsi_3_15m_gt_20) | (rsi_3_1h_gt_25) | (stochrsi_k_4h_lt_80))
             # 15m & 1h & 4h down move, 15m & 1h still high
@@ -15929,7 +15941,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1d down move, 15m still high
             & ((rsi_3_15m_gt_20) | (rsi_3_1d_gt_30) | (stochrsi_k_15m_lt_50))
             # 15m down move, 15m still not low enough, 1h high
-            & ((rsi_3_15m_gt_20) | (aroonu_14_15m_lt_25) | (stochrsi_k_1h < 90.0))
+            & ((rsi_3_15m_gt_20) | (aroonu_14_15m_lt_25) | (stochrsi_k_1h_lt_90))
             # 15m down move, 15m still high, 1h high
             & ((rsi_3_15m_gt_20) | (aroonu_14_15m_lt_40) | aroonu_14_1h_lt_70)
             # 15m down move, 15m still high, 4h high
@@ -15977,7 +15989,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1d down move, 1h high
             & ((rsi_3_15m_gt_25) | (rsi_3_1d_gt_25) | aroonu_14_1h_lt_80)
             # 15m down move, 15m still not low enough, 1h high
-            & ((rsi_3_15m_gt_25) | (aroonu_14_15m_lt_25) | (stochrsi_k_1h < 90.0))
+            & ((rsi_3_15m_gt_25) | (aroonu_14_15m_lt_25) | (stochrsi_k_1h_lt_90))
             # 15m down move, 15m still high, 1h high
             & ((rsi_3_15m_gt_25) | (aroonu_14_15m_lt_40) | (stochrsi_k_1h_lt_80))
             # 15m down move, 1h high, 1d overbought
@@ -15993,9 +16005,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 4h high, 1d overbought
             & ((rsi_3_15m_gt_25) | aroonu_14_4h_lt_80 | (roc_9_1d < 100.0))
             # 15m down move, 1h high, 1d downtrend
-            & ((rsi_3_15m_gt_25) | (stochrsi_k_1h < 70.0) | (roc_9_1d_gt_neg_20))
+            & ((rsi_3_15m_gt_25) | (stochrsi_k_1h_lt_70) | (roc_9_1d_gt_neg_20))
             # 15m down move, 1h high & overbought
-            & ((rsi_3_15m_gt_25) | (stochrsi_k_1h < 90.0) | (roc_9_1h < 20.0))
+            & ((rsi_3_15m_gt_25) | (stochrsi_k_1h_lt_90) | (roc_9_1h < 20.0))
             # 15m down move, 4h high & overbought
             & ((rsi_3_15m_gt_25) | (stochrsi_k_4h_lt_90) | (roc_9_4h_lt_30))
             # 15m & 1h down move, 1h high
@@ -16033,11 +16045,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 4h high & overbought
             & ((rsi_3_15m_gt_35) | aroonu_14_4h_lt_100 | (roc_9_4h < 70.0))
             # 15m down move, 1h high & overbought
-            & ((rsi_3_15m_gt_35) | (stochrsi_k_1h < 90.0) | (roc_9_1h < 40.0))
+            & ((rsi_3_15m_gt_35) | (stochrsi_k_1h_lt_90) | (roc_9_1h < 40.0))
             # 15m & 1h down move, 4h high
             & ((rsi_3_15m_gt_40) | (rsi_3_1h_gt_40) | aroonu_14_4h_lt_100)
             # 15m & 4h down move, 1h high
-            & ((rsi_3_15m_gt_40) | (rsi_3_4h_gt_45) | (stochrsi_k_1h < 90.0))
+            & ((rsi_3_15m_gt_40) | (rsi_3_4h_gt_45) | (stochrsi_k_1h_lt_90))
             # 15m down move, 15m still high, 1d high
             & ((rsi_3_15m_gt_40) | (stochrsi_k_15m_lt_40) | (roc_9_1d_lt_100))
             # 15m down move, 4h high & overbought
@@ -16091,7 +16103,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 4h downtrend, 1d overbought
             & (rsi_3_1h_gt_20 | (roc_9_4h > -10.0) | (roc_9_1d_lt_20))
             # 1h & 4h down move, 1h still high
-            & ((rsi_3_1h_gt_25) | (rsi_3_4h_gt_10) | (stochrsi_k_1h < 40.0))
+            & ((rsi_3_1h_gt_25) | (rsi_3_4h_gt_10) | (stochrsi_k_1h_lt_40))
             # 1h & 4h down move, 15m high
             & ((rsi_3_1h_gt_25) | (rsi_3_4h_gt_30) | (stochrsi_k_15m_lt_70))
             # 1h down move, 4h downtrend, 4h high
@@ -16139,7 +16151,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 1d down move, 1d high
             & ((rsi_3_1h_gt_35) | (rsi_3_1d_gt_45) | (aroonu_14_1d_lt_90))
             # 1h & 4h down move, 1h high
-            & ((rsi_3_1h_gt_40) | (rsi_3_4h_gt_50) | (stochrsi_k_1h < 60.0))
+            & ((rsi_3_1h_gt_40) | (rsi_3_4h_gt_50) | (stochrsi_k_1h_lt_60))
             # 1h down move, 1h high, 1d overbought
             & ((rsi_3_1h_gt_40) | (aroonu_14_1h_lt_60) | (roc_9_1d_lt_40))
             # 1h down move, 1h still high, 1d high
@@ -16161,7 +16173,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h still not low enough, 1d downtrend
             & ((rsi_3_1h_gt_45) | (aroonu_14_1h_lt_30) | (roc_9_1d > -25.0))
             # 1h down move, 1h still high, 1d overbought
-            & ((rsi_3_1h_gt_45) | (stochrsi_k_1h < 40.0) | (roc_9_1d_lt_100))
+            & ((rsi_3_1h_gt_45) | (stochrsi_k_1h_lt_40) | (roc_9_1d_lt_100))
             # 1h down move, 4h high, 1h overbought
             & ((rsi_3_1h_gt_50) | (aroonu_14_4h_lt_85) | (roc_9_1h < 20.0))
             # 1h down move, 1d high, 4h overbought
@@ -16187,11 +16199,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h high, 1d downtrend
             & ((rsi_3_1h_gt_60) | (stochrsi_k_1h_lt_70) | (roc_9_1d > -10.0))
             # 1h down move, 1h high, 1d overbought
-            & ((rsi_3_1h_gt_60) | (stochrsi_k_1h < 80.0) | (roc_9_1d_lt_100))
+            & ((rsi_3_1h_gt_60) | (stochrsi_k_1h_lt_80) | (roc_9_1d_lt_100))
             # 1h down move, 1h high, 4h overbought
             & ((rsi_3_1h_gt_65) | aroonu_14_1h_lt_70 | (roc_9_4h < 25.0))
             # 1h down move, 1h high, 1d overbought
-            & ((rsi_3_1h_gt_65) | (stochrsi_k_1h < 90.0) | (roc_9_1d_lt_20))
+            & ((rsi_3_1h_gt_65) | (stochrsi_k_1h_lt_90) | (roc_9_1d_lt_20))
             # 4h down move, 1h still not low enough, 4h downtrend
             & ((rsi_3_4h_gt_3) | (aroonu_14_1h_lt_20) | (roc_9_4h > -10.0))
             # 4h down move, 4h & 1d downtrend
@@ -16199,7 +16211,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h & 1d down move, 15m still high
             & ((rsi_3_4h_gt_5) | (rsi_3_1d_gt_25) | (stochrsi_k_15m_lt_40))
             # 4h & 1d down move, 1h still not low enough
-            & ((rsi_3_4h_gt_10) | (rsi_3_1d_gt_10) | (stochrsi_k_1h < 20.0))
+            & ((rsi_3_4h_gt_10) | (rsi_3_1d_gt_10) | (stochrsi_k_1h_lt_20))
             # 4h & 1d down move, 1d downtrend
             & ((rsi_3_4h_gt_10) | (rsi_3_1d_gt_15) | (roc_9_1d_gt_neg_40))
             # 4h & 1d down move, 1d still high
@@ -16213,7 +16225,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h & 1d down move, 4h high
             & ((rsi_3_4h_gt_15) | (rsi_3_1d_gt_25) | aroonu_14_4h_lt_70)
             # 4h & 1d down move, 1h still high
-            & ((rsi_3_4h_gt_15) | (rsi_3_1d_gt_30) | (stochrsi_k_1h < 40.0))
+            & ((rsi_3_4h_gt_15) | (rsi_3_1d_gt_30) | (stochrsi_k_1h_lt_40))
             # 4h & 1d down move, 1d high
             & ((rsi_3_4h_gt_15) | (rsi_3_1d_gt_25) | (aroonu_14_1d_lt_70))
             # 4h & 1d down move, 1d downtrend
@@ -16235,7 +16247,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 15m high
             & (rsi_3_4h_gt_20 | (stochrsi_k_15m_lt_80))
             # 4h down move, 1h high, 4h downtrend
-            & (rsi_3_4h_gt_20 | (stochrsi_k_1h < 70.0) | (roc_9_4h_gt_neg_20))
+            & (rsi_3_4h_gt_20 | (stochrsi_k_1h_lt_70) | (roc_9_4h_gt_neg_20))
             # 4h down move, 4h still high, 4h downtrend
             & ((rsi_3_4h_gt_25) | (aroonu_14_4h_lt_50) | (cmf_20_4h > -0.40))
             # 4h down move, 4h high, 1d downtrend
@@ -16247,7 +16259,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 1h high, 4h downtrend
             & ((rsi_3_4h_gt_30) | aroonu_14_1h_lt_70 | (roc_9_4h > -10.0))
             # 4h down move, 1h still high, 1d overbought
-            & ((rsi_3_4h_gt_30) | (stochrsi_k_1h < 40.0) | (roc_9_1d_lt_30))
+            & ((rsi_3_4h_gt_30) | (stochrsi_k_1h_lt_40) | (roc_9_1d_lt_30))
             # 4h & 1d down move, 1d overbought
             & ((rsi_3_4h_gt_35) | (rsi_3_1d > 50.0) | (roc_9_1d_lt_100))
             # 4h down move, 4h & 1d high
@@ -16267,7 +16279,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 4h high & overbought
             & ((rsi_3_4h_gt_50) | aroonu_14_4h_lt_80 | (roc_9_4h_lt_10))
             # 4h down move, 1h high, 1d downtrend
-            & ((rsi_3_4h_gt_50) | (stochrsi_k_1h < 80.0) | (roc_9_1d_gt_neg_30))
+            & ((rsi_3_4h_gt_50) | (stochrsi_k_1h_lt_80) | (roc_9_1d_gt_neg_30))
             # 4h down move, 4h high & overbought
             & ((rsi_3_4h_gt_55) | aroonu_14_4h_lt_70 | (roc_9_4h_lt_20))
             # 4h down move, 4h high, 1d overbought
@@ -16291,7 +16303,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1d down move, 15m still high
             & ((rsi_3_1d_gt_5) | (stochrsi_k_15m_lt_40))
             # 1d down move, 1h & 4h still not low enough
-            & ((rsi_3_1d_gt_5) | (stochrsi_k_1h < 20.0) | (stochrsi_k_4h_lt_20))
+            & ((rsi_3_1d_gt_5) | (stochrsi_k_1h_lt_20) | (stochrsi_k_4h_lt_20))
             # 1d down move, 1h high
             & ((rsi_3_1d_gt_10) | aroonu_14_1h_lt_70)
             # 1d down move, 4h downtrend, 4h high
@@ -16361,11 +16373,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h high, 1h overbought, 4h downtrend
             & ((stochrsi_k_1h_lt_80) | (roc_9_1h_lt_10) | (roc_9_4h > -10.0))
             # 1h high, 4h & 1d downtrend
-            & ((stochrsi_k_1h < 80.0) | (roc_9_4h_gt_neg_20) | (roc_9_1d > -80.0))
+            & ((stochrsi_k_1h_lt_80) | (roc_9_4h_gt_neg_20) | (roc_9_1d > -80.0))
             # 1h down move, 1h & 1d overbought
-            & ((stochrsi_k_1h < 90.0) | (roc_9_1h_lt_10) | roc_9_1d_lt_50)
+            & ((stochrsi_k_1h_lt_90) | (roc_9_1h_lt_10) | roc_9_1d_lt_50)
             # 1h high & overbought
-            & ((stochrsi_k_1h < 90.0) | (roc_9_1h < 40.0))
+            & ((stochrsi_k_1h_lt_90) | (roc_9_1h < 40.0))
             # 4h high, 1h & 4h overbought
             & ((stochrsi_k_4h_lt_70) | (roc_9_1h_lt_10) | (roc_9_4h_lt_20))
             # 4h high, 1h & 1d overbought
@@ -16466,7 +16478,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 4h high, 1d overbought
             & ((rsi_3_15m_gt_25) | aroonu_14_4h_lt_100 | (roc_9_1d < 100.0))
             # 15m down move, 1h high & overbought
-            & ((rsi_3_15m_gt_25) | (stochrsi_k_1h < 90.0) | (roc_9_1h < 20.0))
+            & ((rsi_3_15m_gt_25) | (stochrsi_k_1h_lt_90) | (roc_9_1h < 20.0))
             # 15m down move, 1h & 4h overbought
             & ((rsi_3_15m_gt_25) | (roc_9_1h < 40.0) | (roc_9_4h_lt_40))
             # 15m down move, 4h high & overbought
@@ -16480,7 +16492,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 4h high
             & (rsi_3_1h_gt_20 | (roc_9_4h < 50.0) | aroonu_14_4h_lt_80)
             # 1h & 4h down move, 1h still high
-            & (rsi_3_1h_gt_20 | (roc_9_4h < 50.0) | (stochrsi_k_1h < 40.0))
+            & (rsi_3_1h_gt_20 | (roc_9_4h < 50.0) | (stochrsi_k_1h_lt_40))
             # 1h & 4h down move, 4h overbought
             & (rsi_3_1h_gt_20 | (roc_9_4h < 50.0) | (roc_9_4h_lt_10))
             # 1h down move, 1h & 4h high
@@ -16490,7 +16502,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 4h high & overbought
             & (rsi_3_1h_gt_20 | aroonu_14_4h_lt_100 | (roc_9_4h < 50.0))
             # 1h down move, 1h still high, 1d overbought
-            & (rsi_3_1h_gt_20 | (stochrsi_k_1h < 40.0) | (roc_9_4h_lt_10))
+            & (rsi_3_1h_gt_20 | (stochrsi_k_1h_lt_40) | (roc_9_4h_lt_10))
             # 1h down move, 4h & 1d overbought
             & (rsi_3_1h_gt_20 | (roc_9_4h_lt_40) | (roc_9_1d_lt_100))
             # 1h down move, 1d high, 4h overbought
@@ -16514,7 +16526,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h high & overbought
             & ((rsi_3_1h_gt_50) | (aroonu_14_1h_lt_90) | (roc_9_1h_lt_10))
             # 1h down move, 1h high, 1d downtrend
-            & ((rsi_3_1h_gt_50) | (stochrsi_k_1h < 70.0) | (roc_9_1d_gt_neg_20))
+            & ((rsi_3_1h_gt_50) | (stochrsi_k_1h_lt_70) | (roc_9_1d_gt_neg_20))
             # 1h down move, 1h & 1d overbought
             & ((rsi_3_1h_gt_50) | (roc_9_1h < 25.0) | (roc_9_1d < 200.0))
             # 1h down move, 1h high, 4h overbought
@@ -16556,7 +16568,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1d downtrend, 1d high & overbought
             & ((cmf_20_1d > -0.40) | (aroonu_14_1d_lt_85) | (roc_9_1d_lt_20))
             # 15m not low enough, 1h high, 1d overbought
-            & ((aroonu_14_15m_lt_25) | (stochrsi_k_1h < 90.0) | (roc_9_1d < 200.0))
+            & ((aroonu_14_15m_lt_25) | (stochrsi_k_1h_lt_90) | (roc_9_1d < 200.0))
             # 1h still high, 1h & 4h overbought
             & ((aroonu_14_1h_lt_50) | (roc_9_1h < 40.0) | (roc_9_4h_lt_40))
             # 1h & 4h high, 4h overbought
@@ -16602,7 +16614,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1d high, 1h & 4h overbought
             & (aroonu_14_1d_lt_100 | (roc_9_1h_lt_10) | (roc_9_4h < 20.0))
             # 1h high, 1h & 4h overbought
-            & ((stochrsi_k_1h < 60.0) | (roc_9_1h < 40.0) | (roc_9_4h_lt_40))
+            & ((stochrsi_k_1h_lt_60) | (roc_9_1h < 40.0) | (roc_9_4h_lt_40))
             # 1h high, 1h overbought
             & ((stochrsi_k_1h_lt_80) | (roc_9_1h_lt_10))
             # 1h high, 4h overbought. 1d downtrend
@@ -16640,7 +16652,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 1d still high
             & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_3) | (stochrsi_k_1d < 50.0))
             # 15m & 1h down move, 1h still not low enough
-            & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_5) | (stochrsi_k_1h < 30.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_5) | (stochrsi_k_1h_lt_30))
             # 15m & 1h & 4h down move, 4h still not low enough
             & ((rsi_3_15m_gt_3) | (rsi_3_1h_gt_10) | (rsi_3_4h_gt_20) | (aroonu_14_4h_lt_20))
             # 15m & 1h down move, 15m downtrend
@@ -16648,7 +16660,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 4h high
             & ((rsi_3_15m_gt_3) | (rsi_3_1h_gt_10) | (aroonu_14_4h_lt_80))
             # 15m & 1h down move, 1h still high
-            & ((rsi_3_15m_gt_3) | (rsi_3_1h_gt_10) | (stochrsi_k_1h < 40.0))
+            & ((rsi_3_15m_gt_3) | (rsi_3_1h_gt_10) | (stochrsi_k_1h_lt_40))
             # 15m & 1h down move, 4h high
             & ((rsi_3_15m_gt_3) | (rsi_3_1h_gt_10) | (stochrsi_k_4h_lt_60))
             # 15m & 1h down move, 1d downtrend
@@ -16686,7 +16698,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 1h & 4h high
             & ((rsi_3_15m_gt_3) | (stochrsi_k_1h_lt_80) | (stochrsi_k_4h_lt_80))
             # 15m down move, 1h high, 4h overbought
-            & ((rsi_3_15m_gt_3) | (stochrsi_k_1h < 90.0) | (roc_9_4h_lt_10))
+            & ((rsi_3_15m_gt_3) | (stochrsi_k_1h_lt_90) | (roc_9_4h_lt_10))
             # 15m down move, 4h high & overbought
             & ((rsi_3_15m_gt_3) | (stochrsi_k_4h_lt_80) | (roc_9_4h_lt_10))
             # 15m down move, 4h & 1d downtrend
@@ -16770,9 +16782,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 1h high, 15m downtrend
             & ((rsi_3_15m_gt_10) | (stochrsi_k_1h_lt_80) | (roc_9_15m > -10.0))
             # 15m down move, 1h high, 1d downtrend
-            & ((rsi_3_15m_gt_10) | (stochrsi_k_1h < 90.0) | (roc_9_1d_gt_neg_30))
+            & ((rsi_3_15m_gt_10) | (stochrsi_k_1h_lt_90) | (roc_9_1d_gt_neg_30))
             # 15m down move, 1h high, 1d overbought
-            & ((rsi_3_15m_gt_10) | (stochrsi_k_1h < 90.0) | (roc_9_1d_lt_30))
+            & ((rsi_3_15m_gt_10) | (stochrsi_k_1h_lt_90) | (roc_9_1d_lt_30))
             # 15m down move, 4h high & overbought
             & ((rsi_3_15m_gt_10) | (stochrsi_k_4h_lt_90) | (roc_9_4h_lt_20))
             # 15m & 1h down move, 1d overbought
@@ -16930,7 +16942,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 1d down move, 4h high
             & ((rsi_3_1h_gt_10) | (rsi_3_1d_gt_15) | (stochrsi_k_4h_lt_70))
             # 1h & 1d down move, 1h still not low enough
-            & ((rsi_3_1h_gt_10) | (rsi_3_1d_gt_20) | (stochrsi_k_1h < 20.0))
+            & ((rsi_3_1h_gt_10) | (rsi_3_1d_gt_20) | (stochrsi_k_1h_lt_20))
             # 1h & 1d down move, 1h high
             & ((rsi_3_1h_gt_10) | (rsi_3_1d_gt_25) | (aroonu_14_1h_lt_70))
             # 1h & 1d down move, 1h downtrend
@@ -16958,11 +16970,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 1d high
             & ((rsi_3_1h_gt_15) | rsi_3_4h_gt_20 | (aroonu_14_1d_lt_100))
             # 1h & 1d down move, 1h still high
-            & ((rsi_3_1h_gt_15) | (rsi_3_1d_gt_30) | (stochrsi_k_1h < 40.0))
+            & ((rsi_3_1h_gt_15) | (rsi_3_1d_gt_30) | (stochrsi_k_1h_lt_40))
             # 1h & 1d down move, 1h high
             & ((rsi_3_1h_gt_15) | (rsi_3_1d_gt_30) | (aroonu_14_1h_lt_80))
             # 1h down move, 1h downtrend, 1h still high
-            & ((rsi_3_1h_gt_15) | (cmf_20_1h > -0.30) | (stochrsi_k_1h < 40.0))
+            & ((rsi_3_1h_gt_15) | (cmf_20_1h > -0.30) | (stochrsi_k_1h_lt_40))
             # 1h down move, 1d downtrend, 1d high
             & ((rsi_3_1h_gt_15) | (cmf_20_1d > -0.30) | (stochrsi_k_1d < 80.0))
             # 1h down move, 1h & 1d high
@@ -17102,7 +17114,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h high, 1d downtrend
             & ((rsi_3_1h_gt_50) | (aroonu_14_1h_lt_60) | (roc_9_1d > -70.0))
             # 1h down move, 1h high, 1d overbought
-            & ((rsi_3_1h_gt_50) | (stochrsi_k_1h < 70.0) | (roc_9_1d_lt_100))
+            & ((rsi_3_1h_gt_50) | (stochrsi_k_1h_lt_70) | (roc_9_1d_lt_100))
             # 1h down move, 4h high, 1d downtrend
             & ((rsi_3_1h_gt_50) | (stochrsi_k_4h_lt_60) | (roc_9_1d > -60.0))
             # 1h down move, 1h high
@@ -17134,7 +17146,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 4h still high, 1d overbought
             & ((rsi_3_4h_gt_15) | (aroonu_14_4h_lt_40) | (roc_9_1d_lt_40))
             # 4h down move, 1h still not low enough, 1d downtrend
-            & ((rsi_3_4h_gt_15) | (stochrsi_k_1h < 20.0) | (roc_9_1d > -20.0))
+            & ((rsi_3_4h_gt_15) | (stochrsi_k_1h_lt_20) | (roc_9_1d > -20.0))
             # 4h & 1d down move, 1d high
             & (rsi_3_4h_gt_20 | (rsi_3_1d_gt_20) | (stochrsi_k_1d < 70.0))
             # 4h down move, 1d high & overbought
@@ -17186,7 +17198,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1d down move, 1h still high, 4h downtrend
             & ((rsi_3_1d_gt_25) | (stochrsi_k_1h_lt_50) | (roc_9_4h_gt_neg_30))
             # 1d down move, 1h high & overbought
-            & ((rsi_3_1d_gt_35) | (stochrsi_k_1h < 90.0) | (roc_9_1h_lt_10))
+            & ((rsi_3_1d_gt_35) | (stochrsi_k_1h_lt_90) | (roc_9_1h_lt_10))
             # 15m downtrend, 4h & 1d high
             & ((cmf_20_15m > -0.30) | aroonu_14_4h_lt_80 | aroonu_14_1d_lt_100)
             # 15m & 1h high, 1h overbought
@@ -17240,7 +17252,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h high, 4h overbought
             & ((stochrsi_k_1h_lt_80) | (roc_9_4h < 80.0))
             # 1h high, 1h overbought, 4h downtrend
-            & ((stochrsi_k_1h < 90.0) | (roc_9_1h_lt_10) | (roc_9_4h > -15.0))
+            & ((stochrsi_k_1h_lt_90) | (roc_9_1h_lt_10) | (roc_9_4h > -15.0))
             # 4h high, 1h & 4h overbought
             & ((stochrsi_k_4h_lt_90) | (roc_9_1h < 20.0) | (roc_9_4h < 50.0))
             # 1d high, 4h & 1d overbought
@@ -17806,7 +17818,7 @@ class NostalgiaForInfinityX7(IStrategy):
             (willr_14 < -50.0)
             & (stochrsi_k < 20.0)
             & (willr_84_1h < -70.0)
-            & (stochrsi_k_1h < 20.0)
+            & (stochrsi_k_1h_lt_20)
             & (bbb_20_2_0_1h > 16.0)
             & (close_max_48 >= (close * 1.10))
           )
@@ -17823,7 +17835,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 5m & 1h down move, 1h still not low enough
             & ((rsi_3_gt_3) | (rsi_3_1h_gt_10) | (aroonu_14_1h_lt_30))
             # 5m & 1h down move, 1h still not low enough
-            & ((rsi_3_gt_3) | (rsi_3_1h_gt_15) | (stochrsi_k_1h < 30.0))
+            & ((rsi_3_gt_3) | (rsi_3_1h_gt_15) | (stochrsi_k_1h_lt_30))
             # 5m & 1h down move, 4h high
             & ((rsi_3_gt_3) | (rsi_3_1h_gt_50) | (stochrsi_k_4h_lt_60))
             # 5m & 1d down move, 1d still not low enough
@@ -17833,7 +17845,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 5m down move, 4h high & overbought
             & ((rsi_3_gt_3) | aroonu_14_4h_lt_100 | (roc_9_4h < 20.0))
             # 5m down move, 1h high, 4h overbought
-            & ((rsi_3_gt_3) | (stochrsi_k_1h < 80.0) | (roc_9_4h_lt_20))
+            & ((rsi_3_gt_3) | (stochrsi_k_1h_lt_80) | (roc_9_4h_lt_20))
             # 5m down move, 1d high & overbought
             & ((rsi_3_gt_3) | (stochrsi_k_1d_lt_90) | (roc_9_1d_lt_20))
             # 5m & 1h down move, 1d overbought
@@ -17873,7 +17885,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 1d overbought
             & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_30) | (roc_9_1d < 200.0))
             # 15m & 1h down move, 1h still high
-            & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_35) | (stochrsi_k_1h < 40.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_35) | (stochrsi_k_1h_lt_40))
             # 15m & 1h down move, 4h high
             & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_45) | (aroonu_14_4h_lt_90))
             # 15m & 4h down move, 1d high
@@ -17893,7 +17905,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 1d high & overbought
             & (rsi_3_15m_gt_3 | aroonu_14_1d_lt_100 | (roc_9_1d_lt_40))
             # 15m down move, 1h high, 1d downtrend
-            & (rsi_3_15m_gt_3 | (stochrsi_k_1h < 80.0) | (roc_9_1d_gt_neg_20))
+            & (rsi_3_15m_gt_3 | (stochrsi_k_1h_lt_80) | (roc_9_1d_gt_neg_20))
             # 15m down move, 4h high & overbought
             & (rsi_3_15m_gt_3 | (stochrsi_k_4h_lt_80) | (roc_9_4h_lt_40))
             # 15m down move, 4h high, 1d overbought
@@ -17905,7 +17917,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 4h still high
             & ((rsi_3_15m_gt_5) | (rsi_3_1h_gt_5) | (rsi_14_4h < 40.0))
             # 15m & 1h down move, 1h still not low enough
-            & ((rsi_3_15m_gt_5) | (rsi_3_1h_gt_15) | (stochrsi_k_1h < 20.0))
+            & ((rsi_3_15m_gt_5) | (rsi_3_1h_gt_15) | (stochrsi_k_1h_lt_20))
             # 15m & 1h down move, 1d still high
             & ((rsi_3_15m_gt_5) | rsi_3_1h_gt_20 | (stochrsi_k_1d < 50.0))
             # 15m & 1h down move, 1d overbought
@@ -17915,7 +17927,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 1h high
             & ((rsi_3_15m_gt_5) | (rsi_3_1h_gt_45) | aroonu_14_1h_lt_80)
             # 15m & 4h down move, 1h still high
-            & ((rsi_3_15m_gt_5) | (rsi_3_4h_gt_10) | (stochrsi_k_1h < 50.0))
+            & ((rsi_3_15m_gt_5) | (rsi_3_4h_gt_10) | (stochrsi_k_1h_lt_50))
             # 15m & 4h down move, 1h downtrend
             & ((rsi_3_15m_gt_5) | (rsi_3_4h_gt_10) | (roc_9_1h > -20.0))
             # 15m & 4h down move, 15m still high
@@ -17945,7 +17957,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 15m high
             & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_10) | (aroonu_14_15m_lt_70))
             # 15m & 1h down move, 1h still high
-            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_15) | (stochrsi_k_1h < 40.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_15) | (stochrsi_k_1h_lt_40))
             # 15m & 1h down move, 1d high
             & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_15) | (stochrsi_k_1d_lt_90))
             # 15m & 1h down move, 4h downtrend
@@ -17967,11 +17979,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 4h overbought
             & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_25) | (roc_9_4h_lt_20))
             # 15m & 1h down move, 1h high
-            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_30) | (stochrsi_k_1h < 60.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_30) | (stochrsi_k_1h_lt_60))
             # 15m & 1h down move, 1d high
             & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_40) | (aroonu_14_1d_lt_90))
             # 15m & 1h down move, 1h high
-            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_40) | (stochrsi_k_1h < 90.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_40) | (stochrsi_k_1h_lt_90))
             # 15m & 1h down move, 4h high
             & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_50) | (stochrsi_k_4h_lt_90))
             # 15m & 4h down move, 15m still high
@@ -17979,7 +17991,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 4h down move, 4h still high
             & ((rsi_3_15m_gt_10) | (rsi_3_4h_gt_10) | (stochrsi_k_4h_lt_40))
             # 15m & 4h down move, 1h high
-            & ((rsi_3_15m_gt_10) | (rsi_3_4h_gt_15) | (stochrsi_k_1h < 90.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_4h_gt_15) | (stochrsi_k_1h_lt_90))
             # 15m & 4h down move, 1d downtrend
             & ((rsi_3_15m_gt_10) | (rsi_3_4h_gt_15) | (roc_9_1d > -20.0))
             # 15m & 4h down move, 4h still high
@@ -18193,7 +18205,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1d high & overbought
             & ((rsi_3_1h_gt_35) | (aroonu_14_1d_lt_100) | (roc_9_1d < 200.0))
             # 1h down move, 1h high, 4h downtrend
-            & ((rsi_3_1h_gt_35) | (stochrsi_k_1h < 70.0) | (roc_9_4h_gt_neg_20))
+            & ((rsi_3_1h_gt_35) | (stochrsi_k_1h_lt_70) | (roc_9_4h_gt_neg_20))
             # 1h & 1d down move, 1h high
             & ((rsi_3_1h_gt_40) | (rsi_3_1d_gt_40) | (aroonu_14_1h_lt_90))
             # 1h down move, 1h high, 1d downtrend
@@ -18203,7 +18215,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 4h high & overbought
             & ((rsi_3_1h_gt_40) | (aroonu_14_4h_lt_90) | (roc_9_4h_lt_20))
             # 1h down move, 1h high, 4h overbought
-            & ((rsi_3_1h_gt_40) | (stochrsi_k_1h < 80.0) | (roc_9_4h_lt_20))
+            & ((rsi_3_1h_gt_40) | (stochrsi_k_1h_lt_80) | (roc_9_4h_lt_20))
             # 1h down move, 4h high & overbought
             & ((rsi_3_1h_gt_40) | (stochrsi_k_4h_lt_80) | (roc_9_4h_lt_20))
             # 1h down move, 1d high, 4h overbought
@@ -18215,7 +18227,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h & 1d down move, 15m still high
             & ((rsi_3_4h_gt_3) | (rsi_3_1d_gt_15) | (stochrsi_k_15m_lt_40))
             # 4h & 1d down move, 1h still not low enough
-            & ((rsi_3_4h_gt_3) | (rsi_3_1d_gt_15) | (stochrsi_k_1h < 30.0))
+            & ((rsi_3_4h_gt_3) | (rsi_3_1d_gt_15) | (stochrsi_k_1h_lt_30))
             # 4h down move, 4h still high
             & ((rsi_3_4h_gt_3) | (aroonu_14_4h_lt_50))
             # 4h down move, 1h still high, 4h downtrend
@@ -18239,7 +18251,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 1h still high
             & ((rsi_3_4h_gt_15) | (aroonu_14_1h_lt_50))
             # 4h down move, 1h still high, 1d downtrend
-            & ((rsi_3_4h_gt_15) | (stochrsi_k_1h < 50.0) | (roc_9_1d > -30.0))
+            & ((rsi_3_4h_gt_15) | (stochrsi_k_1h_lt_50) | (roc_9_1d > -30.0))
             # 4h down move, 4h still high, 1d downtrend
             & ((rsi_3_4h_gt_15) | (stochrsi_k_4h_lt_50) | (roc_9_1d > -20.0))
             # 4h down move, 4h still high, 1d downtrend
@@ -18259,7 +18271,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1d down move, 4h high, 1d downtrend
             & ((rsi_3_1d_gt_15) | (stochrsi_k_4h_lt_70) | (roc_9_1d > -70.0))
             # 1d down move, 1h high & overbought
-            & ((rsi_3_1d_gt_35) | (stochrsi_k_1h < 90.0) | (roc_9_1h_lt_10))
+            & ((rsi_3_1d_gt_35) | (stochrsi_k_1h_lt_90) | (roc_9_1h_lt_10))
             # 1d down move, 1h high & overbought
             & ((rsi_3_1d_gt_40) | (aroonu_14_1d_lt_70) | (roc_9_1d_lt_80))
             # 4h downtrend, 1h & 4h high
@@ -18364,7 +18376,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 4h down move, 1h still high
             & ((rsi_3_15m_gt_3) | (rsi_3_4h_gt_15) | (aroonu_14_1h_lt_50))
             # 15m & 4h down move, 1h still high
-            & ((rsi_3_15m_gt_3) | (rsi_3_4h_gt_40) | (stochrsi_k_1h < 40.0))
+            & ((rsi_3_15m_gt_3) | (rsi_3_4h_gt_40) | (stochrsi_k_1h_lt_40))
             # 15m down move, 1h still high, 1d overbought
             & ((rsi_3_15m_gt_3) | (aroonu_14_1h_lt_40) | (roc_9_1d < 70.0))
             # 15m down move, 4h high & overbought
@@ -18378,7 +18390,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 1h downtrend
             & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_10) | (roc_9_1h > -20.0))
             # 15m & 4h down move, 1h still not low enough
-            & ((rsi_3_15m_gt_10) | (rsi_3_4h_gt_10) | (stochrsi_k_1h < 30.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_4h_gt_10) | (stochrsi_k_1h_lt_30))
             # 15m down move, 4h overbought
             & ((rsi_3_15m_gt_10) | (roc_9_4h_lt_30))
             # 15m & 4h down move, 4h high
@@ -18540,7 +18552,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 1d overbought
             & ((rsi_3_4h_gt_3) | (roc_9_1d < 200.0))
             # 4h down move, 1h still high
-            & ((rsi_3_4h_gt_5) | (stochrsi_k_1h < 40.0))
+            & ((rsi_3_4h_gt_5) | (stochrsi_k_1h_lt_40))
             # 4h down move, 1h & 4h downtrend
             & ((rsi_3_4h_gt_5) | (roc_9_1h > -15.0) | (roc_9_4h_gt_neg_20))
             # 4h down move, 4h downtrend
@@ -18618,7 +18630,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1d high, 4h & 1d overbought
             & (aroonu_14_1d_lt_100 | (roc_9_4h < 20.0) | (roc_9_1d_lt_80))
             # 1h still high, 4h & 1d downtrend
-            & ((stochrsi_k_1h < 50.0) | (roc_9_4h_gt_neg_20) | roc_9_1d_gt_neg_50)
+            & ((stochrsi_k_1h_lt_50) | (roc_9_4h_gt_neg_20) | roc_9_1d_gt_neg_50)
             # 1h high, 15m downtrend
             & ((stochrsi_k_1h_lt_70) | (roc_9_15m > -30.0))
             # 4h high, 1d downtrend
@@ -18655,7 +18667,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 5m & 15m down move, 4h still high
           long_entry_logic.append((rsi_3_gt_3) | (rsi_3_15m_gt_15) | (stochrsi_k_4h_lt_50))
           # 15m & 1h down move, 1h still high
-          long_entry_logic.append(rsi_3_15m_gt_3 | (rsi_3_1h_gt_25) | (stochrsi_k_1h < 40.0))
+          long_entry_logic.append(rsi_3_15m_gt_3 | (rsi_3_1h_gt_25) | (stochrsi_k_1h_lt_40))
           # 5m & 4h & 1d down move
           long_entry_logic.append((rsi_3_gt_3) | rsi_3_4h_gt_20 | (rsi_3_1d_gt_20))
           # 15m & 1h down move, 4h high
@@ -18739,7 +18751,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1h & 4h down move, 4h still not low enough
           long_entry_logic.append((rsi_3_1h_gt_3) | (rsi_3_4h_gt_25) | (stochrsi_k_4h_lt_30))
           # 1h down move, 1h still not low enough, 1d high
-          long_entry_logic.append((rsi_3_1h_gt_10) | (stochrsi_k_1h < 20.0) | (aroonu_14_1d_lt_85))
+          long_entry_logic.append((rsi_3_1h_gt_10) | (stochrsi_k_1h_lt_20) | (aroonu_14_1d_lt_85))
           # 1h down move, 1h still not low enough
           long_entry_logic.append((rsi_3_1h_gt_10) | (stochrsi_k_1h < 25.0))
           # 1h down move, 4h high
@@ -18761,7 +18773,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1h down move, 1d high, 4h downtrend
           long_entry_logic.append((rsi_3_1h_gt_15) | (aroonu_14_1d_lt_70) | (roc_9_4h > -20.0))
           # 1h down move, 1h still high
-          long_entry_logic.append((rsi_3_1h_gt_15) | (stochrsi_k_1h < 30.0))
+          long_entry_logic.append((rsi_3_1h_gt_15) | (stochrsi_k_1h_lt_30))
           # 1h & 4h down move, 1d overbought
           long_entry_logic.append(rsi_3_1h_gt_20 | rsi_3_4h_gt_20 | (roc_9_1d_lt_20))
           # 1h down move, 4h high
@@ -18769,7 +18781,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1h down move, 4h still high
           long_entry_logic.append(rsi_3_1h_gt_20 | (stochrsi_k_4h_lt_50))
           # 1h & 4h down move, 1h high
-          long_entry_logic.append((rsi_3_1h_gt_25) | (rsi_3_4h_gt_30) | (stochrsi_k_1h < 60.0))
+          long_entry_logic.append((rsi_3_1h_gt_25) | (rsi_3_4h_gt_30) | (stochrsi_k_1h_lt_60))
           # 1h & 4h down move, 4h high
           long_entry_logic.append((rsi_3_1h_gt_25) | (rsi_3_4h_gt_40) | aroonu_14_4h_lt_70)
           # 1h down move, 1h high
@@ -18801,7 +18813,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 4h downmove, 4h still high
           long_entry_logic.append((rsi_3_4h_gt_10) | (aroonu_14_4h_lt_40))
           # 4h down move, 1h still high, 1d downtrend
-          long_entry_logic.append((rsi_3_4h_gt_10) | (stochrsi_k_1h < 40.0) | (roc_9_1d > -20.0))
+          long_entry_logic.append((rsi_3_4h_gt_10) | (stochrsi_k_1h_lt_40) | (roc_9_1d > -20.0))
           # 4h down move, 1h & 1d downtrend
           long_entry_logic.append((rsi_3_4h_gt_10) | (roc_9_1h > -20.0) | (roc_9_1d > -20.0))
           # 4h & 1d down move, 1d still high
@@ -18827,13 +18839,13 @@ class NostalgiaForInfinityX7(IStrategy):
           # 4h down move, 4h high
           long_entry_logic.append((rsi_3_4h_gt_60) | (stochrsi_k_4h_lt_80))
           # 1d down move, 1h still not low enough
-          long_entry_logic.append((rsi_3_1d_gt_5) | (stochrsi_k_1h < 30.0))
+          long_entry_logic.append((rsi_3_1d_gt_5) | (stochrsi_k_1h_lt_30))
           # 1d down move, 1h still not low enough
-          long_entry_logic.append((rsi_3_1d_gt_15) | (stochrsi_k_1h < 30.0))
+          long_entry_logic.append((rsi_3_1d_gt_15) | (stochrsi_k_1h_lt_30))
           # 1d down move, 4h still high
           long_entry_logic.append((rsi_3_1d_gt_15) | (stochrsi_k_4h_lt_50))
           # 1d down move, 1h high & overbought
-          long_entry_logic.append((rsi_3_1d_gt_35) | (stochrsi_k_1h < 90.0) | (roc_9_1h_lt_10))
+          long_entry_logic.append((rsi_3_1d_gt_35) | (stochrsi_k_1h_lt_90) | (roc_9_1h_lt_10))
           # 15m still high, 1h & 4h high
           long_entry_logic.append((rsi_14_15m < 40.0) | aroonu_14_1h_lt_80 | (aroonu_14_4h_lt_90))
           # 1h & 4h high, 4h overbought
@@ -19176,7 +19188,7 @@ class NostalgiaForInfinityX7(IStrategy):
             & (aroonu_14_15m_lt_25)
             & (stochrsi_k_15m_lt_20)
             & (willr_84_1h < -70.0)
-            & (stochrsi_k_1h < 20.0)
+            & (stochrsi_k_1h_lt_20)
             & (bbb_20_2_0_1h > 12.0)
             & (close_max_48 >= (close * 1.10))
           )
@@ -19219,7 +19231,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 1d high
             & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_30) | (aroonu_14_1d_lt_80))
             # 15m & 1h down move, 1h still high
-            & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_30) | (stochrsi_k_1h < 40.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_30) | (stochrsi_k_1h_lt_40))
             # 15m & 1h down move, 1h high
             & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_45) | aroonu_14_1h_lt_80)
             # 15m & 1h down move, 1h high
@@ -19235,7 +19247,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 4h & 1d downtrend
             & (rsi_3_15m_gt_3 | (roc_9_4h_gt_neg_20) | (roc_9_1d_gt_neg_20))
             # 15m & 1h down move, 1h still high
-            & ((rsi_3_15m_gt_5) | rsi_3_1h_gt_20 | (stochrsi_k_1h < 40.0))
+            & ((rsi_3_15m_gt_5) | rsi_3_1h_gt_20 | (stochrsi_k_1h_lt_40))
             # 15m & 1h down move, 1h high
             & ((rsi_3_15m_gt_5) | (rsi_3_1h_gt_30) | (stochrsi_k_1h_lt_80))
             # 15m & 4h down move, 1h downtrend
@@ -19279,7 +19291,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 1d high, 1d downtrend
             & ((rsi_3_15m_gt_10) | (aroonu_14_1d_lt_85) | (cmf_20_1d > -0.40))
             # 15m down move, 1h high & overbought
-            & ((rsi_3_15m_gt_10) | (stochrsi_k_1h < 90.0) | (roc_9_1h < 20.0))
+            & ((rsi_3_15m_gt_10) | (stochrsi_k_1h_lt_90) | (roc_9_1h < 20.0))
             # 15m down move, 4h high
             & ((rsi_3_15m_gt_10) | (stochrsi_k_4h_lt_70))
             # 15m down move, 4h & 1d overbought
@@ -19287,7 +19299,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 15m high
             & ((rsi_3_15m_gt_15) | (rsi_3_1h_gt_15) | (aroonu_14_15m_lt_60))
             # 15m & 1h down move, 1h still high
-            & ((rsi_3_15m_gt_15) | (rsi_3_1h_gt_15) | (stochrsi_k_1h < 50.0))
+            & ((rsi_3_15m_gt_15) | (rsi_3_1h_gt_15) | (stochrsi_k_1h_lt_50))
             # 15m & 1h down move, 1h high
             & ((rsi_3_15m_gt_15) | (rsi_3_1h_gt_25) | aroonu_14_1h_lt_80)
             # 15m & 1h down move, 1h high
@@ -19351,7 +19363,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1d high, 1d downtrend
             & ((rsi_3_1h_gt_5) | aroonu_14_1d_lt_100 | (roc_9_1d > -20.0))
             # 1h & 4h down move, 1h still not low enough
-            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_10) | (stochrsi_k_1h < 20.0))
+            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_10) | (stochrsi_k_1h_lt_20))
             # 1h & 4h down move, 15m downtrend
             & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_10) | (roc_9_15m > -15.0))
             # 1h & 3h down move, 4h downtrend
@@ -19403,7 +19415,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h still high, 1d overbought
             & ((rsi_3_1h_gt_35) | (stochrsi_k_1h_lt_50) | (roc_9_1d < 200.0))
             # 1h down move, 1h high, 4h downtrend
-            & ((rsi_3_1h_gt_35) | (stochrsi_k_1h < 70.0) | (roc_9_4h_gt_neg_20))
+            & ((rsi_3_1h_gt_35) | (stochrsi_k_1h_lt_70) | (roc_9_4h_gt_neg_20))
             # 1h down move, 4h & 1d overbought
             & ((rsi_3_1h_gt_35) | (roc_9_4h_lt_20) | (roc_9_1d_lt_80))
             # 1h down move, 1h & 4h high
@@ -19411,7 +19423,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h high, 1d overbought
             & ((rsi_3_1h_gt_40) | (aroonu_14_1h_lt_85) | (roc_9_1d_lt_80))
             # 1h down move, 1h high, 4h downtrend
-            & ((rsi_3_1h_gt_40) | (stochrsi_k_1h < 80.0) | (roc_9_4h_gt_neg_20))
+            & ((rsi_3_1h_gt_40) | (stochrsi_k_1h_lt_80) | (roc_9_4h_gt_neg_20))
             # 1h down move, 1h high, 1h overbought
             & ((rsi_3_1h_gt_50) | aroonu_14_1h_lt_70 | (roc_9_1h < 25.0))
             # 1h down move, 4h high, 1d downtrend
@@ -19421,7 +19433,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h & 1d down move, 15m still high
             & ((rsi_3_4h_gt_3) | (rsi_3_1d_gt_15) | (stochrsi_k_15m_lt_40))
             # 4h & 1d down move, 1h still not low enough
-            & ((rsi_3_4h_gt_3) | (rsi_3_1d_gt_15) | (stochrsi_k_1h < 30.0))
+            & ((rsi_3_4h_gt_3) | (rsi_3_1d_gt_15) | (stochrsi_k_1h_lt_30))
             # 4h & 1d down move, 1d still not low enough
             & ((rsi_3_4h_gt_3) | (rsi_3_1d_gt_30) | (aroonu_14_1d_lt_30))
             # 4h down move, 1d high
@@ -19441,7 +19453,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h & 1d down move, 1d downtrend
             & ((rsi_3_4h_gt_10) | (rsi_3_1d_gt_10) | (roc_9_1d_gt_neg_40))
             # 4h down move, 1h high, 1d downtrend
-            & ((rsi_3_4h_gt_10) | (stochrsi_k_1h < 60.0) | (roc_9_1d_gt_neg_40))
+            & ((rsi_3_4h_gt_10) | (stochrsi_k_1h_lt_60) | (roc_9_1d_gt_neg_40))
             # 4h & 1d down move, 1d high
             & ((rsi_3_4h_gt_15) | (rsi_3_1d_gt_20) | (aroonu_14_1d_lt_60))
             # 4h down move, 4h high, 1h downtrend
@@ -19451,7 +19463,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 1d high & overbought
             & (rsi_3_4h_gt_20 | (aroonu_14_1d_lt_80) | roc_9_1d_lt_50)
             # 4h down move, 1h still not low enough, 1d downtrend
-            & ((rsi_3_4h_gt_15) | (stochrsi_k_1h < 20.0) | (roc_9_1d > -20.0))
+            & ((rsi_3_4h_gt_15) | (stochrsi_k_1h_lt_20) | (roc_9_1d > -20.0))
             # 4h down move, 4h still high, 1d downtrend
             & (rsi_3_4h_gt_20 | (stochrsi_k_4h_lt_40) | (roc_9_1d_gt_neg_20))
             # 4h down move, 4h still high, 1d downtrend
@@ -19471,13 +19483,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 4h still high, 1d downtrend
             & ((rsi_3_4h_gt_50) | (stochrsi_k_4h_lt_50) | (roc_9_1d_gt_neg_30))
             # 1d down move, 1h still high, 1d downtrend
-            & ((rsi_3_1d_gt_5) | (stochrsi_k_1h < 50.0) | (roc_9_1d_gt_neg_30))
+            & ((rsi_3_1d_gt_5) | (stochrsi_k_1h_lt_50) | (roc_9_1d_gt_neg_30))
             # 1d down move, 1h high, 1d downtrend
             & ((rsi_3_1d_gt_10) | aroonu_14_1h_lt_80 | (roc_9_1d > -10.0))
             # 1d down move, 1d high, 1d downtrend
             & ((rsi_3_1d_gt_10) | (aroonu_14_1d_lt_70) | (roc_9_1d_gt_neg_40))
             # 1d down move, 1h high & overbought
-            & ((rsi_3_1d_gt_35) | (stochrsi_k_1h < 90.0) | (roc_9_1h_lt_10))
+            & ((rsi_3_1d_gt_35) | (stochrsi_k_1h_lt_90) | (roc_9_1h_lt_10))
             # 1d downtrend, 1d high & overbought
             & ((cmf_20_1d > -0.30) | (aroonu_14_1d_lt_85) | (roc_9_1d_lt_100))
             # 15m high, 1h high & overbought
@@ -19556,7 +19568,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 4h down move, 4h still high
             & (rsi_3_15m_gt_3 | rsi_3_4h_gt_20 | (aroonu_14_4h_lt_40))
             # 15m & 1h down move, 1h still not low enough
-            & ((rsi_3_15m_gt_5) | (rsi_3_1h_gt_10) | (stochrsi_k_1h < 20.0))
+            & ((rsi_3_15m_gt_5) | (rsi_3_1h_gt_10) | (stochrsi_k_1h_lt_20))
             # 15m & 1h down move, 15m still not low enough
             & ((rsi_3_15m_gt_5) | (rsi_3_1h_gt_10) | (stochrsi_k_15m_lt_20))
             # 15m & 1h down move, 4h still high
@@ -19718,7 +19730,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 4h high
             & (rsi_3_1h_gt_20 | (aroonu_14_4h_lt_85))
             # 1h down move, 1h still not low enough, 4h stil high
-            & (rsi_3_1h_gt_20 | (stochrsi_k_1h < 20.0) | (aroonu_14_4h_lt_40))
+            & (rsi_3_1h_gt_20 | (stochrsi_k_1h_lt_20) | (aroonu_14_4h_lt_40))
             # 1h down move, 4h still high, 1d downtrend
             & (rsi_3_1h_gt_20 | (stochrsi_k_4h_lt_40) | (roc_9_1d_gt_neg_40))
             # 1h down move, 1d high, 4h downtrend
@@ -19726,7 +19738,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 4h high
             & (rsi_3_1h_gt_20 | (stochrsi_k_4h_lt_80))
             # 1h & 4h down move, 1h still not low enough
-            & ((rsi_3_1h_gt_25) | (rsi_3_4h_gt_25) | (stochrsi_k_1h < 20.0))
+            & ((rsi_3_1h_gt_25) | (rsi_3_4h_gt_25) | (stochrsi_k_1h_lt_20))
             # 1h & 4h down move, 1d overbought
             & ((rsi_3_1h_gt_25) | (rsi_3_4h_gt_25) | roc_9_1d_lt_50)
             # 1h & 4h down move, 4h high
@@ -19876,7 +19888,7 @@ class NostalgiaForInfinityX7(IStrategy):
             & (stochrsi_k < 20.0)
             & (stochrsi_k_15m_lt_70)
             & (willr_84_1h < -70.0)
-            & (stochrsi_k_1h < 30.0)
+            & (stochrsi_k_1h_lt_30)
             & (bbb_20_2_0_1h > 12.0)
             & (close_max_48 >= (close * 1.10))
           )
@@ -19894,15 +19906,15 @@ class NostalgiaForInfinityX7(IStrategy):
             # 5m & 1d down move, 1d downtrend
             & ((rsi_3_gt_3) | (rsi_3_1d_gt_15) | (cmf_20_1d > -0.25))
             # 5m down move, 1h high, 4h overbought
-            & ((rsi_3_gt_3) | (stochrsi_k_1h < 80.0) | (roc_9_4h_lt_20))
+            & ((rsi_3_gt_3) | (stochrsi_k_1h_lt_80) | (roc_9_4h_lt_20))
             # 5m down move, 1d high & overbought
             & ((rsi_3_gt_3) | (stochrsi_k_1d_lt_90) | (roc_9_1d_lt_20))
             # 15m & 1h down move, 1h still not low enough
-            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_15) | (stochrsi_k_1h < 30.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_15) | (stochrsi_k_1h_lt_30))
             # 15m & 1h down move, 4h still high
             & ((rsi_3_15m_gt_10) | rsi_3_1h_gt_20 | (stochrsi_k_4h_lt_50))
             # 15m & 1h down move 1h still high
-            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_25) | (stochrsi_k_1h < 40.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_25) | (stochrsi_k_1h_lt_40))
             # 15m & 1h down move, 15m still high
             & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_30) | (aroonu_14_15m_lt_50))
             # 15m & 1h down move 1h still high
@@ -19910,7 +19922,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 4h overbought
             & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_30) | (roc_9_4h_lt_10))
             # 15m & 1h down move, 1h high
-            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_50) | (stochrsi_k_1h < 90.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_50) | (stochrsi_k_1h_lt_90))
             # 15m & 4h down move, 4h still not low enough
             & ((rsi_3_15m_gt_10) | (rsi_3_4h_gt_10) | (stochrsi_k_4h_lt_30))
             # 15m & 4h down move, 1d high
@@ -20034,7 +20046,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 15m still not low enough, 4h still high
             & ((rsi_3_1h_gt_3) | (aroonu_14_15m_lt_30) | (stochrsi_k_4h_lt_40))
             # 1h down move, 1h still not low enough
-            & ((rsi_3_1h_gt_3) | (stochrsi_k_1h < 30.0))
+            & ((rsi_3_1h_gt_3) | (stochrsi_k_1h_lt_30))
             # 1h down move, 4h still high, 1d downtrend
             & ((rsi_3_1h_gt_3) | (stochrsi_k_4h_lt_50) | (roc_9_1d_gt_neg_20))
             # 1h down move, 4h high
@@ -20066,7 +20078,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 15m still not low enough
             & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_15) | (aroonu_14_15m_lt_30))
             # 1h & 4h down move, 1h still not low enough
-            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_15) | (stochrsi_k_1h < 20.0))
+            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_15) | (stochrsi_k_1h_lt_20))
             # 1h & 4h down move, 1d high
             & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_25) | (aroonu_14_1d_lt_80))
             # 1h & 4h down move, 1d downtrend
@@ -20076,7 +20088,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 1d overbought
             & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_35) | (roc_9_1d < 70.0))
             # 1h & 1d down move, 1h still high
-            & ((rsi_3_1h_gt_10) | (rsi_3_1d_gt_10) | (stochrsi_k_1h < 40.0))
+            & ((rsi_3_1h_gt_10) | (rsi_3_1d_gt_10) | (stochrsi_k_1h_lt_40))
             # 1h & 1d down move, 4h high
             & ((rsi_3_1h_gt_10) | (rsi_3_1d_gt_15) | (stochrsi_k_4h_lt_70))
             # 1h & 1d downtrend, 1d overbought
@@ -20084,7 +20096,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h downtrend, 1h still not low enough
             & ((rsi_3_1h_gt_10) | (cmf_20_1h > -0.20) | (aroonu_14_1h_lt_30))
             # 1h down move, 1h downtrend, 1h still not low enough
-            & ((rsi_3_1h_gt_10) | (cmf_20_1h > -0.20) | (stochrsi_k_1h < 30.0))
+            & ((rsi_3_1h_gt_10) | (cmf_20_1h > -0.20) | (stochrsi_k_1h_lt_30))
             # 1h down move, 1h downtrend
             & ((rsi_3_1h_gt_10) | (cmf_20_1h > -0.30))
             # 1h down move, 1d high & overbought
@@ -20094,7 +20106,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1d overbought
             & ((rsi_3_1h_gt_10) | (roc_9_1d < 100.0))
             # 1h & 4h down move, 1h still not low enough
-            & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_15) | (stochrsi_k_1h < 30.0))
+            & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_15) | (stochrsi_k_1h_lt_30))
             # 1h & 4h down move, 15m high
             & ((rsi_3_1h_gt_15) | rsi_3_4h_gt_20 | (stochrsi_k_15m < 90.0))
             # 1h & 4h down move, 1d downtrend
@@ -20112,7 +20124,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1d high & overbought
             & ((rsi_3_1h_gt_15) | (aroonu_14_1d_lt_90) | (roc_9_1d_lt_30))
             # 1h down move, 1h still high
-            & ((rsi_3_1h_gt_15) | (stochrsi_k_1h < 40.0))
+            & ((rsi_3_1h_gt_15) | (stochrsi_k_1h_lt_40))
             # 1h & 4h down move, 1d high
             & (rsi_3_1h_gt_20 | (rsi_3_4h_gt_25) | (aroonu_14_1d_lt_80))
             # 1h & 4h down move, 1h high
@@ -20134,7 +20146,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 1d overbought
             & ((rsi_3_1h_gt_25) | (rsi_3_4h_gt_50) | (roc_9_1d_lt_100))
             # 1h down move, 1h still not low enough, 4h still high
-            & ((rsi_3_1h_gt_25) | (stochrsi_k_1h < 30.0) | (stochrsi_k_4h_lt_50))
+            & ((rsi_3_1h_gt_25) | (stochrsi_k_1h_lt_30) | (stochrsi_k_4h_lt_50))
             # 1h down move, 4h high, 1d downtrend
             & ((rsi_3_1h_gt_25) | (stochrsi_k_4h_lt_80) | (roc_9_1d_gt_neg_40))
             # 1h down move, 1h still high, 1h downtrend
@@ -20148,7 +20160,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 4h high, 1d overbought
             & ((rsi_3_1h_gt_25) | (stochrsi_k_4h_lt_80) | (roc_9_1d < 70.0))
             # 1h & 4h down move, 1h high
-            & ((rsi_3_1h_gt_30) | (rsi_3_4h_gt_30) | (stochrsi_k_1h < 60.0))
+            & ((rsi_3_1h_gt_30) | (rsi_3_4h_gt_30) | (stochrsi_k_1h_lt_60))
             # 1h & 4h down move, 4h still high
             & ((rsi_3_1h_gt_30) | (rsi_3_4h_gt_30) | (aroonu_14_4h_lt_50))
             # 1h & 4h down move, 1h high
@@ -20168,9 +20180,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1d high, 4h overbought
             & ((rsi_3_1h_gt_30) | aroonu_14_1d_lt_100 | (roc_9_4h < 80.0))
             # 1h down move, 1h & 4h still high
-            & ((rsi_3_1h_gt_30) | (stochrsi_k_1h < 40.0) | (stochrsi_k_4h_lt_50))
+            & ((rsi_3_1h_gt_30) | (stochrsi_k_1h_lt_40) | (stochrsi_k_4h_lt_50))
             # 1h down move, 1h highm 1d overbought
-            & ((rsi_3_1h_gt_30) | (stochrsi_k_1h < 60.0) | (roc_9_1d_lt_30))
+            & ((rsi_3_1h_gt_30) | (stochrsi_k_1h_lt_60) | (roc_9_1d_lt_30))
             # 1h down move, 4h overbought
             & ((rsi_3_1h_gt_30) | (roc_9_4h < 50.0))
             # 4h down move, 1d downtrend
@@ -20196,7 +20208,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h high, 1d overbought
             & ((rsi_3_1h_gt_40) | aroonu_14_1h_lt_80 | (roc_9_1d_lt_80))
             # 1h down move, 1h high, 4h overbought
-            & ((rsi_3_1h_gt_40) | (stochrsi_k_1h < 80.0) | (roc_9_4h_lt_20))
+            & ((rsi_3_1h_gt_40) | (stochrsi_k_1h_lt_80) | (roc_9_4h_lt_20))
             # 1h down move, 1h & 4h overbought
             & ((rsi_3_1h_gt_40) | (roc_9_1h_lt_10) | (roc_9_4h_lt_10))
             # 1h & 4h down move, 1d overbought
@@ -20218,7 +20230,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h & 1d down move, 4h still not low enough
             & ((rsi_3_4h_gt_3) | (rsi_3_1d_gt_15) | (aroonu_14_4h < 20.0))
             # 4h down move, 1h still not low enough, 4h downtrend
-            & ((rsi_3_4h_gt_3) | (stochrsi_k_1h < 20.0) | (roc_9_4h_gt_neg_30))
+            & ((rsi_3_4h_gt_3) | (stochrsi_k_1h_lt_20) | (roc_9_4h_gt_neg_30))
             # 4h down move, 1h & 4h downtrend
             & ((rsi_3_4h_gt_3) | (roc_9_1h > -30.0) | (roc_9_4h_gt_neg_30))
             # 4h down move, 1d high, 4h downtrend
@@ -20236,9 +20248,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 15m high, 15m downtrend
             & ((rsi_3_4h_gt_10) | (stochrsi_k_15m_lt_60) | (roc_9_15m > -10.0))
             # 4h down move, 1h still high, 1d downtrend
-            & ((rsi_3_4h_gt_10) | (stochrsi_k_1h < 40.0) | (roc_9_1d > -20.0))
+            & ((rsi_3_4h_gt_10) | (stochrsi_k_1h_lt_40) | (roc_9_1d > -20.0))
             # 4h down move, 1h high
-            & ((rsi_3_4h_gt_10) | (stochrsi_k_1h < 70.0))
+            & ((rsi_3_4h_gt_10) | (stochrsi_k_1h_lt_70))
             # 4h down move, 4h still high, 1d downtrend
             & ((rsi_3_4h_gt_10) | (stochrsi_k_4h_lt_40) | (roc_9_1d > -20.0))
             # 4h down move, 4h downtrend, 1d overbought
@@ -20250,7 +20262,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 1h high
             & ((rsi_3_4h_gt_15) | (aroonu_14_1h_lt_50))
             # 4h down move, 1h still high, 1d downtrend
-            & ((rsi_3_4h_gt_15) | (stochrsi_k_1h < 50.0) | (roc_9_1d > -30.0))
+            & ((rsi_3_4h_gt_15) | (stochrsi_k_1h_lt_50) | (roc_9_1d > -30.0))
             # 4h down move, 1d high & overbought
             & ((rsi_3_4h_gt_15) | (stochrsi_k_1d_lt_90) | (roc_9_1d_lt_20))
             # 4h down move, 15m still high
@@ -20264,7 +20276,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 15m still high, 4h high
             & ((rsi_3_4h_gt_25) | (aroonu_14_15m_lt_40) | aroonu_14_4h_lt_70)
             # 4h down move, 1h & 4h still high
-            & ((rsi_3_4h_gt_25) | (stochrsi_k_1h < 40.0) | (stochrsi_k_4h_lt_40))
+            & ((rsi_3_4h_gt_25) | (stochrsi_k_1h_lt_40) | (stochrsi_k_4h_lt_40))
             # 4h dowqn move, 4h still high, 1d downtrend
             & ((rsi_3_4h_gt_25) | (stochrsi_k_4h_lt_30) | (roc_9_1d_gt_neg_30))
             # 4h down move, 4h high, 1d overbought
@@ -20276,7 +20288,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 1d high & overbought
             & ((rsi_3_4h_gt_40) | (aroonu_14_1d_lt_90) | (roc_9_1d_lt_80))
             # 4h down move, 1h high, 1d downtrend
-            & ((rsi_3_4h_gt_40) | (stochrsi_k_1h < 80.0) | (roc_9_1d_gt_neg_20))
+            & ((rsi_3_4h_gt_40) | (stochrsi_k_1h_lt_80) | (roc_9_1d_gt_neg_20))
             # 4h down move, 4h & 1d overbought
             & ((rsi_3_4h_gt_40) | (roc_9_4h_lt_10) | roc_9_1d_lt_50)
             # 4h down move, 4h still high, 1d downtrend
@@ -20286,13 +20298,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 4h still high, 1d downtrend
             & ((rsi_3_4h_gt_50) | (stochrsi_k_4h_lt_50) | (roc_9_1d_gt_neg_30))
             # 4h down move, 1h high, 1d overbought
-            & ((rsi_3_4h_gt_60) | (stochrsi_k_1h < 90.0) | (roc_9_1d_lt_30))
+            & ((rsi_3_4h_gt_60) | (stochrsi_k_1h_lt_90) | (roc_9_1d_lt_30))
             # 4h down move, 4h high & overbought
             & ((rsi_3_4h_gt_60) | (stochrsi_k_4h_lt_70) | (roc_9_4h_lt_20))
             # 1d down move, 1h & 4h still not low enough
-            & ((rsi_3_1d_gt_5) | (stochrsi_k_1h < 20.0) | (stochrsi_k_4h_lt_20))
+            & ((rsi_3_1d_gt_5) | (stochrsi_k_1h_lt_20) | (stochrsi_k_4h_lt_20))
             # 1d down move, 1h high & overbought
-            & ((rsi_3_1d_gt_35) | (stochrsi_k_1h < 90.0) | (roc_9_1h_lt_10))
+            & ((rsi_3_1d_gt_35) | (stochrsi_k_1h_lt_90) | (roc_9_1h_lt_10))
             # 1d down move, 1h high & overbought
             & ((rsi_3_1d_gt_40) | (aroonu_14_1d_lt_70) | (roc_9_1d_lt_80))
             # 1d down move, 4h high & overbought
@@ -20350,7 +20362,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1d high, 4h & 1d overbought
             & (aroonu_14_1d_lt_100 | (roc_9_4h < 20.0) | (roc_9_1d_lt_30))
             # 1h high, 4h & 1d overbought
-            & ((stochrsi_k_1h < 90.0) | (roc_9_4h_lt_20) | (roc_9_1d_lt_100))
+            & ((stochrsi_k_1h_lt_90) | (roc_9_4h_lt_20) | (roc_9_1d_lt_100))
             # 4h still high, 4h & 1d downtrend
             & ((stochrsi_k_4h_lt_40) | (roc_9_4h_gt_neg_20) | (roc_9_1d_gt_neg_40))
             # 4h high, 1h & 1d downtrend
@@ -20406,7 +20418,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 5m & 4h down move, 15m still high
             & ((rsi_3_gt_5) | (rsi_3_4h_gt_25) | (stochrsi_k_15m_lt_50))
             # 5 & 15m down move, 1h high
-            & ((rsi_3_gt_10) | (rsi_3_15m_gt_40) | (stochrsi_k_1h < 90.0))
+            & ((rsi_3_gt_10) | (rsi_3_15m_gt_40) | (stochrsi_k_1h_lt_90))
             # 5m down move, 1h & 4h high
             & ((rsi_3_gt_10) | (aroonu_14_1h_lt_85) | (aroonu_14_4h_lt_90))
             # 15m & 1h & 4h & 1d down move, 1d still high
@@ -20422,7 +20434,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 4h down move, 4h high
             & ((rsi_3_15m_gt_3) | (rsi_3_1h_gt_30) | (aroonu_14_4h_lt_75))
             # 15m & 1h down move, 1h still not low enough
-            & ((rsi_3_15m_gt_3) | (rsi_3_1h_gt_35) | (stochrsi_k_1h < 30.0))
+            & ((rsi_3_15m_gt_3) | (rsi_3_1h_gt_35) | (stochrsi_k_1h_lt_30))
             # 15m & 4h down move, 4h still not low enough
             & ((rsi_3_15m_gt_3) | (rsi_3_4h_gt_10) | (stochrsi_k_4h_lt_20))
             # 15m & 4h down move, 1d downtrend
@@ -20432,7 +20444,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 4h down move, 4h still not low enough
             & ((rsi_3_15m_gt_3) | (rsi_3_4h_gt_25) | (stochrsi_k_4h_lt_30))
             # 15m down move, 15m still not low enough, 1h high
-            & ((rsi_3_15m_gt_3) | (aroonu_14_15m_lt_20) | (stochrsi_k_1h < 60.0))
+            & ((rsi_3_15m_gt_3) | (aroonu_14_15m_lt_20) | (stochrsi_k_1h_lt_60))
             # 15m down move, 15m still not low enough, 4h high
             & ((rsi_3_15m_gt_3) | (aroonu_14_15m_lt_30) | (stochrsi_k_4h_lt_70))
             # 15m down move, 4h high, 1d overbought
@@ -20440,9 +20452,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h & 1d down move
             & ((rsi_3_15m_gt_5) | (rsi_3_1h_gt_10) | (rsi_3_1d_gt_20))
             # 15m down move, 1h still not low enough, 1d high
-            & ((rsi_3_15m_gt_5) | (stochrsi_k_1h < 30.0) | (aroonu_14_1d_lt_90))
+            & ((rsi_3_15m_gt_5) | (stochrsi_k_1h_lt_30) | (aroonu_14_1d_lt_90))
             # 15m & 1h down move, 1h still not low enough
-            & ((rsi_3_15m_gt_5) | (rsi_3_1h_gt_30) | (stochrsi_k_1h < 30.0))
+            & ((rsi_3_15m_gt_5) | (rsi_3_1h_gt_30) | (stochrsi_k_1h_lt_30))
             # 15m & 1h down move, 4h high
             & ((rsi_3_15m_gt_5) | (rsi_3_1h_gt_30) | (stochrsi_k_4h_lt_80))
             # 15m & 1h down move, 4h high
@@ -20472,7 +20484,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 1h still not low enough
             & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_25) | (aroonu_14_1h_lt_25))
             # 15m & 1h down move, 1h still high
-            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_30) | (stochrsi_k_1h < 40.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_30) | (stochrsi_k_1h_lt_40))
             # 15m & 1h down move, 4h still high
             & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_30) | (stochrsi_k_4h_lt_50))
             # 15m & 1h down move, 1h still high
@@ -20504,7 +20516,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 4h high
             & ((rsi_3_15m_gt_15) | rsi_3_1h_gt_20 | (stochrsi_k_4h_lt_90))
             # 15m & 1h down move, 1h still high
-            & ((rsi_3_15m_gt_15) | (rsi_3_1h_gt_25) | (stochrsi_k_1h < 40.0))
+            & ((rsi_3_15m_gt_15) | (rsi_3_1h_gt_25) | (stochrsi_k_1h_lt_40))
             # 15m & 1h down move, 1h still high
             & ((rsi_3_15m_gt_15) | (rsi_3_1h_gt_40) | (aroonu_14_1h_lt_50))
             # 15m & 1h down move, 4h high & overbought
@@ -20512,7 +20524,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 4h & 1d down move
             & ((rsi_3_15m_gt_15) | (rsi_3_4h_gt_15) | (rsi_3_1d_gt_15))
             # 15m & 4h down move, 1h high
-            & ((rsi_3_15m_gt_15) | (rsi_3_4h_gt_15) | (stochrsi_k_1h < 80.0))
+            & ((rsi_3_15m_gt_15) | (rsi_3_4h_gt_15) | (stochrsi_k_1h_lt_80))
             # 15m & 4h down move, 1h still high
             & ((rsi_3_15m_gt_15) | rsi_3_4h_gt_20 | (stochrsi_k_1h_lt_50))
             # 15m & 4h down move, 15m still not low enough
@@ -20534,11 +20546,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 1d high & overbought
             & ((rsi_3_15m_gt_20) | aroonu_14_1d_lt_100 | (roc_9_1d_lt_20))
             # 15m down move, 1h high, 1d downtrend
-            & ((rsi_3_15m_gt_20) | (stochrsi_k_1h < 80.0) | (roc_9_1d_gt_neg_20))
+            & ((rsi_3_15m_gt_20) | (stochrsi_k_1h_lt_80) | (roc_9_1d_gt_neg_20))
             # 15m down move, 1d high & overbought
             & ((rsi_3_15m_gt_20) | (stochrsi_k_1h_lt_80) | (roc_9_1d_lt_20))
             # 15m & 1h down move, 1h high
-            & ((rsi_3_15m_gt_25) | (rsi_3_1h_gt_25) | (stochrsi_k_1h < 60.0))
+            & ((rsi_3_15m_gt_25) | (rsi_3_1h_gt_25) | (stochrsi_k_1h_lt_60))
             # 15m & 1h down move, 1h high
             & ((rsi_3_15m_gt_25) | (rsi_3_1h_gt_60) | (aroonu_14_1h_lt_85))
             # 15m down move, 15m still not low enough, 4h high
@@ -20574,15 +20586,15 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h & 1d down move
             & ((rsi_3_1h_gt_15) | rsi_3_4h_gt_20 | (rsi_3_1d_gt_30))
             # 1h & 4h down move, 1h still high
-            & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_30) | (stochrsi_k_1h < 40.0))
+            & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_30) | (stochrsi_k_1h_lt_40))
             # 1h & 4h down move, 1h still not low enough
-            & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_40) | (stochrsi_k_1h < 30.0))
+            & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_40) | (stochrsi_k_1h_lt_30))
             # 1h & 4h down move, 1h still high
             & ((rsi_3_1h_gt_15) | (rsi_3_1d_gt_10) | (aroonu_14_1h_lt_40))
             # 1h down move, 1d high & overbought
             & (rsi_3_1h_gt_20 | (aroonu_14_1d_lt_90) | (roc_9_1d_lt_30))
             # 1h down move, 1h still not low enough, 4h high
-            & (rsi_3_1h_gt_20 | (stochrsi_k_1h < 20.0) | aroonu_14_4h_lt_80)
+            & (rsi_3_1h_gt_20 | (stochrsi_k_1h_lt_20) | aroonu_14_4h_lt_80)
             # 1h & 4h down move, 1h still high
             & ((rsi_3_1h_gt_25) | (rsi_3_4h_gt_25) | (stochrsi_k_1h_lt_50))
             # 1h & 4h down move, 1d high
@@ -20602,7 +20614,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h & 4h high
             & ((rsi_3_1h_gt_40) | aroonu_14_1h_lt_80 | aroonu_14_4h_lt_100)
             # 1h down move, 1h high, 1d high & overbought
-            & ((rsi_3_1h_gt_45) | (stochrsi_k_1h < 60.0) | (stochrsi_k_1d < 70.0) | (roc_9_1d < 40.0))
+            & ((rsi_3_1h_gt_45) | (stochrsi_k_1h_lt_60) | (stochrsi_k_1d < 70.0) | (roc_9_1d < 40.0))
             # 1h down move, 1h high & overbought
             & ((rsi_3_1h_gt_55) | (stochrsi_k_1h_lt_80) | (roc_9_1h_lt_10))
             # 1h down move, 4h high
@@ -20640,7 +20652,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1d down move, 1h still high, 4h high
             & ((rsi_3_1d_gt_20) | (aroonu_14_1h_lt_50) | (aroonu_14_4h_lt_85))
             # 1d down move, 1h high & overbought
-            & ((rsi_3_1d_gt_35) | (stochrsi_k_1h < 90.0) | (roc_9_1h_lt_10))
+            & ((rsi_3_1d_gt_35) | (stochrsi_k_1h_lt_90) | (roc_9_1h_lt_10))
             # 1d down move, 4h high, 1d overbought
             & ((rsi_3_1d_gt_45) | (stochrsi_k_4h_lt_90) | (roc_9_1d < 10.0))
             # 4h still high, 4h moving lower, 4h overbought
@@ -20652,7 +20664,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1d high, 4h & 1d overbought
             & (aroonu_14_1d_lt_100 | (roc_9_4h_lt_10) | (roc_9_1d_lt_20))
             # 1h high, 4h downtrend
-            & ((stochrsi_k_1h < 80.0) | (roc_9_4h_gt_neg_20))
+            & ((stochrsi_k_1h_lt_80) | (roc_9_4h_gt_neg_20))
             # 1h high, 4h overbought
             & ((stochrsi_k_1h_lt_80) | (roc_9_4h < 80.0))
             # 4h high, 4h & 1d overbought
@@ -20721,7 +20733,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 5m & 15m down move, 15m still high
             & ((rsi_3_gt_3) | (rsi_3_15m_gt_20) | (aroonu_14_15m_lt_40))
             # 5m & 15m down move, 1h still high
-            & ((rsi_3_gt_3) | (rsi_3_15m_gt_25) | (stochrsi_k_1h < 40.0))
+            & ((rsi_3_gt_3) | (rsi_3_15m_gt_25) | (stochrsi_k_1h_lt_40))
             # 5m & 1h down move, 4h still high
             & ((rsi_3_gt_3) | (rsi_3_1h_gt_25) | (aroonu_14_4h_lt_50))
             # 5m & 4h & 1d down move
@@ -20733,9 +20745,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 5m down move, 15m & 1h still high
             & ((rsi_3_gt_3) | (stochrsi_k_15m_lt_40) | (aroonu_14_1h_lt_40))
             # 5m down move, 1h high
-            & ((rsi_3_gt_3) | aroonu_14_1h_lt_70 | (stochrsi_k_1h < 50.0))
+            & ((rsi_3_gt_3) | aroonu_14_1h_lt_70 | (stochrsi_k_1h_lt_50))
             # 5m & 1h down move, 1h high
-            & ((rsi_3_gt_5) | (rsi_3_1h_gt_40) | (stochrsi_k_1h < 60.0))
+            & ((rsi_3_gt_5) | (rsi_3_1h_gt_40) | (stochrsi_k_1h_lt_60))
             # 5m & 4h down move, 4h high
             & ((rsi_3_gt_5) | (rsi_3_4h_gt_50) | aroonu_14_4h_lt_70)
             # 5m down move, 15m still high, 1h high
@@ -20749,7 +20761,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 5m & 15m down move, 1d high
             & ((rsi_3_gt_10) | (rsi_3_15m_gt_20) | (stochrsi_k_1d < 80.0))
             # 5m & 15m down move, 1h high
-            & ((rsi_3_gt_10) | (rsi_3_15m_gt_25) | (stochrsi_k_1h < 90.0))
+            & ((rsi_3_gt_10) | (rsi_3_15m_gt_25) | (stochrsi_k_1h_lt_90))
             # 5m & 1h down move, 4h still high
             & ((rsi_3_gt_10) | (rsi_3_1h_gt_30) | (stochrsi_k_4h_lt_50))
             # 5m down move, 1h & 4h high
@@ -20757,15 +20769,15 @@ class NostalgiaForInfinityX7(IStrategy):
             # 5m down move, 4h high, 1d high
             & ((rsi_3_gt_10) | (aroonu_14_4h_lt_60) | (stochrsi_k_1d_lt_90))
             # 5m down move, 15m still high, 1h high
-            & ((rsi_3_gt_15) | (rsi_14_15m < 40.0) | (stochrsi_k_1h < 90.0))
+            & ((rsi_3_gt_15) | (rsi_14_15m < 40.0) | (stochrsi_k_1h_lt_90))
             # 5m down move, 15m still high, 4h high
             & ((rsi_3_gt_15) | (rsi_14_15m < 40.0) | (stochrsi_k_4h_lt_90))
             # 15m down move, 15m still not low enough, 1h high
-            & (rsi_3_15m_gt_3 | (aroonu_14_15m_lt_20) | (stochrsi_k_1h < 60.0))
+            & (rsi_3_15m_gt_3 | (aroonu_14_15m_lt_20) | (stochrsi_k_1h_lt_60))
             # 15m & 1h down move, 1d high
             & ((rsi_3_15m_gt_10) | rsi_3_1h_gt_20 | (aroonu_14_1d_lt_70))
             # 15m & 1h down move, 1h still not low enough
-            & ((rsi_3_15m_gt_10) | rsi_3_1h_gt_20 | (stochrsi_k_1h < 20.0))
+            & ((rsi_3_15m_gt_10) | rsi_3_1h_gt_20 | (stochrsi_k_1h_lt_20))
             # 15m & 1h & 4h down move, 1d high
             & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_25) | (rsi_3_4h_gt_25) | (stochrsi_k_1d < 70.0))
             # 15m & 1h down move, 1h still not low enough
@@ -20789,7 +20801,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 4h down move, 4h still high
             & ((rsi_3_15m_gt_10) | (rsi_3_4h_gt_30) | (stochrsi_k_4h_lt_40))
             # 15m & 4h down move, 1h still high
-            & ((rsi_3_15m_gt_10) | rsi_3_4h_gt_20 | (stochrsi_k_1h < 40.0))
+            & ((rsi_3_15m_gt_10) | rsi_3_4h_gt_20 | (stochrsi_k_1h_lt_40))
             # 15m & 4h down move, 1d high
             & ((rsi_3_15m_gt_10) | (rsi_3_4h_gt_25) | (aroonu_14_1d_lt_85))
             # 15m & 4h down move, 1h still high
@@ -20847,7 +20859,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 15m high
             & ((rsi_3_15m_gt_20) | (rsi_3_1h_gt_40) | (aroonu_14_15m_lt_60))
             # 15m & 4h down move, 1h high
-            & ((rsi_3_15m_gt_20) | rsi_3_4h_gt_20 | (stochrsi_k_1h < 60.0))
+            & ((rsi_3_15m_gt_20) | rsi_3_4h_gt_20 | (stochrsi_k_1h_lt_60))
             # 15m & 4h down move, 4h high
             & ((rsi_3_15m_gt_20) | (rsi_3_4h_gt_60) | aroonu_14_4h_lt_80)
             # 15m & 1d down move, 4h high
@@ -20863,7 +20875,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 15m still not low enough, 1h still high
             & ((rsi_3_15m_gt_20) | (stochrsi_k_15m_lt_30) | (aroonu_14_1h_lt_50))
             # 15m down move, 15m & 1h still high
-            & ((rsi_3_15m_gt_20) | (aroonu_14_15m_lt_50) | (stochrsi_k_1h < 40.0))
+            & ((rsi_3_15m_gt_20) | (aroonu_14_15m_lt_50) | (stochrsi_k_1h_lt_40))
             # 15m down move, 1h & 4h high
             & ((rsi_3_15m_gt_20) | aroonu_14_1h_lt_70 | (aroonu_14_4h_lt_90))
             # 15m & 1h down move, 1h high
@@ -20921,7 +20933,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 4h still high
             & ((rsi_3_1h_gt_15) | rsi_3_4h_gt_20 | (rsi_14_4h < 40.0))
             # 1h & 4h down move, 1h still high
-            & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_30) | (stochrsi_k_1h < 50.0))
+            & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_30) | (stochrsi_k_1h_lt_50))
             # 1h & 4h down move, 4h still high
             & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_30) | (aroonu_14_4h_lt_40))
             # 1h & 1d down move, 4h downtrend
@@ -20933,7 +20945,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 4h high
             & ((rsi_3_1h_gt_25) | (rsi_3_4h_gt_40) | aroonu_14_4h_lt_70)
             # 1h down move, 1h still not low enough, 4h high
-            & ((rsi_3_1h_gt_25) | (stochrsi_k_1h < 30.0) | (stochrsi_k_4h_lt_70))
+            & ((rsi_3_1h_gt_25) | (stochrsi_k_1h_lt_30) | (stochrsi_k_4h_lt_70))
             # 1h down move, 1d still high, 1d downtrend
             & ((rsi_3_1h_gt_25) | (stochrsi_k_1d < 50.0) | (roc_9_1d_gt_neg_20))
             # 1h down move, 4h high & overbought
@@ -20983,13 +20995,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 4h & 1d overbought
             & ((rsi_3_4h_gt_60) | (roc_9_4h_lt_20) | (roc_9_1d_lt_20))
             # 1d down move, 1h & 4h still not low enough
-            & ((rsi_3_1d_gt_5) | (stochrsi_k_1h < 20.0) | (stochrsi_k_4h_lt_20))
+            & ((rsi_3_1d_gt_5) | (stochrsi_k_1h_lt_20) | (stochrsi_k_4h_lt_20))
             # 1d down move, 1h high, 1d downtrend
             & ((rsi_3_1d_gt_10) | (aroonu_14_1h_lt_85) | (roc_9_1d_gt_neg_30))
             # 1d down move, 15m still not low enough, 1h still high
             & ((rsi_3_1d_gt_15) | (aroonu_14_15m_lt_30) | (stochrsi_k_1h_lt_50))
             # 15m still not low enough, 1h high, 1d overbought
-            & ((aroonu_14_15m_lt_30) | (stochrsi_k_1h < 80.0) | (roc_9_1d_lt_100))
+            & ((aroonu_14_15m_lt_30) | (stochrsi_k_1h_lt_80) | (roc_9_1d_lt_100))
             # 15m still high, 4h high & overbought
             & ((aroonu_14_15m_lt_40) | (stochrsi_k_4h_lt_80) | (roc_9_4h_lt_30))
             # 15m & 1h & 4h high
@@ -21047,7 +21059,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # big drop in the last 4 days, 4h down move
             & ((close > (high_max_24_4h * 0.20)) | rsi_3_4h_gt_20)
             # big drop in the last 12 days, 1h high
-            & ((close > (high_max_12_1d * 0.30)) | (stochrsi_k_1h < 90.0))
+            & ((close > (high_max_12_1d * 0.30)) | (stochrsi_k_1h_lt_90))
             # big drop in the last 20 days, 1d down move
             & ((close > (high_max_20_1d * 0.40)) | (rsi_3_1d_gt_30))
             # big drop in the last 30 days, 4h down move, 4h still high
@@ -21179,7 +21191,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 4h down move, 15m still high, 1h high
           long_entry_logic.append((rsi_3_4h_gt_60) | (aroonu_14_15m_lt_50) | (aroonu_14_1h_lt_90))
           # 4h down move, 1h high, 1d overbought
-          long_entry_logic.append((rsi_3_4h_gt_60) | (stochrsi_k_1h < 90.0) | (roc_9_1d_lt_30))
+          long_entry_logic.append((rsi_3_4h_gt_60) | (stochrsi_k_1h_lt_90) | (roc_9_1d_lt_30))
           # 1d down move, 1h high, 1d downtrend
           long_entry_logic.append((rsi_3_1d_gt_10) | aroonu_14_1h_lt_80 | (roc_9_1d > -10.0))
           # 1d down move, 4h high
@@ -21215,7 +21227,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1d high, 4h & 1d overbought
           long_entry_logic.append(aroonu_14_1d_lt_100 | (roc_9_4h_lt_10) | roc_9_1d_lt_50)
           # 15m still high, 1h high
-          long_entry_logic.append((stochrsi_k_15m_lt_40) | (aroonu_14_1h_lt_90) | (stochrsi_k_1h < 90.0))
+          long_entry_logic.append((stochrsi_k_15m_lt_40) | (aroonu_14_1h_lt_90) | (stochrsi_k_1h_lt_90))
           # 15m still high, 1d high
           long_entry_logic.append((stochrsi_k_15m_lt_50) | (stochrsi_k_1d_lt_90))
           # 4h high, 4h & 1d overbought
@@ -21235,13 +21247,13 @@ class NostalgiaForInfinityX7(IStrategy):
             | (close < (low_min_24_4h * 1.25))
           )
           # pump, 1h high
-          long_entry_logic.append((((high_max_24_4h - low_min_24_4h) / low_min_24_4h) < 4.0) | (stochrsi_k_1h < 90.0))
+          long_entry_logic.append((((high_max_24_4h - low_min_24_4h) / low_min_24_4h) < 4.0) | (stochrsi_k_1h_lt_90))
           # big drop in the last 2 days, 1d down move
           long_entry_logic.append((close > (high_max_12_4h * 0.30)) | (rsi_3_1d_gt_30))
           # big drop in the last 12 days, 1h still high
           long_entry_logic.append((close > (high_max_12_1d * 0.25)) | (aroonu_14_1h_lt_50))
           # big drop in the last 12 days, 1h still not low enough
-          long_entry_logic.append((close > (high_max_12_1d * 0.10)) | (stochrsi_k_1h < 30.0))
+          long_entry_logic.append((close > (high_max_12_1d * 0.10)) | (stochrsi_k_1h_lt_30))
           # big drop in the last 12 days, 15m still high
           long_entry_logic.append((close > (high_max_12_1d * 0.20)) | (aroonu_14_15m_lt_50))
           # big drop in the last 20 days, 4h down move
@@ -21275,7 +21287,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m & 1h down move, 1d still high
           long_entry_logic.append(rsi_3_15m_gt_3 | (rsi_3_1h_gt_10) | (aroonu_14_1d_lt_50))
           # 15m & 1h down move, 1h still not low enough
-          long_entry_logic.append(rsi_3_15m_gt_3 | (rsi_3_1h_gt_15) | (stochrsi_k_1h < 30.0))
+          long_entry_logic.append(rsi_3_15m_gt_3 | (rsi_3_1h_gt_15) | (stochrsi_k_1h_lt_30))
           # 15m & 4h down move, 4h still high
           long_entry_logic.append(rsi_3_15m_gt_3 | (rsi_3_4h_gt_30) | (rsi_14_4h < 40.0))
           # 15m & 1h & 4h down move
@@ -21291,7 +21303,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m & 1h down move, 15m & 1h downtrend
           long_entry_logic.append((rsi_3_15m_gt_10) | (rsi_3_1h_gt_10) | (cmf_20_15m > -0.40) | (cmf_20_1h > -0.40))
           # 15m & 1h down move, 1h still not low enough
-          long_entry_logic.append((rsi_3_15m_gt_10) | (rsi_3_1h_gt_10) | (stochrsi_k_1h < 20.0))
+          long_entry_logic.append((rsi_3_15m_gt_10) | (rsi_3_1h_gt_10) | (stochrsi_k_1h_lt_20))
           # 15m & 1h down move, 4h still high
           long_entry_logic.append((rsi_3_15m_gt_10) | rsi_3_1h_gt_20 | (stochrsi_k_4h_lt_50))
           # 15m & 1h down move, 4h overbought
@@ -21321,7 +21333,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m & 1h down move, 4h high
           long_entry_logic.append((rsi_3_15m_gt_15) | (rsi_3_1h_gt_25) | aroonu_14_4h_lt_70)
           # 15m & 1h down move, 1h high
-          long_entry_logic.append((rsi_3_15m_gt_15) | (rsi_3_1h_gt_25) | (stochrsi_k_1h < 60.0))
+          long_entry_logic.append((rsi_3_15m_gt_15) | (rsi_3_1h_gt_25) | (stochrsi_k_1h_lt_60))
           # 15m & 1h down move, 1h still high
           long_entry_logic.append((rsi_3_15m_gt_15) | (rsi_3_1h_gt_30) | (aroonu_14_1h_lt_40))
           # 15m down move, 4h still high, 4h downtrend
@@ -21365,7 +21377,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1h & 4h & 1d down move
           long_entry_logic.append((rsi_3_1h_gt_15) | rsi_3_4h_gt_20 | (rsi_3_1d_gt_30))
           # 1h & 4h down move, 1h still not low enough
-          long_entry_logic.append((rsi_3_1h_gt_15) | rsi_3_4h_gt_20 | (stochrsi_k_1h < 20.0))
+          long_entry_logic.append((rsi_3_1h_gt_15) | rsi_3_4h_gt_20 | (stochrsi_k_1h_lt_20))
           # 1h & 4h down move, 4h still not low enough
           long_entry_logic.append((rsi_3_1h_gt_15) | rsi_3_4h_gt_20 | (stochrsi_k_4h_lt_30))
           # 1h & 4h & 1d down move
@@ -21403,7 +21415,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1h down move, 4h still not low enough, 1d overbought
           long_entry_logic.append((rsi_3_1h_gt_30) | (aroonu_14_4h_lt_30) | roc_9_1d_lt_50)
           # 1h down move, 1h still not low enough, 4h downtrend
-          long_entry_logic.append((rsi_3_1h_gt_35) | (stochrsi_k_1h < 30.0) | (roc_9_4h_gt_neg_20))
+          long_entry_logic.append((rsi_3_1h_gt_35) | (stochrsi_k_1h_lt_30) | (roc_9_4h_gt_neg_20))
           # 1h down move, 4h still high, 1d downtrend
           long_entry_logic.append((rsi_3_1h_gt_35) | (stochrsi_k_4h_lt_50) | (roc_9_1d_gt_neg_20))
           # 1h down move, 4h & 1d overbought
@@ -21413,7 +21425,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1h down move, 4h high & overbought
           long_entry_logic.append((rsi_3_1h_gt_50) | (stochrsi_k_4h_lt_80) | (roc_9_4h_lt_20))
           # 4h down move, 15m not low enough, 1h still high
-          long_entry_logic.append((rsi_3_4h_gt_3) | (stochrsi_k_15m_lt_20) | (stochrsi_k_1h < 40.0))
+          long_entry_logic.append((rsi_3_4h_gt_3) | (stochrsi_k_15m_lt_20) | (stochrsi_k_1h_lt_40))
           # 4h & 1d down move, 4h downtrend
           long_entry_logic.append((rsi_3_4h_gt_5) | (rsi_3_1d_gt_20) | (roc_9_4h_gt_neg_20))
           # 4h & 1d down move, 1d high
@@ -21433,7 +21445,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 4h down move, 1d high & overbought
           long_entry_logic.append(rsi_3_4h_gt_20 | (aroonu_14_1d_lt_70) | roc_9_1d_lt_50)
           # 4h down move, 1h still high, 1d downtrend
-          long_entry_logic.append(rsi_3_4h_gt_20 | (stochrsi_k_1h < 50.0) | (roc_9_1d_gt_neg_20))
+          long_entry_logic.append(rsi_3_4h_gt_20 | (stochrsi_k_1h_lt_50) | (roc_9_1d_gt_neg_20))
           # 4h down move, 1h high
           long_entry_logic.append(rsi_3_4h_gt_20 | (stochrsi_k_1h_lt_80))
           # 4h down move, 1d high, 1h downtrend
@@ -21449,7 +21461,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 4h down move, 4h & 1d overbought
           long_entry_logic.append((rsi_3_4h_gt_40) | (roc_9_4h_lt_10) | roc_9_1d_lt_50)
           # 1d down move, 1h still not low enough
-          long_entry_logic.append((rsi_3_1d_gt_5) | (stochrsi_k_1h < 20.0))
+          long_entry_logic.append((rsi_3_1d_gt_5) | (stochrsi_k_1h_lt_20))
           # 1h & 4h high, 4h overbought
           long_entry_logic.append((aroonu_14_1h_lt_60) | aroonu_14_4h_lt_100 | (roc_9_4h_lt_30))
           # 4h & 1d high, 4h overbought
@@ -21549,7 +21561,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 5m & 1d down move, 4h still high
             & ((rsi_3_gt_3) | (rsi_3_1d_gt_10) | (stochrsi_k_4h_lt_40))
             # 5m down move, 1h high
-            & ((rsi_3_gt_3) | (stochrsi_k_1h < 90.0))
+            & ((rsi_3_gt_3) | (stochrsi_k_1h_lt_90))
             # 5m down move, 15m & 1d high
             & ((rsi_3_gt_5) | (aroonu_14_15m_lt_60) | aroonu_14_1d_lt_100)
             # 5m down move, 1h & 1d high
@@ -21557,7 +21569,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 1d overbought
             & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_10) | (roc_9_1d < 100.0))
             # 15m & 1h down move, 1h still not low enough
-            & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_10) | (stochrsi_k_1h < 20.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_10) | (stochrsi_k_1h_lt_20))
             # 15m & 1h down move, 1d overbought
             & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_10) | (roc_9_1d < 60.0))
             # 15m & 1h down move, 4h still high
@@ -21593,7 +21605,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 1h still high
             & ((rsi_3_15m_gt_5) | (rsi_3_1h_gt_25) | (stochrsi_k_1h_lt_50))
             # 15m & 1h & 4h down move, 15m still not low enough, 1h still not low enough
-            & ((rsi_3_15m_gt_5) | (rsi_3_1h_gt_30) | (rsi_3_4h_gt_30) | (aroonu_14_15m_lt_30) | (stochrsi_k_1h < 30.0))
+            & ((rsi_3_15m_gt_5) | (rsi_3_1h_gt_30) | (rsi_3_4h_gt_30) | (aroonu_14_15m_lt_30) | (stochrsi_k_1h_lt_30))
             # 15m & 1h down move, 1h high
             & ((rsi_3_15m_gt_5) | (rsi_3_1h_gt_30) | (stochrsi_k_1h_lt_80))
             # 15m & 4h down move, 1d high
@@ -21613,7 +21625,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 15m still high
             & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_15) | (stochrsi_k_15m_lt_50))
             # 15m & 1h down move, 1h still high
-            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_15) | (stochrsi_k_1h < 50.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_15) | (stochrsi_k_1h_lt_50))
             # 15m & 1h down move, 1d still high
             & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_15) | (stochrsi_k_1d < 50.0))
             # 15m & 1h down move, 15m high
@@ -21653,7 +21665,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 4h down move, 4h high
             & ((rsi_3_15m_gt_10) | (rsi_3_4h_gt_45) | aroonu_14_4h_lt_70)
             # 15m down move, 1h high
-            & ((rsi_3_15m_gt_10) | (stochrsi_k_1h < 90.0))
+            & ((rsi_3_15m_gt_10) | (stochrsi_k_1h_lt_90))
             # 15m & 1d down move, 1h still high
             & ((rsi_3_15m_gt_10) | (rsi_3_1d_gt_10) | (stochrsi_k_1h_lt_50))
             # 15m & 1d down move, 1d high
@@ -21675,13 +21687,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 4h high
             & ((rsi_3_15m_gt_15) | (rsi_3_1h_gt_15) | (aroonu_14_4h_lt_80))
             # 15m & 1h & 1d down move, 1h high
-            & ((rsi_3_15m_gt_15) | (rsi_3_1h_gt_25) | (rsi_3_1d_gt_25) | (stochrsi_k_1h < 60.0))
+            & ((rsi_3_15m_gt_15) | (rsi_3_1h_gt_25) | (rsi_3_1d_gt_25) | (stochrsi_k_1h_lt_60))
             # 15m & 1h down move, 1h high
             & ((rsi_3_15m_gt_15) | (rsi_3_1h_gt_40) | (aroonu_14_1h_lt_90))
             # 15m & 4h down move, 15m high
             & ((rsi_3_15m_gt_15) | (rsi_3_4h_gt_15) | (aroonu_14_15m_lt_50))
             # 15m & 4h down move, 1h high
-            & ((rsi_3_15m_gt_15) | (rsi_3_4h_gt_15) | (stochrsi_k_1h < 70.0))
+            & ((rsi_3_15m_gt_15) | (rsi_3_4h_gt_15) | (stochrsi_k_1h_lt_70))
             # 15m & 4h down move, 15m high
             & ((rsi_3_15m_gt_15) | (rsi_3_4h_gt_20) | (aroonu_14_15m_lt_70))
             # 15m & 4h down move, 4h high
@@ -21691,7 +21703,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 4h down move, 1h high
             & ((rsi_3_15m_gt_15) | (rsi_3_4h_gt_35) | (aroonu_14_1h_lt_90))
             # 15m & 1d down move, 1h still high
-            & ((rsi_3_15m_gt_15) | (rsi_3_1d_gt_15) | (stochrsi_k_1h < 30.0))
+            & ((rsi_3_15m_gt_15) | (rsi_3_1d_gt_15) | (stochrsi_k_1h_lt_30))
             # 15m down move, 15m downtrend, 1h high
             & ((rsi_3_15m_gt_15) | (cmf_20_15m > -0.40) | (aroonu_14_1h_lt_60))
             # 15m down move, 15m still high, 4h high
@@ -21709,7 +21721,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 1h high, 1d overbought
             & ((rsi_3_15m_gt_20) | (aroonu_14_1h_lt_80) | (roc_9_1d < 10.0))
             # 15m down move, 1h high, 1d downtrend
-            & ((rsi_3_15m_gt_20) | (stochrsi_k_1h < 80.0) | (roc_9_1d_gt_neg_20))
+            & ((rsi_3_15m_gt_20) | (stochrsi_k_1h_lt_80) | (roc_9_1d_gt_neg_20))
             # 15m down move, 4h high, 1d downtrend
             & ((rsi_3_15m_gt_20) | (stochrsi_k_4h_lt_80) | (roc_9_1d_gt_neg_30))
             # 15m & 1h & 4h down move, 4h high
@@ -21767,7 +21779,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 1h still high
             & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_15) | (aroonu_14_1h_lt_40))
             # 1h & 4h down move, 1h still high
-            & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_15) | (stochrsi_k_1h < 50.0))
+            & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_15) | (stochrsi_k_1h_lt_50))
             # 1h & 4h down move, 1d downtrend
             & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_15) | (roc_9_1d > -30.0))
             # 1h & 1d down move, 4h downtrend
@@ -21829,7 +21841,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h & 4h high
             & ((rsi_3_1h_gt_45) | (aroonu_14_1h_lt_75) | aroonu_14_4h_lt_100)
             # 1h down move, 1h high, 1d high & overbought
-            & ((rsi_3_1h_gt_45) | (stochrsi_k_1h < 60.0) | (stochrsi_k_1d < 70.0) | (roc_9_1d < 40.0))
+            & ((rsi_3_1h_gt_45) | (stochrsi_k_1h_lt_60) | (stochrsi_k_1d < 70.0) | (roc_9_1d < 40.0))
             # 1h down move, 4h high & overbought
             & ((rsi_3_1h_gt_50) | (stochrsi_k_4h_lt_90) | (roc_9_4h < 25.0))
             # 1h & 1d down move, 1h high
@@ -21841,11 +21853,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h & 1d down move, 1d still high
             & ((rsi_3_4h_gt_5) | (rsi_3_1d_gt_30) | (stochrsi_k_1d < 40.0))
             # 4h down move, 1h high
-            & ((rsi_3_4h_gt_5) | (stochrsi_k_1h < 90.0))
+            & ((rsi_3_4h_gt_5) | (stochrsi_k_1h_lt_90))
             # 4h down move, 4h & 1d downtrend
             & ((rsi_3_4h_gt_5) | (roc_9_4h > -10.0) | (roc_9_1d > -10.0))
             # 4h & 1d down move, 1h high
-            & ((rsi_3_4h_gt_10) | (rsi_3_1d_gt_10) | (stochrsi_k_1h < 60.0))
+            & ((rsi_3_4h_gt_10) | (rsi_3_1d_gt_10) | (stochrsi_k_1h_lt_60))
             # 4h & 1d down move, 4h downtrend
             & ((rsi_3_4h_gt_10) | (rsi_3_1d_gt_10) | (roc_9_4h > -20.0))
             # 4h & 1d down move, 1d still high
@@ -21855,17 +21867,17 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h & 1d down move, 1h high
             & ((rsi_3_4h_gt_10) | (rsi_3_1d_gt_30) | (aroonu_14_1h_lt_100))
             # 4h down move, 15m still high, 1h still high
-            & ((rsi_3_4h_gt_10) | (aroonu_14_15m_lt_40) | (stochrsi_k_1h < 50.0))
+            & ((rsi_3_4h_gt_10) | (aroonu_14_15m_lt_40) | (stochrsi_k_1h_lt_50))
             # 4h down move, 4h still high, 4h downtrend
             & ((rsi_3_4h_gt_10) | (aroonu_14_4h_lt_40) | (roc_9_4h > -20.0))
             # 4h down move, 15m high
             & ((rsi_3_4h_gt_10) | (stochrsi_k_15m_lt_80))
             # 4h down move, 1h still not low enough, 4h downtrend
-            & ((rsi_3_4h_gt_10) | (stochrsi_k_1h < 20.0) | (roc_9_4h > -20.0))
+            & ((rsi_3_4h_gt_10) | (stochrsi_k_1h_lt_20) | (roc_9_4h > -20.0))
             # 4h & 1d down move, 15m still high
             & ((rsi_3_4h_gt_15) | (rsi_3_1d_gt_15) | (stochrsi_k_15m_lt_50))
             # 4h & 1d down move, 1h still high
-            & ((rsi_3_4h_gt_15) | (rsi_3_1d_gt_15) | (stochrsi_k_1h < 40.0))
+            & ((rsi_3_4h_gt_15) | (rsi_3_1d_gt_15) | (stochrsi_k_1h_lt_40))
             # 4h & 1d down move, 1d high
             & ((rsi_3_4h_gt_15) | (rsi_3_1d_gt_20) | (aroonu_14_1d_lt_60))
             # 4h & 1d down move, 4h high
@@ -21943,7 +21955,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m high, 1d high & overbought
             & ((aroonu_14_15m_lt_70) | aroonu_14_1d_lt_100 | (roc_9_1d_lt_20))
             # 15m high, 1h high, 1d downtrend
-            & ((aroonu_14_15m_lt_70) | (stochrsi_k_1h < 80.0) | (roc_9_1d_gt_neg_20))
+            & ((aroonu_14_15m_lt_70) | (stochrsi_k_1h_lt_80) | (roc_9_1d_gt_neg_20))
             # 1h & 4h high, 4h overbought
             & ((aroonu_14_1h_lt_90) | (aroonu_14_4h_lt_90) | (roc_9_4h_lt_10))
             # 1h & 4h high, 1d overbought
@@ -21955,7 +21967,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h & 1d high, 1d overbought
             & ((aroonu_14_4h_lt_90) | aroonu_14_1d_lt_100 | roc_9_1d_lt_50)
             # 1h high, 1h & 4h overbought
-            & ((stochrsi_k_1h < 80.0) | (roc_9_1h < 20.0) | (roc_9_4h_lt_20))
+            & ((stochrsi_k_1h_lt_80) | (roc_9_1h < 20.0) | (roc_9_4h_lt_20))
             # 4h & 1d overbought
             & ((roc_9_4h < 100.0) | (roc_9_1d < 200.0))
           )
@@ -21988,7 +22000,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 1d high
             & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_10) | (aroonu_14_1d_lt_70))
             # 15m & 1h down move, 1h still high
-            & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_10) | (stochrsi_k_1h < 40.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_10) | (stochrsi_k_1h_lt_40))
             # 15m & 1h down move, 1d overbought
             & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_10) | (roc_9_1d < 60.0))
             # 15m & 1h down move, 1h still high
@@ -22010,7 +22022,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 4h high
             & (rsi_3_15m_gt_3 | (aroonu_14_4h_lt_90))
             # 15m down move, 1h high, 1d overbought
-            & (rsi_3_15m_gt_3 | (stochrsi_k_1h < 60.0) | (roc_9_1d_lt_20))
+            & (rsi_3_15m_gt_3 | (stochrsi_k_1h_lt_60) | (roc_9_1d_lt_20))
             # 15m down move, 4h high
             & (rsi_3_15m_gt_3 | (stochrsi_k_4h_lt_80))
             # 15m & 1d down move, 1d still high
@@ -22028,7 +22040,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 4h high
             & ((rsi_3_15m_gt_5) | (rsi_3_1h_gt_15) | (stochrsi_k_4h_lt_60))
             # 15m & 1h & 4h down move, 15m still not low enough, 1h still high
-            & ((rsi_3_15m_gt_5) | (rsi_3_1h_gt_30) | (rsi_3_4h_gt_30) | (aroonu_14_15m_lt_30) | (stochrsi_k_1h < 40.0))
+            & ((rsi_3_15m_gt_5) | (rsi_3_1h_gt_30) | (rsi_3_4h_gt_30) | (aroonu_14_15m_lt_30) | (stochrsi_k_1h_lt_40))
             # 15m & 4h down move, 1d high
             & ((rsi_3_15m_gt_5) | rsi_3_4h_gt_20 | (aroonu_14_1d_lt_80))
             # 15m down move, 4h high, 1h overbought
@@ -22038,11 +22050,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 4h high
             & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_10) | (aroonu_14_4h_lt_85))
             # 15m & 1h down move, 1h still high
-            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_10) | (stochrsi_k_1h < 40.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_10) | (stochrsi_k_1h_lt_40))
             # 15m & 1h down move, 4h high
             & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_10) | (stochrsi_k_4h_lt_60))
             # 15m & 1h down move, 1h still high
-            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_15) | (stochrsi_k_1h < 50.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_15) | (stochrsi_k_1h_lt_50))
             # 15m & 1h down move, 15m high
             & ((rsi_3_15m_gt_10) | rsi_3_1h_gt_20 | (aroonu_14_15m_lt_60))
             # 15m & 1h down move, 15m still high
@@ -22120,7 +22132,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 1d high & overbought
             & ((rsi_3_15m_gt_15) | (aroonu_14_1d_lt_100) | (roc_9_1d_lt_80))
             # 15m & 1h down move, 1h high
-            & ((rsi_3_15m_gt_20) | (rsi_3_1h_gt_20) | (stochrsi_k_1h < 60.0))
+            & ((rsi_3_15m_gt_20) | (rsi_3_1h_gt_20) | (stochrsi_k_1h_lt_60))
             # 15m & 1h & 1d down move, 4h still high, 4h downtrend
             & ((rsi_3_15m_gt_20) | (rsi_3_1h_gt_25) | (rsi_3_1d_gt_25) | (aroonu_14_4h_lt_40) | (roc_9_4h_gt_neg_20))
             # 15m & 4h down move, 15m high
@@ -22132,9 +22144,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 15m high, 1d high
             & ((rsi_3_15m_gt_20) | (aroonu_14_15m_lt_90) | aroonu_14_1d_lt_100)
             # 15m down move, 1h high, 1d downtrend
-            & ((rsi_3_15m_gt_20) | (stochrsi_k_1h < 80.0) | (roc_9_1d_gt_neg_20))
+            & ((rsi_3_15m_gt_20) | (stochrsi_k_1h_lt_80) | (roc_9_1d_gt_neg_20))
             # 15m down move, 1h high & overbought
-            & ((rsi_3_15m_gt_20) | (stochrsi_k_1h < 90.0) | (roc_9_1h_lt_10))
+            & ((rsi_3_15m_gt_20) | (stochrsi_k_1h_lt_90) | (roc_9_1h_lt_10))
             # 15m & 1h & 4h down move, 4h high
             & ((rsi_3_15m_gt_25) | (rsi_3_1h_gt_30) | (rsi_3_4h_gt_50) | aroonu_14_4h_lt_70)
             # 15m down move, 15m still high, 4h high
@@ -22182,7 +22194,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 1d still high
             & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_15) | (aroonu_14_1d_lt_50))
             # 1h & 4h down move, 1h still not low enough
-            & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_15) | (stochrsi_k_1h < 30.0))
+            & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_15) | (stochrsi_k_1h_lt_30))
             # 1h & 4h down move, 15m still not low enough
             & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_15) | (stochrsi_k_15m_lt_30))
             # 1h & 4h down move, 4h still high
@@ -22222,7 +22234,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 1d down move, 1d still high
             & ((rsi_3_1h_gt_25) | (rsi_3_1d_gt_25) | (stochrsi_k_1d < 50.0))
             # 1h & 4h down move, 1h high
-            & ((rsi_3_1h_gt_30) | (rsi_3_4h_gt_30) | (stochrsi_k_1h < 60.0))
+            & ((rsi_3_1h_gt_30) | (rsi_3_4h_gt_30) | (stochrsi_k_1h_lt_60))
             # 1h & 4g down move, 4h still high
             & ((rsi_3_1h_gt_30) | (rsi_3_4h_gt_30) | (stochrsi_k_4h_lt_50))
             # 1h down move, 15m still high, 1h high
@@ -22232,13 +22244,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 4h & 1d high
             & ((rsi_3_1h_gt_35) | aroonu_14_4h_lt_100 | aroonu_14_1d_lt_100)
             # 1h down move, 1h still high, 1d downtrend
-            & ((rsi_3_1h_gt_35) | (stochrsi_k_1h < 50.0) | (roc_9_1d_gt_neg_30))
+            & ((rsi_3_1h_gt_35) | (stochrsi_k_1h_lt_50) | (roc_9_1d_gt_neg_30))
             # 1h & 1d down move, 1h high
             & ((rsi_3_1h_gt_45) | (rsi_3_1d_gt_45) | aroonu_14_1h_lt_80)
             # 1h down move, 1h & 4h high
             & ((rsi_3_1h_gt_45) | (aroonu_14_1h_lt_75) | aroonu_14_4h_lt_100)
             # 1h down move, 1h high, 1d high & overbought
-            & ((rsi_3_1h_gt_45) | (stochrsi_k_1h < 60.0) | (stochrsi_k_1d < 70.0) | (roc_9_1d < 40.0))
+            & ((rsi_3_1h_gt_45) | (stochrsi_k_1h_lt_60) | (stochrsi_k_1d < 70.0) | (roc_9_1d < 40.0))
             # 1h down move, 4h high & overbought
             & ((rsi_3_1h_gt_50) | (stochrsi_k_4h_lt_90) | (roc_9_4h < 25.0))
             # 4h & 1d down move, 1d downtrend
@@ -22250,13 +22262,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 4h still high, 4h downtrend
             & ((rsi_3_4h_gt_5) | (aroonu_14_4h_lt_40) | (roc_9_4h > -10.0))
             # 4h down move, 1h high
-            & ((rsi_3_4h_gt_5) | (stochrsi_k_1h < 90.0))
+            & ((rsi_3_4h_gt_5) | (stochrsi_k_1h_lt_90))
             # 4h & 1d down move, 1h still high
-            & ((rsi_3_4h_gt_10) | (rsi_3_1d_gt_10) | (stochrsi_k_1h < 50.0))
+            & ((rsi_3_4h_gt_10) | (rsi_3_1d_gt_10) | (stochrsi_k_1h_lt_50))
             # 4h & 1d down move, 1h high
-            & ((rsi_3_4h_gt_10) | (rsi_3_1d_gt_15) | (stochrsi_k_1h < 70.0))
+            & ((rsi_3_4h_gt_10) | (rsi_3_1d_gt_15) | (stochrsi_k_1h_lt_70))
             # 4h down move, 15m still high, 1h still high
-            & ((rsi_3_4h_gt_10) | (aroonu_14_15m_lt_40) | (stochrsi_k_1h < 50.0))
+            & ((rsi_3_4h_gt_10) | (aroonu_14_15m_lt_40) | (stochrsi_k_1h_lt_50))
             # 4h down move, 1d still high, 1d downtrend
             & ((rsi_3_4h_gt_10) | (aroonu_14_1d_lt_50) | (roc_9_1d > -30.0))
             # 4h down move, 15m high
@@ -22264,9 +22276,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 15m still high, 1d downtrend
             & ((rsi_3_4h_gt_10) | (stochrsi_k_15m_lt_50) | (roc_9_1d > -30.0))
             # 4h down move, 1h still high, 1d downtrend
-            & ((rsi_3_4h_gt_10) | (stochrsi_k_1h < 50.0) | (roc_9_1d > -30.0))
+            & ((rsi_3_4h_gt_10) | (stochrsi_k_1h_lt_50) | (roc_9_1d > -30.0))
             # 4h down move, 1h high, 4h downtrend
-            & ((rsi_3_4h_gt_10) | (stochrsi_k_1h < 70.0) | (roc_9_4h > -20.0))
+            & ((rsi_3_4h_gt_10) | (stochrsi_k_1h_lt_70) | (roc_9_4h > -20.0))
             # 4h down move, 4h & 1d downtrend
             & ((rsi_3_4h_gt_10) | (roc_9_4h > -15.0) | (roc_9_1d > -20.0))
             # 4h & 1d down move, 1d still high
@@ -22384,7 +22396,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m high, 4h & 1d overbought
             & ((stochrsi_k_15m_lt_70) | (roc_9_4h_lt_20) | (roc_9_1d_lt_20))
             # 1h high, 1h & 1d overbought
-            & ((stochrsi_k_1h < 80.0) | (roc_9_1h < 20.0) | (roc_9_1d_lt_100))
+            & ((stochrsi_k_1h_lt_80) | (roc_9_1h < 20.0) | (roc_9_1d_lt_100))
             # 4h high, 4h overbought, 1d downtrend
             & ((stochrsi_k_4h_lt_90) | (roc_9_4h_lt_20) | (roc_9_1d_gt_neg_20))
             # 1d high, 1h & 4h overbought
@@ -22423,7 +22435,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 4h still high
             & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_15) | (aroonu_14_4h_lt_40))
             # 15m & 1h down move, 1h still high
-            & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_15) | (stochrsi_k_1h < 50.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_15) | (stochrsi_k_1h_lt_50))
             # 15m & 1h down move, 4h high
             & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_15) | (stochrsi_k_4h_lt_90))
             # 15m & 1h down move, 15m high
@@ -22449,7 +22461,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 4h down move, 4h high
             & ((rsi_3_15m_gt_5) | (rsi_3_4h_gt_10) | (aroonu_14_4h_lt_80))
             # 15m & 4h down move, 1h still high
-            & ((rsi_3_15m_gt_5) | (rsi_3_4h_gt_10) | (stochrsi_k_1h < 40.0))
+            & ((rsi_3_15m_gt_5) | (rsi_3_4h_gt_10) | (stochrsi_k_1h_lt_40))
             # 15m & 4h down move, 1d downtrend
             & ((rsi_3_15m_gt_5) | (rsi_3_4h_gt_10) | (roc_9_1d > -20.0))
             # 15m & 1d down move, 1h still high
@@ -22479,7 +22491,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 1h high
             & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_30) | (stochrsi_k_1h_lt_70))
             # 15m & 4h down move, 1h still high
-            & ((rsi_3_15m_gt_10) | (rsi_3_4h_gt_10) | (stochrsi_k_1h < 50.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_4h_gt_10) | (stochrsi_k_1h_lt_50))
             # 15m & 4h down move, 4h still high, 1d high & overbought
             & ((rsi_3_15m_gt_10) | (rsi_3_4h_gt_15) | (aroonu_14_4h_lt_40) | (aroonu_14_1d_lt_70) | (roc_9_1d < 10.0))
             # 15m & 4h down move, 1h high
@@ -22499,7 +22511,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 4h high, 1d overbought
             & ((rsi_3_15m_gt_10) | (aroonu_14_4h_lt_70) | (roc_9_1d_lt_100))
             # 15m down move, 1h still high, 1d downtrend
-            & ((rsi_3_15m_gt_10) | (stochrsi_k_1h < 50.0) | (roc_9_1d_gt_neg_20))
+            & ((rsi_3_15m_gt_10) | (stochrsi_k_1h_lt_50) | (roc_9_1d_gt_neg_20))
             # 15m & 1h down move, 1h high, 1d high & overbought
             & ((rsi_3_15m_gt_15) | (rsi_3_1h_gt_15) | (aroonu_14_1h_lt_70) | (aroonu_14_1d_lt_100) | (roc_9_1d < 10.0))
             # 15m & 4h down move, 1h high
@@ -22525,9 +22537,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 4h high
             & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_15) | (aroonu_14_4h_lt_60))
             # 1h down move, 1h still not low enough, 1d overbought
-            & ((rsi_3_1h_gt_15) | (stochrsi_k_1h < 30.0) | roc_9_1d_lt_50)
+            & ((rsi_3_1h_gt_15) | (stochrsi_k_1h_lt_30) | roc_9_1d_lt_50)
             # 1h down move, 1h still high, 1d downtrend
-            & ((rsi_3_1h_gt_15) | (stochrsi_k_1h < 40.0) | (roc_9_1d > -20.0))
+            & ((rsi_3_1h_gt_15) | (stochrsi_k_1h_lt_40) | (roc_9_1d > -20.0))
             # 1h down move, 1d high & overbought
             & ((rsi_3_1h_gt_15) | (stochrsi_k_1d_lt_90) | (roc_9_1d_lt_40))
             # 1h & 4h down move, 1h high
@@ -22551,7 +22563,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 4h & 1d overbought
             & ((rsi_3_1h_gt_25) | (roc_9_4h_lt_20) | (roc_9_1d_lt_30))
             # 1h & 4h down move, 1h high
-            & ((rsi_3_1h_gt_30) | (rsi_3_4h_gt_30) | (stochrsi_k_1h < 60.0))
+            & ((rsi_3_1h_gt_30) | (rsi_3_4h_gt_30) | (stochrsi_k_1h_lt_60))
             # 1h down move, 15m still high, 1h high
             & ((rsi_3_1h_gt_30) | (aroonu_14_15m_lt_50) | (aroonu_14_1h_lt_85))
             # 1h & 1d down move, 1h high
@@ -22573,7 +22585,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 1d high & overbought
             & ((rsi_3_4h_gt_10) | (aroonu_14_1d_lt_100) | (roc_9_1d < 10.0))
             # 4h down move, 1h high, 1d downtrend
-            & ((rsi_3_4h_gt_10) | (stochrsi_k_1h < 50.0) | (roc_9_1d > -30.0))
+            & ((rsi_3_4h_gt_10) | (stochrsi_k_1h_lt_50) | (roc_9_1d > -30.0))
             # 4h down move, 4h & 1d downtrend
             & ((rsi_3_4h_gt_10) | (roc_9_4h > -20.0) | (roc_9_1d_gt_neg_40))
             # 4h & 1d down move, 1d high
@@ -22587,9 +22599,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 4h & 1d high
             & ((rsi_3_4h_gt_15) | aroonu_14_4h_lt_70 | (aroonu_14_1d_lt_70))
             # 4h down move, 1h still not low enough, 1d downtrend
-            & ((rsi_3_4h_gt_15) | (stochrsi_k_1h < 20.0) | (roc_9_1d > -20.0))
+            & ((rsi_3_4h_gt_15) | (stochrsi_k_1h_lt_20) | (roc_9_1d > -20.0))
             # 4h down move, 1h high
-            & ((rsi_3_4h_gt_15) | (stochrsi_k_1h < 80.0))
+            & ((rsi_3_4h_gt_15) | (stochrsi_k_1h_lt_80))
             # 4h down move, 1h downtrend, 1d overbought
             & ((rsi_3_4h_gt_15) | (roc_9_1h > -10.0) | (roc_9_1d < 200.0))
             # 4h & 1d down move, 1d still high
@@ -22603,7 +22615,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h & 1d down move, 1d overbought
             & ((rsi_3_4h_gt_25) | (rsi_3_1d_gt_40) | (roc_9_1d_lt_30))
             # 4h down move, 1h high, 1d downtrend
-            & ((rsi_3_4h_gt_25) | (stochrsi_k_1h < 60.0) | (roc_9_1d_gt_neg_20))
+            & ((rsi_3_4h_gt_25) | (stochrsi_k_1h_lt_60) | (roc_9_1d_gt_neg_20))
             # 4h down move, 15m still high, 1h high
             & ((rsi_3_4h_gt_35) | (aroonu_14_15m_lt_50) | (aroonu_14_1h_lt_100))
             # 4h down move, 1h high
@@ -22660,7 +22672,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 1d high
             & ((rsi_3_15m_gt_5) | (rsi_3_1h_gt_10) | (aroonu_14_1d_lt_100))
             # 15m & 1h & 4h down move, 15m still not low enough, 1h still not low enough
-            & ((rsi_3_15m_gt_5) | (rsi_3_1h_gt_30) | (rsi_3_4h_gt_30) | (aroonu_14_15m_lt_30) | (stochrsi_k_1h < 30.0))
+            & ((rsi_3_15m_gt_5) | (rsi_3_1h_gt_30) | (rsi_3_4h_gt_30) | (aroonu_14_15m_lt_30) | (stochrsi_k_1h_lt_30))
             # 15m & 1h down move, 1d overbought
             & ((rsi_3_15m_gt_5) | (rsi_3_1h_gt_30) | (roc_9_1d_lt_30))
             # 15m & 4h down move, 4h downtrend
@@ -22784,7 +22796,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 4h high & overbought
             & (rsi_3_1h_gt_20 | (aroonu_14_4h_lt_80) | (roc_9_4h < 70.0))
             # 1h down move, 1h high, 1h still not low enough
-            & (rsi_3_1h_gt_20 | (aroonu_14_1d_lt_80) | (stochrsi_k_1h < 20.0))
+            & (rsi_3_1h_gt_20 | (aroonu_14_1d_lt_80) | (stochrsi_k_1h_lt_20))
             # 1h down move, 1d high & overbought
             & (rsi_3_1h_gt_20 | (aroonu_14_1d_lt_100) | (roc_9_1d_lt_20))
             # 1h down move, 4h still high, 1d downtrend
@@ -22906,7 +22918,7 @@ class NostalgiaForInfinityX7(IStrategy):
             (willr_14 < -50.0)
             & (stochrsi_k < 30.0)
             # & (df["STOCHRSIk_14_14_3_3_15m"] < 40.0)
-            & (stochrsi_k_1h < 40.0)
+            & (stochrsi_k_1h_lt_40)
             & (bbb_20_2_0_1h > 12.0)
             & (close_max_48 >= (close * 1.10))
           )
@@ -22928,7 +22940,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 1h downtrend
             & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_3) | (roc_9_1h > -20.0))
             # 15m & 1h down move, 1h still not low enough
-            & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_10) | (stochrsi_k_1h < 20.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_10) | (stochrsi_k_1h_lt_20))
             # 15m & 1h down move, 4h high
             & ((rsi_3_15m_gt_5) | (rsi_3_1h_gt_10) | aroonu_14_4h_lt_70)
             # 15m & 1h down move, 1h high
@@ -23036,7 +23048,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 4h high & overbought
             & ((rsi_3_1h_gt_20) | (aroonu_14_4h_lt_80) | (roc_9_4h < 60.0))
             # 1h down move, 1h still not low enough, 1d downtrend
-            & ((rsi_3_1h_gt_20) | (stochrsi_k_1h < 30.0) | (roc_9_1d_gt_neg_30))
+            & ((rsi_3_1h_gt_20) | (stochrsi_k_1h_lt_30) | (roc_9_1d_gt_neg_30))
             # 1h & 4h down move, 1h high
             & ((rsi_3_1h_gt_25) | (rsi_3_4h_gt_35) | (aroonu_14_1h_lt_70))
             # 1h & 4h down move, 1d overbought
@@ -23046,7 +23058,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h high, 1d overbought
             & ((rsi_3_1h_gt_25) | aroonu_14_1h_lt_80 | (roc_9_1d_lt_30))
             # 1h down move, 1h still high, 4h downtrend
-            & ((rsi_3_1h_gt_25) | (stochrsi_k_1h < 50.0) | (roc_9_4h_gt_neg_20))
+            & ((rsi_3_1h_gt_25) | (stochrsi_k_1h_lt_50) | (roc_9_4h_gt_neg_20))
             # 1h down move, 1d overbought
             & ((rsi_3_1h_gt_25) | (roc_9_1d_lt_80))
             # 1h down move, 1h high, 1d overbought
@@ -23062,7 +23074,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h high, 1d downtrend
             & ((rsi_3_1h_gt_40) | aroonu_14_1h_lt_70 | (roc_9_1d > -30.0))
             # 1h down move, 1h high, 1d downtrend
-            & ((rsi_3_1h_gt_40) | (stochrsi_k_1h < 70.0) | (roc_9_1d_gt_neg_30))
+            & ((rsi_3_1h_gt_40) | (stochrsi_k_1h_lt_70) | (roc_9_1d_gt_neg_30))
             # 1h down move, 1h & 4h high
             & ((rsi_3_1h_gt_45) | aroonu_14_1h_lt_80 | aroonu_14_4h_lt_100)
             # 1h down move, 1h high, 4h overbought
@@ -23078,13 +23090,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 1d still high, 1d downtrend
             & ((rsi_3_4h_gt_10) | (aroonu_14_1d_lt_50) | (roc_9_1d > -30.0))
             # 4h down move, 15m & 1h still not low enough
-            & ((rsi_3_4h_gt_10) | (stochrsi_k_15m_lt_30) | (stochrsi_k_1h < 30.0))
+            & ((rsi_3_4h_gt_10) | (stochrsi_k_15m_lt_30) | (stochrsi_k_1h_lt_30))
             # 4h down move, 15m stil high, 4h downtrend
             & ((rsi_3_4h_gt_10) | (stochrsi_k_15m_lt_50) | (roc_9_4h > -20.0))
             # 4h & 1d down move, 1d downtrend
             & ((rsi_3_4h_gt_15) | (rsi_3_1d_gt_25) | (roc_9_1d > -30.0))
             # 4h & 1d down move, 1h still high
-            & ((rsi_3_4h_gt_15) | (rsi_3_1d_gt_30) | (stochrsi_k_1h < 50.0))
+            & ((rsi_3_4h_gt_15) | (rsi_3_1d_gt_30) | (stochrsi_k_1h_lt_50))
             # 4h & 1d down move, 4h high
             & ((rsi_3_4h_gt_15) | (rsi_3_1d_gt_35) | (stochrsi_k_4h_lt_70))
             # 4h down move, 4h high
@@ -23114,7 +23126,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1d down move, 1h high
             & ((rsi_3_1d_gt_20) | (stochrsi_k_1h_lt_70))
             # 1d down move, 1h high, 1d downtrend
-            & ((rsi_3_1d_gt_25) | (stochrsi_k_1h < 60.0) | (roc_9_1d_gt_neg_30))
+            & ((rsi_3_1d_gt_25) | (stochrsi_k_1h_lt_60) | (roc_9_1d_gt_neg_30))
             # 1d down move, 1d high, 4h downtrend
             & ((rsi_3_1d_gt_35) | (aroonu_14_1d_lt_70) | (roc_9_4h > -10.0))
             # 1d down move, 4h high, 1d overbought
@@ -23186,7 +23198,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m down move, 4h still high, 1d overbought
           long_entry_logic.append((rsi_3_15m_gt_40) | (aroonu_14_4h_lt_50) | (roc_9_1d_lt_100))
           # 15m & 1h down move, 1h still high
-          long_entry_logic.append((rsi_3_15m_gt_45) | (rsi_3_1h_gt_45) | (stochrsi_k_1h < 40.0))
+          long_entry_logic.append((rsi_3_15m_gt_45) | (rsi_3_1h_gt_45) | (stochrsi_k_1h_lt_40))
           # 15m down move, 15m high, 1d overbought
           long_entry_logic.append((rsi_3_15m_gt_45) | (aroonu_14_15m_lt_60) | roc_9_1d_lt_50)
           # 15m down move, 15m high, 4h still high
@@ -23194,7 +23206,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m down move, 15m still not low enough, 4h still high
           long_entry_logic.append((rsi_3_15m_gt_45) | (stochrsi_k_15m_lt_30) | (stochrsi_k_4h_lt_50))
           # 15m down move, 15m & 1h still high
-          long_entry_logic.append((rsi_3_15m_gt_45) | (stochrsi_k_15m < 45.0) | (stochrsi_k_1h < 40.0))
+          long_entry_logic.append((rsi_3_15m_gt_45) | (stochrsi_k_15m < 45.0) | (stochrsi_k_1h_lt_40))
           # 15m down move, 15m still not low enough, 4h high
           long_entry_logic.append((rsi_3_15m_gt_50) | (stochrsi_k_15m_lt_30) | (stochrsi_k_4h_lt_90))
           # 15m down move, 15m still high, 1d overbought
@@ -23209,7 +23221,7 @@ class NostalgiaForInfinityX7(IStrategy):
           long_entry_logic.append((rsi_3_1h_gt_25) | (aroonu_14_4h_lt_50) | (stochrsi_k_1d_lt_90))
           # 1h & 4h down move, 1h still high
           long_entry_logic.append((rsi_3_1h_gt_30) | (rsi_3_4h_gt_65) | (aroonu_14_1h_lt_50))
-          long_entry_logic.append((rsi_3_1h_gt_30) | (stochrsi_k_1h < 40.0) | (stochrsi_k_1d_lt_90))
+          long_entry_logic.append((rsi_3_1h_gt_30) | (stochrsi_k_1h_lt_40) | (stochrsi_k_1d_lt_90))
           # 1h & 4h down move, 4h still high
           long_entry_logic.append((rsi_3_1h_gt_35) | (rsi_3_4h_gt_55) | (stochrsi_k_4h_lt_50))
           # 1h & 4h down move, 4h high
@@ -23219,7 +23231,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1h down move, 1h still high, 4h high
           long_entry_logic.append((rsi_3_1h_gt_40) | (stochrsi_k_1h_lt_50) | (stochrsi_k_4h_lt_70))
           # 1h down move, 1h high
-          long_entry_logic.append((rsi_3_1h_gt_40) | (stochrsi_k_1h < 60.0))
+          long_entry_logic.append((rsi_3_1h_gt_40) | (stochrsi_k_1h_lt_60))
           # 1h down move, 4h & 1d high
           long_entry_logic.append((rsi_3_1h_gt_40) | (aroonu_14_4h_lt_85) | (aroonu_14_1d_lt_90))
           # 1h down move, 1h still high, 4h high
@@ -23227,13 +23239,13 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1h down move, 1h still high, 1d high
           long_entry_logic.append((rsi_3_1h_gt_45) | (aroonu_14_1h_lt_50) | (aroonu_14_1d_lt_90))
           # 1h down move, 1h high
-          long_entry_logic.append((rsi_3_1h_gt_45) | (stochrsi_k_1h < 60.0))
+          long_entry_logic.append((rsi_3_1h_gt_45) | (stochrsi_k_1h_lt_60))
           # 1h & 4h down move, 15m high
           long_entry_logic.append((rsi_3_1h_gt_50) | (rsi_3_4h_gt_60) | (aroonu_14_15m_lt_70))
           # 1h down move, 15m still high, 4h high
           long_entry_logic.append((rsi_3_1h_gt_50) | (aroonu_14_15m_lt_50) | aroonu_14_4h_lt_80)
           # 1h down move, 15m high, 1h still high
-          long_entry_logic.append((rsi_3_1h_gt_50) | (aroonu_14_15m_lt_70) | (stochrsi_k_1h < 40.0))
+          long_entry_logic.append((rsi_3_1h_gt_50) | (aroonu_14_15m_lt_70) | (stochrsi_k_1h_lt_40))
           # 1h down move, 15m still high, 4h high
           long_entry_logic.append((rsi_3_1h_gt_50) | (stochrsi_k_15m_lt_50) | (stochrsi_k_4h_lt_80))
           # 1h down move, 15m & 1h high
@@ -23255,7 +23267,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1h down move, 15m still not low enough, 1h high
           long_entry_logic.append((rsi_3_1h_gt_60) | (stochrsi_k_15m_lt_30) | aroonu_14_1h_lt_70)
           # 1h down move, 15m still not low enough, 1h high
-          long_entry_logic.append((rsi_3_1h_gt_60) | (stochrsi_k_15m_lt_30) | (stochrsi_k_1h < 60.0))
+          long_entry_logic.append((rsi_3_1h_gt_60) | (stochrsi_k_15m_lt_30) | (stochrsi_k_1h_lt_60))
           # 1h down move, 15m & 4h still high
           long_entry_logic.append((rsi_3_1h_gt_60) | (stochrsi_k_15m_lt_50) | (stochrsi_k_4h_lt_50))
           # 1h down move, 15m & 1h high
@@ -23265,7 +23277,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1h down move, 1h high, 4h still high
           long_entry_logic.append((rsi_3_1h_gt_60) | aroonu_14_1h_lt_80 | (aroonu_14_4h_lt_40))
           # 1h down move, 1h still high, 4h high
-          long_entry_logic.append((rsi_3_1h_gt_60) | (stochrsi_k_1h < 40.0) | aroonu_14_4h_lt_70)
+          long_entry_logic.append((rsi_3_1h_gt_60) | (stochrsi_k_1h_lt_40) | aroonu_14_4h_lt_70)
           # 1h down move, 1h & 1d high
           long_entry_logic.append((rsi_3_1h_gt_60) | (stochrsi_k_1h_lt_70) | (aroonu_14_1d_lt_90))
           # 1h down move, 4h & 1d high
@@ -23347,13 +23359,13 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1d high & overbought
           long_entry_logic.append(aroonu_14_1d_lt_100 | (roc_9_1d < 200.0))
           # 15m high, 1h still high
-          long_entry_logic.append((stochrsi_k_15m_lt_70) | (stochrsi_k_1h < 40.0))
+          long_entry_logic.append((stochrsi_k_15m_lt_70) | (stochrsi_k_1h_lt_40))
           # 15m & 4h high
           long_entry_logic.append((stochrsi_k_15m_lt_70) | aroonu_14_4h_lt_70)
           # 15m high, 1d overbought
           long_entry_logic.append((stochrsi_k_15m_lt_70) | (roc_9_1d < 10.0))
           # 15m high, 1h still not low enough
-          long_entry_logic.append((stochrsi_k_15m_lt_80) | (stochrsi_k_1h < 30.0))
+          long_entry_logic.append((stochrsi_k_15m_lt_80) | (stochrsi_k_1h_lt_30))
           # 1d high, 4h overbought
           long_entry_logic.append((stochrsi_k_1d < 80.0) | (roc_9_4h_lt_40))
           # 1d high & overbought
@@ -23475,7 +23487,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 4h high & overbought
             & ((rsi_3_1h_gt_35) | (stochrsi_k_4h_lt_80) | (roc_9_4h_lt_30))
             # 1h down move, 1h high, 4h downtrend
-            & ((rsi_3_1h_gt_40) | (stochrsi_k_1h < 80.0) | (roc_9_4h_gt_neg_20))
+            & ((rsi_3_1h_gt_40) | (stochrsi_k_1h_lt_80) | (roc_9_4h_gt_neg_20))
             # 1h down move, 15m still high, 1d overbought
             & ((rsi_3_1h_gt_45) | (aroonu_14_15m_lt_50) | (roc_9_1d_lt_50))
             # 1h down move, 4h & 1d overbought
@@ -23635,7 +23647,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 4h high & overbought
             & ((rsi_3_15m_gt_15) | (rsi_3_1h_gt_45) | (rsi_14_4h < 70.0) | (roc_9_4h < 50.0))
             # 15m & 1h down move, 1h high
-            & ((rsi_3_15m_gt_15) | (rsi_3_1h_gt_50) | (stochrsi_k_1h < 90.0))
+            & ((rsi_3_15m_gt_15) | (rsi_3_1h_gt_50) | (stochrsi_k_1h_lt_90))
             # 15m & 4h down move, 15m high
             & ((rsi_3_15m_gt_15) | (rsi_3_4h_gt_30) | (aroonu_14_15m_lt_60))
             # 15m & 4h down move, 4h high
@@ -23645,7 +23657,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 4h down move, 1d high
             & ((rsi_3_15m_gt_15) | (rsi_3_4h_gt_35) | (stochrsi_k_1d_lt_90))
             # 15m & 4h down move, 1h high
-            & ((rsi_3_15m_gt_15) | (rsi_3_4h_gt_35) | (stochrsi_k_1h < 60.0))
+            & ((rsi_3_15m_gt_15) | (rsi_3_4h_gt_35) | (stochrsi_k_1h_lt_60))
             # 15m & 4h down move, 1h high
             & ((rsi_3_15m_gt_15) | (rsi_3_4h_gt_50) | (stochrsi_k_1h_lt_80))
             # 15m down move, 4h & 1d up move, 1d downtrend
@@ -23687,7 +23699,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 1h high & overbought
             & ((rsi_3_15m_gt_15) | (stochrsi_k_1h_lt_80) | (roc_9_1h < 20.0))
             # 15m down move, 1h high, 1d overbought
-            & ((rsi_3_15m_gt_15) | (stochrsi_k_1h < 80.0) | (roc_9_1d_lt_100))
+            & ((rsi_3_15m_gt_15) | (stochrsi_k_1h_lt_80) | (roc_9_1d_lt_100))
             # 15m down move, 4h high, 1d overbought
             & ((rsi_3_15m_gt_15) | (stochrsi_k_4h_lt_80) | (roc_9_1d < 25.0))
             # 15m down move, 4h high & overbought
@@ -23701,7 +23713,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 4h & 1d downtrend
             & ((rsi_3_15m_gt_15) | (roc_9_4h_gt_neg_20) | (roc_9_1d_gt_neg_20))
             # 16m & 1h down move, 1h still high
-            & ((rsi_3_15m_gt_20) | (rsi_3_1h_gt_25) | (stochrsi_k_1h < 40.0))
+            & ((rsi_3_15m_gt_20) | (rsi_3_1h_gt_25) | (stochrsi_k_1h_lt_40))
             # 15m & 1h down move, 1h downtrend, 1h downtrend, 15m still high, 1h high
             & (
               (rsi_3_15m_gt_20) | (rsi_3_1h_gt_35) | (cmf_20_1h > -0.10) | (aroonu_14_15m_lt_40) | (aroonu_14_1h_lt_85)
@@ -23772,7 +23784,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 4h high & overbought
             & ((rsi_3_1h_gt_25) | (aroonu_14_4h_lt_90) | (roc_9_4h_lt_20))
             # 1h down move, 1h still not low enough, 1d downtrend
-            & ((rsi_3_1h_gt_25) | (stochrsi_k_1h < 30.0) | (roc_9_1d_gt_neg_40))
+            & ((rsi_3_1h_gt_25) | (stochrsi_k_1h_lt_30) | (roc_9_1d_gt_neg_40))
             # 1h down move, 4h high, 1d overbought
             & ((rsi_3_1h_gt_25) | (stochrsi_k_4h_lt_90) | (roc_9_1d < 25.0))
             # 1h & 4h & 1d down move, 1d high & overbought
@@ -23842,7 +23854,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 15m & 1h high, 1d downtrend
             & ((rsi_3_1h_gt_60) | (aroonu_14_15m < 65.0) | (stochrsi_k_1h_lt_80) | (cmf_20_1d > -0.0))
             # 1h down move, 1h high, 1d downtrend
-            & ((rsi_3_1h_gt_60) | (stochrsi_k_1h < 90.0) | (roc_9_1d_gt_neg_20))
+            & ((rsi_3_1h_gt_60) | (stochrsi_k_1h_lt_90) | (roc_9_1d_gt_neg_20))
             # 4h down move, 15m high
             & ((rsi_3_4h_gt_3) | (aroonu_14_15m_lt_50))
             # 4h & 1d down move, 1d high
@@ -23854,7 +23866,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 4h still high
             & ((rsi_3_4h_gt_10) | (aroonu_14_4h_lt_40))
             # 4h down move, 1h still high, 4h downtrend
-            & ((rsi_3_4h_gt_10) | (stochrsi_k_1h < 50.0) | (cmf_20_4h > -0.3))
+            & ((rsi_3_4h_gt_10) | (stochrsi_k_1h_lt_50) | (cmf_20_4h > -0.3))
             # 4h down move, 1d still high, 1d downtrend
             & ((rsi_3_4h_gt_15) | (rsi_14_1d < 40.0) | (roc_9_1d > -10.0))
             # 4h down move, 4h high
@@ -23876,7 +23888,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 4h high, 1d overbought
             & ((rsi_3_4h_gt_40) | aroonu_14_4h_lt_80 | (roc_9_1d_lt_20))
             # 4h down move, 1h high, 1d downtrend
-            & ((rsi_3_4h_gt_40) | (stochrsi_k_1h < 80.0) | (roc_9_1d_gt_neg_20))
+            & ((rsi_3_4h_gt_40) | (stochrsi_k_1h_lt_80) | (roc_9_1d_gt_neg_20))
             # 4h down move, 4h & 1d overbought
             & ((rsi_3_4h_gt_40) | (roc_9_4h_lt_10) | roc_9_1d_lt_50)
             # 4h down move, 4h high, 1d overbought
@@ -23902,7 +23914,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1d down move, 1h & 4h high
             & ((rsi_3_1d_gt_10) | aroonu_14_1h_lt_80 | (aroonu_14_4h_lt_90))
             # 1d down move, 1h & 4h still high
-            & ((rsi_3_1d_gt_10) | (stochrsi_k_1h < 40.0) | (aroonu_14_4h_lt_40))
+            & ((rsi_3_1d_gt_10) | (stochrsi_k_1h_lt_40) | (aroonu_14_4h_lt_40))
             # 1d down move, 1h high & overbought
             & ((rsi_3_1d_gt_20) | (stochrsi_k_1h_lt_80) | (roc_9_1h < 20.0))
             # 1d down move, 1d high & overbought
@@ -24082,7 +24094,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 5m up move, 15m stil low
           short_entry_logic.append((rsi_3_lt_90) | (aroonu_14_15m > 50.0))
           # 5m up move, 15m & 1h still not high enough
-          short_entry_logic.append((rsi_3_lt_90) | (stochrsi_k_15m > 60.0) | (stochrsi_k_1h > 75.0))
+          short_entry_logic.append((rsi_3_lt_90) | (stochrsi_k_15m > 60.0) | (stochrsi_k_1h_gt_75))
           # 15m up move, 1h low
           short_entry_logic.append((rsi_3_15m < 97.0) | (aroonu_14_1h > 30.0))
           # 15m & 1h up move, 4h still going up
@@ -24094,13 +24106,13 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m & 1h up move, 1h still low
           short_entry_logic.append((rsi_3_15m_lt_95) | (rsi_3_1h < 70.0) | (stochrsi_k_1h_gt_50))
           # 15m & 4h up move, 1h still not high enough
-          short_entry_logic.append((rsi_3_15m_lt_95) | (rsi_3_4h_lt_95) | (stochrsi_k_1h > 75.0))
+          short_entry_logic.append((rsi_3_15m_lt_95) | (rsi_3_4h_lt_95) | (stochrsi_k_1h_gt_75))
           # 15m up move, 1d lost, 1h low
           short_entry_logic.append((rsi_3_15m_lt_95) | (rsi_14_1d > 40.0) | (aroonu_14_1h > 40.0))
           # 15m up move, 15m & 4h uptrend
           short_entry_logic.append((rsi_3_15m_lt_95) | (aroonu_14_15m_lt_90) | (aroonu_14_4h_lt_90))
           # 15m up move, 15m stil not high enough, 1h low
-          short_entry_logic.append((rsi_3_15m_lt_95) | (stochrsi_k_15m > 70.0) | (stochrsi_k_1h > 10.0))
+          short_entry_logic.append((rsi_3_15m_lt_95) | (stochrsi_k_15m > 70.0) | (stochrsi_k_1h_gt_10))
           # 15m up move, 1h still not high enough, 4h low
           short_entry_logic.append((rsi_3_15m_lt_95) | (stochrsi_k_1h_gt_70) | (aroonu_14_4h > 20.0))
           # 15m up move, 1h & 4h still not high enough
@@ -24122,15 +24134,15 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m & 1h up move, 15m still not high enough
           short_entry_logic.append((rsi_3_15m_lt_90) | (rsi_3_1h_lt_80) | (stochrsi_k_15m > 60.0))
           # 15m & 4h up move, 1h still not high enough
-          short_entry_logic.append((rsi_3_15m_lt_90) | (rsi_3_4h_lt_90) | (stochrsi_k_1h > 80.0))
+          short_entry_logic.append((rsi_3_15m_lt_90) | (rsi_3_4h_lt_90) | (stochrsi_k_1h_gt_80))
           # 15m & 4h up move, 1h still not high enough
-          short_entry_logic.append((rsi_3_15m_lt_90) | (rsi_3_4h_lt_90) | (stochrsi_k_1h > 90.0))
+          short_entry_logic.append((rsi_3_15m_lt_90) | (rsi_3_4h_lt_90) | (stochrsi_k_1h_gt_90))
           # 15m & 4h up move, 4h not high enough
           short_entry_logic.append((rsi_3_15m_lt_90) | (rsi_3_4h_lt_90) | (aroond_14_4h < 50.0))
           # 15m & 4h up move, 1d low
           short_entry_logic.append((rsi_3_15m_lt_90) | (rsi_3_4h_lt_85) | (stochrsi_k_1d > 30.0))
           # 15m & 4h up move, 1h low
-          short_entry_logic.append((rsi_3_15m_lt_90) | (rsi_3_4h < 70.0) | (stochrsi_k_1h > 20.0))
+          short_entry_logic.append((rsi_3_15m_lt_90) | (rsi_3_4h < 70.0) | (stochrsi_k_1h_gt_20))
           # 15m & 4h up move, 4h low
           short_entry_logic.append((rsi_3_15m_lt_90) | (rsi_3_4h < 60.0) | (aroonu_14_4h > 30.0))
           # 15m up move, 1h & 4h low
@@ -24162,7 +24174,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m & 4h up move, 15m still low
           short_entry_logic.append((rsi_3_15m < 80.0) | (rsi_3_4h_lt_80) | (aroonu_14_15m > 50.0))
           # 15m up move, 1h low
-          short_entry_logic.append((rsi_3_15m < 80.0) | (stochrsi_k_1h > 20.0))
+          short_entry_logic.append((rsi_3_15m < 80.0) | (stochrsi_k_1h_gt_20))
           # 15m & 1h up move, 1h low
           short_entry_logic.append((rsi_3_15m < 70.0) | (rsi_3_1h < 70.0) | (aroonu_14_1h > 30.0))
           # 15m up move, 15m still not high enough, 1h still low
@@ -24196,7 +24208,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1h up move, 4h low, 1d overbought
           short_entry_logic.append((rsi_3_1h_lt_90) | (aroonu_14_4h > 20.0) | roc_9_1d_lt_50)
           # 1h up move, 1h still low, 1d uptrend
-          short_entry_logic.append((rsi_3_1h_lt_90) | (stochrsi_k_1h > 60.0) | roc_9_1d_lt_50)
+          short_entry_logic.append((rsi_3_1h_lt_90) | (stochrsi_k_1h_gt_60) | roc_9_1d_lt_50)
           # 1h up move, 1h still not high enough, 1d low
           short_entry_logic.append((rsi_3_1h_lt_90) | (stochrsi_k_1h_gt_70) | (stochrsi_k_1d > 30.0))
           # 1h up move, 4h low, 1h uptrend
@@ -24214,7 +24226,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1h up move, 15m still not high enough, 1h still low
           short_entry_logic.append((rsi_3_1h_lt_80) | (stochrsi_k_15m > 80.0) | (stochrsi_k_1h_gt_50))
           # 1h up move, 1h still low
-          short_entry_logic.append((rsi_3_1h_lt_80) | (stochrsi_k_1h > 60.0))
+          short_entry_logic.append((rsi_3_1h_lt_80) | (stochrsi_k_1h_gt_60))
           # 4h & 1d strong up move
           short_entry_logic.append((rsi_3_4h_lt_95) | (rsi_3_1d < 95.0))
           # 4h up move, 15m still low, 1h not high enough
@@ -24238,17 +24250,17 @@ class NostalgiaForInfinityX7(IStrategy):
           # 4h up move, 1d low
           short_entry_logic.append((rsi_3_4h < 70.0) | (aroonu_14_1d > 20.0))
           # 4h up move, 1h low
-          short_entry_logic.append((rsi_3_4h < 70.0) | (stochrsi_k_1h > 20.0))
+          short_entry_logic.append((rsi_3_4h < 70.0) | (stochrsi_k_1h_gt_20))
           # 4h up move, 1d low
           short_entry_logic.append((rsi_3_4h < 70.0) | (stochrsi_k_1d > 20.0))
           # 1d up move, 1h & 4h still not low enough
-          short_entry_logic.append((rsi_3_1d < 90.0) | (stochrsi_k_1h > 80.0) | (stochrsi_k_4h_gt_50))
+          short_entry_logic.append((rsi_3_1d < 90.0) | (stochrsi_k_1h_gt_80) | (stochrsi_k_4h_gt_50))
           # 4h still not high enough, 4h overbought, 4h uptrend
           short_entry_logic.append((rsi_14_4h > 80.0) | (roc_9_4h_lt_40) | (cci_20_change_pct_4h < 0.0))
           # 15m & 1h uptrend, 4h still low
           short_entry_logic.append((cmf_20_15m < 0.30) | (cmf_20_1h < 0.30) | (stochrsi_k_4h > 60.0))
           # 15m uptrend, 1h low
-          short_entry_logic.append((aroonu_14_15m_lt_100) | (stochrsi_k_1h > 20.0))
+          short_entry_logic.append((aroonu_14_15m_lt_100) | (stochrsi_k_1h_gt_20))
           # 1h & 4h uptrend
           short_entry_logic.append((aroonu_14_1h_lt_100) | aroonu_14_4h_lt_100)
           # 1h uptrend, 4h uptrend
@@ -24318,13 +24330,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 4h still not high enough
             & ((rsi_3_15m < 97.0) | (rsi_3_1h_lt_85) | (stochrsi_k_4h > 80.0))
             # 15m up move, 1h still low
-            & ((rsi_3_15m < 97.0) | (stochrsi_k_1h > 60.0))
+            & ((rsi_3_15m < 97.0) | (stochrsi_k_1h_gt_60))
             # 15m & 1h & 4h up move
             & ((rsi_3_15m_lt_95) | (rsi_3_1h_lt_90) | (rsi_3_4h_lt_85))
             # 15m & 1h up move, 4h still low
             & ((rsi_3_15m_lt_95) | (rsi_3_1h_lt_85) | (stochrsi_k_4h > 60.0))
             # 15m up move, 1h still low
-            & ((rsi_3_15m_lt_95) | (stochrsi_k_1h > 40.0))
+            & ((rsi_3_15m_lt_95) | (stochrsi_k_1h_gt_40))
             # 15m up move, 4h still not high enough
             & ((rsi_3_15m_lt_95) | (aroonu_14_4h > 70.0))
             # 15m & 1h & 4h up move
@@ -24334,7 +24346,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h up move, 1d low
             & ((rsi_3_15m_lt_90) | (rsi_3_1h_lt_90) | (stochrsi_k_1d > 40.0))
             # 15m & 1h up move, 1h still not high enough
-            & ((rsi_3_15m_lt_90) | (rsi_3_1h_lt_85) | (stochrsi_k_1h > 80.0))
+            & ((rsi_3_15m_lt_90) | (rsi_3_1h_lt_85) | (stochrsi_k_1h_gt_80))
             # 15m & 1h up move, 4h stil low
             & ((rsi_3_15m_lt_90) | (rsi_3_1h_lt_80) | (aroonu_14_4h > 50.0))
             # 15m & 4h up move, 1d low
@@ -24350,7 +24362,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m up move, 4h uptrend
             & ((rsi_3_15m_lt_90) | (roc_9_4h_lt_20))
             # 15m & 1h up move, 1h still low
-            & ((rsi_3_15m_lt_85) | (rsi_3_1h < 65.0) | (stochrsi_k_1h > 60.0))
+            & ((rsi_3_15m_lt_85) | (rsi_3_1h < 65.0) | (stochrsi_k_1h_gt_60))
             # 15m up move, 1h low
             & ((rsi_3_15m_lt_85) | (stochrsi_k_1h_gt_30))
             # 15m & 1h & 4h up move, 4h uptrend
@@ -24406,7 +24418,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h up move, 1h uptrend
             & ((rsi_3_1h < 70.0) | (roc_9_1h < 40.0))
             # 1h up move, 1h low
-            & ((rsi_3_1h < 60.0) | (stochrsi_k_1h > 20.0))
+            & ((rsi_3_1h < 60.0) | (stochrsi_k_1h_gt_20))
             # 4h up move, 1d still low
             & ((rsi_3_4h < 97.0) | (rsi_14_1d > 50.0))
             # 4h up move, 1h still not high enough
@@ -24430,11 +24442,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h up move, 4h uptrend
             & ((rsi_3_4h_lt_80) | (roc_9_4h_lt_20))
             # 4h up move, 1h low
-            & ((rsi_3_4h < 75.0) | (stochrsi_k_1h > 20.0))
+            & ((rsi_3_4h < 75.0) | (stochrsi_k_1h_gt_20))
             # 4h up move, 4h low
             & ((rsi_3_4h < 70.0) | (stochrsi_k_4h > 40.0))
             # 1d up move, 1h still not high enough
-            & ((rsi_3_1d < 95.0) | (stochrsi_k_1h > 90.0))
+            & ((rsi_3_1d < 95.0) | (stochrsi_k_1h_gt_90))
             # 1d up move, 1h still low
             & ((rsi_3_1d < 90.0) | (stochrsi_k_1h_gt_50))
             # 1d up move, 4h still low
@@ -24456,7 +24468,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h still not high enough, 4h & 1d uptrend
             & ((aroonu_14_4h > 70.0) | (roc_9_4h < 60.0) | (roc_9_1d < 200.0))
             # 1h & 4h low
-            & ((stochrsi_k_1h > 20.0) | (aroonu_14_4h > 20.0))
+            & ((stochrsi_k_1h_gt_20) | (aroonu_14_4h > 20.0))
             # 1d big green, 1d still not high enough
             & ((change_pct_1d < 30.0) | (rsi_14_1d > 65.0))
             # rise in the last hour, relatively stable before the hour
@@ -24502,7 +24514,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 5m down move, 1h & 4h high
           short_entry_logic.append((rsi_3_lt_90) | (df["UO_7_14_28_1h"] > 40.0) | (stochrsi_k_4h_gt_30))
           # 5m down move, 1h high, 4h downtrend
-          short_entry_logic.append((rsi_3 < 98.0) | (stochrsi_k_1h > 10.0) | (roc_9_4h_lt_10))
+          short_entry_logic.append((rsi_3 < 98.0) | (stochrsi_k_1h_gt_10) | (roc_9_4h_lt_10))
           # 5m & 1h down move, 4h down
           short_entry_logic.append((rsi_3_lt_90) | (rsi_3_1h_lt_85) | (cmf_20_4h > -0.2))
           # 5m down move, 1h high
@@ -24513,7 +24525,7 @@ class NostalgiaForInfinityX7(IStrategy):
           short_entry_logic.append((rsi_3_15m_lt_95) | (rsi_3_1h_lt_85) | (stochrsi_k_4h_gt_50))
           # 15m down move, 15m still not low enough, 1h & 4h still not low enough
           short_entry_logic.append(
-            (rsi_3_15m_lt_95) | (aroond_14_15m < 25.0) | (stochrsi_k_1h > 75.0) | (df["MFI_14_4h"] > 50.0)
+            (rsi_3_15m_lt_95) | (aroond_14_15m < 25.0) | (stochrsi_k_1h_gt_75) | (df["MFI_14_4h"] > 50.0)
           )
           # 5m & 1h down move, 1h still high
           short_entry_logic.append((rsi_3_15m_lt_95) | (rsi_3_1h_lt_85) | (stochrsi_k_1h_gt_50))
@@ -24687,7 +24699,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m strong down move, 1h still high
           short_entry_logic.append((rsi_3_15m_lt_95) | (mfi_14_15m < 90.0) | (stochrsi_k_1h_gt_50))
           # 15m & 1h down move, 1h not low enough
-          short_entry_logic.append((rsi_3_15m_lt_95) | (rsi_3_1h_lt_95) | (stochrsi_k_1h > 80.0))
+          short_entry_logic.append((rsi_3_15m_lt_95) | (rsi_3_1h_lt_95) | (stochrsi_k_1h_gt_80))
           # 15m down move, 1h strong down move
           short_entry_logic.append((rsi_3_15m_lt_95) | (df["RSI_14_change_pct_1h"] < 70.0))
           # 15m down move, 4h & 1d downtrend
@@ -24705,7 +24717,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1m down move, 1h still dropping, 4h overbought
           short_entry_logic.append((rsi_3_15m_lt_90) | (cci_20_change_pct_1h < 0.0) | (rsi_14_4h > 20.0))
           # 15m down move, 1h high
-          short_entry_logic.append((df["RSI_3_change_pct_15m"] < 70.0) | (stochrsi_k_1h > 10.0))
+          short_entry_logic.append((df["RSI_3_change_pct_15m"] < 70.0) | (stochrsi_k_1h_gt_10))
           # 1h strong down move, 4h high
           short_entry_logic.append((rsi_3_1h_lt_95) | (stochrsi_k_4h > 10.0))
           # 1h down move, 4h downtrend, 4h not low enough
@@ -24911,7 +24923,7 @@ class NostalgiaForInfinityX7(IStrategy):
           short_entry_logic.append(aroond_14 < 25.0)
           short_entry_logic.append(stochrsi_k > 80.0)
           short_entry_logic.append(willr_84_1h > -30.0)
-          short_entry_logic.append(stochrsi_k_1h > 80.0)
+          short_entry_logic.append(stochrsi_k_1h_gt_80)
           short_entry_logic.append(bbb_20_2_0_1h > 20.0)
           short_entry_logic.append(df["close_min_48"] <= (close * 0.90))
 
@@ -24954,7 +24966,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m & 1h down move, 1h still high
           short_entry_logic.append((rsi_3_15m_lt_85) | (rsi_3_1h < 75.0) | (stochrsi_k_1h_gt_30))
           # 15m down move, 15m still not low enoug, 1h high
-          short_entry_logic.append((rsi_3_15m_lt_85) | (aroond_14_15m < 25.0) | (stochrsi_k_1h > 10.0))
+          short_entry_logic.append((rsi_3_15m_lt_85) | (aroond_14_15m < 25.0) | (stochrsi_k_1h_gt_10))
           # 15m down move, 1h downtrend, 4h overbought
           short_entry_logic.append((rsi_3_15m_lt_85) | (roc_9_1h < 5.0) | (roc_9_4h > -35.0))
           # 1h & 4h down move, 4h still not low enough
@@ -25027,9 +25039,9 @@ class NostalgiaForInfinityX7(IStrategy):
           short_entry_logic.append(rsi_14_4h > 20.0)
           short_entry_logic.append(rsi_14_1d > 10.0)
           # 5m down move, 1h still not low enough, 4h high
-          short_entry_logic.append((rsi_3_lt_90) | (stochrsi_k_1h > 90.0) | (stochrsi_k_4h_gt_30))
+          short_entry_logic.append((rsi_3_lt_90) | (stochrsi_k_1h_gt_90) | (stochrsi_k_4h_gt_30))
           # 5m down move, 1h high, 4h still not low enough
-          short_entry_logic.append((rsi_3_lt_90) | (stochrsi_k_1h > 20.0) | (stochrsi_k_4h > 90.0))
+          short_entry_logic.append((rsi_3_lt_90) | (stochrsi_k_1h_gt_20) | (stochrsi_k_4h > 90.0))
           # 15m down move, 15m still not low enough, 1h still high
           short_entry_logic.append((rsi_3_15m_lt_95) | (aroond_14_15m < 25.0) | (stochrsi_k_1h_gt_50))
           # 15m & 1h down move, 1d still not low enough
@@ -25041,25 +25053,25 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m & 1h down move, 4h still high
           short_entry_logic.append((rsi_3_15m < 80.0) | (rsi_3_1h < 70.0) | (stochrsi_k_4h_gt_50))
           # 15m down move, 1h still not low enough, 4h still high
-          short_entry_logic.append((rsi_3_15m < 75.0) | (stochrsi_k_1h > 80.0) | (stochrsi_k_4h > 60.0))
+          short_entry_logic.append((rsi_3_15m < 75.0) | (stochrsi_k_1h_gt_80) | (stochrsi_k_4h > 60.0))
           # 1h & 4h & 1d down move
           short_entry_logic.append((rsi_3_1h_lt_95) | (rsi_3_4h_lt_90) | (rsi_3_1d < 80.0))
           # 1h & 4h down move, 15m not low enough
           short_entry_logic.append((rsi_3_1h_lt_90) | (rsi_3_4h_lt_90) | (stochrsi_k_15m > 75.0))
           # 1h down move, 1h still not low enough, 4h still high
-          short_entry_logic.append((rsi_3_1h_lt_90) | (stochrsi_k_1h > 90.0) | (stochrsi_k_4h_gt_50))
+          short_entry_logic.append((rsi_3_1h_lt_90) | (stochrsi_k_1h_gt_90) | (stochrsi_k_4h_gt_50))
           # 1h & 4h down move, 1h still not low enough
-          short_entry_logic.append((rsi_3_1h_lt_85) | (rsi_3_4h < 75.0) | (stochrsi_k_1h > 90.0))
+          short_entry_logic.append((rsi_3_1h_lt_85) | (rsi_3_4h < 75.0) | (stochrsi_k_1h_gt_90))
           # 1h & 4h down move, 4h still high
           short_entry_logic.append((rsi_3_1h_lt_85) | (rsi_3_4h < 75.0) | (stochrsi_k_4h_gt_50))
           # 1h & 4h down move, 1h still not low enough
-          short_entry_logic.append((rsi_3_1h_lt_80) | (rsi_3_4h_lt_85) | (stochrsi_k_1h > 75.0))
+          short_entry_logic.append((rsi_3_1h_lt_80) | (rsi_3_4h_lt_85) | (stochrsi_k_1h_gt_75))
           # 1h & 4h down move, 4h still not low enough
           short_entry_logic.append((rsi_3_1h_lt_80) | (rsi_3_4h_lt_85) | (stochrsi_k_4h > 75.0))
           # 1h down move, 1h & 4h still not low enough
-          short_entry_logic.append((rsi_3_1h_lt_80) | (stochrsi_k_1h > 90.0) | (stochrsi_k_4h_gt_70))
+          short_entry_logic.append((rsi_3_1h_lt_80) | (stochrsi_k_1h_gt_90) | (stochrsi_k_4h_gt_70))
           # 4h down move, 15m still high, 1h still not low enough
-          short_entry_logic.append((rsi_3_4h_lt_85) | (stochrsi_k_15m_gt_50) | (stochrsi_k_1h > 75.0))
+          short_entry_logic.append((rsi_3_4h_lt_85) | (stochrsi_k_15m_gt_50) | (stochrsi_k_1h_gt_75))
           # 4h down move, 15m & 4h still not low enough
           short_entry_logic.append((rsi_3_4h < 15.0) | (stochrsi_k_15m > 30.0) | (stochrsi_k_4h > 80.0))
 
@@ -25081,19 +25093,19 @@ class NostalgiaForInfinityX7(IStrategy):
           # 5m down move, 15m & 4h still high
           short_entry_logic.append((rsi_3_lt_90) | (stochrsi_k_15m > 60.0) | (stochrsi_k_4h > 60.0))
           # 5m down move, 15m still high, 1h high
-          short_entry_logic.append((rsi_3 < 85.0) | (aroond_14_15m < 50.0) | (stochrsi_k_1h > 20.0))
+          short_entry_logic.append((rsi_3 < 85.0) | (aroond_14_15m < 50.0) | (stochrsi_k_1h_gt_20))
           # 15m & 1h down move, 1h still not low enough
-          short_entry_logic.append((rsi_3_15m_lt_95) | (rsi_3_1h_lt_95) | (stochrsi_k_1h > 90.0))
+          short_entry_logic.append((rsi_3_15m_lt_95) | (rsi_3_1h_lt_95) | (stochrsi_k_1h_gt_90))
           # 15m & 1h down move, 1d still not low enough
           short_entry_logic.append((rsi_3_15m_lt_95) | (rsi_3_1h_lt_95) | (stochrsi_k_1d > 70.0))
           # 15m strong down move, 4h high
           short_entry_logic.append((rsi_3_15m_lt_95) | (stochrsi_k_4h > 20.0))
           # 15m & 1h down move, 1h still not low enough
-          short_entry_logic.append((rsi_3_15m_lt_95) | (rsi_3_1h_lt_80) | (stochrsi_k_1h > 80.0))
+          short_entry_logic.append((rsi_3_15m_lt_95) | (rsi_3_1h_lt_80) | (stochrsi_k_1h_gt_80))
           # 15m down move, 15m stil high, 1h still not low enough
-          short_entry_logic.append((rsi_3_15m_lt_90) | (stochrsi_k_15m_gt_50) | (stochrsi_k_1h > 80.0))
+          short_entry_logic.append((rsi_3_15m_lt_90) | (stochrsi_k_15m_gt_50) | (stochrsi_k_1h_gt_80))
           # 15m down move, 1h & 4h still high
-          short_entry_logic.append((rsi_3_15m_lt_90) | (stochrsi_k_1h > 60.0) | (stochrsi_k_4h > 60.0))
+          short_entry_logic.append((rsi_3_15m_lt_90) | (stochrsi_k_1h_gt_60) | (stochrsi_k_4h > 60.0))
           # 15m & 1h down move, 4h still not low enough
           short_entry_logic.append((rsi_3_15m_lt_95) | (rsi_3_1h < 70.0) | (stochrsi_k_4h_gt_50))
           # 15m down move, 15m still not low enough, 4h high
@@ -25109,11 +25121,11 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m & 4h down move, 4h still not low enough
           short_entry_logic.append((rsi_3_15m < 75.0) | (rsi_3_4h < 75.0) | (stochrsi_k_4h > 80.0))
           # 15m down move, 1h still high, 4h still high
-          short_entry_logic.append((rsi_3_15m < 75.0) | (stochrsi_k_1h > 80.0) | (stochrsi_k_4h > 60.0))
+          short_entry_logic.append((rsi_3_15m < 75.0) | (stochrsi_k_1h_gt_80) | (stochrsi_k_4h > 60.0))
           # 15m down move, 1h still not low enough, 4h high
-          short_entry_logic.append((rsi_3_15m < 75.0) | (stochrsi_k_1h > 90.0) | (stochrsi_k_4h_gt_30))
+          short_entry_logic.append((rsi_3_15m < 75.0) | (stochrsi_k_1h_gt_90) | (stochrsi_k_4h_gt_30))
           # 15m down move, 1h high, 4h still not low enough
-          short_entry_logic.append((rsi_3_15m < 75.0) | (stochrsi_k_1h > 20.0) | (stochrsi_k_4h > 90.0))
+          short_entry_logic.append((rsi_3_15m < 75.0) | (stochrsi_k_1h_gt_20) | (stochrsi_k_4h > 90.0))
           # 15m down move, 4h high, 1d stil high
           short_entry_logic.append((rsi_3_15m < 75.0) | (stochrsi_k_4h > 20.0) | (stochrsi_k_1d > 50.0))
           # 15m & 4h down move, 1h still not low enough
@@ -25125,11 +25137,11 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m down move, 1h still high, 4h high
           short_entry_logic.append((rsi_3_15m < 70.0) | (stochrsi_k_1h_gt_50) | (stochrsi_k_4h > 10.0))
           # 1h & 4h down move, 1h still not low enough
-          short_entry_logic.append((rsi_3_1h_lt_95) | (rsi_3_4h_lt_95) | (stochrsi_k_1h > 90.0))
+          short_entry_logic.append((rsi_3_1h_lt_95) | (rsi_3_4h_lt_95) | (stochrsi_k_1h_gt_90))
           # 1h & 4h down move, 4h still not low enough
           short_entry_logic.append((rsi_3_1h_lt_95) | (rsi_3_4h_lt_85) | (stochrsi_k_4h > 80.0))
           # 1h & 4h down move, 1h still not low enough
-          short_entry_logic.append((rsi_3_1h_lt_90) | (rsi_3_4h_lt_90) | (stochrsi_k_1h > 90.0))
+          short_entry_logic.append((rsi_3_1h_lt_90) | (rsi_3_4h_lt_90) | (stochrsi_k_1h_gt_90))
           # 1h & 4h down move, 4h still not low enough
           short_entry_logic.append((rsi_3_1h_lt_90) | (rsi_3_4h_lt_90) | (stochrsi_k_4h > 80.0))
           # 1h & 4h down move, 1h still not low enough
@@ -25141,17 +25153,17 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1h down move, 4h still high, 1d high
           short_entry_logic.append((rsi_3_1h_lt_80) | (stochrsi_k_4h > 60.0) | (stochrsi_k_1d > 30.0))
           # 1h & 4h down move, 1h still not low enough
-          short_entry_logic.append((rsi_3_1h_lt_80) | (rsi_3_4h_lt_85) | (stochrsi_k_1h > 75.0))
+          short_entry_logic.append((rsi_3_1h_lt_80) | (rsi_3_4h_lt_85) | (stochrsi_k_1h_gt_75))
           # 1h & 4h down move, 15m still high
           short_entry_logic.append((rsi_3_1h_lt_80) | (rsi_3_4h_lt_80) | (stochrsi_k_15m_gt_50))
           # 1h & 4h down move, 4h still not low enough
-          short_entry_logic.append((rsi_3_1h < 75.0) | (rsi_3_4h_lt_90) | (stochrsi_k_1h > 75.0))
+          short_entry_logic.append((rsi_3_1h < 75.0) | (rsi_3_4h_lt_90) | (stochrsi_k_1h_gt_75))
           # 1h & 4h down move, 1h still high
-          short_entry_logic.append((rsi_3_1h < 70.0) | (rsi_3_4h_lt_85) | (stochrsi_k_1h > 60.0))
+          short_entry_logic.append((rsi_3_1h < 70.0) | (rsi_3_4h_lt_85) | (stochrsi_k_1h_gt_60))
           # 1h down move, 1h still not low enough, 4h still high
-          short_entry_logic.append((rsi_3_1h < 70.0) | (stochrsi_k_1h > 80.0) | (stochrsi_k_4h_gt_50))
+          short_entry_logic.append((rsi_3_1h < 70.0) | (stochrsi_k_1h_gt_80) | (stochrsi_k_4h_gt_50))
           # 4h down move, 15m still high, 1h still not low enough
-          short_entry_logic.append((rsi_3_4h_lt_85) | (stochrsi_k_15m > 60.0) | (stochrsi_k_1h > 80.0))
+          short_entry_logic.append((rsi_3_4h_lt_85) | (stochrsi_k_15m > 60.0) | (stochrsi_k_1h_gt_80))
           # 4h down move, 15m still high, 4h still not low enough
           short_entry_logic.append((rsi_3_4h < 75.0) | (stochrsi_k_15m_gt_50) | (stochrsi_k_4h > 75.0))
           # 4h down move, 1h still not low enough, 1d still high
@@ -25163,7 +25175,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m & 4h high
           short_entry_logic.append((stochrsi_k_15m_gt_50) | (stochrsi_k_4h > 20.0))
           # 15m high, 1h & 4h still not low enough
-          short_entry_logic.append((stochrsi_k_15m > 30.0) | (stochrsi_k_1h > 75.0) | (stochrsi_k_4h > 75.0))
+          short_entry_logic.append((stochrsi_k_15m > 30.0) | (stochrsi_k_1h_gt_75) | (stochrsi_k_4h > 75.0))
           # 15m & 4h high
           short_entry_logic.append((stochrsi_k_15m > 30.0) | (stochrsi_k_4h_gt_30))
           # 1h & 4h still high, 1d high
@@ -25171,7 +25183,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1h & 4h high
           short_entry_logic.append((stochrsi_k_1h_gt_30) | (stochrsi_k_4h > 10.0))
           # 1h & 4h high
-          short_entry_logic.append((stochrsi_k_1h > 20.0) | (stochrsi_k_4h > 20.0))
+          short_entry_logic.append((stochrsi_k_1h_gt_20) | (stochrsi_k_4h > 20.0))
           # 4h & 1d high
           short_entry_logic.append((stochrsi_k_4h > 20.0) | (stochrsi_k_1d > 20.0))
           # 1d red, 1d high
@@ -25216,12 +25228,12 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m down move, 15m high, 4h still high
           short_entry_logic.append((rsi_3_15m < 55.0) | (aroond_14_15m > 30.0) | (stochrsi_k_4h_gt_50))
           # 15m down move, 15m & 1h still high
-          short_entry_logic.append((rsi_3_15m < 55.0) | (stochrsi_k_15m > 55.0) | (stochrsi_k_1h > 60.0))
+          short_entry_logic.append((rsi_3_15m < 55.0) | (stochrsi_k_15m > 55.0) | (stochrsi_k_1h_gt_60))
           # 15m down move, 15m still not low enough, 4h high
           short_entry_logic.append((rsi_3_15m < 50.0) | (stochrsi_k_15m > 70.0) | (stochrsi_k_4h > 10.0))
           # 1h down move, 4h still high, 1d high
           short_entry_logic.append((rsi_3_1h < 75.0) | (aroond_14_4h < 50.0) | (stochrsi_k_1d > 10.0))
-          short_entry_logic.append((rsi_3_1h < 70.0) | (stochrsi_k_1h > 60.0) | (stochrsi_k_1d > 10.0))
+          short_entry_logic.append((rsi_3_1h < 70.0) | (stochrsi_k_1h_gt_60) | (stochrsi_k_1d > 10.0))
           # 1h & 4h down move, 4h high
           short_entry_logic.append((rsi_3_1h < 65.0) | (rsi_3_4h < 40.0) | (stochrsi_k_4h > 20.0))
           # 1h down move, 15m & 1h still high
@@ -25229,19 +25241,19 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1h down move, 1h still high, 4h high
           short_entry_logic.append((rsi_3_1h < 60.0) | (stochrsi_k_1h_gt_50) | (stochrsi_k_4h_gt_70))
           # 1h down move, 1h high
-          short_entry_logic.append((rsi_3_1h < 60.0) | (stochrsi_k_1h > 40.0))
+          short_entry_logic.append((rsi_3_1h < 60.0) | (stochrsi_k_1h_gt_40))
           # 1h down move, 4h & 1d high
           short_entry_logic.append((rsi_3_1h < 60.0) | (aroond_14_4h < 85.0) | (df["AROOND_14_1d"] < 90.0))
           # 1h down move, 1h still high, 4h high
           short_entry_logic.append((rsi_3_1h < 55.0) | (aroond_14_1h < 50.0) | (aroond_14_4h < 90.0))
           # 1h down move, 1h high
-          short_entry_logic.append((rsi_3_1h < 55.0) | (stochrsi_k_1h > 40.0))
+          short_entry_logic.append((rsi_3_1h < 55.0) | (stochrsi_k_1h_gt_40))
           # 1h & 4h down move, 15m high
           short_entry_logic.append((rsi_3_1h < 50.0) | (rsi_3_4h < 40.0) | (aroond_14_15m < 70.0))
           # 1h down move, 15m still high, 4h high
           short_entry_logic.append((rsi_3_1h < 50.0) | (aroond_14_15m < 50.0) | (aroond_14_4h < 80.0))
           # 1h down move, 15m high, 1h still high
-          short_entry_logic.append((rsi_3_1h < 50.0) | (aroond_14_15m < 70.0) | (stochrsi_k_1h > 60.0))
+          short_entry_logic.append((rsi_3_1h < 50.0) | (aroond_14_15m < 70.0) | (stochrsi_k_1h_gt_60))
           # 1h down move, 15m still high, 4h high
           short_entry_logic.append((rsi_3_1h < 50.0) | (stochrsi_k_15m_gt_50) | (stochrsi_k_4h > 20.0))
           # 1h down move, 15m & 1h high
@@ -25255,7 +25267,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1h down move, 15m still not low enough, 1h high
           short_entry_logic.append((rsi_3_1h < 40.0) | (stochrsi_k_15m > 70.0) | (aroond_14_1h < 70.0))
           # 1h down move, 15m still not low enough, 1h high
-          short_entry_logic.append((rsi_3_1h < 40.0) | (stochrsi_k_15m > 70.0) | (stochrsi_k_1h > 40.0))
+          short_entry_logic.append((rsi_3_1h < 40.0) | (stochrsi_k_15m > 70.0) | (stochrsi_k_1h_gt_40))
           # 1h down move, 15m & 4h still high
           short_entry_logic.append((rsi_3_1h < 40.0) | (stochrsi_k_15m_gt_50) | (stochrsi_k_4h_gt_50))
           # 1h down move, 15m & 1h high
@@ -25265,7 +25277,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1h down move, 1h high, 4h still high
           short_entry_logic.append((rsi_3_1h < 40.0) | (aroond_14_1h < 80.0) | (aroond_14_4h < 40.0))
           # 1h down move, 1h still high, 4h high
-          short_entry_logic.append((rsi_3_1h < 40.0) | (stochrsi_k_1h > 60.0) | (aroond_14_4h < 70.0))
+          short_entry_logic.append((rsi_3_1h < 40.0) | (stochrsi_k_1h_gt_60) | (aroond_14_4h < 70.0))
           # 1h down move, 1h & 1d high
           short_entry_logic.append((rsi_3_1h < 40.0) | (stochrsi_k_1h_gt_30) | (df["AROOND_14_1d"] < 90.0))
           # 1h down move, 4h & 1d high
@@ -25273,13 +25285,13 @@ class NostalgiaForInfinityX7(IStrategy):
           # 4h down move, 15m high
           short_entry_logic.append((rsi_3_4h_lt_80) | (aroond_14_15m < 80.0))
           # 4h down move, 1h high
-          short_entry_logic.append((rsi_3_4h < 75.0) | (stochrsi_k_1h > 20.0))
+          short_entry_logic.append((rsi_3_4h < 75.0) | (stochrsi_k_1h_gt_20))
           # 4h down move, 1h & 4h still high
           short_entry_logic.append((rsi_3_4h < 65.0) | (stochrsi_k_1h_gt_50) | (aroond_14_4h < 50.0))
           # 4h down move, 15m & 1h high
           short_entry_logic.append((rsi_3_4h < 60.0) | (aroond_14_15m < 80.0) | (stochrsi_k_1h_gt_30))
           # 4h down move, 15m still high, 1h high
-          short_entry_logic.append((rsi_3_4h < 60.0) | (stochrsi_k_15m > 60.0) | (stochrsi_k_1h > 20.0))
+          short_entry_logic.append((rsi_3_4h < 60.0) | (stochrsi_k_15m > 60.0) | (stochrsi_k_1h_gt_20))
           # 4h down move, 1h still high, 4h still moving down
           short_entry_logic.append((rsi_3_4h < 60.0) | (stochrsi_k_1h_gt_50) | (cci_20_change_pct_4h < 0.0))
           # 4h down move, 1h high, 4h still high
@@ -25311,7 +25323,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m high, 4h still high
           short_entry_logic.append((aroond_14_15m < 80.0) | (stochrsi_k_4h_gt_50))
           # 15m high, 1h still high
-          short_entry_logic.append((stochrsi_k_15m > 30.0) | (stochrsi_k_1h > 60.0))
+          short_entry_logic.append((stochrsi_k_15m > 30.0) | (stochrsi_k_1h_gt_60))
           # 15m & 4h high
           short_entry_logic.append((stochrsi_k_15m > 30.0) | (aroond_14_4h < 70.0))
           # 15m high, 1h still not low enough


### PR DESCRIPTION
## Summary
- Reuse repeated `stochrsi_k_1h` comparison masks inside X7 `populate_entry_trend()`.
- Covers the repeated 1h STOCHRSI entry thresholds while leaving isolated one-off comparisons inline.
- Independent on latest upstream `main`.

## Safety
- Behavior is preserved: this only reuses already-read local Series comparisons inside the same call.
- No indicator formulas, candle selection, order classification, profit arithmetic, thresholds, condition order, return values, or signal behavior are changed.
- Touched function: `populate_entry_trend()`.
- No v3 grind-entry code is touched.

## Backtest scope
- Full backtesting was not required for this patch because it only replaces repeated inline comparisons with equivalent local masks from the same `stochrsi_k_1h` Series.
- Validation focused on static safety, mergeability, and targeted diff review for unchanged thresholds and condition order.

## Checks
- `python3 ~/.codex/skills/nfi-upstream-pr/scripts/validate_nfi_pr.py --base origin/main`
- `git merge-tree` conflict simulation against `origin/main`
- targeted `git diff origin/main...HEAD -- NostalgiaForInfinityX7.py` review
- `git diff --check`
- `ruff format --check NostalgiaForInfinityX7.py`
- `ruff check NostalgiaForInfinityX7.py`
- `PYTHONDONTWRITEBYTECODE=1 python3 -m py_compile NostalgiaForInfinityX7.py`
