### PR TITLE
Reuse X7 entry ROC 1h masks

### DIFF
--- a/NostalgiaForInfinityX7.py
+++ b/NostalgiaForInfinityX7.py
@@ -13120,6 +13120,15 @@ class NostalgiaForInfinityX7(IStrategy):
     stochrsi_k_1d_lt_90 = stochrsi_k_1d < 90.0
 
     roc_9_1h_lt_10 = roc_9_1h < 10.0
+    roc_9_1h_lt_15 = roc_9_1h < 15.0
+    roc_9_1h_lt_20 = roc_9_1h < 20.0
+    roc_9_1h_lt_25 = roc_9_1h < 25.0
+    roc_9_1h_lt_30 = roc_9_1h < 30.0
+    roc_9_1h_lt_40 = roc_9_1h < 40.0
+    roc_9_1h_lt_50 = roc_9_1h < 50.0
+    roc_9_1h_lt_60 = roc_9_1h < 60.0
+    roc_9_1h_lt_80 = roc_9_1h < 80.0
+    roc_9_1h_lt_100 = roc_9_1h < 100.0
     roc_9_4h_gt_neg_30 = roc_9_4h > -30.0
     roc_9_4h_gt_neg_20 = roc_9_4h > -20.0
     roc_9_4h_lt_10 = roc_9_4h < 10.0
@@ -13272,7 +13281,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 1d overbought
             & ((rsi_3_15m_gt_5) | (rsi_3_1h_gt_5) | (roc_9_1d_lt_40))
             # 5m & 1h down move, 1h overbought
-            & ((rsi_3_15m_gt_5) | (rsi_3_1h_gt_60) | (roc_9_1h < 40.0))
+            & ((rsi_3_15m_gt_5) | (rsi_3_1h_gt_60) | (roc_9_1h_lt_40))
             # 15m & 4h down move, 1d still high
             & ((rsi_3_15m_gt_5) | (rsi_3_4h_gt_5) | (stochrsi_k_1d < 40.0))
             # 15m & 4h down move, 1d downtrend
@@ -13326,7 +13335,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 15m & 4h high
             & ((rsi_3_15m_gt_10) | (aroonu_14_15m_lt_70) | aroonu_14_4h_lt_80)
             # 15m down move, 1h high & overbought
-            & ((rsi_3_15m_gt_10) | (aroonu_14_1h_lt_90) | (roc_9_1h < 20.0))
+            & ((rsi_3_15m_gt_10) | (aroonu_14_1h_lt_90) | (roc_9_1h_lt_20))
             # 15m down move, 1h high, 1d downtrend
             & ((rsi_3_15m_gt_10) | (aroonu_14_1h_lt_90) | (roc_9_1d_gt_neg_40))
             # 15m down move, 1h high, 1d overbought
@@ -13336,7 +13345,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 1h high, 1d downtrend
             & ((rsi_3_15m_gt_10) | (stochrsi_k_1h_lt_70) | roc_9_1d_gt_neg_50)
             # 15m down move, 1h high & overbought
-            & ((rsi_3_15m_gt_10) | (stochrsi_k_1h_lt_90) | (roc_9_1h < 20.0))
+            & ((rsi_3_15m_gt_10) | (stochrsi_k_1h_lt_90) | (roc_9_1h_lt_20))
             # 15m down move, 1h & 1d overbought
             & ((rsi_3_15m_gt_10) | (roc_9_1h_lt_10) | (roc_9_1d_lt_80))
             # 15m down move, 4h high
@@ -13354,7 +13363,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 1h & 4h high
             & ((rsi_3_15m_gt_20) | (aroonu_14_1h_lt_100) | aroonu_14_4h_lt_100)
             # 15m down move, 1h high & overbought
-            & ((rsi_3_15m_gt_20) | (aroonu_14_1h_lt_100) | (roc_9_1h < 20.0))
+            & ((rsi_3_15m_gt_20) | (aroonu_14_1h_lt_100) | (roc_9_1h_lt_20))
             # 15m down move, 4h high & overbought
             & ((rsi_3_15m_gt_25) | aroonu_14_4h_lt_100 | (roc_9_4h_lt_10))
             # 15m down move, 1d overbought
@@ -13464,7 +13473,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h & 4h high
             & ((rsi_3_1h_gt_45) | aroonu_14_1h_lt_80 | aroonu_14_4h_lt_100)
             # 1h down move, 1h high & overbought
-            & ((rsi_3_1h_gt_50) | (aroonu_14_1h_lt_90) | (roc_9_1h < 20.0))
+            & ((rsi_3_1h_gt_50) | (aroonu_14_1h_lt_90) | (roc_9_1h_lt_20))
             # 1h down move, 1h still high, 4h high
             & ((rsi_3_1h_gt_60) | (aroonu_14_1h_lt_50) | (rsi_14_4h < 90.0))
             # 4h & 1d down move, 1d high
@@ -13520,11 +13529,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h still high, 1h & 4h downtrend
             & ((aroonu_14_1h_lt_40) | (roc_9_1h > -20.0) | (roc_9_4h_gt_neg_30))
             # 1h & 4h high, 1h overbought
-            & ((aroonu_14_1h_lt_85) | (aroonu_14_4h_lt_90) | (roc_9_1h < 20.0))
+            & ((aroonu_14_1h_lt_85) | (aroonu_14_4h_lt_90) | (roc_9_1h_lt_20))
             # 1h high, 1h & 4h overbought
             & ((aroonu_14_1h_lt_85) | (roc_9_1h_lt_10) | (roc_9_1d_lt_30))
             # 1h high, 1h overbought, 1d downtrend
-            & ((aroonu_14_1h_lt_85) | (roc_9_1h < 20.0) | (roc_9_1d_gt_neg_40))
+            & ((aroonu_14_1h_lt_85) | (roc_9_1h_lt_20) | (roc_9_1d_gt_neg_40))
             # 4h & 1d high, 1d overbought
             & (aroonu_14_4h_lt_80 | aroonu_14_1d_lt_100 | roc_9_1d_lt_50)
             # 4h high, 1h downtrend
@@ -13554,7 +13563,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h downtrend, 4h high & overbought
             & ((roc_9_1h > -25.0) | aroonu_14_4h_lt_80 | (roc_9_4h < 80.0))
             # 1h & 4h overbought, 1d downtrend
-            & ((roc_9_1h < 20.0) | (roc_9_4h_lt_20) | (roc_9_1d_gt_neg_40))
+            & ((roc_9_1h_lt_20) | (roc_9_4h_lt_20) | (roc_9_1d_gt_neg_40))
             # 1d P&D, 1d downtrend
             & ((change_pct_1d > -5.0) | (change_pct_1d.shift(288) < 30.0) | (cmf_20_1d > -0.0))
             # 1d green with top wick, 1h down move
@@ -13635,7 +13644,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 5m & 4h down move, 4h still not low enough
             & ((rsi_3_gt_5) | (rsi_3_4h_gt_15) | (stochrsi_k_4h < 20.0))
             # 5m down move, 4h high, 1h overbought
-            & ((rsi_3_gt_10) | aroonu_14_4h_lt_100 | (roc_9_1h < 30.0))
+            & ((rsi_3_gt_10) | aroonu_14_4h_lt_100 | (roc_9_1h_lt_30))
             # 15m & 1h down move, 1h still high
             & ((rsi_3_15m > 1.0) | (rsi_3_1h_gt_25) | (stochrsi_k_1h_lt_40))
             # 15m & 1h & 4h down move
@@ -13759,7 +13768,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 1h still high, 4h overbought
             & ((rsi_3_15m_gt_5) | (stochrsi_k_1h_lt_50) | (roc_9_4h_lt_30))
             # 15m down move, 1h high & overbought
-            & ((rsi_3_15m_gt_5) | (stochrsi_k_1h_lt_80) | (roc_9_1h < 20.0))
+            & ((rsi_3_15m_gt_5) | (stochrsi_k_1h_lt_80) | (roc_9_1h_lt_20))
             # 15m & 1h down move, 15m high
             & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_10) | (stochrsi_k_15m_lt_50))
             # 15m & 1h down move, 1h still high
@@ -13921,7 +13930,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 1d overbought
             & ((rsi_3_15m_gt_25) | (rsi_3_1h_gt_40) | (roc_9_1d_lt_80))
             # 15m & 4h down move, 1h overbought
-            & ((rsi_3_15m_gt_25) | (rsi_3_4h_gt_35) | (roc_9_1h < 100.0))
+            & ((rsi_3_15m_gt_25) | (rsi_3_4h_gt_35) | (roc_9_1h_lt_100))
             # 15m down move, 15m still not low enough, 1h high
             & ((rsi_3_15m_gt_25) | (aroonu_14_15m_lt_20) | (stochrsi_k_1h_lt_90))
             # 15m down move, 1h & 4h high
@@ -13931,7 +13940,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 4h high, 1d overbought
             & ((rsi_3_15m_gt_25) | (aroonu_14_4h_lt_70) | (roc_9_1d_lt_50))
             # 15m down move, 4h high, 1h overbought
-            & ((rsi_3_15m_gt_25) | (aroonu_14_4h_lt_80) | (roc_9_1h < 50.0))
+            & ((rsi_3_15m_gt_25) | (aroonu_14_4h_lt_80) | (roc_9_1h_lt_50))
             # 15m down move, 4h high & overbought
             & ((rsi_3_15m_gt_30) | (aroonu_14_4h_lt_70) | (roc_9_4h < 50.0))
             # 15m down move, 1h high, 1d downtrend
@@ -13943,7 +13952,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 4h high & overbought
             & ((rsi_3_15m_gt_35) | (aroonu_14_4h_lt_90) | (roc_9_4h < 50.0))
             # 15m down move, 4h high, 1d overbought
-            & ((rsi_3_15m_gt_35) | (aroonu_14_4h_lt_100) | (roc_9_1h < 20.0))
+            & ((rsi_3_15m_gt_35) | (aroonu_14_4h_lt_100) | (roc_9_1h_lt_20))
             # 15m down move, 1h high, 1d overbought
             & ((rsi_3_15m_gt_35) | (stochrsi_k_1h_lt_80) | (roc_9_1d_lt_80))
             # 15m down move, 4h high & overbought
@@ -14125,7 +14134,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h high & overbought
             & ((rsi_3_1h_gt_50) | aroonu_14_1h_lt_80 | (roc_9_1h_lt_10))
             # 1h down move, 4h high, 1h overbought
-            & ((rsi_3_1h_gt_50) | (aroonu_14_4h_lt_85) | (roc_9_1h < 20.0))
+            & ((rsi_3_1h_gt_50) | (aroonu_14_4h_lt_85) | (roc_9_1h_lt_20))
             # 1h down move, 4h high, 1d downtrend
             & ((rsi_3_1h_gt_50) | (stochrsi_k_4h < 60.0) | (roc_9_1d > -60.0))
             # 1h down move, 4h high & overbought
@@ -14235,7 +14244,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1d down move, 1h high, 1d downtrend
             & ((rsi_3_1d_gt_10) | (stochrsi_k_1h_lt_80) | (roc_9_1d_gt_neg_20))
             # 1d down move, 1h overbought, 1d downtrend
-            & ((rsi_3_1d_gt_15) | (roc_9_1h < 20.0) | roc_9_1d_gt_neg_50)
+            & ((rsi_3_1d_gt_15) | (roc_9_1h_lt_20) | roc_9_1d_gt_neg_50)
             # 1d down move, 1h high, 1d downtrend
             & ((rsi_3_1d_gt_20) | (stochrsi_k_1h_lt_90) | (roc_9_1d > -10.0))
             # 1d down move, 1h high, 1d overbought
@@ -14259,7 +14268,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h high, 4h & 1d downtrend
             & (aroonu_14_1h_lt_70 | (roc_9_4h_gt_neg_30) | roc_9_1d_gt_neg_50)
             # 1h & 4h high, 1h overbought
-            & (aroonu_14_1h_lt_80 | (aroonu_14_4h_lt_90) | (roc_9_1h < 30.0))
+            & (aroonu_14_1h_lt_80 | (aroonu_14_4h_lt_90) | (roc_9_1h_lt_30))
             # 1h & 4high, 1d downtrend
             & (aroonu_14_1h_lt_80 | aroonu_14_4h_lt_100 | (roc_9_1d > -20.0))
             # 1h & 4h high, 1d overbought
@@ -14287,7 +14296,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1d high, 4h & 1d overbought
             & ((aroonu_14_1d_lt_85) | (roc_9_4h < 60.0) | (roc_9_1d < 60.0))
             # 1d high, 1h & 4h down move
-            & (aroonu_14_1d_lt_100 | (roc_9_1h < 25.0) | (roc_9_4h < 60.0))
+            & (aroonu_14_1d_lt_100 | (roc_9_1h_lt_25) | (roc_9_4h < 60.0))
             # 15m high, 1d overbought
             & ((stochrsi_k_15m_lt_70) | (roc_9_1d < 60.0))
             # 1h high, 1d downtrend
@@ -15039,7 +15048,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 5m & 4h down move, 15m still high
             & ((rsi_3_gt_5) | (rsi_3_4h_gt_25) | (stochrsi_k_15m_lt_50))
             # 5m down move, 4h high, 1h overbought
-            & ((rsi_3_gt_10) | aroonu_14_4h_lt_100 | (roc_9_1h < 30.0))
+            & ((rsi_3_gt_10) | aroonu_14_4h_lt_100 | (roc_9_1h_lt_30))
             # 15m & 1h down move, 1d still high
             & ((rsi_3_15m_gt_5) | (rsi_3_1h_gt_5) | (aroonu_14_1d_lt_40))
             # 15m & 1h down move, 1d still high
@@ -15097,7 +15106,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 4h high, 1d overbought
             & ((rsi_3_15m_gt_20) | (aroonu_14_4h_lt_90) | (roc_9_1d_lt_100))
             # 15m down move, 4h high, 1h overbought
-            & ((rsi_3_15m_gt_20) | (aroonu_14_4h_lt_100) | (roc_9_1h < 30.0))
+            & ((rsi_3_15m_gt_20) | (aroonu_14_4h_lt_100) | (roc_9_1h_lt_30))
             # 15m down move, 1h high & overbought
             & ((rsi_3_15m_gt_20) | (stochrsi_k_1h_lt_90) | (roc_9_1h_lt_10))
             # 15m & 4h down move, 4h high
@@ -15261,13 +15270,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h still high, 4h & 1d downtrend
             & ((aroonu_14_1h_lt_40) | (roc_9_4h_gt_neg_20) | (roc_9_1d_gt_neg_40))
             # 1h & 4h high, 1h overbought
-            & (aroonu_14_1h_lt_70 | aroonu_14_4h_lt_100 | (roc_9_1h < 80.0))
+            & (aroonu_14_1h_lt_70 | aroonu_14_4h_lt_100 | (roc_9_1h_lt_80))
             # 1h high, 1d overbought
             & (aroonu_14_1h_lt_70 | (roc_9_1d < 70.0))
             # 1h & 4h high, 1h overbought
-            & (aroonu_14_1h_lt_80 | (aroonu_14_4h_lt_90) | (roc_9_1h < 30.0))
+            & (aroonu_14_1h_lt_80 | (aroonu_14_4h_lt_90) | (roc_9_1h_lt_30))
             # 1h & 1d high, 1h overbought
-            & (aroonu_14_1h_lt_80 | (aroonu_14_1d_lt_90) | (roc_9_1h < 30.0))
+            & (aroonu_14_1h_lt_80 | (aroonu_14_1d_lt_90) | (roc_9_1h_lt_30))
             # 4h still not low enough, 4h & 1d downtrend
             & ((aroonu_14_4h_lt_30) | (roc_9_4h > -40.0) | (roc_9_1d_gt_neg_40))
             # 4h still high, 5m downtrend
@@ -15277,13 +15286,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h & 1d high, 4h overbought
             & (aroonu_14_4h_lt_80 | aroonu_14_1d_lt_100 | (roc_9_4h < 50.0))
             # 4h high, 1h & 1d overbought
-            & (aroonu_14_4h_lt_100 | (roc_9_1h < 30.0) | (roc_9_1d < 100.0))
+            & (aroonu_14_4h_lt_100 | (roc_9_1h_lt_30) | (roc_9_1d < 100.0))
             # 4h high, 1h & 4h high
-            & (aroonu_14_4h_lt_100 | (roc_9_1h < 50.0) | (roc_9_4h < 100.0))
+            & (aroonu_14_4h_lt_100 | (roc_9_1h_lt_50) | (roc_9_4h < 100.0))
             # 1d high, 4h & 1d downtrend
             & ((aroonu_14_1d_lt_70) | (roc_9_4h > -40.0) | (roc_9_1d_gt_neg_40))
             # 1d high, 1h & 1d overbought
-            & ((aroonu_14_1d_lt_80) | (roc_9_1h < 30.0) | (roc_9_1d < 200.0))
+            & ((aroonu_14_1d_lt_80) | (roc_9_1h_lt_30) | (roc_9_1d < 200.0))
             # 1d high, 4h & 1d overbought
             & ((aroonu_14_1d_lt_90) | (roc_9_4h_lt_20) | roc_9_1d_lt_50)
             # 1h high, 4h overbought
@@ -15336,7 +15345,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 15m high, 1h high
             & ((rsi_3_15m_gt_25) | (aroonu_14_15m_lt_60) | (stochrsi_k_1h_lt_70))
             # 15m down move, 1h & 4h overbought
-            & ((rsi_3_15m_gt_25) | (roc_9_1h < 40.0) | (roc_9_4h_lt_40))
+            & ((rsi_3_15m_gt_25) | (roc_9_1h_lt_40) | (roc_9_4h_lt_40))
             # 15m down move, 4h & 1d overbought
             & ((rsi_3_15m_gt_25) | (roc_9_4h_lt_10) | roc_9_1d_lt_50)
             # 15m & 4h down move, 4h high
@@ -15362,7 +15371,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 1h high, 4h overbought
             & ((rsi_3_15m_gt_35) | (aroonu_14_1h_lt_85) | (roc_9_4h < 80.0))
             # 15m down move, 4h high, 1h overbought
-            & ((rsi_3_15m_gt_35) | aroonu_14_4h_lt_100 | (roc_9_1h < 20.0))
+            & ((rsi_3_15m_gt_35) | aroonu_14_4h_lt_100 | (roc_9_1h_lt_20))
             # 15m & 1h down move, 1h high
             & ((rsi_3_15m_gt_40) | (rsi_3_1h_gt_40) | (aroonu_14_1h_lt_100))
             # 15m down move, 15m still high, 1h high
@@ -15494,9 +15503,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1d high & overbought
             & ((rsi_3_1h_gt_40) | (aroonu_14_1d_lt_80) | roc_9_1d_lt_50)
             # 1h down move, 1h & 4h overbought
-            & ((rsi_3_1h_gt_40) | (roc_9_1h < 20.0) | (roc_9_4h_lt_20))
+            & ((rsi_3_1h_gt_40) | (roc_9_1h_lt_20) | (roc_9_4h_lt_20))
             # 1h down move, 1h overbought
-            & ((rsi_3_1h_gt_40) | (roc_9_1h < 30.0))
+            & ((rsi_3_1h_gt_40) | (roc_9_1h_lt_30))
             # 1h & 4h down move, 1d overbought
             & ((rsi_3_1h_gt_45) | (rsi_3_4h_gt_65) | (roc_9_1d < 200.0))
             # 1h down move, 15m still high, 1h high
@@ -15508,7 +15517,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h high, 1d downtrend
             & ((rsi_3_1h_gt_50) | (aroonu_14_1h_lt_90) | (roc_9_1d_gt_neg_30))
             # 1h down move, 4h high, 1h overbought
-            & ((rsi_3_1h_gt_50) | (aroonu_14_4h_lt_90) | (roc_9_1h < 40.0))
+            & ((rsi_3_1h_gt_50) | (aroonu_14_4h_lt_90) | (roc_9_1h_lt_40))
             # 1h down move, 4h & 1d high
             & ((rsi_3_1h_gt_50) | aroonu_14_4h_lt_100 | aroonu_14_1d_lt_100)
             # 1h down move, 4h high, 1d downtrend
@@ -15606,17 +15615,17 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h & 1d high, 1d overbought
             & (aroonu_14_4h_lt_80 | aroonu_14_1d_lt_100 | (roc_9_1d_lt_80))
             # 4h high, 1h & 4h overbought
-            & ((aroonu_14_4h_lt_85) | (roc_9_1h < 80.0) | (roc_9_4h < 80.0))
+            & ((aroonu_14_4h_lt_85) | (roc_9_1h_lt_80) | (roc_9_4h < 80.0))
             # 4h high, 4h & 1d overbought
             & ((aroonu_14_4h_lt_85) | (roc_9_4h_lt_10) | (roc_9_1d_lt_40))
             # 4h & 1d high, 4h overbought
             & (aroonu_14_4h_lt_100 | aroonu_14_1d_lt_100 | (roc_9_4h_lt_40))
             # 4h high, 1h & 1d overbought
-            & (aroonu_14_4h_lt_100 | (roc_9_1h < 40.0) | (roc_9_1d < 100.0))
+            & (aroonu_14_4h_lt_100 | (roc_9_1h_lt_40) | (roc_9_1d < 100.0))
             # 4h high, 4h & 1d overbought
             & (aroonu_14_4h_lt_100 | (roc_9_4h < 20.0) | (roc_9_1d_lt_80))
             # 1d high, 1h & 4h down move
-            & (aroonu_14_1d_lt_100 | (roc_9_1h < 25.0) | (roc_9_4h < 60.0))
+            & (aroonu_14_1d_lt_100 | (roc_9_1h_lt_25) | (roc_9_4h < 60.0))
             # 1d high, 1h downtrend, 1d overbought
             & (aroonu_14_1d_lt_100 | (roc_9_1h > -30.0) | (roc_9_1d < 100.0))
             # 1d high, 4h & 1d overbought
@@ -15626,13 +15635,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h high, 4h & 1d overbought
             & ((stochrsi_k_1h_lt_90) | (roc_9_4h_lt_20) | (roc_9_1d_lt_100))
             # 4h high, 1h overbought, 1d downtrend
-            & ((stochrsi_k_4h_lt_80) | (roc_9_1h < 40.0) | (roc_9_1d > -70.0))
+            & ((stochrsi_k_4h_lt_80) | (roc_9_1h_lt_40) | (roc_9_1d > -70.0))
             # 4h high, 4h & 1d overbought
             & ((stochrsi_k_4h_lt_80) | (roc_9_4h < 80.0) | (roc_9_1d_lt_100))
             # 4h high, 1h & 4h overbought
             & ((stochrsi_k_4h_lt_90) | (roc_9_1h_lt_10) | (roc_9_4h < 80.0))
             # 4h high, 1h & 4h overbought
-            & ((stochrsi_k_4h_lt_90) | (roc_9_1h < 20.0) | (roc_9_4h < 50.0))
+            & ((stochrsi_k_4h_lt_90) | (roc_9_1h_lt_20) | (roc_9_4h < 50.0))
             # 1d high, 4h & 1d overbought
             & ((stochrsi_k_1d_lt_90) | (roc_9_4h_lt_40) | (roc_9_1d_lt_100))
             # 1d P&D, dh downtrend
@@ -15919,7 +15928,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 4h high & overbought
             & ((rsi_3_15m_gt_15) | aroonu_14_4h_lt_70 | (roc_9_4h_lt_30))
             # 15m down move, 4h high, 1h overbought
-            & ((rsi_3_15m_gt_15) | (aroonu_14_4h_lt_90) | (roc_9_1h < 25.0))
+            & ((rsi_3_15m_gt_15) | (aroonu_14_4h_lt_90) | (roc_9_1h_lt_25))
             # 15m down move, 4h high, 1h overbought
             & ((rsi_3_15m_gt_15) | aroonu_14_4h_lt_100 | (roc_9_1h_lt_10))
             # 15m down move, 1h still high, 4h overbought
@@ -15971,7 +15980,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 4h high & overbought
             & ((rsi_3_15m_gt_20) | aroonu_14_4h_lt_70 | (roc_9_4h_lt_30))
             # 15m down move, 4h high, 1h overbought
-            & ((rsi_3_15m_gt_20) | aroonu_14_4h_lt_100 | (roc_9_1h < 30.0))
+            & ((rsi_3_15m_gt_20) | aroonu_14_4h_lt_100 | (roc_9_1h_lt_30))
             # 15m down move, 1d high, 4h downtrend
             & ((rsi_3_15m_gt_20) | (aroonu_14_1d_lt_90) | (roc_9_4h_gt_neg_20))
             # 15m down move, 1d high, 4h overbought
@@ -16027,7 +16036,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 1h high, 1d downtrend
             & ((rsi_3_15m_gt_25) | (stochrsi_k_1h_lt_70) | (roc_9_1d_gt_neg_20))
             # 15m down move, 1h high & overbought
-            & ((rsi_3_15m_gt_25) | (stochrsi_k_1h_lt_90) | (roc_9_1h < 20.0))
+            & ((rsi_3_15m_gt_25) | (stochrsi_k_1h_lt_90) | (roc_9_1h_lt_20))
             # 15m down move, 4h high & overbought
             & ((rsi_3_15m_gt_25) | (stochrsi_k_4h_lt_90) | (roc_9_4h_lt_30))
             # 15m & 1h down move, 1h high
@@ -16065,7 +16074,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 4h high & overbought
             & ((rsi_3_15m_gt_35) | aroonu_14_4h_lt_100 | (roc_9_4h < 70.0))
             # 15m down move, 1h high & overbought
-            & ((rsi_3_15m_gt_35) | (stochrsi_k_1h_lt_90) | (roc_9_1h < 40.0))
+            & ((rsi_3_15m_gt_35) | (stochrsi_k_1h_lt_90) | (roc_9_1h_lt_40))
             # 15m & 1h down move, 4h high
             & ((rsi_3_15m_gt_40) | (rsi_3_1h_gt_40) | aroonu_14_4h_lt_100)
             # 15m & 4h down move, 1h high
@@ -16187,7 +16196,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1d high, 4h overbought
             & ((rsi_3_1h_gt_40) | (stochrsi_k_1d_lt_90) | (roc_9_4h_lt_20))
             # 1h down move, 1h overbought
-            & ((rsi_3_1h_gt_40) | (roc_9_1h < 30.0))
+            & ((rsi_3_1h_gt_40) | (roc_9_1h_lt_30))
             # 1h & 4h down move, 1d overbought
             & ((rsi_3_1h_gt_45) | (rsi_3_4h_gt_65) | (roc_9_1d < 200.0))
             # 1h down move, 1h still not low enough, 1d downtrend
@@ -16195,7 +16204,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h still high, 1d overbought
             & ((rsi_3_1h_gt_45) | (stochrsi_k_1h_lt_40) | (roc_9_1d_lt_100))
             # 1h down move, 4h high, 1h overbought
-            & ((rsi_3_1h_gt_50) | (aroonu_14_4h_lt_85) | (roc_9_1h < 20.0))
+            & ((rsi_3_1h_gt_50) | (aroonu_14_4h_lt_85) | (roc_9_1h_lt_20))
             # 1h down move, 1d high, 4h overbought
             & ((rsi_3_1h_gt_50) | (aroonu_14_1d_lt_90) | (roc_9_4h_lt_20))
             # 1h down move, 1h high & overbought
@@ -16341,15 +16350,15 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h downtrend, 4h high & over
             & ((cmf_20_4h > -0.10) | aroonu_14_4h_lt_100 | (roc_9_4h_lt_30))
             # 15m still high, 4h high, 1h overbought
-            & ((aroonu_14_15m_lt_40) | (aroonu_14_4h_lt_85) | (roc_9_1h < 20.0))
+            & ((aroonu_14_15m_lt_40) | (aroonu_14_4h_lt_85) | (roc_9_1h_lt_20))
             # 15m still high, 4h high, 1h overbought
-            & ((aroonu_14_15m_lt_40) | aroonu_14_4h_lt_100 | (roc_9_1h < 20.0))
+            & ((aroonu_14_15m_lt_40) | aroonu_14_4h_lt_100 | (roc_9_1h_lt_20))
             # 4h down move, 1h still high, 1d downtrend
             & ((rsi_3_4h_gt_15) | (aroonu_14_1h_lt_40) | roc_9_1d_gt_neg_50)
             # 1h high, 4h high & overbought
             & (aroonu_14_1h_lt_80 | aroonu_14_4h_lt_80 | (roc_9_4h_lt_30))
             # 1h & 4h high, 1h overbought
-            & (aroonu_14_1h_lt_80 | (aroonu_14_4h_lt_90) | (roc_9_1h < 30.0))
+            & (aroonu_14_1h_lt_80 | (aroonu_14_4h_lt_90) | (roc_9_1h_lt_30))
             # 1h & 4h & 1d high
             & (aroonu_14_1h_lt_80 | aroonu_14_4h_lt_100 | aroonu_14_1d_lt_100)
             # 1h & 4h high, 1d overbought
@@ -16361,7 +16370,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h high, 1h & 4h overbought
             & (aroonu_14_1h_lt_80 | (roc_9_1h_lt_10) | (roc_9_4h_lt_10))
             # 1h high, 1h overbought, 1d downtrend
-            & (aroonu_14_1h_lt_80 | (roc_9_1h < 50.0) | roc_9_1d_gt_neg_50)
+            & (aroonu_14_1h_lt_80 | (roc_9_1h_lt_50) | roc_9_1d_gt_neg_50)
             # 1h high, 4h &1d overbought
             & ((aroonu_14_1h_lt_85) | (roc_9_4h_lt_30) | (roc_9_1d_lt_30))
             # 1h high, 4h & 1d overbought
@@ -16377,7 +16386,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1d high, 4h & 1d overbought
             & ((aroonu_14_1d_lt_70) | (roc_9_4h_lt_30) | (roc_9_1d < 200.0))
             # 1d high, 1h & 1d overbought
-            & ((aroonu_14_1d_lt_80) | (roc_9_1h < 20.0) | roc_9_1d_lt_50)
+            & ((aroonu_14_1d_lt_80) | (roc_9_1h_lt_20) | roc_9_1d_lt_50)
             # 1d high, 1d downtrend
             & ((aroonu_14_1d_lt_80) | (roc_9_1d_gt_neg_30))
             # 1d high, 1h & 4h downtrend
@@ -16399,21 +16408,21 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h & 1d overbought
             & ((stochrsi_k_1h_lt_90) | (roc_9_1h_lt_10) | roc_9_1d_lt_50)
             # 1h high & overbought
-            & ((stochrsi_k_1h_lt_90) | (roc_9_1h < 40.0))
+            & ((stochrsi_k_1h_lt_90) | (roc_9_1h_lt_40))
             # 4h high, 1h & 4h overbought
             & ((stochrsi_k_4h_lt_70) | (roc_9_1h_lt_10) | (roc_9_4h_lt_20))
             # 4h high, 1h & 1d overbought
-            & ((stochrsi_k_4h_lt_70) | (roc_9_1h < 20.0) | (roc_9_1d < 200.0))
+            & ((stochrsi_k_4h_lt_70) | (roc_9_1h_lt_20) | (roc_9_1d < 200.0))
             # 4h high, 4h & 1d overbought
             & ((stochrsi_k_4h_lt_80) | (roc_9_4h_lt_30) | (roc_9_1d_lt_30))
             # 4h high, 1d downtrend
             & ((stochrsi_k_4h_lt_80) | roc_9_1d_gt_neg_50)
             # 4h high, 1h & 1d overbought
-            & ((stochrsi_k_4h_lt_90) | (roc_9_1h < 20.0) | (roc_9_1d_lt_20))
+            & ((stochrsi_k_4h_lt_90) | (roc_9_1h_lt_20) | (roc_9_1d_lt_20))
             # 4h high, 4h & 1d overbought
             & ((stochrsi_k_4h_lt_90) | (roc_9_4h_lt_10) | (roc_9_1d < 10.0))
             # 1d hihg, 1h & 1d overbought
-            & ((stochrsi_k_1d_lt_90) | (roc_9_1h < 30.0) | (roc_9_1d_lt_100))
+            & ((stochrsi_k_1d_lt_90) | (roc_9_1h_lt_30) | (roc_9_1d_lt_100))
             # 1d P&D, dh downtrend
             & ((change_pct_1d > -50.0) | (change_pct_1d.shift(288) < 50.0) | (rsi_3_4h_gt_15))
             # big drop in the last 20 days, 1d high, 1d downtrend
@@ -16442,9 +16451,9 @@ class NostalgiaForInfinityX7(IStrategy):
 
           long_entry_logic.append(
             # 5m down move, 4h high, 1h overbought
-            ((rsi_3_gt_10) | aroonu_14_4h_lt_100 | (roc_9_1h < 30.0))
+            ((rsi_3_gt_10) | aroonu_14_4h_lt_100 | (roc_9_1h_lt_30))
             # 15m down move, 1h & 4h overbought
-            & ((rsi_3_15m_gt_5) | (roc_9_1h < 25.0) | (roc_9_4h < 50.0))
+            & ((rsi_3_15m_gt_5) | (roc_9_1h_lt_25) | (roc_9_4h < 50.0))
             # 15m & 1h down move, 1d overbought
             & ((rsi_3_15m_gt_10) | rsi_3_1h_gt_20 | (roc_9_1d_lt_80))
             # 15m & 1h down move, 1h high
@@ -16478,7 +16487,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 4h high, 4h downtrend
             & ((rsi_3_15m_gt_15) | (aroonu_14_4h_lt_90) | (cmf_20_4h > -0.25))
             # 15m down move, 1h & 4h high
-            & ((rsi_3_15m_gt_15) | (roc_9_1h < 30.0) | (roc_9_4h < 50.0))
+            & ((rsi_3_15m_gt_15) | (roc_9_1h_lt_30) | (roc_9_4h < 50.0))
             # 15m down move, 4h & 1d overbought
             & ((rsi_3_15m_gt_15) | (roc_9_4h < 60.0) | (roc_9_1d_lt_80))
             # 15m down move, 1h & 4h high
@@ -16496,19 +16505,19 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 1h & 4h high
             & ((rsi_3_15m_gt_25) | (aroonu_14_1h_lt_90) | aroonu_14_4h_lt_100)
             # 15m down move, 4h high, 1h overbought
-            & ((rsi_3_15m_gt_25) | (aroonu_14_4h_lt_100) | (roc_9_1h < 20.0))
+            & ((rsi_3_15m_gt_25) | (aroonu_14_4h_lt_100) | (roc_9_1h_lt_20))
             # 15m down move, 4h high, 1d overbought
             & ((rsi_3_15m_gt_25) | (aroonu_14_4h_lt_100) | (roc_9_1d < 100.0))
             # 15m down move, 1h high & overbought
-            & ((rsi_3_15m_gt_25) | (stochrsi_k_1h_lt_90) | (roc_9_1h < 20.0))
+            & ((rsi_3_15m_gt_25) | (stochrsi_k_1h_lt_90) | (roc_9_1h_lt_20))
             # 15m down move, 1h & 4h overbought
-            & ((rsi_3_15m_gt_25) | (roc_9_1h < 40.0) | (roc_9_4h_lt_40))
+            & ((rsi_3_15m_gt_25) | (roc_9_1h_lt_40) | (roc_9_4h_lt_40))
             # 15m & 4h & 1d down move, 4h & 1d high
             & ((rsi_3_15m_gt_30) | (rsi_3_4h_gt_50) | (rsi_3_1d_gt_55) | (aroonu_14_4h_lt_70) | (aroonu_14_1d_lt_100))
             # 15m down move, 4h high & overbought
             & ((rsi_3_15m_gt_30) | (stochrsi_k_4h_lt_90) | (roc_9_4h < 200.0))
             # 15m down move, 1h & 4h overbought
-            & ((rsi_3_15m_gt_30) | (roc_9_1h < 60.0) | (roc_9_4h < 80.0))
+            & ((rsi_3_15m_gt_30) | (roc_9_1h_lt_60) | (roc_9_4h < 80.0))
             # 15m down move, 4h & 1d overbought
             & ((rsi_3_15m_gt_40) | (roc_9_4h < 100.0) | (roc_9_1d_lt_100))
             # 1h down move, 4h overbought, 1d downtrend
@@ -16538,11 +16547,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 4h high, 1d downtrend
             & ((rsi_3_1h_gt_35) | (stochrsi_k_4h_lt_80) | roc_9_1d_gt_neg_50)
             # 1h down move, 1h & 1d overbought
-            & ((rsi_3_1h_gt_40) | (roc_9_1h < 30.0) | (roc_9_1d < 60.0))
+            & ((rsi_3_1h_gt_40) | (roc_9_1h_lt_30) | (roc_9_1d < 60.0))
             # 1h down move, 1h high, 4h overbought
             & ((rsi_3_1h_gt_45) | aroonu_14_1h_lt_80 | (roc_9_4h < 25.0))
             # 1h down move, 4h high, 1h overbought
-            & ((rsi_3_1h_gt_45) | (aroonu_14_4h_lt_90) | (roc_9_1h < 20.0))
+            & ((rsi_3_1h_gt_45) | (aroonu_14_4h_lt_90) | (roc_9_1h_lt_20))
             # 1h down move, 4h high, 1h overbought
             & ((rsi_3_1h_gt_45) | aroonu_14_4h_lt_100 | (roc_9_1h_lt_10))
             # 1h down move, 1d high, 1d downtrend
@@ -16552,7 +16561,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h high, 1d downtrend
             & ((rsi_3_1h_gt_50) | (stochrsi_k_1h_lt_70) | (roc_9_1d_gt_neg_20))
             # 1h down move, 1h & 1d overbought
-            & ((rsi_3_1h_gt_50) | (roc_9_1h < 25.0) | (roc_9_1d < 200.0))
+            & ((rsi_3_1h_gt_50) | (roc_9_1h_lt_25) | (roc_9_1d < 200.0))
             # 1h down move, 1h high, 4h overbought
             & ((rsi_3_1h_gt_55) | aroonu_14_1h_lt_70 | (roc_9_4h_lt_40))
             # 1h down move, 4h high & overbought
@@ -16564,19 +16573,19 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h high, 4h overbought
             & ((rsi_3_1h_gt_65) | aroonu_14_1h_lt_80 | (roc_9_4h_lt_30))
             # 1h down move, 1h overbought
-            & ((rsi_3_1h_gt_65) | (roc_9_1h < 40.0))
+            & ((rsi_3_1h_gt_65) | (roc_9_1h_lt_40))
             # 4h down move, 1h high & overbought
-            & ((rsi_3_4h_gt_3) | (aroonu_14_1h_lt_85) | (roc_9_1h < 60.0))
+            & ((rsi_3_4h_gt_3) | (aroonu_14_1h_lt_85) | (roc_9_1h_lt_60))
             # 1d down move, 4h high & overbought
             & ((rsi_3_1d_gt_5) | (aroonu_14_4h_lt_90) | (roc_9_4h < 50.0))
             # 1d down move, 1h high
             & ((rsi_3_1d_gt_10) | aroonu_14_1h_lt_70)
             # 1d down move, 4h high, 1h overbought
-            & ((rsi_3_1d_gt_20) | aroonu_14_4h_lt_100 | (roc_9_1h < 25.0))
+            & ((rsi_3_1d_gt_20) | aroonu_14_4h_lt_100 | (roc_9_1h_lt_25))
             # 1d down move, 4h high, 4h overbought
             & ((rsi_3_1d_gt_20) | aroonu_14_4h_lt_100 | (roc_9_4h_lt_40))
             # 1d down move, 1h & 4h overbought
-            & ((rsi_3_1d_gt_30) | (roc_9_1h < 30.0) | (roc_9_4h < 60.0))
+            & ((rsi_3_1d_gt_30) | (roc_9_1h_lt_30) | (roc_9_4h < 60.0))
             # 1d down move, 4h high & overbought
             & ((rsi_3_1d_gt_35) | aroonu_14_4h_lt_100 | (roc_9_4h < 20.0))
             # 1d down move, 1h & 4h high
@@ -16594,13 +16603,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m not low enough, 1h high, 1d overbought
             & ((aroonu_14_15m_lt_25) | (stochrsi_k_1h_lt_90) | (roc_9_1d < 200.0))
             # 1h still high, 1h & 4h overbought
-            & ((aroonu_14_1h_lt_50) | (roc_9_1h < 40.0) | (roc_9_4h_lt_40))
+            & ((aroonu_14_1h_lt_50) | (roc_9_1h_lt_40) | (roc_9_4h_lt_40))
             # 1h & 4h high, 4h overbought
             & (aroonu_14_1h_lt_70 | aroonu_14_4h_lt_100 | (roc_9_4h < 20.0))
             # 1h & 4h high, 4h overbought
             & (aroonu_14_1h_lt_80 | aroonu_14_4h_lt_80 | (roc_9_4h_lt_30))
             # 1h & 4h high, 1h overbought
-            & (aroonu_14_1h_lt_80 | (aroonu_14_4h_lt_90) | (roc_9_1h < 30.0))
+            & (aroonu_14_1h_lt_80 | (aroonu_14_4h_lt_90) | (roc_9_1h_lt_30))
             # 1h & 4h high, 1d overbought
             & (aroonu_14_1h_lt_80 | (aroonu_14_4h_lt_90) | (roc_9_1d < 100.0))
             # 1h & 1d high, 4h overbought
@@ -16608,7 +16617,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h high, 1h overbought
             & (aroonu_14_1h_lt_80 | (stochrsi_k_4h_lt_90) | (roc_9_1h_lt_10))
             # 1h high & overbought
-            & (aroonu_14_1h_lt_80 | (roc_9_1h < 80.0))
+            & (aroonu_14_1h_lt_80 | (roc_9_1h_lt_80))
             # 1h high, 1h & 4h overbought
             & (aroonu_14_1h_lt_80 | (roc_9_1h_lt_10) | (roc_9_4h_lt_10))
             # 1h high, 4h overbought, 1d downtrend
@@ -16618,11 +16627,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h high, 1h overbought
             & ((aroonu_14_1h_lt_90) | (aroonu_14_4h_lt_90) | (roc_9_1h_lt_10))
             # 4h high, 1h overbought, 1d downtrend
-            & (aroonu_14_4h_lt_80 | (roc_9_1h < 30.0) | (roc_9_1d > -30.0))
+            & (aroonu_14_4h_lt_80 | (roc_9_1h_lt_30) | (roc_9_1d > -30.0))
             # 4h & 1d high, 4h downtrend
             & ((aroonu_14_4h_lt_85) | aroonu_14_1d_lt_100 | (cmf_20_4h > -0.30))
             # 4h & 1d high, 1h overbought
-            & ((aroonu_14_4h_lt_85) | (aroonu_14_1d_lt_90) | (roc_9_1h < 20.0))
+            & ((aroonu_14_4h_lt_85) | (aroonu_14_1d_lt_90) | (roc_9_1h_lt_20))
             # 4h & 1d high, 4h overbought
             & ((aroonu_14_4h_lt_85) | (aroonu_14_1d_lt_90) | (roc_9_4h < 60.0))
             # 4h high, 1h & 4h overbought
@@ -16630,15 +16639,15 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h high, 1d high & overbought
             & ((aroonu_14_4h_lt_90) | aroonu_14_1d_lt_100 | (roc_9_1d_lt_30))
             # 4h high, 1h & 4h overbought
-            & ((aroonu_14_4h_lt_90) | (roc_9_1h < 40.0) | (roc_9_4h_lt_40))
+            & ((aroonu_14_4h_lt_90) | (roc_9_1h_lt_40) | (roc_9_4h_lt_40))
             # 4h high, 4h & 1d overbought
             & ((aroonu_14_4h_lt_90) | (roc_9_4h_lt_30) | (roc_9_1d_lt_100))
             # 4h high, 1h & 4h overbought
-            & (aroonu_14_4h_lt_100 | (roc_9_1h < 40.0) | (roc_9_4h < 80.0))
+            & (aroonu_14_4h_lt_100 | (roc_9_1h_lt_40) | (roc_9_4h < 80.0))
             # 1d high, 1h & 4h overbought
             & (aroonu_14_1d_lt_100 | (roc_9_1h_lt_10) | (roc_9_4h < 20.0))
             # 1h high, 1h & 4h overbought
-            & ((stochrsi_k_1h_lt_60) | (roc_9_1h < 40.0) | (roc_9_4h_lt_40))
+            & ((stochrsi_k_1h_lt_60) | (roc_9_1h_lt_40) | (roc_9_4h_lt_40))
             # 1h high, 1h overbought
             & ((stochrsi_k_1h_lt_80) | (roc_9_1h_lt_10))
             # 1h high, 4h overbought. 1d downtrend
@@ -16650,7 +16659,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1d high, 1h & 4h overbought
             & ((stochrsi_k_1d < 80.0) | (roc_9_1h_lt_10) | (roc_9_4h_lt_20))
             # 1d hihg, 1h & 1d overbought
-            & ((stochrsi_k_1d_lt_90) | (roc_9_1h < 30.0) | (roc_9_1d_lt_100))
+            & ((stochrsi_k_1d_lt_90) | (roc_9_1h_lt_30) | (roc_9_1d_lt_100))
             # 1d high, 4h & 1d overbought
             & ((stochrsi_k_1d_lt_90) | (roc_9_4h_lt_40) | (roc_9_1d_lt_100))
           )
@@ -16752,7 +16761,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 5m down move, 4h high, 1d downtrend
             & ((rsi_3_15m_gt_5) | (stochrsi_k_4h_lt_80) | (roc_9_1d_gt_neg_40))
             # 15m down move, 1h & 4h overbought
-            & ((rsi_3_15m_gt_5) | (roc_9_1h < 25.0) | (roc_9_4h < 25.0))
+            & ((rsi_3_15m_gt_5) | (roc_9_1h_lt_25) | (roc_9_4h < 25.0))
             # 15m down move, 4h & 1d overbought
             & ((rsi_3_15m_gt_5) | (roc_9_4h_lt_30) | (roc_9_1d_lt_100))
             # 15m & 1h down move, 1h high
@@ -16862,7 +16871,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 1h high, 4h downtrend
             & ((rsi_3_15m_gt_20) | aroonu_14_1h_lt_80 | (roc_9_4h > -15.0))
             # 15m down move, 1h high & overbought
-            & ((rsi_3_15m_gt_20) | (aroonu_14_1h_lt_100) | (roc_9_1h < 50.0))
+            & ((rsi_3_15m_gt_20) | (aroonu_14_1h_lt_100) | (roc_9_1h_lt_50))
             # 15m down move, 4h high & overbought
             & ((rsi_3_15m_gt_20) | aroonu_14_4h_lt_70 | (roc_9_4h_lt_20))
             # 15m down move, 4h high, 1d overbought
@@ -17048,7 +17057,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1d high & overbought
             & (rsi_3_1h_gt_20 | (stochrsi_k_1d_lt_90) | (roc_9_1d_lt_40))
             # 1h down move, 1h & 4h overbought
-            & (rsi_3_1h_gt_20 | (roc_9_1h < 20.0) | (roc_9_4h_lt_40))
+            & (rsi_3_1h_gt_20 | (roc_9_1h_lt_20) | (roc_9_4h_lt_40))
             # 1h down move, 4h & 1d downtrend
             & (rsi_3_1h_gt_20 | (roc_9_4h_gt_neg_30) | (roc_9_1d_gt_neg_40))
             # 1h & 4h down move, 1d overbought
@@ -17076,7 +17085,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h downtrend, 4h overbought
             & ((rsi_3_1h_gt_25) | (roc_9_1h > -25.0) | (roc_9_4h < 50.0))
             # 1h down move, 1h & 4h overbought
-            & ((rsi_3_1h_gt_25) | (roc_9_1h < 30.0) | (roc_9_4h < 100.0))
+            & ((rsi_3_1h_gt_25) | (roc_9_1h_lt_30) | (roc_9_4h < 100.0))
             # 1h & 4h down move, 1h high
             & ((rsi_3_1h_gt_30) | (rsi_3_4h_gt_30) | (aroonu_14_1h_lt_90))
             # 1h & 4h down move, 4h downtrend
@@ -17090,7 +17099,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h high, 1d downtrend
             & ((rsi_3_1h_gt_30) | aroonu_14_1h_lt_70 | (roc_9_1d > -60.0))
             # 1h down move, 4h high, 1h overbought
-            & ((rsi_3_1h_gt_30) | aroonu_14_4h_lt_80 | (roc_9_1h < 50.0))
+            & ((rsi_3_1h_gt_30) | aroonu_14_4h_lt_80 | (roc_9_1h_lt_50))
             # 1h down move, 4h high, 1d downtrend
             & ((rsi_3_1h_gt_30) | (aroonu_14_4h_lt_90) | (roc_9_1d_gt_neg_30))
             # 1h down move, 4h high, 1d overbought
@@ -17144,7 +17153,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h high
             & ((rsi_3_1h_gt_60) | (stochrsi_k_1h_lt_80))
             # 1h down move, 1h overbought
-            & ((rsi_3_1h_gt_60) | (roc_9_1h < 30.0))
+            & ((rsi_3_1h_gt_60) | (roc_9_1h_lt_30))
             # 1h down move, 4h & 1d overbought
             & ((rsi_3_1h_gt_60) | (roc_9_4h_lt_30) | (roc_9_1d < 60.0))
             # 4h & 1d down move, 1d still not low enough
@@ -17226,25 +17235,25 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m downtrend, 4h & 1d high
             & ((cmf_20_15m > -0.30) | aroonu_14_4h_lt_80 | aroonu_14_1d_lt_100)
             # 15m & 1h high, 1h overbought
-            & ((aroonu_14_15m_lt_70) | (aroonu_14_1h_lt_100) | (roc_9_1h < 50.0))
+            & ((aroonu_14_15m_lt_70) | (aroonu_14_1h_lt_100) | (roc_9_1h_lt_50))
             # 15m & 1d high, 1d overbought
             & ((aroonu_14_15m_lt_70) | (aroonu_14_1d_lt_90) | (roc_9_1d_lt_30))
             # 1h & 4h high, 1h downtrend
             & (aroonu_14_1h_lt_70 | aroonu_14_4h_lt_100 | (cmf_20_1h > -0.30))
             # 1h high, 4h high, 1h overbought
-            & (aroonu_14_1h_lt_70 | aroonu_14_4h_lt_100 | (roc_9_1h < 20.0))
+            & (aroonu_14_1h_lt_70 | aroonu_14_4h_lt_100 | (roc_9_1h_lt_20))
             # 1h & 1d high, 1h overbought
-            & (aroonu_14_1h_lt_70 | (aroonu_14_1d_lt_70) | (roc_9_1h < 20.0))
+            & (aroonu_14_1h_lt_70 | (aroonu_14_1d_lt_70) | (roc_9_1h_lt_20))
             # 1h high, 1d high & overbought
             & (aroonu_14_1h_lt_70 | aroonu_14_1d_lt_100 | (roc_9_1d < 200.0))
             # 1h high, 1h & 1d overbought
-            & (aroonu_14_1h_lt_70 | (roc_9_1h < 20.0) | (roc_9_1d < 200.0))
+            & (aroonu_14_1h_lt_70 | (roc_9_1h_lt_20) | (roc_9_1d < 200.0))
             # 1h high, 4h downtrend, 1d overbought
             & (aroonu_14_1h_lt_70 | (roc_9_4h > -40.0) | (roc_9_1d < 100.0))
             # 1h high, 1h & 1d overbought
-            & (aroonu_14_1h_lt_80 | (roc_9_1h < 20.0) | (roc_9_1d_lt_20))
+            & (aroonu_14_1h_lt_80 | (roc_9_1h_lt_20) | (roc_9_1d_lt_20))
             # 1h high, 1h overbought, 1d downtrend
-            & (aroonu_14_1h_lt_80 | (roc_9_1h < 30.0) | (roc_9_1d_gt_neg_40))
+            & (aroonu_14_1h_lt_80 | (roc_9_1h_lt_30) | (roc_9_1d_gt_neg_40))
             # 1h high, 4h & 1d overbought
             & (aroonu_14_1h_lt_80 | (roc_9_4h_lt_10) | (roc_9_1d_lt_40))
             # 1h high, 4h & 1d downtrend
@@ -17260,9 +17269,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h high, 15m downtrend, 4h overbought
             & (aroonu_14_4h_lt_100 | (roc_9_15m > -30.0) | (roc_9_4h_lt_30))
             # 4h high, 1h & 4h overbought
-            & (aroonu_14_4h_lt_100 | (roc_9_1h < 30.0) | (roc_9_4h < 70.0))
+            & (aroonu_14_4h_lt_100 | (roc_9_1h_lt_30) | (roc_9_4h < 70.0))
             # 4h & 1d high, 1h overbought
-            & (aroonu_14_4h_lt_100 | aroonu_14_1d_lt_100 | (roc_9_1h < 50.0))
+            & (aroonu_14_4h_lt_100 | aroonu_14_1d_lt_100 | (roc_9_1h_lt_50))
             # 1d still high, 4h & 1d downtrend
             & ((aroonu_14_1d_lt_50) | (roc_9_4h > -50.0) | roc_9_1d_gt_neg_50)
             # 1d high, 1h & 4h downtrend
@@ -17278,7 +17287,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h high, 1h overbought, 4h downtrend
             & ((stochrsi_k_1h_lt_90) | (roc_9_1h_lt_10) | (roc_9_4h > -15.0))
             # 4h high, 1h & 4h overbought
-            & ((stochrsi_k_4h_lt_90) | (roc_9_1h < 20.0) | (roc_9_4h < 50.0))
+            & ((stochrsi_k_4h_lt_90) | (roc_9_1h_lt_20) | (roc_9_4h < 50.0))
             # 1d high, 4h & 1d overbought
             & ((stochrsi_k_1d_lt_90) | (roc_9_4h < 100.0) | (roc_9_1d_lt_100))
             # 1d P&D, 4h overbought
@@ -17830,7 +17839,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m still high, 1h & 4h downtrend
             & ((stochrsi_k_15m_lt_50) | (roc_9_1h > -20.0) | (roc_9_4h_gt_neg_20))
             # 4h high, 1h & 4h overbought
-            & ((stochrsi_k_4h_lt_90) | (roc_9_1h < 20.0) | (roc_9_4h_lt_30))
+            & ((stochrsi_k_4h_lt_90) | (roc_9_1h_lt_20) | (roc_9_4h_lt_30))
             # 4h high, 4h & 1d overbought
             & ((stochrsi_k_4h_lt_90) | (roc_9_4h_lt_20) | (roc_9_1d_lt_80))
             # 1d still high, 4h & 1d downtrend
@@ -18307,7 +18316,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h downtrend, 1h & 4h high
             & ((cmf_20_4h > -0.30) | aroonu_14_1h_lt_70 | aroonu_14_4h_lt_100)
             # 15m still high, 1h & 4h overbought
-            & ((aroonu_14_15m_lt_50) | (roc_9_1h < 100.0) | (roc_9_4h < 100.0))
+            & ((aroonu_14_15m_lt_50) | (roc_9_1h_lt_100) | (roc_9_4h < 100.0))
             # 15m & 1d high, 1d overbought
             & ((aroonu_14_15m_lt_70) | (aroonu_14_1d_lt_90) | (roc_9_1d_lt_30))
             # 1h still high, 4h & 1d downtrend
@@ -18325,11 +18334,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h high, 1d downtrend
             & (aroonu_14_1h_lt_80 | (roc_9_1d > -60.0))
             # 1h high, 1h & 4h overbought
-            & ((aroonu_14_1h_lt_100) | (roc_9_1h < 100.0) | (roc_9_4h < 100.0))
+            & ((aroonu_14_1h_lt_100) | (roc_9_1h_lt_100) | (roc_9_4h < 100.0))
             # 4h & 1d high, 1d overbought
             & ((aroonu_14_4h_lt_60) | aroonu_14_1d_lt_100 | (roc_9_1d < 70.0))
             # 4h high, 1h & 4h overbought
-            & ((aroonu_14_4h_lt_85) | (roc_9_1h < 80.0) | (roc_9_4h < 80.0))
+            & ((aroonu_14_4h_lt_85) | (roc_9_1h_lt_80) | (roc_9_4h < 80.0))
             # 4h high, 1h downtrend, 4h overbought
             & ((aroonu_14_4h_lt_90) | (roc_9_1h > -40.0) | (roc_9_4h < 100.0))
             # 4h & 1d high, 4h overbought
@@ -18351,11 +18360,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h high, 4h & 1d downtrend
             & ((stochrsi_k_1h < 85.0) | (roc_9_4h > -70.0) | (roc_9_1d > -70.0))
             # 4h high, 1h & 4h overbought
-            & ((stochrsi_k_4h_lt_80) | (roc_9_1h < 40.0) | (roc_9_4h < 100.0))
+            & ((stochrsi_k_4h_lt_80) | (roc_9_1h_lt_40) | (roc_9_4h < 100.0))
             # 1d high, 4h & 1d overbought
             & ((stochrsi_k_1d_lt_90) | (roc_9_4h_lt_20) | (roc_9_1d_lt_100))
             # 1h & 4h overbought, 1d downtrend
-            & ((roc_9_1h < 40.0) | (roc_9_4h < 50.0) | (roc_9_1d_gt_neg_30))
+            & ((roc_9_1h_lt_40) | (roc_9_4h < 50.0) | (roc_9_1d_gt_neg_30))
             # big drop in last hour, 15m high
             & ((close > (close_max_12 * 0.60)) | (aroonu_14_15m_lt_70))
             # big drop in last hour, 4h high
@@ -19141,7 +19150,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h & 4h high
             & ((rsi_3_1h_gt_50) | (aroonu_14_1h_lt_70) | (aroonu_14_4h_lt_100))
             # 1h down move, 1h overbought
-            & ((rsi_3_1h_gt_50) | (roc_9_1h < 40.0))
+            & ((rsi_3_1h_gt_50) | (roc_9_1h_lt_40))
             # 4h & 1d down move, 1d high
             & ((rsi_3_4h_gt_5) | (rsi_3_1d_gt_30) | (aroonu_14_1d_lt_70))
             # 4h down move, 1h & 4h downtrend
@@ -19179,11 +19188,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h & 1d high, 4h overbought
             & (aroonu_14_4h_lt_80 | aroonu_14_1d_lt_100 | (roc_9_4h < 20.0))
             # 4h high, 1h overbought
-            & (aroonu_14_4h_lt_80 | (roc_9_1h < 40.0))
+            & (aroonu_14_4h_lt_80 | (roc_9_1h_lt_40))
             # 4h high, 4h overbought
             & (aroonu_14_4h_lt_80 | (roc_9_4h_lt_40))
             # 4h high, 1h overbought
-            & ((stochrsi_k_4h_lt_70) | (roc_9_1h < 40.0))
+            & ((stochrsi_k_4h_lt_70) | (roc_9_1h_lt_40))
             # 4h high, 4h overbought
             & ((stochrsi_k_4h_lt_70) | (roc_9_4h_lt_40))
             # 4h high, 4h overbought, 1d downtrend
@@ -19333,7 +19342,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 1d high, 1d downtrend
             & ((rsi_3_15m_gt_10) | (aroonu_14_1d_lt_85) | (cmf_20_1d > -0.40))
             # 15m down move, 1h high & overbought
-            & ((rsi_3_15m_gt_10) | (stochrsi_k_1h_lt_90) | (roc_9_1h < 20.0))
+            & ((rsi_3_15m_gt_10) | (stochrsi_k_1h_lt_90) | (roc_9_1h_lt_20))
             # 15m down move, 4h high
             & ((rsi_3_15m_gt_10) | (stochrsi_k_4h_lt_70))
             # 15m down move, 4h & 1d overbought
@@ -19353,7 +19362,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 1d high, 4h overbought
             & ((rsi_3_15m_gt_15) | (stochrsi_k_1d_lt_90) | (roc_9_4h_lt_40))
             # 15m down move, 1h & 4h overbought
-            & ((rsi_3_15m_gt_15) | (roc_9_1h < 20.0) | (roc_9_4h_lt_40))
+            & ((rsi_3_15m_gt_15) | (roc_9_1h_lt_20) | (roc_9_4h_lt_40))
             # 15m down move, 4h & 1d downtrend
             & ((rsi_3_15m_gt_15) | (roc_9_4h > -10.0) | (roc_9_1d_gt_neg_40))
             # 15m down move, 4h & 1d overbought
@@ -19467,7 +19476,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h high, 4h downtrend
             & ((rsi_3_1h_gt_40) | (stochrsi_k_1h_lt_80) | (roc_9_4h_gt_neg_20))
             # 1h down move, 1h high, 1h overbought
-            & ((rsi_3_1h_gt_50) | aroonu_14_1h_lt_70 | (roc_9_1h < 25.0))
+            & ((rsi_3_1h_gt_50) | aroonu_14_1h_lt_70 | (roc_9_1h_lt_25))
             # 1h down move, 4h high, 1d downtrend
             & ((rsi_3_1h_gt_50) | (stochrsi_k_4h_lt_60) | (roc_9_1d > -60.0))
             # 1h down move, 4h & 1d overbought
@@ -19537,9 +19546,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m high, 1h high & overbought
             & ((aroonu_14_15m_lt_60) | (aroonu_14_1h_lt_85) | (roc_9_1h_lt_10))
             # 1h high, 4h high, 1h overbought
-            & (aroonu_14_1h_lt_70 | aroonu_14_4h_lt_100 | (roc_9_1h < 20.0))
+            & (aroonu_14_1h_lt_70 | aroonu_14_4h_lt_100 | (roc_9_1h_lt_20))
             # 1h & 1d high, 1h overbought
-            & (aroonu_14_1h_lt_70 | (aroonu_14_1d_lt_70) | (roc_9_1h < 20.0))
+            & (aroonu_14_1h_lt_70 | (aroonu_14_1d_lt_70) | (roc_9_1h_lt_20))
             # 1h & 4h high, 1d downtrend
             & ((aroonu_14_1h_lt_85) | aroonu_14_4h_lt_100 | (roc_9_1d > -80.0))
             # 4h still high, 5m downtrend
@@ -19555,17 +19564,17 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1d high, 1h & 4h downtrend
             & ((aroonu_14_1d_lt_85) | (roc_9_1h > -30.0) | (roc_9_4h > -50.0))
             # 1d high, 1h & 1d overbought
-            & ((aroonu_14_1d_lt_85) | (roc_9_1h < 20.0) | (roc_9_1d_lt_100))
+            & ((aroonu_14_1d_lt_85) | (roc_9_1h_lt_20) | (roc_9_1d_lt_100))
             # 1d high, 4h & 1d overbought
             & ((aroonu_14_1d_lt_90) | (roc_9_4h_lt_30) | (roc_9_1d < 60.0))
             # 1h high, 1d overbought
             & ((stochrsi_k_1h_lt_70) | (roc_9_1d_lt_40))
             # 4h high, 1h overbought, 1d downtrend
-            & ((stochrsi_k_4h_lt_80) | (roc_9_1h < 40.0) | (roc_9_1d > -70.0))
+            & ((stochrsi_k_4h_lt_80) | (roc_9_1h_lt_40) | (roc_9_1d > -70.0))
             # 4h high, 1h & 4h overbought
-            & ((stochrsi_k_4h_lt_90) | (roc_9_1h < 20.0) | (roc_9_4h < 50.0))
+            & ((stochrsi_k_4h_lt_90) | (roc_9_1h_lt_20) | (roc_9_4h < 50.0))
             # 1h & 4h overbought
-            & ((roc_9_1h < 100.0) | (roc_9_4h < 100.0))
+            & ((roc_9_1h_lt_100) | (roc_9_4h < 100.0))
             # big drop in the last 20 days, 1d high, 1d downtrend
             & ((close > (high_max_20_1d * 0.20)) | (stochrsi_k_1d < 70.0) | (roc_9_1d > -15.0))
           )
@@ -19830,7 +19839,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 4h high & overbought
             & ((rsi_3_1h_gt_45) | aroonu_14_4h_lt_80 | (roc_9_4h < 100.0))
             # 1h down move, 1h overbought
-            & ((rsi_3_1h_gt_50) | (roc_9_1h < 40.0))
+            & ((rsi_3_1h_gt_50) | (roc_9_1h_lt_40))
             # 1h down move, 4h & 1d overbought
             & ((rsi_3_1h_gt_60) | (roc_9_4h_lt_30) | (roc_9_1d_lt_100))
             # 4h & 1d down move, 1d still high
@@ -19912,13 +19921,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h & 1d high, 1d overbought
             & (aroonu_14_4h_lt_70 | aroonu_14_1d_lt_100 | (roc_9_1d_lt_80))
             # 4h high, 1h & 4h overbought
-            & (aroonu_14_4h_lt_80 | (roc_9_1h < 40.0) | (roc_9_4h_lt_40))
+            & (aroonu_14_4h_lt_80 | (roc_9_1h_lt_40) | (roc_9_4h_lt_40))
             # 1d high, 4h downtrend, 1d overbought
             & ((aroonu_14_1d_lt_85) | (roc_9_4h_gt_neg_20) | (roc_9_1d < 200.0))
             # 1d high, 4h & 1d overbought
             & ((aroonu_14_1d_lt_90) | (roc_9_4h_lt_30) | (roc_9_1d < 60.0))
             # 4h high, 1h & 4h overbought
-            & ((stochrsi_k_4h_lt_70) | (roc_9_1h < 40.0) | (roc_9_4h_lt_40))
+            & ((stochrsi_k_4h_lt_70) | (roc_9_1h_lt_40) | (roc_9_4h_lt_40))
             # 4h high, 4h & 1d overbought
             & ((stochrsi_k_4h_lt_80) | (roc_9_4h_lt_20) | (roc_9_1d_lt_20))
             # 1d green, 4h down move, 4h still high
@@ -20368,7 +20377,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1d downtrend, 1d high & overbought
             & ((cmf_20_1d > -0.40) | (aroonu_14_1d_lt_85) | (roc_9_1d_lt_20))
             # 15m still high, 1h overbought
-            & ((aroonu_14_15m_lt_40) | (roc_9_1h < 40.0))
+            & ((aroonu_14_15m_lt_40) | (roc_9_1h_lt_40))
             # 15m still high, 4h overbought
             & ((aroonu_14_15m_lt_40) | (roc_9_4h < 80.0))
             # 15m still high, 1h high
@@ -20380,11 +20389,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h still high, 4h & 1d downtrend
             & ((aroonu_14_1h_lt_40) | (roc_9_4h_gt_neg_20) | (roc_9_1d_gt_neg_40))
             # 1h high, 4h high, 1h overbought
-            & (aroonu_14_1h_lt_70 | aroonu_14_4h_lt_100 | (roc_9_1h < 20.0))
+            & (aroonu_14_1h_lt_70 | aroonu_14_4h_lt_100 | (roc_9_1h_lt_20))
             # 1h & 4h high, 4h overbought
             & (aroonu_14_1h_lt_70 | aroonu_14_4h_lt_100 | (roc_9_4h_lt_40))
             # 1h & 1d high, 1h overbought
-            & (aroonu_14_1h_lt_70 | (aroonu_14_1d_lt_70) | (roc_9_1h < 20.0))
+            & (aroonu_14_1h_lt_70 | (aroonu_14_1d_lt_70) | (roc_9_1h_lt_20))
             # 1h high, 1h & 4h overbought
             & (aroonu_14_1h_lt_70 | (roc_9_1h_lt_10) | (roc_9_4h_lt_40))
             # 1h high, 1d downtrend
@@ -20406,9 +20415,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1d high, 1h & 4h downtrend
             & ((aroonu_14_1d_lt_85) | (roc_9_1h > -30.0) | (roc_9_4h > -50.0))
             # 1d high, 1h & 1d overbought
-            & ((aroonu_14_1d_lt_85) | (roc_9_1h < 20.0) | (roc_9_1d_lt_100))
+            & ((aroonu_14_1d_lt_85) | (roc_9_1h_lt_20) | (roc_9_1d_lt_100))
             # 1d high, 1h & 4h down move
-            & (aroonu_14_1d_lt_100 | (roc_9_1h < 25.0) | (roc_9_4h < 60.0))
+            & (aroonu_14_1d_lt_100 | (roc_9_1h_lt_25) | (roc_9_4h < 60.0))
             # 1d high, 4h & 1d overbought
             & (aroonu_14_1d_lt_100 | (roc_9_4h < 20.0) | (roc_9_1d_lt_30))
             # 1h high, 4h & 1d overbought
@@ -20420,15 +20429,15 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h high, 4h & 1d overbought
             & ((stochrsi_k_4h_lt_70) | (roc_9_4h_lt_20) | (roc_9_1d_lt_30))
             # 4h high, 1h overbought, 1d downtrend
-            & ((stochrsi_k_4h_lt_80) | (roc_9_1h < 40.0) | (roc_9_1d > -70.0))
+            & ((stochrsi_k_4h_lt_80) | (roc_9_1h_lt_40) | (roc_9_1d > -70.0))
             # 4h high, 4h overbought
             & ((stochrsi_k_4h_lt_80) | (roc_9_4h_lt_10))
             # 4h high, 1h & 4h overbought
-            & ((stochrsi_k_4h_lt_90) | (roc_9_1h < 20.0) | (roc_9_4h < 50.0))
+            & ((stochrsi_k_4h_lt_90) | (roc_9_1h_lt_20) | (roc_9_4h < 50.0))
             # 1d high, 4h & 1d overbought
             & ((stochrsi_k_1d_lt_90) | (roc_9_4h_lt_40) | (roc_9_1d_lt_100))
             # 1h & 4h overbought
-            & ((roc_9_1h < 30.0) | (roc_9_4h < 80.0))
+            & ((roc_9_1h_lt_30) | (roc_9_4h < 80.0))
             # 1d green with top wick, 4h high
             & ((change_pct_1d < 30.0) | (top_wick_pct_1d < 20.0) | aroonu_14_4h_lt_80)
             # 1d top wick, 4h down move, 1d overbought
@@ -21073,7 +21082,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h still high, 4h high & overbought
             & ((aroonu_14_1h_lt_50) | (aroonu_14_4h_lt_90) | (roc_9_4h < 80.0))
             # 1h & 4h high, 1h overbought
-            & (aroonu_14_1h_lt_80 | aroonu_14_4h_lt_100 | (roc_9_1h < 40.0))
+            & (aroonu_14_1h_lt_80 | aroonu_14_4h_lt_100 | (roc_9_1h_lt_40))
             # 1h & 1d high, 1d overbought
             & (aroonu_14_1h_lt_80 | aroonu_14_1d_lt_100 | (roc_9_1d_lt_30))
             # 1h high, 4h & 1d overbought
@@ -21166,7 +21175,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 1h & 1d high
             & ((rsi_3_15m_gt_25) | (stochrsi_k_1h_lt_80) | (stochrsi_k_1d_lt_90))
             # 15m down move, 1h high & overbought
-            & ((rsi_3_15m_gt_25) | (stochrsi_k_1h_lt_80) | (roc_9_1h < 20.0))
+            & ((rsi_3_15m_gt_25) | (stochrsi_k_1h_lt_80) | (roc_9_1h_lt_20))
             # 15m & 1h down move, 15m high
             & ((rsi_3_15m_gt_30) | (rsi_3_1h_gt_30) | (aroonu_14_15m_lt_70))
             # 15m & 4h & 1d down move, 4h & 1d high
@@ -21212,7 +21221,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h high, 4h overbought
             & ((rsi_3_1h_gt_40) | aroonu_14_1h_lt_70 | (roc_9_4h_lt_30))
             # 1h down move, 1h overbought
-            & ((rsi_3_1h_gt_40) | (roc_9_1h < 30.0))
+            & ((rsi_3_1h_gt_40) | (roc_9_1h_lt_30))
             # 1h down move, 1d high & overbought
             & ((rsi_3_1h_gt_45) | aroonu_14_1d_lt_100 | (roc_9_1d_lt_30))
             # 1h down move, 15m & 1h still high
@@ -21254,7 +21263,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1d down move, 15m still high, 1h high
             & ((rsi_3_1d_gt_15) | (aroonu_14_15m_lt_50) | (aroonu_14_1h_lt_85))
             # 1d down move, 1h & 1d overbought
-            & ((rsi_3_1d_gt_45) | (roc_9_1h < 80.0) | (roc_9_1d_lt_80))
+            & ((rsi_3_1d_gt_45) | (roc_9_1h_lt_80) | (roc_9_1d_lt_80))
             # 15m still high, 1h & 4h high
             & ((rsi_14_15m < 40.0) | aroonu_14_1h_lt_80 | (aroonu_14_4h_lt_90))
             # 15m & 1h still high, 4h high
@@ -22023,7 +22032,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h & 1d high, 1d overbought
             & ((aroonu_14_4h_lt_90) | aroonu_14_1d_lt_100 | roc_9_1d_lt_50)
             # 1h high, 1h & 4h overbought
-            & ((stochrsi_k_1h_lt_80) | (roc_9_1h < 20.0) | (roc_9_4h_lt_20))
+            & ((stochrsi_k_1h_lt_80) | (roc_9_1h_lt_20) | (roc_9_4h_lt_20))
             # 4h & 1d overbought
             & ((roc_9_4h < 100.0) | (roc_9_1d < 200.0))
           )
@@ -22220,7 +22229,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 15m high, 1d overbought
             & ((rsi_3_15m_gt_35) | (aroonu_14_15m_lt_80) | roc_9_1d_lt_50)
             # 15m down move, 1d high, 1h overbought
-            & ((rsi_3_15m_gt_40) | (stochrsi_k_1d < 80.0) | (roc_9_1h < 20.0))
+            & ((rsi_3_15m_gt_40) | (stochrsi_k_1d < 80.0) | (roc_9_1h_lt_20))
             # 1h & 4h down move, 1d still high
             & ((rsi_3_1h_gt_3) | (rsi_3_4h_gt_10) | (aroonu_14_1d_lt_50))
             # 1h & 4h down move, 1d overbought
@@ -22444,7 +22453,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h & 1d high, 1d overbought
             & (aroonu_14_4h_lt_100 | aroonu_14_1d_lt_100 | (roc_9_1d_lt_30))
             # 4h high, 1h & 4h overbought
-            & (aroonu_14_4h_lt_100 | (roc_9_1h < 20.0) | (roc_9_4h_lt_40))
+            & (aroonu_14_4h_lt_100 | (roc_9_1h_lt_20) | (roc_9_4h_lt_40))
             # 1d high, 4h & 1d downtrend
             & ((aroonu_14_1d_lt_60) | (roc_9_4h_gt_neg_20) | (roc_9_1d_gt_neg_30))
             # 1d high, 4h & 1d overbought
@@ -22452,11 +22461,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m high, 4h & 1d overbought
             & ((stochrsi_k_15m_lt_70) | (roc_9_4h_lt_20) | (roc_9_1d_lt_20))
             # 1h high, 1h & 1d overbought
-            & ((stochrsi_k_1h_lt_80) | (roc_9_1h < 20.0) | (roc_9_1d_lt_100))
+            & ((stochrsi_k_1h_lt_80) | (roc_9_1h_lt_20) | (roc_9_1d_lt_100))
             # 4h high, 4h overbought, 1d downtrend
             & ((stochrsi_k_4h_lt_90) | (roc_9_4h_lt_20) | (roc_9_1d_gt_neg_20))
             # 1d high, 1h & 4h overbought
-            & ((stochrsi_k_1d < 80.0) | (roc_9_1h < 20.0) | (roc_9_4h_lt_20))
+            & ((stochrsi_k_1d < 80.0) | (roc_9_1h_lt_20) | (roc_9_4h_lt_20))
           )
 
           # Logic
@@ -23599,15 +23608,15 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1d still high, 1h & 4h downtrend
             & ((aroonu_14_1d_lt_50) | (roc_9_1h > -20.0) | (roc_9_4h_gt_neg_20))
             # 1h high, 1h overbought
-            & ((stochrsi_k_1h_lt_80) | (roc_9_1h < 50.0))
+            & ((stochrsi_k_1h_lt_80) | (roc_9_1h_lt_50))
             # 1h high, 1d downtrend
             & ((stochrsi_k_1h_lt_80) | (roc_9_1d > -60.0))
             # 4h high, 1h overbought, 1d downtrend
             & ((stochrsi_k_4h_lt_80) | (roc_9_1h_lt_10) | (roc_9_1d > -70.0))
             # 4h high, 1h & 4h overbought
-            & ((stochrsi_k_4h_lt_90) | (roc_9_1h < 20.0) | (roc_9_4h < 50.0))
+            & ((stochrsi_k_4h_lt_90) | (roc_9_1h_lt_20) | (roc_9_4h < 50.0))
             # 1h & 4h overbought
-            & ((roc_9_1h < 100.0) | (roc_9_4h < 100.0))
+            & ((roc_9_1h_lt_100) | (roc_9_4h < 100.0))
             # 1h P&D, 1h down move
             & ((change_pct_1h > -10.0) | (change_pct_1h.shift(12) < 10.0) | (rsi_3_1h_gt_50))
             # 4h P&D, 4h high
@@ -23755,7 +23764,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 1h high, 1d overbought
             & ((rsi_3_15m_gt_15) | (stochrsi_k_1h_lt_70) | (roc_9_1d < 150.0))
             # 15m down move, 1h high & overbought
-            & ((rsi_3_15m_gt_15) | (stochrsi_k_1h_lt_80) | (roc_9_1h < 20.0))
+            & ((rsi_3_15m_gt_15) | (stochrsi_k_1h_lt_80) | (roc_9_1h_lt_20))
             # 15m down move, 1h high, 1d overbought
             & ((rsi_3_15m_gt_15) | (stochrsi_k_1h_lt_80) | (roc_9_1d_lt_100))
             # 15m down move, 4h high, 1d overbought
@@ -23910,7 +23919,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 4h & 1d high
             & ((rsi_3_1h_gt_50) | (aroonu_14_4h_lt_90) | (aroonu_14_1d_lt_90))
             # 1h down move, 4h high, 1h overbought
-            & ((rsi_3_1h_gt_55) | aroonu_14_4h_lt_100 | (roc_9_1h < 20.0))
+            & ((rsi_3_1h_gt_55) | aroonu_14_4h_lt_100 | (roc_9_1h_lt_20))
             # 1h down move, 15m & 1h high, 1d downtrend
             & ((rsi_3_1h_gt_60) | (aroonu_14_15m < 65.0) | (stochrsi_k_1h_lt_80) | (cmf_20_1d > -0.0))
             # 1h down move, 1h high, 1d downtrend
@@ -23976,7 +23985,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1d down move, 1h & 4h still high
             & ((rsi_3_1d_gt_10) | (stochrsi_k_1h_lt_40) | (aroonu_14_4h_lt_40))
             # 1d down move, 1h high & overbought
-            & ((rsi_3_1d_gt_20) | (stochrsi_k_1h_lt_80) | (roc_9_1h < 20.0))
+            & ((rsi_3_1d_gt_20) | (stochrsi_k_1h_lt_80) | (roc_9_1h_lt_20))
             # 1d down move, 1d high & overbought
             & ((rsi_3_1d_gt_40) | (aroonu_14_1d_lt_70) | (roc_9_1d_lt_20))
             # 1d down move, 4h high & overbought
@@ -24254,11 +24263,11 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1h up move, 4h still low
           short_entry_logic.append((rsi_3_1h_lt_95) | (rsi_14_4h > 60.0))
           # 1h up move, 1d still low, 1h uptrend
-          short_entry_logic.append((rsi_3_1h_lt_95) | (rsi_14_1d > 50.0) | (roc_9_1h < 30.0))
+          short_entry_logic.append((rsi_3_1h_lt_95) | (rsi_14_1d > 50.0) | (roc_9_1h_lt_30))
           # 1h & 4h strong up move
           short_entry_logic.append((rsi_3_1h_lt_95) | (mfi_14_1h < 95.0) | (rsi_3_4h_lt_95))
           # 1h up move, 1d still low, 1h uptrend
-          short_entry_logic.append((rsi_3_1h_lt_95) | (stochrsi_k_1d > 50.0) | (roc_9_1h < 20.0))
+          short_entry_logic.append((rsi_3_1h_lt_95) | (stochrsi_k_1d > 50.0) | (roc_9_1h_lt_20))
           # 1h strong up move, 15m still move higher
           short_entry_logic.append((rsi_3_1h_lt_95) | (df["CCI_20_change_pct_15m"] < -0.0))
           # 1h & 4h up move, 1h still low
@@ -24274,9 +24283,9 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1h up move, 4h low, 1h uptrend
           short_entry_logic.append((rsi_3_1h_lt_90) | (stochrsi_k_4h > 20.0) | (roc_9_1h_lt_10))
           # 1h up move, 4h low, 1h overbought
-          short_entry_logic.append((rsi_3_1h_lt_90) | (stochrsi_k_4h > 40.0) | (roc_9_1h < 30.0))
+          short_entry_logic.append((rsi_3_1h_lt_90) | (stochrsi_k_4h > 40.0) | (roc_9_1h_lt_30))
           # 1h up move, 15m & 1h uptrend
-          short_entry_logic.append((rsi_3_1h_lt_90) | (roc_9_15m < 15.0) | (roc_9_1h < 15.0))
+          short_entry_logic.append((rsi_3_1h_lt_90) | (roc_9_15m < 15.0) | (roc_9_1h_lt_15))
           # 1h up move, 15m & 4h still low
           short_entry_logic.append((rsi_3_1h_lt_85) | (stochrsi_k_15m_gt_50) | (stochrsi_k_4h_gt_50))
           # 1h & 4h up move, 15m still not high enough
@@ -24296,9 +24305,9 @@ class NostalgiaForInfinityX7(IStrategy):
           # 4h up move, 15m uptrend
           short_entry_logic.append((rsi_3_4h_lt_95) | (roc_9_15m < 20.0))
           # 4h up move, 1h uptrend
-          short_entry_logic.append((rsi_3_4h_lt_95) | (roc_9_1h < 20.0))
+          short_entry_logic.append((rsi_3_4h_lt_95) | (roc_9_1h_lt_20))
           # 4h up move, 1h & 4h overbought
-          short_entry_logic.append((rsi_3_4h_lt_95) | (roc_9_1h < 30.0) | (roc_9_4h < 60.0))
+          short_entry_logic.append((rsi_3_4h_lt_95) | (roc_9_1h_lt_30) | (roc_9_4h < 60.0))
           # 4h up move, 1h still low
           short_entry_logic.append((rsi_3_4h_lt_90) | (aroonu_14_1h > 40.0))
           # 4h up move, 1d still low, 4h uptrend
@@ -24330,13 +24339,13 @@ class NostalgiaForInfinityX7(IStrategy):
           # 4h uptrend, 15m uptrend
           short_entry_logic.append(aroonu_14_4h_lt_100 | (roc_9_15m < 10.0))
           # 4h uptrend, 1h uptrend
-          short_entry_logic.append(aroonu_14_4h_lt_100 | (roc_9_1h < 20.0))
+          short_entry_logic.append(aroonu_14_4h_lt_100 | (roc_9_1h_lt_20))
           # 1d uptrend, 15m uptrend
           short_entry_logic.append(aroonu_14_1d_lt_100 | (roc_9_15m < 20.0))
           # 1d uptrend, 1h uptrend
-          short_entry_logic.append(aroonu_14_1d_lt_100 | (roc_9_1h < 20.0))
+          short_entry_logic.append(aroonu_14_1d_lt_100 | (roc_9_1h_lt_20))
           # 15m still not high enough, 1h & 4h overbought
-          short_entry_logic.append((stochrsi_k_15m > 70.0) | (roc_9_1h < 30.0) | (roc_9_4h < 60.0))
+          short_entry_logic.append((stochrsi_k_15m > 70.0) | (roc_9_1h_lt_30) | (roc_9_4h < 60.0))
           # 1h & 4h overbought, 1h uptrend
           short_entry_logic.append((roc_9_1h_lt_10) | (roc_9_4h_lt_40) | (cci_20_change_pct_1h < 0.0))
           # 1h & 4h overbought, 4h uptrend
@@ -24436,7 +24445,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m up move, 4h low
             & ((rsi_3_15m < 80.0) | (stochrsi_k_4h > 40.0))
             # 15m up move, 1h uptrend
-            & ((rsi_3_15m < 75.0) | (roc_9_1h < 40.0))
+            & ((rsi_3_15m < 75.0) | (roc_9_1h_lt_40))
             # 1h & 1d strong up move
             & ((rsi_3_1h_lt_95) | (rsi_3_1d < 95.0))
             # 1h up move, 1h still not high enough
@@ -24454,7 +24463,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h up move, 1d low
             & ((rsi_3_1h_lt_90) | (stochrsi_k_1d > 10.0))
             # 1h up move, 1h & 4h uptrend
-            & ((rsi_3_1h_lt_90) | (roc_9_1h < 30.0) | (roc_9_4h_lt_30))
+            & ((rsi_3_1h_lt_90) | (roc_9_1h_lt_30) | (roc_9_4h_lt_30))
             # 1h up move, 4h uptrend
             & ((rsi_3_1h_lt_90) | (roc_9_4h_lt_20))
             # 1h up move, 4h still low
@@ -24476,7 +24485,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h up move, 4h low
             & ((rsi_3_1h < 70.0) | (stochrsi_k_4h > 40.0))
             # 1h up move, 1h uptrend
-            & ((rsi_3_1h < 70.0) | (roc_9_1h < 40.0))
+            & ((rsi_3_1h < 70.0) | (roc_9_1h_lt_40))
             # 1h up move, 1h low
             & ((rsi_3_1h < 60.0) | (stochrsi_k_1h_gt_20))
             # 4h up move, 1d still low
@@ -24570,7 +24579,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 5m & 4h strong down move, 4h still not low enough
           short_entry_logic.append((rsi_3 < 95.0) | (rsi_3_1h_lt_95) | (stochrsi_k_4h > 60.0))
           # 5m down move, 1h high, 1d overbought
-          short_entry_logic.append((rsi_3_lt_90) | (roc_9_1h < 15.0) | (roc_9_1d_gt_neg_40))
+          short_entry_logic.append((rsi_3_lt_90) | (roc_9_1h_lt_15) | (roc_9_1d_gt_neg_40))
           # 5m down move, 1h & 4h high
           short_entry_logic.append((rsi_3_lt_90) | (df["UO_7_14_28_1h"] > 40.0) | (stochrsi_k_4h_gt_30))
           # 5m down move, 1h high, 4h downtrend
@@ -24681,7 +24690,7 @@ class NostalgiaForInfinityX7(IStrategy):
           )
           # 4h red, 4h still not low enough, 1h downtrend, 1h overbought
           short_entry_logic.append(
-            (change_pct_4h < 10.0) | (aroond_14_4h < 25.0) | (roc_9_1h < 20.0) | (roc_9_1d_gt_neg_40)
+            (change_pct_4h < 10.0) | (aroond_14_4h < 25.0) | (roc_9_1h_lt_20) | (roc_9_1d_gt_neg_40)
           )
           # 4h red, 4h still high, 1d downtrend
           short_entry_logic.append((change_pct_4h < 10.0) | (stochrsi_k_4h_gt_30) | (roc_9_1d_lt_40))
@@ -24769,7 +24778,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m down move, 1h & 4h still high
           short_entry_logic.append((rsi_3_15m_lt_85) | (stochrsi_k_1h_gt_50) | (stochrsi_k_4h_gt_50))
           # 15m down move, 1h downtrend, 4h still high
-          short_entry_logic.append((rsi_3_15m_lt_90) | (roc_9_1h < 20.0) | (stochrsi_k_4h_gt_50))
+          short_entry_logic.append((rsi_3_15m_lt_90) | (roc_9_1h_lt_20) | (stochrsi_k_4h_gt_50))
           # 15m & 1h down move, 4h high
           short_entry_logic.append((rsi_3_15m_lt_90) | (rsi_3_1h_lt_85) | (stochrsi_k_4h_gt_30))
           # 15m down move, 1h down move, 4h high
@@ -24815,7 +24824,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1h P&D, 4h still high
           short_entry_logic.append((df["ROC_2_1h"] < 10.0) | (roc_9_1h > -5.0) | (stochrsi_k_4h_gt_30))
           # 1h downtrend, 4h down move, 1d downtrend
-          short_entry_logic.append((roc_9_1h < 40.0) | (rsi_3_4h_lt_90) | roc_9_1d_lt_50)
+          short_entry_logic.append((roc_9_1h_lt_40) | (rsi_3_4h_lt_90) | roc_9_1d_lt_50)
           short_entry_logic.append((roc_9_4h > -200.0) | (rsi_14_4h > 20.0))
           # 4h down move, 1d P&D
           short_entry_logic.append((roc_9_4h_lt_20) | (roc_2_1d < 20.0) | roc_9_1d_gt_neg_50)
@@ -24931,7 +24940,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 4h down move, 15m still not high enough, 1d low
           short_entry_logic.append((rsi_3_4h_lt_95) | (stochrsi_k_15m > 80.0) | (df["AROOND_14_1d"] < 75.0))
           # 4h up move, 1h & 4h uptrend
-          short_entry_logic.append((rsi_3_4h_lt_95) | (roc_9_1h < 20.0) | (roc_9_4h_lt_20))
+          short_entry_logic.append((rsi_3_4h_lt_95) | (roc_9_1h_lt_20) | (roc_9_4h_lt_20))
           # 4h up move, 15m low
           short_entry_logic.append((rsi_3_4h_lt_90) | (stochrsi_k_15m > 45.0))
           # 4h up move, 4h & 1d uptrend
@@ -24953,13 +24962,13 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m & 1h high, 4h uptrend
           short_entry_logic.append((aroonu_14_15m_lt_100) | (aroonu_14_1h_lt_100) | (roc_9_4h_lt_20))
           # 15m & 4h high, 1h uptrend
-          short_entry_logic.append((aroonu_14_15m_lt_100) | aroonu_14_4h_lt_100 | (roc_9_1h < 20.0))
+          short_entry_logic.append((aroonu_14_15m_lt_100) | aroonu_14_4h_lt_100 | (roc_9_1h_lt_20))
           # 15m high, 1d low
           short_entry_logic.append((aroonu_14_15m_lt_100) | (stochrsi_k_1d > 20.0))
           # 15m high & uptrend
           short_entry_logic.append((aroonu_14_15m_lt_100) | (roc_9_15m < 30.0))
           # 15m high, 1h & 4h uptrend
-          short_entry_logic.append((aroonu_14_15m_lt_100) | (roc_9_1h < 20.0) | (roc_9_4h_lt_20))
+          short_entry_logic.append((aroonu_14_15m_lt_100) | (roc_9_1h_lt_20) | (roc_9_4h_lt_20))
           # 1h high, 15m uptrend
           short_entry_logic.append((aroonu_14_1h_lt_100) | (roc_9_15m < 20.0))
           # 15m & 4h still not high enough


### PR DESCRIPTION
## Summary
- Reuse repeated `roc_9_1h < ...` comparison masks inside X7 `populate_entry_trend()`.
- Covers repeated 1h ROC entry thresholds while leaving isolated one-off comparisons inline.
- Independent on latest upstream `main`.

## Safety
- Behavior is preserved: this only reuses already-read local Series comparisons inside the same call.
- No indicator formulas, candle selection, order classification, profit arithmetic, thresholds, condition order, return values, or signal behavior are changed.
- Touched function: `populate_entry_trend()`.
- No v3 grind-entry code is touched.

## Backtest scope
- Full backtesting was not required for this patch because it only replaces repeated inline comparisons with equivalent local masks from the same `roc_9_1h` Series.
- Validation focused on static safety, mergeability, and targeted diff review for unchanged thresholds and condition order.

## Checks
- `python3 ~/.codex/skills/nfi-upstream-pr/scripts/validate_nfi_pr.py --base origin/main`
- `git merge-tree` conflict simulation against `origin/main`
- targeted `git diff origin/main...HEAD -- NostalgiaForInfinityX7.py` review
- `git diff --check`
- `ruff format --check NostalgiaForInfinityX7.py`
- `ruff check NostalgiaForInfinityX7.py`
- `PYTHONDONTWRITEBYTECODE=1 python3 -m py_compile NostalgiaForInfinityX7.py`
