### PR TITLE
Reuse X7 entry ROC 4h masks

### DIFF
--- a/NostalgiaForInfinityX7.py
+++ b/NostalgiaForInfinityX7.py
@@ -13122,10 +13122,18 @@ class NostalgiaForInfinityX7(IStrategy):
     roc_9_1h_lt_10 = roc_9_1h < 10.0
     roc_9_4h_gt_neg_30 = roc_9_4h > -30.0
     roc_9_4h_gt_neg_20 = roc_9_4h > -20.0
+    roc_9_4h_lt_5 = roc_9_4h < 5.0
     roc_9_4h_lt_10 = roc_9_4h < 10.0
+    roc_9_4h_lt_15 = roc_9_4h < 15.0
     roc_9_4h_lt_20 = roc_9_4h < 20.0
+    roc_9_4h_lt_25 = roc_9_4h < 25.0
     roc_9_4h_lt_30 = roc_9_4h < 30.0
     roc_9_4h_lt_40 = roc_9_4h < 40.0
+    roc_9_4h_lt_50 = roc_9_4h < 50.0
+    roc_9_4h_lt_60 = roc_9_4h < 60.0
+    roc_9_4h_lt_70 = roc_9_4h < 70.0
+    roc_9_4h_lt_80 = roc_9_4h < 80.0
+    roc_9_4h_lt_100 = roc_9_4h < 100.0
     roc_9_1d_gt_neg_50 = roc_9_1d > -50.0
     roc_9_1d_gt_neg_40 = roc_9_1d > -40.0
     roc_9_1d_gt_neg_30 = roc_9_1d > -30.0
@@ -13304,7 +13312,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 15m still high
             & ((rsi_3_15m_gt_10) | rsi_3_1h_gt_20 | (aroonu_14_15m_lt_50))
             # 15m & 1h down move, 4h overbought
-            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_25) | (roc_9_4h < 80.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_25) | (roc_9_4h_lt_80))
             # 15m & 4h down move, 1h high
             & ((rsi_3_15m_gt_10) | (rsi_3_4h_gt_10) | (aroonu_14_1h_lt_75))
             # 15m & 4h down move, 15m still high
@@ -13340,11 +13348,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 1h & 1d overbought
             & ((rsi_3_15m_gt_10) | (roc_9_1h_lt_10) | (roc_9_1d_lt_80))
             # 15m down move, 4h high
-            & ((rsi_3_15m_gt_10) | (roc_9_4h < 60.0))
+            & ((rsi_3_15m_gt_10) | (roc_9_4h_lt_60))
             # 15m & 1h down move, 1h high
             & ((rsi_3_15m_gt_15) | rsi_3_1h_gt_20 | aroonu_14_1h_lt_80)
             # 15m down move, 15m still high, 4h overbought
-            & ((rsi_3_15m_gt_15) | (rsi_14_15m < 50.0) | (roc_9_4h < 50.0))
+            & ((rsi_3_15m_gt_15) | (rsi_14_15m < 50.0) | (roc_9_4h_lt_50))
             # 15m down move, 15m & 1h high
             & ((rsi_3_15m_gt_15) | (aroonu_14_15m_lt_70) | (aroonu_14_1h_lt_100))
             # 15m down move, 15m & 1h high
@@ -13406,7 +13414,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h high, 4h overbought
             & ((rsi_3_1h_gt_10) | (aroonu_14_1h_lt_70) | (roc_9_4h_lt_10))
             # 1h down move, 4h overbought
-            & ((rsi_3_1h_gt_10) | (roc_9_4h < 50.0))
+            & ((rsi_3_1h_gt_10) | (roc_9_4h_lt_50))
             # 1h & 4h down move, 4h still high
             & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_15) | (aroonu_14_4h_lt_40))
             # 1h & 4h down move, 4h high
@@ -13426,7 +13434,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h & 4h downtrend
             & ((rsi_3_1h_gt_15) | (roc_9_1h > -30.0) | (roc_9_4h_gt_neg_30))
             # 1h & 4h down move, 4h overbought
-            & (rsi_3_1h_gt_20 | (rsi_3_4h_gt_50) | (roc_9_4h < 80.0))
+            & (rsi_3_1h_gt_20 | (rsi_3_4h_gt_50) | (roc_9_4h_lt_80))
             # 1h down move, 1h still high, 4h downtrend
             & (rsi_3_1h_gt_20 | (aroonu_14_1h_lt_40) | (roc_9_4h_gt_neg_30))
             # 1h down move, 4h high, 1d overbought
@@ -13434,7 +13442,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 4h high, 1d overbought
             & (rsi_3_1h_gt_20 | (aroonu_14_4h_lt_90) | (roc_9_1d < 60.0))
             # 1h down move, 4h high & overbought
-            & (rsi_3_1h_gt_20 | aroonu_14_4h_lt_100 | (roc_9_4h < 50.0))
+            & (rsi_3_1h_gt_20 | aroonu_14_4h_lt_100 | (roc_9_4h_lt_50))
             # 1h down move, 1d high & overbought
             & (rsi_3_1h_gt_20 | (stochrsi_k_1d_lt_90) | (roc_9_1d_lt_80))
             # 1h down move, 1h high, 15n downtrend
@@ -13442,7 +13450,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h still high, 1d overbought
             & ((rsi_3_1h_gt_25) | (stochrsi_k_1h_lt_50) | (roc_9_1d_lt_40))
             # 1h down move, 4h & 1d overbought
-            & ((rsi_3_1h_gt_25) | (roc_9_4h < 80.0) | (roc_9_1d_lt_100))
+            & ((rsi_3_1h_gt_25) | (roc_9_4h_lt_80) | (roc_9_1d_lt_100))
             # 1h & 4h down move, 4h downtrend
             & ((rsi_3_1h_gt_30) | (rsi_3_4h_gt_30) | (roc_9_4h_gt_neg_20))
             # 1h down move, 4h high, 1d downtrend
@@ -13538,7 +13546,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1d high, 4h & 1d overbought
             & ((aroonu_14_1d_lt_90) | (roc_9_4h_lt_40) | (roc_9_1d_lt_80))
             # 1h high, 4h overbought
-            & ((stochrsi_k_1h_lt_80) | (roc_9_4h < 80.0))
+            & ((stochrsi_k_1h_lt_80) | (roc_9_4h_lt_80))
             # 4h high, 1h downtrend
             & ((stochrsi_k_4h_lt_70) | (roc_9_1h > -15.0))
             # 4h high, 1d downtrend
@@ -13552,7 +13560,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 5m down move, 4h down move, 15m downtrend, 1h high
             & ((roc_9 > -15.0) | (rsi_3_4h_gt_45) | (cmf_20_15m > -0.3) | (aroonu_14_1h_lt_60))
             # 1h downtrend, 4h high & overbought
-            & ((roc_9_1h > -25.0) | aroonu_14_4h_lt_80 | (roc_9_4h < 80.0))
+            & ((roc_9_1h > -25.0) | aroonu_14_4h_lt_80 | (roc_9_4h_lt_80))
             # 1h & 4h overbought, 1d downtrend
             & ((roc_9_1h < 20.0) | (roc_9_4h_lt_20) | (roc_9_1d_gt_neg_40))
             # 1d P&D, 1d downtrend
@@ -13564,7 +13572,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1d green, 1h down move, 1d downtrend
             & ((change_pct_1d < 40.0) | (rsi_3_1h_gt_25) | (cmf_20_1d > -0.2))
             # 1d green with top wick, 4h overbought
-            & ((change_pct_1d < 50.0) | (top_wick_pct_1d < 30.0) | (roc_9_4h < 80.0))
+            & ((change_pct_1d < 50.0) | (top_wick_pct_1d < 30.0) | (roc_9_4h_lt_80))
             # big drop in the last hour, 15m downtrend
             & ((close > (close_max_12 * 0.65)) | (cmf_20_15m > -0.5))
             # big drop in the last 6 hours, 1h down move, 1h high
@@ -13621,7 +13629,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 5m down move, 4h high, 1d overbought
             & ((rsi_3_gt_3) | aroonu_14_4h_lt_80 | (roc_9_1d_lt_30))
             # 5m down move, 4h high & overbought
-            & ((rsi_3_gt_3) | aroonu_14_4h_lt_100 | (roc_9_4h < 20.0))
+            & ((rsi_3_gt_3) | aroonu_14_4h_lt_100 | (roc_9_4h_lt_20))
             # 5m down move, 4h & 1d overbought
             & ((rsi_3_gt_3) | (roc_9_4h_lt_20) | (roc_9_1d_lt_40))
             # 5m down move, 1d downtrend
@@ -13813,7 +13821,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 4h down move, 1d overbought
             & ((rsi_3_15m_gt_10) | (rsi_3_4h_gt_30) | (roc_9_1d_lt_30))
             # 15m & 4h down move, 4h overbought
-            & ((rsi_3_15m_gt_10) | (rsi_3_4h_gt_55) | (roc_9_4h < 50.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_4h_gt_55) | (roc_9_4h_lt_50))
             # 15m & 1d down move, 1d still high
             & ((rsi_3_15m_gt_10) | (rsi_3_1d_gt_10) | (rsi_14_1d < 40.0))
             # 15m & 1d down move, 1h high
@@ -13871,7 +13879,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 15m & 4h still high
             & ((rsi_3_15m_gt_15) | (aroonu_14_15m_lt_40) | (aroonu_14_4h_lt_40))
             # 15m down move, 1h still high, 4h overbought
-            & ((rsi_3_15m_gt_15) | (aroonu_14_1h_lt_50) | (roc_9_4h < 60.0))
+            & ((rsi_3_15m_gt_15) | (aroonu_14_1h_lt_50) | (roc_9_4h_lt_60))
             # 15m down move, 1h & 4h high
             & ((rsi_3_15m_gt_15) | (aroonu_14_1h_lt_60) | (aroonu_14_4h_lt_90))
             # 15m down move, 1h & 1d high
@@ -13891,7 +13899,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 15m still not low enough
             & ((rsi_3_15m_gt_20) | (rsi_3_1h_gt_20) | (aroonu_14_15m_lt_30))
             # 15m & 1h down move, 4h overbought
-            & ((rsi_3_15m_gt_20) | (rsi_3_1h_gt_20) | (roc_9_4h < 50.0))
+            & ((rsi_3_15m_gt_20) | (rsi_3_1h_gt_20) | (roc_9_4h_lt_50))
             # 15m & 1h down move, 15m high
             & ((rsi_3_15m_gt_20) | (rsi_3_1h_gt_25) | (stochrsi_k_15m_lt_80))
             # 15m & 1h down move, 4h high
@@ -13933,15 +13941,15 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 4h high, 1h overbought
             & ((rsi_3_15m_gt_25) | (aroonu_14_4h_lt_80) | (roc_9_1h < 50.0))
             # 15m down move, 4h high & overbought
-            & ((rsi_3_15m_gt_30) | (aroonu_14_4h_lt_70) | (roc_9_4h < 50.0))
+            & ((rsi_3_15m_gt_30) | (aroonu_14_4h_lt_70) | (roc_9_4h_lt_50))
             # 15m down move, 1h high, 1d downtrend
             & ((rsi_3_15m_gt_30) | (stochrsi_k_1h_lt_80) | (roc_9_1d_gt_neg_20))
             # 15m down move, 4h high & overbought
             & ((rsi_3_15m_gt_30) | (stochrsi_k_4h_lt_80) | (roc_9_4h_lt_30))
             # 15m down move, 1h high, 4h overbought
-            & ((rsi_3_15m_gt_35) | (aroonu_14_1h_lt_80) | (roc_9_4h < 80.0))
+            & ((rsi_3_15m_gt_35) | (aroonu_14_1h_lt_80) | (roc_9_4h_lt_80))
             # 15m down move, 4h high & overbought
-            & ((rsi_3_15m_gt_35) | (aroonu_14_4h_lt_90) | (roc_9_4h < 50.0))
+            & ((rsi_3_15m_gt_35) | (aroonu_14_4h_lt_90) | (roc_9_4h_lt_50))
             # 15m down move, 4h high, 1d overbought
             & ((rsi_3_15m_gt_35) | (aroonu_14_4h_lt_100) | (roc_9_1h < 20.0))
             # 15m down move, 1h high, 1d overbought
@@ -14099,7 +14107,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h high, 1d downtrend
             & ((rsi_3_1h_gt_35) | aroonu_14_1h_lt_70 | (roc_9_1d > -25.0))
             # 1h down move, 4h high & overbought
-            & ((rsi_3_1h_gt_35) | (aroonu_14_4h_lt_85) | (roc_9_4h < 100.0))
+            & ((rsi_3_1h_gt_35) | (aroonu_14_4h_lt_85) | (roc_9_4h_lt_100))
             # 1h down move, 4h high, 1d overbought
             & ((rsi_3_1h_gt_35) | (aroonu_14_4h_lt_85) | (roc_9_1d_lt_100))
             # 1h down move, 1d high, 4h overbought
@@ -14129,9 +14137,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 4h high, 1d downtrend
             & ((rsi_3_1h_gt_50) | (stochrsi_k_4h < 60.0) | (roc_9_1d > -60.0))
             # 1h down move, 4h high & overbought
-            & ((rsi_3_1h_gt_50) | (stochrsi_k_4h_lt_80) | (roc_9_4h < 100.0))
+            & ((rsi_3_1h_gt_50) | (stochrsi_k_4h_lt_80) | (roc_9_4h_lt_100))
             # 1h down move, 1h & 4h overbought
-            & ((rsi_3_1h_gt_50) | (roc_9_1h_lt_10) | (roc_9_4h < 100.0))
+            & ((rsi_3_1h_gt_50) | (roc_9_1h_lt_10) | (roc_9_4h_lt_100))
             # 1h down move, 1h high & overbought
             & ((rsi_3_1h_gt_55) | (aroonu_14_1h_lt_90) | (roc_9_1h_lt_10))
             # 1h down move, 4h high & overbought
@@ -14223,7 +14231,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 4h & 1d overbought
             & ((rsi_3_4h_gt_60) | (roc_9_4h_lt_20) | (roc_9_1d_lt_20))
             # 4h down move, 4h overbought
-            & ((rsi_3_4h_gt_60) | (roc_9_4h < 60.0))
+            & ((rsi_3_4h_gt_60) | (roc_9_4h_lt_60))
             # 1d down move, 1d high, 1d downtrend
             & ((rsi_3_1d_gt_5) | (aroonu_14_1d_lt_80) | (roc_9_1d_gt_neg_20))
             # 1d down move, 1h & 4h still not low enough
@@ -14245,13 +14253,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1d down move, 1h high & overbought
             & ((rsi_3_1d_gt_40) | (aroonu_14_1d_lt_70) | (roc_9_1d_lt_80))
             # 1d down move, 4h high & overbought
-            & ((rsi_3_1d_gt_45) | (stochrsi_k_4h_lt_90) | (roc_9_4h < 60.0))
+            & ((rsi_3_1d_gt_45) | (stochrsi_k_4h_lt_90) | (roc_9_4h_lt_60))
             # 1d down move, 1d still high, 4h still high
             & ((rsi_3_1d_gt_50) | (rsi_14_1d < 50.0) | (stochrsi_k_4h_lt_50))
             # 1d downtrend, 1d high & overbought
             & ((cmf_20_1d > -0.40) | (aroonu_14_1d_lt_85) | (roc_9_1d_lt_20))
             # 1h high, 4h & 1d overbought
-            & (aroonu_14_1h_lt_70 | (roc_9_4h < 50.0) | (roc_9_1d < 200.0))
+            & (aroonu_14_1h_lt_70 | (roc_9_4h_lt_50) | (roc_9_1d < 200.0))
             # 1h & 4h high, 1d overbought
             & (aroonu_14_1h_lt_70 | (aroonu_14_4h_lt_90) | roc_9_1d_lt_50)
             # 1h & 4h high, 1d downtrend
@@ -14275,19 +14283,19 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h still high, 5m downtrend
             & ((aroonu_14_4h_lt_40) | (roc_9 > -40.0))
             # 4h high & overbought
-            & (aroonu_14_4h_lt_70 | (roc_9_4h < 80.0))
+            & (aroonu_14_4h_lt_70 | (roc_9_4h_lt_80))
             # 4h & 1d high, 1d overbought
             & (aroonu_14_4h_lt_80 | aroonu_14_1d_lt_100 | (roc_9_1d_lt_40))
             # 4h high, 1h & 4h overbought
-            & (aroonu_14_4h_lt_100 | (roc_9_1h_lt_10) | (roc_9_4h < 20.0))
+            & (aroonu_14_4h_lt_100 | (roc_9_1h_lt_10) | (roc_9_4h_lt_20))
             # 1d high, 1d downtrend
             & ((aroonu_14_1d_lt_80) | (roc_9_1d_gt_neg_30))
             # 1d high, 1h & 4h downtrend
             & ((aroonu_14_1d_lt_85) | (roc_9_1h > -30.0) | (roc_9_4h > -50.0))
             # 1d high, 4h & 1d overbought
-            & ((aroonu_14_1d_lt_85) | (roc_9_4h < 60.0) | (roc_9_1d < 60.0))
+            & ((aroonu_14_1d_lt_85) | (roc_9_4h_lt_60) | (roc_9_1d < 60.0))
             # 1d high, 1h & 4h down move
-            & (aroonu_14_1d_lt_100 | (roc_9_1h < 25.0) | (roc_9_4h < 60.0))
+            & (aroonu_14_1d_lt_100 | (roc_9_1h < 25.0) | (roc_9_4h_lt_60))
             # 15m high, 1d overbought
             & ((stochrsi_k_15m_lt_70) | (roc_9_1d < 60.0))
             # 1h high, 1d downtrend
@@ -14297,13 +14305,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h high, 4h downtrend
             & ((stochrsi_k_1h_lt_80) | (roc_9_4h_gt_neg_20))
             # 1h high, 4h overbought
-            & ((stochrsi_k_1h_lt_80) | (roc_9_4h < 80.0))
+            & ((stochrsi_k_1h_lt_80) | (roc_9_4h_lt_80))
             # 4h high, 1h & 4h overbought
             & ((stochrsi_k_4h < 80.0) | (roc_9_1h_lt_10) | (roc_9_4h_lt_20))
             # 1d high, 1h & 1d overbought
             & ((stochrsi_k_1d < 80.0) | (roc_9_1h_lt_10) | (roc_9_1d_lt_80))
             # 1d high, 4h & 1d overbought
-            & ((stochrsi_k_1d < 80.0) | (roc_9_4h < 60.0) | (roc_9_1d < 60.0))
+            & ((stochrsi_k_1d < 80.0) | (roc_9_4h_lt_60) | (roc_9_1d < 60.0))
             # big drop in the last 20 days, 1d high, 1d downtrend
             & ((close > (high_max_20_1d * 0.20)) | (stochrsi_k_1d < 70.0) | (roc_9_1d > -15.0))
             # drop in last 20 days, 1h high, 1d downtrend
@@ -14408,7 +14416,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 1h high, 1d overbought
             & ((rsi_3_15m_gt_15) | (stochrsi_k_1h_lt_80) | (roc_9_1d_lt_20))
             # 15m down move, 4h & 1d overbought
-            & ((rsi_3_15m_gt_15) | (roc_9_4h < 25.0) | (roc_9_1d_lt_100))
+            & ((rsi_3_15m_gt_15) | (roc_9_4h_lt_25) | (roc_9_1d_lt_100))
             # 15m & 1h down move, 1h still high
             & ((rsi_3_15m_gt_20) | (rsi_3_1h_gt_25) | (aroonu_14_1h_lt_40))
             # 15m & 1h down move, 1h high
@@ -14434,7 +14442,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m &1d down move, 1d overbought
             & ((rsi_3_15m_gt_20) | (rsi_3_1d > 50.0) | (roc_9_1d_lt_20))
             # 15m down move, 15m still not low enough, 4h overbought
-            & ((rsi_3_15m_gt_20) | (aroonu_14_15m_lt_30) | (roc_9_4h < 60.0))
+            & ((rsi_3_15m_gt_20) | (aroonu_14_15m_lt_30) | (roc_9_4h_lt_60))
             # 15m down move, 15m still high, 4h high
             & ((rsi_3_15m_gt_20) | (aroonu_14_15m_lt_40) | (stochrsi_k_4h_lt_90))
             # 15m down move, 15m still high, 1h high
@@ -14456,9 +14464,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 15m high, 1d overbought
             & ((rsi_3_15m_gt_20) | (aroonu_14_15m_lt_70) | roc_9_1d_lt_50)
             # 15m down move, 1h high, 4h overbought
-            & ((rsi_3_15m_gt_20) | aroonu_14_1h_lt_80 | (roc_9_4h < 20.0))
+            & ((rsi_3_15m_gt_20) | aroonu_14_1h_lt_80 | (roc_9_4h_lt_20))
             # 15m down move, 4h high & overbought
-            & ((rsi_3_15m_gt_20) | aroonu_14_4h_lt_70 | (roc_9_4h < 50.0))
+            & ((rsi_3_15m_gt_20) | aroonu_14_4h_lt_70 | (roc_9_4h_lt_50))
             # 15m down move, 1h high, 4h downtrend
             & ((rsi_3_15m_gt_20) | (stochrsi_k_1h_lt_60) | (roc_9_4h_gt_neg_20))
             # 15m down move, 1h high, 1d overbought
@@ -14470,7 +14478,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 4h high, 1d downtrend
             & ((rsi_3_15m_gt_20) | (stochrsi_k_4h_lt_80) | (roc_9_1d_gt_neg_30))
             # 15m down move, 4h & 1d overbought
-            & ((rsi_3_15m_gt_20) | (roc_9_4h < 25.0) | (roc_9_1d_lt_100))
+            & ((rsi_3_15m_gt_20) | (roc_9_4h_lt_25) | (roc_9_1d_lt_100))
             # 15m & 1h & 4h down move, 15m still not low enough, 4h high
             & ((rsi_3_15m_gt_25) | (rsi_3_1h_gt_30) | (rsi_3_4h_gt_30) | (aroonu_14_15m_lt_30) | (aroonu_14_4h_lt_60))
             # 15m & 1h down move, 15m high
@@ -14508,7 +14516,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 1h high, 4h high
             & ((rsi_3_15m_gt_25) | (stochrsi_k_1h_lt_70) | (aroonu_14_4h_lt_100))
             # 15m down move, 4h & 1d overbought
-            & ((rsi_3_15m_gt_25) | (roc_9_4h < 50.0) | (roc_9_1d_lt_50))
+            & ((rsi_3_15m_gt_25) | (roc_9_4h_lt_50) | (roc_9_1d_lt_50))
             # 15m & 1h down move, 1h high
             & ((rsi_3_15m_gt_30) | (rsi_3_1h_gt_30) | (aroonu_14_1h_lt_80))
             # 15m & 1h down move, 1d overbought
@@ -14528,9 +14536,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 1h high, 1d overbought
             & ((rsi_3_15m_gt_30) | (aroonu_14_1h_lt_100) | (roc_9_1d_lt_30))
             # 15m down move, 4h high & overbought
-            & ((rsi_3_15m_gt_30) | (aroonu_14_4h_lt_70) | (roc_9_4h < 60.0))
+            & ((rsi_3_15m_gt_30) | (aroonu_14_4h_lt_70) | (roc_9_4h_lt_60))
             # 15m down move, 15m high, 4h overbought
-            & ((rsi_3_15m_gt_30) | (stochrsi_k_15m_lt_70) | (roc_9_4h < 70.0))
+            & ((rsi_3_15m_gt_30) | (stochrsi_k_15m_lt_70) | (roc_9_4h_lt_70))
             # 15m down move, 1h high, 1d overbought
             & ((rsi_3_15m_gt_30) | (stochrsi_k_1h_lt_90) | (roc_9_1d_lt_50))
             # 15m & 1h down move, 15m still high, 1h high
@@ -14538,9 +14546,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 15m high, 4h high
             & ((rsi_3_15m_gt_35) | (aroonu_14_15m_lt_60) | (stochrsi_k_4h_lt_90))
             # 15m down move, 15m high, 4h overbought
-            & ((rsi_3_15m_gt_35) | (aroonu_14_15m_lt_70) | (roc_9_4h < 80.0))
+            & ((rsi_3_15m_gt_35) | (aroonu_14_15m_lt_70) | (roc_9_4h_lt_80))
             # 15m down move, 1h high, 4h overbought
-            & ((rsi_3_15m_gt_35) | (aroonu_14_1h_lt_90) | (roc_9_4h < 100.0))
+            & ((rsi_3_15m_gt_35) | (aroonu_14_1h_lt_90) | (roc_9_4h_lt_100))
             # 15m down move, 4h high, 1d overbought
             & ((rsi_3_15m_gt_35) | (aroonu_14_4h_lt_80) | (roc_9_1d < 200.0))
             # 15m down move, 1h high, 1d downtrend
@@ -14562,7 +14570,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 4h still high, 4h downtrend
             & ((rsi_3_1h_gt_10) | (aroonu_14_4h_lt_40) | (roc_9_4h > -20.0))
             # 1h down move, 4h high & overbought
-            & ((rsi_3_1h_gt_10) | aroonu_14_4h_lt_70 | (roc_9_4h < 20.0))
+            & ((rsi_3_1h_gt_10) | aroonu_14_4h_lt_70 | (roc_9_4h_lt_20))
             # 1h & 4h down move, 1d high
             & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_15) | (rsi_14_1d < 60.0))
             # 1h & 4h down move, 15m high
@@ -14642,7 +14650,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h still high, 1d overbought
             & ((rsi_3_1h_gt_40) | (aroonu_14_1h_lt_50) | (roc_9_1d_lt_100))
             # 1h down move, 1h high, 4h overbought
-            & ((rsi_3_1h_gt_40) | aroonu_14_1h_lt_70 | (roc_9_4h < 20.0))
+            & ((rsi_3_1h_gt_40) | aroonu_14_1h_lt_70 | (roc_9_4h_lt_20))
             # 1h down move, 1h high, 1d downtrend
             & ((rsi_3_1h_gt_40) | (aroonu_14_1h_lt_85) | (roc_9_1d > -60.0))
             # 1h down move, 1h & 4h high
@@ -14656,7 +14664,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h high, 4h overbought
             & ((rsi_3_1h_gt_45) | (aroonu_14_1h_lt_100) | (roc_9_4h_lt_20))
             # 1h down move, 4h high & overbought
-            & ((rsi_3_1h_gt_45) | aroonu_14_4h_lt_80 | (roc_9_4h < 20.0))
+            & ((rsi_3_1h_gt_45) | aroonu_14_4h_lt_80 | (roc_9_4h_lt_20))
             # 1h down move, 4h high & overbought
             & ((rsi_3_1h_gt_45) | aroonu_14_4h_lt_80 | (roc_9_4h_lt_40))
             # 1h down move, 1d high & overbought
@@ -14672,7 +14680,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 4h still high, 1d overbought
             & ((rsi_3_1h_gt_50) | (aroonu_14_4h_lt_50) | (roc_9_1d < 200.0))
             # 1h down move, 4h high & overbought
-            & ((rsi_3_1h_gt_50) | aroonu_14_4h_lt_100 | (roc_9_4h < 50.0))
+            & ((rsi_3_1h_gt_50) | aroonu_14_4h_lt_100 | (roc_9_4h_lt_50))
             # 1h down move, 1h & 4h high
             & ((rsi_3_1h_gt_50) | (stochrsi_k_1h_lt_80) | aroonu_14_4h_lt_100)
             # 1h down move, 4h high & overbought
@@ -14682,7 +14690,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h high, 1d downtrend
             & ((rsi_3_1h_gt_55) | (stochrsi_k_1h_lt_80) | (roc_9_1d_gt_neg_30))
             # 1h down move, 4h high & overbought
-            & ((rsi_3_1h_gt_55) | (stochrsi_k_4h_lt_80) | (roc_9_4h < 100.0))
+            & ((rsi_3_1h_gt_55) | (stochrsi_k_4h_lt_80) | (roc_9_4h_lt_100))
             # 1h down move, 1h high, 1d overbought
             & ((rsi_3_1h_gt_60) | (stochrsi_k_1h_lt_80) | (roc_9_1d_lt_100))
             # 1h down move, 15m & 1h high
@@ -15103,11 +15111,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 4h down move, 4h high
             & ((rsi_3_15m_gt_25) | (rsi_3_4h_gt_50) | (stochrsi_k_4h_lt_80))
             # 15m down move, 4h high, 4h overbought
-            & ((rsi_3_15m_gt_25) | (aroonu_14_4h_lt_60) | (roc_9_4h < 50.0))
+            & ((rsi_3_15m_gt_25) | (aroonu_14_4h_lt_60) | (roc_9_4h_lt_50))
             # 15m & 1h down move, 4h high
             & ((rsi_3_15m_gt_30) | (rsi_3_1h_gt_40) | (aroonu_14_4h_lt_85))
             # 15m & 1h down move, 4h overbought
-            & ((rsi_3_15m_gt_40) | (rsi_3_1h_gt_50) | (roc_9_4h < 50.0))
+            & ((rsi_3_15m_gt_40) | (rsi_3_1h_gt_50) | (roc_9_4h_lt_50))
             # 1h & 4h down move, 15m downtrend
             & ((rsi_3_1h_gt_3) | (rsi_3_4h_gt_3) | (roc_9_15m > -30.0))
             # 1h & 4h down move, 15m downtrend
@@ -15275,11 +15283,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h high, 4h & 1d overbought
             & ((aroonu_14_4h_lt_60) | (roc_9_4h_lt_30) | roc_9_1d_lt_50)
             # 4h & 1d high, 4h overbought
-            & (aroonu_14_4h_lt_80 | aroonu_14_1d_lt_100 | (roc_9_4h < 50.0))
+            & (aroonu_14_4h_lt_80 | aroonu_14_1d_lt_100 | (roc_9_4h_lt_50))
             # 4h high, 1h & 1d overbought
             & (aroonu_14_4h_lt_100 | (roc_9_1h < 30.0) | (roc_9_1d < 100.0))
             # 4h high, 1h & 4h high
-            & (aroonu_14_4h_lt_100 | (roc_9_1h < 50.0) | (roc_9_4h < 100.0))
+            & (aroonu_14_4h_lt_100 | (roc_9_1h < 50.0) | (roc_9_4h_lt_100))
             # 1d high, 4h & 1d downtrend
             & ((aroonu_14_1d_lt_70) | (roc_9_4h > -40.0) | (roc_9_1d_gt_neg_40))
             # 1d high, 1h & 1d overbought
@@ -15287,9 +15295,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1d high, 4h & 1d overbought
             & ((aroonu_14_1d_lt_90) | (roc_9_4h_lt_20) | roc_9_1d_lt_50)
             # 1h high, 4h overbought
-            & ((stochrsi_k_1h_lt_80) | (roc_9_4h < 80.0))
+            & ((stochrsi_k_1h_lt_80) | (roc_9_4h_lt_80))
             # 4h & 1d overbought
-            & ((roc_9_4h < 100.0) | (roc_9_1d < 200.0))
+            & ((roc_9_4h_lt_100) | (roc_9_1d < 200.0))
             # big drop in the last 20 days, 1d high, 1d downtrend
             & ((close > (high_max_20_1d * 0.20)) | (stochrsi_k_1d < 70.0) | (roc_9_1d > -15.0))
             # drop in last 20 days, 1h high, 1d downtrend
@@ -15324,7 +15332,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 4h high
             & ((rsi_3_15m_gt_25) | (rsi_3_1h_gt_25) | (stochrsi_k_4h_lt_80))
             # 15m & 1h down move, 4h overbought
-            & ((rsi_3_15m_gt_25) | (rsi_3_1h_gt_30) | (roc_9_4h < 70.0))
+            & ((rsi_3_15m_gt_25) | (rsi_3_1h_gt_30) | (roc_9_4h_lt_70))
             # 15m & 1h down move, 1h high
             & ((rsi_3_15m_gt_25) | (rsi_3_1h_gt_40) | aroonu_14_1h_lt_80)
             # 15m & 1h down move, 1h high
@@ -15354,13 +15362,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 4h high, 1h downtrend
             & ((rsi_3_15m < 30.0) | (aroonu_14_4h_lt_85) | (roc_9_1h > -40.0))
             # 15m down move, 4h high & overbought
-            & ((rsi_3_15m_gt_30) | aroonu_14_4h_lt_100 | (roc_9_4h < 25.0))
+            & ((rsi_3_15m_gt_30) | aroonu_14_4h_lt_100 | (roc_9_4h_lt_25))
             # 15m & 4h down move, 4h high
             & ((rsi_3_15m_gt_35) | (rsi_3_4h_gt_35) | (stochrsi_k_4h_lt_80))
             # 15m down move, 15m high, 4h overbought
             & ((rsi_3_15m_gt_35) | (aroonu_14_15m_lt_70) | (roc_9_4h_lt_10))
             # 15m down move, 1h high, 4h overbought
-            & ((rsi_3_15m_gt_35) | (aroonu_14_1h_lt_85) | (roc_9_4h < 80.0))
+            & ((rsi_3_15m_gt_35) | (aroonu_14_1h_lt_85) | (roc_9_4h_lt_80))
             # 15m down move, 4h high, 1h overbought
             & ((rsi_3_15m_gt_35) | aroonu_14_4h_lt_100 | (roc_9_1h < 20.0))
             # 15m & 1h down move, 1h high
@@ -15406,7 +15414,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h still high, 15m downtrend
             & ((rsi_3_1h_gt_10) | (aroonu_14_1h_lt_40) | (cmf_20_15m > -0.30))
             # 1h down move, 1d high, 4h overbought
-            & ((rsi_3_1h_gt_10) | (aroonu_14_1d_lt_100) | (roc_9_4h < 20.0))
+            & ((rsi_3_1h_gt_10) | (aroonu_14_1d_lt_100) | (roc_9_4h_lt_20))
             # 1h down move, 1h still high, 1d downtrend
             & ((rsi_3_1h_gt_10) | (stochrsi_k_1h_lt_50) | (roc_9_1d_gt_neg_40))
             # 1h down move, 1d high & overbought
@@ -15430,7 +15438,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1d high, 1d downtrend
             & ((rsi_3_1h_gt_15) | (aroonu_14_1d_lt_70) | (roc_9_1d > -20.0))
             # 1h down move, 1d high, 4h overbought
-            & ((rsi_3_1h_gt_15) | (aroonu_14_1d_lt_100) | (roc_9_4h < 60.0))
+            & ((rsi_3_1h_gt_15) | (aroonu_14_1d_lt_100) | (roc_9_4h_lt_60))
             # 1h down move, 1d high & overbought
             & ((rsi_3_1h_gt_15) | (aroonu_14_1d_lt_100) | (roc_9_1d < 10.0))
             # 1h down move, 1h downtrend, 1d overbought
@@ -15458,13 +15466,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h & 4h high
             & ((rsi_3_1h_gt_30) | (aroonu_14_1h_lt_70) | (aroonu_14_4h_lt_85))
             # 1h down move, 1h high, 4h overbought
-            & ((rsi_3_1h_gt_30) | (aroonu_14_1h_lt_70) | (roc_9_4h < 20.0))
+            & ((rsi_3_1h_gt_30) | (aroonu_14_1h_lt_70) | (roc_9_4h_lt_20))
             # 1h & 4h down move, 4h & 1d high, 4h overbought
-            & ((rsi_3_1h_gt_30) | (rsi_3_4h_gt_65) | (aroonu_14_4h_lt_70) | (aroonu_14_1d_lt_100) | (roc_9_4h < 30.0))
+            & ((rsi_3_1h_gt_30) | (rsi_3_4h_gt_65) | (aroonu_14_4h_lt_70) | (aroonu_14_1d_lt_100) | (roc_9_4h_lt_30))
             # 1h down move, 4h high, 1d overbought
             & ((rsi_3_1h_gt_30) | (aroonu_14_4h_lt_80) | (roc_9_1d_lt_30))
             # 1h down move, 4h high & overbought
-            & ((rsi_3_1h_gt_30) | (aroonu_14_4h_lt_90) | (roc_9_4h < 100.0))
+            & ((rsi_3_1h_gt_30) | (aroonu_14_4h_lt_90) | (roc_9_4h_lt_100))
             # 1h down move, 15m still high, 1h high
             & ((rsi_3_1h_gt_30) | (stochrsi_k_15m_lt_40) | (aroonu_14_1h_lt_60))
             # 1h down move, 1h high, 1d downtrend
@@ -15502,7 +15510,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 15m still high, 1h high
             & ((rsi_3_1h_gt_45) | (aroonu_14_15m_lt_50) | (aroonu_14_1h_lt_85))
             # 1h down move, 1h high, 4h overbought
-            & ((rsi_3_1h_gt_45) | aroonu_14_1h_lt_80 | (roc_9_4h < 50.0))
+            & ((rsi_3_1h_gt_45) | aroonu_14_1h_lt_80 | (roc_9_4h_lt_50))
             # 1h down move, 1h high, 1d overbought
             & ((rsi_3_1h_gt_45) | (stochrsi_k_1h_lt_70) | roc_9_1d_lt_50)
             # 1h down move, 1h high, 1d downtrend
@@ -15592,7 +15600,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m high, 1h high & overbought
             & ((aroonu_14_15m_lt_70) | (aroonu_14_1h_lt_85) | (roc_9_1h_lt_10))
             # 4h high, 4h & 1d overbought
-            & (aroonu_14_4h_lt_70 | (roc_9_4h < 60.0) | (roc_9_1d_lt_80))
+            & (aroonu_14_4h_lt_70 | (roc_9_4h_lt_60) | (roc_9_1d_lt_80))
             # 1h & 4h high, 4h overbought
             & (aroonu_14_1h_lt_80 | aroonu_14_4h_lt_100 | (roc_9_4h_lt_10))
             # 1h & 1d high, 1d overbought
@@ -15602,11 +15610,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h still high, 5m downtrend
             & ((aroonu_14_4h_lt_40) | (roc_9 > -40.0))
             # 4h & 1d high, 4h overbought
-            & (aroonu_14_4h_lt_80 | aroonu_14_1d_lt_100 | (roc_9_4h < 80.0))
+            & (aroonu_14_4h_lt_80 | aroonu_14_1d_lt_100 | (roc_9_4h_lt_80))
             # 4h & 1d high, 1d overbought
             & (aroonu_14_4h_lt_80 | aroonu_14_1d_lt_100 | (roc_9_1d_lt_80))
             # 4h high, 1h & 4h overbought
-            & ((aroonu_14_4h_lt_85) | (roc_9_1h < 80.0) | (roc_9_4h < 80.0))
+            & ((aroonu_14_4h_lt_85) | (roc_9_1h < 80.0) | (roc_9_4h_lt_80))
             # 4h high, 4h & 1d overbought
             & ((aroonu_14_4h_lt_85) | (roc_9_4h_lt_10) | (roc_9_1d_lt_40))
             # 4h & 1d high, 4h overbought
@@ -15614,13 +15622,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h high, 1h & 1d overbought
             & (aroonu_14_4h_lt_100 | (roc_9_1h < 40.0) | (roc_9_1d < 100.0))
             # 4h high, 4h & 1d overbought
-            & (aroonu_14_4h_lt_100 | (roc_9_4h < 20.0) | (roc_9_1d_lt_80))
+            & (aroonu_14_4h_lt_100 | (roc_9_4h_lt_20) | (roc_9_1d_lt_80))
             # 1d high, 1h & 4h down move
-            & (aroonu_14_1d_lt_100 | (roc_9_1h < 25.0) | (roc_9_4h < 60.0))
+            & (aroonu_14_1d_lt_100 | (roc_9_1h < 25.0) | (roc_9_4h_lt_60))
             # 1d high, 1h downtrend, 1d overbought
             & (aroonu_14_1d_lt_100 | (roc_9_1h > -30.0) | (roc_9_1d < 100.0))
             # 1d high, 4h & 1d overbought
-            & (aroonu_14_1d_lt_100 | (roc_9_4h < 20.0) | (roc_9_1d_lt_80))
+            & (aroonu_14_1d_lt_100 | (roc_9_4h_lt_20) | (roc_9_1d_lt_80))
             # 15m high, 4h & 1d downtrend
             & ((stochrsi_k_15m_lt_70) | (roc_9_4h_gt_neg_30) | (roc_9_1d_gt_neg_30))
             # 1h high, 4h & 1d overbought
@@ -15628,11 +15636,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h high, 1h overbought, 1d downtrend
             & ((stochrsi_k_4h_lt_80) | (roc_9_1h < 40.0) | (roc_9_1d > -70.0))
             # 4h high, 4h & 1d overbought
-            & ((stochrsi_k_4h_lt_80) | (roc_9_4h < 80.0) | (roc_9_1d_lt_100))
+            & ((stochrsi_k_4h_lt_80) | (roc_9_4h_lt_80) | (roc_9_1d_lt_100))
             # 4h high, 1h & 4h overbought
-            & ((stochrsi_k_4h_lt_90) | (roc_9_1h_lt_10) | (roc_9_4h < 80.0))
+            & ((stochrsi_k_4h_lt_90) | (roc_9_1h_lt_10) | (roc_9_4h_lt_80))
             # 4h high, 1h & 4h overbought
-            & ((stochrsi_k_4h_lt_90) | (roc_9_1h < 20.0) | (roc_9_4h < 50.0))
+            & ((stochrsi_k_4h_lt_90) | (roc_9_1h < 20.0) | (roc_9_4h_lt_50))
             # 1d high, 4h & 1d overbought
             & ((stochrsi_k_1d_lt_90) | (roc_9_4h_lt_40) | (roc_9_1d_lt_100))
             # 1d P&D, dh downtrend
@@ -15705,7 +15713,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 5m down move, 1h & 1d high
             & ((rsi_3_gt_5) | aroonu_14_1h_lt_70 | aroonu_14_1d_lt_100)
             # 5m down move, 4h high & overbought
-            & ((rsi_3_gt_5) | aroonu_14_4h_lt_100 | (roc_9_4h < 25.0))
+            & ((rsi_3_gt_5) | aroonu_14_4h_lt_100 | (roc_9_4h_lt_25))
             # 5m down move, 1h high
             & ((rsi_3_gt_5) | (stochrsi_k_1h_lt_80))
             # 5m & 1d down move, 1d still high
@@ -15975,7 +15983,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 1d high, 4h downtrend
             & ((rsi_3_15m_gt_20) | (aroonu_14_1d_lt_90) | (roc_9_4h_gt_neg_20))
             # 15m down move, 1d high, 4h overbought
-            & ((rsi_3_15m_gt_20) | aroonu_14_1d_lt_100 | (roc_9_4h < 20.0))
+            & ((rsi_3_15m_gt_20) | aroonu_14_1d_lt_100 | (roc_9_4h_lt_20))
             # 15m down move, 1d high, 1d overbought
             & ((rsi_3_15m_gt_20) | aroonu_14_1d_lt_100 | (roc_9_1d_lt_20))
             # 15m down move, 15m high, 4h downtrend
@@ -16021,7 +16029,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 1h & 4h high
             & ((rsi_3_15m_gt_25) | (aroonu_14_1h_lt_90) | (aroonu_14_4h_lt_90))
             # 15m down move, 4h high & overbought
-            & ((rsi_3_15m_gt_25) | aroonu_14_4h_lt_70 | (roc_9_4h < 50.0))
+            & ((rsi_3_15m_gt_25) | aroonu_14_4h_lt_70 | (roc_9_4h_lt_50))
             # 15m down move, 4h high, 1d overbought
             & ((rsi_3_15m_gt_25) | aroonu_14_4h_lt_80 | (roc_9_1d < 100.0))
             # 15m down move, 1h high, 1d downtrend
@@ -16059,11 +16067,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 15m still not low enough, 1h high
             & ((rsi_3_15m_gt_35) | (aroonu_14_15m_lt_25) | (stochrsi_k_1h_lt_80))
             # 15m down move, 1m still high, 4h overbought
-            & ((rsi_3_15m_gt_35) | (aroonu_14_15m_lt_40) | (roc_9_4h < 50.0))
+            & ((rsi_3_15m_gt_35) | (aroonu_14_15m_lt_40) | (roc_9_4h_lt_50))
             # 15m down move, 1h high, 4h overbought
             & ((rsi_3_15m_gt_35) | aroonu_14_1h_lt_80 | (roc_9_4h_lt_10))
             # 15m down move, 4h high & overbought
-            & ((rsi_3_15m_gt_35) | aroonu_14_4h_lt_100 | (roc_9_4h < 70.0))
+            & ((rsi_3_15m_gt_35) | aroonu_14_4h_lt_100 | (roc_9_4h_lt_70))
             # 15m down move, 1h high & overbought
             & ((rsi_3_15m_gt_35) | (stochrsi_k_1h_lt_90) | (roc_9_1h < 40.0))
             # 15m & 1h down move, 4h high
@@ -16131,7 +16139,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h still high, 1d high
             & ((rsi_3_1h_gt_25) | (aroonu_14_1h_lt_40) | (aroonu_14_1d_lt_90))
             # 1h down move, 1h still high, 4h overbought
-            & ((rsi_3_1h_gt_25) | (aroonu_14_1h_lt_50) | (roc_9_4h < 60.0))
+            & ((rsi_3_1h_gt_25) | (aroonu_14_1h_lt_50) | (roc_9_4h_lt_60))
             # 1h down move, 4h high, 1d overbought
             & ((rsi_3_1h_gt_25) | (aroonu_14_4h_lt_40) | (roc_9_1d_lt_100))
             # 1h down move, 1d still high, 1d downtrend
@@ -16149,7 +16157,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 4h & 1d down move
             & ((rsi_3_1h_gt_30) | aroonu_14_4h_lt_70 | aroonu_14_1d_lt_100)
             # 1h down move, 4h high & overbought
-            & ((rsi_3_1h_gt_30) | (aroonu_14_4h_lt_85) | (roc_9_4h < 80.0))
+            & ((rsi_3_1h_gt_30) | (aroonu_14_4h_lt_85) | (roc_9_4h_lt_80))
             # 1h down move, 1d still high, 1d downtrend
             & ((rsi_3_1h_gt_30) | (aroonu_14_1d_lt_40) | (roc_9_1d_gt_neg_20))
             # 1h down move, 1d high, 4h downtrend
@@ -16201,7 +16209,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h high & overbought
             & ((rsi_3_1h_gt_50) | (stochrsi_k_1h_lt_80) | (roc_9_1h_lt_10))
             # 1h down move, 1h & 4h overbought
-            & ((rsi_3_1h_gt_50) | (roc_9_1h_lt_10) | (roc_9_4h < 100.0))
+            & ((rsi_3_1h_gt_50) | (roc_9_1h_lt_10) | (roc_9_4h_lt_100))
             # 1h down move, 4h & 1d overbought
             & ((rsi_3_1h_gt_50) | (roc_9_4h_lt_20) | (roc_9_1d_lt_20))
             # 1h & 4h down move, 1h high
@@ -16223,7 +16231,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h high, 1d overbought
             & ((rsi_3_1h_gt_60) | (stochrsi_k_1h_lt_80) | (roc_9_1d_lt_100))
             # 1h down move, 1h high, 4h overbought
-            & ((rsi_3_1h_gt_65) | aroonu_14_1h_lt_70 | (roc_9_4h < 25.0))
+            & ((rsi_3_1h_gt_65) | aroonu_14_1h_lt_70 | (roc_9_4h_lt_25))
             # 1h down move, 1h high, 1d overbought
             & ((rsi_3_1h_gt_65) | (stochrsi_k_1h_lt_90) | (roc_9_1d_lt_20))
             # 4h down move, 1h still not low enough, 4h downtrend
@@ -16319,7 +16327,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 4h high, 1d overbought
             & ((rsi_3_4h_gt_65) | (aroonu_14_4h_lt_75) | (roc_9_1d_lt_30))
             # 4h down move, 4h high & overbought
-            & ((rsi_3_4h_gt_65) | aroonu_14_4h_lt_80 | (roc_9_4h < 20.0))
+            & ((rsi_3_4h_gt_65) | aroonu_14_4h_lt_80 | (roc_9_4h_lt_20))
             # 1d down move, 1d still not low enough, 1d downtrend
             & ((rsi_3_1d_gt_5) | (aroonu_14_1d < 20.0) | (roc_9_1d_gt_neg_20))
             # 1d down move, 15m still high
@@ -16367,7 +16375,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h high, 4h & 1d overbought
             & ((aroonu_14_1h_lt_90) | (roc_9_4h_lt_10) | (roc_9_1d < 15.0))
             # 4h & 1d high, 4h overbought
-            & (aroonu_14_4h_lt_70 | aroonu_14_1d_lt_100 | (roc_9_4h < 50.0))
+            & (aroonu_14_4h_lt_70 | aroonu_14_1d_lt_100 | (roc_9_4h_lt_50))
             # 4h & 1d high, 1d overbought
             & (aroonu_14_4h_lt_70 | aroonu_14_1d_lt_100 | (roc_9_1d_lt_20))
             # 4h & 1d high, 4h overbought
@@ -16444,7 +16452,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 5m down move, 4h high, 1h overbought
             ((rsi_3_gt_10) | aroonu_14_4h_lt_100 | (roc_9_1h < 30.0))
             # 15m down move, 1h & 4h overbought
-            & ((rsi_3_15m_gt_5) | (roc_9_1h < 25.0) | (roc_9_4h < 50.0))
+            & ((rsi_3_15m_gt_5) | (roc_9_1h < 25.0) | (roc_9_4h_lt_50))
             # 15m & 1h down move, 1d overbought
             & ((rsi_3_15m_gt_10) | rsi_3_1h_gt_20 | (roc_9_1d_lt_80))
             # 15m & 1h down move, 1h high
@@ -16452,13 +16460,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 1h high
             & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_35) | (stochrsi_k_1h_lt_80))
             # 15m & 1h down move, 4h overbought
-            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_45) | (roc_9_4h < 50.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_45) | (roc_9_4h_lt_50))
             # 15m & 1h down move, 4h overbought
-            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_60) | (roc_9_4h < 70.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_60) | (roc_9_4h_lt_70))
             # 15m & 4h down move, 4h high
             & ((rsi_3_15m_gt_10) | (rsi_3_4h_gt_55) | (aroonu_14_4h_lt_90))
             # 15m down move, 4h high & overbought
-            & ((rsi_3_15m_gt_10) | (aroonu_14_4h_lt_100) | (roc_9_4h < 80.0))
+            & ((rsi_3_15m_gt_10) | (aroonu_14_4h_lt_100) | (roc_9_4h_lt_80))
             # 15m down move, 1h high, 1d downtrend
             & ((rsi_3_15m_gt_10) | (stochrsi_k_1h_lt_70) | roc_9_1d_gt_neg_50)
             # 15m down move, 4h high & overbought
@@ -16466,7 +16474,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 1d high, 1d downtrend
             & ((rsi_3_15m_gt_10) | (stochrsi_k_1d < 70.0) | (roc_9_1d > -15.0))
             # 15m & 1h down move, 4h overbought
-            & ((rsi_3_15m_gt_15) | (rsi_3_1h_gt_35) | (roc_9_4h < 100.0))
+            & ((rsi_3_15m_gt_15) | (rsi_3_1h_gt_35) | (roc_9_4h_lt_100))
             # 15m & 1d down move, 1h high
             & ((rsi_3_15m_gt_15) | (rsi_3_1d_gt_35) | (aroonu_14_1h_lt_90))
             # 15m down move, 15m still high, 4h high
@@ -16474,19 +16482,19 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 1h & 4h high
             & ((rsi_3_15m_gt_15) | (aroonu_14_1h_lt_40) | aroonu_14_4h_lt_100)
             # 15m down move, 1h high, 4h overbought
-            & ((rsi_3_15m_gt_15) | (aroonu_14_1h_lt_60) | (roc_9_4h < 80.0))
+            & ((rsi_3_15m_gt_15) | (aroonu_14_1h_lt_60) | (roc_9_4h_lt_80))
             # 15m down move, 4h high, 4h downtrend
             & ((rsi_3_15m_gt_15) | (aroonu_14_4h_lt_90) | (cmf_20_4h > -0.25))
             # 15m down move, 1h & 4h high
-            & ((rsi_3_15m_gt_15) | (roc_9_1h < 30.0) | (roc_9_4h < 50.0))
+            & ((rsi_3_15m_gt_15) | (roc_9_1h < 30.0) | (roc_9_4h_lt_50))
             # 15m down move, 4h & 1d overbought
-            & ((rsi_3_15m_gt_15) | (roc_9_4h < 60.0) | (roc_9_1d_lt_80))
+            & ((rsi_3_15m_gt_15) | (roc_9_4h_lt_60) | (roc_9_1d_lt_80))
             # 15m down move, 1h & 4h high
             & ((rsi_3_15m_gt_20) | (aroonu_14_1h_lt_60) | aroonu_14_4h_lt_100)
             # 15m down move, 4h high, 1h overbought
             & ((rsi_3_15m_gt_20) | (stochrsi_k_4h_lt_80) | (roc_9_1h_lt_10))
             # 15m down move, 4h & 1d overbought
-            & ((rsi_3_15m_gt_20) | (roc_9_4h < 80.0) | (roc_9_1d < 200.0))
+            & ((rsi_3_15m_gt_20) | (roc_9_4h_lt_80) | (roc_9_1d < 200.0))
             # 15m & 1h down move, 1d overbought
             & ((rsi_3_15m_gt_25) | (rsi_3_1h_gt_25) | (roc_9_1d_lt_80))
             # 15m & 1h down move, 1h high
@@ -16508,29 +16516,29 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 4h high & overbought
             & ((rsi_3_15m_gt_30) | (stochrsi_k_4h_lt_90) | (roc_9_4h < 200.0))
             # 15m down move, 1h & 4h overbought
-            & ((rsi_3_15m_gt_30) | (roc_9_1h < 60.0) | (roc_9_4h < 80.0))
+            & ((rsi_3_15m_gt_30) | (roc_9_1h < 60.0) | (roc_9_4h_lt_80))
             # 15m down move, 4h & 1d overbought
-            & ((rsi_3_15m_gt_40) | (roc_9_4h < 100.0) | (roc_9_1d_lt_100))
+            & ((rsi_3_15m_gt_40) | (roc_9_4h_lt_100) | (roc_9_1d_lt_100))
             # 1h down move, 4h overbought, 1d downtrend
-            & ((rsi_3_1h_gt_15) | (roc_9_4h < 50.0) | (roc_9_1d > -30.0))
+            & ((rsi_3_1h_gt_15) | (roc_9_4h_lt_50) | (roc_9_1d > -30.0))
             # 1h & 4h down move, 4h high
-            & ((rsi_3_1h_gt_20) | (roc_9_4h < 50.0) | aroonu_14_4h_lt_80)
+            & ((rsi_3_1h_gt_20) | (roc_9_4h_lt_50) | aroonu_14_4h_lt_80)
             # 1h & 4h down move, 1h still high
-            & ((rsi_3_1h_gt_20) | (roc_9_4h < 50.0) | (stochrsi_k_1h_lt_40))
+            & ((rsi_3_1h_gt_20) | (roc_9_4h_lt_50) | (stochrsi_k_1h_lt_40))
             # 1h & 4h down move, 4h overbought
-            & ((rsi_3_1h_gt_20) | (roc_9_4h < 50.0) | (roc_9_4h_lt_10))
+            & ((rsi_3_1h_gt_20) | (roc_9_4h_lt_50) | (roc_9_4h_lt_10))
             # 1h down move, 1h & 4h high
             & ((rsi_3_1h_gt_20) | (aroonu_14_1h_lt_80) | (aroonu_14_4h_lt_100))
             # 1h down move, 4h high & overbought
             & ((rsi_3_1h_gt_20) | (aroonu_14_4h_lt_80) | (roc_9_4h_lt_10))
             # 1h down move, 4h high & overbought
-            & ((rsi_3_1h_gt_20) | (aroonu_14_4h_lt_100) | (roc_9_4h < 50.0))
+            & ((rsi_3_1h_gt_20) | (aroonu_14_4h_lt_100) | (roc_9_4h_lt_50))
             # 1h down move, 1h still high, 1d overbought
             & ((rsi_3_1h_gt_20) | (stochrsi_k_1h_lt_40) | (roc_9_4h_lt_10))
             # 1h down move, 4h & 1d overbought
             & ((rsi_3_1h_gt_20) | (roc_9_4h_lt_40) | (roc_9_1d_lt_100))
             # 1h down move, 1d high, 4h overbought
-            & ((rsi_3_1h_gt_25) | aroonu_14_1d_lt_100 | (roc_9_4h < 60.0))
+            & ((rsi_3_1h_gt_25) | aroonu_14_1d_lt_100 | (roc_9_4h_lt_60))
             # 1h down move, 4h high & overbought
             & ((rsi_3_1h_gt_30) | aroonu_14_4h_lt_80 | (roc_9_4h_lt_30))
             # 1h down move, 1h high, 1d downtrend
@@ -16540,7 +16548,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h & 1d overbought
             & ((rsi_3_1h_gt_40) | (roc_9_1h < 30.0) | (roc_9_1d < 60.0))
             # 1h down move, 1h high, 4h overbought
-            & ((rsi_3_1h_gt_45) | aroonu_14_1h_lt_80 | (roc_9_4h < 25.0))
+            & ((rsi_3_1h_gt_45) | aroonu_14_1h_lt_80 | (roc_9_4h_lt_25))
             # 1h down move, 4h high, 1h overbought
             & ((rsi_3_1h_gt_45) | (aroonu_14_4h_lt_90) | (roc_9_1h < 20.0))
             # 1h down move, 4h high, 1h overbought
@@ -16556,9 +16564,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h high, 4h overbought
             & ((rsi_3_1h_gt_55) | aroonu_14_1h_lt_70 | (roc_9_4h_lt_40))
             # 1h down move, 4h high & overbought
-            & ((rsi_3_1h_gt_55) | (aroonu_14_4h_lt_85) | (roc_9_4h < 80.0))
+            & ((rsi_3_1h_gt_55) | (aroonu_14_4h_lt_85) | (roc_9_4h_lt_80))
             # 1h down move, 4h high & overbought
-            & ((rsi_3_1h_gt_60) | aroonu_14_4h_lt_80 | (roc_9_4h < 100.0))
+            & ((rsi_3_1h_gt_60) | aroonu_14_4h_lt_80 | (roc_9_4h_lt_100))
             # 1h down move, 1h & 1d overbought
             & ((rsi_3_1h_gt_60) | (roc_9_1h_lt_10) | (roc_9_1d < 250.0))
             # 1h down move, 1h high, 4h overbought
@@ -16568,7 +16576,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 1h high & overbought
             & ((rsi_3_4h_gt_3) | (aroonu_14_1h_lt_85) | (roc_9_1h < 60.0))
             # 1d down move, 4h high & overbought
-            & ((rsi_3_1d_gt_5) | (aroonu_14_4h_lt_90) | (roc_9_4h < 50.0))
+            & ((rsi_3_1d_gt_5) | (aroonu_14_4h_lt_90) | (roc_9_4h_lt_50))
             # 1d down move, 1h high
             & ((rsi_3_1d_gt_10) | aroonu_14_1h_lt_70)
             # 1d down move, 4h high, 1h overbought
@@ -16576,9 +16584,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1d down move, 4h high, 4h overbought
             & ((rsi_3_1d_gt_20) | aroonu_14_4h_lt_100 | (roc_9_4h_lt_40))
             # 1d down move, 1h & 4h overbought
-            & ((rsi_3_1d_gt_30) | (roc_9_1h < 30.0) | (roc_9_4h < 60.0))
+            & ((rsi_3_1d_gt_30) | (roc_9_1h < 30.0) | (roc_9_4h_lt_60))
             # 1d down move, 4h high & overbought
-            & ((rsi_3_1d_gt_35) | aroonu_14_4h_lt_100 | (roc_9_4h < 20.0))
+            & ((rsi_3_1d_gt_35) | aroonu_14_4h_lt_100 | (roc_9_4h_lt_20))
             # 1d down move, 1h & 4h high
             & ((rsi_3_1d_gt_40) | aroonu_14_1h_lt_80 | aroonu_14_4h_lt_100)
             # 1d down move, 4h & 1d high
@@ -16596,7 +16604,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h still high, 1h & 4h overbought
             & ((aroonu_14_1h_lt_50) | (roc_9_1h < 40.0) | (roc_9_4h_lt_40))
             # 1h & 4h high, 4h overbought
-            & (aroonu_14_1h_lt_70 | aroonu_14_4h_lt_100 | (roc_9_4h < 20.0))
+            & (aroonu_14_1h_lt_70 | aroonu_14_4h_lt_100 | (roc_9_4h_lt_20))
             # 1h & 4h high, 4h overbought
             & (aroonu_14_1h_lt_80 | aroonu_14_4h_lt_80 | (roc_9_4h_lt_30))
             # 1h & 4h high, 1h overbought
@@ -16624,7 +16632,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h & 1d high, 1h overbought
             & ((aroonu_14_4h_lt_85) | (aroonu_14_1d_lt_90) | (roc_9_1h < 20.0))
             # 4h & 1d high, 4h overbought
-            & ((aroonu_14_4h_lt_85) | (aroonu_14_1d_lt_90) | (roc_9_4h < 60.0))
+            & ((aroonu_14_4h_lt_85) | (aroonu_14_1d_lt_90) | (roc_9_4h_lt_60))
             # 4h high, 1h & 4h overbought
             & ((aroonu_14_4h_lt_85) | (roc_9_1h_lt_10) | (roc_9_4h_lt_20))
             # 4h high, 1d high & overbought
@@ -16634,9 +16642,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h high, 4h & 1d overbought
             & ((aroonu_14_4h_lt_90) | (roc_9_4h_lt_30) | (roc_9_1d_lt_100))
             # 4h high, 1h & 4h overbought
-            & (aroonu_14_4h_lt_100 | (roc_9_1h < 40.0) | (roc_9_4h < 80.0))
+            & (aroonu_14_4h_lt_100 | (roc_9_1h < 40.0) | (roc_9_4h_lt_80))
             # 1d high, 1h & 4h overbought
-            & (aroonu_14_1d_lt_100 | (roc_9_1h_lt_10) | (roc_9_4h < 20.0))
+            & (aroonu_14_1d_lt_100 | (roc_9_1h_lt_10) | (roc_9_4h_lt_20))
             # 1h high, 1h & 4h overbought
             & ((stochrsi_k_1h_lt_60) | (roc_9_1h < 40.0) | (roc_9_4h_lt_40))
             # 1h high, 1h overbought
@@ -16752,7 +16760,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 5m down move, 4h high, 1d downtrend
             & ((rsi_3_15m_gt_5) | (stochrsi_k_4h_lt_80) | (roc_9_1d_gt_neg_40))
             # 15m down move, 1h & 4h overbought
-            & ((rsi_3_15m_gt_5) | (roc_9_1h < 25.0) | (roc_9_4h < 25.0))
+            & ((rsi_3_15m_gt_5) | (roc_9_1h < 25.0) | (roc_9_4h_lt_25))
             # 15m down move, 4h & 1d overbought
             & ((rsi_3_15m_gt_5) | (roc_9_4h_lt_30) | (roc_9_1d_lt_100))
             # 15m & 1h down move, 1h high
@@ -16842,7 +16850,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 1d high, 4h overbought
             & ((rsi_3_15m_gt_15) | (stochrsi_k_1d_lt_90) | (roc_9_4h_lt_40))
             # 15m down move, 1h downtrend, 4h overbought
-            & ((rsi_3_15m_gt_15) | (roc_9_1h > -20.0) | (roc_9_4h < 80.0))
+            & ((rsi_3_15m_gt_15) | (roc_9_1h > -20.0) | (roc_9_4h_lt_80))
             # 15m down move, 4h & 1d downtrend
             & ((rsi_3_15m_gt_15) | (roc_9_4h > -10.0) | (roc_9_1d_gt_neg_40))
             # 15m & 1h down move, 1h high
@@ -16878,7 +16886,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 1h high, 4h overbought
             & ((rsi_3_15m_gt_25) | (aroonu_14_1h_lt_90) | (roc_9_4h_lt_30))
             # 15m down move, 1h high, 4h overbought
-            & ((rsi_3_15m_gt_25) | (aroonu_14_1h_lt_100) | (roc_9_4h < 15.0))
+            & ((rsi_3_15m_gt_25) | (aroonu_14_1h_lt_100) | (roc_9_4h_lt_15))
             # 15m down move, 1h high, 1d overbought
             & ((rsi_3_15m_gt_25) | (aroonu_14_1h_lt_100) | (roc_9_1d_lt_20))
             # 15m down move, 4h high & overbought
@@ -16974,7 +16982,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1d downtrend, 4h high
             & ((rsi_3_1h_gt_10) | (cmf_20_1d > -0.30) | (stochrsi_k_4h_lt_90))
             # 1h down move, 1h still high, 4h overbought
-            & ((rsi_3_1h_gt_10) | (aroonu_14_1h_lt_50) | (roc_9_4h < 20.0))
+            & ((rsi_3_1h_gt_10) | (aroonu_14_1h_lt_50) | (roc_9_4h_lt_20))
             # 1h down move, 1h & 4h high
             & ((rsi_3_1h_gt_10) | (aroonu_14_1h_lt_60) | (aroonu_14_4h_lt_60))
             # 1h down move, 1h high, 1d high
@@ -17020,7 +17028,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 4h still not low enough, 1d downtrend
             & ((rsi_3_1h_gt_15) | (stochrsi_k_4h_lt_30) | (roc_9_1d > -30.0))
             # 1h down move, 4h high & overbought
-            & ((rsi_3_1h_gt_15) | (stochrsi_k_4h_lt_80) | (roc_9_4h < 100.0))
+            & ((rsi_3_1h_gt_15) | (stochrsi_k_4h_lt_80) | (roc_9_4h_lt_100))
             # 1h down move, 1h downtrend, 1d overbought
             & ((rsi_3_1h_gt_15) | (roc_9_1h > -30.0) | (roc_9_1d < 35.0))
             # 1h down move, 4h downtrend, 1d overbought
@@ -17060,7 +17068,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h & 1d high
             & ((rsi_3_1h_gt_25) | aroonu_14_1h_lt_70 | (aroonu_14_1d_lt_90))
             # 1h down move, 1h high, 4h overbought
-            & ((rsi_3_1h_gt_25) | aroonu_14_1h_lt_80 | (roc_9_4h < 20.0))
+            & ((rsi_3_1h_gt_25) | aroonu_14_1h_lt_80 | (roc_9_4h_lt_20))
             # 1h down move, 1h high, 1d overbought
             & ((rsi_3_1h_gt_25) | (aroonu_14_1h_lt_85) | roc_9_1d_lt_50)
             # 1h down move, 4h high
@@ -17074,9 +17082,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h & 1d downtrend
             & ((rsi_3_1h_gt_25) | (roc_9_1h > -50.0) | roc_9_1d_gt_neg_50)
             # 1h down move, 1h downtrend, 4h overbought
-            & ((rsi_3_1h_gt_25) | (roc_9_1h > -25.0) | (roc_9_4h < 50.0))
+            & ((rsi_3_1h_gt_25) | (roc_9_1h > -25.0) | (roc_9_4h_lt_50))
             # 1h down move, 1h & 4h overbought
-            & ((rsi_3_1h_gt_25) | (roc_9_1h < 30.0) | (roc_9_4h < 100.0))
+            & ((rsi_3_1h_gt_25) | (roc_9_1h < 30.0) | (roc_9_4h_lt_100))
             # 1h & 4h down move, 1h high
             & ((rsi_3_1h_gt_30) | (rsi_3_4h_gt_30) | (aroonu_14_1h_lt_90))
             # 1h & 4h down move, 4h downtrend
@@ -17110,11 +17118,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 4h high, 1d overbought
             & ((rsi_3_1h_gt_35) | aroonu_14_4h_lt_70 | (roc_9_1d < 200.0))
             # 1h down move, 4h high & overbought
-            & ((rsi_3_1h_gt_35) | aroonu_14_4h_lt_100 | (roc_9_4h < 20.0))
+            & ((rsi_3_1h_gt_35) | aroonu_14_4h_lt_100 | (roc_9_4h_lt_20))
             # 1h down move, 4h high & overbought
             & ((rsi_3_1h_gt_35) | (stochrsi_k_4h_lt_80) | (roc_9_4h_lt_30))
             # 1h down move, 1h downtrend, 4h overbought
-            & ((rsi_3_1h_gt_35) | (roc_9_1h > -30.0) | (roc_9_4h < 100.0))
+            & ((rsi_3_1h_gt_35) | (roc_9_1h > -30.0) | (roc_9_4h_lt_100))
             # 1h down move, 4h & 1d overbought
             & ((rsi_3_1h_gt_35) | (roc_9_4h_lt_20) | (roc_9_1d < 70.0))
             # 1h down move, 1h & 4h high
@@ -17134,7 +17142,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h high, 1d overbought
             & ((rsi_3_1h_gt_45) | (aroonu_14_1h_lt_100) | (roc_9_1d < 200.0))
             # 1h down move, 4h high & overbought
-            & ((rsi_3_1h_gt_45) | (stochrsi_k_4h_lt_80) | (roc_9_4h < 100.0))
+            & ((rsi_3_1h_gt_45) | (stochrsi_k_4h_lt_80) | (roc_9_4h_lt_100))
             # 1h down move, 1h high, 1d downtrend
             & ((rsi_3_1h_gt_50) | (aroonu_14_1h_lt_60) | (roc_9_1d > -70.0))
             # 1h down move, 1h high, 1d overbought
@@ -17256,11 +17264,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h & 1d high, 4h overbought
             & (aroonu_14_4h_lt_80 | aroonu_14_1d_lt_100 | (roc_9_4h_lt_30))
             # 4h high, 4h & 1d overbought
-            & (aroonu_14_4h_lt_80 | (roc_9_4h < 20.0) | (roc_9_1d_lt_20))
+            & (aroonu_14_4h_lt_80 | (roc_9_4h_lt_20) | (roc_9_1d_lt_20))
             # 4h high, 15m downtrend, 4h overbought
             & (aroonu_14_4h_lt_100 | (roc_9_15m > -30.0) | (roc_9_4h_lt_30))
             # 4h high, 1h & 4h overbought
-            & (aroonu_14_4h_lt_100 | (roc_9_1h < 30.0) | (roc_9_4h < 70.0))
+            & (aroonu_14_4h_lt_100 | (roc_9_1h < 30.0) | (roc_9_4h_lt_70))
             # 4h & 1d high, 1h overbought
             & (aroonu_14_4h_lt_100 | aroonu_14_1d_lt_100 | (roc_9_1h < 50.0))
             # 1d still high, 4h & 1d downtrend
@@ -17274,13 +17282,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h high, 1d overbought
             & ((stochrsi_k_1h_lt_70) | (roc_9_1d_lt_40))
             # 1h high, 4h overbought
-            & ((stochrsi_k_1h_lt_80) | (roc_9_4h < 80.0))
+            & ((stochrsi_k_1h_lt_80) | (roc_9_4h_lt_80))
             # 1h high, 1h overbought, 4h downtrend
             & ((stochrsi_k_1h_lt_90) | (roc_9_1h_lt_10) | (roc_9_4h > -15.0))
             # 4h high, 1h & 4h overbought
-            & ((stochrsi_k_4h_lt_90) | (roc_9_1h < 20.0) | (roc_9_4h < 50.0))
+            & ((stochrsi_k_4h_lt_90) | (roc_9_1h < 20.0) | (roc_9_4h_lt_50))
             # 1d high, 4h & 1d overbought
-            & ((stochrsi_k_1d_lt_90) | (roc_9_4h < 100.0) | (roc_9_1d_lt_100))
+            & ((stochrsi_k_1d_lt_90) | (roc_9_4h_lt_100) | (roc_9_1d_lt_100))
             # 1d P&D, 4h overbought
             & ((change_pct_1d > -10.0) | (change_pct_1d.shift(288) < 30.0) | (roc_9_4h_lt_10))
             # big drop in the last 20 days, 1d high, 1d downtrend
@@ -17622,7 +17630,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 4h high & overbought
             & ((rsi_3_1h_gt_40) | (stochrsi_k_4h_lt_70) | (roc_9_4h_lt_40))
             # 1h down move, 4h high & overbought
-            & ((rsi_3_1h_gt_45) | aroonu_14_4h_lt_80 | (roc_9_4h < 100.0))
+            & ((rsi_3_1h_gt_45) | aroonu_14_4h_lt_80 | (roc_9_4h_lt_100))
             # 1h down move, 4h high & overbought
             & ((rsi_3_1h_gt_50) | aroonu_14_4h_lt_100 | (roc_9_4h_lt_40))
             # 1h down move, 1d high & overbought
@@ -17774,7 +17782,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 4h overbought, 1d downtrend
             & ((rsi_3_4h_gt_40) | (roc_9_4h_lt_10) | (roc_9_1d_gt_neg_40))
             # 4h down move, 4h & 1d overbought
-            & ((rsi_3_4h_gt_40) | (roc_9_4h < 60.0) | (roc_9_1d_lt_80))
+            & ((rsi_3_4h_gt_40) | (roc_9_4h_lt_60) | (roc_9_1d_lt_80))
             # 4h down move, 4h & 1d high
             & ((rsi_3_4h_gt_45) | aroonu_14_4h_lt_80 | aroonu_14_1d_lt_100)
             # 4h down move, 4h overbought
@@ -17802,7 +17810,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h & 1d downtrend, 1d high
             & ((cmf_20_4h > -0.50) | (cmf_20_1d > -0.50) | (aroonu_14_1d_lt_85))
             # 15m & 1d high, 4h overbought
-            & ((aroonu_14_15m_lt_70) | aroonu_14_1d_lt_100 | (roc_9_4h < 20.0))
+            & ((aroonu_14_15m_lt_70) | aroonu_14_1d_lt_100 | (roc_9_4h_lt_20))
             # 15m & 4h high, 1d downtrend
             & ((aroonu_14_15m_lt_85) | (aroonu_14_4h_lt_85) | (roc_9_1d_gt_neg_20))
             # 1h still high, 1h & 4h downtrend
@@ -17869,7 +17877,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 5m down move, 1h & 4h high
             & ((rsi_3_gt_3) | aroonu_14_1h_lt_80 | aroonu_14_4h_lt_100)
             # 5m down move, 4h high & overbought
-            & ((rsi_3_gt_3) | aroonu_14_4h_lt_100 | (roc_9_4h < 20.0))
+            & ((rsi_3_gt_3) | aroonu_14_4h_lt_100 | (roc_9_4h_lt_20))
             # 5m down move, 1h high, 4h overbought
             & ((rsi_3_gt_3) | (stochrsi_k_1h_lt_80) | (roc_9_4h_lt_20))
             # 5m down move, 1d high & overbought
@@ -17927,7 +17935,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1d down move, 1d high
             & ((rsi_3_15m_gt_3) | (rsi_3_1d_gt_45) | (aroonu_14_1d_lt_70))
             # 15m down move, 4h high & overbought
-            & ((rsi_3_15m_gt_3) | (aroonu_14_4h_lt_90) | (roc_9_4h < 100.0))
+            & ((rsi_3_15m_gt_3) | (aroonu_14_4h_lt_90) | (roc_9_4h_lt_100))
             # 15m down move, 1d high & overbought
             & ((rsi_3_15m_gt_3) | (aroonu_14_1d_lt_100) | (roc_9_1d_lt_40))
             # 15m down move, 1h high, 1d downtrend
@@ -17937,7 +17945,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 4h high, 1d overbought
             & ((rsi_3_15m_gt_3) | (stochrsi_k_4h_lt_80) | (roc_9_1d < 10.0))
             # 15m down move, 1h downtrend, 4h overbought
-            & ((rsi_3_15m_gt_3) | (roc_9_1h > -30.0) | (roc_9_4h < 100.0))
+            & ((rsi_3_15m_gt_3) | (roc_9_1h > -30.0) | (roc_9_4h_lt_100))
             # 15m down move, 4h & 1d downtrend
             & ((rsi_3_15m_gt_3) | (roc_9_4h > -70.0) | (roc_9_1d > -70.0))
             # 15m & 1h down move, 4h still high
@@ -17973,7 +17981,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 1h high, 4h overbought
             & ((rsi_3_15m_gt_5) | (aroonu_14_1h_lt_80) | (roc_9_4h_lt_10))
             # 15m down move, 4h high & overbought
-            & ((rsi_3_15m_gt_5) | (aroonu_14_4h_lt_80) | (roc_9_4h < 50.0))
+            & ((rsi_3_15m_gt_5) | (aroonu_14_4h_lt_80) | (roc_9_4h_lt_50))
             # 15m down move, 1d still high, 1d downtrend
             & ((rsi_3_15m_gt_5) | (stochrsi_k_1d < 50.0) | (roc_9_1d_gt_neg_20))
             # 15m down move, 1d downtrend
@@ -18073,7 +18081,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 1h high, 4h downtrend
             & ((rsi_3_15m_gt_15) | (stochrsi_k_1h_lt_70) | (roc_9_4h_gt_neg_30))
             # 15m down move, 4h high & overbought
-            & ((rsi_3_15m_gt_15) | (stochrsi_k_4h_lt_90) | (roc_9_4h < 25.0))
+            & ((rsi_3_15m_gt_15) | (stochrsi_k_4h_lt_90) | (roc_9_4h_lt_25))
             # 15m down move, 4h high, 1d downtrend
             & ((rsi_3_15m_gt_15) | (stochrsi_k_4h_lt_90) | (roc_9_1d_gt_neg_40))
             # 15m down move, 4h high, 1d overbought
@@ -18201,7 +18209,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h high & overbought
             & ((rsi_3_1h_gt_25) | (aroonu_14_1h_lt_80) | (roc_9_1h_lt_10))
             # 1h down move, 1h high, 4h overbought
-            & ((rsi_3_1h_gt_25) | (aroonu_14_1h_lt_80) | (roc_9_4h < 50.0))
+            & ((rsi_3_1h_gt_25) | (aroonu_14_1h_lt_80) | (roc_9_4h_lt_50))
             # 1h down move, 4h & 1d high
             & ((rsi_3_1h_gt_25) | (aroonu_14_4h_lt_90) | (aroonu_14_1d_lt_100))
             # 1h down move, 1d high, 4h downtrend
@@ -18307,7 +18315,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h downtrend, 1h & 4h high
             & ((cmf_20_4h > -0.30) | aroonu_14_1h_lt_70 | aroonu_14_4h_lt_100)
             # 15m still high, 1h & 4h overbought
-            & ((aroonu_14_15m_lt_50) | (roc_9_1h < 100.0) | (roc_9_4h < 100.0))
+            & ((aroonu_14_15m_lt_50) | (roc_9_1h < 100.0) | (roc_9_4h_lt_100))
             # 15m & 1d high, 1d overbought
             & ((aroonu_14_15m_lt_70) | (aroonu_14_1d_lt_90) | (roc_9_1d_lt_30))
             # 1h still high, 4h & 1d downtrend
@@ -18325,15 +18333,15 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h high, 1d downtrend
             & (aroonu_14_1h_lt_80 | (roc_9_1d > -60.0))
             # 1h high, 1h & 4h overbought
-            & ((aroonu_14_1h_lt_100) | (roc_9_1h < 100.0) | (roc_9_4h < 100.0))
+            & ((aroonu_14_1h_lt_100) | (roc_9_1h < 100.0) | (roc_9_4h_lt_100))
             # 4h & 1d high, 1d overbought
             & ((aroonu_14_4h_lt_60) | aroonu_14_1d_lt_100 | (roc_9_1d < 70.0))
             # 4h high, 1h & 4h overbought
-            & ((aroonu_14_4h_lt_85) | (roc_9_1h < 80.0) | (roc_9_4h < 80.0))
+            & ((aroonu_14_4h_lt_85) | (roc_9_1h < 80.0) | (roc_9_4h_lt_80))
             # 4h high, 1h downtrend, 4h overbought
-            & ((aroonu_14_4h_lt_90) | (roc_9_1h > -40.0) | (roc_9_4h < 100.0))
+            & ((aroonu_14_4h_lt_90) | (roc_9_1h > -40.0) | (roc_9_4h_lt_100))
             # 4h & 1d high, 4h overbought
-            & ((aroonu_14_4h_lt_90) | aroonu_14_1d_lt_100 | (roc_9_4h < 100.0))
+            & ((aroonu_14_4h_lt_90) | aroonu_14_1d_lt_100 | (roc_9_4h_lt_100))
             # 4h high, 1h & 4h overbought
             & ((aroonu_14_4h_lt_90) | (roc_9_1h_lt_10) | (roc_9_4h_lt_20))
             # 4h & 1d high, 4h overbought
@@ -18343,19 +18351,19 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1d high, 1h & 4h downtrend
             & (aroonu_14_1d_lt_100 | (roc_9_1h > -30.0) | (roc_9_4h_gt_neg_30))
             # 1d high, 4h & 1d overbought
-            & (aroonu_14_1d_lt_100 | (roc_9_4h < 20.0) | (roc_9_1d < 100.0))
+            & (aroonu_14_1d_lt_100 | (roc_9_4h_lt_20) | (roc_9_1d < 100.0))
             # 1h high, 1d overbought
             & ((stochrsi_k_1h_lt_70) | (roc_9_1d_lt_40))
             # 1h high, 4h overbought
-            & ((stochrsi_k_1h_lt_80) | (roc_9_4h < 80.0))
+            & ((stochrsi_k_1h_lt_80) | (roc_9_4h_lt_80))
             # 1h high, 4h & 1d downtrend
             & ((stochrsi_k_1h < 85.0) | (roc_9_4h > -70.0) | (roc_9_1d > -70.0))
             # 4h high, 1h & 4h overbought
-            & ((stochrsi_k_4h_lt_80) | (roc_9_1h < 40.0) | (roc_9_4h < 100.0))
+            & ((stochrsi_k_4h_lt_80) | (roc_9_1h < 40.0) | (roc_9_4h_lt_100))
             # 1d high, 4h & 1d overbought
             & ((stochrsi_k_1d_lt_90) | (roc_9_4h_lt_20) | (roc_9_1d_lt_100))
             # 1h & 4h overbought, 1d downtrend
-            & ((roc_9_1h < 40.0) | (roc_9_4h < 50.0) | (roc_9_1d_gt_neg_30))
+            & ((roc_9_1h < 40.0) | (roc_9_4h_lt_50) | (roc_9_1d_gt_neg_30))
             # big drop in last hour, 15m high
             & ((close > (close_max_12 * 0.60)) | (aroonu_14_15m_lt_70))
             # big drop in last hour, 4h high
@@ -18410,7 +18418,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 1h still high, 1d overbought
             & ((rsi_3_15m_gt_3) | (aroonu_14_1h_lt_40) | (roc_9_1d < 70.0))
             # 15m down move, 4h high & overbought
-            & ((rsi_3_15m_gt_3) | (aroonu_14_4h_lt_100) | (roc_9_4h < 100.0))
+            & ((rsi_3_15m_gt_3) | (aroonu_14_4h_lt_100) | (roc_9_4h_lt_100))
             # 15m down move, 1h high
             & ((rsi_3_15m_gt_3) | (stochrsi_k_1h_lt_70))
             # 15m down move, 4h high, 15m downtrend
@@ -18524,7 +18532,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 4h overbought
             & ((rsi_3_1h_gt_10) | (roc_9_4h_lt_10))
             # 1h down move, 4h high & overbought
-            & ((rsi_3_1h_gt_10) | (stochrsi_k_4h_lt_80) | (roc_9_4h < 20.0))
+            & ((rsi_3_1h_gt_10) | (stochrsi_k_4h_lt_80) | (roc_9_4h_lt_20))
             # 1h down move, 4h & 1d downtrend
             & ((rsi_3_1h_gt_10) | (roc_9_4h_gt_neg_30) | (roc_9_1d_gt_neg_50))
             # 1h & 4h down move, 4h high
@@ -18540,7 +18548,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h high, 4h downtrend
             & ((rsi_3_1h_gt_15) | (aroonu_14_1h_lt_70) | (roc_9_4h > -10.0))
             # 1h down move, 4h high & overbought
-            & ((rsi_3_1h_gt_15) | (aroonu_14_4h_lt_80) | (roc_9_4h < 100.0))
+            & ((rsi_3_1h_gt_15) | (aroonu_14_4h_lt_80) | (roc_9_4h_lt_100))
             # 1h down move, 1d high & overbought
             & ((rsi_3_1h_gt_15) | (aroonu_14_1d_lt_80) | (roc_9_1d < 100.0))
             # 1h down move, 1h & 4h downtrend
@@ -18548,7 +18556,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h & 4h overbought
             & ((rsi_3_1h_gt_15) | (roc_9_4h_lt_10) | (roc_9_1d_lt_50))
             # 1h down move, 1h & 4h overbought
-            & ((rsi_3_1h_gt_15) | (roc_9_4h < 20.0) | (roc_9_1d_lt_20))
+            & ((rsi_3_1h_gt_15) | (roc_9_4h_lt_20) | (roc_9_1d_lt_20))
             # 1h & 4h down move, 4h high
             & (rsi_3_1h_gt_20 | (rsi_3_4h_gt_50) | (aroonu_14_4h_lt_90))
             # 1h down move, 1h still high, 4h downtrend
@@ -18620,7 +18628,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 4h high
             & ((rsi_3_4h_gt_50) | (stochrsi_k_4h_lt_70))
             # 4h down move, 4h overbought
-            & ((rsi_3_4h_gt_50) | (roc_9_4h < 60.0))
+            & ((rsi_3_4h_gt_50) | (roc_9_4h_lt_60))
             # 4h downtrend, 4h high
             & ((cmf_20_4h > -0.50) | aroonu_14_4h_lt_70)
             # 1h & 1d high, 4h downtrend
@@ -18644,7 +18652,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h high, 1h downtrend
             & (aroonu_14_4h_lt_80 | (roc_9_1h > -40.0))
             # 4h high & overbought
-            & (aroonu_14_4h_lt_80 | (roc_9_4h < 100.0))
+            & (aroonu_14_4h_lt_80 | (roc_9_4h_lt_100))
             # 4h high, 1d downtrend
             & (aroonu_14_4h_lt_80 | (roc_9_1d > -30.0))
             # 1d still high, 1d downtrend
@@ -18660,7 +18668,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1d high & overbought
             & ((aroonu_14_1d_lt_90) | (roc_9_1d < 200.0))
             # 1d high, 4h & 1d overbought
-            & (aroonu_14_1d_lt_100 | (roc_9_4h < 20.0) | (roc_9_1d_lt_80))
+            & (aroonu_14_1d_lt_100 | (roc_9_4h_lt_20) | (roc_9_1d_lt_80))
             # 1h still high, 4h & 1d downtrend
             & ((stochrsi_k_1h_lt_50) | (roc_9_4h_gt_neg_20) | roc_9_1d_gt_neg_50)
             # 1h high, 15m downtrend
@@ -18742,7 +18750,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 1h high & overbought
             & ((rsi_3_15m_gt_10) | aroonu_14_1h_lt_70 | (roc_9_1h_lt_10))
             # 15m down move, 1h high, 4h overbought
-            & ((rsi_3_15m_gt_10) | aroonu_14_1h_lt_70 | (roc_9_4h < 20.0))
+            & ((rsi_3_15m_gt_10) | aroonu_14_1h_lt_70 | (roc_9_4h_lt_20))
             # 15m down move, 4h & 1d high
             & ((rsi_3_15m_gt_10) | (aroonu_14_4h_lt_75) | aroonu_14_1d_lt_100)
             # 15m down move, 4h high, 1h overbought
@@ -18886,7 +18894,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m still high, 1h & 4h high
             & ((rsi_14_15m < 40.0) | aroonu_14_1h_lt_80 | (aroonu_14_4h_lt_90))
             # 1h & 4h high, 4h overbought
-            & (aroonu_14_1h_lt_70 | aroonu_14_4h_lt_100 | (roc_9_4h < 20.0))
+            & (aroonu_14_1h_lt_70 | aroonu_14_4h_lt_100 | (roc_9_4h_lt_20))
             # 4h high, 1d overbought
             & (aroonu_14_4h_lt_70 | (roc_9_1d_lt_80))
             # 4h high, 1h & 1d downtrend
@@ -18894,11 +18902,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h high, 1h & 4h overbought
             & (aroonu_14_4h_lt_80 | (roc_9_1h_lt_10) | (roc_9_4h_lt_10))
             # 4h high & overbought
-            & ((aroonu_14_4h_lt_90) | (roc_9_4h < 80.0))
+            & ((aroonu_14_4h_lt_90) | (roc_9_4h_lt_80))
             # 1d high, 4h & 1d downtrend
             & ((aroonu_14_1d_lt_80) | (roc_9_4h_gt_neg_20) | (roc_9_1d_gt_neg_20))
             # 1h high, 4h overbought
-            & ((stochrsi_k_1h_lt_80) | (roc_9_4h < 80.0))
+            & ((stochrsi_k_1h_lt_80) | (roc_9_4h_lt_80))
             # 4h high, 1h & 1d downtrend
             & ((stochrsi_k_4h_lt_70) | (roc_9_1h > -20.0) | (roc_9_1d_gt_neg_20))
             # 4h high, 1h & 4h overbought
@@ -19177,7 +19185,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1d down move, 1d high, 1d downtrend
             & ((rsi_3_1d_gt_25) | (aroonu_14_1d_lt_80) | (roc_9_1d_gt_neg_30))
             # 4h & 1d high, 4h overbought
-            & (aroonu_14_4h_lt_80 | aroonu_14_1d_lt_100 | (roc_9_4h < 20.0))
+            & (aroonu_14_4h_lt_80 | aroonu_14_1d_lt_100 | (roc_9_4h_lt_20))
             # 4h high, 1h overbought
             & (aroonu_14_4h_lt_80 | (roc_9_1h < 40.0))
             # 4h high, 4h overbought
@@ -19315,7 +19323,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 15m still high
             & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_30) | (aroonu_14_15m_lt_50))
             # 15m & 1h down move, 4h overbought
-            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_30) | (roc_9_4h < 50.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_30) | (roc_9_4h_lt_50))
             # 15m & 4h down move, 4h still not low enough
             & ((rsi_3_15m_gt_10) | (rsi_3_4h_gt_10) | (stochrsi_k_4h_lt_30))
             # 15m & 4h down move, 4h still high, 1d high & overbought
@@ -19323,7 +19331,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 4h down move, 4h high
             & ((rsi_3_15m_gt_10) | (rsi_3_4h_gt_25) | (aroonu_14_4h_lt_70))
             # 15m & 4h down move, 4h overbought
-            & ((rsi_3_15m_gt_10) | (rsi_3_4h_gt_55) | (roc_9_4h < 50.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_4h_gt_55) | (roc_9_4h_lt_50))
             # 15m down move, 15m still not low enough, 1d downtrend
             & ((rsi_3_15m_gt_10) | (aroonu_14_15m_lt_30) | (roc_9_1d_gt_neg_30))
             # 15m down move, 15m still high, 1d overbought
@@ -19551,7 +19559,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h & 1d high, 1d overbought
             & (aroonu_14_4h_lt_80 | aroonu_14_1d_lt_100 | roc_9_1d_lt_50)
             # 4h high, 4h & 1d overbought
-            & (aroonu_14_4h_lt_80 | (roc_9_4h < 20.0) | (roc_9_1d_lt_20))
+            & (aroonu_14_4h_lt_80 | (roc_9_4h_lt_20) | (roc_9_1d_lt_20))
             # 1d high, 1h & 4h downtrend
             & ((aroonu_14_1d_lt_85) | (roc_9_1h > -30.0) | (roc_9_4h > -50.0))
             # 1d high, 1h & 1d overbought
@@ -19563,9 +19571,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h high, 1h overbought, 1d downtrend
             & ((stochrsi_k_4h_lt_80) | (roc_9_1h < 40.0) | (roc_9_1d > -70.0))
             # 4h high, 1h & 4h overbought
-            & ((stochrsi_k_4h_lt_90) | (roc_9_1h < 20.0) | (roc_9_4h < 50.0))
+            & ((stochrsi_k_4h_lt_90) | (roc_9_1h < 20.0) | (roc_9_4h_lt_50))
             # 1h & 4h overbought
-            & ((roc_9_1h < 100.0) | (roc_9_4h < 100.0))
+            & ((roc_9_1h < 100.0) | (roc_9_4h_lt_100))
             # big drop in the last 20 days, 1d high, 1d downtrend
             & ((close > (high_max_20_1d * 0.20)) | (stochrsi_k_1d < 70.0) | (roc_9_1d > -15.0))
           )
@@ -19810,7 +19818,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1d high, 4h downtrend
             & ((rsi_3_1h_gt_30) | (aroonu_14_1d_lt_80) | (roc_9_4h_gt_neg_30))
             # 1h down move, 1d high, 4h overbought
-            & ((rsi_3_1h_gt_30) | aroonu_14_1d_lt_100 | (roc_9_4h < 20.0))
+            & ((rsi_3_1h_gt_30) | aroonu_14_1d_lt_100 | (roc_9_4h_lt_20))
             # 1h down move, 4h still high, 1d downtrend
             & ((rsi_3_1h_gt_30) | (stochrsi_k_4h_lt_40) | (roc_9_1d > -80.0))
             # 1h down move, 4h high & overbought
@@ -19828,7 +19836,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 4h high & overbought
             & ((rsi_3_1h_gt_40) | (stochrsi_k_4h_lt_70) | (roc_9_4h_lt_30))
             # 1h down move, 4h high & overbought
-            & ((rsi_3_1h_gt_45) | aroonu_14_4h_lt_80 | (roc_9_4h < 100.0))
+            & ((rsi_3_1h_gt_45) | aroonu_14_4h_lt_80 | (roc_9_4h_lt_100))
             # 1h down move, 1h overbought
             & ((rsi_3_1h_gt_50) | (roc_9_1h < 40.0))
             # 1h down move, 4h & 1d overbought
@@ -20228,13 +20236,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1d high, 4h downtrend
             & ((rsi_3_1h_gt_30) | (aroonu_14_1d_lt_90) | (roc_9_4h > -40.0))
             # 1h down move, 1d high, 4h overbought
-            & ((rsi_3_1h_gt_30) | (aroonu_14_1d_lt_100) | (roc_9_4h < 80.0))
+            & ((rsi_3_1h_gt_30) | (aroonu_14_1d_lt_100) | (roc_9_4h_lt_80))
             # 1h down move, 1h & 4h still high
             & ((rsi_3_1h_gt_30) | (stochrsi_k_1h_lt_40) | (stochrsi_k_4h_lt_50))
             # 1h down move, 1h highm 1d overbought
             & ((rsi_3_1h_gt_30) | (stochrsi_k_1h_lt_60) | (roc_9_1d_lt_30))
             # 1h down move, 4h overbought
-            & ((rsi_3_1h_gt_30) | (roc_9_4h < 50.0))
+            & ((rsi_3_1h_gt_30) | (roc_9_4h_lt_50))
             # 4h down move, 1d downtrend
             & ((rsi_3_4h_gt_30) | (roc_9_1d_gt_neg_50))
             # 1h down move, 1h high, 4h overbought
@@ -20242,9 +20250,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h high, 1d downtrend
             & ((rsi_3_1h_gt_35) | (aroonu_14_1h_lt_70) | (roc_9_1d > -25.0))
             # 1h down move, 4h high & overbought
-            & ((rsi_3_1h_gt_35) | (aroonu_14_4h_lt_85) | (roc_9_4h < 100.0))
+            & ((rsi_3_1h_gt_35) | (aroonu_14_4h_lt_85) | (roc_9_4h_lt_100))
             # 1h down move, 4h high & overbought
-            & ((rsi_3_1h_gt_35) | (aroonu_14_4h_lt_100) | (roc_9_4h < 20.0))
+            & ((rsi_3_1h_gt_35) | (aroonu_14_4h_lt_100) | (roc_9_4h_lt_20))
             # 1h down move, 4h high & overbought
             & ((rsi_3_1h_gt_35) | (stochrsi_k_4h_lt_70) | (roc_9_4h_lt_10))
             # 1h down move, 1d high & overbought
@@ -20270,7 +20278,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h high, 1d downtrend
             & ((rsi_3_1h_gt_50) | (aroonu_14_1h_lt_90) | (roc_9_1d_gt_neg_30))
             # 1h down move, 4h high & overbought
-            & ((rsi_3_1h_gt_50) | aroonu_14_4h_lt_100 | (roc_9_4h < 100.0))
+            & ((rsi_3_1h_gt_50) | aroonu_14_4h_lt_100 | (roc_9_4h_lt_100))
             # 1h down move, 4h high, 1d downtrend
             & ((rsi_3_1h_gt_50) | (stochrsi_k_4h_lt_60) | (roc_9_1d > -60.0))
             # 1h down move, 15m high, 1h high
@@ -20370,7 +20378,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m still high, 1h overbought
             & ((aroonu_14_15m_lt_40) | (roc_9_1h < 40.0))
             # 15m still high, 4h overbought
-            & ((aroonu_14_15m_lt_40) | (roc_9_4h < 80.0))
+            & ((aroonu_14_15m_lt_40) | (roc_9_4h_lt_80))
             # 15m still high, 1h high
             & ((aroonu_14_15m_lt_50) | (aroonu_14_1h_lt_85))
             # 15m still high, 4h high & overbought
@@ -20408,9 +20416,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1d high, 1h & 1d overbought
             & ((aroonu_14_1d_lt_85) | (roc_9_1h < 20.0) | (roc_9_1d_lt_100))
             # 1d high, 1h & 4h down move
-            & (aroonu_14_1d_lt_100 | (roc_9_1h < 25.0) | (roc_9_4h < 60.0))
+            & (aroonu_14_1d_lt_100 | (roc_9_1h < 25.0) | (roc_9_4h_lt_60))
             # 1d high, 4h & 1d overbought
-            & (aroonu_14_1d_lt_100 | (roc_9_4h < 20.0) | (roc_9_1d_lt_30))
+            & (aroonu_14_1d_lt_100 | (roc_9_4h_lt_20) | (roc_9_1d_lt_30))
             # 1h high, 4h & 1d overbought
             & ((stochrsi_k_1h_lt_90) | (roc_9_4h_lt_20) | (roc_9_1d_lt_100))
             # 4h still high, 4h & 1d downtrend
@@ -20424,11 +20432,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h high, 4h overbought
             & ((stochrsi_k_4h_lt_80) | (roc_9_4h_lt_10))
             # 4h high, 1h & 4h overbought
-            & ((stochrsi_k_4h_lt_90) | (roc_9_1h < 20.0) | (roc_9_4h < 50.0))
+            & ((stochrsi_k_4h_lt_90) | (roc_9_1h < 20.0) | (roc_9_4h_lt_50))
             # 1d high, 4h & 1d overbought
             & ((stochrsi_k_1d_lt_90) | (roc_9_4h_lt_40) | (roc_9_1d_lt_100))
             # 1h & 4h overbought
-            & ((roc_9_1h < 30.0) | (roc_9_4h < 80.0))
+            & ((roc_9_1h < 30.0) | (roc_9_4h_lt_80))
             # 1d green with top wick, 4h high
             & ((change_pct_1d < 30.0) | (top_wick_pct_1d < 20.0) | aroonu_14_4h_lt_80)
             # 1d top wick, 4h down move, 1d overbought
@@ -20710,17 +20718,17 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h high, 1d downtrend
             & ((aroonu_14_1d_lt_70) | (roc_9_1d_gt_neg_30))
             # 1d high, 4h & 1d overbought
-            & ((aroonu_14_1d_lt_85) | (roc_9_4h < 60.0) | (roc_9_1d < 60.0))
+            & ((aroonu_14_1d_lt_85) | (roc_9_4h_lt_60) | (roc_9_1d < 60.0))
             # 1d high, 4h & 1d overbought
             & (aroonu_14_1d_lt_100 | (roc_9_4h_lt_10) | (roc_9_1d_lt_20))
             # 1h high, 4h downtrend
             & ((stochrsi_k_1h_lt_80) | (roc_9_4h_gt_neg_20))
             # 1h high, 4h overbought
-            & ((stochrsi_k_1h_lt_80) | (roc_9_4h < 80.0))
+            & ((stochrsi_k_1h_lt_80) | (roc_9_4h_lt_80))
             # 4h high, 4h & 1d overbought
             & ((stochrsi_k_4h_lt_80) | (roc_9_4h_lt_30) | (roc_9_1d_lt_30))
             # 1d high, 4h & 1d overbought
-            & ((stochrsi_k_1d < 80.0) | (roc_9_4h < 60.0) | (roc_9_1d < 60.0))
+            & ((stochrsi_k_1d < 80.0) | (roc_9_4h_lt_60) | (roc_9_1d < 60.0))
             # 1d red, 4h down move, 1h still high
             & ((change_pct_1d > -30.0) | (rsi_3_4h_gt_30) | (stochrsi_k_1h_lt_50))
             # pump, drop but not yet near the previous lows
@@ -20863,7 +20871,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 15m still not low enough, 1h high
             & ((rsi_3_15m_gt_10) | (aroonu_14_15m_lt_30) | (stochrsi_k_1h_lt_80))
             # 15m down move, 1h high, 4h overbought
-            & ((rsi_3_15m_gt_10) | aroonu_14_1h_lt_70 | (roc_9_4h < 50.0))
+            & ((rsi_3_15m_gt_10) | aroonu_14_1h_lt_70 | (roc_9_4h_lt_50))
             # 15m down move, 1d high & overbought
             & ((rsi_3_15m_gt_10) | (aroonu_14_1d_lt_80) | (roc_9_1d_lt_20))
             # 15m & 1h down move, 1h still high
@@ -21071,7 +21079,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h high
             & ((aroonu_14_15m_lt_90) | (aroonu_14_1h_lt_90))
             # 1h still high, 4h high & overbought
-            & ((aroonu_14_1h_lt_50) | (aroonu_14_4h_lt_90) | (roc_9_4h < 80.0))
+            & ((aroonu_14_1h_lt_50) | (aroonu_14_4h_lt_90) | (roc_9_4h_lt_80))
             # 1h & 4h high, 1h overbought
             & (aroonu_14_1h_lt_80 | aroonu_14_4h_lt_100 | (roc_9_1h < 40.0))
             # 1h & 1d high, 1d overbought
@@ -21083,11 +21091,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h & 1d high, 1d overbought
             & (aroonu_14_4h_lt_70 | aroonu_14_1d_lt_100 | (roc_9_1d < 10.0))
             # 4h high & overbought
-            & ((aroonu_14_4h_lt_90) | (stochrsi_k_4h < 85.0) | (roc_9_4h < 50.0))
+            & ((aroonu_14_4h_lt_90) | (stochrsi_k_4h < 85.0) | (roc_9_4h_lt_50))
             # 1d high, 4h & 1d overbought
             & (aroonu_14_1d_lt_100 | (roc_9_4h_lt_10) | roc_9_1d_lt_50)
             # 1d high, 4h & 1d overbought
-            & (aroonu_14_1d_lt_100 | (roc_9_4h < 20.0) | (roc_9_1d_lt_40))
+            & (aroonu_14_1d_lt_100 | (roc_9_4h_lt_20) | (roc_9_1d_lt_40))
             # 4h high, 4h & 1d overbought
             & ((stochrsi_k_4h_lt_70) | (roc_9_4h_lt_30) | (roc_9_1d_lt_30))
             # 5m red, 1h still high
@@ -21158,7 +21166,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 15m & 1h still high
             & ((rsi_3_15m_gt_20) | (stochrsi_k_15m_lt_50) | (stochrsi_k_1h_lt_50))
             # 15m down move, 4h overbought
-            & ((rsi_3_15m_gt_20) | (roc_9_4h < 70.0))
+            & ((rsi_3_15m_gt_20) | (roc_9_4h_lt_70))
             # 15m down move, 15m still high, 1h high
             & ((rsi_3_15m_gt_25) | (aroonu_14_15m_lt_50) | aroonu_14_1h_lt_80)
             # 15m down move, 4h & 1d high
@@ -21182,7 +21190,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 15m & 1h high
             & ((rsi_3_15m_gt_35) | (aroonu_14_15m_lt_70) | (stochrsi_k_1h_lt_80))
             # 15m down move, 1h high, 4h overbought
-            & ((rsi_3_15m_gt_35) | (aroonu_14_1h_lt_85) | (roc_9_4h < 80.0))
+            & ((rsi_3_15m_gt_35) | (aroonu_14_1h_lt_85) | (roc_9_4h_lt_80))
             # 1h & 4h down move, 1h still high
             & ((rsi_3_1h_gt_10) | rsi_3_4h_gt_20 | (aroonu_14_1h_lt_40))
             # 1h & 4h down move, 15m still not low enough
@@ -21240,7 +21248,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 4h still high, 1d downtrend
             & ((rsi_3_4h_gt_50) | (rsi_14_4h < 40.0) | (roc_9_1d_gt_neg_30))
             # 4h down move, 4h high & overbought
-            & ((rsi_3_4h_gt_50) | (aroonu_14_4h_lt_80) | (roc_9_4h < 20.0))
+            & ((rsi_3_4h_gt_50) | (aroonu_14_4h_lt_80) | (roc_9_4h_lt_20))
             # 4h down move, 4h still high, 1d downtrend
             & ((rsi_3_4h_gt_50) | (stochrsi_k_4h_lt_50) | (roc_9_1d_gt_neg_30))
             # 4h down move, 15m still high, 1h high
@@ -21260,7 +21268,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h still high, 4h high
             & ((rsi_14_15m < 45.0) | (aroonu_14_1h_lt_40) | (stochrsi_k_4h_lt_70))
             # 15m still high, 4h high & overbought
-            & ((rsi_14_15m < 50.0) | (aroonu_14_4h_lt_90) | (roc_9_4h < 80.0))
+            & ((rsi_14_15m < 50.0) | (aroonu_14_4h_lt_90) | (roc_9_4h_lt_80))
             # 15m still high, 1h high, 4h still high
             & ((aroonu_14_15m_lt_50) | (aroonu_14_1h_lt_90) | (stochrsi_k_4h_lt_50))
             # 15m still high, 1d high
@@ -21278,7 +21286,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h & 1d high, 1d overbought
             & (aroonu_14_4h_lt_70 | aroonu_14_1d_lt_100 | (roc_9_1d < 10.0))
             # 4h high, 4h & 1d overbought
-            & (aroonu_14_4h_lt_80 | (roc_9_4h < 80.0) | (roc_9_1d < 100.0))
+            & (aroonu_14_4h_lt_80 | (roc_9_4h_lt_80) | (roc_9_1d < 100.0))
             # 1d high, 4h & 1d overbought
             & (aroonu_14_1d_lt_100 | (roc_9_4h_lt_10) | roc_9_1d_lt_50)
             # 15m still high, 1h high
@@ -21292,7 +21300,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1d top wick, 4h high
             & ((top_wick_pct_1d < 30.0) | (aroonu_14_4h_lt_90))
             # pump, 4h overbought
-            & ((((df["high_max_6_1h"] - df["low_min_6_1h"]) / df["low_min_6_1h"]) < 0.5) | (roc_9_4h < 50.0))
+            & ((((df["high_max_6_1h"] - df["low_min_6_1h"]) / df["low_min_6_1h"]) < 0.5) | (roc_9_4h_lt_50))
             # pump, drop but not yet near the previous lows
             & (
               (((high_max_24_4h - low_min_24_4h) / low_min_24_4h) < 2.0)
@@ -21363,7 +21371,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m & 1h down move, 4h still high
           long_entry_logic.append((rsi_3_15m_gt_10) | rsi_3_1h_gt_20 | (stochrsi_k_4h_lt_50))
           # 15m & 1h down move, 4h overbought
-          long_entry_logic.append((rsi_3_15m_gt_10) | (rsi_3_1h_gt_40) | (roc_9_4h < 50.0))
+          long_entry_logic.append((rsi_3_15m_gt_10) | (rsi_3_1h_gt_40) | (roc_9_4h_lt_50))
           # 15m & 1h down move, 1h high
           long_entry_logic.append((rsi_3_15m_gt_10) | (rsi_3_1h_gt_25) | aroonu_14_1h_lt_80)
           # 15m & 4h down move, 1h & 4h downtrend
@@ -21395,7 +21403,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m down move, 4h still high, 4h downtrend
           long_entry_logic.append((rsi_3_15m_gt_15) | (aroonu_14_4h_lt_40) | (roc_9_4h_gt_neg_20))
           # 15m down move, 1d high, 4h overbought
-          long_entry_logic.append((rsi_3_15m_gt_15) | aroonu_14_1d_lt_100 | (roc_9_4h < 50.0))
+          long_entry_logic.append((rsi_3_15m_gt_15) | aroonu_14_1d_lt_100 | (roc_9_4h_lt_50))
           # 15m & 3h down move, 15m still not low enough
           long_entry_logic.append((rsi_3_15m_gt_20) | rsi_3_4h_gt_20 | (stochrsi_k_15m_lt_20))
           # 15m & 1h down move, 1h still high
@@ -21899,7 +21907,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h high, 1d high & overbought
             & ((rsi_3_1h_gt_45) | (stochrsi_k_1h_lt_60) | (stochrsi_k_1d < 70.0) | (roc_9_1d < 40.0))
             # 1h down move, 4h high & overbought
-            & ((rsi_3_1h_gt_50) | (stochrsi_k_4h_lt_90) | (roc_9_4h < 25.0))
+            & ((rsi_3_1h_gt_50) | (stochrsi_k_4h_lt_90) | (roc_9_4h_lt_25))
             # 1h & 1d down move, 1h high
             & ((rsi_3_1h_gt_60) | (rsi_3_1d_gt_60) | aroonu_14_1h_lt_70)
             # 4h & 1d down move, 1d still high
@@ -22001,7 +22009,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1d down move, 1d overbought
             & ((rsi_3_1d_gt_60) | (roc_9_1d < 200.0))
             # 15m & 1h high, 4h overbought
-            & ((aroonu_14_15m_lt_70) | (aroonu_14_1h_lt_100) | (roc_9_4h < 15.0))
+            & ((aroonu_14_15m_lt_70) | (aroonu_14_1h_lt_100) | (roc_9_4h_lt_15))
             # 15m & 1h high, 1d overbought
             & ((aroonu_14_15m_lt_70) | (aroonu_14_1h_lt_100) | (roc_9_1d_lt_100))
             # 15m & 1h high, 1d downtrend
@@ -22019,13 +22027,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 1d high, 1d overbought
             & ((aroonu_14_1h_lt_100) | aroonu_14_1d_lt_100 | (roc_9_1d_lt_40))
             # 4h & 1d high, 4h overbought
-            & (aroonu_14_4h_lt_100 | aroonu_14_1d_lt_100 | (roc_9_4h < 50.0))
+            & (aroonu_14_4h_lt_100 | aroonu_14_1d_lt_100 | (roc_9_4h_lt_50))
             # 4h & 1d high, 1d overbought
             & ((aroonu_14_4h_lt_90) | aroonu_14_1d_lt_100 | roc_9_1d_lt_50)
             # 1h high, 1h & 4h overbought
             & ((stochrsi_k_1h_lt_80) | (roc_9_1h < 20.0) | (roc_9_4h_lt_20))
             # 4h & 1d overbought
-            & ((roc_9_4h < 100.0) | (roc_9_1d < 200.0))
+            & ((roc_9_4h_lt_100) | (roc_9_1d < 200.0))
           )
 
           # Logic
@@ -22278,7 +22286,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 4h high
             & (rsi_3_1h_gt_20 | (rsi_3_4h_gt_50) | aroonu_14_4h_lt_100)
             # 1h down move, 1d high, 4h & 1d overbought
-            & ((rsi_3_1h_gt_20) | (aroonu_14_1d_lt_80) | (roc_9_4h < 10.0) | (roc_9_1d < 40.0))
+            & ((rsi_3_1h_gt_20) | (aroonu_14_1d_lt_80) | (roc_9_4h_lt_10) | (roc_9_1d < 40.0))
             # 1h down move, 4h high & overbought, 1d downtrend
             & ((rsi_3_1h_gt_20) | (stochrsi_k_4h_lt_80) | (roc_9_4h_lt_10) | (roc_9_1d_gt_neg_20))
             # 1h & 4h down move, 15m high
@@ -22308,7 +22316,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h high, 1d high & overbought
             & ((rsi_3_1h_gt_45) | (stochrsi_k_1h_lt_60) | (stochrsi_k_1d < 70.0) | (roc_9_1d < 40.0))
             # 1h down move, 4h high & overbought
-            & ((rsi_3_1h_gt_50) | (stochrsi_k_4h_lt_90) | (roc_9_4h < 25.0))
+            & ((rsi_3_1h_gt_50) | (stochrsi_k_4h_lt_90) | (roc_9_4h_lt_25))
             # 4h & 1d down move, 1d downtrend
             & ((rsi_3_4h_gt_3) | (rsi_3_1d_gt_10) | (roc_9_1d_gt_neg_20))
             # 4h & 1d down move, 1d still high
@@ -22368,13 +22376,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 1d overbought
             & ((rsi_3_4h_gt_20) | (roc_9_1d_lt_80))
             # 4h & 1d down move, 4h overbought
-            & ((rsi_3_4h_gt_25) | (rsi_3_1d_gt_45) | (roc_9_4h < 5.0))
+            & ((rsi_3_4h_gt_25) | (rsi_3_1d_gt_45) | (roc_9_4h_lt_5))
             # 4h & 1d down move, 1d overbought
             & ((rsi_3_4h_gt_25) | (rsi_3_1d_gt_45) | (roc_9_1d < 10.0))
             # 4h down move, 15m still not low enough, 4h still high
             & ((rsi_3_4h_gt_25) | (aroonu_14_15m_lt_30) | (stochrsi_k_4h_lt_40))
             # 4h down move, 1d high, 4h overbought
-            & ((rsi_3_4h_gt_25) | (aroonu_14_1d_lt_80) | (roc_9_4h < 5.0))
+            & ((rsi_3_4h_gt_25) | (aroonu_14_1d_lt_80) | (roc_9_4h_lt_5))
             # 4h & 1d down move, 4h still high
             & ((rsi_3_4h_gt_30) | (rsi_3_1d_gt_30) | (stochrsi_k_4h_lt_50))
             # 4h & 1d down move, 1d high
@@ -22416,7 +22424,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1d down move, 1h & 4h high
             & ((rsi_3_1d_gt_30) | aroonu_14_1h_lt_70 | aroonu_14_4h_lt_100)
             # 15m & 1h high, 4h overbought
-            & ((aroonu_14_15m_lt_70) | (aroonu_14_1h_lt_100) | (roc_9_4h < 15.0))
+            & ((aroonu_14_15m_lt_70) | (aroonu_14_1h_lt_100) | (roc_9_4h_lt_15))
             # 15m & 1h high, 1d overbought
             & ((aroonu_14_15m_lt_70) | (aroonu_14_1h_lt_100) | (roc_9_1d_lt_100))
             # 15m & 1h high, 1d downtrend
@@ -22440,7 +22448,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h high, 4h overbought
             & ((aroonu_14_1h_lt_100) | aroonu_14_4h_lt_100 | (roc_9_4h_lt_10))
             # 4h & 1d high, 4h overbought
-            & (aroonu_14_4h_lt_100 | aroonu_14_1d_lt_100 | (roc_9_4h < 20.0))
+            & (aroonu_14_4h_lt_100 | aroonu_14_1d_lt_100 | (roc_9_4h_lt_20))
             # 4h & 1d high, 1d overbought
             & (aroonu_14_4h_lt_100 | aroonu_14_1d_lt_100 | (roc_9_1d_lt_30))
             # 4h high, 1h & 4h overbought
@@ -22448,7 +22456,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1d high, 4h & 1d downtrend
             & ((aroonu_14_1d_lt_60) | (roc_9_4h_gt_neg_20) | (roc_9_1d_gt_neg_30))
             # 1d high, 4h & 1d overbought
-            & (aroonu_14_1d_lt_100 | (roc_9_4h < 60.0) | (roc_9_1d < 100.0))
+            & (aroonu_14_1d_lt_100 | (roc_9_4h_lt_60) | (roc_9_1d < 100.0))
             # 15m high, 4h & 1d overbought
             & ((stochrsi_k_15m_lt_70) | (roc_9_4h_lt_20) | (roc_9_1d_lt_20))
             # 1h high, 1h & 1d overbought
@@ -22611,7 +22619,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1d high, 1d downtrend
             & (rsi_3_1h_gt_20 | (aroonu_14_1d_lt_70) | (roc_9_1d_gt_neg_20))
             # 1h down move, 1d high, 4h & 1d overbought
-            & ((rsi_3_1h_gt_20) | (aroonu_14_1d_lt_80) | (roc_9_4h < 10.0) | (roc_9_1d < 40.0))
+            & ((rsi_3_1h_gt_20) | (aroonu_14_1d_lt_80) | (roc_9_4h_lt_10) | (roc_9_1d < 40.0))
             # 1h down move, 4h high & overbought, 1d downtrend
             & ((rsi_3_1h_gt_20) | (stochrsi_k_4h_lt_80) | (roc_9_4h_lt_10) | (roc_9_1d_gt_neg_20))
             # 1h down move, 1h & 4h high
@@ -22758,7 +22766,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 4h high
             & ((rsi_3_15m_gt_25) | (rsi_3_1h_gt_40) | (stochrsi_k_4h_lt_90))
             # 15m down move, 4h & 1d high, 4h overbought
-            & ((rsi_3_15m_gt_25) | (aroonu_14_4h_lt_80) | (aroonu_14_1d_lt_100) | (roc_9_4h < 30.0))
+            & ((rsi_3_15m_gt_25) | (aroonu_14_4h_lt_80) | (aroonu_14_1d_lt_100) | (roc_9_4h_lt_30))
             # 15m down move, 4h high, 1d downtrend
             & ((rsi_3_15m_gt_25) | (stochrsi_k_4h_lt_80) | (roc_9_1d_gt_neg_30))
             # 15m & 1h down move, 15m high
@@ -22834,7 +22842,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1d high & overbought
             & ((rsi_3_1h_gt_15) | (aroonu_14_1d_lt_80) | (roc_9_1d < 10.0))
             # 1h down move, 4h high & overbought
-            & ((rsi_3_1h_gt_15) | (stochrsi_k_4h_lt_80) | (roc_9_4h < 20.0))
+            & ((rsi_3_1h_gt_15) | (stochrsi_k_4h_lt_80) | (roc_9_4h_lt_20))
             # 1h down move, 4h high, 1d downtrend
             & ((rsi_3_1h_gt_15) | (stochrsi_k_4h_lt_80) | (roc_9_1d > -30.0))
             # 1h & 4h down move, 4h still high
@@ -22850,7 +22858,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 1d down move, 1h still high
             & (rsi_3_1h_gt_20 | (rsi_3_1d_gt_25) | (aroonu_14_1h_lt_50))
             # 1h down move, 4h high & overbought
-            & (rsi_3_1h_gt_20 | (aroonu_14_4h_lt_80) | (roc_9_4h < 70.0))
+            & (rsi_3_1h_gt_20 | (aroonu_14_4h_lt_80) | (roc_9_4h_lt_70))
             # 1h down move, 1h high, 1h still not low enough
             & (rsi_3_1h_gt_20 | (aroonu_14_1d_lt_80) | (stochrsi_k_1h_lt_20))
             # 1h down move, 1d high & overbought
@@ -22922,7 +22930,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 1d high & overbought
             & (rsi_3_4h_gt_20 | (aroonu_14_1d_lt_80) | (roc_9_1d < 70.0))
             # 4h & 1d down move, 4h overbought
-            & ((rsi_3_4h_gt_25) | (rsi_3_1d_gt_45) | (roc_9_4h < 5.0))
+            & ((rsi_3_4h_gt_25) | (rsi_3_1d_gt_45) | (roc_9_4h_lt_5))
             # 4h & 1d down move, 1d overbought
             & ((rsi_3_4h_gt_25) | (rsi_3_1d_gt_45) | (roc_9_1d < 10.0))
             # 4h & 1d down move, 1d overbought
@@ -22964,7 +22972,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1d high, 4h & 1d overbought
             & ((stochrsi_k_1d_lt_90) | (roc_9_4h_lt_30) | (roc_9_1d_lt_100))
             # 4h & 1d overbought
-            & ((roc_9_4h < 100.0) | (roc_9_1d < 200.0))
+            & ((roc_9_4h_lt_100) | (roc_9_1d < 200.0))
             # 1d P&D, 4h overbought
             & ((change_pct_1d > -10.0) | (change_pct_1d.shift(288) < 50.0) | (roc_9_4h_lt_30))
           )
@@ -23102,7 +23110,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h high, 1d overbought
             & ((rsi_3_1h_gt_20) | (aroonu_14_1h_lt_70) | (roc_9_1d_lt_20))
             # 1h down move, 4h high & overbought
-            & ((rsi_3_1h_gt_20) | (aroonu_14_4h_lt_80) | (roc_9_4h < 60.0))
+            & ((rsi_3_1h_gt_20) | (aroonu_14_4h_lt_80) | (roc_9_4h_lt_60))
             # 1h down move, 1h still not low enough, 1d downtrend
             & ((rsi_3_1h_gt_20) | (stochrsi_k_1h_lt_30) | (roc_9_1d_gt_neg_30))
             # 1h & 4h down move, 1h high
@@ -23124,7 +23132,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h still high, 1d overbought
             & ((rsi_3_1h_gt_35) | (aroonu_14_1h_lt_40) | (roc_9_1d_lt_40))
             # 1h down move, 4h high & overbought
-            & ((rsi_3_1h_gt_35) | (aroonu_14_4h_lt_90) | (roc_9_4h < 60.0))
+            & ((rsi_3_1h_gt_35) | (aroonu_14_4h_lt_90) | (roc_9_4h_lt_60))
             # 1h down move, 4h high, 1d downtrend
             & ((rsi_3_1h_gt_35) | (stochrsi_k_4h_lt_90) | (roc_9_1d_gt_neg_20))
             # 1h down move, 1h high, 1d downtrend
@@ -23136,7 +23144,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h high, 4h overbought
             & ((rsi_3_1h_gt_50) | aroonu_14_1h_lt_80 | (roc_9_4h_lt_10))
             # 1h down move, 4h high & overbought
-            & ((rsi_3_1h_gt_50) | (stochrsi_k_4h_lt_90) | (roc_9_4h < 25.0))
+            & ((rsi_3_1h_gt_50) | (stochrsi_k_4h_lt_90) | (roc_9_4h_lt_25))
             # 4h down move, 4h & 1d downtrend
             & ((rsi_3_4h_gt_5) | (roc_9_4h > -15.0) | (roc_9_1d_gt_neg_20))
             # 4h & 1d down move, 1d still high
@@ -23535,7 +23543,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 15m & 4h high
             & ((rsi_3_1h_gt_30) | (rsi_3_4h_gt_50) | (aroonu_14_15m_lt_70) | (aroonu_14_1h_lt_70))
             # 1h down move, 1h high, 4h overbought
-            & ((rsi_3_1h_gt_30) | (aroonu_14_1h_lt_60) | (roc_9_4h < 50.0))
+            & ((rsi_3_1h_gt_30) | (aroonu_14_1h_lt_60) | (roc_9_4h_lt_50))
             # 1h down move, 1h high, 1d overbought
             & ((rsi_3_1h_gt_30) | (aroonu_14_1h_lt_80) | (roc_9_1d_lt_80))
             # 1h down move, 1h & 4h high
@@ -23595,7 +23603,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h & 1d high, 4h overbought
             & (aroonu_14_4h_lt_80 | aroonu_14_1d_lt_100 | (roc_9_4h_lt_30))
             # 4h high, 4h & 1d overbought
-            & (aroonu_14_4h_lt_80 | (roc_9_4h < 20.0) | (roc_9_1d_lt_20))
+            & (aroonu_14_4h_lt_80 | (roc_9_4h_lt_20) | (roc_9_1d_lt_20))
             # 1d still high, 1h & 4h downtrend
             & ((aroonu_14_1d_lt_50) | (roc_9_1h > -20.0) | (roc_9_4h_gt_neg_20))
             # 1h high, 1h overbought
@@ -23605,9 +23613,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h high, 1h overbought, 1d downtrend
             & ((stochrsi_k_4h_lt_80) | (roc_9_1h_lt_10) | (roc_9_1d > -70.0))
             # 4h high, 1h & 4h overbought
-            & ((stochrsi_k_4h_lt_90) | (roc_9_1h < 20.0) | (roc_9_4h < 50.0))
+            & ((stochrsi_k_4h_lt_90) | (roc_9_1h < 20.0) | (roc_9_4h_lt_50))
             # 1h & 4h overbought
-            & ((roc_9_1h < 100.0) | (roc_9_4h < 100.0))
+            & ((roc_9_1h < 100.0) | (roc_9_4h_lt_100))
             # 1h P&D, 1h down move
             & ((change_pct_1h > -10.0) | (change_pct_1h.shift(12) < 10.0) | (rsi_3_1h_gt_50))
             # 4h P&D, 4h high
@@ -23703,7 +23711,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 15m still not low enough, 1h & 4h high
             & ((rsi_3_15m_gt_15) | (rsi_3_1h_gt_40) | (aroonu_14_15m_lt_30) | aroonu_14_1h_lt_80 | aroonu_14_4h_lt_80)
             # 15m & 1h down move, 4h high & overbought
-            & ((rsi_3_15m_gt_15) | (rsi_3_1h_gt_45) | (rsi_14_4h < 70.0) | (roc_9_4h < 50.0))
+            & ((rsi_3_15m_gt_15) | (rsi_3_1h_gt_45) | (rsi_14_4h < 70.0) | (roc_9_4h_lt_50))
             # 15m & 1h down move, 1h high
             & ((rsi_3_15m_gt_15) | (rsi_3_1h_gt_50) | (stochrsi_k_1h_lt_90))
             # 15m & 4h down move, 15m high
@@ -23761,7 +23769,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 4h high, 1d overbought
             & ((rsi_3_15m_gt_15) | (stochrsi_k_4h_lt_80) | (roc_9_1d < 25.0))
             # 15m down move, 4h high & overbought
-            & ((rsi_3_15m_gt_15) | (stochrsi_k_4h_lt_90) | (roc_9_4h < 25.0))
+            & ((rsi_3_15m_gt_15) | (stochrsi_k_4h_lt_90) | (roc_9_4h_lt_25))
             # 15m down move, 4h high
             & ((rsi_3_15m_gt_15) | (rsi_14_4h < 70.0) | (stochrsi_k_4h_lt_90) | (ema_9 < (ema_26 * 0.972)))
             # 15m down move, 4h high and downtrend
@@ -23777,7 +23785,7 @@ class NostalgiaForInfinityX7(IStrategy):
               (rsi_3_15m_gt_20) | (rsi_3_1h_gt_35) | (cmf_20_1h > -0.10) | (aroonu_14_15m_lt_40) | (aroonu_14_1h_lt_85)
             )
             # 15m & 1h down move, 4h high & overbought
-            & ((rsi_3_15m_gt_20) | (rsi_3_1h_gt_45) | (rsi_14_4h < 70.0) | (roc_9_4h < 50.0))
+            & ((rsi_3_15m_gt_20) | (rsi_3_1h_gt_45) | (rsi_14_4h < 70.0) | (roc_9_4h_lt_50))
             # 15m & 1h down move, 1h high, 1d overbought
             & ((rsi_3_15m_gt_20) | (rsi_3_1h_gt_45) | (aroonu_14_1h_lt_90) | (roc_9_1d_lt_40))
             # 15m & 4h down move, 15m high
@@ -23816,7 +23824,7 @@ class NostalgiaForInfinityX7(IStrategy):
               | aroonu_14_4h_lt_100
             )
             # 15m & 4h down move, 4h overbought
-            & ((rsi_3_15m_gt_30) | (rsi_3_4h_gt_60) | (roc_9_4h < 60.0))
+            & ((rsi_3_15m_gt_30) | (rsi_3_4h_gt_60) | (roc_9_4h_lt_60))
             # 15m & 4h down move, 4h high
             & ((rsi_3_15m_gt_35) | (rsi_3_4h_gt_35) | (stochrsi_k_4h_lt_80))
             # 1h & 4h down move, 1d high
@@ -23868,7 +23876,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 4h high & overbought
             & ((rsi_3_1h_gt_30) | aroonu_14_4h_lt_100 | (roc_9_4h_lt_30))
             # 1h down move, 1d high, 4h overbought
-            & ((rsi_3_1h_gt_30) | aroonu_14_1d_lt_100 | (roc_9_4h < 20.0))
+            & ((rsi_3_1h_gt_30) | aroonu_14_1d_lt_100 | (roc_9_4h_lt_20))
             # 1h & 4h down move, 1h still high, 4h high
             & ((rsi_3_1h_gt_35) | (rsi_3_4h_gt_60) | (rsi_14_1h < 50.0) | (rsi_14_4h < 70.0))
             # 1h down move, 1d downtrend, 15m still high, 1d high
@@ -23878,7 +23886,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h & 1d high
             & ((rsi_3_1h_gt_35) | (aroonu_14_1h_lt_60) | aroonu_14_1d_lt_100)
             # 1h down move, 1h high, 4h overbought
-            & ((rsi_3_1h_gt_35) | (aroonu_14_1h_lt_70) | (roc_9_4h < 25.0))
+            & ((rsi_3_1h_gt_35) | (aroonu_14_1h_lt_70) | (roc_9_4h_lt_25))
             # 1h down move, 1h & 4h high
             & ((rsi_3_1h_gt_35) | (aroonu_14_1h_lt_70) | (aroonu_14_4h_lt_90))
             # 1h down move, 1h & 1d high
@@ -24002,7 +24010,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h high, 1d overbought
             & ((aroonu_14_15m_lt_60) | (aroonu_14_1h_lt_100) | (roc_9_1d_lt_20))
             # 4h high, 4h & 1d overbought
-            & (aroonu_14_4h_lt_80 | (roc_9_4h < 20.0) | (roc_9_1d_lt_20))
+            & (aroonu_14_4h_lt_80 | (roc_9_4h_lt_20) | (roc_9_1d_lt_20))
             # 4h & 1d high, 1d overbought
             & ((aroonu_14_4h_lt_85) | (aroonu_14_1d_lt_85) | (roc_9_1d < 60.0))
             # 4h & 1d high, 1d overbought
@@ -24228,7 +24236,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m down move, 15m still not high enough, 4h low
           short_entry_logic.append((rsi_3_15m_lt_85) | (rsi_14_15m > 70.0) | (stochrsi_k_4h > 40.0))
           # 15m up move, 4h overbought
-          short_entry_logic.append((rsi_3_15m_lt_85) | (roc_9_4h < 50.0))
+          short_entry_logic.append((rsi_3_15m_lt_85) | (roc_9_4h_lt_50))
           # 15m & 1h up move, 1h still not high enough
           short_entry_logic.append((rsi_3_15m < 80.0) | (rsi_3_1h < 70.0) | (aroonu_14_1h > 60.0))
           # 15m & 4h up move, 15m still low
@@ -24292,13 +24300,13 @@ class NostalgiaForInfinityX7(IStrategy):
           # 4h up move, 15m still low, 1h not high enough
           short_entry_logic.append((rsi_3_4h_lt_95) | (stochrsi_k_15m_gt_50) | (aroond_14_1h < 25.0))
           # 4h up move, 15m still not high enough, 4h overbought
-          short_entry_logic.append((rsi_3_4h_lt_95) | (stochrsi_k_15m > 70.0) | (roc_9_4h < 60.0))
+          short_entry_logic.append((rsi_3_4h_lt_95) | (stochrsi_k_15m > 70.0) | (roc_9_4h_lt_60))
           # 4h up move, 15m uptrend
           short_entry_logic.append((rsi_3_4h_lt_95) | (roc_9_15m < 20.0))
           # 4h up move, 1h uptrend
           short_entry_logic.append((rsi_3_4h_lt_95) | (roc_9_1h < 20.0))
           # 4h up move, 1h & 4h overbought
-          short_entry_logic.append((rsi_3_4h_lt_95) | (roc_9_1h < 30.0) | (roc_9_4h < 60.0))
+          short_entry_logic.append((rsi_3_4h_lt_95) | (roc_9_1h < 30.0) | (roc_9_4h_lt_60))
           # 4h up move, 1h still low
           short_entry_logic.append((rsi_3_4h_lt_90) | (aroonu_14_1h > 40.0))
           # 4h up move, 1d still low, 4h uptrend
@@ -24336,7 +24344,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1d uptrend, 1h uptrend
           short_entry_logic.append(aroonu_14_1d_lt_100 | (roc_9_1h < 20.0))
           # 15m still not high enough, 1h & 4h overbought
-          short_entry_logic.append((stochrsi_k_15m > 70.0) | (roc_9_1h < 30.0) | (roc_9_4h < 60.0))
+          short_entry_logic.append((stochrsi_k_15m > 70.0) | (roc_9_1h < 30.0) | (roc_9_4h_lt_60))
           # 1h & 4h overbought, 1h uptrend
           short_entry_logic.append((roc_9_1h_lt_10) | (roc_9_4h_lt_40) | (cci_20_change_pct_1h < 0.0))
           # 1h & 4h overbought, 4h uptrend
@@ -24526,7 +24534,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h low, 1d low
             & ((aroonu_14_1h > 30.0) | (stochrsi_k_1d > 30.0))
             # 4h still not high enough, 4h & 1d uptrend
-            & ((aroonu_14_4h > 70.0) | (roc_9_4h < 60.0) | (roc_9_1d < 200.0))
+            & ((aroonu_14_4h > 70.0) | (roc_9_4h_lt_60) | (roc_9_1d < 200.0))
             # 1h & 4h low
             & ((stochrsi_k_1h_gt_20) | (aroonu_14_4h > 20.0))
             # 1d big green, 1d still not high enough
@@ -24873,7 +24881,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m up move, 15m still not high enough, 4h still low
           short_entry_logic.append((rsi_3_15m_lt_85) | (stochrsi_k_15m > 80.0) | (aroonu_14_4h > 50.0))
           # 15m up move, 4h overbought
-          short_entry_logic.append((rsi_3_15m_lt_85) | (roc_9_4h < 50.0))
+          short_entry_logic.append((rsi_3_15m_lt_85) | (roc_9_4h_lt_50))
           # 15m & 1h up move, 15m still low
           short_entry_logic.append((rsi_3_15m < 70.0) | (rsi_3_1h < 70.0) | (aroonu_14_15m > 40.0))
           # 15m & 1h up move, 15m still low


### PR DESCRIPTION
## Summary
- Reuse repeated `roc_9_4h < ...` comparison masks inside X7 `populate_entry_trend()`.
- Covers repeated 4h ROC entry thresholds while leaving isolated one-off comparisons inline.
- Independent on latest upstream `main`.

## Safety
- Behavior is preserved: this only reuses already-read local Series comparisons inside the same call.
- No indicator formulas, candle selection, order classification, profit arithmetic, thresholds, condition order, return values, or signal behavior are changed.
- Touched function: `populate_entry_trend()`.
- No v3 grind-entry code is touched.

## Backtest scope
- Full backtesting was not required for this patch because it only replaces repeated inline comparisons with equivalent local masks from the same `roc_9_4h` Series.
- Validation focused on static safety, mergeability, and targeted diff review for unchanged thresholds and condition order.

## Checks
- `python3 ~/.codex/skills/nfi-upstream-pr/scripts/validate_nfi_pr.py --base origin/main`
- `git merge-tree` conflict simulation against `origin/main`
- targeted `git diff origin/main...HEAD -- NostalgiaForInfinityX7.py` review
- `git diff --check`
- `ruff format --check NostalgiaForInfinityX7.py`
- `ruff check NostalgiaForInfinityX7.py`
- `PYTHONDONTWRITEBYTECODE=1 python3 -m py_compile NostalgiaForInfinityX7.py`
