### PR TITLE
Reuse X7 entry ROC 1d masks

### DIFF
--- a/NostalgiaForInfinityX7.py
+++ b/NostalgiaForInfinityX7.py
@@ -13130,12 +13130,20 @@ class NostalgiaForInfinityX7(IStrategy):
     roc_9_1d_gt_neg_40 = roc_9_1d > -40.0
     roc_9_1d_gt_neg_30 = roc_9_1d > -30.0
     roc_9_1d_gt_neg_20 = roc_9_1d > -20.0
+    roc_9_1d_lt_10 = roc_9_1d < 10.0
+    roc_9_1d_lt_15 = roc_9_1d < 15.0
     roc_9_1d_lt_20 = roc_9_1d < 20.0
+    roc_9_1d_lt_25 = roc_9_1d < 25.0
     roc_9_1d_lt_30 = roc_9_1d < 30.0
+    roc_9_1d_lt_35 = roc_9_1d < 35.0
     roc_9_1d_lt_40 = roc_9_1d < 40.0
     roc_9_1d_lt_50 = roc_9_1d < 50.0
+    roc_9_1d_lt_60 = roc_9_1d < 60.0
+    roc_9_1d_lt_70 = roc_9_1d < 70.0
     roc_9_1d_lt_80 = roc_9_1d < 80.0
     roc_9_1d_lt_100 = roc_9_1d < 100.0
+    roc_9_1d_lt_150 = roc_9_1d < 150.0
+    roc_9_1d_lt_200 = roc_9_1d < 200.0
 
     is_backtest = self.dp.runmode.value in ["backtest", "hyperopt", "plot", "webserver"]
     # the number of free slots
@@ -13372,7 +13380,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 1d down move, 4h still high
             & ((rsi_3_1h_gt_3) | (rsi_3_1d_gt_15) | (stochrsi_k_4h_lt_50))
             # 1h & 4h down move, 1d overbought
-            & ((rsi_3_1h_gt_5) | (rsi_3_4h_gt_5) | (roc_9_1d < 10.0))
+            & ((rsi_3_1h_gt_5) | (rsi_3_4h_gt_5) | (roc_9_1d_lt_10))
             # 1h & 4h down move, 4h still high
             & ((rsi_3_1h_gt_5) | (rsi_3_4h_gt_10) | (aroonu_14_4h_lt_40))
             # 1h & 4h down move, 1h downtrend
@@ -13430,9 +13438,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h still high, 4h downtrend
             & (rsi_3_1h_gt_20 | (aroonu_14_1h_lt_40) | (roc_9_4h_gt_neg_30))
             # 1h down move, 4h high, 1d overbought
-            & (rsi_3_1h_gt_20 | aroonu_14_4h_lt_70 | (roc_9_1d < 200.0))
+            & (rsi_3_1h_gt_20 | aroonu_14_4h_lt_70 | (roc_9_1d_lt_200))
             # 1h down move, 4h high, 1d overbought
-            & (rsi_3_1h_gt_20 | (aroonu_14_4h_lt_90) | (roc_9_1d < 60.0))
+            & (rsi_3_1h_gt_20 | (aroonu_14_4h_lt_90) | (roc_9_1d_lt_60))
             # 1h down move, 4h high & overbought
             & (rsi_3_1h_gt_20 | aroonu_14_4h_lt_100 | (roc_9_4h < 50.0))
             # 1h down move, 1d high & overbought
@@ -13458,7 +13466,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h high, 15m downtrend
             & ((rsi_3_1h_gt_40) | aroonu_14_1h_lt_80 | (roc_9_15m > -15.0))
             # 1h down move, 1h high, 1d overbought
-            & ((rsi_3_1h_gt_40) | aroonu_14_1h_lt_80 | (roc_9_1d < 100.0))
+            & ((rsi_3_1h_gt_40) | aroonu_14_1h_lt_80 | (roc_9_1d_lt_100))
             # 1h down move, 1h high, 4h overbought
             & ((rsi_3_1h_gt_40) | (stochrsi_k_1h_lt_80) | (roc_9_4h_lt_20))
             # 1h down move, 1h & 4h high
@@ -13498,7 +13506,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 4h high, 1d overbought
             & ((rsi_3_4h_gt_50) | aroonu_14_4h_lt_70 | (roc_9_1d_lt_40))
             # 4h down move, 1h high, 1d overbought
-            & ((rsi_3_4h_gt_60) | (stochrsi_k_1h_lt_90) | (roc_9_1d < 60.0))
+            & ((rsi_3_4h_gt_60) | (stochrsi_k_1h_lt_90) | (roc_9_1d_lt_60))
             # 1d down move, 1h high, 1d downtrend
             & ((rsi_3_1d_gt_5) | (stochrsi_k_1h_lt_90) | (roc_9_1d_gt_neg_20))
             # 1d down move, 1h still high, 4h high
@@ -13508,7 +13516,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1d down move, 1d high
             & ((rsi_3_1d_gt_40) | (aroonu_14_1d_lt_80))
             # 1d down move, 4h still high, 1d overbought
-            & ((rsi_3_1d > 50.0) | (aroonu_14_4h_lt_50) | (roc_9_1d < 200.0))
+            & ((rsi_3_1d > 50.0) | (aroonu_14_4h_lt_50) | (roc_9_1d_lt_200))
             # 1d down move, 1d high & overbought
             & ((rsi_3_1d_gt_60) | (aroonu_14_1d_lt_80) | roc_9_1d_lt_50)
             # 1h down move, 4h high, 1d overbought
@@ -13739,7 +13747,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 4h down move, 4h still high
             & ((rsi_3_15m_gt_5) | (rsi_3_4h_gt_15) | (stochrsi_k_4h_lt_50))
             # 15m & 4h down move, 1d overbought
-            & ((rsi_3_15m_gt_5) | (rsi_3_4h_gt_20) | (roc_9_1d < 10.0))
+            & ((rsi_3_15m_gt_5) | (rsi_3_4h_gt_20) | (roc_9_1d_lt_10))
             # 15m & 4h down move, 4h still high
             & ((rsi_3_15m_gt_5) | (rsi_3_4h_gt_45) | (aroonu_14_4h_lt_40))
             # 15m & 1d down move, 15m still not low enough
@@ -13887,7 +13895,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 1h high & overbought
             & ((rsi_3_15m_gt_15) | (stochrsi_k_1h_lt_90) | (roc_9_1h_lt_10))
             # 15m down move, 4h high, 1d overbought
-            & ((rsi_3_15m_gt_15) | (stochrsi_k_4h_lt_70) | (roc_9_1d < 10.0))
+            & ((rsi_3_15m_gt_15) | (stochrsi_k_4h_lt_70) | (roc_9_1d_lt_10))
             # 15m & 1h down move, 15m still not low enough
             & ((rsi_3_15m_gt_20) | (rsi_3_1h_gt_20) | (aroonu_14_15m_lt_30))
             # 15m & 1h down move, 4h overbought
@@ -13965,7 +13973,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 1d high
             & ((rsi_3_1h_gt_3) | rsi_3_4h_gt_20 | (aroonu_14_1d_lt_80))
             # 1h & 4h down move, 1d overbought
-            & ((rsi_3_1h_gt_3) | (rsi_3_4h_gt_25) | (roc_9_1d < 10.0))
+            & ((rsi_3_1h_gt_3) | (rsi_3_4h_gt_25) | (roc_9_1d_lt_10))
             # 1h & 4h down move, 4h high
             & ((rsi_3_1h_gt_3) | (rsi_3_4h_gt_50) | aroonu_14_4h_lt_70)
             # 1h & 1d down move, 15m still high
@@ -14009,7 +14017,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 4h still high
             & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_35) | (rsi_14_4h < 40.0))
             # 1h down move, 1h still not low enough 1d overbought
-            & ((rsi_3_1h_gt_10) | (aroonu_14_1h_lt_30) | (roc_9_1d < 100.0))
+            & ((rsi_3_1h_gt_10) | (aroonu_14_1h_lt_30) | (roc_9_1d_lt_100))
             # 1h & 4h down move, 1d high
             & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_15) | (rsi_14_1d < 60.0))
             # 1h & 4h down move, 1h still not low enough
@@ -14033,7 +14041,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 1d down move, 1d high
             & ((rsi_3_1h_gt_15) | (rsi_3_1d_gt_25) | (aroonu_14_1d_lt_80))
             # 1h & 1d down move, 1d overbought
-            & ((rsi_3_1h_gt_15) | (rsi_3_1d_gt_35) | (roc_9_1d < 10.0))
+            & ((rsi_3_1h_gt_15) | (rsi_3_1d_gt_35) | (roc_9_1d_lt_10))
             # 1h down move, 1h still high, 1d downtrend
             & ((rsi_3_1h_gt_15) | (aroonu_14_1h_lt_40) | (roc_9_1d_gt_neg_40))
             # 1h down move, 4h high, 1d high
@@ -14089,7 +14097,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 4h high, 1d overbought
             & ((rsi_3_1h_gt_30) | aroonu_14_4h_lt_80 | (roc_9_1d_lt_30))
             # 1h down move, 4h downtrend, 1d overbought
-            & ((rsi_3_1h_gt_30) | (roc_9_4h_gt_neg_30) | (roc_9_1d < 200.0))
+            & ((rsi_3_1h_gt_30) | (roc_9_4h_gt_neg_30) | (roc_9_1d_lt_200))
             # 1h down move, 4h & 1d downtrend
             & ((rsi_3_1h_gt_30) | (roc_9_4h > -25.0) | (roc_9_1d > -60.0))
             # 1h & 4h down move, 1h still high
@@ -14105,7 +14113,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1d high, 4h overbought
             & ((rsi_3_1h_gt_35) | aroonu_14_1d_lt_100 | (roc_9_4h_lt_40))
             # 1h down move, 1h still high, 1d overbought
-            & ((rsi_3_1h_gt_35) | (stochrsi_k_1h_lt_50) | (roc_9_1d < 200.0))
+            & ((rsi_3_1h_gt_35) | (stochrsi_k_1h_lt_50) | (roc_9_1d_lt_200))
             # 1h & 4h & 1d down move, 1d overbought
             & ((rsi_3_1h_gt_40) | (rsi_3_4h_gt_40) | (rsi_3_1d_gt_60) | (roc_9_1d_lt_40))
             # 1h down move, 1h & 4h high
@@ -14113,15 +14121,15 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h & 1d high
             & ((rsi_3_1h_gt_40) | aroonu_14_1h_lt_80 | (aroonu_14_1d_lt_80))
             # 1h down move, 1h high, 1d overbought
-            & ((rsi_3_1h_gt_40) | aroonu_14_1h_lt_80 | (roc_9_1d < 10.0))
+            & ((rsi_3_1h_gt_40) | aroonu_14_1h_lt_80 | (roc_9_1d_lt_10))
             # 1h down move, 4h still high, 1d overbought
             & ((rsi_3_1h_gt_40) | (aroonu_14_4h_lt_40) | (roc_9_1d_lt_100))
             # 1h & 4h down move, 4h high
             & ((rsi_3_1h_gt_45) | (rsi_3_4h_gt_60) | aroonu_14_4h_lt_100)
             # 1h & 4h down move, 1d overbought
-            & ((rsi_3_1h_gt_45) | (rsi_3_4h_gt_65) | (roc_9_1d < 200.0))
+            & ((rsi_3_1h_gt_45) | (rsi_3_4h_gt_65) | (roc_9_1d_lt_200))
             # 1h down move, 1h high, 1d high & overbought
-            & ((rsi_3_1h_gt_45) | (stochrsi_k_1h_lt_60) | (stochrsi_k_1d < 70.0) | (roc_9_1d < 40.0))
+            & ((rsi_3_1h_gt_45) | (stochrsi_k_1h_lt_60) | (stochrsi_k_1d < 70.0) | (roc_9_1d_lt_40))
             # 1h down move, 1h high & overbought
             & ((rsi_3_1h_gt_50) | aroonu_14_1h_lt_80 | (roc_9_1h_lt_10))
             # 1h down move, 4h high, 1h overbought
@@ -14159,7 +14167,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h & 1d down move, 1d high
             & ((rsi_3_4h_gt_10) | (rsi_3_1d_gt_35) | (aroonu_14_1d_lt_100))
             # 4h & 1d down move, 1d overbought
-            & ((rsi_3_4h_gt_10) | (rsi_3_1d_gt_45) | (roc_9_1d < 10.0))
+            & ((rsi_3_4h_gt_10) | (rsi_3_1d_gt_45) | (roc_9_1d_lt_10))
             # 4h down move, 1d still high, 1d downtrend
             & ((rsi_3_4h_gt_10) | (aroonu_14_1d_lt_40) | (roc_9_1d > -20.0))
             # 4h down move, 1d high & overbought
@@ -14191,11 +14199,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 4h high, 4h downtrend
             & ((rsi_3_4h_gt_25) | aroonu_14_4h_lt_70 | (roc_9_4h_gt_neg_30))
             # 4h & 1d down move, 1d overbought
-            & ((rsi_3_4h_gt_30) | (rsi_3_1d_gt_60) | (roc_9_1d < 60.0))
+            & ((rsi_3_4h_gt_30) | (rsi_3_1d_gt_60) | (roc_9_1d_lt_60))
             # 4h down move, 1d downtrend
             & ((rsi_3_4h_gt_30) | roc_9_1d_gt_neg_50)
             # 4h down move, 4h & 1d overbought
-            & ((rsi_3_4h_gt_35) | (roc_9_4h_lt_30) | (roc_9_1d < 200.0))
+            & ((rsi_3_4h_gt_35) | (roc_9_4h_lt_30) | (roc_9_1d_lt_200))
             # 4h down move, 1h high, 1d overbought
             & ((rsi_3_4h_gt_40) | aroonu_14_1h_lt_70 | (roc_9_1d_lt_40))
             # 4h down move, 4h & 1d downtrend
@@ -14219,7 +14227,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 4h high & overbought
             & ((rsi_3_4h_gt_60) | aroonu_14_4h_lt_70 | (roc_9_4h_lt_20))
             # 4h down move, 1d high & overbought
-            & ((rsi_3_4h_gt_60) | aroonu_14_1d_lt_100 | (roc_9_1d < 200.0))
+            & ((rsi_3_4h_gt_60) | aroonu_14_1d_lt_100 | (roc_9_1d_lt_200))
             # 4h down move, 4h & 1d overbought
             & ((rsi_3_4h_gt_60) | (roc_9_4h_lt_20) | (roc_9_1d_lt_20))
             # 4h down move, 4h overbought
@@ -14239,7 +14247,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1d down move, 1h high, 1d downtrend
             & ((rsi_3_1d_gt_20) | (stochrsi_k_1h_lt_90) | (roc_9_1d > -10.0))
             # 1d down move, 1h high, 1d overbought
-            & ((rsi_3_1d_gt_25) | aroonu_14_1h_lt_70 | (roc_9_1d < 25.0))
+            & ((rsi_3_1d_gt_25) | aroonu_14_1h_lt_70 | (roc_9_1d_lt_25))
             # 1d down move, 1d still high, 1d downtrend
             & ((rsi_3_1d_gt_25) | (stochrsi_k_1d < 50.0) | (roc_9_1d_gt_neg_20))
             # 1d down move, 1h high & overbought
@@ -14251,7 +14259,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1d downtrend, 1d high & overbought
             & ((cmf_20_1d > -0.40) | (aroonu_14_1d_lt_85) | (roc_9_1d_lt_20))
             # 1h high, 4h & 1d overbought
-            & (aroonu_14_1h_lt_70 | (roc_9_4h < 50.0) | (roc_9_1d < 200.0))
+            & (aroonu_14_1h_lt_70 | (roc_9_4h < 50.0) | (roc_9_1d_lt_200))
             # 1h & 4h high, 1d overbought
             & (aroonu_14_1h_lt_70 | (aroonu_14_4h_lt_90) | roc_9_1d_lt_50)
             # 1h & 4h high, 1d downtrend
@@ -14285,11 +14293,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1d high, 1h & 4h downtrend
             & ((aroonu_14_1d_lt_85) | (roc_9_1h > -30.0) | (roc_9_4h > -50.0))
             # 1d high, 4h & 1d overbought
-            & ((aroonu_14_1d_lt_85) | (roc_9_4h < 60.0) | (roc_9_1d < 60.0))
+            & ((aroonu_14_1d_lt_85) | (roc_9_4h < 60.0) | (roc_9_1d_lt_60))
             # 1d high, 1h & 4h down move
             & (aroonu_14_1d_lt_100 | (roc_9_1h < 25.0) | (roc_9_4h < 60.0))
             # 15m high, 1d overbought
-            & ((stochrsi_k_15m_lt_70) | (roc_9_1d < 60.0))
+            & ((stochrsi_k_15m_lt_70) | (roc_9_1d_lt_60))
             # 1h high, 1d downtrend
             & ((stochrsi_k_1h_lt_70) | roc_9_1d_gt_neg_50)
             # 1h high, 1d overbought
@@ -14303,7 +14311,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1d high, 1h & 1d overbought
             & ((stochrsi_k_1d < 80.0) | (roc_9_1h_lt_10) | (roc_9_1d_lt_80))
             # 1d high, 4h & 1d overbought
-            & ((stochrsi_k_1d < 80.0) | (roc_9_4h < 60.0) | (roc_9_1d < 60.0))
+            & ((stochrsi_k_1d < 80.0) | (roc_9_4h < 60.0) | (roc_9_1d_lt_60))
             # big drop in the last 20 days, 1d high, 1d downtrend
             & ((close > (high_max_20_1d * 0.20)) | (stochrsi_k_1d < 70.0) | (roc_9_1d > -15.0))
             # drop in last 20 days, 1h high, 1d downtrend
@@ -14492,7 +14500,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 15m high, 4h overbought
             & ((rsi_3_15m_gt_25) | (aroonu_14_15m_lt_70) | (roc_9_4h_lt_10))
             # 15m down move, 15m high, 1d overbought
-            & ((rsi_3_15m_gt_25) | (aroonu_14_15m_lt_70) | (roc_9_1d < 60.0))
+            & ((rsi_3_15m_gt_25) | (aroonu_14_15m_lt_70) | (roc_9_1d_lt_60))
             # 15m down move, 1h & 4h high
             & ((rsi_3_15m_gt_25) | (aroonu_14_1h_lt_70) | (aroonu_14_4h_lt_70))
             # 15m down move, 1h high, 1d downtrend
@@ -14524,7 +14532,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 15m high, 15m downtrend
             & ((rsi_3_15m_gt_30) | (aroonu_14_15m_lt_70) | (cmf_20_15m > -0.30))
             # 15m down move, 15m high, 1d overbought
-            & ((rsi_3_15m_gt_30) | (aroonu_14_15m_lt_70) | (roc_9_1d < 70.0))
+            & ((rsi_3_15m_gt_30) | (aroonu_14_15m_lt_70) | (roc_9_1d_lt_70))
             # 15m down move, 1h high, 1d overbought
             & ((rsi_3_15m_gt_30) | (aroonu_14_1h_lt_100) | (roc_9_1d_lt_30))
             # 15m down move, 4h high & overbought
@@ -14542,7 +14550,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 1h high, 4h overbought
             & ((rsi_3_15m_gt_35) | (aroonu_14_1h_lt_90) | (roc_9_4h < 100.0))
             # 15m down move, 4h high, 1d overbought
-            & ((rsi_3_15m_gt_35) | (aroonu_14_4h_lt_80) | (roc_9_1d < 200.0))
+            & ((rsi_3_15m_gt_35) | (aroonu_14_4h_lt_80) | (roc_9_1d_lt_200))
             # 15m down move, 1h high, 1d downtrend
             & ((rsi_3_15m_gt_35) | (stochrsi_k_1h_lt_90) | roc_9_1d_gt_neg_50)
             # 15m down move, 4h high & overbought
@@ -14570,7 +14578,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 1d downtrend
             & ((rsi_3_1h_gt_15) | rsi_3_4h_gt_20 | (roc_9_1d > -30.0))
             # 1h & 1d down move, 1d overbought
-            & ((rsi_3_1h_gt_15) | (rsi_3_1d_gt_35) | (roc_9_1d < 10.0))
+            & ((rsi_3_1h_gt_15) | (rsi_3_1d_gt_35) | (roc_9_1d_lt_10))
             # 1h & 1d down move, 1d overbought
             & ((rsi_3_1h_gt_15) | (rsi_3_1d_gt_60) | (roc_9_1d_lt_40))
             # 1h down move, 1h still not low enough, 1d downtrend
@@ -14580,7 +14588,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 1d overbought
             & (rsi_3_1h_gt_20 | (rsi_3_4h_gt_25) | (roc_9_1d_lt_30))
             # 1h down move, 4h high, 1d overbought
-            & (rsi_3_1h_gt_20 | aroonu_14_4h_lt_80 | (roc_9_1d < 100.0))
+            & (rsi_3_1h_gt_20 | aroonu_14_4h_lt_80 | (roc_9_1d_lt_100))
             # 1h & 4h down move, 4h high
             & ((rsi_3_1h_gt_25) | (rsi_3_4h_gt_40) | aroonu_14_4h_lt_80)
             # 1h & 1d down move, 1d still high
@@ -14596,7 +14604,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 15m & 1h still high
             & ((rsi_3_1h_gt_30) | (aroonu_14_15m_lt_40) | (aroonu_14_1h_lt_50))
             # 1h down move, 1h still high 1d overbought
-            & ((rsi_3_1h_gt_30) | (aroonu_14_1h_lt_50) | (roc_9_1d < 200.0))
+            & ((rsi_3_1h_gt_30) | (aroonu_14_1h_lt_50) | (roc_9_1d_lt_200))
             # 1h down move, 1h high, 4h downtrend
             & ((rsi_3_1h_gt_30) | (aroonu_14_1h_lt_60) | (roc_9_4h_gt_neg_20))
             # 1h down move, 1h high, 1d overbought
@@ -14662,15 +14670,15 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1d high & overbought
             & ((rsi_3_1h_gt_45) | aroonu_14_1d_lt_100 | (roc_9_1d_lt_30))
             # 1h down move, 1h still high, 1d overbought
-            & ((rsi_3_1h_gt_45) | (stochrsi_k_1h_lt_40) | (roc_9_1d < 200.0))
+            & ((rsi_3_1h_gt_45) | (stochrsi_k_1h_lt_40) | (roc_9_1d_lt_200))
             # 1h down move, 1d high & overbought
-            & ((rsi_3_1h_gt_45) | (stochrsi_k_1d < 80.0) | (roc_9_1d < 10.0))
+            & ((rsi_3_1h_gt_45) | (stochrsi_k_1d < 80.0) | (roc_9_1d_lt_10))
             # 1h down move, 15m & 1h high
             & ((rsi_3_1h_gt_50) | (aroonu_14_15m_lt_70) | (aroonu_14_1h_lt_100))
             # 1h down move, 1h high, 4h overbought
             & ((rsi_3_1h_gt_50) | aroonu_14_1h_lt_80 | (roc_9_4h_lt_10))
             # 1h down move, 4h still high, 1d overbought
-            & ((rsi_3_1h_gt_50) | (aroonu_14_4h_lt_50) | (roc_9_1d < 200.0))
+            & ((rsi_3_1h_gt_50) | (aroonu_14_4h_lt_50) | (roc_9_1d_lt_200))
             # 1h down move, 4h high & overbought
             & ((rsi_3_1h_gt_50) | aroonu_14_4h_lt_100 | (roc_9_4h < 50.0))
             # 1h down move, 1h & 4h high
@@ -14744,7 +14752,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 4h still high, 1d downtrend
             & (rsi_3_4h_gt_20 | (aroonu_14_4h_lt_50) | (roc_9_1d_gt_neg_40))
             # 4h down move, 1d high & overbought
-            & (rsi_3_4h_gt_20 | (aroonu_14_1d_lt_90) | (roc_9_1d < 10.0))
+            & (rsi_3_4h_gt_20 | (aroonu_14_1d_lt_90) | (roc_9_1d_lt_10))
             # 4h down move, 15m high, 4h downtrend
             & (rsi_3_4h_gt_20 | (stochrsi_k_15m_lt_80) | (roc_9_4h > -50.0))
             # 4h down move, 1h high, 1d downtrend
@@ -14792,7 +14800,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 1h high, 1d overbought
             & ((rsi_3_4h_gt_30) | (stochrsi_k_1h_lt_90) | roc_9_1d_lt_50)
             # 4h down move, 1d high & overbought
-            & ((rsi_3_4h_gt_30) | (stochrsi_k_1d < 80.0) | (roc_9_1d < 10.0))
+            & ((rsi_3_4h_gt_30) | (stochrsi_k_1d < 80.0) | (roc_9_1d_lt_10))
             # 4h down move, 15m still high, 1h high
             & ((rsi_3_4h_gt_35) | (aroonu_14_15m_lt_40) | (stochrsi_k_1h_lt_90))
             # 4h down move, 15m still high, 4h high
@@ -14808,7 +14816,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 15m still high, 1d overbought
             & ((rsi_3_4h_gt_40) | (aroonu_14_15m_lt_50) | roc_9_1d_lt_50)
             # 4h down move, 15m high, 1d overbought
-            & ((rsi_3_4h_gt_40) | (aroonu_14_15m_lt_70) | (roc_9_1d < 200.0))
+            & ((rsi_3_4h_gt_40) | (aroonu_14_15m_lt_70) | (roc_9_1d_lt_200))
             # 4h down move, 1h & 4h high
             & ((rsi_3_4h_gt_40) | aroonu_14_1h_lt_70 | aroonu_14_4h_lt_80)
             # 4h down move, 1d high & overbought
@@ -14816,7 +14824,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 15m high, 1h high
             & ((rsi_3_4h_gt_40) | (stochrsi_k_15m_lt_70) | (aroonu_14_1h_lt_100))
             # 4h down move, 1h high, 1d overbought
-            & ((rsi_3_4h_gt_40) | (stochrsi_k_1h_lt_70) | (roc_9_1d < 60.0))
+            & ((rsi_3_4h_gt_40) | (stochrsi_k_1h_lt_70) | (roc_9_1d_lt_60))
             # 4h down move, 4h & 1d overbought
             & ((rsi_3_4h_gt_40) | (roc_9_4h_lt_10) | (roc_9_1d_lt_30))
             # 4h down move, 15m still high, 4h high
@@ -14838,7 +14846,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 1d high & overbought
             & ((rsi_3_4h_gt_45) | (stochrsi_k_1d_lt_90) | (roc_9_1d_lt_20))
             # 4h down move, 4h & 1d overbought
-            & ((rsi_3_4h_gt_45) | (roc_9_4h_lt_30) | (roc_9_1d < 200.0))
+            & ((rsi_3_4h_gt_45) | (roc_9_4h_lt_30) | (roc_9_1d_lt_200))
             # 4h down move, 15m & 1h high
             & ((rsi_3_4h_gt_50) | (aroonu_14_15m_lt_70) | (aroonu_14_1h_lt_100))
             # 4h down move, 4h still high, 1h high
@@ -14858,7 +14866,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 4h high & overbought
             & ((rsi_3_4h_gt_55) | aroonu_14_4h_lt_70 | (roc_9_4h_lt_20))
             # 4h down move, 1d high & overbought
-            & ((rsi_3_4h_gt_55) | (aroonu_14_1d_lt_90) | (roc_9_1d < 60.0))
+            & ((rsi_3_4h_gt_55) | (aroonu_14_1d_lt_90) | (roc_9_1d_lt_60))
             # 4h down move, 4h high & overbought
             & ((rsi_3_4h_gt_55) | (stochrsi_k_4h_lt_80) | (roc_9_4h_lt_10))
             # 4h down move, 15m high, 1h high
@@ -14900,7 +14908,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1d down move, 1d still high, 1d downtrend
             & ((rsi_3_1d_gt_25) | (stochrsi_k_1d < 50.0) | (roc_9_1d_gt_neg_20))
             # 1d down move, 1d high & overbought
-            & ((rsi_3_1d_gt_30) | (aroonu_14_1d_lt_60) | (roc_9_1d < 10.0))
+            & ((rsi_3_1d_gt_30) | (aroonu_14_1d_lt_60) | (roc_9_1d_lt_10))
             # 1d down move, 1h high, 1d downtrend
             & ((rsi_3_1d_gt_30) | (stochrsi_k_1h_lt_70) | (roc_9_1d_lt_20))
             # 1d down move, 1h & 1d high
@@ -14910,17 +14918,17 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1d down move, 1d high & overbought
             & ((rsi_3_1d_gt_40) | aroonu_14_1d_lt_100 | (roc_9_1d_lt_30))
             # 1d down move, 1d high & overbought
-            & ((rsi_3_1d_gt_40) | (aroonu_14_1d_lt_80) | (roc_9_1d < 10.0))
+            & ((rsi_3_1d_gt_40) | (aroonu_14_1d_lt_80) | (roc_9_1d_lt_10))
             # 1d down move, 1h high, 1d overbought
             & ((rsi_3_1d_gt_40) | (stochrsi_k_1h_lt_70) | roc_9_1d_lt_50)
             # 15m still high, 4h high, 1d overbought
-            & ((aroonu_14_15m_lt_50) | (rsi_14_4h < 60.0) | (roc_9_1d < 70.0))
+            & ((aroonu_14_15m_lt_50) | (rsi_14_4h < 60.0) | (roc_9_1d_lt_70))
             # 15m still high, 1h downtrend, 4h overbought
             & ((aroonu_14_15m_lt_50) | (roc_9_1h > -10.0) | (roc_9_4h_lt_40))
             # 15m high, 4h high & overbought
             & ((aroonu_14_15m_lt_60) | aroonu_14_4h_lt_70 | (roc_9_4h_lt_20))
             # 15m & 4h high, 1d overbought
-            & ((aroonu_14_15m_lt_60) | aroonu_14_4h_lt_70 | (roc_9_1d < 10.0))
+            & ((aroonu_14_15m_lt_60) | aroonu_14_4h_lt_70 | (roc_9_1d_lt_10))
             # 15m high, 15m & 4h overbought
             & ((aroonu_14_15m_lt_60) | (roc_9_15m < 10.0) | (roc_9_4h_lt_20))
             # 15m high, 4h downtrend
@@ -14936,7 +14944,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1d high, 1d overbought
             & ((aroonu_14_15m_lt_70) | (aroonu_14_1d_lt_90) | (roc_9_1d_lt_100))
             # 15m high, 4h downtrend, 1d overbought
-            & ((aroonu_14_15m_lt_70) | (roc_9_4h_gt_neg_30) | (roc_9_1d < 200.0))
+            & ((aroonu_14_15m_lt_70) | (roc_9_4h_gt_neg_30) | (roc_9_1d_lt_200))
             # 4h down move, 1h still high, 1d downtrend
             & ((rsi_3_4h_gt_15) | (aroonu_14_1h_lt_40) | roc_9_1d_gt_neg_50)
             # 1h & 4h high, 4h overbought
@@ -14958,7 +14966,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1d high, 4h downtrend
             & ((aroonu_14_1d_lt_85) | (roc_9_4h_gt_neg_30))
             # 1d high, 4h downtrend, 1d overbought
-            & ((aroonu_14_1d_lt_85) | (roc_9_4h_gt_neg_30) | (roc_9_1d < 70.0))
+            & ((aroonu_14_1d_lt_85) | (roc_9_4h_gt_neg_30) | (roc_9_1d_lt_70))
             # 1d high, 4h & 1d overbought
             & (aroonu_14_1d_lt_100 | (roc_9_4h_lt_30) | (roc_9_1d_lt_40))
             # 15m & 1h high, 1d overbought
@@ -14990,7 +14998,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1d green, 4h down move, 4h still high
             & ((change_pct_1d < 40.0) | (rsi_3_4h_gt_35) | (aroonu_14_4h_lt_40))
             # 1d top wick, 4h down move, 1d overbought
-            & ((top_wick_pct_1d < 50.0) | (rsi_3_4h_gt_35) | (roc_9_1d < 60.0))
+            & ((top_wick_pct_1d < 50.0) | (rsi_3_4h_gt_35) | (roc_9_1d_lt_60))
             # big drop in the last 20 days, 1d high, 1d downtrend
             & ((close > (high_max_20_1d * 0.20)) | (stochrsi_k_1d < 70.0) | (roc_9_1d > -15.0))
           )
@@ -15053,7 +15061,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h & 4h down move, 1d high & overbought
             & ((rsi_3_15m_gt_5) | (rsi_3_1h_gt_45) | (rsi_3_4h_gt_45) | (aroonu_14_1d_lt_100) | (roc_9_1d_lt_50))
             # 15m & 4h down move, 1d overbought
-            & ((rsi_3_15m_gt_5) | (rsi_3_4h_gt_15) | (roc_9_1d < 70.0))
+            & ((rsi_3_15m_gt_5) | (rsi_3_4h_gt_15) | (roc_9_1d_lt_70))
             # 15m & 4h down move, 1d high
             & ((rsi_3_15m_gt_5) | (rsi_3_4h_gt_30) | aroonu_14_1d_lt_100)
             # 15m down move, 1h high & overbought
@@ -15183,7 +15191,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 4h high, 1d overbought
             & ((rsi_3_1h_gt_30) | aroonu_14_4h_lt_80 | (roc_9_1d_lt_30))
             # 1h down move, 1d high & overbought
-            & ((rsi_3_1h_gt_30) | (aroonu_14_1d_lt_80) | (roc_9_1d < 200.0))
+            & ((rsi_3_1h_gt_30) | (aroonu_14_1d_lt_80) | (roc_9_1d_lt_200))
             # 1h & 4h down move, 1d overbought
             & ((rsi_3_1h_gt_30) | (rsi_3_4h_gt_30) | (roc_9_1d_lt_40))
             # 1h & 4h down move, 15m high
@@ -15203,7 +15211,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 4h high, 1d overbought
             & ((rsi_3_1h_gt_35) | (aroonu_14_4h_lt_85) | (roc_9_1d_lt_100))
             # 1h down move, 1h still high, 1d overbought
-            & ((rsi_3_1h_gt_35) | (stochrsi_k_1h_lt_50) | (roc_9_1d < 200.0))
+            & ((rsi_3_1h_gt_35) | (stochrsi_k_1h_lt_50) | (roc_9_1d_lt_200))
             # 1h down move, 1h high, 4h downtrend
             & ((rsi_3_1h_gt_35) | (stochrsi_k_1h_lt_70) | (roc_9_4h_gt_neg_20))
             # 1h down move, 1h high, 4h overbought
@@ -15217,7 +15225,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h high & overbought
             & ((rsi_3_1h_gt_55) | (stochrsi_k_1h_lt_80) | (roc_9_1h_lt_10))
             # 1h down move, 4h & 1d overbought
-            & ((rsi_3_1h_gt_60) | (roc_9_4h_lt_30) | (roc_9_1d < 60.0))
+            & ((rsi_3_1h_gt_60) | (roc_9_4h_lt_30) | (roc_9_1d_lt_60))
             # 4h & 1d down move, 4h still not low enough
             & ((rsi_3_4h_gt_3) | (rsi_3_1d_gt_15) | (aroonu_14_4h < 20.0))
             # 4h down move, 4h high, 4h downtrend
@@ -15251,7 +15259,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 4h still high, 1d downtrend
             & ((rsi_3_4h_gt_30) | (aroonu_14_4h_lt_50) | (roc_9_1d_gt_neg_40))
             # 4h down move, 1d high & overbought
-            & ((rsi_3_4h_gt_40) | (stochrsi_k_1d_lt_90) | (roc_9_1d < 200.0))
+            & ((rsi_3_4h_gt_40) | (stochrsi_k_1d_lt_90) | (roc_9_1d_lt_200))
             # 4h down move, 4h high, 1d downtrend
             & ((rsi_3_4h_gt_45) | aroonu_14_4h_lt_70 | (roc_9_1d_gt_neg_30))
             # 4h down move, 4h high & overbought
@@ -15263,7 +15271,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h high, 1h overbought
             & (aroonu_14_1h_lt_70 | aroonu_14_4h_lt_100 | (roc_9_1h < 80.0))
             # 1h high, 1d overbought
-            & (aroonu_14_1h_lt_70 | (roc_9_1d < 70.0))
+            & (aroonu_14_1h_lt_70 | (roc_9_1d_lt_70))
             # 1h & 4h high, 1h overbought
             & (aroonu_14_1h_lt_80 | (aroonu_14_4h_lt_90) | (roc_9_1h < 30.0))
             # 1h & 1d high, 1h overbought
@@ -15277,19 +15285,19 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h & 1d high, 4h overbought
             & (aroonu_14_4h_lt_80 | aroonu_14_1d_lt_100 | (roc_9_4h < 50.0))
             # 4h high, 1h & 1d overbought
-            & (aroonu_14_4h_lt_100 | (roc_9_1h < 30.0) | (roc_9_1d < 100.0))
+            & (aroonu_14_4h_lt_100 | (roc_9_1h < 30.0) | (roc_9_1d_lt_100))
             # 4h high, 1h & 4h high
             & (aroonu_14_4h_lt_100 | (roc_9_1h < 50.0) | (roc_9_4h < 100.0))
             # 1d high, 4h & 1d downtrend
             & ((aroonu_14_1d_lt_70) | (roc_9_4h > -40.0) | (roc_9_1d_gt_neg_40))
             # 1d high, 1h & 1d overbought
-            & ((aroonu_14_1d_lt_80) | (roc_9_1h < 30.0) | (roc_9_1d < 200.0))
+            & ((aroonu_14_1d_lt_80) | (roc_9_1h < 30.0) | (roc_9_1d_lt_200))
             # 1d high, 4h & 1d overbought
             & ((aroonu_14_1d_lt_90) | (roc_9_4h_lt_20) | roc_9_1d_lt_50)
             # 1h high, 4h overbought
             & ((stochrsi_k_1h_lt_80) | (roc_9_4h < 80.0))
             # 4h & 1d overbought
-            & ((roc_9_4h < 100.0) | (roc_9_1d < 200.0))
+            & ((roc_9_4h < 100.0) | (roc_9_1d_lt_200))
             # big drop in the last 20 days, 1d high, 1d downtrend
             & ((close > (high_max_20_1d * 0.20)) | (stochrsi_k_1d < 70.0) | (roc_9_1d > -15.0))
             # drop in last 20 days, 1h high, 1d downtrend
@@ -15372,7 +15380,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 4h still high
             & ((rsi_3_1h_gt_3) | (rsi_3_4h_gt_10) | (aroonu_14_4h_lt_40))
             # 1h & 4h down move, 1d overbought
-            & ((rsi_3_1h_gt_3) | (rsi_3_4h_gt_10) | (roc_9_1d < 15.0))
+            & ((rsi_3_1h_gt_3) | (rsi_3_4h_gt_10) | (roc_9_1d_lt_15))
             # 1h & 4h down move, 4h downtrend
             & ((rsi_3_1h_gt_3) | (rsi_3_4h_gt_15) | (roc_9_4h > -40.0))
             # 1h & 4h down move, 1d downtrend
@@ -15394,7 +15402,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 4h high
             & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_15) | (aroonu_14_4h_lt_60))
             # 1h & 4h down move, 1d overbought
-            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_30) | (roc_9_1d < 100.0))
+            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_30) | (roc_9_1d_lt_100))
             # 1h & 4h down move, 4h still high
             & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_45) | (stochrsi_k_4h_lt_40))
             # 1h down move, 4h downtrend. 4h still not low enough
@@ -15432,11 +15440,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1d high, 4h overbought
             & ((rsi_3_1h_gt_15) | (aroonu_14_1d_lt_100) | (roc_9_4h < 60.0))
             # 1h down move, 1d high & overbought
-            & ((rsi_3_1h_gt_15) | (aroonu_14_1d_lt_100) | (roc_9_1d < 10.0))
+            & ((rsi_3_1h_gt_15) | (aroonu_14_1d_lt_100) | (roc_9_1d_lt_10))
             # 1h down move, 1h downtrend, 1d overbought
             & ((rsi_3_1h_gt_15) | (roc_9_1h > -30.0) | (roc_9_1d_lt_80))
             # 1h down move, 4h & 1d overbought
-            & ((rsi_3_1h_gt_15) | (roc_9_4h_lt_10) | (roc_9_1d < 60.0))
+            & ((rsi_3_1h_gt_15) | (roc_9_4h_lt_10) | (roc_9_1d_lt_60))
             # 1h & 4h down move, 4h high
             & (rsi_3_1h_gt_20 | rsi_3_4h_gt_20 | aroonu_14_4h_lt_70)
             # 1h & 4h down move, 4h high
@@ -15482,7 +15490,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h high, 4h downtrend
             & ((rsi_3_1h_gt_35) | (aroonu_14_1h_lt_80) | (roc_9_4h > -20.0))
             # 1h down move, 1h still high, 1d overbought
-            & ((rsi_3_1h_gt_35) | (stochrsi_k_1h_lt_50) | (roc_9_1d < 200.0))
+            & ((rsi_3_1h_gt_35) | (stochrsi_k_1h_lt_50) | (roc_9_1d_lt_200))
             # 1h down move, 15m high, 1h high
             & ((rsi_3_1h_gt_40) | (aroonu_14_15m_lt_60) | (aroonu_14_1h_lt_70))
             # 1h down move, 1h still high, 1d overbought
@@ -15498,7 +15506,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h overbought
             & ((rsi_3_1h_gt_40) | (roc_9_1h < 30.0))
             # 1h & 4h down move, 1d overbought
-            & ((rsi_3_1h_gt_45) | (rsi_3_4h_gt_65) | (roc_9_1d < 200.0))
+            & ((rsi_3_1h_gt_45) | (rsi_3_4h_gt_65) | (roc_9_1d_lt_200))
             # 1h down move, 15m still high, 1h high
             & ((rsi_3_1h_gt_45) | (aroonu_14_15m_lt_50) | (aroonu_14_1h_lt_85))
             # 1h down move, 1h high, 4h overbought
@@ -15518,7 +15526,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 15m high, 1h high
             & ((rsi_3_1h_gt_55) | (aroonu_14_15m_lt_60) | (stochrsi_k_1h_lt_80))
             # 1h down move, 1h high & overbought
-            & ((rsi_3_1h_gt_55) | (stochrsi_k_1h_lt_60) | (roc_9_1d < 10.0))
+            & ((rsi_3_1h_gt_55) | (stochrsi_k_1h_lt_60) | (roc_9_1d_lt_10))
             # 1h down move, 4h & 1d overbought
             & ((rsi_3_1h_gt_60) | (roc_9_4h_lt_10) | (roc_9_1d_lt_40))
             # 1h down move, 4h high, 1d overbought
@@ -15562,7 +15570,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 1d high, 1d downtrend
             & (rsi_3_4h_gt_20 | (aroonu_14_1d_lt_80) | (roc_9_1d_gt_neg_30))
             # 4h down move, 1d high & overbought
-            & (rsi_3_4h_gt_20 | (aroonu_14_1d_lt_80) | (roc_9_1d < 70.0))
+            & (rsi_3_4h_gt_20 | (aroonu_14_1d_lt_80) | (roc_9_1d_lt_70))
             # 4h down move, 4h still high. 4h downtrend
             & ((rsi_3_4h_gt_25) | (aroonu_14_4h_lt_50) | (cmf_20_4h > -0.40))
             # 4h down move, 4h high, 1d downtrend
@@ -15596,7 +15604,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h high, 4h overbought
             & (aroonu_14_1h_lt_80 | aroonu_14_4h_lt_100 | (roc_9_4h_lt_10))
             # 1h & 1d high, 1d overbought
-            & (aroonu_14_1h_lt_80 | (aroonu_14_1d_lt_80) | (roc_9_1d < 200.0))
+            & (aroonu_14_1h_lt_80 | (aroonu_14_1d_lt_80) | (roc_9_1d_lt_200))
             # 1h high, 1h overbought
             & (aroonu_14_1h_lt_80 | (roc_9_1h_lt_10))
             # 4h still high, 5m downtrend
@@ -15612,13 +15620,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h & 1d high, 4h overbought
             & (aroonu_14_4h_lt_100 | aroonu_14_1d_lt_100 | (roc_9_4h_lt_40))
             # 4h high, 1h & 1d overbought
-            & (aroonu_14_4h_lt_100 | (roc_9_1h < 40.0) | (roc_9_1d < 100.0))
+            & (aroonu_14_4h_lt_100 | (roc_9_1h < 40.0) | (roc_9_1d_lt_100))
             # 4h high, 4h & 1d overbought
             & (aroonu_14_4h_lt_100 | (roc_9_4h < 20.0) | (roc_9_1d_lt_80))
             # 1d high, 1h & 4h down move
             & (aroonu_14_1d_lt_100 | (roc_9_1h < 25.0) | (roc_9_4h < 60.0))
             # 1d high, 1h downtrend, 1d overbought
-            & (aroonu_14_1d_lt_100 | (roc_9_1h > -30.0) | (roc_9_1d < 100.0))
+            & (aroonu_14_1d_lt_100 | (roc_9_1h > -30.0) | (roc_9_1d_lt_100))
             # 1d high, 4h & 1d overbought
             & (aroonu_14_1d_lt_100 | (roc_9_4h < 20.0) | (roc_9_1d_lt_80))
             # 15m high, 4h & 1d downtrend
@@ -15697,7 +15705,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 5m & 4h down move, 15m still high
             & ((rsi_3_gt_5) | (rsi_3_4h_gt_25) | (stochrsi_k_15m_lt_50))
             # 5m & 4h down move, 1d overbought
-            & ((rsi_3_gt_5) | (rsi_3_4h_gt_30) | (roc_9_1d < 60.0))
+            & ((rsi_3_gt_5) | (rsi_3_4h_gt_30) | (roc_9_1d_lt_60))
             # 5m & 4h down move, 4h high
             & ((rsi_3_gt_5) | (rsi_3_4h_gt_60) | aroonu_14_4h_lt_80)
             # 5m down move, 15m still not low enough, 4h high
@@ -15739,7 +15747,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1d down move, 4h high
             & ((rsi_3_15m_gt_3) | (rsi_3_1d_gt_55) | (stochrsi_k_4h_lt_70))
             # 1h & 1d downtrend, 1d high
-            & ((rsi_3_15m_gt_3) | (aroonu_14_1d_lt_70) | (roc_9_1d < 10.0))
+            & ((rsi_3_15m_gt_3) | (aroonu_14_1d_lt_70) | (roc_9_1d_lt_10))
             # 15m & 1h down move, 1h high
             & ((rsi_3_15m_gt_5) | (rsi_3_1h_gt_25) | (aroonu_14_1h_lt_60))
             # 15m & 1h down move, 1h still high
@@ -15791,7 +15799,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 1h still high
             & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_45) | (stochrsi_k_1h_lt_40))
             # 15m & 1h down move, 1d overbought
-            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_45) | (roc_9_1d < 150.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_45) | (roc_9_1d_lt_150))
             # 15m & 1h down move, 4h high
             & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_50) | (stochrsi_k_4h_lt_80))
             # 15m & 1h down move, 1h high
@@ -15853,7 +15861,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 4h high & overbought
             & ((rsi_3_15m_gt_10) | (stochrsi_k_4h_lt_70) | (roc_9_4h_lt_10))
             # 15m down move, 4h high, 1d overbought
-            & ((rsi_3_15m_gt_10) | (stochrsi_k_4h_lt_70) | (roc_9_1d < 10.0))
+            & ((rsi_3_15m_gt_10) | (stochrsi_k_4h_lt_70) | (roc_9_1d_lt_10))
             # 15m & 1h & 4h down move
             & ((rsi_3_15m_gt_15) | (rsi_3_1h_gt_15) | (rsi_3_1h_gt_15))
             # 15m & 1h down move, 1h still high
@@ -15897,7 +15905,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1d down move, 1h still high
             & ((rsi_3_15m_gt_15) | (rsi_3_1d_gt_20) | (stochrsi_k_1h_lt_50))
             # 15m & 1d down move, 1d overbought
-            & ((rsi_3_15m_gt_15) | (rsi_3_1d_gt_30) | (roc_9_1d < 10.0))
+            & ((rsi_3_15m_gt_15) | (rsi_3_1d_gt_30) | (roc_9_1d_lt_10))
             # 15m down move, 15m still not low enough, 1h high
             & ((rsi_3_15m_gt_15) | (aroonu_14_15m_lt_25) | (stochrsi_k_1h_lt_80))
             # 15m down move, 15m still high, 4h high
@@ -15967,7 +15975,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 1h & 4h high
             & ((rsi_3_15m_gt_20) | aroonu_14_1h_lt_80 | aroonu_14_4h_lt_80)
             # 15m down move, 1h high, 1d overbought
-            & ((rsi_3_15m_gt_20) | aroonu_14_1h_lt_80 | (roc_9_1d < 10.0))
+            & ((rsi_3_15m_gt_20) | aroonu_14_1h_lt_80 | (roc_9_1d_lt_10))
             # 15m down move, 4h high & overbought
             & ((rsi_3_15m_gt_20) | aroonu_14_4h_lt_70 | (roc_9_4h_lt_30))
             # 15m down move, 4h high, 1h overbought
@@ -15981,7 +15989,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 15m high, 4h downtrend
             & ((rsi_3_15m_gt_20) | (stochrsi_k_15m_lt_60) | (roc_9_4h > -50.0))
             # 15 down move, 1h high, 1d overbought
-            & ((rsi_3_15m_gt_20) | (stochrsi_k_1h_lt_70) | (roc_9_1d < 10.0))
+            & ((rsi_3_15m_gt_20) | (stochrsi_k_1h_lt_70) | (roc_9_1d_lt_10))
             # 15m down move, 4h high, 15m downtrend
             & ((rsi_3_15m_gt_20) | (stochrsi_k_4h_lt_70) | (cmf_20_15m > -0.40))
             # 15m & 1h & 4h down move, 1h still not low enough, 4h still high
@@ -16013,7 +16021,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 15m still high, 1h high
             & ((rsi_3_15m_gt_25) | (aroonu_14_15m_lt_40) | (stochrsi_k_1h_lt_80))
             # 15m down move, 1h high, 1d overbought
-            & ((rsi_3_15m_gt_25) | (aroonu_14_1h_lt_60) | (roc_9_1d < 60.0))
+            & ((rsi_3_15m_gt_25) | (aroonu_14_1h_lt_60) | (roc_9_1d_lt_60))
             # 15m down move, 1h high, 4h overbought
             & ((rsi_3_15m_gt_25) | aroonu_14_1h_lt_70 | (roc_9_4h_lt_40))
             # 15m down move, 1h & 4h high
@@ -16023,7 +16031,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 4h high & overbought
             & ((rsi_3_15m_gt_25) | aroonu_14_4h_lt_70 | (roc_9_4h < 50.0))
             # 15m down move, 4h high, 1d overbought
-            & ((rsi_3_15m_gt_25) | aroonu_14_4h_lt_80 | (roc_9_1d < 100.0))
+            & ((rsi_3_15m_gt_25) | aroonu_14_4h_lt_80 | (roc_9_1d_lt_100))
             # 15m down move, 1h high, 1d downtrend
             & ((rsi_3_15m_gt_25) | (stochrsi_k_1h_lt_70) | (roc_9_1d_gt_neg_20))
             # 15m down move, 1h high & overbought
@@ -16107,7 +16115,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 4h still high
             & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_35) | (stochrsi_k_4h_lt_50))
             # 1h down move, 1d high & overbought
-            & ((rsi_3_1h_gt_15) | (aroonu_14_1d_lt_80) | (roc_9_1d < 10.0))
+            & ((rsi_3_1h_gt_15) | (aroonu_14_1d_lt_80) | (roc_9_1d_lt_10))
             # 1h down move, 1d high, 4h downtrend
             & ((rsi_3_1h_gt_15) | (aroonu_14_1d_lt_90) | (roc_9_4h > -20.0))
             # 1h & 4h down move, 4h high
@@ -16189,7 +16197,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h overbought
             & ((rsi_3_1h_gt_40) | (roc_9_1h < 30.0))
             # 1h & 4h down move, 1d overbought
-            & ((rsi_3_1h_gt_45) | (rsi_3_4h_gt_65) | (roc_9_1d < 200.0))
+            & ((rsi_3_1h_gt_45) | (rsi_3_4h_gt_65) | (roc_9_1d_lt_200))
             # 1h down move, 1h still not low enough, 1d downtrend
             & ((rsi_3_1h_gt_45) | (aroonu_14_1h_lt_30) | (roc_9_1d > -25.0))
             # 1h down move, 1h still high, 1d overbought
@@ -16241,7 +16249,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h & 1d down move, 1d high
             & ((rsi_3_4h_gt_10) | (rsi_3_1d_gt_35) | (aroonu_14_1d_lt_100))
             # 4h & 1d down move, 1d overbought
-            & ((rsi_3_4h_gt_10) | (rsi_3_1d_gt_45) | (roc_9_1d < 10.0))
+            & ((rsi_3_4h_gt_10) | (rsi_3_1d_gt_45) | (roc_9_1d_lt_10))
             # 4h down move, 15m high
             & ((rsi_3_4h_gt_10) | (stochrsi_k_15m_lt_70))
             # 4h & 1d down move, 4h high
@@ -16297,7 +16305,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 4h high & overbought
             & ((rsi_3_4h_gt_45) | (stochrsi_k_4h_lt_60) | (roc_9_4h_lt_20))
             # 4h down move, 4h high, 1d overbought
-            & ((rsi_3_4h_gt_45) | (stochrsi_k_4h_lt_80) | (roc_9_1d < 10.0))
+            & ((rsi_3_4h_gt_45) | (stochrsi_k_4h_lt_80) | (roc_9_1d_lt_10))
             # 4h down move, 4h high & overbought
             & ((rsi_3_4h_gt_50) | aroonu_14_4h_lt_80 | (roc_9_4h_lt_10))
             # 4h down move, 1h high, 1d downtrend
@@ -16307,13 +16315,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 4h high, 1d overbought
             & ((rsi_3_4h_gt_55) | aroonu_14_4h_lt_70 | (roc_9_1d_lt_100))
             # 4h down move, 1d high & overbought
-            & ((rsi_3_4h_gt_55) | (aroonu_14_1d_lt_90) | (roc_9_1d < 60.0))
+            & ((rsi_3_4h_gt_55) | (aroonu_14_1d_lt_90) | (roc_9_1d_lt_60))
             # 4h down move, 4h & 1d high
             & ((rsi_3_4h_gt_60) | aroonu_14_4h_lt_70 | (aroonu_14_1d_lt_70))
             # 4h down move, 1d high, 4h overbought
             & ((rsi_3_4h_gt_60) | aroonu_14_1d_lt_100 | (roc_9_4h_lt_10))
             # 4h down move, 1d high & overbought
-            & ((rsi_3_4h_gt_60) | aroonu_14_1d_lt_100 | (roc_9_1d < 200.0))
+            & ((rsi_3_4h_gt_60) | aroonu_14_1d_lt_100 | (roc_9_1d_lt_200))
             # 4h down move, 4h still high, 4h overbought
             & ((rsi_3_4h_gt_60) | (stochrsi_k_4h_lt_50) | (roc_9_4h_lt_10))
             # 4h down move, 4h high, 1d overbought
@@ -16335,9 +16343,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1d down move, 4h & 1d high
             & ((rsi_3_1d_gt_40) | aroonu_14_4h_lt_70 | aroonu_14_1d_lt_100)
             # 1d down move, 1d high & overbought
-            & ((rsi_3_1d_gt_40) | (aroonu_14_1d_lt_80) | (roc_9_1d < 10.0))
+            & ((rsi_3_1d_gt_40) | (aroonu_14_1d_lt_80) | (roc_9_1d_lt_10))
             # 1d down move, 1h high, 1d overbought
-            & ((rsi_3_1d_gt_60) | aroonu_14_1h_lt_70 | (roc_9_1d < 100.0))
+            & ((rsi_3_1d_gt_60) | aroonu_14_1h_lt_70 | (roc_9_1d_lt_100))
             # 4h downtrend, 4h high & over
             & ((cmf_20_4h > -0.10) | aroonu_14_4h_lt_100 | (roc_9_4h_lt_30))
             # 15m still high, 4h high, 1h overbought
@@ -16365,7 +16373,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h high, 4h &1d overbought
             & ((aroonu_14_1h_lt_85) | (roc_9_4h_lt_30) | (roc_9_1d_lt_30))
             # 1h high, 4h & 1d overbought
-            & ((aroonu_14_1h_lt_90) | (roc_9_4h_lt_10) | (roc_9_1d < 15.0))
+            & ((aroonu_14_1h_lt_90) | (roc_9_4h_lt_10) | (roc_9_1d_lt_15))
             # 4h & 1d high, 4h overbought
             & (aroonu_14_4h_lt_70 | aroonu_14_1d_lt_100 | (roc_9_4h < 50.0))
             # 4h & 1d high, 1d overbought
@@ -16375,7 +16383,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h high, 4h overbought, 1d downtrend
             & ((aroonu_14_4h_lt_90) | (roc_9_4h_lt_20) | (roc_9_1d_gt_neg_40))
             # 1d high, 4h & 1d overbought
-            & ((aroonu_14_1d_lt_70) | (roc_9_4h_lt_30) | (roc_9_1d < 200.0))
+            & ((aroonu_14_1d_lt_70) | (roc_9_4h_lt_30) | (roc_9_1d_lt_200))
             # 1d high, 1h & 1d overbought
             & ((aroonu_14_1d_lt_80) | (roc_9_1h < 20.0) | roc_9_1d_lt_50)
             # 1d high, 1d downtrend
@@ -16403,7 +16411,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h high, 1h & 4h overbought
             & ((stochrsi_k_4h_lt_70) | (roc_9_1h_lt_10) | (roc_9_4h_lt_20))
             # 4h high, 1h & 1d overbought
-            & ((stochrsi_k_4h_lt_70) | (roc_9_1h < 20.0) | (roc_9_1d < 200.0))
+            & ((stochrsi_k_4h_lt_70) | (roc_9_1h < 20.0) | (roc_9_1d_lt_200))
             # 4h high, 4h & 1d overbought
             & ((stochrsi_k_4h_lt_80) | (roc_9_4h_lt_30) | (roc_9_1d_lt_30))
             # 4h high, 1d downtrend
@@ -16411,7 +16419,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h high, 1h & 1d overbought
             & ((stochrsi_k_4h_lt_90) | (roc_9_1h < 20.0) | (roc_9_1d_lt_20))
             # 4h high, 4h & 1d overbought
-            & ((stochrsi_k_4h_lt_90) | (roc_9_4h_lt_10) | (roc_9_1d < 10.0))
+            & ((stochrsi_k_4h_lt_90) | (roc_9_4h_lt_10) | (roc_9_1d_lt_10))
             # 1d hihg, 1h & 1d overbought
             & ((stochrsi_k_1d_lt_90) | (roc_9_1h < 30.0) | (roc_9_1d_lt_100))
             # 1d P&D, dh downtrend
@@ -16486,7 +16494,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 4h high, 1h overbought
             & ((rsi_3_15m_gt_20) | (stochrsi_k_4h_lt_80) | (roc_9_1h_lt_10))
             # 15m down move, 4h & 1d overbought
-            & ((rsi_3_15m_gt_20) | (roc_9_4h < 80.0) | (roc_9_1d < 200.0))
+            & ((rsi_3_15m_gt_20) | (roc_9_4h < 80.0) | (roc_9_1d_lt_200))
             # 15m & 1h down move, 1d overbought
             & ((rsi_3_15m_gt_25) | (rsi_3_1h_gt_25) | (roc_9_1d_lt_80))
             # 15m & 1h down move, 1h high
@@ -16498,7 +16506,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 4h high, 1h overbought
             & ((rsi_3_15m_gt_25) | (aroonu_14_4h_lt_100) | (roc_9_1h < 20.0))
             # 15m down move, 4h high, 1d overbought
-            & ((rsi_3_15m_gt_25) | (aroonu_14_4h_lt_100) | (roc_9_1d < 100.0))
+            & ((rsi_3_15m_gt_25) | (aroonu_14_4h_lt_100) | (roc_9_1d_lt_100))
             # 15m down move, 1h high & overbought
             & ((rsi_3_15m_gt_25) | (stochrsi_k_1h_lt_90) | (roc_9_1h < 20.0))
             # 15m down move, 1h & 4h overbought
@@ -16538,7 +16546,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 4h high, 1d downtrend
             & ((rsi_3_1h_gt_35) | (stochrsi_k_4h_lt_80) | roc_9_1d_gt_neg_50)
             # 1h down move, 1h & 1d overbought
-            & ((rsi_3_1h_gt_40) | (roc_9_1h < 30.0) | (roc_9_1d < 60.0))
+            & ((rsi_3_1h_gt_40) | (roc_9_1h < 30.0) | (roc_9_1d_lt_60))
             # 1h down move, 1h high, 4h overbought
             & ((rsi_3_1h_gt_45) | aroonu_14_1h_lt_80 | (roc_9_4h < 25.0))
             # 1h down move, 4h high, 1h overbought
@@ -16552,7 +16560,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h high, 1d downtrend
             & ((rsi_3_1h_gt_50) | (stochrsi_k_1h_lt_70) | (roc_9_1d_gt_neg_20))
             # 1h down move, 1h & 1d overbought
-            & ((rsi_3_1h_gt_50) | (roc_9_1h < 25.0) | (roc_9_1d < 200.0))
+            & ((rsi_3_1h_gt_50) | (roc_9_1h < 25.0) | (roc_9_1d_lt_200))
             # 1h down move, 1h high, 4h overbought
             & ((rsi_3_1h_gt_55) | aroonu_14_1h_lt_70 | (roc_9_4h_lt_40))
             # 1h down move, 4h high & overbought
@@ -16592,7 +16600,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1d downtrend, 1d high & overbought
             & ((cmf_20_1d > -0.40) | (aroonu_14_1d_lt_85) | (roc_9_1d_lt_20))
             # 15m not low enough, 1h high, 1d overbought
-            & ((aroonu_14_15m_lt_25) | (stochrsi_k_1h_lt_90) | (roc_9_1d < 200.0))
+            & ((aroonu_14_15m_lt_25) | (stochrsi_k_1h_lt_90) | (roc_9_1d_lt_200))
             # 1h still high, 1h & 4h overbought
             & ((aroonu_14_1h_lt_50) | (roc_9_1h < 40.0) | (roc_9_4h_lt_40))
             # 1h & 4h high, 4h overbought
@@ -16602,7 +16610,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h high, 1h overbought
             & (aroonu_14_1h_lt_80 | (aroonu_14_4h_lt_90) | (roc_9_1h < 30.0))
             # 1h & 4h high, 1d overbought
-            & (aroonu_14_1h_lt_80 | (aroonu_14_4h_lt_90) | (roc_9_1d < 100.0))
+            & (aroonu_14_1h_lt_80 | (aroonu_14_4h_lt_90) | (roc_9_1d_lt_100))
             # 1h & 1d high, 4h overbought
             & ((aroonu_14_1h_lt_90) | (aroonu_14_1d_lt_90) | (roc_9_4h_lt_30))
             # 1h & 4h high, 1h overbought
@@ -16800,7 +16808,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 4h high, 15m downtrend
             & ((rsi_3_15m_gt_10) | (aroonu_14_4h_lt_100) | (roc_9_15m > -30.0))
             # 15m down move, 1h high & overbought
-            & ((rsi_3_15m_gt_10) | aroonu_14_1d_lt_100 | (roc_9_1d < 60.0))
+            & ((rsi_3_15m_gt_10) | aroonu_14_1d_lt_100 | (roc_9_1d_lt_60))
             # 15m down move, 1d high, 1d downtrend
             & ((rsi_3_15m_gt_10) | (aroonu_14_1d_lt_85) | (cmf_20_1d > -0.40))
             # 15m down move, 1h high, 15m downtrend
@@ -16866,7 +16874,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 4h high & overbought
             & ((rsi_3_15m_gt_20) | aroonu_14_4h_lt_70 | (roc_9_4h_lt_20))
             # 15m down move, 4h high, 1d overbought
-            & ((rsi_3_15m_gt_20) | aroonu_14_4h_lt_80 | (roc_9_1d < 60.0))
+            & ((rsi_3_15m_gt_20) | aroonu_14_4h_lt_80 | (roc_9_1d_lt_60))
             # 15m & 4h down move, 4h high
             & ((rsi_3_15m_gt_25) | (rsi_3_4h_gt_25) | (stochrsi_k_4h_lt_60))
             # 15m & 1d down move, 1h high
@@ -16908,7 +16916,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h & 1d down move
             & ((rsi_3_1h_gt_5) | (rsi_3_4h_gt_10) | (rsi_3_1d_gt_20))
             # 1h & 4h down move, 1d overbought
-            & ((rsi_3_1h_gt_5) | (rsi_3_4h_gt_10) | (roc_9_1d < 100.0))
+            & ((rsi_3_1h_gt_5) | (rsi_3_4h_gt_10) | (roc_9_1d_lt_100))
             # 1h & 4h down move, 4h still not low enough
             & ((rsi_3_1h_gt_5) | (rsi_3_4h_gt_15) | (aroonu_14_4h_lt_20))
             # 1h & 4h down move, 4h still high
@@ -17010,7 +17018,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h high, 4h downtrend
             & ((rsi_3_1h_gt_15) | (aroonu_14_1h_lt_80) | (roc_9_4h_gt_neg_30))
             # 1h down move, 4h still high, 1d overbought
-            & ((rsi_3_1h_gt_15) | (aroonu_14_4h_lt_50) | (roc_9_1d < 60.0))
+            & ((rsi_3_1h_gt_15) | (aroonu_14_4h_lt_50) | (roc_9_1d_lt_60))
             # 1h down move, 4h high, 15m downtrend
             & ((rsi_3_1h_gt_15) | (aroonu_14_4h_lt_85) | (roc_9_15m > -15.0))
             # 1h down move, 4h high, 1h downtrend
@@ -17022,9 +17030,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 4h high & overbought
             & ((rsi_3_1h_gt_15) | (stochrsi_k_4h_lt_80) | (roc_9_4h < 100.0))
             # 1h down move, 1h downtrend, 1d overbought
-            & ((rsi_3_1h_gt_15) | (roc_9_1h > -30.0) | (roc_9_1d < 35.0))
+            & ((rsi_3_1h_gt_15) | (roc_9_1h > -30.0) | (roc_9_1d_lt_35))
             # 1h down move, 4h downtrend, 1d overbought
-            & ((rsi_3_1h_gt_15) | (roc_9_4h > -25.0) | (roc_9_1d < 100.0))
+            & ((rsi_3_1h_gt_15) | (roc_9_4h > -25.0) | (roc_9_1d_lt_100))
             # 1h & 4h down move, 1d high
             & (rsi_3_1h_gt_20 | rsi_3_4h_gt_20 | (aroonu_14_1d_lt_80))
             # 1h & 4h down move, 4h high
@@ -17038,9 +17046,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h still high, 4h high
             & (rsi_3_1h_gt_20 | (aroonu_14_1h_lt_50) | (aroonu_14_4h_lt_90))
             # 1h down move, 1h high, 1d overbought
-            & (rsi_3_1h_gt_20 | aroonu_14_1h_lt_70 | (roc_9_1d < 100.0))
+            & (rsi_3_1h_gt_20 | aroonu_14_1h_lt_70 | (roc_9_1d_lt_100))
             # 1h down move, 1d high & overbought
-            & (rsi_3_1h_gt_20 | aroonu_14_1d_lt_100 | (roc_9_1d < 60.0))
+            & (rsi_3_1h_gt_20 | aroonu_14_1d_lt_100 | (roc_9_1d_lt_60))
             # 1h down move, 1h high, 4h overbought
             & (rsi_3_1h_gt_20 | (stochrsi_k_1h_lt_70) | (roc_9_4h_lt_10))
             # 1h down move, 1d high, 1d downtrend
@@ -17056,7 +17064,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 15m still high, 1h high
             & ((rsi_3_1h_gt_25) | (aroonu_14_15m_lt_50) | (aroonu_14_1h_lt_90))
             # 1h down move, 1h high, 1d overbought
-            & ((rsi_3_1h_gt_25) | aroonu_14_1h_lt_70 | (roc_9_1d < 200.0))
+            & ((rsi_3_1h_gt_25) | aroonu_14_1h_lt_70 | (roc_9_1d_lt_200))
             # 1h down move, 1h & 1d high
             & ((rsi_3_1h_gt_25) | aroonu_14_1h_lt_70 | (aroonu_14_1d_lt_90))
             # 1h down move, 1h high, 4h overbought
@@ -17108,7 +17116,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h high, 4h overbought
             & ((rsi_3_1h_gt_35) | (aroonu_14_1h_lt_90) | (roc_9_4h_lt_10))
             # 1h down move, 4h high, 1d overbought
-            & ((rsi_3_1h_gt_35) | aroonu_14_4h_lt_70 | (roc_9_1d < 200.0))
+            & ((rsi_3_1h_gt_35) | aroonu_14_4h_lt_70 | (roc_9_1d_lt_200))
             # 1h down move, 4h high & overbought
             & ((rsi_3_1h_gt_35) | aroonu_14_4h_lt_100 | (roc_9_4h < 20.0))
             # 1h down move, 4h high & overbought
@@ -17116,7 +17124,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h downtrend, 4h overbought
             & ((rsi_3_1h_gt_35) | (roc_9_1h > -30.0) | (roc_9_4h < 100.0))
             # 1h down move, 4h & 1d overbought
-            & ((rsi_3_1h_gt_35) | (roc_9_4h_lt_20) | (roc_9_1d < 70.0))
+            & ((rsi_3_1h_gt_35) | (roc_9_4h_lt_20) | (roc_9_1d_lt_70))
             # 1h down move, 1h & 4h high
             & ((rsi_3_1h_gt_40) | aroonu_14_1h_lt_70 | aroonu_14_4h_lt_100)
             # 1h down move, 1h high & overbought
@@ -17132,7 +17140,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 4h & 1d overbought
             & ((rsi_3_1h_gt_40) | (roc_9_4h_lt_30) | (roc_9_1d_lt_40))
             # 1h down move, 1h high, 1d overbought
-            & ((rsi_3_1h_gt_45) | (aroonu_14_1h_lt_100) | (roc_9_1d < 200.0))
+            & ((rsi_3_1h_gt_45) | (aroonu_14_1h_lt_100) | (roc_9_1d_lt_200))
             # 1h down move, 4h high & overbought
             & ((rsi_3_1h_gt_45) | (stochrsi_k_4h_lt_80) | (roc_9_4h < 100.0))
             # 1h down move, 1h high, 1d downtrend
@@ -17146,7 +17154,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h overbought
             & ((rsi_3_1h_gt_60) | (roc_9_1h < 30.0))
             # 1h down move, 4h & 1d overbought
-            & ((rsi_3_1h_gt_60) | (roc_9_4h_lt_30) | (roc_9_1d < 60.0))
+            & ((rsi_3_1h_gt_60) | (roc_9_4h_lt_30) | (roc_9_1d_lt_60))
             # 4h & 1d down move, 1d still not low enough
             & ((rsi_3_4h_gt_3) | (rsi_3_1d_gt_30) | (aroonu_14_1d_lt_30))
             # 4h down move, 4h high, 1h downtrend
@@ -17164,7 +17172,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 1h & 4h downtrend
             & ((rsi_3_4h_gt_10) | (roc_9_1h > -30.0) | (roc_9_4h_gt_neg_30))
             # 4h down move, 1d high & overbought
-            & ((rsi_3_4h_gt_10) | (stochrsi_k_1d < 70.0) | (roc_9_1d < 35.0))
+            & ((rsi_3_4h_gt_10) | (stochrsi_k_1d < 70.0) | (roc_9_1d_lt_35))
             # 4h down move, 4h & 1d downtrend
             & ((rsi_3_4h_gt_10) | (roc_9_4h > -15.0) | (roc_9_1d > -35.0))
             # 4h down move, 4h still high, 1d overbought
@@ -17174,7 +17182,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h & 1d down move, 1d high
             & (rsi_3_4h_gt_20 | (rsi_3_1d_gt_20) | (stochrsi_k_1d < 70.0))
             # 4h down move, 1d high & overbought
-            & (rsi_3_4h_gt_20 | (aroonu_14_1d_lt_80) | (roc_9_1d < 200.0))
+            & (rsi_3_4h_gt_20 | (aroonu_14_1d_lt_80) | (roc_9_1d_lt_200))
             # 4h down move, 4h & 1d downtrend
             & (rsi_3_4h_gt_20 | (roc_9_4h_gt_neg_20) | (roc_9_1d_gt_neg_30))
             # 4h down move, 15m high, 1d overbought
@@ -17186,9 +17194,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 4h still high, 1d downtrend
             & ((rsi_3_4h_gt_30) | (aroonu_14_4h_lt_50) | (roc_9_1d_gt_neg_40))
             # 4h down move, 4h still high, 1d overbought
-            & ((rsi_3_4h_gt_30) | (aroonu_14_4h_lt_50) | (roc_9_1d < 200.0))
+            & ((rsi_3_4h_gt_30) | (aroonu_14_4h_lt_50) | (roc_9_1d_lt_200))
             # 4h down move, 4h still not low enough, 1d overbought
-            & ((rsi_3_4h_gt_30) | (stochrsi_k_4h_lt_20) | (roc_9_1d < 60.0))
+            & ((rsi_3_4h_gt_30) | (stochrsi_k_4h_lt_20) | (roc_9_1d_lt_60))
             # 4h down move, 1d high, 1d downtrend
             & ((rsi_3_4h_gt_35) | (stochrsi_k_1d < 60.0) | (roc_9_1d_gt_neg_30))
             # 1h & 4h down move, 1d high & overbought
@@ -17198,7 +17206,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 1d high, 1d downtrend
             & ((rsi_3_4h_gt_45) | (aroonu_14_1d_lt_80) | (roc_9_1d > -15.0))
             # 4h down move, 1d high & overbought
-            & ((rsi_3_4h_gt_45) | (stochrsi_k_1d_lt_90) | (roc_9_1d < 25.0))
+            & ((rsi_3_4h_gt_45) | (stochrsi_k_1d_lt_90) | (roc_9_1d_lt_25))
             # 4h down move, 4h still high, 1d downtrend
             & ((rsi_3_4h_gt_50) | (rsi_14_4h < 40.0) | (roc_9_1d_gt_neg_30))
             # 4h down move, 4h high & overbought
@@ -17236,11 +17244,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 1d high, 1h overbought
             & (aroonu_14_1h_lt_70 | (aroonu_14_1d_lt_70) | (roc_9_1h < 20.0))
             # 1h high, 1d high & overbought
-            & (aroonu_14_1h_lt_70 | aroonu_14_1d_lt_100 | (roc_9_1d < 200.0))
+            & (aroonu_14_1h_lt_70 | aroonu_14_1d_lt_100 | (roc_9_1d_lt_200))
             # 1h high, 1h & 1d overbought
-            & (aroonu_14_1h_lt_70 | (roc_9_1h < 20.0) | (roc_9_1d < 200.0))
+            & (aroonu_14_1h_lt_70 | (roc_9_1h < 20.0) | (roc_9_1d_lt_200))
             # 1h high, 4h downtrend, 1d overbought
-            & (aroonu_14_1h_lt_70 | (roc_9_4h > -40.0) | (roc_9_1d < 100.0))
+            & (aroonu_14_1h_lt_70 | (roc_9_4h > -40.0) | (roc_9_1d_lt_100))
             # 1h high, 1h & 1d overbought
             & (aroonu_14_1h_lt_80 | (roc_9_1h < 20.0) | (roc_9_1d_lt_20))
             # 1h high, 1h overbought, 1d downtrend
@@ -17252,7 +17260,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h high, 1h overbought
             & ((aroonu_14_1h_lt_100) | aroonu_14_4h_lt_100 | (roc_9_1h_lt_10))
             # 4h high, 4h & 1d overbought
-            & ((aroonu_14_4h_lt_60) | (roc_9_4h_lt_30) | (roc_9_1d < 60.0))
+            & ((aroonu_14_4h_lt_60) | (roc_9_4h_lt_30) | (roc_9_1d_lt_60))
             # 4h & 1d high, 4h overbought
             & (aroonu_14_4h_lt_80 | aroonu_14_1d_lt_100 | (roc_9_4h_lt_30))
             # 4h high, 4h & 1d overbought
@@ -17352,7 +17360,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 4h high
             & ((rsi_3_15m_gt_10) | rsi_3_1h_gt_20 | aroonu_14_4h_lt_100)
             # 15m & 1h down move, 1d overbought
-            & ((rsi_3_15m_gt_10) | rsi_3_1h_gt_20 | (roc_9_1d < 10.0))
+            & ((rsi_3_15m_gt_10) | rsi_3_1h_gt_20 | (roc_9_1d_lt_10))
             # 15m & 4h down move, 1d high
             & ((rsi_3_15m_gt_10) | (rsi_3_4h_gt_30) | (stochrsi_k_1d_lt_90))
             # 15m & 1d down move, 4h still high
@@ -17436,7 +17444,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 1d downtrend
             & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_10) | (roc_9_1d > -20.0))
             # 1h & 4h down move, 1d overbought
-            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_10) | (roc_9_1d < 10.0))
+            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_10) | (roc_9_1d_lt_10))
             # 1h & 4h down move, 1d high
             & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_15) | (aroonu_14_1d_lt_80))
             # 1h & 4h down move, 4h still not low enough
@@ -17504,7 +17512,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 1d down move, 4h high
             & ((rsi_3_1h_gt_15) | (rsi_3_1d_gt_20) | (stochrsi_k_4h_lt_60))
             # 1h & 1d down move, 1d overbought
-            & ((rsi_3_1h_gt_15) | (rsi_3_1d_gt_35) | (roc_9_1d < 10.0))
+            & ((rsi_3_1h_gt_15) | (rsi_3_1d_gt_35) | (roc_9_1d_lt_10))
             # 1h down move, 1h downtrend, 1h high
             & ((rsi_3_1h_gt_15) | (cmf_20_1h > -0.30) | (aroonu_14_1h_lt_70))
             # 1h down move, 1h still high, 4h downtrend
@@ -17564,7 +17572,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 4h high & overbought
             & ((rsi_3_1h_gt_25) | aroonu_14_4h_lt_70 | (roc_9_4h_lt_10))
             # 1h down move, 1d high & overbought
-            & ((rsi_3_1h_gt_25) | (aroonu_14_1d_lt_80) | (roc_9_1d < 200.0))
+            & ((rsi_3_1h_gt_25) | (aroonu_14_1d_lt_80) | (roc_9_1d_lt_200))
             # 1h down move, 1d high, 4h overbought
             & ((rsi_3_1h_gt_25) | (aroonu_14_1d_lt_100) | (roc_9_4h_lt_10))
             # 1h down move, 1h high & overbought
@@ -17662,7 +17670,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h & 1d down move, 4h downtrend
             & ((rsi_3_4h_gt_10) | (rsi_3_1d_gt_30) | (roc_9_4h > -20.0))
             # 4h & 1d down move, 1d overbought
-            & ((rsi_3_4h_gt_10) | (rsi_3_1d_gt_45) | (roc_9_1d < 10.0))
+            & ((rsi_3_4h_gt_10) | (rsi_3_1d_gt_45) | (roc_9_1d_lt_10))
             # 4h & 1d down move, 4h still not low enough
             & ((rsi_3_4h_gt_10) | (rsi_3_1d > 50.0) | (stochrsi_k_4h_lt_20))
             # 4h down move, 15m high, 1h downtrend
@@ -17712,7 +17720,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 4h high
             & (rsi_3_4h_gt_20 | aroonu_14_4h_lt_100)
             # 4h down move, 1d high & overbought
-            & (rsi_3_4h_gt_20 | (aroonu_14_1d_lt_70) | (roc_9_1d < 70.0))
+            & (rsi_3_4h_gt_20 | (aroonu_14_1d_lt_70) | (roc_9_1d_lt_70))
             # 4h down move, 1d high, 4h downtrend
             & (rsi_3_4h_gt_20 | (aroonu_14_1d_lt_90) | (roc_9_4h > -50.0))
             # 4h down move, 1d high & overbought
@@ -17752,7 +17760,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 4h high
             & ((rsi_3_4h_gt_30) | aroonu_14_4h_lt_100)
             # 4h down move, 1d high & overbought
-            & ((rsi_3_4h_gt_30) | (aroonu_14_1d_lt_70) | (roc_9_1d < 60.0))
+            & ((rsi_3_4h_gt_30) | (aroonu_14_1d_lt_70) | (roc_9_1d_lt_60))
             # 4h down move, 15m still high, 4h high
             & ((rsi_3_4h_gt_35) | (aroonu_14_15m_lt_50) | aroonu_14_4h_lt_80)
             # 4h down move, 1h high
@@ -17764,7 +17772,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 1d high & overbought
             & ((rsi_3_4h_gt_35) | aroonu_14_1d_lt_100 | (roc_9_1d_lt_20))
             # 4h down move, 4h still high, 1d overbought
-            & ((rsi_3_4h_gt_35) | (stochrsi_k_4h_lt_50) | (roc_9_1d < 200.0))
+            & ((rsi_3_4h_gt_35) | (stochrsi_k_4h_lt_50) | (roc_9_1d_lt_200))
             # 4h down move, 4h & 1d high
             & ((rsi_3_4h_gt_40) | aroonu_14_4h_lt_70 | aroonu_14_1d_lt_100)
             # 4h down move, 4h high, 1d overbought
@@ -17816,17 +17824,17 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h & 1d high, 1d overbought
             & (aroonu_14_4h_lt_70 | aroonu_14_1d_lt_100 | (roc_9_1d_lt_80))
             # 4h high, 4h & 1d overbought
-            & ((aroonu_14_4h_lt_90) | (roc_9_4h_lt_10) | (roc_9_1d < 10.0))
+            & ((aroonu_14_4h_lt_90) | (roc_9_4h_lt_10) | (roc_9_1d_lt_10))
             # 1d high, 4h & 1d overbought
-            & ((aroonu_14_1d_lt_70) | (roc_9_4h_lt_30) | (roc_9_1d < 200.0))
+            & ((aroonu_14_1d_lt_70) | (roc_9_4h_lt_30) | (roc_9_1d_lt_200))
             # 1d high, 4h downtrend, 1d overbought
-            & ((aroonu_14_1d_lt_85) | (roc_9_4h_gt_neg_20) | (roc_9_1d < 200.0))
+            & ((aroonu_14_1d_lt_85) | (roc_9_4h_gt_neg_20) | (roc_9_1d_lt_200))
             # 1d high, 1h & 4h downtrend
             & (aroonu_14_1d_lt_100 | (roc_9_1h > -30.0) | (roc_9_4h_gt_neg_30))
             # 1d high, 1h & 1d overbought
             & (aroonu_14_1d_lt_100 | (roc_9_1h_lt_10) | (roc_9_1d_lt_30))
             # 1d high, 4h & 1d overbought
-            & (aroonu_14_1d_lt_100 | (roc_9_4h_lt_30) | (roc_9_1d < 60.0))
+            & (aroonu_14_1d_lt_100 | (roc_9_4h_lt_30) | (roc_9_1d_lt_60))
             # 15m still high, 1h & 4h downtrend
             & ((stochrsi_k_15m_lt_50) | (roc_9_1h > -20.0) | (roc_9_4h_gt_neg_20))
             # 4h high, 1h & 4h overbought
@@ -17893,7 +17901,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 1d high
             & ((rsi_3_15m_gt_3) | (rsi_3_1h_gt_10) | (aroonu_14_1d_lt_70))
             # 15m & 1d down move, 1d overbought
-            & ((rsi_3_15m_gt_3) | (rsi_3_1h_gt_10) | (roc_9_1d < 10.0))
+            & ((rsi_3_15m_gt_3) | (rsi_3_1h_gt_10) | (roc_9_1d_lt_10))
             # 15m & 1h down move, 1h still high
             & ((rsi_3_15m_gt_3) | (rsi_3_1h_gt_15) | (aroonu_14_1h_lt_40))
             # 15m & 1h down move, 1d high
@@ -17909,7 +17917,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 1d high
             & ((rsi_3_15m_gt_3) | (rsi_3_1h_gt_30) | (stochrsi_k_1d_lt_90))
             # 15m & 1h down move, 1d overbought
-            & ((rsi_3_15m_gt_3) | (rsi_3_1h_gt_30) | (roc_9_1d < 200.0))
+            & ((rsi_3_15m_gt_3) | (rsi_3_1h_gt_30) | (roc_9_1d_lt_200))
             # 15m & 1h down move, 1h still high
             & ((rsi_3_15m_gt_3) | (rsi_3_1h_gt_35) | (stochrsi_k_1h_lt_40))
             # 15m & 1h down move, 4h high
@@ -17919,7 +17927,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 4h down move, 15m high
             & ((rsi_3_15m_gt_3) | (rsi_3_4h_gt_20) | (aroonu_14_15m_lt_70))
             # 15m & 4h down move, 1d overbought
-            & ((rsi_3_15m_gt_3) | (rsi_3_4h_gt_35) | (roc_9_1d < 60.0))
+            & ((rsi_3_15m_gt_3) | (rsi_3_4h_gt_35) | (roc_9_1d_lt_60))
             # 15m & 1d down move, 1d still high
             & ((rsi_3_15m_gt_3) | (rsi_3_1d_gt_10) | (aroonu_14_1d_lt_40))
             # 15m & 1d down move, 4h still high
@@ -17935,7 +17943,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 4h high & overbought
             & ((rsi_3_15m_gt_3) | (stochrsi_k_4h_lt_80) | (roc_9_4h_lt_40))
             # 15m down move, 4h high, 1d overbought
-            & ((rsi_3_15m_gt_3) | (stochrsi_k_4h_lt_80) | (roc_9_1d < 10.0))
+            & ((rsi_3_15m_gt_3) | (stochrsi_k_4h_lt_80) | (roc_9_1d_lt_10))
             # 15m down move, 1h downtrend, 4h overbought
             & ((rsi_3_15m_gt_3) | (roc_9_1h > -30.0) | (roc_9_4h < 100.0))
             # 15m down move, 4h & 1d downtrend
@@ -17947,7 +17955,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 1d still high
             & ((rsi_3_15m_gt_5) | rsi_3_1h_gt_20 | (stochrsi_k_1d < 50.0))
             # 15m & 1h down move, 1d overbought
-            & ((rsi_3_15m_gt_5) | (rsi_3_1h_gt_25) | (roc_9_1d < 70.0))
+            & ((rsi_3_15m_gt_5) | (rsi_3_1h_gt_25) | (roc_9_1d_lt_70))
             # 15m & 1h down move, 4h high
             & ((rsi_3_15m_gt_5) | (rsi_3_1h_gt_30) | (aroonu_14_4h_lt_70))
             # 15m & 1h down move, 1h high
@@ -18043,11 +18051,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 4h & 1d high
             & ((rsi_3_15m_gt_10) | (aroonu_14_4h_lt_90) | aroonu_14_1d_lt_100)
             # 15m down move, 1d high & overbought
-            & ((rsi_3_15m_gt_10) | aroonu_14_1d_lt_100 | (roc_9_1d < 100.0))
+            & ((rsi_3_15m_gt_10) | aroonu_14_1d_lt_100 | (roc_9_1d_lt_100))
             # 15m down move, 4h still high, 1d overbought
             & ((rsi_3_15m_gt_10) | (stochrsi_k_4h_lt_50) | (roc_9_1d_lt_30))
             # 15m down move, 4h & 1d overbought
-            & ((rsi_3_15m_gt_10) | (roc_9_4h_lt_10) | (roc_9_1d < 200.0))
+            & ((rsi_3_15m_gt_10) | (roc_9_4h_lt_10) | (roc_9_1d_lt_200))
             # 15m & 1h down move, 1h high
             & ((rsi_3_15m_gt_15) | (rsi_3_1h_gt_15) | (aroonu_14_1h_lt_90))
             # 15m & 1h down move, 1d high
@@ -18067,9 +18075,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 4h high & overbought
             & ((rsi_3_15m_gt_15) | (aroonu_14_4h_lt_60) | (roc_9_4h_lt_30))
             # 15m down move, 4h high, 1d overbought
-            & ((rsi_3_15m_gt_15) | (aroonu_14_4h_lt_70) | (roc_9_1d < 200.0))
+            & ((rsi_3_15m_gt_15) | (aroonu_14_4h_lt_70) | (roc_9_1d_lt_200))
             # 15m down move, 4h high, 1d overbought
-            & ((rsi_3_15m_gt_15) | (aroonu_14_4h_lt_100) | (roc_9_1d < 100.0))
+            & ((rsi_3_15m_gt_15) | (aroonu_14_4h_lt_100) | (roc_9_1d_lt_100))
             # 15m down move, 1h high, 4h downtrend
             & ((rsi_3_15m_gt_15) | (stochrsi_k_1h_lt_70) | (roc_9_4h_gt_neg_30))
             # 15m down move, 4h high & overbought
@@ -18093,7 +18101,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 1h high, 4h overbought
             & ((rsi_3_15m_gt_20) | aroonu_14_1h_lt_80 | (roc_9_4h_lt_10))
             # 15m down move, 1h high, 1d overbought
-            & ((rsi_3_15m_gt_20) | aroonu_14_1h_lt_80 | (roc_9_1d < 10.0))
+            & ((rsi_3_15m_gt_20) | aroonu_14_1h_lt_80 | (roc_9_1d_lt_10))
             # 15m down move, 4h high & overbought
             & ((rsi_3_15m_gt_20) | aroonu_14_4h_lt_80 | (roc_9_4h_lt_10))
             # 15m & 1h down move, 15m high
@@ -18161,7 +18169,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 1h downtrend
             & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_15) | (roc_9_1h > -15.0))
             # 1h & 4h down move, 1d overbought
-            & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_15) | (roc_9_1d < 10.0))
+            & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_15) | (roc_9_1d_lt_10))
             # 1h & 4h down move, 4h still high
             & ((rsi_3_1h_gt_15) | rsi_3_4h_gt_20 | (rsi_14_4h < 40.0))
             # 1h & 4h down move, 1h high
@@ -18183,7 +18191,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h high, 4h overbought
             & (rsi_3_1h_gt_20 | aroonu_14_1h_lt_70 | (roc_9_4h_lt_10))
             # 1h down move, 1h high & overbought
-            & (rsi_3_1h_gt_20 | aroonu_14_1d_lt_100 | (roc_9_1d < 100.0))
+            & (rsi_3_1h_gt_20 | aroonu_14_1d_lt_100 | (roc_9_1d_lt_100))
             # 1h down move, 4h downtrend, 1d overbought
             & (rsi_3_1h_gt_20 | (roc_9_4h > -40.0) | roc_9_1d_lt_50)
             # 1h & 4h down move, 1d high
@@ -18215,7 +18223,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 15m & 4h high
             & ((rsi_3_1h_gt_30) | (rsi_3_4h_gt_50) | (aroonu_14_15m_lt_70) | (aroonu_14_1h_lt_70))
             # 1h down move, 1h high, 1d overbought
-            & ((rsi_3_1h_gt_30) | (aroonu_14_1h_lt_80) | (roc_9_1d < 10.0))
+            & ((rsi_3_1h_gt_30) | (aroonu_14_1h_lt_80) | (roc_9_1d_lt_10))
             # 1h down move, 4h high, 1d overbought
             & ((rsi_3_1h_gt_30) | (aroonu_14_4h_lt_70) | (roc_9_1d_lt_40))
             # 1h down move, 4h high & overbought
@@ -18225,7 +18233,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1d high, 4h overbought
             & ((rsi_3_1h_gt_30) | (aroonu_14_1d_lt_100) | (roc_9_4h_lt_30))
             # 1h down move, 4h & 1d overbought
-            & ((rsi_3_1h_gt_30) | (roc_9_4h_lt_30) | (roc_9_1d < 200.0))
+            & ((rsi_3_1h_gt_30) | (roc_9_4h_lt_30) | (roc_9_1d_lt_200))
             # 1h & 4h down move, 1d high
             & ((rsi_3_1h_gt_35) | (rsi_3_4h_gt_35) | (aroonu_14_1d_lt_90))
             # 1h down move, 1h high, 1d overbought
@@ -18233,7 +18241,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h & 4h high
             & ((rsi_3_1h_gt_35) | (aroonu_14_1h_lt_100) | (aroonu_14_4h_lt_100))
             # 1h down move, 1d high & overbought
-            & ((rsi_3_1h_gt_35) | (aroonu_14_1d_lt_100) | (roc_9_1d < 200.0))
+            & ((rsi_3_1h_gt_35) | (aroonu_14_1d_lt_100) | (roc_9_1d_lt_200))
             # 1h down move, 1h high, 4h downtrend
             & ((rsi_3_1h_gt_35) | (stochrsi_k_1h_lt_70) | (roc_9_4h_gt_neg_20))
             # 1h & 1d down move, 1h high
@@ -18317,9 +18325,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h high, 1d overbought
             & (aroonu_14_1h_lt_70 | aroonu_14_4h_lt_100 | (roc_9_1d_lt_20))
             # 1h & 1d high, 1d overbought
-            & (aroonu_14_1h_lt_70 | (aroonu_14_1d_lt_90) | (roc_9_1d < 200.0))
+            & (aroonu_14_1h_lt_70 | (aroonu_14_1d_lt_90) | (roc_9_1d_lt_200))
             # 1h high, 4h downtrend, 1d overbought
-            & (aroonu_14_1h_lt_70 | (roc_9_4h > -40.0) | (roc_9_1d < 100.0))
+            & (aroonu_14_1h_lt_70 | (roc_9_4h > -40.0) | (roc_9_1d_lt_100))
             # 1h & 4h high, 4h overbought
             & (aroonu_14_1h_lt_80 | aroonu_14_4h_lt_100 | (roc_9_4h_lt_30))
             # 1h high, 1d downtrend
@@ -18327,7 +18335,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h high, 1h & 4h overbought
             & ((aroonu_14_1h_lt_100) | (roc_9_1h < 100.0) | (roc_9_4h < 100.0))
             # 4h & 1d high, 1d overbought
-            & ((aroonu_14_4h_lt_60) | aroonu_14_1d_lt_100 | (roc_9_1d < 70.0))
+            & ((aroonu_14_4h_lt_60) | aroonu_14_1d_lt_100 | (roc_9_1d_lt_70))
             # 4h high, 1h & 4h overbought
             & ((aroonu_14_4h_lt_85) | (roc_9_1h < 80.0) | (roc_9_4h < 80.0))
             # 4h high, 1h downtrend, 4h overbought
@@ -18343,7 +18351,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1d high, 1h & 4h downtrend
             & (aroonu_14_1d_lt_100 | (roc_9_1h > -30.0) | (roc_9_4h_gt_neg_30))
             # 1d high, 4h & 1d overbought
-            & (aroonu_14_1d_lt_100 | (roc_9_4h < 20.0) | (roc_9_1d < 100.0))
+            & (aroonu_14_1d_lt_100 | (roc_9_4h < 20.0) | (roc_9_1d_lt_100))
             # 1h high, 1d overbought
             & ((stochrsi_k_1h_lt_70) | (roc_9_1d_lt_40))
             # 1h high, 4h overbought
@@ -18408,7 +18416,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 4h down move, 1h still high
             & ((rsi_3_15m_gt_3) | (rsi_3_4h_gt_40) | (stochrsi_k_1h_lt_40))
             # 15m down move, 1h still high, 1d overbought
-            & ((rsi_3_15m_gt_3) | (aroonu_14_1h_lt_40) | (roc_9_1d < 70.0))
+            & ((rsi_3_15m_gt_3) | (aroonu_14_1h_lt_40) | (roc_9_1d_lt_70))
             # 15m down move, 4h high & overbought
             & ((rsi_3_15m_gt_3) | (aroonu_14_4h_lt_100) | (roc_9_4h < 100.0))
             # 15m down move, 1h high
@@ -18516,11 +18524,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 4h & 1d high
             & ((rsi_3_1h_gt_10) | (aroonu_14_4h_lt_60) | (aroonu_14_1d_lt_100))
             # 1h down move, 4h high, 1d overbought
-            & ((rsi_3_1h_gt_10) | (aroonu_14_4h_lt_90) | (roc_9_1d < 100.0))
+            & ((rsi_3_1h_gt_10) | (aroonu_14_4h_lt_90) | (roc_9_1d_lt_100))
             # 1h down move, 4h high
             & ((rsi_3_1h_gt_10) | (aroonu_14_4h_lt_100))
             # 1h down move, 1d high & overbought
-            & ((rsi_3_1h_gt_10) | (aroonu_14_1d_lt_100) | (roc_9_1d < 60.0))
+            & ((rsi_3_1h_gt_10) | (aroonu_14_1d_lt_100) | (roc_9_1d_lt_60))
             # 1h down move, 4h overbought
             & ((rsi_3_1h_gt_10) | (roc_9_4h_lt_10))
             # 1h down move, 4h high & overbought
@@ -18542,7 +18550,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 4h high & overbought
             & ((rsi_3_1h_gt_15) | (aroonu_14_4h_lt_80) | (roc_9_4h < 100.0))
             # 1h down move, 1d high & overbought
-            & ((rsi_3_1h_gt_15) | (aroonu_14_1d_lt_80) | (roc_9_1d < 100.0))
+            & ((rsi_3_1h_gt_15) | (aroonu_14_1d_lt_80) | (roc_9_1d_lt_100))
             # 1h down move, 1h & 4h downtrend
             & ((rsi_3_1h_gt_15) | (roc_9_1h > -30.0) | (roc_9_4h_gt_neg_30))
             # 1h down move, 1h & 4h overbought
@@ -18572,7 +18580,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h downtrend, 4h overbought
             & ((rsi_3_1h_gt_25) | (roc_9_1h > -20.0) | (roc_9_4h_lt_20))
             # 1h down move, 1d overbought
-            & ((rsi_3_1h_gt_25) | (roc_9_1d < 200.0))
+            & ((rsi_3_1h_gt_25) | (roc_9_1d_lt_200))
             # 1h down move, 4h high
             & ((rsi_3_1h_gt_30) | (aroonu_14_4h_lt_100))
             # 1h down move, 4h high & overbought
@@ -18582,7 +18590,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 1d still high, 4h downtrend
             & ((rsi_3_4h_gt_3) | (stochrsi_k_1d < 50.0) | (roc_9_4h_gt_neg_30))
             # 4h down move, 1d overbought
-            & ((rsi_3_4h_gt_3) | (roc_9_1d < 200.0))
+            & ((rsi_3_4h_gt_3) | (roc_9_1d_lt_200))
             # 4h down move, 1h still high
             & ((rsi_3_4h_gt_5) | (stochrsi_k_1h_lt_40))
             # 4h down move, 1h & 4h downtrend
@@ -18658,7 +18666,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1d high, 4h downtrend
             & ((aroonu_14_1d_lt_90) | (roc_9_4h > -40.0))
             # 1d high & overbought
-            & ((aroonu_14_1d_lt_90) | (roc_9_1d < 200.0))
+            & ((aroonu_14_1d_lt_90) | (roc_9_1d_lt_200))
             # 1d high, 4h & 1d overbought
             & (aroonu_14_1d_lt_100 | (roc_9_4h < 20.0) | (roc_9_1d_lt_80))
             # 1h still high, 4h & 1d downtrend
@@ -18672,9 +18680,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1d high, 1d downtrend
             & ((stochrsi_k_1d < 60.0) | (roc_9_1d_gt_neg_30))
             # 15m downtrend, 1d overbought
-            & ((roc_9_15m > -60.0) | (roc_9_1d < 200.0))
+            & ((roc_9_15m > -60.0) | (roc_9_1d_lt_200))
             # 1h downtrend, 1d overbought
-            & ((roc_9_1h > -60.0) | (roc_9_1d < 200.0))
+            & ((roc_9_1h > -60.0) | (roc_9_1d_lt_200))
             # big drop in the last 20 days, 1d high, 1d downtrend
             & ((close > (high_max_20_1d * 0.20)) | (stochrsi_k_1d < 70.0) | (roc_9_1d > -15.0))
           )
@@ -18796,7 +18804,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1d high & overbought
             & ((rsi_3_1h_gt_10) | (aroonu_14_1d_lt_70) | roc_9_1d_lt_50)
             # 1h down move, 1d overbought
-            & ((rsi_3_1h_gt_10) | (roc_9_1d < 100.0))
+            & ((rsi_3_1h_gt_10) | (roc_9_1d_lt_100))
             # 1h & 4h down move, 4h still high
             & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_15) | (aroonu_14_4h_lt_40))
             # 1h & 4h down move, 1d high
@@ -19007,7 +19015,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 1h & 4h still high
             & ((rsi_3_15m_gt_20) | (aroonu_14_1h_lt_40) | (stochrsi_k_4h_lt_50))
             # 15m & 1h & 4h down move, 1d high
-            & ((rsi_3_15m_gt_25) | (rsi_3_1h_gt_25) | (rsi_3_4h_gt_25) | (roc_9_1d < 70.0))
+            & ((rsi_3_15m_gt_25) | (rsi_3_1h_gt_25) | (rsi_3_4h_gt_25) | (roc_9_1d_lt_70))
             # 15m & 4h down move, 4h high
             & ((rsi_3_15m_gt_25) | (rsi_3_4h_gt_45) | (aroonu_14_4h_lt_85))
             # 15m & 1h down move, 15m still not low enough
@@ -19295,7 +19303,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 4h down move, 1h downtrend
             & ((rsi_3_15m_gt_5) | (rsi_3_4h_gt_10) | (roc_9_1h > -20.0))
             # 15m & 4h down move, 1d overbought
-            & ((rsi_3_15m_gt_5) | (rsi_3_4h_gt_15) | (roc_9_1d < 70.0))
+            & ((rsi_3_15m_gt_5) | (rsi_3_4h_gt_15) | (roc_9_1d_lt_70))
             # 15m & 4h down move, 1h high
             & ((rsi_3_15m_gt_5) | rsi_3_4h_gt_20 | (stochrsi_k_1h_lt_80))
             # 15m down move, 15m still low, 4h still high
@@ -19319,7 +19327,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 4h down move, 4h still not low enough
             & ((rsi_3_15m_gt_10) | (rsi_3_4h_gt_10) | (stochrsi_k_4h_lt_30))
             # 15m & 4h down move, 4h still high, 1d high & overbought
-            & ((rsi_3_15m_gt_10) | (rsi_3_4h_gt_15) | (aroonu_14_4h_lt_40) | (aroonu_14_1d_lt_70) | (roc_9_1d < 10.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_4h_gt_15) | (aroonu_14_4h_lt_40) | (aroonu_14_1d_lt_70) | (roc_9_1d_lt_10))
             # 15m & 4h down move, 4h high
             & ((rsi_3_15m_gt_10) | (rsi_3_4h_gt_25) | (aroonu_14_4h_lt_70))
             # 15m & 4h down move, 4h overbought
@@ -19357,7 +19365,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 4h & 1d downtrend
             & ((rsi_3_15m_gt_15) | (roc_9_4h > -10.0) | (roc_9_1d_gt_neg_40))
             # 15m down move, 4h & 1d overbought
-            & ((rsi_3_15m_gt_15) | (roc_9_4h_lt_20) | (roc_9_1d < 60.0))
+            & ((rsi_3_15m_gt_15) | (roc_9_4h_lt_20) | (roc_9_1d_lt_60))
             # 15m & 1h down move, 15m high
             & ((rsi_3_15m_gt_20) | rsi_3_1h_gt_20 | (aroonu_14_15m_lt_60))
             # 15m & 1h down move, 1h high
@@ -19399,7 +19407,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 4h still not low enough
             & ((rsi_3_1h_gt_5) | rsi_3_4h_gt_20 | (stochrsi_k_4h_lt_30))
             # 1h down move, 4h high, 1d overbought
-            & ((rsi_3_1h_gt_5) | (aroonu_14_4h_lt_60) | (roc_9_1d < 10.0))
+            & ((rsi_3_1h_gt_5) | (aroonu_14_4h_lt_60) | (roc_9_1d_lt_10))
             # 1h down move, 1d high, 4h downtrend
             & ((rsi_3_1h_gt_5) | (aroonu_14_1d_lt_90) | (roc_9_4h_gt_neg_30))
             # 1h down move, 1d high, 1d downtrend
@@ -19417,13 +19425,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 15m still high, 4h high
             & ((rsi_3_1h_gt_10) | (aroonu_14_15m_lt_40) | (stochrsi_k_4h_lt_90))
             # 1h down move, 1d high & overbought
-            & ((rsi_3_1h_gt_10) | (aroonu_14_1d_lt_100) | (roc_9_1d < 10.0))
+            & ((rsi_3_1h_gt_10) | (aroonu_14_1d_lt_100) | (roc_9_1d_lt_10))
             # 1h down move, 4h still high, 4d downtrend
             & ((rsi_3_1h_gt_10) | (stochrsi_k_4h_lt_50) | roc_9_1d_gt_neg_50)
             # 1h down move, 4h downtrend, 1d overbought
             & ((rsi_3_1h_gt_10) | (roc_9_4h > -10.0) | (roc_9_1d_lt_40))
             # 1h down move, 1d overbought
-            & ((rsi_3_1h_gt_10) | (roc_9_1d < 100.0))
+            & ((rsi_3_1h_gt_10) | (roc_9_1d_lt_100))
             # 1h & 4h down move, 4h high
             & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_40) | (aroonu_14_4h_lt_80))
             # 1h down move, 1d downtrend, 1d high
@@ -19455,7 +19463,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h high, 4h downtrend
             & ((rsi_3_1h_gt_35) | aroonu_14_1h_lt_80 | (roc_9_4h > -40.0))
             # 1h down move, 1h still high, 1d overbought
-            & ((rsi_3_1h_gt_35) | (stochrsi_k_1h_lt_50) | (roc_9_1d < 200.0))
+            & ((rsi_3_1h_gt_35) | (stochrsi_k_1h_lt_50) | (roc_9_1d_lt_200))
             # 1h down move, 1h high, 4h downtrend
             & ((rsi_3_1h_gt_35) | (stochrsi_k_1h_lt_70) | (roc_9_4h_gt_neg_20))
             # 1h down move, 4h & 1d overbought
@@ -19471,7 +19479,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 4h high, 1d downtrend
             & ((rsi_3_1h_gt_50) | (stochrsi_k_4h_lt_60) | (roc_9_1d > -60.0))
             # 1h down move, 4h & 1d overbought
-            & ((rsi_3_1h_gt_60) | (roc_9_4h_lt_30) | (roc_9_1d < 60.0))
+            & ((rsi_3_1h_gt_60) | (roc_9_4h_lt_30) | (roc_9_1d_lt_60))
             # 4h & 1d down move, 15m still high
             & ((rsi_3_4h_gt_3) | (rsi_3_1d_gt_15) | (stochrsi_k_15m_lt_40))
             # 4h & 1d down move, 1h still not low enough
@@ -19545,7 +19553,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h still high, 5m downtrend
             & ((aroonu_14_4h_lt_40) | (roc_9 > -40.0))
             # 4h high, 4h & 1d overbought
-            & ((aroonu_14_4h_lt_60) | (roc_9_4h_lt_30) | (roc_9_1d < 60.0))
+            & ((aroonu_14_4h_lt_60) | (roc_9_4h_lt_30) | (roc_9_1d_lt_60))
             # 4h & 1d high, 4h overbought
             & (aroonu_14_4h_lt_80 | aroonu_14_1d_lt_100 | (roc_9_4h_lt_30))
             # 4h & 1d high, 1d overbought
@@ -19557,7 +19565,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1d high, 1h & 1d overbought
             & ((aroonu_14_1d_lt_85) | (roc_9_1h < 20.0) | (roc_9_1d_lt_100))
             # 1d high, 4h & 1d overbought
-            & ((aroonu_14_1d_lt_90) | (roc_9_4h_lt_30) | (roc_9_1d < 60.0))
+            & ((aroonu_14_1d_lt_90) | (roc_9_4h_lt_30) | (roc_9_1d_lt_60))
             # 1h high, 1d overbought
             & ((stochrsi_k_1h_lt_70) | (roc_9_1d_lt_40))
             # 4h high, 1h overbought, 1d downtrend
@@ -19654,7 +19662,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 4h down move, 1d high
             & ((rsi_3_15m_gt_10) | (rsi_3_4h_gt_30) | (stochrsi_k_1d_lt_90))
             # 15m & 4h down move, 1d overbought
-            & ((rsi_3_15m_gt_10) | (rsi_3_4h_gt_40) | (roc_9_1d < 200.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_4h_gt_40) | (roc_9_1d_lt_200))
             # 15m & 1d down move, 1d high
             & ((rsi_3_15m_gt_10) | (rsi_3_1d_gt_20) | (aroonu_14_1d_lt_75))
             # 15m down move, 4h high, 1d downtrend
@@ -19722,7 +19730,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 1d downtrend
             & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_10) | (roc_9_1d > -20.0))
             # 1h & 4h down move, 1d overbought
-            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_10) | (roc_9_1d < 10.0))
+            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_10) | (roc_9_1d_lt_10))
             # 1h & 4h down move, 4h still high
             & ((rsi_3_1h_gt_10) | rsi_3_4h_gt_20 | (aroonu_14_4h_lt_40))
             # 1h & 4h down move, 4h high
@@ -19752,7 +19760,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 1d down move, 4h high
             & ((rsi_3_1h_gt_15) | (rsi_3_1d_gt_15) | (stochrsi_k_4h_lt_80))
             # 1h down move, 4h high, 1d overbought
-            & ((rsi_3_1h_gt_15) | aroonu_14_4h_lt_70 | (roc_9_1d < 100.0))
+            & ((rsi_3_1h_gt_15) | aroonu_14_4h_lt_70 | (roc_9_1d_lt_100))
             # 1h down move, 1d high, 4h downtrend
             & ((rsi_3_1h_gt_15) | (aroonu_14_1d_lt_90) | (roc_9_4h > -20.0))
             # 1h & 4h down move, 4h & 1d still not low enough, 15m still not low enough
@@ -19852,7 +19860,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 1h downtrend, 1d downtrend
             & ((rsi_3_4h_gt_15) | (cmf_20_1h > -0.40) | (roc_9_1d > -20.0))
             # 4h down move, 15m high, 1d overbought
-            & ((rsi_3_4h_gt_15) | (aroonu_14_15m_lt_70) | (roc_9_1d < 100.0))
+            & ((rsi_3_4h_gt_15) | (aroonu_14_15m_lt_70) | (roc_9_1d_lt_100))
             # 4h down move, 4h still high, 4h downtrend
             & ((rsi_3_4h_gt_15) | (aroonu_14_4h_lt_40) | (roc_9_4h > -20.0))
             # 4h down move, 15m still not low enough, 1d downtrend
@@ -19866,7 +19874,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 1d high & overbought
             & (rsi_3_4h_gt_20 | (aroonu_14_1d_lt_80) | (roc_9_1d_lt_30))
             # 4h & 1d down move, 1d overbought
-            & ((rsi_3_4h_gt_25) | (rsi_3_1d_gt_45) | (roc_9_1d < 10.0))
+            & ((rsi_3_4h_gt_25) | (rsi_3_1d_gt_45) | (roc_9_1d_lt_10))
             # 4h down move, 15m high, 4h high
             & ((rsi_3_4h_gt_25) | (aroonu_14_15m_lt_70) | aroonu_14_4h_lt_80)
             # 4h down move, 4h still high, 1d downtrend
@@ -19886,7 +19894,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 15m & 4h still high
             & ((rsi_3_4h_gt_40) | (stochrsi_k_15m_lt_50) | (stochrsi_k_4h_lt_50))
             # 4h down move, 1d high & overbought
-            & ((rsi_3_4h_gt_40) | (stochrsi_k_1d_lt_90) | (roc_9_1d < 200.0))
+            & ((rsi_3_4h_gt_40) | (stochrsi_k_1d_lt_90) | (roc_9_1d_lt_200))
             # 4h down move, 4h high
             & ((rsi_3_4h_gt_40) | aroonu_14_4h_lt_100)
             # 4h down move, 4h still high, 1d downtrend
@@ -19914,9 +19922,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h high, 1h & 4h overbought
             & (aroonu_14_4h_lt_80 | (roc_9_1h < 40.0) | (roc_9_4h_lt_40))
             # 1d high, 4h downtrend, 1d overbought
-            & ((aroonu_14_1d_lt_85) | (roc_9_4h_gt_neg_20) | (roc_9_1d < 200.0))
+            & ((aroonu_14_1d_lt_85) | (roc_9_4h_gt_neg_20) | (roc_9_1d_lt_200))
             # 1d high, 4h & 1d overbought
-            & ((aroonu_14_1d_lt_90) | (roc_9_4h_lt_30) | (roc_9_1d < 60.0))
+            & ((aroonu_14_1d_lt_90) | (roc_9_4h_lt_30) | (roc_9_1d_lt_60))
             # 4h high, 1h & 4h overbought
             & ((stochrsi_k_4h_lt_70) | (roc_9_1h < 40.0) | (roc_9_4h_lt_40))
             # 4h high, 4h & 1d overbought
@@ -19986,9 +19994,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 15m still high, 4h high
             & ((rsi_3_15m_gt_10) | (aroonu_14_15m_lt_50) | aroonu_14_4h_lt_80)
             # 15m down move, 1h still high, 1d overbought
-            & ((rsi_3_15m_gt_10) | (aroonu_14_1h_lt_50) | (roc_9_1d < 60.0))
+            & ((rsi_3_15m_gt_10) | (aroonu_14_1h_lt_50) | (roc_9_1d_lt_60))
             # 15m down move, 4h high, 1d overbought
-            & ((rsi_3_15m_gt_10) | (aroonu_14_4h_lt_60) | (roc_9_1d < 60.0))
+            & ((rsi_3_15m_gt_10) | (aroonu_14_4h_lt_60) | (roc_9_1d_lt_60))
             # 15m down move, 1d high & overbought
             & ((rsi_3_15m_gt_10) | (aroonu_14_1d_lt_90) | (roc_9_1d_lt_20))
             # 15m down move, 1d high, 4h overbought
@@ -20016,7 +20024,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 15m still not low enough, 1h still high
             & ((rsi_3_15m_gt_15) | (stochrsi_k_15m_lt_30) | (stochrsi_k_1h_lt_50))
             # 15m down move, 4h & 1d overbought
-            & ((rsi_3_15m_gt_15) | (roc_9_4h_lt_20) | (roc_9_1d < 60.0))
+            & ((rsi_3_15m_gt_15) | (roc_9_4h_lt_20) | (roc_9_1d_lt_60))
             # 15m & 1h down move, 1h high
             & ((rsi_3_15m_gt_20) | rsi_3_1h_gt_20 | (stochrsi_k_1h_lt_70))
             # 15m & 4h down move, 4h high
@@ -20132,13 +20140,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 4h still high
             & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_30) | (stochrsi_k_4h_lt_50))
             # 1h & 4h down move, 1d overbought
-            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_35) | (roc_9_1d < 70.0))
+            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_35) | (roc_9_1d_lt_70))
             # 1h & 1d down move, 1h still high
             & ((rsi_3_1h_gt_10) | (rsi_3_1d_gt_10) | (stochrsi_k_1h_lt_40))
             # 1h & 1d down move, 4h high
             & ((rsi_3_1h_gt_10) | (rsi_3_1d_gt_15) | (stochrsi_k_4h_lt_70))
             # 1h & 1d downtrend, 1d overbought
-            & ((rsi_3_1h_gt_10) | (rsi_3_1d_gt_45) | (roc_9_1d < 10.0))
+            & ((rsi_3_1h_gt_10) | (rsi_3_1d_gt_45) | (roc_9_1d_lt_10))
             # 1h down move, 1h downtrend, 1h still not low enough
             & ((rsi_3_1h_gt_10) | (cmf_20_1h > -0.20) | (aroonu_14_1h_lt_30))
             # 1h down move, 1h downtrend, 1h still not low enough
@@ -20150,7 +20158,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 4h still not low enough
             & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_10) | (stochrsi_k_4h_lt_20))
             # 1h down move, 1d overbought
-            & ((rsi_3_1h_gt_10) | (roc_9_1d < 100.0))
+            & ((rsi_3_1h_gt_10) | (roc_9_1d_lt_100))
             # 1h & 4h down move, 1h still not low enough
             & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_15) | (stochrsi_k_1h_lt_30))
             # 1h & 4h down move, 15m high
@@ -20158,7 +20166,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 1d downtrend
             & ((rsi_3_1h_gt_15) | rsi_3_4h_gt_20 | (roc_9_1d_gt_neg_40))
             # 1h & 4h down mov, 1d overbought
-            & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_30) | (roc_9_1d < 100.0))
+            & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_30) | (roc_9_1d_lt_100))
             # 1h down move, 1d downtrend, 1d high
             & ((rsi_3_1h_gt_15) | (cmf_20_1d > -0.30) | (stochrsi_k_1d < 80.0))
             # 1h down move, 1h still high
@@ -20176,9 +20184,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 1h high
             & ((rsi_3_1h_gt_20) | (rsi_3_4h_gt_45) | (aroonu_14_1h_lt_60))
             # 1h & 1d down move, 1d high & overbought
-            & ((rsi_3_1h_gt_20) | (rsi_3_1d_gt_55) | (aroonu_14_1d_lt_90) | (roc_9_1d < 20.0))
+            & ((rsi_3_1h_gt_20) | (rsi_3_1d_gt_55) | (aroonu_14_1d_lt_90) | (roc_9_1d_lt_20))
             # 1h down move, 1h high, 1d overbought
-            & ((rsi_3_1h_gt_20) | (aroonu_14_1h_lt_70) | (roc_9_1d < 100.0))
+            & ((rsi_3_1h_gt_20) | (aroonu_14_1h_lt_70) | (roc_9_1d_lt_100))
             # 1h down move, 4h still high
             & ((rsi_3_1h_gt_20) | (aroonu_14_4h_lt_40))
             # 1h down move, 4h still high, 1d downtrend
@@ -20206,7 +20214,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 4h high & overbought
             & ((rsi_3_1h_gt_25) | (stochrsi_k_4h_lt_80) | (roc_9_4h_lt_20))
             # 1h down move, 4h high, 1d overbought
-            & ((rsi_3_1h_gt_25) | (stochrsi_k_4h_lt_80) | (roc_9_1d < 70.0))
+            & ((rsi_3_1h_gt_25) | (stochrsi_k_4h_lt_80) | (roc_9_1d_lt_70))
             # 1h & 4h down move, 1h high
             & ((rsi_3_1h_gt_30) | (rsi_3_4h_gt_30) | (stochrsi_k_1h_lt_60))
             # 1h & 4h down move, 4h still high
@@ -20224,7 +20232,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 4h high & overbought
             & ((rsi_3_1h_gt_30) | (aroonu_14_4h_lt_90) | (roc_9_4h_lt_20))
             # 1h down move, 1d high & overbought
-            & ((rsi_3_1h_gt_30) | (aroonu_14_1d_lt_80) | (roc_9_1d < 200.0))
+            & ((rsi_3_1h_gt_30) | (aroonu_14_1d_lt_80) | (roc_9_1d_lt_200))
             # 1h down move, 1d high, 4h downtrend
             & ((rsi_3_1h_gt_30) | (aroonu_14_1d_lt_90) | (roc_9_4h > -40.0))
             # 1h down move, 1d high, 4h overbought
@@ -20248,11 +20256,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 4h high & overbought
             & ((rsi_3_1h_gt_35) | (stochrsi_k_4h_lt_70) | (roc_9_4h_lt_10))
             # 1h down move, 1d high & overbought
-            & ((rsi_3_1h_gt_35) | (aroonu_14_1d_lt_100) | (roc_9_1d < 100.0))
+            & ((rsi_3_1h_gt_35) | (aroonu_14_1d_lt_100) | (roc_9_1d_lt_100))
             # 1h down move, 1h still high, 1d overbought
-            & ((rsi_3_1h_gt_35) | (stochrsi_k_1h_lt_50) | (roc_9_1d < 200.0))
+            & ((rsi_3_1h_gt_35) | (stochrsi_k_1h_lt_50) | (roc_9_1d_lt_200))
             # 1h down move, 1d high & overbought
-            & ((rsi_3_1h_gt_40) | (rsi_14_1d < 80.0) | (roc_9_1d < 150.0))
+            & ((rsi_3_1h_gt_40) | (rsi_14_1d < 80.0) | (roc_9_1d_lt_150))
             # 1h down move, 15m high, 1h high
             & ((rsi_3_1h_gt_40) | (aroonu_14_15m_lt_60) | aroonu_14_1h_lt_70)
             # 1h down move, 1h high, 1d overbought
@@ -20262,7 +20270,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h & 4h overbought
             & ((rsi_3_1h_gt_40) | (roc_9_1h_lt_10) | (roc_9_4h_lt_10))
             # 1h & 4h down move, 1d overbought
-            & ((rsi_3_1h_gt_45) | (rsi_3_4h_gt_65) | (roc_9_1d < 200.0))
+            & ((rsi_3_1h_gt_45) | (rsi_3_4h_gt_65) | (roc_9_1d_lt_200))
             # 1h down move, 1h high & overbought
             & ((rsi_3_1h_gt_45) | aroonu_14_1h_lt_70 | (roc_9_1h_lt_10))
             # 1h down move, 4h high & overbought
@@ -20290,7 +20298,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 4h & 1d downtrend
             & ((rsi_3_4h_gt_5) | (roc_9_4h > -15.0) | (roc_9_1d_gt_neg_20))
             # 4h & 1d down move, 1d overbought
-            & ((rsi_3_4h_gt_10) | (rsi_3_1d_gt_45) | (roc_9_1d < 10.0))
+            & ((rsi_3_4h_gt_10) | (rsi_3_1d_gt_45) | (roc_9_1d_lt_10))
             # 4h down move, 1d still high, 1d downtrend
             & ((rsi_3_4h_gt_10) | (aroonu_14_1d_lt_50) | (roc_9_1d > -30.0))
             # 4h down move, 1d high, 4h downtrend
@@ -20432,7 +20440,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1d green with top wick, 4h high
             & ((change_pct_1d < 30.0) | (top_wick_pct_1d < 20.0) | aroonu_14_4h_lt_80)
             # 1d top wick, 4h down move, 1d overbought
-            & ((top_wick_pct_1d < 50.0) | (rsi_3_4h_gt_35) | (roc_9_1d < 60.0))
+            & ((top_wick_pct_1d < 50.0) | (rsi_3_4h_gt_35) | (roc_9_1d_lt_60))
             # drop in last 20 days, 4h high
             & ((close > (high_max_20_1d * 0.10)) | (stochrsi_k_4h_lt_90))
             # drop in last 20 days, 1h high, 1d downtrend
@@ -20582,7 +20590,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 4h down move, 4h still high
             & ((rsi_3_15m_gt_15) | (rsi_3_4h_gt_50) | (aroonu_14_4h_lt_50))
             # 1h & 1d down move, 1d overbought
-            & ((rsi_3_1h_gt_15) | (rsi_3_1d_gt_35) | (roc_9_1d < 10.0))
+            & ((rsi_3_1h_gt_15) | (rsi_3_1d_gt_35) | (roc_9_1d_lt_10))
             # 15m down move, 15m still not low enough, 1h high
             & ((rsi_3_15m_gt_15) | (aroonu_14_15m_lt_25) | (stochrsi_k_1h_lt_80))
             # 15m down move, 4h high & overbought
@@ -20664,7 +20672,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h & 4h high
             & ((rsi_3_1h_gt_40) | aroonu_14_1h_lt_80 | aroonu_14_4h_lt_100)
             # 1h down move, 1h high, 1d high & overbought
-            & ((rsi_3_1h_gt_45) | (stochrsi_k_1h_lt_60) | (stochrsi_k_1d < 70.0) | (roc_9_1d < 40.0))
+            & ((rsi_3_1h_gt_45) | (stochrsi_k_1h_lt_60) | (stochrsi_k_1d < 70.0) | (roc_9_1d_lt_40))
             # 1h down move, 1h high & overbought
             & ((rsi_3_1h_gt_55) | (stochrsi_k_1h_lt_80) | (roc_9_1h_lt_10))
             # 1h down move, 4h high
@@ -20704,13 +20712,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1d down move, 1h high & overbought
             & ((rsi_3_1d_gt_35) | (stochrsi_k_1h_lt_90) | (roc_9_1h_lt_10))
             # 1d down move, 4h high, 1d overbought
-            & ((rsi_3_1d_gt_45) | (stochrsi_k_4h_lt_90) | (roc_9_1d < 10.0))
+            & ((rsi_3_1d_gt_45) | (stochrsi_k_4h_lt_90) | (roc_9_1d_lt_10))
             # 4h still high, 4h moving lower, 4h overbought
             & ((aroonu_14_4h_lt_50) | (aroonu_14_4h > aroonu_14_4h.shift(48)) | (roc_9_4h_lt_40))
             # 1h high, 1d downtrend
             & ((aroonu_14_1d_lt_70) | (roc_9_1d_gt_neg_30))
             # 1d high, 4h & 1d overbought
-            & ((aroonu_14_1d_lt_85) | (roc_9_4h < 60.0) | (roc_9_1d < 60.0))
+            & ((aroonu_14_1d_lt_85) | (roc_9_4h < 60.0) | (roc_9_1d_lt_60))
             # 1d high, 4h & 1d overbought
             & (aroonu_14_1d_lt_100 | (roc_9_4h_lt_10) | (roc_9_1d_lt_20))
             # 1h high, 4h downtrend
@@ -20720,7 +20728,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h high, 4h & 1d overbought
             & ((stochrsi_k_4h_lt_80) | (roc_9_4h_lt_30) | (roc_9_1d_lt_30))
             # 1d high, 4h & 1d overbought
-            & ((stochrsi_k_1d < 80.0) | (roc_9_4h < 60.0) | (roc_9_1d < 60.0))
+            & ((stochrsi_k_1d < 80.0) | (roc_9_4h < 60.0) | (roc_9_1d_lt_60))
             # 1d red, 4h down move, 1h still high
             & ((change_pct_1d > -30.0) | (rsi_3_4h_gt_30) | (stochrsi_k_1h_lt_50))
             # pump, drop but not yet near the previous lows
@@ -21023,7 +21031,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1d high, 1h overbought
             & ((rsi_3_1h_gt_60) | (aroonu_14_1d_lt_90) | (roc_9_1h_lt_10))
             # 4h down move, 4h still not low enough, 1d overbought
-            & ((rsi_3_4h_gt_15) | (aroonu_14_4h_lt_30) | (roc_9_1d < 100.0))
+            & ((rsi_3_4h_gt_15) | (aroonu_14_4h_lt_30) | (roc_9_1d_lt_100))
             # 4h down move, 15m still high, 1d downtrend
             & ((rsi_3_4h_gt_15) | (stochrsi_k_15m_lt_50) | (roc_9_1d > -20.0))
             # 4h & 1d down move, 15m still not low enough
@@ -21081,7 +21089,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h & 1d high, 4h overbought
             & (aroonu_14_4h_lt_80 | aroonu_14_1d_lt_100 | (roc_9_4h_lt_30))
             # 4h & 1d high, 1d overbought
-            & (aroonu_14_4h_lt_70 | aroonu_14_1d_lt_100 | (roc_9_1d < 10.0))
+            & (aroonu_14_4h_lt_70 | aroonu_14_1d_lt_100 | (roc_9_1d_lt_10))
             # 4h high & overbought
             & ((aroonu_14_4h_lt_90) | (stochrsi_k_4h < 85.0) | (roc_9_4h < 50.0))
             # 1d high, 4h & 1d overbought
@@ -21188,7 +21196,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 15m still not low enough
             & ((rsi_3_1h_gt_10) | rsi_3_4h_gt_20 | (stochrsi_k_15m_lt_20))
             # 1h down move, 1d high & overbought
-            & ((rsi_3_1h_gt_10) | (aroonu_14_1d_lt_90) | (roc_9_1d < 10.0))
+            & ((rsi_3_1h_gt_10) | (aroonu_14_1d_lt_90) | (roc_9_1d_lt_10))
             # 1h & 4h down move, 4h still high
             & ((rsi_3_1h_gt_15) | rsi_3_4h_gt_20 | (aroonu_14_4h_lt_40))
             # 1h down move, 4h still high, 4h downtrend
@@ -21276,9 +21284,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h high, 1h & 1d overbought
             & ((aroonu_14_1h_lt_90) | (roc_9_1h_lt_10) | (roc_9_1d_lt_30))
             # 4h & 1d high, 1d overbought
-            & (aroonu_14_4h_lt_70 | aroonu_14_1d_lt_100 | (roc_9_1d < 10.0))
+            & (aroonu_14_4h_lt_70 | aroonu_14_1d_lt_100 | (roc_9_1d_lt_10))
             # 4h high, 4h & 1d overbought
-            & (aroonu_14_4h_lt_80 | (roc_9_4h < 80.0) | (roc_9_1d < 100.0))
+            & (aroonu_14_4h_lt_80 | (roc_9_4h < 80.0) | (roc_9_1d_lt_100))
             # 1d high, 4h & 1d overbought
             & (aroonu_14_1d_lt_100 | (roc_9_4h_lt_10) | roc_9_1d_lt_50)
             # 15m still high, 1h high
@@ -21623,11 +21631,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 5m down move, 1h & 1d high
             & ((rsi_3_gt_10) | aroonu_14_1h_lt_80 | aroonu_14_1d_lt_100)
             # 15m & 1h down move, 1d overbought
-            & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_10) | (roc_9_1d < 100.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_10) | (roc_9_1d_lt_100))
             # 15m & 1h down move, 1h still not low enough
             & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_10) | (stochrsi_k_1h_lt_20))
             # 15m & 1h down move, 1d overbought
-            & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_10) | (roc_9_1d < 60.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_10) | (roc_9_1d_lt_60))
             # 15m & 1h down move, 4h still high
             & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_15) | (aroonu_14_4h_lt_40))
             # 15m & 1h down move, 4h high
@@ -21655,7 +21663,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 1h high, 4h overbought
             & (rsi_3_15m_gt_3 | aroonu_14_1h_lt_70 | (roc_9_4h_lt_10))
             # 15m down move, 1d high & overbought
-            & (rsi_3_15m_gt_3 | (aroonu_14_1d_lt_70) | (roc_9_1d < 10.0))
+            & (rsi_3_15m_gt_3 | (aroonu_14_1d_lt_70) | (roc_9_1d_lt_10))
             # 15m & 1h down move, 4h still high
             & ((rsi_3_15m_gt_5) | (rsi_3_1h_gt_10) | (stochrsi_k_4h_lt_50))
             # 15m & 1h down move, 1h still high
@@ -21691,7 +21699,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 1h high
             & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_30) | (stochrsi_k_1h_lt_70))
             # 15m & 1h down move, 1d overbought
-            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_30) | (roc_9_1d < 60.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_30) | (roc_9_1d_lt_60))
             # 15m & 4h down move, 15m still high
             & ((rsi_3_15m_gt_10) | (rsi_3_4h_gt_10) | (aroonu_14_15m_lt_40))
             # 15m & 4h down move, 1d high
@@ -21775,7 +21783,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 4h high & overbought
             & ((rsi_3_15m_gt_20) | (rsi_3_1h_gt_30) | (stochrsi_k_4h_lt_80) | (roc_9_4h_lt_10))
             # 15m down move, 1h high, 1d overbought
-            & ((rsi_3_15m_gt_20) | (aroonu_14_1h_lt_80) | (roc_9_1d < 10.0))
+            & ((rsi_3_15m_gt_20) | (aroonu_14_1h_lt_80) | (roc_9_1d_lt_10))
             # 15m down move, 1h high, 1d downtrend
             & ((rsi_3_15m_gt_20) | (stochrsi_k_1h_lt_80) | (roc_9_1d_gt_neg_20))
             # 15m down move, 4h high, 1d downtrend
@@ -21803,7 +21811,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 1d still high
             & ((rsi_3_1h_gt_3) | (rsi_3_4h_gt_10) | (stochrsi_k_1d < 40.0))
             # 1h & 4h down move, 1d overbought
-            & ((rsi_3_1h_gt_3) | (rsi_3_4h_gt_25) | (roc_9_1d < 10.0))
+            & ((rsi_3_1h_gt_3) | (rsi_3_4h_gt_25) | (roc_9_1d_lt_10))
             # 1h & 1d down move, 1d still high
             & ((rsi_3_1h_gt_3) | (rsi_3_1d_gt_25) | (stochrsi_k_1d < 40.0))
             # 1h & 4h down move, 15m still not low enough
@@ -21867,7 +21875,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 15m still high, 1d high
             & (rsi_3_1h_gt_20 | (aroonu_14_15m_lt_40) | (aroonu_14_1d_lt_90))
             # 1h down move, 1h high, 1d overbought
-            & (rsi_3_1h_gt_20 | (aroonu_14_1h_lt_60) | (roc_9_1d < 10.0))
+            & (rsi_3_1h_gt_20 | (aroonu_14_1h_lt_60) | (roc_9_1d_lt_10))
             # 1h & 4h down move, 15m high
             & ((rsi_3_1h_gt_25) | (rsi_3_4h_gt_25) | (stochrsi_k_15m_lt_70))
             # 1h & 4h down move, 1h high
@@ -21897,7 +21905,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h & 4h high
             & ((rsi_3_1h_gt_45) | (aroonu_14_1h_lt_75) | aroonu_14_4h_lt_100)
             # 1h down move, 1h high, 1d high & overbought
-            & ((rsi_3_1h_gt_45) | (stochrsi_k_1h_lt_60) | (stochrsi_k_1d < 70.0) | (roc_9_1d < 40.0))
+            & ((rsi_3_1h_gt_45) | (stochrsi_k_1h_lt_60) | (stochrsi_k_1d < 70.0) | (roc_9_1d_lt_40))
             # 1h down move, 4h high & overbought
             & ((rsi_3_1h_gt_50) | (stochrsi_k_4h_lt_90) | (roc_9_4h < 25.0))
             # 1h & 1d down move, 1h high
@@ -21953,11 +21961,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 4h still not low enough, 1d downtrend
             & ((rsi_3_4h_gt_15) | (stochrsi_k_4h_lt_20) | (roc_9_1d > -20.0))
             # 4h down move, 1h downtrend, 1d overbought
-            & ((rsi_3_4h_gt_15) | (roc_9_1h > -10.0) | (roc_9_1d < 200.0))
+            & ((rsi_3_4h_gt_15) | (roc_9_1h > -10.0) | (roc_9_1d_lt_200))
             # 4h down move, 4h high, 4h downtrend
             & (rsi_3_4h_gt_20 | (aroonu_14_4h_lt_60) | (roc_9_4h_gt_neg_20))
             # 4h down move, 1d high & overbought
-            & (rsi_3_4h_gt_20 | (aroonu_14_1d_lt_80) | (roc_9_1d < 70.0))
+            & (rsi_3_4h_gt_20 | (aroonu_14_1d_lt_80) | (roc_9_1d_lt_70))
             # 4h down move, 4h & 1d downtrend
             & ((rsi_3_4h_gt_25) | (roc_9_4h > -10.0) | (roc_9_1d > -10.0))
             # 1h down move, 4h still not low enough, 1d downtrend
@@ -21995,11 +22003,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1d down move, 1h & 4h high
             & ((rsi_3_1d_gt_30) | aroonu_14_1h_lt_70 | aroonu_14_4h_lt_100)
             # 1d down move, 4h high, 1d overbought
-            & ((rsi_3_1d_gt_45) | (stochrsi_k_4h_lt_90) | (roc_9_1d < 10.0))
+            & ((rsi_3_1d_gt_45) | (stochrsi_k_4h_lt_90) | (roc_9_1d_lt_10))
             # 1d down move, 1d high & overbought
-            & ((rsi_3_1d_gt_55) | (stochrsi_k_1d < 80.0) | (roc_9_1d < 10.0))
+            & ((rsi_3_1d_gt_55) | (stochrsi_k_1d < 80.0) | (roc_9_1d_lt_10))
             # 1d down move, 1d overbought
-            & ((rsi_3_1d_gt_60) | (roc_9_1d < 200.0))
+            & ((rsi_3_1d_gt_60) | (roc_9_1d_lt_200))
             # 15m & 1h high, 4h overbought
             & ((aroonu_14_15m_lt_70) | (aroonu_14_1h_lt_100) | (roc_9_4h < 15.0))
             # 15m & 1h high, 1d overbought
@@ -22025,7 +22033,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h high, 1h & 4h overbought
             & ((stochrsi_k_1h_lt_80) | (roc_9_1h < 20.0) | (roc_9_4h_lt_20))
             # 4h & 1d overbought
-            & ((roc_9_4h < 100.0) | (roc_9_1d < 200.0))
+            & ((roc_9_4h < 100.0) | (roc_9_1d_lt_200))
           )
 
           # Logic
@@ -22058,7 +22066,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 1h still high
             & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_10) | (stochrsi_k_1h_lt_40))
             # 15m & 1h down move, 1d overbought
-            & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_10) | (roc_9_1d < 60.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_10) | (roc_9_1d_lt_60))
             # 15m & 1h down move, 1h still high
             & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_15) | (aroonu_14_1h_lt_50))
             # 15m & 1h down move, 4h still high
@@ -22118,7 +22126,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 1h high
             & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_30) | (stochrsi_k_1h_lt_70))
             # 15m & 1h down move, 1d overbought
-            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_30) | (roc_9_1d < 60.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_30) | (roc_9_1d_lt_60))
             # 15m & 4h down move, 1d still high
             & ((rsi_3_15m_gt_10) | (rsi_3_4h_gt_10) | (aroonu_14_1d_lt_50))
             # 15m & 4h down move, 15m still high
@@ -22182,7 +22190,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 15m still high, 4h high
             & ((rsi_3_15m_gt_15) | (aroonu_14_15m_lt_50) | (stochrsi_k_4h_lt_80))
             # 15m down move, 15m high, 1d overbought
-            & ((rsi_3_15m_gt_15) | (aroonu_14_15m_lt_70) | (roc_9_1d < 10.0))
+            & ((rsi_3_15m_gt_15) | (aroonu_14_15m_lt_70) | (roc_9_1d_lt_10))
             # 15m down move, 1h & 4h high
             & ((rsi_3_15m_gt_15) | (aroonu_14_1h_lt_100) | aroonu_14_4h_lt_100)
             # 15m down move, 1d high & overbought
@@ -22224,7 +22232,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 1d still high
             & ((rsi_3_1h_gt_3) | (rsi_3_4h_gt_10) | (aroonu_14_1d_lt_50))
             # 1h & 4h down move, 1d overbought
-            & ((rsi_3_1h_gt_3) | (rsi_3_4h_gt_25) | (roc_9_1d < 10.0))
+            & ((rsi_3_1h_gt_3) | (rsi_3_4h_gt_25) | (roc_9_1d_lt_10))
             # 1h & 4h down move, 1d still high
             & ((rsi_3_1h_gt_5) | (rsi_3_4h_gt_15) | (aroonu_14_1d_lt_40))
             # 1h & 4h & 1d down move
@@ -22240,7 +22248,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 1h still not low enough
             & ((rsi_3_1h_gt_10) | rsi_3_4h_gt_20 | (aroonu_14_1h_lt_30))
             # 1h & 4h down move, 1d overbought
-            & ((rsi_3_1h_gt_10) | rsi_3_4h_gt_20 | (roc_9_1d < 100.0))
+            & ((rsi_3_1h_gt_10) | rsi_3_4h_gt_20 | (roc_9_1d_lt_100))
             # 1h & 1d downtrend, 1d high
             & ((rsi_3_1h_gt_10) | (rsi_3_1d_gt_45) | (aroonu_14_1d_lt_70))
             # 1h & 4h down move, 1h still not low enough
@@ -22278,7 +22286,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 4h high
             & (rsi_3_1h_gt_20 | (rsi_3_4h_gt_50) | aroonu_14_4h_lt_100)
             # 1h down move, 1d high, 4h & 1d overbought
-            & ((rsi_3_1h_gt_20) | (aroonu_14_1d_lt_80) | (roc_9_4h < 10.0) | (roc_9_1d < 40.0))
+            & ((rsi_3_1h_gt_20) | (aroonu_14_1d_lt_80) | (roc_9_4h < 10.0) | (roc_9_1d_lt_40))
             # 1h down move, 4h high & overbought, 1d downtrend
             & ((rsi_3_1h_gt_20) | (stochrsi_k_4h_lt_80) | (roc_9_4h_lt_10) | (roc_9_1d_gt_neg_20))
             # 1h & 4h down move, 15m high
@@ -22286,7 +22294,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 4h high
             & ((rsi_3_1h_gt_25) | (rsi_3_4h_gt_30) | (aroonu_14_4h_lt_60))
             # 1h down move, 4h & 1d overbought
-            & ((rsi_3_1h_gt_25) | (roc_9_4h_lt_30) | (roc_9_1d < 60.0))
+            & ((rsi_3_1h_gt_25) | (roc_9_4h_lt_30) | (roc_9_1d_lt_60))
             # 1h & 1d down move, 1d still high
             & ((rsi_3_1h_gt_25) | (rsi_3_1d_gt_25) | (stochrsi_k_1d < 50.0))
             # 1h & 4h down move, 1h high
@@ -22306,7 +22314,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h & 4h high
             & ((rsi_3_1h_gt_45) | (aroonu_14_1h_lt_75) | aroonu_14_4h_lt_100)
             # 1h down move, 1h high, 1d high & overbought
-            & ((rsi_3_1h_gt_45) | (stochrsi_k_1h_lt_60) | (stochrsi_k_1d < 70.0) | (roc_9_1d < 40.0))
+            & ((rsi_3_1h_gt_45) | (stochrsi_k_1h_lt_60) | (stochrsi_k_1d < 70.0) | (roc_9_1d_lt_40))
             # 1h down move, 4h high & overbought
             & ((rsi_3_1h_gt_50) | (stochrsi_k_4h_lt_90) | (roc_9_4h < 25.0))
             # 4h & 1d down move, 1d downtrend
@@ -22360,7 +22368,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 4h high
             & ((rsi_3_4h_gt_20) | (aroonu_14_4h_lt_80))
             # 4h down move, 1d high & overbought
-            & ((rsi_3_4h_gt_20) | (aroonu_14_1d_lt_80) | (roc_9_1d < 70.0))
+            & ((rsi_3_4h_gt_20) | (aroonu_14_1d_lt_80) | (roc_9_1d_lt_70))
             # 4h down move, 4h still high, 4h downtrend
             & ((rsi_3_4h_gt_20) | (stochrsi_k_4h_lt_50) | (roc_9_4h_gt_neg_20))
             # 4h down move, 4h high, 1d downtrend
@@ -22370,7 +22378,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h & 1d down move, 4h overbought
             & ((rsi_3_4h_gt_25) | (rsi_3_1d_gt_45) | (roc_9_4h < 5.0))
             # 4h & 1d down move, 1d overbought
-            & ((rsi_3_4h_gt_25) | (rsi_3_1d_gt_45) | (roc_9_1d < 10.0))
+            & ((rsi_3_4h_gt_25) | (rsi_3_1d_gt_45) | (roc_9_1d_lt_10))
             # 4h down move, 15m still not low enough, 4h still high
             & ((rsi_3_4h_gt_25) | (aroonu_14_15m_lt_30) | (stochrsi_k_4h_lt_40))
             # 4h down move, 1d high, 4h overbought
@@ -22400,7 +22408,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 4h high, 1d downtrend
             & ((rsi_3_4h_gt_45) | (stochrsi_k_4h_lt_40) | (roc_9_1d > -25.0))
             # 4h down move, 1d high & overbought
-            & ((rsi_3_4h_gt_50) | (aroonu_14_1d_lt_85) | (roc_9_1d < 200.0))
+            & ((rsi_3_4h_gt_50) | (aroonu_14_1d_lt_85) | (roc_9_1d_lt_200))
             # 4h down move, 4h high & overbought
             & ((rsi_3_4h_gt_50) | (stochrsi_k_4h_lt_70) | (roc_9_4h_lt_10))
             # 4h down move, 4h still high, 1d downtrend
@@ -22434,7 +22442,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 4h high
             & ((aroonu_14_15m_lt_90) | aroonu_14_4h_lt_100)
             # 1h & 1d high, 1d overbought
-            & ((aroonu_14_1h_lt_100) | aroonu_14_1d_lt_100 | (roc_9_1d < 10.0))
+            & ((aroonu_14_1h_lt_100) | aroonu_14_1d_lt_100 | (roc_9_1d_lt_10))
             # 1h & 4h high, 1h overbought
             & ((aroonu_14_1h_lt_100) | aroonu_14_4h_lt_100 | (roc_9_1h_lt_10))
             # 1h & 4h high, 4h overbought
@@ -22448,7 +22456,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1d high, 4h & 1d downtrend
             & ((aroonu_14_1d_lt_60) | (roc_9_4h_gt_neg_20) | (roc_9_1d_gt_neg_30))
             # 1d high, 4h & 1d overbought
-            & (aroonu_14_1d_lt_100 | (roc_9_4h < 60.0) | (roc_9_1d < 100.0))
+            & (aroonu_14_1d_lt_100 | (roc_9_4h < 60.0) | (roc_9_1d_lt_100))
             # 15m high, 4h & 1d overbought
             & ((stochrsi_k_15m_lt_70) | (roc_9_4h_lt_20) | (roc_9_1d_lt_20))
             # 1h high, 1h & 1d overbought
@@ -22549,7 +22557,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 4h down move, 1h still high
             & ((rsi_3_15m_gt_10) | (rsi_3_4h_gt_10) | (stochrsi_k_1h_lt_50))
             # 15m & 4h down move, 4h still high, 1d high & overbought
-            & ((rsi_3_15m_gt_10) | (rsi_3_4h_gt_15) | (aroonu_14_4h_lt_40) | (aroonu_14_1d_lt_70) | (roc_9_1d < 10.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_4h_gt_15) | (aroonu_14_4h_lt_40) | (aroonu_14_1d_lt_70) | (roc_9_1d_lt_10))
             # 15m & 4h down move, 1h high
             & ((rsi_3_15m_gt_10) | (rsi_3_4h_gt_20) | (stochrsi_k_1h_lt_70))
             # 15m & 4h down move, 4h overbought
@@ -22569,7 +22577,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 1h still high, 1d downtrend
             & ((rsi_3_15m_gt_10) | (stochrsi_k_1h_lt_50) | (roc_9_1d_gt_neg_20))
             # 15m & 1h down move, 1h high, 1d high & overbought
-            & ((rsi_3_15m_gt_15) | (rsi_3_1h_gt_15) | (aroonu_14_1h_lt_70) | (aroonu_14_1d_lt_100) | (roc_9_1d < 10.0))
+            & ((rsi_3_15m_gt_15) | (rsi_3_1h_gt_15) | (aroonu_14_1h_lt_70) | (aroonu_14_1d_lt_100) | (roc_9_1d_lt_10))
             # 15m & 4h down move, 1h high
             & ((rsi_3_15m_gt_15) | (rsi_3_4h_gt_35) | (aroonu_14_1h_lt_90))
             # 15m & 1h & 1d down move, 4h still high, 4h downtrend
@@ -22611,7 +22619,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1d high, 1d downtrend
             & (rsi_3_1h_gt_20 | (aroonu_14_1d_lt_70) | (roc_9_1d_gt_neg_20))
             # 1h down move, 1d high, 4h & 1d overbought
-            & ((rsi_3_1h_gt_20) | (aroonu_14_1d_lt_80) | (roc_9_4h < 10.0) | (roc_9_1d < 40.0))
+            & ((rsi_3_1h_gt_20) | (aroonu_14_1d_lt_80) | (roc_9_4h < 10.0) | (roc_9_1d_lt_40))
             # 1h down move, 4h high & overbought, 1d downtrend
             & ((rsi_3_1h_gt_20) | (stochrsi_k_4h_lt_80) | (roc_9_4h_lt_10) | (roc_9_1d_gt_neg_20))
             # 1h down move, 1h & 4h high
@@ -22639,7 +22647,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h & 1d down move, 15m still high
             & ((rsi_3_4h_gt_10) | (rsi_3_1d_gt_20) | (stochrsi_k_15m_lt_40))
             # 4h down move, 1d high & overbought
-            & ((rsi_3_4h_gt_10) | (aroonu_14_1d_lt_100) | (roc_9_1d < 10.0))
+            & ((rsi_3_4h_gt_10) | (aroonu_14_1d_lt_100) | (roc_9_1d_lt_10))
             # 4h down move, 1h high, 1d downtrend
             & ((rsi_3_4h_gt_10) | (stochrsi_k_1h_lt_50) | (roc_9_1d > -30.0))
             # 4h down move, 4h & 1d downtrend
@@ -22659,13 +22667,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 1h high
             & ((rsi_3_4h_gt_15) | (stochrsi_k_1h_lt_80))
             # 4h down move, 1h downtrend, 1d overbought
-            & ((rsi_3_4h_gt_15) | (roc_9_1h > -10.0) | (roc_9_1d < 200.0))
+            & ((rsi_3_4h_gt_15) | (roc_9_1h > -10.0) | (roc_9_1d_lt_200))
             # 4h & 1d down move, 1d still high
             & (rsi_3_4h_gt_20 | (rsi_3_1d_gt_20) | (aroonu_14_1d_lt_50))
             # 4h down move, 4h & 1d high
             & (rsi_3_4h_gt_20 | aroonu_14_4h_lt_70 | (aroonu_14_1d_lt_70))
             # 4h down move, 1d high & overbought
-            & (rsi_3_4h_gt_20 | (aroonu_14_1d_lt_80) | (roc_9_1d < 70.0))
+            & (rsi_3_4h_gt_20 | (aroonu_14_1d_lt_80) | (roc_9_1d_lt_70))
             # 4h down move, 4h high, 1d downtrend
             & (rsi_3_4h_gt_20 | (stochrsi_k_4h_lt_60) | (roc_9_1d_gt_neg_20))
             # 4h & 1d down move, 1d overbought
@@ -22752,7 +22760,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 4h down move, 15m still high
             & ((rsi_3_15m_gt_15) | (rsi_3_4h_gt_15) | (aroonu_14_15m_lt_40))
             # 15m down move, 4h & 1d overbought
-            & ((rsi_3_15m_gt_15) | (roc_9_4h_lt_20) | (roc_9_1d < 200.0))
+            & ((rsi_3_15m_gt_15) | (roc_9_4h_lt_20) | (roc_9_1d_lt_200))
             # 15m & 1h down move, 4h high
             & ((rsi_3_15m_gt_25) | (rsi_3_1h_gt_30) | aroonu_14_4h_lt_100)
             # 15m & 1h down move, 4h high
@@ -22832,7 +22840,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1d high, 4h downtrend
             & ((rsi_3_1h_gt_15) | (aroonu_14_1d_lt_70) | (roc_9_4h > -20.0))
             # 1h down move, 1d high & overbought
-            & ((rsi_3_1h_gt_15) | (aroonu_14_1d_lt_80) | (roc_9_1d < 10.0))
+            & ((rsi_3_1h_gt_15) | (aroonu_14_1d_lt_80) | (roc_9_1d_lt_10))
             # 1h down move, 4h high & overbought
             & ((rsi_3_1h_gt_15) | (stochrsi_k_4h_lt_80) | (roc_9_4h < 20.0))
             # 1h down move, 4h high, 1d downtrend
@@ -22920,11 +22928,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h & 1d down move, 1d downtrend
             & (rsi_3_4h_gt_20 | (rsi_3_1d_gt_25) | (roc_9_1d_gt_neg_30))
             # 4h down move, 1d high & overbought
-            & (rsi_3_4h_gt_20 | (aroonu_14_1d_lt_80) | (roc_9_1d < 70.0))
+            & (rsi_3_4h_gt_20 | (aroonu_14_1d_lt_80) | (roc_9_1d_lt_70))
             # 4h & 1d down move, 4h overbought
             & ((rsi_3_4h_gt_25) | (rsi_3_1d_gt_45) | (roc_9_4h < 5.0))
             # 4h & 1d down move, 1d overbought
-            & ((rsi_3_4h_gt_25) | (rsi_3_1d_gt_45) | (roc_9_1d < 10.0))
+            & ((rsi_3_4h_gt_25) | (rsi_3_1d_gt_45) | (roc_9_1d_lt_10))
             # 4h & 1d down move, 1d overbought
             & ((rsi_3_4h_gt_30) | (rsi_3_1d > 70.0) | (roc_9_1d_lt_20))
             # 4h down move, 4h high, 1d high
@@ -22954,17 +22962,17 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h & 1d high, 1h overbought
             & ((aroonu_14_4h_lt_85) | aroonu_14_1d_lt_100 | (roc_9_1h_lt_10))
             # 4h high, 4h & 1d overbought
-            & ((aroonu_14_4h_lt_90) | (roc_9_4h_lt_30) | (roc_9_1d < 60.0))
+            & ((aroonu_14_4h_lt_90) | (roc_9_4h_lt_30) | (roc_9_1d_lt_60))
             # 15m high, 4h & 1d overbought
             & ((stochrsi_k_15m_lt_80) | (roc_9_4h_lt_20) | (roc_9_1d_lt_20))
             # 15m still high, 4h & 1d overbought
             & ((stochrsi_k_15m_lt_50) | (roc_9_4h_lt_40) | (roc_9_1d_lt_100))
             # 4h high, 4h & 1d overbought
-            & ((stochrsi_k_4h_lt_90) | (roc_9_4h_lt_30) | (roc_9_1d < 60.0))
+            & ((stochrsi_k_4h_lt_90) | (roc_9_4h_lt_30) | (roc_9_1d_lt_60))
             # 1d high, 4h & 1d overbought
             & ((stochrsi_k_1d_lt_90) | (roc_9_4h_lt_30) | (roc_9_1d_lt_100))
             # 4h & 1d overbought
-            & ((roc_9_4h < 100.0) | (roc_9_1d < 200.0))
+            & ((roc_9_4h < 100.0) | (roc_9_1d_lt_200))
             # 1d P&D, 4h overbought
             & ((change_pct_1d > -10.0) | (change_pct_1d.shift(288) < 50.0) | (roc_9_4h_lt_30))
           )
@@ -23164,11 +23172,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 1d high & overbought
             & (rsi_3_4h_gt_20 | (aroonu_14_1d_lt_90) | (roc_9_1d_lt_30))
             # 4h & 1d down move, 1d overbought
-            & ((rsi_3_4h_gt_25) | (rsi_3_1d_gt_40) | (roc_9_1d < 10.0))
+            & ((rsi_3_4h_gt_25) | (rsi_3_1d_gt_40) | (roc_9_1d_lt_10))
             # 4h & 1d down move, 1d high
             & ((rsi_3_4h_gt_25) | (rsi_3_1d_gt_45) | (aroonu_14_1d_lt_80))
             # 4h down move, 15m high, 1d overbought
-            & ((rsi_3_4h_gt_30) | (stochrsi_k_15m < 90.0) | (roc_9_1d < 10.0))
+            & ((rsi_3_4h_gt_30) | (stochrsi_k_15m < 90.0) | (roc_9_1d_lt_10))
             # 4h down move, 4h still high, 1d downtrend
             & ((rsi_3_4h_gt_35) | (stochrsi_k_4h_lt_40) | (roc_9_1d_gt_neg_30))
             # 4h down move, 4h high, 1d overbought
@@ -23188,7 +23196,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1d down move, 4h high, 1d overbought
             & ((rsi_3_1d_gt_60) | aroonu_14_4h_lt_70 | (roc_9_1d_lt_40))
             # 15m high, 1d high & overbought
-            & ((aroonu_14_15m_lt_70) | aroonu_14_1d_lt_100 | (roc_9_1d < 100.0))
+            & ((aroonu_14_15m_lt_70) | aroonu_14_1d_lt_100 | (roc_9_1d_lt_100))
             # 15m high, 4h overbought, 1d downtrend
             & ((aroonu_14_15m_lt_80) | (roc_9_4h_lt_20) | (roc_9_1d_gt_neg_30))
             # 1h & 4h high, 4h overbought
@@ -23198,7 +23206,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h high, 4h & 1d downtrend
             & ((aroonu_14_1h_lt_100) | (roc_9_4h > -10.0) | (roc_9_1d > -25.0))
             # 4h & 1d high, 1d overbought
-            & (aroonu_14_4h_lt_100 | aroonu_14_1d_lt_100 | (roc_9_1d < 60.0))
+            & (aroonu_14_4h_lt_100 | aroonu_14_1d_lt_100 | (roc_9_1d_lt_60))
             # 1h high, 4h & 1d downtrend
             & ((stochrsi_k_1h_lt_80) | (roc_9_4h > -10.0) | (roc_9_1d > -25.0))
           )
@@ -23347,7 +23355,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 4h down move, 15m & 4h still high
           long_entry_logic.append((rsi_3_4h_gt_30) | (aroonu_14_15m_lt_50) | (aroonu_14_4h_lt_50))
           # 4h down move, 15m still high, 1d overbought
-          long_entry_logic.append((rsi_3_4h_gt_30) | (stochrsi_k_15m_lt_50) | (roc_9_1d < 10.0))
+          long_entry_logic.append((rsi_3_4h_gt_30) | (stochrsi_k_15m_lt_50) | (roc_9_1d_lt_10))
           # 4h down move, 1h & 4h still high
           long_entry_logic.append((rsi_3_4h_gt_35) | (stochrsi_k_1h_lt_50) | (aroonu_14_4h_lt_50))
           # 4h down move, 1d high & overbought
@@ -23363,7 +23371,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 4h down move, 1h still high, 4h still moving down
           long_entry_logic.append((rsi_3_4h_gt_40) | (stochrsi_k_1h_lt_50) | (cci_20_change_pct_4h > -0.0))
           # 4h down move, 1d high & overbought
-          long_entry_logic.append((rsi_3_4h_gt_40) | (stochrsi_k_1d < 80.0) | (roc_9_1d < 10.0))
+          long_entry_logic.append((rsi_3_4h_gt_40) | (stochrsi_k_1d < 80.0) | (roc_9_1d_lt_10))
           # 4h down move, 1h high, 4h still high
           long_entry_logic.append((rsi_3_4h_gt_45) | aroonu_14_1h_lt_70 | (aroonu_14_4h_lt_50))
           # 4h down move, 15m high, 4h still high
@@ -23395,7 +23403,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 4h down move, 4h still high, 1d high
           long_entry_logic.append((rsi_3_4h_gt_60) | (stochrsi_k_4h_lt_50) | (stochrsi_k_1d < 80.0))
           # 15m still high, 1d high & overbought
-          long_entry_logic.append((aroonu_14_15m_lt_50) | aroonu_14_1d_lt_100 | (roc_9_1d < 100.0))
+          long_entry_logic.append((aroonu_14_15m_lt_50) | aroonu_14_1d_lt_100 | (roc_9_1d_lt_100))
           # 15m high, 4h high
           long_entry_logic.append((aroonu_14_15m_lt_70) | (aroonu_14_4h_lt_85))
           # 15m & 1d high, 1d overbought
@@ -23413,13 +23421,13 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1d high, 4h overbought
           long_entry_logic.append((aroonu_14_1d_lt_90) | (roc_9_4h_lt_40))
           # 1d high & overbought
-          long_entry_logic.append(aroonu_14_1d_lt_100 | (roc_9_1d < 200.0))
+          long_entry_logic.append(aroonu_14_1d_lt_100 | (roc_9_1d_lt_200))
           # 15m high, 1h still high
           long_entry_logic.append((stochrsi_k_15m_lt_70) | (stochrsi_k_1h_lt_40))
           # 15m & 4h high
           long_entry_logic.append((stochrsi_k_15m_lt_70) | aroonu_14_4h_lt_70)
           # 15m high, 1d overbought
-          long_entry_logic.append((stochrsi_k_15m_lt_70) | (roc_9_1d < 10.0))
+          long_entry_logic.append((stochrsi_k_15m_lt_70) | (roc_9_1d_lt_10))
           # 15m high, 1h still not low enough
           long_entry_logic.append((stochrsi_k_15m_lt_80) | (stochrsi_k_1h_lt_30))
           # 1d high, 4h overbought
@@ -23455,7 +23463,7 @@ class NostalgiaForInfinityX7(IStrategy):
           long_entry_logic.append(num_empty_288 <= allowed_empty_candles_288)
           long_entry_logic.append(protections_long_global == True)
 
-          long_entry_logic.append((rsi_3_gt_5) & (rsi_3_15m_gt_5) & (roc_9_15m > -10.0) & (roc_9_1d < 200.0))
+          long_entry_logic.append((rsi_3_gt_5) & (rsi_3_15m_gt_5) & (roc_9_15m > -10.0) & (roc_9_1d_lt_200))
 
           long_entry_logic.append(
             # 15m & 1h down move, 4h high
@@ -23493,7 +23501,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 4h high
             & ((rsi_3_15m_gt_25) | (rsi_3_1h_gt_25) | (stochrsi_k_4h_lt_90))
             # 15m down move, 15m high, 1d overbought
-            & ((rsi_3_15m_gt_25) | (aroonu_14_15m_lt_60) | (roc_9_1d < 150.0))
+            & ((rsi_3_15m_gt_25) | (aroonu_14_15m_lt_60) | (roc_9_1d_lt_150))
             # 15m down move, 15m still high, 1d high, 1d downtrend
             & ((rsi_3_15m_gt_30) | (aroonu_14_15m_lt_50) | (stochrsi_k_1d < 70.0) | (roc_9_1d > -15.0))
             # 15m down move, 1h & 4h high
@@ -23507,7 +23515,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 4h high
             & ((rsi_3_1h_gt_5) | (rsi_3_4h_gt_30) | (aroonu_14_4h_lt_90))
             # 1h down move, 4h high, 1d overbought
-            & ((rsi_3_1h_gt_5) | (aroonu_14_4h_lt_60) | (roc_9_1d < 10.0))
+            & ((rsi_3_1h_gt_5) | (aroonu_14_4h_lt_60) | (roc_9_1d_lt_10))
             # 1h & 4h down move, 4h still high
             & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_10) | (aroonu_14_4h_lt_50))
             # 1h & 3h down move, 1d high
@@ -23549,7 +23557,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 4h & 1d overbought
             & ((rsi_3_1h_gt_45) | (roc_9_4h_lt_10) | (roc_9_1d_lt_50))
             # 1h down move,  4h high, 1d overbought
-            & ((rsi_3_1h_gt_50) | (stochrsi_k_4h_lt_90) | (roc_9_1d < 150.0))
+            & ((rsi_3_1h_gt_50) | (stochrsi_k_4h_lt_90) | (roc_9_1d_lt_150))
             # 4h down move, 1d high
             & ((rsi_3_4h_gt_3) | (aroonu_14_1d_lt_90))
             # 4h down move, 15m still high
@@ -23745,7 +23753,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 4h still high, 4h downtrend
             & ((rsi_3_15m_gt_15) | (aroonu_14_4h_lt_40) | (roc_9_4h_gt_neg_20))
             # 15m down move, 1d high & overbought
-            & ((rsi_3_15m_gt_15) | (aroonu_14_1d_lt_100) | (roc_9_1d < 100.0))
+            & ((rsi_3_15m_gt_15) | (aroonu_14_1d_lt_100) | (roc_9_1d_lt_100))
             # 15m down move, 15m still not low enough, 4h high
             & ((rsi_3_15m_gt_15) | (stochrsi_k_15m_lt_30) | (stochrsi_k_4h_lt_50))
             # 15m down move, 15m & 1h high
@@ -23753,13 +23761,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 1h high, 1d overbought
             & ((rsi_3_15m_gt_15) | (stochrsi_k_1h_lt_70) | (roc_9_1d_lt_30))
             # 15m down move, 1h high, 1d overbought
-            & ((rsi_3_15m_gt_15) | (stochrsi_k_1h_lt_70) | (roc_9_1d < 150.0))
+            & ((rsi_3_15m_gt_15) | (stochrsi_k_1h_lt_70) | (roc_9_1d_lt_150))
             # 15m down move, 1h high & overbought
             & ((rsi_3_15m_gt_15) | (stochrsi_k_1h_lt_80) | (roc_9_1h < 20.0))
             # 15m down move, 1h high, 1d overbought
             & ((rsi_3_15m_gt_15) | (stochrsi_k_1h_lt_80) | (roc_9_1d_lt_100))
             # 15m down move, 4h high, 1d overbought
-            & ((rsi_3_15m_gt_15) | (stochrsi_k_4h_lt_80) | (roc_9_1d < 25.0))
+            & ((rsi_3_15m_gt_15) | (stochrsi_k_4h_lt_80) | (roc_9_1d_lt_25))
             # 15m down move, 4h high & overbought
             & ((rsi_3_15m_gt_15) | (stochrsi_k_4h_lt_90) | (roc_9_4h < 25.0))
             # 15m down move, 4h high
@@ -23844,9 +23852,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h still not low enough, 1d downtrend
             & ((rsi_3_1h_gt_25) | (stochrsi_k_1h_lt_30) | (roc_9_1d_gt_neg_40))
             # 1h down move, 4h high, 1d overbought
-            & ((rsi_3_1h_gt_25) | (stochrsi_k_4h_lt_90) | (roc_9_1d < 25.0))
+            & ((rsi_3_1h_gt_25) | (stochrsi_k_4h_lt_90) | (roc_9_1d_lt_25))
             # 1h & 4h & 1d down move, 1d high & overbought
-            & ((rsi_3_1h_gt_30) | (rsi_3_4h_gt_30) | (rsi_3_1d_gt_55) | (aroonu_14_1d_lt_80) | (roc_9_1d < 20.0))
+            & ((rsi_3_1h_gt_30) | (rsi_3_4h_gt_30) | (rsi_3_1d_gt_55) | (aroonu_14_1d_lt_80) | (roc_9_1d_lt_20))
             # 1h & 4h down move, 1h still high
             & ((rsi_3_1h_gt_30) | (rsi_3_4h_gt_30) | (aroonu_14_1h_lt_40))
             # 1h & 1d down move, 1d still high
@@ -23898,7 +23906,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h high, 1d downtrend
             & ((rsi_3_1h_gt_40) | (stochrsi_k_1h_lt_80) | (roc_9_1d_gt_neg_40))
             # 1h & 4h down move, 1d overbought
-            & ((rsi_3_1h_gt_45) | (rsi_3_4h_gt_65) | (roc_9_1d < 200.0))
+            & ((rsi_3_1h_gt_45) | (rsi_3_4h_gt_65) | (roc_9_1d_lt_200))
             # 1h & 1d down move, 4h high
             & ((rsi_3_1h_gt_45) | (rsi_3_1d > 50.0) | (stochrsi_k_4h_lt_90))
             # 1h down move, 1h high, 4h overbought
@@ -23940,7 +23948,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 4h still high 1d downtrend
             & ((rsi_3_4h_gt_25) | (aroonu_14_4h_lt_50) | (roc_9_1d_gt_neg_20))
             # 4h down move, 1d high & overbought
-            & ((rsi_3_4h_gt_25) | (stochrsi_k_1d < 80.0) | (roc_9_1d < 25.0))
+            & ((rsi_3_4h_gt_25) | (stochrsi_k_1d < 80.0) | (roc_9_1d_lt_25))
             # 4h down move, 4h & 1d high
             & ((rsi_3_4h_gt_35) | aroonu_14_4h_lt_70 | aroonu_14_1d_lt_100)
             # 4h down move, 15m still high, 1d overbought
@@ -23986,7 +23994,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1d down move, 15m still high, 1d overbought
             & ((rsi_3_1d_gt_65) | (aroonu_14_15m_lt_40) | (roc_9_1d_lt_100))
             # 1d down move, 4h & 1d high
-            & ((rsi_3_1d_gt_65) | (roc_9_4h_lt_10) | (roc_9_1d < 10.0))
+            & ((rsi_3_1d_gt_65) | (roc_9_4h_lt_10) | (roc_9_1d_lt_10))
             # 5m still high, 1h down move, 15m still high, 1h high
             & ((rsi_3 < 40.0) | (rsi_3_1h_gt_30) | (aroonu_14_15m_lt_50) | (aroonu_14_4h_lt_90))
             # 5m still high, 15m high
@@ -24004,7 +24012,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h high, 4h & 1d overbought
             & (aroonu_14_4h_lt_80 | (roc_9_4h < 20.0) | (roc_9_1d_lt_20))
             # 4h & 1d high, 1d overbought
-            & ((aroonu_14_4h_lt_85) | (aroonu_14_1d_lt_85) | (roc_9_1d < 60.0))
+            & ((aroonu_14_4h_lt_85) | (aroonu_14_1d_lt_85) | (roc_9_1d_lt_60))
             # 4h & 1d high, 1d overbought
             & (aroonu_14_4h_lt_100 | aroonu_14_1d_lt_100 | (roc_9_1d_lt_30))
             # 1d still high, 4h & 1d downtrend
@@ -24140,7 +24148,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 5m & 15m strong up move
           short_entry_logic.append((rsi_3 < 95.0) | (rsi_3_15m_lt_95))
           # 5m & 1h up move, 1d uptrend
-          short_entry_logic.append((rsi_3 < 95.0) | (rsi_3_1h_lt_90) | (roc_9_1d < 100.0))
+          short_entry_logic.append((rsi_3 < 95.0) | (rsi_3_1h_lt_90) | (roc_9_1d_lt_100))
           # 5m up move, 15m & 1h still not high enough
           short_entry_logic.append((rsi_3 < 95.0) | (aroond_14_15m < 25.0) | (aroond_14_1h < 25.0))
           # 4m up move, 1h & 4h still low
@@ -24526,7 +24534,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h low, 1d low
             & ((aroonu_14_1h > 30.0) | (stochrsi_k_1d > 30.0))
             # 4h still not high enough, 4h & 1d uptrend
-            & ((aroonu_14_4h > 70.0) | (roc_9_4h < 60.0) | (roc_9_1d < 200.0))
+            & ((aroonu_14_4h > 70.0) | (roc_9_4h < 60.0) | (roc_9_1d_lt_200))
             # 1h & 4h low
             & ((stochrsi_k_1h_gt_20) | (aroonu_14_4h > 20.0))
             # 1d big green, 1d still not high enough
@@ -24799,11 +24807,11 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1h down move, 1h still high, 1d going down
           short_entry_logic.append((rsi_3_1h_lt_85) | (stochrsi_k_1h_gt_50) | (roc_2_1d > -50.0))
           # 4h downtrend, 4h still high, 1d strong downtrend
-          short_entry_logic.append((rsi_3_4h_lt_85) | (stochrsi_k_4h_gt_70) | (roc_9_1d < 60.0))
+          short_entry_logic.append((rsi_3_4h_lt_85) | (stochrsi_k_4h_gt_70) | (roc_9_1d_lt_60))
           # 15m down move, 1h strong down move, 1d overbought
           short_entry_logic.append((mfi_14_15m < 80.0) | (rsi_3_change_pct_1h < 80.0) | roc_9_1d_gt_neg_50)
           # 1h not low enough, 4h high, 1d strong downtrend
-          short_entry_logic.append((stochrsi_k_1h_gt_70) | (stochrsi_k_4h > 10.0) | (roc_9_1d < 60.0))
+          short_entry_logic.append((stochrsi_k_1h_gt_70) | (stochrsi_k_4h > 10.0) | (roc_9_1d_lt_60))
           # 1h down move, 4h still high, 1d downtrend
           short_entry_logic.append((rsi_3_change_pct_1h < 65.0) | (stochrsi_k_4h_gt_30) | roc_9_1d_lt_50)
           # 15m strong down move, 1h still high
@@ -24885,7 +24893,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1h & 4h up move, 15m still not high enough
           short_entry_logic.append((rsi_3_1h_lt_95) | (rsi_3_4h_lt_95) | (stochrsi_k_15m > 80.0))
           # 1h & 4h up move, 1d uptrend
-          short_entry_logic.append((rsi_3_1h_lt_95) | (rsi_3_4h_lt_95) | (roc_9_1d < 100.0))
+          short_entry_logic.append((rsi_3_1h_lt_95) | (rsi_3_4h_lt_95) | (roc_9_1d_lt_100))
           # 1h & 4h up move, 1d still low
           short_entry_logic.append((rsi_3_1h_lt_95) | (rsi_3_4h_lt_85) | (rsi_14_1d > 50.0))
           # 1h up move, 4h still low, 1h still moving higher
@@ -25044,7 +25052,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 4h down move, 4h still high, 1d downtrend
           short_entry_logic.append((rsi_3_4h < 75.0) | (stochrsi_k_4h_gt_50) | roc_9_1d_lt_50)
           # 4h & 1d down move, 1d strong downtrend
-          short_entry_logic.append((rsi_3_4h_lt_90) | (rsi_3_1d < 90.0) | (roc_9_1d < 60.0))
+          short_entry_logic.append((rsi_3_4h_lt_90) | (rsi_3_1d < 90.0) | (roc_9_1d_lt_60))
           # 4h overbought, 1h still high, 1d downtrend
           short_entry_logic.append((roc_9_4h > -50.0) | (stochrsi_k_1h_gt_70) | roc_9_1d_lt_50)
           # 4h red, previous 4h green, 4h overbought


### PR DESCRIPTION
## Summary
- Reuse repeated `roc_9_1d < ...` comparison masks inside X7 `populate_entry_trend()`.
- Covers repeated 1d ROC entry thresholds while leaving isolated one-off comparisons inline.
- Independent on latest upstream `main`.

## Safety
- Behavior is preserved: this only reuses already-read local Series comparisons inside the same call.
- No indicator formulas, candle selection, order classification, profit arithmetic, thresholds, condition order, return values, or signal behavior are changed.
- Touched function: `populate_entry_trend()`.
- No v3 grind-entry code is touched.

## Backtest scope
- Full backtesting was not required for this patch because it only replaces repeated inline comparisons with equivalent local masks from the same `roc_9_1d` Series.
- Validation focused on static safety, mergeability, and targeted diff review for unchanged thresholds and condition order.

## Checks
- `python3 ~/.codex/skills/nfi-upstream-pr/scripts/validate_nfi_pr.py --base origin/main`
- `git merge-tree` conflict simulation against `origin/main`
- targeted `git diff origin/main...HEAD -- NostalgiaForInfinityX7.py` review
- `git diff --check`
- `ruff format --check NostalgiaForInfinityX7.py`
- `ruff check NostalgiaForInfinityX7.py`
- `PYTHONDONTWRITEBYTECODE=1 python3 -m py_compile NostalgiaForInfinityX7.py`
