### PR TITLE
Reuse X7 entry STOCHRSI and ROC masks

### DIFF
--- a/NostalgiaForInfinityX7.py
+++ b/NostalgiaForInfinityX7.py
@@ -13117,25 +13117,62 @@ class NostalgiaForInfinityX7(IStrategy):
     stochrsi_k_4h_lt_70 = stochrsi_k_4h < 70.0
     stochrsi_k_4h_lt_80 = stochrsi_k_4h < 80.0
     stochrsi_k_4h_lt_90 = stochrsi_k_4h < 90.0
+    stochrsi_k_1d_gt_20 = stochrsi_k_1d > 20.0
+    stochrsi_k_1d_gt_30 = stochrsi_k_1d > 30.0
+    stochrsi_k_1d_gt_50 = stochrsi_k_1d > 50.0
+    stochrsi_k_1d_gt_60 = stochrsi_k_1d > 60.0
+    stochrsi_k_1d_gt_70 = stochrsi_k_1d > 70.0
+    stochrsi_k_1d_lt_20 = stochrsi_k_1d < 20.0
+    stochrsi_k_1d_lt_30 = stochrsi_k_1d < 30.0
+    stochrsi_k_1d_lt_40 = stochrsi_k_1d < 40.0
+    stochrsi_k_1d_lt_50 = stochrsi_k_1d < 50.0
+    stochrsi_k_1d_lt_60 = stochrsi_k_1d < 60.0
+    stochrsi_k_1d_lt_70 = stochrsi_k_1d < 70.0
+    stochrsi_k_1d_lt_80 = stochrsi_k_1d < 80.0
     stochrsi_k_1d_lt_90 = stochrsi_k_1d < 90.0
 
     roc_9_1h_lt_10 = roc_9_1h < 10.0
+    roc_9_1h_lt_15 = roc_9_1h < 15.0
+    roc_9_1h_lt_20 = roc_9_1h < 20.0
+    roc_9_1h_lt_25 = roc_9_1h < 25.0
+    roc_9_1h_lt_30 = roc_9_1h < 30.0
+    roc_9_1h_lt_40 = roc_9_1h < 40.0
+    roc_9_1h_lt_50 = roc_9_1h < 50.0
+    roc_9_1h_lt_60 = roc_9_1h < 60.0
+    roc_9_1h_lt_80 = roc_9_1h < 80.0
+    roc_9_1h_lt_100 = roc_9_1h < 100.0
     roc_9_4h_gt_neg_30 = roc_9_4h > -30.0
     roc_9_4h_gt_neg_20 = roc_9_4h > -20.0
+    roc_9_4h_lt_5 = roc_9_4h < 5.0
     roc_9_4h_lt_10 = roc_9_4h < 10.0
+    roc_9_4h_lt_15 = roc_9_4h < 15.0
     roc_9_4h_lt_20 = roc_9_4h < 20.0
+    roc_9_4h_lt_25 = roc_9_4h < 25.0
     roc_9_4h_lt_30 = roc_9_4h < 30.0
     roc_9_4h_lt_40 = roc_9_4h < 40.0
+    roc_9_4h_lt_50 = roc_9_4h < 50.0
+    roc_9_4h_lt_60 = roc_9_4h < 60.0
+    roc_9_4h_lt_70 = roc_9_4h < 70.0
+    roc_9_4h_lt_80 = roc_9_4h < 80.0
+    roc_9_4h_lt_100 = roc_9_4h < 100.0
     roc_9_1d_gt_neg_50 = roc_9_1d > -50.0
     roc_9_1d_gt_neg_40 = roc_9_1d > -40.0
     roc_9_1d_gt_neg_30 = roc_9_1d > -30.0
     roc_9_1d_gt_neg_20 = roc_9_1d > -20.0
+    roc_9_1d_lt_10 = roc_9_1d < 10.0
+    roc_9_1d_lt_15 = roc_9_1d < 15.0
     roc_9_1d_lt_20 = roc_9_1d < 20.0
+    roc_9_1d_lt_25 = roc_9_1d < 25.0
     roc_9_1d_lt_30 = roc_9_1d < 30.0
+    roc_9_1d_lt_35 = roc_9_1d < 35.0
     roc_9_1d_lt_40 = roc_9_1d < 40.0
     roc_9_1d_lt_50 = roc_9_1d < 50.0
+    roc_9_1d_lt_60 = roc_9_1d < 60.0
+    roc_9_1d_lt_70 = roc_9_1d < 70.0
     roc_9_1d_lt_80 = roc_9_1d < 80.0
     roc_9_1d_lt_100 = roc_9_1d < 100.0
+    roc_9_1d_lt_150 = roc_9_1d < 150.0
+    roc_9_1d_lt_200 = roc_9_1d < 200.0
 
     is_backtest = self.dp.runmode.value in ["backtest", "hyperopt", "plot", "webserver"]
     # the number of free slots
@@ -13206,7 +13243,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 5m & 1h down move, 4h high
             & ((rsi_3_gt_3) | (rsi_3_1h_gt_25) | (stochrsi_k_4h_lt_80))
             # 15m & 1h down move, 1d still high
-            & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_3) | (stochrsi_k_1d < 50.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_3) | (stochrsi_k_1d_lt_50))
             # 5m & 1h down move, 15m still not low enough
             & ((rsi_3_gt_3) | (rsi_3_1h_gt_15) | (aroonu_14_15m_lt_30))
             # 5m & 4h down move, 4h high
@@ -13272,15 +13309,15 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 1d overbought
             & ((rsi_3_15m_gt_5) | (rsi_3_1h_gt_5) | (roc_9_1d_lt_40))
             # 5m & 1h down move, 1h overbought
-            & ((rsi_3_15m_gt_5) | (rsi_3_1h_gt_60) | (roc_9_1h < 40.0))
+            & ((rsi_3_15m_gt_5) | (rsi_3_1h_gt_60) | (roc_9_1h_lt_40))
             # 15m & 4h down move, 1d still high
-            & ((rsi_3_15m_gt_5) | (rsi_3_4h_gt_5) | (stochrsi_k_1d < 40.0))
+            & ((rsi_3_15m_gt_5) | (rsi_3_4h_gt_5) | (stochrsi_k_1d_lt_40))
             # 15m & 4h down move, 1d downtrend
             & ((rsi_3_15m_gt_5) | (rsi_3_4h_gt_5) | (roc_9_1d_gt_neg_20))
             # 15m & 4h down move, 1h still high
             & ((rsi_3_15m_gt_5) | (rsi_3_4h_gt_10) | (stochrsi_k_1h_lt_50))
             # 15m & 4h down move, 1d high
-            & ((rsi_3_15m_gt_5) | (rsi_3_4h_gt_15) | (stochrsi_k_1d < 60.0))
+            & ((rsi_3_15m_gt_5) | (rsi_3_4h_gt_15) | (stochrsi_k_1d_lt_60))
             # 15m & 4h down move, 15m still high
             & ((rsi_3_15m_gt_5) | (rsi_3_4h_gt_30) | (stochrsi_k_15m_lt_50))
             # 15m down move, 15m & 4h still high
@@ -13304,7 +13341,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 15m still high
             & ((rsi_3_15m_gt_10) | rsi_3_1h_gt_20 | (aroonu_14_15m_lt_50))
             # 15m & 1h down move, 4h overbought
-            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_25) | (roc_9_4h < 80.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_25) | (roc_9_4h_lt_80))
             # 15m & 4h down move, 1h high
             & ((rsi_3_15m_gt_10) | (rsi_3_4h_gt_10) | (aroonu_14_1h_lt_75))
             # 15m & 4h down move, 15m still high
@@ -13320,13 +13357,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 4h down move, 4h high
             & ((rsi_3_15m_gt_10) | (rsi_3_4h_gt_60) | (stochrsi_k_4h_lt_90))
             # 15m & 1d down move, 1d high
-            & ((rsi_3_15m_gt_10) | (rsi_3_1d > 50.0) | (stochrsi_k_1d < 80.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_1d > 50.0) | (stochrsi_k_1d_lt_80))
             # 15m down move & downtrend, 4h high
             & ((rsi_3_15m_gt_10) | (cmf_20_15m > -0.3) | aroonu_14_4h_lt_100)
             # 15m down move, 15m & 4h high
             & ((rsi_3_15m_gt_10) | (aroonu_14_15m_lt_70) | aroonu_14_4h_lt_80)
             # 15m down move, 1h high & overbought
-            & ((rsi_3_15m_gt_10) | (aroonu_14_1h_lt_90) | (roc_9_1h < 20.0))
+            & ((rsi_3_15m_gt_10) | (aroonu_14_1h_lt_90) | (roc_9_1h_lt_20))
             # 15m down move, 1h high, 1d downtrend
             & ((rsi_3_15m_gt_10) | (aroonu_14_1h_lt_90) | (roc_9_1d_gt_neg_40))
             # 15m down move, 1h high, 1d overbought
@@ -13336,15 +13373,15 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 1h high, 1d downtrend
             & ((rsi_3_15m_gt_10) | (stochrsi_k_1h_lt_70) | roc_9_1d_gt_neg_50)
             # 15m down move, 1h high & overbought
-            & ((rsi_3_15m_gt_10) | (stochrsi_k_1h_lt_90) | (roc_9_1h < 20.0))
+            & ((rsi_3_15m_gt_10) | (stochrsi_k_1h_lt_90) | (roc_9_1h_lt_20))
             # 15m down move, 1h & 1d overbought
             & ((rsi_3_15m_gt_10) | (roc_9_1h_lt_10) | (roc_9_1d_lt_80))
             # 15m down move, 4h high
-            & ((rsi_3_15m_gt_10) | (roc_9_4h < 60.0))
+            & ((rsi_3_15m_gt_10) | (roc_9_4h_lt_60))
             # 15m & 1h down move, 1h high
             & ((rsi_3_15m_gt_15) | rsi_3_1h_gt_20 | aroonu_14_1h_lt_80)
             # 15m down move, 15m still high, 4h overbought
-            & ((rsi_3_15m_gt_15) | (rsi_14_15m < 50.0) | (roc_9_4h < 50.0))
+            & ((rsi_3_15m_gt_15) | (rsi_14_15m < 50.0) | (roc_9_4h_lt_50))
             # 15m down move, 15m & 1h high
             & ((rsi_3_15m_gt_15) | (aroonu_14_15m_lt_70) | (aroonu_14_1h_lt_100))
             # 15m down move, 15m & 1h high
@@ -13354,7 +13391,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 1h & 4h high
             & ((rsi_3_15m_gt_20) | (aroonu_14_1h_lt_100) | aroonu_14_4h_lt_100)
             # 15m down move, 1h high & overbought
-            & ((rsi_3_15m_gt_20) | (aroonu_14_1h_lt_100) | (roc_9_1h < 20.0))
+            & ((rsi_3_15m_gt_20) | (aroonu_14_1h_lt_100) | (roc_9_1h_lt_20))
             # 15m down move, 4h high & overbought
             & ((rsi_3_15m_gt_25) | aroonu_14_4h_lt_100 | (roc_9_4h_lt_10))
             # 15m down move, 1d overbought
@@ -13372,7 +13409,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 1d down move, 4h still high
             & ((rsi_3_1h_gt_3) | (rsi_3_1d_gt_15) | (stochrsi_k_4h_lt_50))
             # 1h & 4h down move, 1d overbought
-            & ((rsi_3_1h_gt_5) | (rsi_3_4h_gt_5) | (roc_9_1d < 10.0))
+            & ((rsi_3_1h_gt_5) | (rsi_3_4h_gt_5) | (roc_9_1d_lt_10))
             # 1h & 4h down move, 4h still high
             & ((rsi_3_1h_gt_5) | (rsi_3_4h_gt_10) | (aroonu_14_4h_lt_40))
             # 1h & 4h down move, 1h downtrend
@@ -13406,7 +13443,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h high, 4h overbought
             & ((rsi_3_1h_gt_10) | (aroonu_14_1h_lt_70) | (roc_9_4h_lt_10))
             # 1h down move, 4h overbought
-            & ((rsi_3_1h_gt_10) | (roc_9_4h < 50.0))
+            & ((rsi_3_1h_gt_10) | (roc_9_4h_lt_50))
             # 1h & 4h down move, 4h still high
             & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_15) | (aroonu_14_4h_lt_40))
             # 1h & 4h down move, 4h high
@@ -13426,15 +13463,15 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h & 4h downtrend
             & ((rsi_3_1h_gt_15) | (roc_9_1h > -30.0) | (roc_9_4h_gt_neg_30))
             # 1h & 4h down move, 4h overbought
-            & (rsi_3_1h_gt_20 | (rsi_3_4h_gt_50) | (roc_9_4h < 80.0))
+            & (rsi_3_1h_gt_20 | (rsi_3_4h_gt_50) | (roc_9_4h_lt_80))
             # 1h down move, 1h still high, 4h downtrend
             & (rsi_3_1h_gt_20 | (aroonu_14_1h_lt_40) | (roc_9_4h_gt_neg_30))
             # 1h down move, 4h high, 1d overbought
-            & (rsi_3_1h_gt_20 | aroonu_14_4h_lt_70 | (roc_9_1d < 200.0))
+            & (rsi_3_1h_gt_20 | aroonu_14_4h_lt_70 | (roc_9_1d_lt_200))
             # 1h down move, 4h high, 1d overbought
-            & (rsi_3_1h_gt_20 | (aroonu_14_4h_lt_90) | (roc_9_1d < 60.0))
+            & (rsi_3_1h_gt_20 | (aroonu_14_4h_lt_90) | (roc_9_1d_lt_60))
             # 1h down move, 4h high & overbought
-            & (rsi_3_1h_gt_20 | aroonu_14_4h_lt_100 | (roc_9_4h < 50.0))
+            & (rsi_3_1h_gt_20 | aroonu_14_4h_lt_100 | (roc_9_4h_lt_50))
             # 1h down move, 1d high & overbought
             & (rsi_3_1h_gt_20 | (stochrsi_k_1d_lt_90) | (roc_9_1d_lt_80))
             # 1h down move, 1h high, 15n downtrend
@@ -13442,7 +13479,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h still high, 1d overbought
             & ((rsi_3_1h_gt_25) | (stochrsi_k_1h_lt_50) | (roc_9_1d_lt_40))
             # 1h down move, 4h & 1d overbought
-            & ((rsi_3_1h_gt_25) | (roc_9_4h < 80.0) | (roc_9_1d_lt_100))
+            & ((rsi_3_1h_gt_25) | (roc_9_4h_lt_80) | (roc_9_1d_lt_100))
             # 1h & 4h down move, 4h downtrend
             & ((rsi_3_1h_gt_30) | (rsi_3_4h_gt_30) | (roc_9_4h_gt_neg_20))
             # 1h down move, 4h high, 1d downtrend
@@ -13458,13 +13495,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h high, 15m downtrend
             & ((rsi_3_1h_gt_40) | aroonu_14_1h_lt_80 | (roc_9_15m > -15.0))
             # 1h down move, 1h high, 1d overbought
-            & ((rsi_3_1h_gt_40) | aroonu_14_1h_lt_80 | (roc_9_1d < 100.0))
+            & ((rsi_3_1h_gt_40) | aroonu_14_1h_lt_80 | (roc_9_1d_lt_100))
             # 1h down move, 1h high, 4h overbought
             & ((rsi_3_1h_gt_40) | (stochrsi_k_1h_lt_80) | (roc_9_4h_lt_20))
             # 1h down move, 1h & 4h high
             & ((rsi_3_1h_gt_45) | aroonu_14_1h_lt_80 | aroonu_14_4h_lt_100)
             # 1h down move, 1h high & overbought
-            & ((rsi_3_1h_gt_50) | (aroonu_14_1h_lt_90) | (roc_9_1h < 20.0))
+            & ((rsi_3_1h_gt_50) | (aroonu_14_1h_lt_90) | (roc_9_1h_lt_20))
             # 1h down move, 1h still high, 4h high
             & ((rsi_3_1h_gt_60) | (aroonu_14_1h_lt_50) | (rsi_14_4h < 90.0))
             # 4h & 1d down move, 1d high
@@ -13474,7 +13511,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h & 1d down move, 4h still not low enough
             & ((rsi_3_4h_gt_10) | (rsi_3_1d_gt_15) | (aroonu_14_4h_lt_20))
             # 4h & 1d down move, 1d still high
-            & ((rsi_3_4h_gt_10) | (rsi_3_1d_gt_25) | (stochrsi_k_1d < 50.0))
+            & ((rsi_3_4h_gt_10) | (rsi_3_1d_gt_25) | (stochrsi_k_1d_lt_50))
             # 4h down move, 4h still high
             & ((rsi_3_4h_gt_10) | (aroonu_14_4h_lt_50))
             # 4h down move, 1d high
@@ -13498,7 +13535,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 4h high, 1d overbought
             & ((rsi_3_4h_gt_50) | aroonu_14_4h_lt_70 | (roc_9_1d_lt_40))
             # 4h down move, 1h high, 1d overbought
-            & ((rsi_3_4h_gt_60) | (stochrsi_k_1h_lt_90) | (roc_9_1d < 60.0))
+            & ((rsi_3_4h_gt_60) | (stochrsi_k_1h_lt_90) | (roc_9_1d_lt_60))
             # 1d down move, 1h high, 1d downtrend
             & ((rsi_3_1d_gt_5) | (stochrsi_k_1h_lt_90) | (roc_9_1d_gt_neg_20))
             # 1d down move, 1h still high, 4h high
@@ -13508,7 +13545,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1d down move, 1d high
             & ((rsi_3_1d_gt_40) | (aroonu_14_1d_lt_80))
             # 1d down move, 4h still high, 1d overbought
-            & ((rsi_3_1d > 50.0) | (aroonu_14_4h_lt_50) | (roc_9_1d < 200.0))
+            & ((rsi_3_1d > 50.0) | (aroonu_14_4h_lt_50) | (roc_9_1d_lt_200))
             # 1d down move, 1d high & overbought
             & ((rsi_3_1d_gt_60) | (aroonu_14_1d_lt_80) | roc_9_1d_lt_50)
             # 1h down move, 4h high, 1d overbought
@@ -13520,11 +13557,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h still high, 1h & 4h downtrend
             & ((aroonu_14_1h_lt_40) | (roc_9_1h > -20.0) | (roc_9_4h_gt_neg_30))
             # 1h & 4h high, 1h overbought
-            & ((aroonu_14_1h_lt_85) | (aroonu_14_4h_lt_90) | (roc_9_1h < 20.0))
+            & ((aroonu_14_1h_lt_85) | (aroonu_14_4h_lt_90) | (roc_9_1h_lt_20))
             # 1h high, 1h & 4h overbought
             & ((aroonu_14_1h_lt_85) | (roc_9_1h_lt_10) | (roc_9_1d_lt_30))
             # 1h high, 1h overbought, 1d downtrend
-            & ((aroonu_14_1h_lt_85) | (roc_9_1h < 20.0) | (roc_9_1d_gt_neg_40))
+            & ((aroonu_14_1h_lt_85) | (roc_9_1h_lt_20) | (roc_9_1d_gt_neg_40))
             # 4h & 1d high, 1d overbought
             & (aroonu_14_4h_lt_80 | aroonu_14_1d_lt_100 | roc_9_1d_lt_50)
             # 4h high, 1h downtrend
@@ -13538,7 +13575,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1d high, 4h & 1d overbought
             & ((aroonu_14_1d_lt_90) | (roc_9_4h_lt_40) | (roc_9_1d_lt_80))
             # 1h high, 4h overbought
-            & ((stochrsi_k_1h_lt_80) | (roc_9_4h < 80.0))
+            & ((stochrsi_k_1h_lt_80) | (roc_9_4h_lt_80))
             # 4h high, 1h downtrend
             & ((stochrsi_k_4h_lt_70) | (roc_9_1h > -15.0))
             # 4h high, 1d downtrend
@@ -13552,9 +13589,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 5m down move, 4h down move, 15m downtrend, 1h high
             & ((roc_9 > -15.0) | (rsi_3_4h_gt_45) | (cmf_20_15m > -0.3) | (aroonu_14_1h_lt_60))
             # 1h downtrend, 4h high & overbought
-            & ((roc_9_1h > -25.0) | aroonu_14_4h_lt_80 | (roc_9_4h < 80.0))
+            & ((roc_9_1h > -25.0) | aroonu_14_4h_lt_80 | (roc_9_4h_lt_80))
             # 1h & 4h overbought, 1d downtrend
-            & ((roc_9_1h < 20.0) | (roc_9_4h_lt_20) | (roc_9_1d_gt_neg_40))
+            & ((roc_9_1h_lt_20) | (roc_9_4h_lt_20) | (roc_9_1d_gt_neg_40))
             # 1d P&D, 1d downtrend
             & ((change_pct_1d > -5.0) | (change_pct_1d.shift(288) < 30.0) | (cmf_20_1d > -0.0))
             # 1d green with top wick, 1h down move
@@ -13564,7 +13601,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1d green, 1h down move, 1d downtrend
             & ((change_pct_1d < 40.0) | (rsi_3_1h_gt_25) | (cmf_20_1d > -0.2))
             # 1d green with top wick, 4h overbought
-            & ((change_pct_1d < 50.0) | (top_wick_pct_1d < 30.0) | (roc_9_4h < 80.0))
+            & ((change_pct_1d < 50.0) | (top_wick_pct_1d < 30.0) | (roc_9_4h_lt_80))
             # big drop in the last hour, 15m downtrend
             & ((close > (close_max_12 * 0.65)) | (cmf_20_15m > -0.5))
             # big drop in the last 6 hours, 1h down move, 1h high
@@ -13574,7 +13611,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # big drop in the last 4 days, 1h high
             & ((close > (high_max_24_4h * 0.20)) | aroonu_14_1h_lt_70)
             # big drop in the last 20 days, 1d high, 1d downtrend
-            & ((close > (high_max_20_1d * 0.20)) | (stochrsi_k_1d < 70.0) | (roc_9_1d > -15.0))
+            & ((close > (high_max_20_1d * 0.20)) | (stochrsi_k_1d_lt_70) | (roc_9_1d > -15.0))
           )
 
           # Logic
@@ -13621,7 +13658,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 5m down move, 4h high, 1d overbought
             & ((rsi_3_gt_3) | aroonu_14_4h_lt_80 | (roc_9_1d_lt_30))
             # 5m down move, 4h high & overbought
-            & ((rsi_3_gt_3) | aroonu_14_4h_lt_100 | (roc_9_4h < 20.0))
+            & ((rsi_3_gt_3) | aroonu_14_4h_lt_100 | (roc_9_4h_lt_20))
             # 5m down move, 4h & 1d overbought
             & ((rsi_3_gt_3) | (roc_9_4h_lt_20) | (roc_9_1d_lt_40))
             # 5m down move, 1d downtrend
@@ -13635,7 +13672,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 5m & 4h down move, 4h still not low enough
             & ((rsi_3_gt_5) | (rsi_3_4h_gt_15) | (stochrsi_k_4h < 20.0))
             # 5m down move, 4h high, 1h overbought
-            & ((rsi_3_gt_10) | aroonu_14_4h_lt_100 | (roc_9_1h < 30.0))
+            & ((rsi_3_gt_10) | aroonu_14_4h_lt_100 | (roc_9_1h_lt_30))
             # 15m & 1h down move, 1h still high
             & ((rsi_3_15m > 1.0) | (rsi_3_1h_gt_25) | (stochrsi_k_1h_lt_40))
             # 15m & 1h & 4h down move
@@ -13675,7 +13712,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 1h still high
             & ((rsi_3_15m_gt_3) | (rsi_3_1h_gt_35) | (aroonu_14_1h_lt_40))
             # 15m & 1h down move, 1d high
-            & ((rsi_3_15m_gt_3) | (rsi_3_1h_gt_35) | (stochrsi_k_1d < 70.0))
+            & ((rsi_3_15m_gt_3) | (rsi_3_1h_gt_35) | (stochrsi_k_1d_lt_70))
             # 15m & 1h down move, 1h high
             & ((rsi_3_15m_gt_3) | (rsi_3_1h_gt_40) | (aroonu_14_1h_lt_70))
             # 15m & 1h down move, 4h high
@@ -13727,11 +13764,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 1h high
             & ((rsi_3_15m_gt_5) | (rsi_3_1h_gt_45) | (aroonu_14_1h_lt_80))
             # 15m & 4h down move, 1d still high
-            & ((rsi_3_15m_gt_5) | (rsi_3_4h_gt_5) | (stochrsi_k_1d < 40.0))
+            & ((rsi_3_15m_gt_5) | (rsi_3_4h_gt_5) | (stochrsi_k_1d_lt_40))
             # 15m & 4h down move, 15m still not low enough
             & ((rsi_3_15m_gt_5) | (rsi_3_4h_gt_10) | (stochrsi_k_15m_lt_30))
             # 15m & 4h down move, 1d high
-            & ((rsi_3_15m_gt_5) | (rsi_3_4h_gt_10) | (stochrsi_k_1d < 70.0))
+            & ((rsi_3_15m_gt_5) | (rsi_3_4h_gt_10) | (stochrsi_k_1d_lt_70))
             # 15m & 4h down move, 15m still high
             & ((rsi_3_15m_gt_5) | (rsi_3_4h_gt_15) | (aroonu_14_15m_lt_40))
             # 15m & 4h down move, 1h still high
@@ -13739,7 +13776,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 4h down move, 4h still high
             & ((rsi_3_15m_gt_5) | (rsi_3_4h_gt_15) | (stochrsi_k_4h_lt_50))
             # 15m & 4h down move, 1d overbought
-            & ((rsi_3_15m_gt_5) | (rsi_3_4h_gt_20) | (roc_9_1d < 10.0))
+            & ((rsi_3_15m_gt_5) | (rsi_3_4h_gt_20) | (roc_9_1d_lt_10))
             # 15m & 4h down move, 4h still high
             & ((rsi_3_15m_gt_5) | (rsi_3_4h_gt_45) | (aroonu_14_4h_lt_40))
             # 15m & 1d down move, 15m still not low enough
@@ -13759,7 +13796,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 1h still high, 4h overbought
             & ((rsi_3_15m_gt_5) | (stochrsi_k_1h_lt_50) | (roc_9_4h_lt_30))
             # 15m down move, 1h high & overbought
-            & ((rsi_3_15m_gt_5) | (stochrsi_k_1h_lt_80) | (roc_9_1h < 20.0))
+            & ((rsi_3_15m_gt_5) | (stochrsi_k_1h_lt_80) | (roc_9_1h_lt_20))
             # 15m & 1h down move, 15m high
             & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_10) | (stochrsi_k_15m_lt_50))
             # 15m & 1h down move, 1h still high
@@ -13767,13 +13804,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 4h high
             & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_10) | (aroonu_14_4h_lt_60))
             # 15m & 1h down move, 1d high
-            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_10) | (stochrsi_k_1d < 70.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_10) | (stochrsi_k_1d_lt_70))
             # 15m & 1h down move, 1h high
             & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_15) | (aroonu_14_1h_lt_80))
             # 15m & 1h down move, 4h high
             & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_20) | (stochrsi_k_4h_lt_70))
             # 15m & 1h & 4h down move, 1d high
-            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_25) | (rsi_3_4h_gt_25) | (stochrsi_k_1d < 70.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_25) | (rsi_3_4h_gt_25) | (stochrsi_k_1d_lt_70))
             # 15m & 1h down move, 4h high
             & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_25) | (aroonu_14_4h_lt_75))
             # 15m & 1h down move, 4h still high
@@ -13801,7 +13838,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 4h down move, 4h still not low enough
             & ((rsi_3_15m_gt_10) | (rsi_3_4h_gt_10) | (stochrsi_k_4h < 30.0))
             # 15m & 4h down move, 1d high
-            & ((rsi_3_15m_gt_10) | (rsi_3_4h_gt_10) | (stochrsi_k_1d < 80.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_4h_gt_10) | (stochrsi_k_1d_lt_80))
             # 15m & 4h down move, 1d overbought
             & ((rsi_3_15m_gt_10) | (rsi_3_4h_gt_10) | (roc_9_1d_lt_20))
             # 15m & 4h down move, 4h still not low enough
@@ -13813,7 +13850,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 4h down move, 1d overbought
             & ((rsi_3_15m_gt_10) | (rsi_3_4h_gt_30) | (roc_9_1d_lt_30))
             # 15m & 4h down move, 4h overbought
-            & ((rsi_3_15m_gt_10) | (rsi_3_4h_gt_55) | (roc_9_4h < 50.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_4h_gt_55) | (roc_9_4h_lt_50))
             # 15m & 1d down move, 1d still high
             & ((rsi_3_15m_gt_10) | (rsi_3_1d_gt_10) | (rsi_14_1d < 40.0))
             # 15m & 1d down move, 1h high
@@ -13823,7 +13860,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1d down move, 1h high
             & ((rsi_3_15m_gt_10) | (rsi_3_1d_gt_25) | (aroonu_14_1h_lt_70))
             # 15m & 1d down move, 1d high
-            & ((rsi_3_15m_gt_10) | (rsi_3_1d_gt_25) | (stochrsi_k_1d < 70.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_1d_gt_25) | (stochrsi_k_1d_lt_70))
             # 15m down move, 15m downtrend, 1h high
             & ((rsi_3_15m_gt_10) | (cmf_20_15m > -0.40) | (aroonu_14_1h_lt_80))
             # 15m down move, 1h high, 1d overbought
@@ -13871,7 +13908,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 15m & 4h still high
             & ((rsi_3_15m_gt_15) | (aroonu_14_15m_lt_40) | (aroonu_14_4h_lt_40))
             # 15m down move, 1h still high, 4h overbought
-            & ((rsi_3_15m_gt_15) | (aroonu_14_1h_lt_50) | (roc_9_4h < 60.0))
+            & ((rsi_3_15m_gt_15) | (aroonu_14_1h_lt_50) | (roc_9_4h_lt_60))
             # 15m down move, 1h & 4h high
             & ((rsi_3_15m_gt_15) | (aroonu_14_1h_lt_60) | (aroonu_14_4h_lt_90))
             # 15m down move, 1h & 1d high
@@ -13887,11 +13924,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 1h high & overbought
             & ((rsi_3_15m_gt_15) | (stochrsi_k_1h_lt_90) | (roc_9_1h_lt_10))
             # 15m down move, 4h high, 1d overbought
-            & ((rsi_3_15m_gt_15) | (stochrsi_k_4h_lt_70) | (roc_9_1d < 10.0))
+            & ((rsi_3_15m_gt_15) | (stochrsi_k_4h_lt_70) | (roc_9_1d_lt_10))
             # 15m & 1h down move, 15m still not low enough
             & ((rsi_3_15m_gt_20) | (rsi_3_1h_gt_20) | (aroonu_14_15m_lt_30))
             # 15m & 1h down move, 4h overbought
-            & ((rsi_3_15m_gt_20) | (rsi_3_1h_gt_20) | (roc_9_4h < 50.0))
+            & ((rsi_3_15m_gt_20) | (rsi_3_1h_gt_20) | (roc_9_4h_lt_50))
             # 15m & 1h down move, 15m high
             & ((rsi_3_15m_gt_20) | (rsi_3_1h_gt_25) | (stochrsi_k_15m_lt_80))
             # 15m & 1h down move, 4h high
@@ -13921,7 +13958,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 1d overbought
             & ((rsi_3_15m_gt_25) | (rsi_3_1h_gt_40) | (roc_9_1d_lt_80))
             # 15m & 4h down move, 1h overbought
-            & ((rsi_3_15m_gt_25) | (rsi_3_4h_gt_35) | (roc_9_1h < 100.0))
+            & ((rsi_3_15m_gt_25) | (rsi_3_4h_gt_35) | (roc_9_1h_lt_100))
             # 15m down move, 15m still not low enough, 1h high
             & ((rsi_3_15m_gt_25) | (aroonu_14_15m_lt_20) | (stochrsi_k_1h_lt_90))
             # 15m down move, 1h & 4h high
@@ -13931,19 +13968,19 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 4h high, 1d overbought
             & ((rsi_3_15m_gt_25) | (aroonu_14_4h_lt_70) | (roc_9_1d_lt_50))
             # 15m down move, 4h high, 1h overbought
-            & ((rsi_3_15m_gt_25) | (aroonu_14_4h_lt_80) | (roc_9_1h < 50.0))
+            & ((rsi_3_15m_gt_25) | (aroonu_14_4h_lt_80) | (roc_9_1h_lt_50))
             # 15m down move, 4h high & overbought
-            & ((rsi_3_15m_gt_30) | (aroonu_14_4h_lt_70) | (roc_9_4h < 50.0))
+            & ((rsi_3_15m_gt_30) | (aroonu_14_4h_lt_70) | (roc_9_4h_lt_50))
             # 15m down move, 1h high, 1d downtrend
             & ((rsi_3_15m_gt_30) | (stochrsi_k_1h_lt_80) | (roc_9_1d_gt_neg_20))
             # 15m down move, 4h high & overbought
             & ((rsi_3_15m_gt_30) | (stochrsi_k_4h_lt_80) | (roc_9_4h_lt_30))
             # 15m down move, 1h high, 4h overbought
-            & ((rsi_3_15m_gt_35) | (aroonu_14_1h_lt_80) | (roc_9_4h < 80.0))
+            & ((rsi_3_15m_gt_35) | (aroonu_14_1h_lt_80) | (roc_9_4h_lt_80))
             # 15m down move, 4h high & overbought
-            & ((rsi_3_15m_gt_35) | (aroonu_14_4h_lt_90) | (roc_9_4h < 50.0))
+            & ((rsi_3_15m_gt_35) | (aroonu_14_4h_lt_90) | (roc_9_4h_lt_50))
             # 15m down move, 4h high, 1d overbought
-            & ((rsi_3_15m_gt_35) | (aroonu_14_4h_lt_100) | (roc_9_1h < 20.0))
+            & ((rsi_3_15m_gt_35) | (aroonu_14_4h_lt_100) | (roc_9_1h_lt_20))
             # 15m down move, 1h high, 1d overbought
             & ((rsi_3_15m_gt_35) | (stochrsi_k_1h_lt_80) | (roc_9_1d_lt_80))
             # 15m down move, 4h high & overbought
@@ -13957,7 +13994,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 4h still high
             & ((rsi_3_1h_gt_3) | (rsi_3_4h_gt_5) | (aroonu_14_4h_lt_40))
             # 1h & 4h down move, 1d still high
-            & ((rsi_3_1h_gt_3) | (rsi_3_4h_gt_10) | (stochrsi_k_1d < 40.0))
+            & ((rsi_3_1h_gt_3) | (rsi_3_4h_gt_10) | (stochrsi_k_1d_lt_40))
             # 1h & 4h down move, 4h still high
             & ((rsi_3_1h_gt_3) | (rsi_3_4h_gt_15) | (rsi_14_4h < 40.0))
             # 1h & 4h down move, 1h still not low enough
@@ -13965,7 +14002,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 1d high
             & ((rsi_3_1h_gt_3) | rsi_3_4h_gt_20 | (aroonu_14_1d_lt_80))
             # 1h & 4h down move, 1d overbought
-            & ((rsi_3_1h_gt_3) | (rsi_3_4h_gt_25) | (roc_9_1d < 10.0))
+            & ((rsi_3_1h_gt_3) | (rsi_3_4h_gt_25) | (roc_9_1d_lt_10))
             # 1h & 4h down move, 4h high
             & ((rsi_3_1h_gt_3) | (rsi_3_4h_gt_50) | aroonu_14_4h_lt_70)
             # 1h & 1d down move, 15m still high
@@ -13973,7 +14010,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 4h high
             & ((rsi_3_1h_gt_5) | (rsi_3_4h_gt_5) | (stochrsi_k_4h < 40.0))
             # 1h & 4h down move, 1d still high
-            & ((rsi_3_1h_gt_5) | (rsi_3_4h_gt_5) | (stochrsi_k_1d < 50.0))
+            & ((rsi_3_1h_gt_5) | (rsi_3_4h_gt_5) | (stochrsi_k_1d_lt_50))
             # 1h & 4h down move, 1d downtrend
             & ((rsi_3_1h_gt_5) | (rsi_3_4h_gt_5) | (roc_9_1d_gt_neg_30))
             # 1h % 4h down move, 4h downtrend
@@ -14009,7 +14046,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 4h still high
             & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_35) | (rsi_14_4h < 40.0))
             # 1h down move, 1h still not low enough 1d overbought
-            & ((rsi_3_1h_gt_10) | (aroonu_14_1h_lt_30) | (roc_9_1d < 100.0))
+            & ((rsi_3_1h_gt_10) | (aroonu_14_1h_lt_30) | (roc_9_1d_lt_100))
             # 1h & 4h down move, 1d high
             & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_15) | (rsi_14_1d < 60.0))
             # 1h & 4h down move, 1h still not low enough
@@ -14023,7 +14060,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 4h still not low enough
             & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_25) | (stochrsi_k_4h < 30.0))
             # 1h & 4h down move, 1d high
-            & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_30) | (stochrsi_k_1d < 80.0))
+            & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_30) | (stochrsi_k_1d_lt_80))
             # 1h & 4h down move, 4h downtrend
             & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_30) | (roc_9_4h_gt_neg_30))
             # 1h & 4h down move, 4h high
@@ -14033,7 +14070,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 1d down move, 1d high
             & ((rsi_3_1h_gt_15) | (rsi_3_1d_gt_25) | (aroonu_14_1d_lt_80))
             # 1h & 1d down move, 1d overbought
-            & ((rsi_3_1h_gt_15) | (rsi_3_1d_gt_35) | (roc_9_1d < 10.0))
+            & ((rsi_3_1h_gt_15) | (rsi_3_1d_gt_35) | (roc_9_1d_lt_10))
             # 1h down move, 1h still high, 1d downtrend
             & ((rsi_3_1h_gt_15) | (aroonu_14_1h_lt_40) | (roc_9_1d_gt_neg_40))
             # 1h down move, 4h high, 1d high
@@ -14063,7 +14100,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1d high & overbought
             & (rsi_3_1h_gt_20 | aroonu_14_1d_lt_100 | (roc_9_1d_lt_20))
             # 1h down move, 1d high, 4h downtrend
-            & (rsi_3_1h_gt_20 | (stochrsi_k_1d < 80.0) | (roc_9_4h_gt_neg_20))
+            & (rsi_3_1h_gt_20 | (stochrsi_k_1d_lt_80) | (roc_9_4h_gt_neg_20))
             # 1h & 4h down move, 4h high
             & ((rsi_3_1h_gt_25) | (rsi_3_4h_gt_30) | (aroonu_14_4h_lt_60))
             # 1h & 4h down move, 1d downtrend
@@ -14089,7 +14126,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 4h high, 1d overbought
             & ((rsi_3_1h_gt_30) | aroonu_14_4h_lt_80 | (roc_9_1d_lt_30))
             # 1h down move, 4h downtrend, 1d overbought
-            & ((rsi_3_1h_gt_30) | (roc_9_4h_gt_neg_30) | (roc_9_1d < 200.0))
+            & ((rsi_3_1h_gt_30) | (roc_9_4h_gt_neg_30) | (roc_9_1d_lt_200))
             # 1h down move, 4h & 1d downtrend
             & ((rsi_3_1h_gt_30) | (roc_9_4h > -25.0) | (roc_9_1d > -60.0))
             # 1h & 4h down move, 1h still high
@@ -14099,13 +14136,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h high, 1d downtrend
             & ((rsi_3_1h_gt_35) | aroonu_14_1h_lt_70 | (roc_9_1d > -25.0))
             # 1h down move, 4h high & overbought
-            & ((rsi_3_1h_gt_35) | (aroonu_14_4h_lt_85) | (roc_9_4h < 100.0))
+            & ((rsi_3_1h_gt_35) | (aroonu_14_4h_lt_85) | (roc_9_4h_lt_100))
             # 1h down move, 4h high, 1d overbought
             & ((rsi_3_1h_gt_35) | (aroonu_14_4h_lt_85) | (roc_9_1d_lt_100))
             # 1h down move, 1d high, 4h overbought
             & ((rsi_3_1h_gt_35) | aroonu_14_1d_lt_100 | (roc_9_4h_lt_40))
             # 1h down move, 1h still high, 1d overbought
-            & ((rsi_3_1h_gt_35) | (stochrsi_k_1h_lt_50) | (roc_9_1d < 200.0))
+            & ((rsi_3_1h_gt_35) | (stochrsi_k_1h_lt_50) | (roc_9_1d_lt_200))
             # 1h & 4h & 1d down move, 1d overbought
             & ((rsi_3_1h_gt_40) | (rsi_3_4h_gt_40) | (rsi_3_1d_gt_60) | (roc_9_1d_lt_40))
             # 1h down move, 1h & 4h high
@@ -14113,25 +14150,25 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h & 1d high
             & ((rsi_3_1h_gt_40) | aroonu_14_1h_lt_80 | (aroonu_14_1d_lt_80))
             # 1h down move, 1h high, 1d overbought
-            & ((rsi_3_1h_gt_40) | aroonu_14_1h_lt_80 | (roc_9_1d < 10.0))
+            & ((rsi_3_1h_gt_40) | aroonu_14_1h_lt_80 | (roc_9_1d_lt_10))
             # 1h down move, 4h still high, 1d overbought
             & ((rsi_3_1h_gt_40) | (aroonu_14_4h_lt_40) | (roc_9_1d_lt_100))
             # 1h & 4h down move, 4h high
             & ((rsi_3_1h_gt_45) | (rsi_3_4h_gt_60) | aroonu_14_4h_lt_100)
             # 1h & 4h down move, 1d overbought
-            & ((rsi_3_1h_gt_45) | (rsi_3_4h_gt_65) | (roc_9_1d < 200.0))
+            & ((rsi_3_1h_gt_45) | (rsi_3_4h_gt_65) | (roc_9_1d_lt_200))
             # 1h down move, 1h high, 1d high & overbought
-            & ((rsi_3_1h_gt_45) | (stochrsi_k_1h_lt_60) | (stochrsi_k_1d < 70.0) | (roc_9_1d < 40.0))
+            & ((rsi_3_1h_gt_45) | (stochrsi_k_1h_lt_60) | (stochrsi_k_1d_lt_70) | (roc_9_1d_lt_40))
             # 1h down move, 1h high & overbought
             & ((rsi_3_1h_gt_50) | aroonu_14_1h_lt_80 | (roc_9_1h_lt_10))
             # 1h down move, 4h high, 1h overbought
-            & ((rsi_3_1h_gt_50) | (aroonu_14_4h_lt_85) | (roc_9_1h < 20.0))
+            & ((rsi_3_1h_gt_50) | (aroonu_14_4h_lt_85) | (roc_9_1h_lt_20))
             # 1h down move, 4h high, 1d downtrend
             & ((rsi_3_1h_gt_50) | (stochrsi_k_4h < 60.0) | (roc_9_1d > -60.0))
             # 1h down move, 4h high & overbought
-            & ((rsi_3_1h_gt_50) | (stochrsi_k_4h_lt_80) | (roc_9_4h < 100.0))
+            & ((rsi_3_1h_gt_50) | (stochrsi_k_4h_lt_80) | (roc_9_4h_lt_100))
             # 1h down move, 1h & 4h overbought
-            & ((rsi_3_1h_gt_50) | (roc_9_1h_lt_10) | (roc_9_4h < 100.0))
+            & ((rsi_3_1h_gt_50) | (roc_9_1h_lt_10) | (roc_9_4h_lt_100))
             # 1h down move, 1h high & overbought
             & ((rsi_3_1h_gt_55) | (aroonu_14_1h_lt_90) | (roc_9_1h_lt_10))
             # 1h down move, 4h high & overbought
@@ -14143,7 +14180,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h & 1d down move, 1d still high
             & ((rsi_3_4h_gt_3) | (rsi_3_1d_gt_15) | (aroonu_14_1d_lt_40))
             # 4h & 1d down move, 1d still high
-            & ((rsi_3_4h_gt_3) | (rsi_3_1d_gt_20) | (stochrsi_k_1d < 40.0))
+            & ((rsi_3_4h_gt_3) | (rsi_3_1d_gt_20) | (stochrsi_k_1d_lt_40))
             # 4h & 1d down move, 1d downtrend
             & ((rsi_3_4h_gt_5) | (rsi_3_1d_gt_15) | (roc_9_1d_gt_neg_20))
             # 4h down move, 4h still high, 1d high
@@ -14153,13 +14190,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h & 1d down move, 1h still not low enough
             & ((rsi_3_4h_gt_10) | (rsi_3_1d_gt_10) | (stochrsi_k_1h_lt_20))
             # 4h & 1d down move, 1d still high
-            & ((rsi_3_4h_gt_10) | (rsi_3_1d_gt_15) | (stochrsi_k_1d < 40.0))
+            & ((rsi_3_4h_gt_10) | (rsi_3_1d_gt_15) | (stochrsi_k_1d_lt_40))
             # 4h & 1d down move, 1d downtrend
             & ((rsi_3_4h_gt_10) | (rsi_3_1d_gt_20) | (roc_9_1d > -25.0))
             # 4h & 1d down move, 1d high
             & ((rsi_3_4h_gt_10) | (rsi_3_1d_gt_35) | (aroonu_14_1d_lt_100))
             # 4h & 1d down move, 1d overbought
-            & ((rsi_3_4h_gt_10) | (rsi_3_1d_gt_45) | (roc_9_1d < 10.0))
+            & ((rsi_3_4h_gt_10) | (rsi_3_1d_gt_45) | (roc_9_1d_lt_10))
             # 4h down move, 1d still high, 1d downtrend
             & ((rsi_3_4h_gt_10) | (aroonu_14_1d_lt_40) | (roc_9_1d > -20.0))
             # 4h down move, 1d high & overbought
@@ -14173,7 +14210,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h & 1d down move, 4h still high
             & ((rsi_3_4h_gt_20) | (rsi_3_1d_gt_20) | (stochrsi_k_4h < 40.0))
             # 4h & 1d down move, 1d high
-            & ((rsi_3_4h_gt_20) | (rsi_3_1d_gt_20) | (stochrsi_k_1d < 80.0))
+            & ((rsi_3_4h_gt_20) | (rsi_3_1d_gt_20) | (stochrsi_k_1d_lt_80))
             # 4h down move, 1h high, 1d downtrend
             & ((rsi_3_4h_gt_15) | (aroonu_14_1h_lt_90) | (roc_9_1d > -10.0))
             # 4h down move, 4h still high, 4h downtrend
@@ -14191,11 +14228,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 4h high, 4h downtrend
             & ((rsi_3_4h_gt_25) | aroonu_14_4h_lt_70 | (roc_9_4h_gt_neg_30))
             # 4h & 1d down move, 1d overbought
-            & ((rsi_3_4h_gt_30) | (rsi_3_1d_gt_60) | (roc_9_1d < 60.0))
+            & ((rsi_3_4h_gt_30) | (rsi_3_1d_gt_60) | (roc_9_1d_lt_60))
             # 4h down move, 1d downtrend
             & ((rsi_3_4h_gt_30) | roc_9_1d_gt_neg_50)
             # 4h down move, 4h & 1d overbought
-            & ((rsi_3_4h_gt_35) | (roc_9_4h_lt_30) | (roc_9_1d < 200.0))
+            & ((rsi_3_4h_gt_35) | (roc_9_4h_lt_30) | (roc_9_1d_lt_200))
             # 4h down move, 1h high, 1d overbought
             & ((rsi_3_4h_gt_40) | aroonu_14_1h_lt_70 | (roc_9_1d_lt_40))
             # 4h down move, 4h & 1d downtrend
@@ -14219,11 +14256,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 4h high & overbought
             & ((rsi_3_4h_gt_60) | aroonu_14_4h_lt_70 | (roc_9_4h_lt_20))
             # 4h down move, 1d high & overbought
-            & ((rsi_3_4h_gt_60) | aroonu_14_1d_lt_100 | (roc_9_1d < 200.0))
+            & ((rsi_3_4h_gt_60) | aroonu_14_1d_lt_100 | (roc_9_1d_lt_200))
             # 4h down move, 4h & 1d overbought
             & ((rsi_3_4h_gt_60) | (roc_9_4h_lt_20) | (roc_9_1d_lt_20))
             # 4h down move, 4h overbought
-            & ((rsi_3_4h_gt_60) | (roc_9_4h < 60.0))
+            & ((rsi_3_4h_gt_60) | (roc_9_4h_lt_60))
             # 1d down move, 1d high, 1d downtrend
             & ((rsi_3_1d_gt_5) | (aroonu_14_1d_lt_80) | (roc_9_1d_gt_neg_20))
             # 1d down move, 1h & 4h still not low enough
@@ -14235,23 +14272,23 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1d down move, 1h high, 1d downtrend
             & ((rsi_3_1d_gt_10) | (stochrsi_k_1h_lt_80) | (roc_9_1d_gt_neg_20))
             # 1d down move, 1h overbought, 1d downtrend
-            & ((rsi_3_1d_gt_15) | (roc_9_1h < 20.0) | roc_9_1d_gt_neg_50)
+            & ((rsi_3_1d_gt_15) | (roc_9_1h_lt_20) | roc_9_1d_gt_neg_50)
             # 1d down move, 1h high, 1d downtrend
             & ((rsi_3_1d_gt_20) | (stochrsi_k_1h_lt_90) | (roc_9_1d > -10.0))
             # 1d down move, 1h high, 1d overbought
-            & ((rsi_3_1d_gt_25) | aroonu_14_1h_lt_70 | (roc_9_1d < 25.0))
+            & ((rsi_3_1d_gt_25) | aroonu_14_1h_lt_70 | (roc_9_1d_lt_25))
             # 1d down move, 1d still high, 1d downtrend
-            & ((rsi_3_1d_gt_25) | (stochrsi_k_1d < 50.0) | (roc_9_1d_gt_neg_20))
+            & ((rsi_3_1d_gt_25) | (stochrsi_k_1d_lt_50) | (roc_9_1d_gt_neg_20))
             # 1d down move, 1h high & overbought
             & ((rsi_3_1d_gt_40) | (aroonu_14_1d_lt_70) | (roc_9_1d_lt_80))
             # 1d down move, 4h high & overbought
-            & ((rsi_3_1d_gt_45) | (stochrsi_k_4h_lt_90) | (roc_9_4h < 60.0))
+            & ((rsi_3_1d_gt_45) | (stochrsi_k_4h_lt_90) | (roc_9_4h_lt_60))
             # 1d down move, 1d still high, 4h still high
             & ((rsi_3_1d_gt_50) | (rsi_14_1d < 50.0) | (stochrsi_k_4h_lt_50))
             # 1d downtrend, 1d high & overbought
             & ((cmf_20_1d > -0.40) | (aroonu_14_1d_lt_85) | (roc_9_1d_lt_20))
             # 1h high, 4h & 1d overbought
-            & (aroonu_14_1h_lt_70 | (roc_9_4h < 50.0) | (roc_9_1d < 200.0))
+            & (aroonu_14_1h_lt_70 | (roc_9_4h_lt_50) | (roc_9_1d_lt_200))
             # 1h & 4h high, 1d overbought
             & (aroonu_14_1h_lt_70 | (aroonu_14_4h_lt_90) | roc_9_1d_lt_50)
             # 1h & 4h high, 1d downtrend
@@ -14259,7 +14296,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h high, 4h & 1d downtrend
             & (aroonu_14_1h_lt_70 | (roc_9_4h_gt_neg_30) | roc_9_1d_gt_neg_50)
             # 1h & 4h high, 1h overbought
-            & (aroonu_14_1h_lt_80 | (aroonu_14_4h_lt_90) | (roc_9_1h < 30.0))
+            & (aroonu_14_1h_lt_80 | (aroonu_14_4h_lt_90) | (roc_9_1h_lt_30))
             # 1h & 4high, 1d downtrend
             & (aroonu_14_1h_lt_80 | aroonu_14_4h_lt_100 | (roc_9_1d > -20.0))
             # 1h & 4h high, 1d overbought
@@ -14275,21 +14312,21 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h still high, 5m downtrend
             & ((aroonu_14_4h_lt_40) | (roc_9 > -40.0))
             # 4h high & overbought
-            & (aroonu_14_4h_lt_70 | (roc_9_4h < 80.0))
+            & (aroonu_14_4h_lt_70 | (roc_9_4h_lt_80))
             # 4h & 1d high, 1d overbought
             & (aroonu_14_4h_lt_80 | aroonu_14_1d_lt_100 | (roc_9_1d_lt_40))
             # 4h high, 1h & 4h overbought
-            & (aroonu_14_4h_lt_100 | (roc_9_1h_lt_10) | (roc_9_4h < 20.0))
+            & (aroonu_14_4h_lt_100 | (roc_9_1h_lt_10) | (roc_9_4h_lt_20))
             # 1d high, 1d downtrend
             & ((aroonu_14_1d_lt_80) | (roc_9_1d_gt_neg_30))
             # 1d high, 1h & 4h downtrend
             & ((aroonu_14_1d_lt_85) | (roc_9_1h > -30.0) | (roc_9_4h > -50.0))
             # 1d high, 4h & 1d overbought
-            & ((aroonu_14_1d_lt_85) | (roc_9_4h < 60.0) | (roc_9_1d < 60.0))
+            & ((aroonu_14_1d_lt_85) | (roc_9_4h_lt_60) | (roc_9_1d_lt_60))
             # 1d high, 1h & 4h down move
-            & (aroonu_14_1d_lt_100 | (roc_9_1h < 25.0) | (roc_9_4h < 60.0))
+            & (aroonu_14_1d_lt_100 | (roc_9_1h_lt_25) | (roc_9_4h_lt_60))
             # 15m high, 1d overbought
-            & ((stochrsi_k_15m_lt_70) | (roc_9_1d < 60.0))
+            & ((stochrsi_k_15m_lt_70) | (roc_9_1d_lt_60))
             # 1h high, 1d downtrend
             & ((stochrsi_k_1h_lt_70) | roc_9_1d_gt_neg_50)
             # 1h high, 1d overbought
@@ -14297,15 +14334,15 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h high, 4h downtrend
             & ((stochrsi_k_1h_lt_80) | (roc_9_4h_gt_neg_20))
             # 1h high, 4h overbought
-            & ((stochrsi_k_1h_lt_80) | (roc_9_4h < 80.0))
+            & ((stochrsi_k_1h_lt_80) | (roc_9_4h_lt_80))
             # 4h high, 1h & 4h overbought
             & ((stochrsi_k_4h < 80.0) | (roc_9_1h_lt_10) | (roc_9_4h_lt_20))
             # 1d high, 1h & 1d overbought
-            & ((stochrsi_k_1d < 80.0) | (roc_9_1h_lt_10) | (roc_9_1d_lt_80))
+            & ((stochrsi_k_1d_lt_80) | (roc_9_1h_lt_10) | (roc_9_1d_lt_80))
             # 1d high, 4h & 1d overbought
-            & ((stochrsi_k_1d < 80.0) | (roc_9_4h < 60.0) | (roc_9_1d < 60.0))
+            & ((stochrsi_k_1d_lt_80) | (roc_9_4h_lt_60) | (roc_9_1d_lt_60))
             # big drop in the last 20 days, 1d high, 1d downtrend
-            & ((close > (high_max_20_1d * 0.20)) | (stochrsi_k_1d < 70.0) | (roc_9_1d > -15.0))
+            & ((close > (high_max_20_1d * 0.20)) | (stochrsi_k_1d_lt_70) | (roc_9_1d > -15.0))
             # drop in last 20 days, 1h high, 1d downtrend
             & ((close > (high_max_20_1d * 0.20)) | aroonu_14_1h_lt_70 | (roc_9_1d > -70.0))
             # drop in last 20 days. 4h high
@@ -14408,7 +14445,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 1h high, 1d overbought
             & ((rsi_3_15m_gt_15) | (stochrsi_k_1h_lt_80) | (roc_9_1d_lt_20))
             # 15m down move, 4h & 1d overbought
-            & ((rsi_3_15m_gt_15) | (roc_9_4h < 25.0) | (roc_9_1d_lt_100))
+            & ((rsi_3_15m_gt_15) | (roc_9_4h_lt_25) | (roc_9_1d_lt_100))
             # 15m & 1h down move, 1h still high
             & ((rsi_3_15m_gt_20) | (rsi_3_1h_gt_25) | (aroonu_14_1h_lt_40))
             # 15m & 1h down move, 1h high
@@ -14434,7 +14471,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m &1d down move, 1d overbought
             & ((rsi_3_15m_gt_20) | (rsi_3_1d > 50.0) | (roc_9_1d_lt_20))
             # 15m down move, 15m still not low enough, 4h overbought
-            & ((rsi_3_15m_gt_20) | (aroonu_14_15m_lt_30) | (roc_9_4h < 60.0))
+            & ((rsi_3_15m_gt_20) | (aroonu_14_15m_lt_30) | (roc_9_4h_lt_60))
             # 15m down move, 15m still high, 4h high
             & ((rsi_3_15m_gt_20) | (aroonu_14_15m_lt_40) | (stochrsi_k_4h_lt_90))
             # 15m down move, 15m still high, 1h high
@@ -14456,9 +14493,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 15m high, 1d overbought
             & ((rsi_3_15m_gt_20) | (aroonu_14_15m_lt_70) | roc_9_1d_lt_50)
             # 15m down move, 1h high, 4h overbought
-            & ((rsi_3_15m_gt_20) | aroonu_14_1h_lt_80 | (roc_9_4h < 20.0))
+            & ((rsi_3_15m_gt_20) | aroonu_14_1h_lt_80 | (roc_9_4h_lt_20))
             # 15m down move, 4h high & overbought
-            & ((rsi_3_15m_gt_20) | aroonu_14_4h_lt_70 | (roc_9_4h < 50.0))
+            & ((rsi_3_15m_gt_20) | aroonu_14_4h_lt_70 | (roc_9_4h_lt_50))
             # 15m down move, 1h high, 4h downtrend
             & ((rsi_3_15m_gt_20) | (stochrsi_k_1h_lt_60) | (roc_9_4h_gt_neg_20))
             # 15m down move, 1h high, 1d overbought
@@ -14470,7 +14507,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 4h high, 1d downtrend
             & ((rsi_3_15m_gt_20) | (stochrsi_k_4h_lt_80) | (roc_9_1d_gt_neg_30))
             # 15m down move, 4h & 1d overbought
-            & ((rsi_3_15m_gt_20) | (roc_9_4h < 25.0) | (roc_9_1d_lt_100))
+            & ((rsi_3_15m_gt_20) | (roc_9_4h_lt_25) | (roc_9_1d_lt_100))
             # 15m & 1h & 4h down move, 15m still not low enough, 4h high
             & ((rsi_3_15m_gt_25) | (rsi_3_1h_gt_30) | (rsi_3_4h_gt_30) | (aroonu_14_15m_lt_30) | (aroonu_14_4h_lt_60))
             # 15m & 1h down move, 15m high
@@ -14492,7 +14529,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 15m high, 4h overbought
             & ((rsi_3_15m_gt_25) | (aroonu_14_15m_lt_70) | (roc_9_4h_lt_10))
             # 15m down move, 15m high, 1d overbought
-            & ((rsi_3_15m_gt_25) | (aroonu_14_15m_lt_70) | (roc_9_1d < 60.0))
+            & ((rsi_3_15m_gt_25) | (aroonu_14_15m_lt_70) | (roc_9_1d_lt_60))
             # 15m down move, 1h & 4h high
             & ((rsi_3_15m_gt_25) | (aroonu_14_1h_lt_70) | (aroonu_14_4h_lt_70))
             # 15m down move, 1h high, 1d downtrend
@@ -14508,7 +14545,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 1h high, 4h high
             & ((rsi_3_15m_gt_25) | (stochrsi_k_1h_lt_70) | (aroonu_14_4h_lt_100))
             # 15m down move, 4h & 1d overbought
-            & ((rsi_3_15m_gt_25) | (roc_9_4h < 50.0) | (roc_9_1d_lt_50))
+            & ((rsi_3_15m_gt_25) | (roc_9_4h_lt_50) | (roc_9_1d_lt_50))
             # 15m & 1h down move, 1h high
             & ((rsi_3_15m_gt_30) | (rsi_3_1h_gt_30) | (aroonu_14_1h_lt_80))
             # 15m & 1h down move, 1d overbought
@@ -14524,13 +14561,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 15m high, 15m downtrend
             & ((rsi_3_15m_gt_30) | (aroonu_14_15m_lt_70) | (cmf_20_15m > -0.30))
             # 15m down move, 15m high, 1d overbought
-            & ((rsi_3_15m_gt_30) | (aroonu_14_15m_lt_70) | (roc_9_1d < 70.0))
+            & ((rsi_3_15m_gt_30) | (aroonu_14_15m_lt_70) | (roc_9_1d_lt_70))
             # 15m down move, 1h high, 1d overbought
             & ((rsi_3_15m_gt_30) | (aroonu_14_1h_lt_100) | (roc_9_1d_lt_30))
             # 15m down move, 4h high & overbought
-            & ((rsi_3_15m_gt_30) | (aroonu_14_4h_lt_70) | (roc_9_4h < 60.0))
+            & ((rsi_3_15m_gt_30) | (aroonu_14_4h_lt_70) | (roc_9_4h_lt_60))
             # 15m down move, 15m high, 4h overbought
-            & ((rsi_3_15m_gt_30) | (stochrsi_k_15m_lt_70) | (roc_9_4h < 70.0))
+            & ((rsi_3_15m_gt_30) | (stochrsi_k_15m_lt_70) | (roc_9_4h_lt_70))
             # 15m down move, 1h high, 1d overbought
             & ((rsi_3_15m_gt_30) | (stochrsi_k_1h_lt_90) | (roc_9_1d_lt_50))
             # 15m & 1h down move, 15m still high, 1h high
@@ -14538,11 +14575,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 15m high, 4h high
             & ((rsi_3_15m_gt_35) | (aroonu_14_15m_lt_60) | (stochrsi_k_4h_lt_90))
             # 15m down move, 15m high, 4h overbought
-            & ((rsi_3_15m_gt_35) | (aroonu_14_15m_lt_70) | (roc_9_4h < 80.0))
+            & ((rsi_3_15m_gt_35) | (aroonu_14_15m_lt_70) | (roc_9_4h_lt_80))
             # 15m down move, 1h high, 4h overbought
-            & ((rsi_3_15m_gt_35) | (aroonu_14_1h_lt_90) | (roc_9_4h < 100.0))
+            & ((rsi_3_15m_gt_35) | (aroonu_14_1h_lt_90) | (roc_9_4h_lt_100))
             # 15m down move, 4h high, 1d overbought
-            & ((rsi_3_15m_gt_35) | (aroonu_14_4h_lt_80) | (roc_9_1d < 200.0))
+            & ((rsi_3_15m_gt_35) | (aroonu_14_4h_lt_80) | (roc_9_1d_lt_200))
             # 15m down move, 1h high, 1d downtrend
             & ((rsi_3_15m_gt_35) | (stochrsi_k_1h_lt_90) | roc_9_1d_gt_neg_50)
             # 15m down move, 4h high & overbought
@@ -14562,7 +14599,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 4h still high, 4h downtrend
             & ((rsi_3_1h_gt_10) | (aroonu_14_4h_lt_40) | (roc_9_4h > -20.0))
             # 1h down move, 4h high & overbought
-            & ((rsi_3_1h_gt_10) | aroonu_14_4h_lt_70 | (roc_9_4h < 20.0))
+            & ((rsi_3_1h_gt_10) | aroonu_14_4h_lt_70 | (roc_9_4h_lt_20))
             # 1h & 4h down move, 1d high
             & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_15) | (rsi_14_1d < 60.0))
             # 1h & 4h down move, 15m high
@@ -14570,7 +14607,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 1d downtrend
             & ((rsi_3_1h_gt_15) | rsi_3_4h_gt_20 | (roc_9_1d > -30.0))
             # 1h & 1d down move, 1d overbought
-            & ((rsi_3_1h_gt_15) | (rsi_3_1d_gt_35) | (roc_9_1d < 10.0))
+            & ((rsi_3_1h_gt_15) | (rsi_3_1d_gt_35) | (roc_9_1d_lt_10))
             # 1h & 1d down move, 1d overbought
             & ((rsi_3_1h_gt_15) | (rsi_3_1d_gt_60) | (roc_9_1d_lt_40))
             # 1h down move, 1h still not low enough, 1d downtrend
@@ -14580,11 +14617,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 1d overbought
             & (rsi_3_1h_gt_20 | (rsi_3_4h_gt_25) | (roc_9_1d_lt_30))
             # 1h down move, 4h high, 1d overbought
-            & (rsi_3_1h_gt_20 | aroonu_14_4h_lt_80 | (roc_9_1d < 100.0))
+            & (rsi_3_1h_gt_20 | aroonu_14_4h_lt_80 | (roc_9_1d_lt_100))
             # 1h & 4h down move, 4h high
             & ((rsi_3_1h_gt_25) | (rsi_3_4h_gt_40) | aroonu_14_4h_lt_80)
             # 1h & 1d down move, 1d still high
-            & ((rsi_3_1h_gt_25) | (rsi_3_1d_gt_40) | (stochrsi_k_1d < 50.0))
+            & ((rsi_3_1h_gt_25) | (rsi_3_1d_gt_40) | (stochrsi_k_1d_lt_50))
             # 1h down move, 1h high, 1d overbought
             & ((rsi_3_1h_gt_25) | aroonu_14_1h_lt_70 | (roc_9_1d_lt_20))
             # 1h down move, 1d high & overbought
@@ -14596,7 +14633,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 15m & 1h still high
             & ((rsi_3_1h_gt_30) | (aroonu_14_15m_lt_40) | (aroonu_14_1h_lt_50))
             # 1h down move, 1h still high 1d overbought
-            & ((rsi_3_1h_gt_30) | (aroonu_14_1h_lt_50) | (roc_9_1d < 200.0))
+            & ((rsi_3_1h_gt_30) | (aroonu_14_1h_lt_50) | (roc_9_1d_lt_200))
             # 1h down move, 1h high, 4h downtrend
             & ((rsi_3_1h_gt_30) | (aroonu_14_1h_lt_60) | (roc_9_4h_gt_neg_20))
             # 1h down move, 1h high, 1d overbought
@@ -14642,7 +14679,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h still high, 1d overbought
             & ((rsi_3_1h_gt_40) | (aroonu_14_1h_lt_50) | (roc_9_1d_lt_100))
             # 1h down move, 1h high, 4h overbought
-            & ((rsi_3_1h_gt_40) | aroonu_14_1h_lt_70 | (roc_9_4h < 20.0))
+            & ((rsi_3_1h_gt_40) | aroonu_14_1h_lt_70 | (roc_9_4h_lt_20))
             # 1h down move, 1h high, 1d downtrend
             & ((rsi_3_1h_gt_40) | (aroonu_14_1h_lt_85) | (roc_9_1d > -60.0))
             # 1h down move, 1h & 4h high
@@ -14656,23 +14693,23 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h high, 4h overbought
             & ((rsi_3_1h_gt_45) | (aroonu_14_1h_lt_100) | (roc_9_4h_lt_20))
             # 1h down move, 4h high & overbought
-            & ((rsi_3_1h_gt_45) | aroonu_14_4h_lt_80 | (roc_9_4h < 20.0))
+            & ((rsi_3_1h_gt_45) | aroonu_14_4h_lt_80 | (roc_9_4h_lt_20))
             # 1h down move, 4h high & overbought
             & ((rsi_3_1h_gt_45) | aroonu_14_4h_lt_80 | (roc_9_4h_lt_40))
             # 1h down move, 1d high & overbought
             & ((rsi_3_1h_gt_45) | aroonu_14_1d_lt_100 | (roc_9_1d_lt_30))
             # 1h down move, 1h still high, 1d overbought
-            & ((rsi_3_1h_gt_45) | (stochrsi_k_1h_lt_40) | (roc_9_1d < 200.0))
+            & ((rsi_3_1h_gt_45) | (stochrsi_k_1h_lt_40) | (roc_9_1d_lt_200))
             # 1h down move, 1d high & overbought
-            & ((rsi_3_1h_gt_45) | (stochrsi_k_1d < 80.0) | (roc_9_1d < 10.0))
+            & ((rsi_3_1h_gt_45) | (stochrsi_k_1d_lt_80) | (roc_9_1d_lt_10))
             # 1h down move, 15m & 1h high
             & ((rsi_3_1h_gt_50) | (aroonu_14_15m_lt_70) | (aroonu_14_1h_lt_100))
             # 1h down move, 1h high, 4h overbought
             & ((rsi_3_1h_gt_50) | aroonu_14_1h_lt_80 | (roc_9_4h_lt_10))
             # 1h down move, 4h still high, 1d overbought
-            & ((rsi_3_1h_gt_50) | (aroonu_14_4h_lt_50) | (roc_9_1d < 200.0))
+            & ((rsi_3_1h_gt_50) | (aroonu_14_4h_lt_50) | (roc_9_1d_lt_200))
             # 1h down move, 4h high & overbought
-            & ((rsi_3_1h_gt_50) | aroonu_14_4h_lt_100 | (roc_9_4h < 50.0))
+            & ((rsi_3_1h_gt_50) | aroonu_14_4h_lt_100 | (roc_9_4h_lt_50))
             # 1h down move, 1h & 4h high
             & ((rsi_3_1h_gt_50) | (stochrsi_k_1h_lt_80) | aroonu_14_4h_lt_100)
             # 1h down move, 4h high & overbought
@@ -14682,7 +14719,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h high, 1d downtrend
             & ((rsi_3_1h_gt_55) | (stochrsi_k_1h_lt_80) | (roc_9_1d_gt_neg_30))
             # 1h down move, 4h high & overbought
-            & ((rsi_3_1h_gt_55) | (stochrsi_k_4h_lt_80) | (roc_9_4h < 100.0))
+            & ((rsi_3_1h_gt_55) | (stochrsi_k_4h_lt_80) | (roc_9_4h_lt_100))
             # 1h down move, 1h high, 1d overbought
             & ((rsi_3_1h_gt_60) | (stochrsi_k_1h_lt_80) | (roc_9_1d_lt_100))
             # 1h down move, 15m & 1h high
@@ -14702,13 +14739,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 4h still high, 1d downtrend
             & ((rsi_3_4h_gt_5) | (stochrsi_k_4h_lt_40) | (roc_9_1d_gt_neg_20))
             # 4h & 1d down move, 1d still high
-            & ((rsi_3_4h_gt_10) | (rsi_3_1d_gt_20) | (stochrsi_k_1d < 50.0))
+            & ((rsi_3_4h_gt_10) | (rsi_3_1d_gt_20) | (stochrsi_k_1d_lt_50))
             # 4h & 1d down move, 1d downtrend
             & ((rsi_3_4h_gt_10) | (rsi_3_1d_gt_20) | (roc_9_1d > -20.0))
             # 4h & 1d down move, 4h still high
             & ((rsi_3_4h_gt_10) | (rsi_3_1d_gt_30) | (stochrsi_k_4h_lt_50))
             # 4h & 1d down move, 1d still high
-            & ((rsi_3_4h_gt_10) | (rsi_3_1d_gt_35) | (stochrsi_k_1d < 40.0))
+            & ((rsi_3_4h_gt_10) | (rsi_3_1d_gt_35) | (stochrsi_k_1d_lt_40))
             # 4h down move, 15m still not low enough, 1d downtrend
             & ((rsi_3_4h_gt_10) | (stochrsi_k_15m_lt_30) | (roc_9_1d_gt_neg_40))
             # 4h down move, 15m high, 4h downtrend
@@ -14728,7 +14765,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 15m high
             & ((rsi_3_4h_gt_15) | (stochrsi_k_15m_lt_80))
             # 4h down move, 1d high
-            & ((rsi_3_4h_gt_15) | (stochrsi_k_1d < 80.0))
+            & ((rsi_3_4h_gt_15) | (stochrsi_k_1d_lt_80))
             # 4h down move, 1h & 4h downtrend
             & ((rsi_3_4h_gt_15) | (roc_9_1h > -30.0) | (roc_9_4h_gt_neg_30))
             # 4h & 1d down move, 1h still high
@@ -14740,11 +14777,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 15m & 4h still high
             & (rsi_3_4h_gt_20 | (aroonu_14_15m_lt_50) | (aroonu_14_4h_lt_50))
             # 4h down move, 15m high, 1d high
-            & (rsi_3_4h_gt_20 | (aroonu_14_15m_lt_70) | (stochrsi_k_1d < 70.0))
+            & (rsi_3_4h_gt_20 | (aroonu_14_15m_lt_70) | (stochrsi_k_1d_lt_70))
             # 4h down move, 4h still high, 1d downtrend
             & (rsi_3_4h_gt_20 | (aroonu_14_4h_lt_50) | (roc_9_1d_gt_neg_40))
             # 4h down move, 1d high & overbought
-            & (rsi_3_4h_gt_20 | (aroonu_14_1d_lt_90) | (roc_9_1d < 10.0))
+            & (rsi_3_4h_gt_20 | (aroonu_14_1d_lt_90) | (roc_9_1d_lt_10))
             # 4h down move, 15m high, 4h downtrend
             & (rsi_3_4h_gt_20 | (stochrsi_k_15m_lt_80) | (roc_9_4h > -50.0))
             # 4h down move, 1h high, 1d downtrend
@@ -14792,7 +14829,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 1h high, 1d overbought
             & ((rsi_3_4h_gt_30) | (stochrsi_k_1h_lt_90) | roc_9_1d_lt_50)
             # 4h down move, 1d high & overbought
-            & ((rsi_3_4h_gt_30) | (stochrsi_k_1d < 80.0) | (roc_9_1d < 10.0))
+            & ((rsi_3_4h_gt_30) | (stochrsi_k_1d_lt_80) | (roc_9_1d_lt_10))
             # 4h down move, 15m still high, 1h high
             & ((rsi_3_4h_gt_35) | (aroonu_14_15m_lt_40) | (stochrsi_k_1h_lt_90))
             # 4h down move, 15m still high, 4h high
@@ -14802,13 +14839,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 4h & 1d high
             & ((rsi_3_4h_gt_35) | aroonu_14_4h_lt_80 | aroonu_14_1d_lt_100)
             # 4h down move, 1d high, 1d downtrend
-            & ((rsi_3_4h_gt_35) | (stochrsi_k_1d < 60.0) | (roc_9_1d_gt_neg_30))
+            & ((rsi_3_4h_gt_35) | (stochrsi_k_1d_lt_60) | (roc_9_1d_gt_neg_30))
             # 4h down move, 1d high & overbought
             & ((rsi_3_4h_gt_35) | (stochrsi_k_1d_lt_90) | (roc_9_1d_lt_40))
             # 4h down move, 15m still high, 1d overbought
             & ((rsi_3_4h_gt_40) | (aroonu_14_15m_lt_50) | roc_9_1d_lt_50)
             # 4h down move, 15m high, 1d overbought
-            & ((rsi_3_4h_gt_40) | (aroonu_14_15m_lt_70) | (roc_9_1d < 200.0))
+            & ((rsi_3_4h_gt_40) | (aroonu_14_15m_lt_70) | (roc_9_1d_lt_200))
             # 4h down move, 1h & 4h high
             & ((rsi_3_4h_gt_40) | aroonu_14_1h_lt_70 | aroonu_14_4h_lt_80)
             # 4h down move, 1d high & overbought
@@ -14816,7 +14853,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 15m high, 1h high
             & ((rsi_3_4h_gt_40) | (stochrsi_k_15m_lt_70) | (aroonu_14_1h_lt_100))
             # 4h down move, 1h high, 1d overbought
-            & ((rsi_3_4h_gt_40) | (stochrsi_k_1h_lt_70) | (roc_9_1d < 60.0))
+            & ((rsi_3_4h_gt_40) | (stochrsi_k_1h_lt_70) | (roc_9_1d_lt_60))
             # 4h down move, 4h & 1d overbought
             & ((rsi_3_4h_gt_40) | (roc_9_4h_lt_10) | (roc_9_1d_lt_30))
             # 4h down move, 15m still high, 4h high
@@ -14838,7 +14875,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 1d high & overbought
             & ((rsi_3_4h_gt_45) | (stochrsi_k_1d_lt_90) | (roc_9_1d_lt_20))
             # 4h down move, 4h & 1d overbought
-            & ((rsi_3_4h_gt_45) | (roc_9_4h_lt_30) | (roc_9_1d < 200.0))
+            & ((rsi_3_4h_gt_45) | (roc_9_4h_lt_30) | (roc_9_1d_lt_200))
             # 4h down move, 15m & 1h high
             & ((rsi_3_4h_gt_50) | (aroonu_14_15m_lt_70) | (aroonu_14_1h_lt_100))
             # 4h down move, 4h still high, 1h high
@@ -14858,7 +14895,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 4h high & overbought
             & ((rsi_3_4h_gt_55) | aroonu_14_4h_lt_70 | (roc_9_4h_lt_20))
             # 4h down move, 1d high & overbought
-            & ((rsi_3_4h_gt_55) | (aroonu_14_1d_lt_90) | (roc_9_1d < 60.0))
+            & ((rsi_3_4h_gt_55) | (aroonu_14_1d_lt_90) | (roc_9_1d_lt_60))
             # 4h down move, 4h high & overbought
             & ((rsi_3_4h_gt_55) | (stochrsi_k_4h_lt_80) | (roc_9_4h_lt_10))
             # 4h down move, 15m high, 1h high
@@ -14898,9 +14935,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1d down move, 1h & 1d high
             & ((rsi_3_1d_gt_25) | aroonu_14_1h_lt_80 | (aroonu_14_1d_lt_80))
             # 1d down move, 1d still high, 1d downtrend
-            & ((rsi_3_1d_gt_25) | (stochrsi_k_1d < 50.0) | (roc_9_1d_gt_neg_20))
+            & ((rsi_3_1d_gt_25) | (stochrsi_k_1d_lt_50) | (roc_9_1d_gt_neg_20))
             # 1d down move, 1d high & overbought
-            & ((rsi_3_1d_gt_30) | (aroonu_14_1d_lt_60) | (roc_9_1d < 10.0))
+            & ((rsi_3_1d_gt_30) | (aroonu_14_1d_lt_60) | (roc_9_1d_lt_10))
             # 1d down move, 1h high, 1d downtrend
             & ((rsi_3_1d_gt_30) | (stochrsi_k_1h_lt_70) | (roc_9_1d_lt_20))
             # 1d down move, 1h & 1d high
@@ -14910,17 +14947,17 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1d down move, 1d high & overbought
             & ((rsi_3_1d_gt_40) | aroonu_14_1d_lt_100 | (roc_9_1d_lt_30))
             # 1d down move, 1d high & overbought
-            & ((rsi_3_1d_gt_40) | (aroonu_14_1d_lt_80) | (roc_9_1d < 10.0))
+            & ((rsi_3_1d_gt_40) | (aroonu_14_1d_lt_80) | (roc_9_1d_lt_10))
             # 1d down move, 1h high, 1d overbought
             & ((rsi_3_1d_gt_40) | (stochrsi_k_1h_lt_70) | roc_9_1d_lt_50)
             # 15m still high, 4h high, 1d overbought
-            & ((aroonu_14_15m_lt_50) | (rsi_14_4h < 60.0) | (roc_9_1d < 70.0))
+            & ((aroonu_14_15m_lt_50) | (rsi_14_4h < 60.0) | (roc_9_1d_lt_70))
             # 15m still high, 1h downtrend, 4h overbought
             & ((aroonu_14_15m_lt_50) | (roc_9_1h > -10.0) | (roc_9_4h_lt_40))
             # 15m high, 4h high & overbought
             & ((aroonu_14_15m_lt_60) | aroonu_14_4h_lt_70 | (roc_9_4h_lt_20))
             # 15m & 4h high, 1d overbought
-            & ((aroonu_14_15m_lt_60) | aroonu_14_4h_lt_70 | (roc_9_1d < 10.0))
+            & ((aroonu_14_15m_lt_60) | aroonu_14_4h_lt_70 | (roc_9_1d_lt_10))
             # 15m high, 15m & 4h overbought
             & ((aroonu_14_15m_lt_60) | (roc_9_15m < 10.0) | (roc_9_4h_lt_20))
             # 15m high, 4h downtrend
@@ -14936,7 +14973,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1d high, 1d overbought
             & ((aroonu_14_15m_lt_70) | (aroonu_14_1d_lt_90) | (roc_9_1d_lt_100))
             # 15m high, 4h downtrend, 1d overbought
-            & ((aroonu_14_15m_lt_70) | (roc_9_4h_gt_neg_30) | (roc_9_1d < 200.0))
+            & ((aroonu_14_15m_lt_70) | (roc_9_4h_gt_neg_30) | (roc_9_1d_lt_200))
             # 4h down move, 1h still high, 1d downtrend
             & ((rsi_3_4h_gt_15) | (aroonu_14_1h_lt_40) | roc_9_1d_gt_neg_50)
             # 1h & 4h high, 4h overbought
@@ -14958,7 +14995,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1d high, 4h downtrend
             & ((aroonu_14_1d_lt_85) | (roc_9_4h_gt_neg_30))
             # 1d high, 4h downtrend, 1d overbought
-            & ((aroonu_14_1d_lt_85) | (roc_9_4h_gt_neg_30) | (roc_9_1d < 70.0))
+            & ((aroonu_14_1d_lt_85) | (roc_9_4h_gt_neg_30) | (roc_9_1d_lt_70))
             # 1d high, 4h & 1d overbought
             & (aroonu_14_1d_lt_100 | (roc_9_4h_lt_30) | (roc_9_1d_lt_40))
             # 15m & 1h high, 1d overbought
@@ -14974,7 +15011,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h high, 4h overbought, 1d downtrend
             & ((stochrsi_k_4h_lt_90) | (roc_9_4h_lt_20) | (roc_9_1d_gt_neg_20))
             # 1d still high, 4h & 1d downtrend
-            & ((stochrsi_k_1d < 50.0) | (roc_9_4h_gt_neg_30) | (roc_9_1d_gt_neg_30))
+            & ((stochrsi_k_1d_lt_50) | (roc_9_4h_gt_neg_30) | (roc_9_1d_gt_neg_30))
             # 1d P&D, 4h downtrend
             & ((change_pct_1d > -50.0) | (change_pct_1d.shift(288) < 50.0) | (rsi_3_4h_gt_15))
             # 1d P&D, 15m high
@@ -14990,9 +15027,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1d green, 4h down move, 4h still high
             & ((change_pct_1d < 40.0) | (rsi_3_4h_gt_35) | (aroonu_14_4h_lt_40))
             # 1d top wick, 4h down move, 1d overbought
-            & ((top_wick_pct_1d < 50.0) | (rsi_3_4h_gt_35) | (roc_9_1d < 60.0))
+            & ((top_wick_pct_1d < 50.0) | (rsi_3_4h_gt_35) | (roc_9_1d_lt_60))
             # big drop in the last 20 days, 1d high, 1d downtrend
-            & ((close > (high_max_20_1d * 0.20)) | (stochrsi_k_1d < 70.0) | (roc_9_1d > -15.0))
+            & ((close > (high_max_20_1d * 0.20)) | (stochrsi_k_1d_lt_70) | (roc_9_1d > -15.0))
           )
 
           # Logic
@@ -15039,7 +15076,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 5m & 4h down move, 15m still high
             & ((rsi_3_gt_5) | (rsi_3_4h_gt_25) | (stochrsi_k_15m_lt_50))
             # 5m down move, 4h high, 1h overbought
-            & ((rsi_3_gt_10) | aroonu_14_4h_lt_100 | (roc_9_1h < 30.0))
+            & ((rsi_3_gt_10) | aroonu_14_4h_lt_100 | (roc_9_1h_lt_30))
             # 15m & 1h down move, 1d still high
             & ((rsi_3_15m_gt_5) | (rsi_3_1h_gt_5) | (aroonu_14_1d_lt_40))
             # 15m & 1h down move, 1d still high
@@ -15053,7 +15090,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h & 4h down move, 1d high & overbought
             & ((rsi_3_15m_gt_5) | (rsi_3_1h_gt_45) | (rsi_3_4h_gt_45) | (aroonu_14_1d_lt_100) | (roc_9_1d_lt_50))
             # 15m & 4h down move, 1d overbought
-            & ((rsi_3_15m_gt_5) | (rsi_3_4h_gt_15) | (roc_9_1d < 70.0))
+            & ((rsi_3_15m_gt_5) | (rsi_3_4h_gt_15) | (roc_9_1d_lt_70))
             # 15m & 4h down move, 1d high
             & ((rsi_3_15m_gt_5) | (rsi_3_4h_gt_30) | aroonu_14_1d_lt_100)
             # 15m down move, 1h high & overbought
@@ -15083,7 +15120,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 1h still high
             & ((rsi_3_15m_gt_15) | (rsi_3_1h_gt_25) | (stochrsi_k_1h_lt_40))
             # 15m & 4h down move, 1d high
-            & ((rsi_3_15m_gt_15) | (rsi_3_4h_gt_15) | (stochrsi_k_1d < 80.0))
+            & ((rsi_3_15m_gt_15) | (rsi_3_4h_gt_15) | (stochrsi_k_1d_lt_80))
             # 15m & 4h down move, 4h & 1d high
             & ((rsi_3_15m_gt_15) | (rsi_3_4h_gt_25) | (aroonu_14_4h_lt_80) | (aroonu_14_1d_lt_100))
             # 15m down move, 4h high & overbought
@@ -15097,23 +15134,23 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 4h high, 1d overbought
             & ((rsi_3_15m_gt_20) | (aroonu_14_4h_lt_90) | (roc_9_1d_lt_100))
             # 15m down move, 4h high, 1h overbought
-            & ((rsi_3_15m_gt_20) | (aroonu_14_4h_lt_100) | (roc_9_1h < 30.0))
+            & ((rsi_3_15m_gt_20) | (aroonu_14_4h_lt_100) | (roc_9_1h_lt_30))
             # 15m down move, 1h high & overbought
             & ((rsi_3_15m_gt_20) | (stochrsi_k_1h_lt_90) | (roc_9_1h_lt_10))
             # 15m & 4h down move, 4h high
             & ((rsi_3_15m_gt_25) | (rsi_3_4h_gt_50) | (stochrsi_k_4h_lt_80))
             # 15m down move, 4h high, 4h overbought
-            & ((rsi_3_15m_gt_25) | (aroonu_14_4h_lt_60) | (roc_9_4h < 50.0))
+            & ((rsi_3_15m_gt_25) | (aroonu_14_4h_lt_60) | (roc_9_4h_lt_50))
             # 15m & 1h down move, 4h high
             & ((rsi_3_15m_gt_30) | (rsi_3_1h_gt_40) | (aroonu_14_4h_lt_85))
             # 15m & 1h down move, 4h overbought
-            & ((rsi_3_15m_gt_40) | (rsi_3_1h_gt_50) | (roc_9_4h < 50.0))
+            & ((rsi_3_15m_gt_40) | (rsi_3_1h_gt_50) | (roc_9_4h_lt_50))
             # 1h & 4h down move, 15m downtrend
             & ((rsi_3_1h_gt_3) | (rsi_3_4h_gt_3) | (roc_9_15m > -30.0))
             # 1h & 4h down move, 15m downtrend
             & ((rsi_3_1h_gt_3) | (rsi_3_4h_gt_10) | (cmf_20_15m > -0.40))
             # 1h & 4h down move, 1d high
-            & ((rsi_3_1h_gt_3) | rsi_3_4h_gt_20 | (stochrsi_k_1d < 70.0))
+            & ((rsi_3_1h_gt_3) | rsi_3_4h_gt_20 | (stochrsi_k_1d_lt_70))
             # 1h down move, 1h high, 4h high
             & ((rsi_3_1h_gt_3) | aroonu_14_1h_lt_70 | (stochrsi_k_4h_lt_80))
             # 1h down move, 15m still high
@@ -15161,7 +15198,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 4h still not low enough
             & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_25) | (stochrsi_k_4h_lt_30))
             # 1h & 1d down move, 1d still high
-            & ((rsi_3_1h_gt_15) | (rsi_3_1d_gt_20) | (stochrsi_k_1d < 40.0))
+            & ((rsi_3_1h_gt_15) | (rsi_3_1d_gt_20) | (stochrsi_k_1d_lt_40))
             # 1h & 1d down move, 1d high
             & ((rsi_3_1h_gt_15) | (rsi_3_1d_gt_25) | (aroonu_14_1d_lt_80))
             # 1h down move, 1h still high, 4h downtrend
@@ -15183,7 +15220,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 4h high, 1d overbought
             & ((rsi_3_1h_gt_30) | aroonu_14_4h_lt_80 | (roc_9_1d_lt_30))
             # 1h down move, 1d high & overbought
-            & ((rsi_3_1h_gt_30) | (aroonu_14_1d_lt_80) | (roc_9_1d < 200.0))
+            & ((rsi_3_1h_gt_30) | (aroonu_14_1d_lt_80) | (roc_9_1d_lt_200))
             # 1h & 4h down move, 1d overbought
             & ((rsi_3_1h_gt_30) | (rsi_3_4h_gt_30) | (roc_9_1d_lt_40))
             # 1h & 4h down move, 15m high
@@ -15203,7 +15240,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 4h high, 1d overbought
             & ((rsi_3_1h_gt_35) | (aroonu_14_4h_lt_85) | (roc_9_1d_lt_100))
             # 1h down move, 1h still high, 1d overbought
-            & ((rsi_3_1h_gt_35) | (stochrsi_k_1h_lt_50) | (roc_9_1d < 200.0))
+            & ((rsi_3_1h_gt_35) | (stochrsi_k_1h_lt_50) | (roc_9_1d_lt_200))
             # 1h down move, 1h high, 4h downtrend
             & ((rsi_3_1h_gt_35) | (stochrsi_k_1h_lt_70) | (roc_9_4h_gt_neg_20))
             # 1h down move, 1h high, 4h overbought
@@ -15217,7 +15254,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h high & overbought
             & ((rsi_3_1h_gt_55) | (stochrsi_k_1h_lt_80) | (roc_9_1h_lt_10))
             # 1h down move, 4h & 1d overbought
-            & ((rsi_3_1h_gt_60) | (roc_9_4h_lt_30) | (roc_9_1d < 60.0))
+            & ((rsi_3_1h_gt_60) | (roc_9_4h_lt_30) | (roc_9_1d_lt_60))
             # 4h & 1d down move, 4h still not low enough
             & ((rsi_3_4h_gt_3) | (rsi_3_1d_gt_15) | (aroonu_14_4h < 20.0))
             # 4h down move, 4h high, 4h downtrend
@@ -15235,7 +15272,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h & 1d down move, 1d still high
             & ((rsi_3_4h_gt_10) | (rsi_3_1d_gt_25) | (aroonu_14_1d_lt_40))
             # 4h & 1d down move, 1d still high
-            & ((rsi_3_4h_gt_10) | (rsi_3_1d_gt_25) | (stochrsi_k_1d < 50.0))
+            & ((rsi_3_4h_gt_10) | (rsi_3_1d_gt_25) | (stochrsi_k_1d_lt_50))
             # 4h & 1d down move, 1d high
             & ((rsi_3_4h_gt_15) | (rsi_3_1d_gt_20) | (aroonu_14_1d_lt_60))
             # 4h & 1d down move, 4h high
@@ -15251,7 +15288,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 4h still high, 1d downtrend
             & ((rsi_3_4h_gt_30) | (aroonu_14_4h_lt_50) | (roc_9_1d_gt_neg_40))
             # 4h down move, 1d high & overbought
-            & ((rsi_3_4h_gt_40) | (stochrsi_k_1d_lt_90) | (roc_9_1d < 200.0))
+            & ((rsi_3_4h_gt_40) | (stochrsi_k_1d_lt_90) | (roc_9_1d_lt_200))
             # 4h down move, 4h high, 1d downtrend
             & ((rsi_3_4h_gt_45) | aroonu_14_4h_lt_70 | (roc_9_1d_gt_neg_30))
             # 4h down move, 4h high & overbought
@@ -15261,13 +15298,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h still high, 4h & 1d downtrend
             & ((aroonu_14_1h_lt_40) | (roc_9_4h_gt_neg_20) | (roc_9_1d_gt_neg_40))
             # 1h & 4h high, 1h overbought
-            & (aroonu_14_1h_lt_70 | aroonu_14_4h_lt_100 | (roc_9_1h < 80.0))
+            & (aroonu_14_1h_lt_70 | aroonu_14_4h_lt_100 | (roc_9_1h_lt_80))
             # 1h high, 1d overbought
-            & (aroonu_14_1h_lt_70 | (roc_9_1d < 70.0))
+            & (aroonu_14_1h_lt_70 | (roc_9_1d_lt_70))
             # 1h & 4h high, 1h overbought
-            & (aroonu_14_1h_lt_80 | (aroonu_14_4h_lt_90) | (roc_9_1h < 30.0))
+            & (aroonu_14_1h_lt_80 | (aroonu_14_4h_lt_90) | (roc_9_1h_lt_30))
             # 1h & 1d high, 1h overbought
-            & (aroonu_14_1h_lt_80 | (aroonu_14_1d_lt_90) | (roc_9_1h < 30.0))
+            & (aroonu_14_1h_lt_80 | (aroonu_14_1d_lt_90) | (roc_9_1h_lt_30))
             # 4h still not low enough, 4h & 1d downtrend
             & ((aroonu_14_4h_lt_30) | (roc_9_4h > -40.0) | (roc_9_1d_gt_neg_40))
             # 4h still high, 5m downtrend
@@ -15275,23 +15312,23 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h high, 4h & 1d overbought
             & ((aroonu_14_4h_lt_60) | (roc_9_4h_lt_30) | roc_9_1d_lt_50)
             # 4h & 1d high, 4h overbought
-            & (aroonu_14_4h_lt_80 | aroonu_14_1d_lt_100 | (roc_9_4h < 50.0))
+            & (aroonu_14_4h_lt_80 | aroonu_14_1d_lt_100 | (roc_9_4h_lt_50))
             # 4h high, 1h & 1d overbought
-            & (aroonu_14_4h_lt_100 | (roc_9_1h < 30.0) | (roc_9_1d < 100.0))
+            & (aroonu_14_4h_lt_100 | (roc_9_1h_lt_30) | (roc_9_1d_lt_100))
             # 4h high, 1h & 4h high
-            & (aroonu_14_4h_lt_100 | (roc_9_1h < 50.0) | (roc_9_4h < 100.0))
+            & (aroonu_14_4h_lt_100 | (roc_9_1h_lt_50) | (roc_9_4h_lt_100))
             # 1d high, 4h & 1d downtrend
             & ((aroonu_14_1d_lt_70) | (roc_9_4h > -40.0) | (roc_9_1d_gt_neg_40))
             # 1d high, 1h & 1d overbought
-            & ((aroonu_14_1d_lt_80) | (roc_9_1h < 30.0) | (roc_9_1d < 200.0))
+            & ((aroonu_14_1d_lt_80) | (roc_9_1h_lt_30) | (roc_9_1d_lt_200))
             # 1d high, 4h & 1d overbought
             & ((aroonu_14_1d_lt_90) | (roc_9_4h_lt_20) | roc_9_1d_lt_50)
             # 1h high, 4h overbought
-            & ((stochrsi_k_1h_lt_80) | (roc_9_4h < 80.0))
+            & ((stochrsi_k_1h_lt_80) | (roc_9_4h_lt_80))
             # 4h & 1d overbought
-            & ((roc_9_4h < 100.0) | (roc_9_1d < 200.0))
+            & ((roc_9_4h_lt_100) | (roc_9_1d_lt_200))
             # big drop in the last 20 days, 1d high, 1d downtrend
-            & ((close > (high_max_20_1d * 0.20)) | (stochrsi_k_1d < 70.0) | (roc_9_1d > -15.0))
+            & ((close > (high_max_20_1d * 0.20)) | (stochrsi_k_1d_lt_70) | (roc_9_1d > -15.0))
             # drop in last 20 days, 1h high, 1d downtrend
             & ((close > (high_max_20_1d * 0.20)) | aroonu_14_1h_lt_70 | (roc_9_1d > -70.0))
           )
@@ -15324,7 +15361,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 4h high
             & ((rsi_3_15m_gt_25) | (rsi_3_1h_gt_25) | (stochrsi_k_4h_lt_80))
             # 15m & 1h down move, 4h overbought
-            & ((rsi_3_15m_gt_25) | (rsi_3_1h_gt_30) | (roc_9_4h < 70.0))
+            & ((rsi_3_15m_gt_25) | (rsi_3_1h_gt_30) | (roc_9_4h_lt_70))
             # 15m & 1h down move, 1h high
             & ((rsi_3_15m_gt_25) | (rsi_3_1h_gt_40) | aroonu_14_1h_lt_80)
             # 15m & 1h down move, 1h high
@@ -15336,7 +15373,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 15m high, 1h high
             & ((rsi_3_15m_gt_25) | (aroonu_14_15m_lt_60) | (stochrsi_k_1h_lt_70))
             # 15m down move, 1h & 4h overbought
-            & ((rsi_3_15m_gt_25) | (roc_9_1h < 40.0) | (roc_9_4h_lt_40))
+            & ((rsi_3_15m_gt_25) | (roc_9_1h_lt_40) | (roc_9_4h_lt_40))
             # 15m down move, 4h & 1d overbought
             & ((rsi_3_15m_gt_25) | (roc_9_4h_lt_10) | roc_9_1d_lt_50)
             # 15m & 4h down move, 4h high
@@ -15344,7 +15381,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 1h high
             & ((rsi_3_15m_gt_30) | (rsi_3_1h_gt_30) | (aroonu_14_1h_lt_85))
             # 15m down move, 15m still high, 1d high
-            & ((rsi_3_15m_gt_30) | (aroonu_14_15m_lt_50) | (stochrsi_k_1d < 70.0))
+            & ((rsi_3_15m_gt_30) | (aroonu_14_15m_lt_50) | (stochrsi_k_1d_lt_70))
             # 15m down move, 15m high, 4h high
             & ((rsi_3_15m_gt_30) | (aroonu_14_15m_lt_60) | (stochrsi_k_4h_lt_70))
             # 15m down move, 1h & 4h high
@@ -15354,15 +15391,15 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 4h high, 1h downtrend
             & ((rsi_3_15m < 30.0) | (aroonu_14_4h_lt_85) | (roc_9_1h > -40.0))
             # 15m down move, 4h high & overbought
-            & ((rsi_3_15m_gt_30) | aroonu_14_4h_lt_100 | (roc_9_4h < 25.0))
+            & ((rsi_3_15m_gt_30) | aroonu_14_4h_lt_100 | (roc_9_4h_lt_25))
             # 15m & 4h down move, 4h high
             & ((rsi_3_15m_gt_35) | (rsi_3_4h_gt_35) | (stochrsi_k_4h_lt_80))
             # 15m down move, 15m high, 4h overbought
             & ((rsi_3_15m_gt_35) | (aroonu_14_15m_lt_70) | (roc_9_4h_lt_10))
             # 15m down move, 1h high, 4h overbought
-            & ((rsi_3_15m_gt_35) | (aroonu_14_1h_lt_85) | (roc_9_4h < 80.0))
+            & ((rsi_3_15m_gt_35) | (aroonu_14_1h_lt_85) | (roc_9_4h_lt_80))
             # 15m down move, 4h high, 1h overbought
-            & ((rsi_3_15m_gt_35) | aroonu_14_4h_lt_100 | (roc_9_1h < 20.0))
+            & ((rsi_3_15m_gt_35) | aroonu_14_4h_lt_100 | (roc_9_1h_lt_20))
             # 15m & 1h down move, 1h high
             & ((rsi_3_15m_gt_40) | (rsi_3_1h_gt_40) | (aroonu_14_1h_lt_100))
             # 15m down move, 15m still high, 1h high
@@ -15372,7 +15409,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 4h still high
             & ((rsi_3_1h_gt_3) | (rsi_3_4h_gt_10) | (aroonu_14_4h_lt_40))
             # 1h & 4h down move, 1d overbought
-            & ((rsi_3_1h_gt_3) | (rsi_3_4h_gt_10) | (roc_9_1d < 15.0))
+            & ((rsi_3_1h_gt_3) | (rsi_3_4h_gt_10) | (roc_9_1d_lt_15))
             # 1h & 4h down move, 4h downtrend
             & ((rsi_3_1h_gt_3) | (rsi_3_4h_gt_15) | (roc_9_4h > -40.0))
             # 1h & 4h down move, 1d downtrend
@@ -15394,7 +15431,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 4h high
             & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_15) | (aroonu_14_4h_lt_60))
             # 1h & 4h down move, 1d overbought
-            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_30) | (roc_9_1d < 100.0))
+            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_30) | (roc_9_1d_lt_100))
             # 1h & 4h down move, 4h still high
             & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_45) | (stochrsi_k_4h_lt_40))
             # 1h down move, 4h downtrend. 4h still not low enough
@@ -15406,11 +15443,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h still high, 15m downtrend
             & ((rsi_3_1h_gt_10) | (aroonu_14_1h_lt_40) | (cmf_20_15m > -0.30))
             # 1h down move, 1d high, 4h overbought
-            & ((rsi_3_1h_gt_10) | (aroonu_14_1d_lt_100) | (roc_9_4h < 20.0))
+            & ((rsi_3_1h_gt_10) | (aroonu_14_1d_lt_100) | (roc_9_4h_lt_20))
             # 1h down move, 1h still high, 1d downtrend
             & ((rsi_3_1h_gt_10) | (stochrsi_k_1h_lt_50) | (roc_9_1d_gt_neg_40))
             # 1h down move, 1d high & overbought
-            & ((rsi_3_1h_gt_10) | (stochrsi_k_1d < 80.0) | (roc_9_1d_lt_30))
+            & ((rsi_3_1h_gt_10) | (stochrsi_k_1d_lt_80) | (roc_9_1d_lt_30))
             # 1h & 4h & 1d down move, 1d high
             & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_15) | (rsi_3_1d_gt_55) | (aroonu_14_1d_lt_90))
             # 1h & 4h down move, 1h still high
@@ -15426,17 +15463,17 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 4h high, 1d overbought
             & ((rsi_3_1h_gt_15) | (aroonu_14_4h_lt_60) | roc_9_1d_lt_50)
             # 1h down move, 4h high, 1d high
-            & ((rsi_3_1h_gt_15) | (aroonu_14_4h_lt_80) | (stochrsi_k_1d < 80.0))
+            & ((rsi_3_1h_gt_15) | (aroonu_14_4h_lt_80) | (stochrsi_k_1d_lt_80))
             # 1h down move, 1d high, 1d downtrend
             & ((rsi_3_1h_gt_15) | (aroonu_14_1d_lt_70) | (roc_9_1d > -20.0))
             # 1h down move, 1d high, 4h overbought
-            & ((rsi_3_1h_gt_15) | (aroonu_14_1d_lt_100) | (roc_9_4h < 60.0))
+            & ((rsi_3_1h_gt_15) | (aroonu_14_1d_lt_100) | (roc_9_4h_lt_60))
             # 1h down move, 1d high & overbought
-            & ((rsi_3_1h_gt_15) | (aroonu_14_1d_lt_100) | (roc_9_1d < 10.0))
+            & ((rsi_3_1h_gt_15) | (aroonu_14_1d_lt_100) | (roc_9_1d_lt_10))
             # 1h down move, 1h downtrend, 1d overbought
             & ((rsi_3_1h_gt_15) | (roc_9_1h > -30.0) | (roc_9_1d_lt_80))
             # 1h down move, 4h & 1d overbought
-            & ((rsi_3_1h_gt_15) | (roc_9_4h_lt_10) | (roc_9_1d < 60.0))
+            & ((rsi_3_1h_gt_15) | (roc_9_4h_lt_10) | (roc_9_1d_lt_60))
             # 1h & 4h down move, 4h high
             & (rsi_3_1h_gt_20 | rsi_3_4h_gt_20 | aroonu_14_4h_lt_70)
             # 1h & 4h down move, 4h high
@@ -15458,13 +15495,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h & 4h high
             & ((rsi_3_1h_gt_30) | (aroonu_14_1h_lt_70) | (aroonu_14_4h_lt_85))
             # 1h down move, 1h high, 4h overbought
-            & ((rsi_3_1h_gt_30) | (aroonu_14_1h_lt_70) | (roc_9_4h < 20.0))
+            & ((rsi_3_1h_gt_30) | (aroonu_14_1h_lt_70) | (roc_9_4h_lt_20))
             # 1h & 4h down move, 4h & 1d high, 4h overbought
-            & ((rsi_3_1h_gt_30) | (rsi_3_4h_gt_65) | (aroonu_14_4h_lt_70) | (aroonu_14_1d_lt_100) | (roc_9_4h < 30.0))
+            & ((rsi_3_1h_gt_30) | (rsi_3_4h_gt_65) | (aroonu_14_4h_lt_70) | (aroonu_14_1d_lt_100) | (roc_9_4h_lt_30))
             # 1h down move, 4h high, 1d overbought
             & ((rsi_3_1h_gt_30) | (aroonu_14_4h_lt_80) | (roc_9_1d_lt_30))
             # 1h down move, 4h high & overbought
-            & ((rsi_3_1h_gt_30) | (aroonu_14_4h_lt_90) | (roc_9_4h < 100.0))
+            & ((rsi_3_1h_gt_30) | (aroonu_14_4h_lt_90) | (roc_9_4h_lt_100))
             # 1h down move, 15m still high, 1h high
             & ((rsi_3_1h_gt_30) | (stochrsi_k_15m_lt_40) | (aroonu_14_1h_lt_60))
             # 1h down move, 1h high, 1d downtrend
@@ -15482,7 +15519,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h high, 4h downtrend
             & ((rsi_3_1h_gt_35) | (aroonu_14_1h_lt_80) | (roc_9_4h > -20.0))
             # 1h down move, 1h still high, 1d overbought
-            & ((rsi_3_1h_gt_35) | (stochrsi_k_1h_lt_50) | (roc_9_1d < 200.0))
+            & ((rsi_3_1h_gt_35) | (stochrsi_k_1h_lt_50) | (roc_9_1d_lt_200))
             # 1h down move, 15m high, 1h high
             & ((rsi_3_1h_gt_40) | (aroonu_14_15m_lt_60) | (aroonu_14_1h_lt_70))
             # 1h down move, 1h still high, 1d overbought
@@ -15494,21 +15531,21 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1d high & overbought
             & ((rsi_3_1h_gt_40) | (aroonu_14_1d_lt_80) | roc_9_1d_lt_50)
             # 1h down move, 1h & 4h overbought
-            & ((rsi_3_1h_gt_40) | (roc_9_1h < 20.0) | (roc_9_4h_lt_20))
+            & ((rsi_3_1h_gt_40) | (roc_9_1h_lt_20) | (roc_9_4h_lt_20))
             # 1h down move, 1h overbought
-            & ((rsi_3_1h_gt_40) | (roc_9_1h < 30.0))
+            & ((rsi_3_1h_gt_40) | (roc_9_1h_lt_30))
             # 1h & 4h down move, 1d overbought
-            & ((rsi_3_1h_gt_45) | (rsi_3_4h_gt_65) | (roc_9_1d < 200.0))
+            & ((rsi_3_1h_gt_45) | (rsi_3_4h_gt_65) | (roc_9_1d_lt_200))
             # 1h down move, 15m still high, 1h high
             & ((rsi_3_1h_gt_45) | (aroonu_14_15m_lt_50) | (aroonu_14_1h_lt_85))
             # 1h down move, 1h high, 4h overbought
-            & ((rsi_3_1h_gt_45) | aroonu_14_1h_lt_80 | (roc_9_4h < 50.0))
+            & ((rsi_3_1h_gt_45) | aroonu_14_1h_lt_80 | (roc_9_4h_lt_50))
             # 1h down move, 1h high, 1d overbought
             & ((rsi_3_1h_gt_45) | (stochrsi_k_1h_lt_70) | roc_9_1d_lt_50)
             # 1h down move, 1h high, 1d downtrend
             & ((rsi_3_1h_gt_50) | (aroonu_14_1h_lt_90) | (roc_9_1d_gt_neg_30))
             # 1h down move, 4h high, 1h overbought
-            & ((rsi_3_1h_gt_50) | (aroonu_14_4h_lt_90) | (roc_9_1h < 40.0))
+            & ((rsi_3_1h_gt_50) | (aroonu_14_4h_lt_90) | (roc_9_1h_lt_40))
             # 1h down move, 4h & 1d high
             & ((rsi_3_1h_gt_50) | aroonu_14_4h_lt_100 | aroonu_14_1d_lt_100)
             # 1h down move, 4h high, 1d downtrend
@@ -15518,7 +15555,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 15m high, 1h high
             & ((rsi_3_1h_gt_55) | (aroonu_14_15m_lt_60) | (stochrsi_k_1h_lt_80))
             # 1h down move, 1h high & overbought
-            & ((rsi_3_1h_gt_55) | (stochrsi_k_1h_lt_60) | (roc_9_1d < 10.0))
+            & ((rsi_3_1h_gt_55) | (stochrsi_k_1h_lt_60) | (roc_9_1d_lt_10))
             # 1h down move, 4h & 1d overbought
             & ((rsi_3_1h_gt_60) | (roc_9_4h_lt_10) | (roc_9_1d_lt_40))
             # 1h down move, 4h high, 1d overbought
@@ -15534,7 +15571,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h & 1d down move, 1d downtrend
             & ((rsi_3_4h_gt_10) | (rsi_3_1d_gt_15) | (roc_9_1d > -15.0))
             # 4h & 1d down move, 1d still high
-            & ((rsi_3_4h_gt_10) | (rsi_3_1d_gt_25) | (stochrsi_k_1d < 50.0))
+            & ((rsi_3_4h_gt_10) | (rsi_3_1d_gt_25) | (stochrsi_k_1d_lt_50))
             # 4h down move, 15m downtrend, 1d high
             & ((rsi_3_4h_gt_10) | (cmf_20_15m > -0.30) | (aroonu_14_1d_lt_80))
             # 4h down move, 15m still high, 1d downtrend
@@ -15562,7 +15599,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 1d high, 1d downtrend
             & (rsi_3_4h_gt_20 | (aroonu_14_1d_lt_80) | (roc_9_1d_gt_neg_30))
             # 4h down move, 1d high & overbought
-            & (rsi_3_4h_gt_20 | (aroonu_14_1d_lt_80) | (roc_9_1d < 70.0))
+            & (rsi_3_4h_gt_20 | (aroonu_14_1d_lt_80) | (roc_9_1d_lt_70))
             # 4h down move, 4h still high. 4h downtrend
             & ((rsi_3_4h_gt_25) | (aroonu_14_4h_lt_50) | (cmf_20_4h > -0.40))
             # 4h down move, 4h high, 1d downtrend
@@ -15592,53 +15629,53 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m high, 1h high & overbought
             & ((aroonu_14_15m_lt_70) | (aroonu_14_1h_lt_85) | (roc_9_1h_lt_10))
             # 4h high, 4h & 1d overbought
-            & (aroonu_14_4h_lt_70 | (roc_9_4h < 60.0) | (roc_9_1d_lt_80))
+            & (aroonu_14_4h_lt_70 | (roc_9_4h_lt_60) | (roc_9_1d_lt_80))
             # 1h & 4h high, 4h overbought
             & (aroonu_14_1h_lt_80 | aroonu_14_4h_lt_100 | (roc_9_4h_lt_10))
             # 1h & 1d high, 1d overbought
-            & (aroonu_14_1h_lt_80 | (aroonu_14_1d_lt_80) | (roc_9_1d < 200.0))
+            & (aroonu_14_1h_lt_80 | (aroonu_14_1d_lt_80) | (roc_9_1d_lt_200))
             # 1h high, 1h overbought
             & (aroonu_14_1h_lt_80 | (roc_9_1h_lt_10))
             # 4h still high, 5m downtrend
             & ((aroonu_14_4h_lt_40) | (roc_9 > -40.0))
             # 4h & 1d high, 4h overbought
-            & (aroonu_14_4h_lt_80 | aroonu_14_1d_lt_100 | (roc_9_4h < 80.0))
+            & (aroonu_14_4h_lt_80 | aroonu_14_1d_lt_100 | (roc_9_4h_lt_80))
             # 4h & 1d high, 1d overbought
             & (aroonu_14_4h_lt_80 | aroonu_14_1d_lt_100 | (roc_9_1d_lt_80))
             # 4h high, 1h & 4h overbought
-            & ((aroonu_14_4h_lt_85) | (roc_9_1h < 80.0) | (roc_9_4h < 80.0))
+            & ((aroonu_14_4h_lt_85) | (roc_9_1h_lt_80) | (roc_9_4h_lt_80))
             # 4h high, 4h & 1d overbought
             & ((aroonu_14_4h_lt_85) | (roc_9_4h_lt_10) | (roc_9_1d_lt_40))
             # 4h & 1d high, 4h overbought
             & (aroonu_14_4h_lt_100 | aroonu_14_1d_lt_100 | (roc_9_4h_lt_40))
             # 4h high, 1h & 1d overbought
-            & (aroonu_14_4h_lt_100 | (roc_9_1h < 40.0) | (roc_9_1d < 100.0))
+            & (aroonu_14_4h_lt_100 | (roc_9_1h_lt_40) | (roc_9_1d_lt_100))
             # 4h high, 4h & 1d overbought
-            & (aroonu_14_4h_lt_100 | (roc_9_4h < 20.0) | (roc_9_1d_lt_80))
+            & (aroonu_14_4h_lt_100 | (roc_9_4h_lt_20) | (roc_9_1d_lt_80))
             # 1d high, 1h & 4h down move
-            & (aroonu_14_1d_lt_100 | (roc_9_1h < 25.0) | (roc_9_4h < 60.0))
+            & (aroonu_14_1d_lt_100 | (roc_9_1h_lt_25) | (roc_9_4h_lt_60))
             # 1d high, 1h downtrend, 1d overbought
-            & (aroonu_14_1d_lt_100 | (roc_9_1h > -30.0) | (roc_9_1d < 100.0))
+            & (aroonu_14_1d_lt_100 | (roc_9_1h > -30.0) | (roc_9_1d_lt_100))
             # 1d high, 4h & 1d overbought
-            & (aroonu_14_1d_lt_100 | (roc_9_4h < 20.0) | (roc_9_1d_lt_80))
+            & (aroonu_14_1d_lt_100 | (roc_9_4h_lt_20) | (roc_9_1d_lt_80))
             # 15m high, 4h & 1d downtrend
             & ((stochrsi_k_15m_lt_70) | (roc_9_4h_gt_neg_30) | (roc_9_1d_gt_neg_30))
             # 1h high, 4h & 1d overbought
             & ((stochrsi_k_1h_lt_90) | (roc_9_4h_lt_20) | (roc_9_1d_lt_100))
             # 4h high, 1h overbought, 1d downtrend
-            & ((stochrsi_k_4h_lt_80) | (roc_9_1h < 40.0) | (roc_9_1d > -70.0))
+            & ((stochrsi_k_4h_lt_80) | (roc_9_1h_lt_40) | (roc_9_1d > -70.0))
             # 4h high, 4h & 1d overbought
-            & ((stochrsi_k_4h_lt_80) | (roc_9_4h < 80.0) | (roc_9_1d_lt_100))
+            & ((stochrsi_k_4h_lt_80) | (roc_9_4h_lt_80) | (roc_9_1d_lt_100))
             # 4h high, 1h & 4h overbought
-            & ((stochrsi_k_4h_lt_90) | (roc_9_1h_lt_10) | (roc_9_4h < 80.0))
+            & ((stochrsi_k_4h_lt_90) | (roc_9_1h_lt_10) | (roc_9_4h_lt_80))
             # 4h high, 1h & 4h overbought
-            & ((stochrsi_k_4h_lt_90) | (roc_9_1h < 20.0) | (roc_9_4h < 50.0))
+            & ((stochrsi_k_4h_lt_90) | (roc_9_1h_lt_20) | (roc_9_4h_lt_50))
             # 1d high, 4h & 1d overbought
             & ((stochrsi_k_1d_lt_90) | (roc_9_4h_lt_40) | (roc_9_1d_lt_100))
             # 1d P&D, dh downtrend
             & ((change_pct_1d > -50.0) | (change_pct_1d.shift(288) < 50.0) | (rsi_3_4h_gt_15))
             # big drop in the last 20 days, 1d high, 1d downtrend
-            & ((close > (high_max_20_1d * 0.20)) | (stochrsi_k_1d < 70.0) | (roc_9_1d > -15.0))
+            & ((close > (high_max_20_1d * 0.20)) | (stochrsi_k_1d_lt_70) | (roc_9_1d > -15.0))
             # drop in last 20 days, 1h high, 1d downtrend
             & ((close > (high_max_20_1d * 0.20)) | aroonu_14_1h_lt_70 | (roc_9_1d > -70.0))
             # drop in last 20 days. 4h high
@@ -15697,7 +15734,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 5m & 4h down move, 15m still high
             & ((rsi_3_gt_5) | (rsi_3_4h_gt_25) | (stochrsi_k_15m_lt_50))
             # 5m & 4h down move, 1d overbought
-            & ((rsi_3_gt_5) | (rsi_3_4h_gt_30) | (roc_9_1d < 60.0))
+            & ((rsi_3_gt_5) | (rsi_3_4h_gt_30) | (roc_9_1d_lt_60))
             # 5m & 4h down move, 4h high
             & ((rsi_3_gt_5) | (rsi_3_4h_gt_60) | aroonu_14_4h_lt_80)
             # 5m down move, 15m still not low enough, 4h high
@@ -15705,11 +15742,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 5m down move, 1h & 1d high
             & ((rsi_3_gt_5) | aroonu_14_1h_lt_70 | aroonu_14_1d_lt_100)
             # 5m down move, 4h high & overbought
-            & ((rsi_3_gt_5) | aroonu_14_4h_lt_100 | (roc_9_4h < 25.0))
+            & ((rsi_3_gt_5) | aroonu_14_4h_lt_100 | (roc_9_4h_lt_25))
             # 5m down move, 1h high
             & ((rsi_3_gt_5) | (stochrsi_k_1h_lt_80))
             # 5m & 1d down move, 1d still high
-            & ((rsi_3_gt_10) | (rsi_3_1d_gt_15) | (stochrsi_k_1d < 40.0))
+            & ((rsi_3_gt_10) | (rsi_3_1d_gt_15) | (stochrsi_k_1d_lt_40))
             # 15m & 1h down move, 1h still high
             & ((rsi_3_15m_gt_3) | (rsi_3_1h_gt_20) | (aroonu_14_1h_lt_50))
             # 15m & 1h down move, 4h still not low enough
@@ -15739,7 +15776,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1d down move, 4h high
             & ((rsi_3_15m_gt_3) | (rsi_3_1d_gt_55) | (stochrsi_k_4h_lt_70))
             # 1h & 1d downtrend, 1d high
-            & ((rsi_3_15m_gt_3) | (aroonu_14_1d_lt_70) | (roc_9_1d < 10.0))
+            & ((rsi_3_15m_gt_3) | (aroonu_14_1d_lt_70) | (roc_9_1d_lt_10))
             # 15m & 1h down move, 1h high
             & ((rsi_3_15m_gt_5) | (rsi_3_1h_gt_25) | (aroonu_14_1h_lt_60))
             # 15m & 1h down move, 1h still high
@@ -15775,7 +15812,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h & 4h down move, 4h still not low enough
             & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_25) | (rsi_3_4h_gt_25) | (stochrsi_k_4h_lt_30))
             # 15m & 1h & 4h down move, 1d high
-            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_25) | (rsi_3_4h_gt_25) | (stochrsi_k_1d < 70.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_25) | (rsi_3_4h_gt_25) | (stochrsi_k_1d_lt_70))
             # 15m & 1h down move, 4h still high
             & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_25) | (aroonu_14_4h_lt_50))
             # 15m & 1h down move, 4h high
@@ -15791,7 +15828,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 1h still high
             & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_45) | (stochrsi_k_1h_lt_40))
             # 15m & 1h down move, 1d overbought
-            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_45) | (roc_9_1d < 150.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_45) | (roc_9_1d_lt_150))
             # 15m & 1h down move, 4h high
             & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_50) | (stochrsi_k_4h_lt_80))
             # 15m & 1h down move, 1h high
@@ -15803,7 +15840,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 4h down move, 4h still not low enough
             & ((rsi_3_15m_gt_10) | (rsi_3_4h_gt_10) | (stochrsi_k_4h_lt_30))
             # 15m & 4h down move, 1d high
-            & ((rsi_3_15m_gt_10) | (rsi_3_4h_gt_10) | (stochrsi_k_1d < 70.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_4h_gt_10) | (stochrsi_k_1d_lt_70))
             # 15m & 4h down move, 1d high
             & ((rsi_3_15m_gt_10) | (rsi_3_4h_gt_15) | (rsi_14_1d < 60.0))
             # 15m & 4h down move, 4h still high
@@ -15853,7 +15890,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 4h high & overbought
             & ((rsi_3_15m_gt_10) | (stochrsi_k_4h_lt_70) | (roc_9_4h_lt_10))
             # 15m down move, 4h high, 1d overbought
-            & ((rsi_3_15m_gt_10) | (stochrsi_k_4h_lt_70) | (roc_9_1d < 10.0))
+            & ((rsi_3_15m_gt_10) | (stochrsi_k_4h_lt_70) | (roc_9_1d_lt_10))
             # 15m & 1h & 4h down move
             & ((rsi_3_15m_gt_15) | (rsi_3_1h_gt_15) | (rsi_3_1h_gt_15))
             # 15m & 1h down move, 1h still high
@@ -15869,7 +15906,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 1d overbought
             & ((rsi_3_15m_gt_15) | (rsi_3_1h_gt_25) | (roc_9_1d_lt_100))
             # 15m & 1h down move, 1d high
-            & ((rsi_3_15m_gt_15) | (rsi_3_1h_gt_30) | (stochrsi_k_1d < 80.0))
+            & ((rsi_3_15m_gt_15) | (rsi_3_1h_gt_30) | (stochrsi_k_1d_lt_80))
             # 15m & 1h down move, 4h high
             & ((rsi_3_15m_gt_15) | (rsi_3_1h_gt_50) | aroonu_14_4h_lt_100)
             # 15m & 1h down move, 1h high
@@ -15897,7 +15934,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1d down move, 1h still high
             & ((rsi_3_15m_gt_15) | (rsi_3_1d_gt_20) | (stochrsi_k_1h_lt_50))
             # 15m & 1d down move, 1d overbought
-            & ((rsi_3_15m_gt_15) | (rsi_3_1d_gt_30) | (roc_9_1d < 10.0))
+            & ((rsi_3_15m_gt_15) | (rsi_3_1d_gt_30) | (roc_9_1d_lt_10))
             # 15m down move, 15m still not low enough, 1h high
             & ((rsi_3_15m_gt_15) | (aroonu_14_15m_lt_25) | (stochrsi_k_1h_lt_80))
             # 15m down move, 15m still high, 4h high
@@ -15919,7 +15956,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 4h high & overbought
             & ((rsi_3_15m_gt_15) | aroonu_14_4h_lt_70 | (roc_9_4h_lt_30))
             # 15m down move, 4h high, 1h overbought
-            & ((rsi_3_15m_gt_15) | (aroonu_14_4h_lt_90) | (roc_9_1h < 25.0))
+            & ((rsi_3_15m_gt_15) | (aroonu_14_4h_lt_90) | (roc_9_1h_lt_25))
             # 15m down move, 4h high, 1h overbought
             & ((rsi_3_15m_gt_15) | aroonu_14_4h_lt_100 | (roc_9_1h_lt_10))
             # 15m down move, 1h still high, 4h overbought
@@ -15967,21 +16004,21 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 1h & 4h high
             & ((rsi_3_15m_gt_20) | aroonu_14_1h_lt_80 | aroonu_14_4h_lt_80)
             # 15m down move, 1h high, 1d overbought
-            & ((rsi_3_15m_gt_20) | aroonu_14_1h_lt_80 | (roc_9_1d < 10.0))
+            & ((rsi_3_15m_gt_20) | aroonu_14_1h_lt_80 | (roc_9_1d_lt_10))
             # 15m down move, 4h high & overbought
             & ((rsi_3_15m_gt_20) | aroonu_14_4h_lt_70 | (roc_9_4h_lt_30))
             # 15m down move, 4h high, 1h overbought
-            & ((rsi_3_15m_gt_20) | aroonu_14_4h_lt_100 | (roc_9_1h < 30.0))
+            & ((rsi_3_15m_gt_20) | aroonu_14_4h_lt_100 | (roc_9_1h_lt_30))
             # 15m down move, 1d high, 4h downtrend
             & ((rsi_3_15m_gt_20) | (aroonu_14_1d_lt_90) | (roc_9_4h_gt_neg_20))
             # 15m down move, 1d high, 4h overbought
-            & ((rsi_3_15m_gt_20) | aroonu_14_1d_lt_100 | (roc_9_4h < 20.0))
+            & ((rsi_3_15m_gt_20) | aroonu_14_1d_lt_100 | (roc_9_4h_lt_20))
             # 15m down move, 1d high, 1d overbought
             & ((rsi_3_15m_gt_20) | aroonu_14_1d_lt_100 | (roc_9_1d_lt_20))
             # 15m down move, 15m high, 4h downtrend
             & ((rsi_3_15m_gt_20) | (stochrsi_k_15m_lt_60) | (roc_9_4h > -50.0))
             # 15 down move, 1h high, 1d overbought
-            & ((rsi_3_15m_gt_20) | (stochrsi_k_1h_lt_70) | (roc_9_1d < 10.0))
+            & ((rsi_3_15m_gt_20) | (stochrsi_k_1h_lt_70) | (roc_9_1d_lt_10))
             # 15m down move, 4h high, 15m downtrend
             & ((rsi_3_15m_gt_20) | (stochrsi_k_4h_lt_70) | (cmf_20_15m > -0.40))
             # 15m & 1h & 4h down move, 1h still not low enough, 4h still high
@@ -16013,7 +16050,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 15m still high, 1h high
             & ((rsi_3_15m_gt_25) | (aroonu_14_15m_lt_40) | (stochrsi_k_1h_lt_80))
             # 15m down move, 1h high, 1d overbought
-            & ((rsi_3_15m_gt_25) | (aroonu_14_1h_lt_60) | (roc_9_1d < 60.0))
+            & ((rsi_3_15m_gt_25) | (aroonu_14_1h_lt_60) | (roc_9_1d_lt_60))
             # 15m down move, 1h high, 4h overbought
             & ((rsi_3_15m_gt_25) | aroonu_14_1h_lt_70 | (roc_9_4h_lt_40))
             # 15m down move, 1h & 4h high
@@ -16021,13 +16058,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 1h & 4h high
             & ((rsi_3_15m_gt_25) | (aroonu_14_1h_lt_90) | (aroonu_14_4h_lt_90))
             # 15m down move, 4h high & overbought
-            & ((rsi_3_15m_gt_25) | aroonu_14_4h_lt_70 | (roc_9_4h < 50.0))
+            & ((rsi_3_15m_gt_25) | aroonu_14_4h_lt_70 | (roc_9_4h_lt_50))
             # 15m down move, 4h high, 1d overbought
-            & ((rsi_3_15m_gt_25) | aroonu_14_4h_lt_80 | (roc_9_1d < 100.0))
+            & ((rsi_3_15m_gt_25) | aroonu_14_4h_lt_80 | (roc_9_1d_lt_100))
             # 15m down move, 1h high, 1d downtrend
             & ((rsi_3_15m_gt_25) | (stochrsi_k_1h_lt_70) | (roc_9_1d_gt_neg_20))
             # 15m down move, 1h high & overbought
-            & ((rsi_3_15m_gt_25) | (stochrsi_k_1h_lt_90) | (roc_9_1h < 20.0))
+            & ((rsi_3_15m_gt_25) | (stochrsi_k_1h_lt_90) | (roc_9_1h_lt_20))
             # 15m down move, 4h high & overbought
             & ((rsi_3_15m_gt_25) | (stochrsi_k_4h_lt_90) | (roc_9_4h_lt_30))
             # 15m & 1h down move, 1h high
@@ -16059,13 +16096,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 15m still not low enough, 1h high
             & ((rsi_3_15m_gt_35) | (aroonu_14_15m_lt_25) | (stochrsi_k_1h_lt_80))
             # 15m down move, 1m still high, 4h overbought
-            & ((rsi_3_15m_gt_35) | (aroonu_14_15m_lt_40) | (roc_9_4h < 50.0))
+            & ((rsi_3_15m_gt_35) | (aroonu_14_15m_lt_40) | (roc_9_4h_lt_50))
             # 15m down move, 1h high, 4h overbought
             & ((rsi_3_15m_gt_35) | aroonu_14_1h_lt_80 | (roc_9_4h_lt_10))
             # 15m down move, 4h high & overbought
-            & ((rsi_3_15m_gt_35) | aroonu_14_4h_lt_100 | (roc_9_4h < 70.0))
+            & ((rsi_3_15m_gt_35) | aroonu_14_4h_lt_100 | (roc_9_4h_lt_70))
             # 15m down move, 1h high & overbought
-            & ((rsi_3_15m_gt_35) | (stochrsi_k_1h_lt_90) | (roc_9_1h < 40.0))
+            & ((rsi_3_15m_gt_35) | (stochrsi_k_1h_lt_90) | (roc_9_1h_lt_40))
             # 15m & 1h down move, 4h high
             & ((rsi_3_15m_gt_40) | (rsi_3_1h_gt_40) | aroonu_14_4h_lt_100)
             # 15m & 4h down move, 1h high
@@ -16077,7 +16114,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 1h high, 4h overbought
             & ((rsi_3_15m_gt_50) | (stochrsi_k_1h_lt_80) | (roc_9_4h_lt_40))
             # 1h & 4h down move, 1d high
-            & ((rsi_3_1h_gt_3) | (rsi_3_4h_gt_15) | (stochrsi_k_1d < 70.0))
+            & ((rsi_3_1h_gt_3) | (rsi_3_4h_gt_15) | (stochrsi_k_1d_lt_70))
             # 1h & 4h down move, 4h high
             & ((rsi_3_1h_gt_5) | (rsi_3_4h_gt_5) | (stochrsi_k_4h_lt_40))
             # 1h & 4h down move, 4h high
@@ -16107,19 +16144,19 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 4h still high
             & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_35) | (stochrsi_k_4h_lt_50))
             # 1h down move, 1d high & overbought
-            & ((rsi_3_1h_gt_15) | (aroonu_14_1d_lt_80) | (roc_9_1d < 10.0))
+            & ((rsi_3_1h_gt_15) | (aroonu_14_1d_lt_80) | (roc_9_1d_lt_10))
             # 1h down move, 1d high, 4h downtrend
             & ((rsi_3_1h_gt_15) | (aroonu_14_1d_lt_90) | (roc_9_4h > -20.0))
             # 1h & 4h down move, 4h high
             & (rsi_3_1h_gt_20 | (rsi_3_4h_gt_35) | (stochrsi_k_4h_lt_70))
             # 1h & 1d down move, 1d high
-            & (rsi_3_1h_gt_20 | (rsi_3_1d > 50.0) | (stochrsi_k_1d < 60.0))
+            & (rsi_3_1h_gt_20 | (rsi_3_1d > 50.0) | (stochrsi_k_1d_lt_60))
             # 1h down move, 1h high, 1d overbought
             & (rsi_3_1h_gt_20 | (aroonu_14_1h_lt_60) | roc_9_1d_lt_50)
             # 1h down move, 1h high, 1d overbought
             & (rsi_3_1h_gt_20 | aroonu_14_1h_lt_70 | (roc_9_1d_lt_20))
             # 1h down move, 1d high, 4h downtrend
-            & (rsi_3_1h_gt_20 | (stochrsi_k_1d < 80.0) | (roc_9_4h_gt_neg_20))
+            & (rsi_3_1h_gt_20 | (stochrsi_k_1d_lt_80) | (roc_9_4h_gt_neg_20))
             # 1h down move, 4h downtrend, 1d overbought
             & (rsi_3_1h_gt_20 | (roc_9_4h > -10.0) | (roc_9_1d_lt_20))
             # 1h & 4h down move, 1h still high
@@ -16131,17 +16168,17 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h still high, 1d high
             & ((rsi_3_1h_gt_25) | (aroonu_14_1h_lt_40) | (aroonu_14_1d_lt_90))
             # 1h down move, 1h still high, 4h overbought
-            & ((rsi_3_1h_gt_25) | (aroonu_14_1h_lt_50) | (roc_9_4h < 60.0))
+            & ((rsi_3_1h_gt_25) | (aroonu_14_1h_lt_50) | (roc_9_4h_lt_60))
             # 1h down move, 4h high, 1d overbought
             & ((rsi_3_1h_gt_25) | (aroonu_14_4h_lt_40) | (roc_9_1d_lt_100))
             # 1h down move, 1d still high, 1d downtrend
-            & ((rsi_3_1h_gt_25) | (stochrsi_k_1d < 50.0) | (roc_9_1d_gt_neg_20))
+            & ((rsi_3_1h_gt_25) | (stochrsi_k_1d_lt_50) | (roc_9_1d_gt_neg_20))
             # 1h & 4h down move, 1d high
             & ((rsi_3_1h_gt_30) | (rsi_3_4h_gt_35) | (rsi_14_1d < 80.0))
             # 1h & 4h down move, 4h high
             & ((rsi_3_1h_gt_30) | (rsi_3_4h_gt_40) | (aroonu_14_4h_lt_60))
             # 1h & 4h & 1d down move, 1d still high
-            & ((rsi_3_1h_gt_30) | (rsi_3_4h_gt_50) | (rsi_3_1d_gt_60) | (stochrsi_k_1d < 50.0))
+            & ((rsi_3_1h_gt_30) | (rsi_3_4h_gt_50) | (rsi_3_1d_gt_60) | (stochrsi_k_1d_lt_50))
             # 1h & 4h down move, 4h high
             & ((rsi_3_1h_gt_30) | (rsi_3_4h_gt_60) | (stochrsi_k_4h_lt_80))
             # 1h & 1d down move, 1h high
@@ -16149,7 +16186,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 4h & 1d down move
             & ((rsi_3_1h_gt_30) | aroonu_14_4h_lt_70 | aroonu_14_1d_lt_100)
             # 1h down move, 4h high & overbought
-            & ((rsi_3_1h_gt_30) | (aroonu_14_4h_lt_85) | (roc_9_4h < 80.0))
+            & ((rsi_3_1h_gt_30) | (aroonu_14_4h_lt_85) | (roc_9_4h_lt_80))
             # 1h down move, 1d still high, 1d downtrend
             & ((rsi_3_1h_gt_30) | (aroonu_14_1d_lt_40) | (roc_9_1d_gt_neg_20))
             # 1h down move, 1d high, 4h downtrend
@@ -16187,21 +16224,21 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1d high, 4h overbought
             & ((rsi_3_1h_gt_40) | (stochrsi_k_1d_lt_90) | (roc_9_4h_lt_20))
             # 1h down move, 1h overbought
-            & ((rsi_3_1h_gt_40) | (roc_9_1h < 30.0))
+            & ((rsi_3_1h_gt_40) | (roc_9_1h_lt_30))
             # 1h & 4h down move, 1d overbought
-            & ((rsi_3_1h_gt_45) | (rsi_3_4h_gt_65) | (roc_9_1d < 200.0))
+            & ((rsi_3_1h_gt_45) | (rsi_3_4h_gt_65) | (roc_9_1d_lt_200))
             # 1h down move, 1h still not low enough, 1d downtrend
             & ((rsi_3_1h_gt_45) | (aroonu_14_1h_lt_30) | (roc_9_1d > -25.0))
             # 1h down move, 1h still high, 1d overbought
             & ((rsi_3_1h_gt_45) | (stochrsi_k_1h_lt_40) | (roc_9_1d_lt_100))
             # 1h down move, 4h high, 1h overbought
-            & ((rsi_3_1h_gt_50) | (aroonu_14_4h_lt_85) | (roc_9_1h < 20.0))
+            & ((rsi_3_1h_gt_50) | (aroonu_14_4h_lt_85) | (roc_9_1h_lt_20))
             # 1h down move, 1d high, 4h overbought
             & ((rsi_3_1h_gt_50) | (aroonu_14_1d_lt_90) | (roc_9_4h_lt_20))
             # 1h down move, 1h high & overbought
             & ((rsi_3_1h_gt_50) | (stochrsi_k_1h_lt_80) | (roc_9_1h_lt_10))
             # 1h down move, 1h & 4h overbought
-            & ((rsi_3_1h_gt_50) | (roc_9_1h_lt_10) | (roc_9_4h < 100.0))
+            & ((rsi_3_1h_gt_50) | (roc_9_1h_lt_10) | (roc_9_4h_lt_100))
             # 1h down move, 4h & 1d overbought
             & ((rsi_3_1h_gt_50) | (roc_9_4h_lt_20) | (roc_9_1d_lt_20))
             # 1h & 4h down move, 1h high
@@ -16223,7 +16260,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h high, 1d overbought
             & ((rsi_3_1h_gt_60) | (stochrsi_k_1h_lt_80) | (roc_9_1d_lt_100))
             # 1h down move, 1h high, 4h overbought
-            & ((rsi_3_1h_gt_65) | aroonu_14_1h_lt_70 | (roc_9_4h < 25.0))
+            & ((rsi_3_1h_gt_65) | aroonu_14_1h_lt_70 | (roc_9_4h_lt_25))
             # 1h down move, 1h high, 1d overbought
             & ((rsi_3_1h_gt_65) | (stochrsi_k_1h_lt_90) | (roc_9_1d_lt_20))
             # 4h down move, 1h still not low enough, 4h downtrend
@@ -16237,11 +16274,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h & 1d down move, 1d downtrend
             & ((rsi_3_4h_gt_10) | (rsi_3_1d_gt_15) | (roc_9_1d_gt_neg_40))
             # 4h & 1d down move, 1d still high
-            & ((rsi_3_4h_gt_10) | (rsi_3_1d_gt_20) | (stochrsi_k_1d < 50.0))
+            & ((rsi_3_4h_gt_10) | (rsi_3_1d_gt_20) | (stochrsi_k_1d_lt_50))
             # 4h & 1d down move, 1d high
             & ((rsi_3_4h_gt_10) | (rsi_3_1d_gt_35) | (aroonu_14_1d_lt_100))
             # 4h & 1d down move, 1d overbought
-            & ((rsi_3_4h_gt_10) | (rsi_3_1d_gt_45) | (roc_9_1d < 10.0))
+            & ((rsi_3_4h_gt_10) | (rsi_3_1d_gt_45) | (roc_9_1d_lt_10))
             # 4h down move, 15m high
             & ((rsi_3_4h_gt_10) | (stochrsi_k_15m_lt_70))
             # 4h & 1d down move, 4h high
@@ -16297,7 +16334,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 4h high & overbought
             & ((rsi_3_4h_gt_45) | (stochrsi_k_4h_lt_60) | (roc_9_4h_lt_20))
             # 4h down move, 4h high, 1d overbought
-            & ((rsi_3_4h_gt_45) | (stochrsi_k_4h_lt_80) | (roc_9_1d < 10.0))
+            & ((rsi_3_4h_gt_45) | (stochrsi_k_4h_lt_80) | (roc_9_1d_lt_10))
             # 4h down move, 4h high & overbought
             & ((rsi_3_4h_gt_50) | aroonu_14_4h_lt_80 | (roc_9_4h_lt_10))
             # 4h down move, 1h high, 1d downtrend
@@ -16307,19 +16344,19 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 4h high, 1d overbought
             & ((rsi_3_4h_gt_55) | aroonu_14_4h_lt_70 | (roc_9_1d_lt_100))
             # 4h down move, 1d high & overbought
-            & ((rsi_3_4h_gt_55) | (aroonu_14_1d_lt_90) | (roc_9_1d < 60.0))
+            & ((rsi_3_4h_gt_55) | (aroonu_14_1d_lt_90) | (roc_9_1d_lt_60))
             # 4h down move, 4h & 1d high
             & ((rsi_3_4h_gt_60) | aroonu_14_4h_lt_70 | (aroonu_14_1d_lt_70))
             # 4h down move, 1d high, 4h overbought
             & ((rsi_3_4h_gt_60) | aroonu_14_1d_lt_100 | (roc_9_4h_lt_10))
             # 4h down move, 1d high & overbought
-            & ((rsi_3_4h_gt_60) | aroonu_14_1d_lt_100 | (roc_9_1d < 200.0))
+            & ((rsi_3_4h_gt_60) | aroonu_14_1d_lt_100 | (roc_9_1d_lt_200))
             # 4h down move, 4h still high, 4h overbought
             & ((rsi_3_4h_gt_60) | (stochrsi_k_4h_lt_50) | (roc_9_4h_lt_10))
             # 4h down move, 4h high, 1d overbought
             & ((rsi_3_4h_gt_65) | (aroonu_14_4h_lt_75) | (roc_9_1d_lt_30))
             # 4h down move, 4h high & overbought
-            & ((rsi_3_4h_gt_65) | aroonu_14_4h_lt_80 | (roc_9_4h < 20.0))
+            & ((rsi_3_4h_gt_65) | aroonu_14_4h_lt_80 | (roc_9_4h_lt_20))
             # 1d down move, 1d still not low enough, 1d downtrend
             & ((rsi_3_1d_gt_5) | (aroonu_14_1d < 20.0) | (roc_9_1d_gt_neg_20))
             # 1d down move, 15m still high
@@ -16331,25 +16368,25 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1d down move, 4h downtrend, 4h high
             & ((rsi_3_1d_gt_20) | (cmf_20_4h > -0.25) | aroonu_14_4h_lt_70)
             # 1d down move, 1d still high, 1d downtrend
-            & ((rsi_3_1d_gt_25) | (stochrsi_k_1d < 50.0) | (roc_9_1d_gt_neg_20))
+            & ((rsi_3_1d_gt_25) | (stochrsi_k_1d_lt_50) | (roc_9_1d_gt_neg_20))
             # 1d down move, 4h & 1d high
             & ((rsi_3_1d_gt_40) | aroonu_14_4h_lt_70 | aroonu_14_1d_lt_100)
             # 1d down move, 1d high & overbought
-            & ((rsi_3_1d_gt_40) | (aroonu_14_1d_lt_80) | (roc_9_1d < 10.0))
+            & ((rsi_3_1d_gt_40) | (aroonu_14_1d_lt_80) | (roc_9_1d_lt_10))
             # 1d down move, 1h high, 1d overbought
-            & ((rsi_3_1d_gt_60) | aroonu_14_1h_lt_70 | (roc_9_1d < 100.0))
+            & ((rsi_3_1d_gt_60) | aroonu_14_1h_lt_70 | (roc_9_1d_lt_100))
             # 4h downtrend, 4h high & over
             & ((cmf_20_4h > -0.10) | aroonu_14_4h_lt_100 | (roc_9_4h_lt_30))
             # 15m still high, 4h high, 1h overbought
-            & ((aroonu_14_15m_lt_40) | (aroonu_14_4h_lt_85) | (roc_9_1h < 20.0))
+            & ((aroonu_14_15m_lt_40) | (aroonu_14_4h_lt_85) | (roc_9_1h_lt_20))
             # 15m still high, 4h high, 1h overbought
-            & ((aroonu_14_15m_lt_40) | aroonu_14_4h_lt_100 | (roc_9_1h < 20.0))
+            & ((aroonu_14_15m_lt_40) | aroonu_14_4h_lt_100 | (roc_9_1h_lt_20))
             # 4h down move, 1h still high, 1d downtrend
             & ((rsi_3_4h_gt_15) | (aroonu_14_1h_lt_40) | roc_9_1d_gt_neg_50)
             # 1h high, 4h high & overbought
             & (aroonu_14_1h_lt_80 | aroonu_14_4h_lt_80 | (roc_9_4h_lt_30))
             # 1h & 4h high, 1h overbought
-            & (aroonu_14_1h_lt_80 | (aroonu_14_4h_lt_90) | (roc_9_1h < 30.0))
+            & (aroonu_14_1h_lt_80 | (aroonu_14_4h_lt_90) | (roc_9_1h_lt_30))
             # 1h & 4h & 1d high
             & (aroonu_14_1h_lt_80 | aroonu_14_4h_lt_100 | aroonu_14_1d_lt_100)
             # 1h & 4h high, 1d overbought
@@ -16361,13 +16398,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h high, 1h & 4h overbought
             & (aroonu_14_1h_lt_80 | (roc_9_1h_lt_10) | (roc_9_4h_lt_10))
             # 1h high, 1h overbought, 1d downtrend
-            & (aroonu_14_1h_lt_80 | (roc_9_1h < 50.0) | roc_9_1d_gt_neg_50)
+            & (aroonu_14_1h_lt_80 | (roc_9_1h_lt_50) | roc_9_1d_gt_neg_50)
             # 1h high, 4h &1d overbought
             & ((aroonu_14_1h_lt_85) | (roc_9_4h_lt_30) | (roc_9_1d_lt_30))
             # 1h high, 4h & 1d overbought
-            & ((aroonu_14_1h_lt_90) | (roc_9_4h_lt_10) | (roc_9_1d < 15.0))
+            & ((aroonu_14_1h_lt_90) | (roc_9_4h_lt_10) | (roc_9_1d_lt_15))
             # 4h & 1d high, 4h overbought
-            & (aroonu_14_4h_lt_70 | aroonu_14_1d_lt_100 | (roc_9_4h < 50.0))
+            & (aroonu_14_4h_lt_70 | aroonu_14_1d_lt_100 | (roc_9_4h_lt_50))
             # 4h & 1d high, 1d overbought
             & (aroonu_14_4h_lt_70 | aroonu_14_1d_lt_100 | (roc_9_1d_lt_20))
             # 4h & 1d high, 4h overbought
@@ -16375,9 +16412,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h high, 4h overbought, 1d downtrend
             & ((aroonu_14_4h_lt_90) | (roc_9_4h_lt_20) | (roc_9_1d_gt_neg_40))
             # 1d high, 4h & 1d overbought
-            & ((aroonu_14_1d_lt_70) | (roc_9_4h_lt_30) | (roc_9_1d < 200.0))
+            & ((aroonu_14_1d_lt_70) | (roc_9_4h_lt_30) | (roc_9_1d_lt_200))
             # 1d high, 1h & 1d overbought
-            & ((aroonu_14_1d_lt_80) | (roc_9_1h < 20.0) | roc_9_1d_lt_50)
+            & ((aroonu_14_1d_lt_80) | (roc_9_1h_lt_20) | roc_9_1d_lt_50)
             # 1d high, 1d downtrend
             & ((aroonu_14_1d_lt_80) | (roc_9_1d_gt_neg_30))
             # 1d high, 1h & 4h downtrend
@@ -16399,25 +16436,25 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h & 1d overbought
             & ((stochrsi_k_1h_lt_90) | (roc_9_1h_lt_10) | roc_9_1d_lt_50)
             # 1h high & overbought
-            & ((stochrsi_k_1h_lt_90) | (roc_9_1h < 40.0))
+            & ((stochrsi_k_1h_lt_90) | (roc_9_1h_lt_40))
             # 4h high, 1h & 4h overbought
             & ((stochrsi_k_4h_lt_70) | (roc_9_1h_lt_10) | (roc_9_4h_lt_20))
             # 4h high, 1h & 1d overbought
-            & ((stochrsi_k_4h_lt_70) | (roc_9_1h < 20.0) | (roc_9_1d < 200.0))
+            & ((stochrsi_k_4h_lt_70) | (roc_9_1h_lt_20) | (roc_9_1d_lt_200))
             # 4h high, 4h & 1d overbought
             & ((stochrsi_k_4h_lt_80) | (roc_9_4h_lt_30) | (roc_9_1d_lt_30))
             # 4h high, 1d downtrend
             & ((stochrsi_k_4h_lt_80) | roc_9_1d_gt_neg_50)
             # 4h high, 1h & 1d overbought
-            & ((stochrsi_k_4h_lt_90) | (roc_9_1h < 20.0) | (roc_9_1d_lt_20))
+            & ((stochrsi_k_4h_lt_90) | (roc_9_1h_lt_20) | (roc_9_1d_lt_20))
             # 4h high, 4h & 1d overbought
-            & ((stochrsi_k_4h_lt_90) | (roc_9_4h_lt_10) | (roc_9_1d < 10.0))
+            & ((stochrsi_k_4h_lt_90) | (roc_9_4h_lt_10) | (roc_9_1d_lt_10))
             # 1d hihg, 1h & 1d overbought
-            & ((stochrsi_k_1d_lt_90) | (roc_9_1h < 30.0) | (roc_9_1d_lt_100))
+            & ((stochrsi_k_1d_lt_90) | (roc_9_1h_lt_30) | (roc_9_1d_lt_100))
             # 1d P&D, dh downtrend
             & ((change_pct_1d > -50.0) | (change_pct_1d.shift(288) < 50.0) | (rsi_3_4h_gt_15))
             # big drop in the last 20 days, 1d high, 1d downtrend
-            & ((close > (high_max_20_1d * 0.20)) | (stochrsi_k_1d < 70.0) | (roc_9_1d > -15.0))
+            & ((close > (high_max_20_1d * 0.20)) | (stochrsi_k_1d_lt_70) | (roc_9_1d > -15.0))
             # drop in last 20 days, 1h high, 1d downtrend
             & ((close > (high_max_20_1d * 0.20)) | aroonu_14_1h_lt_70 | (roc_9_1d > -70.0))
             # drop in last 20 days. 4h high
@@ -16442,9 +16479,9 @@ class NostalgiaForInfinityX7(IStrategy):
 
           long_entry_logic.append(
             # 5m down move, 4h high, 1h overbought
-            ((rsi_3_gt_10) | aroonu_14_4h_lt_100 | (roc_9_1h < 30.0))
+            ((rsi_3_gt_10) | aroonu_14_4h_lt_100 | (roc_9_1h_lt_30))
             # 15m down move, 1h & 4h overbought
-            & ((rsi_3_15m_gt_5) | (roc_9_1h < 25.0) | (roc_9_4h < 50.0))
+            & ((rsi_3_15m_gt_5) | (roc_9_1h_lt_25) | (roc_9_4h_lt_50))
             # 15m & 1h down move, 1d overbought
             & ((rsi_3_15m_gt_10) | rsi_3_1h_gt_20 | (roc_9_1d_lt_80))
             # 15m & 1h down move, 1h high
@@ -16452,21 +16489,21 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 1h high
             & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_35) | (stochrsi_k_1h_lt_80))
             # 15m & 1h down move, 4h overbought
-            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_45) | (roc_9_4h < 50.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_45) | (roc_9_4h_lt_50))
             # 15m & 1h down move, 4h overbought
-            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_60) | (roc_9_4h < 70.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_60) | (roc_9_4h_lt_70))
             # 15m & 4h down move, 4h high
             & ((rsi_3_15m_gt_10) | (rsi_3_4h_gt_55) | (aroonu_14_4h_lt_90))
             # 15m down move, 4h high & overbought
-            & ((rsi_3_15m_gt_10) | (aroonu_14_4h_lt_100) | (roc_9_4h < 80.0))
+            & ((rsi_3_15m_gt_10) | (aroonu_14_4h_lt_100) | (roc_9_4h_lt_80))
             # 15m down move, 1h high, 1d downtrend
             & ((rsi_3_15m_gt_10) | (stochrsi_k_1h_lt_70) | roc_9_1d_gt_neg_50)
             # 15m down move, 4h high & overbought
             & ((rsi_3_15m_gt_10) | (stochrsi_k_4h_lt_80) | (roc_9_4h_lt_30))
             # 15m down move, 1d high, 1d downtrend
-            & ((rsi_3_15m_gt_10) | (stochrsi_k_1d < 70.0) | (roc_9_1d > -15.0))
+            & ((rsi_3_15m_gt_10) | (stochrsi_k_1d_lt_70) | (roc_9_1d > -15.0))
             # 15m & 1h down move, 4h overbought
-            & ((rsi_3_15m_gt_15) | (rsi_3_1h_gt_35) | (roc_9_4h < 100.0))
+            & ((rsi_3_15m_gt_15) | (rsi_3_1h_gt_35) | (roc_9_4h_lt_100))
             # 15m & 1d down move, 1h high
             & ((rsi_3_15m_gt_15) | (rsi_3_1d_gt_35) | (aroonu_14_1h_lt_90))
             # 15m down move, 15m still high, 4h high
@@ -16474,19 +16511,19 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 1h & 4h high
             & ((rsi_3_15m_gt_15) | (aroonu_14_1h_lt_40) | aroonu_14_4h_lt_100)
             # 15m down move, 1h high, 4h overbought
-            & ((rsi_3_15m_gt_15) | (aroonu_14_1h_lt_60) | (roc_9_4h < 80.0))
+            & ((rsi_3_15m_gt_15) | (aroonu_14_1h_lt_60) | (roc_9_4h_lt_80))
             # 15m down move, 4h high, 4h downtrend
             & ((rsi_3_15m_gt_15) | (aroonu_14_4h_lt_90) | (cmf_20_4h > -0.25))
             # 15m down move, 1h & 4h high
-            & ((rsi_3_15m_gt_15) | (roc_9_1h < 30.0) | (roc_9_4h < 50.0))
+            & ((rsi_3_15m_gt_15) | (roc_9_1h_lt_30) | (roc_9_4h_lt_50))
             # 15m down move, 4h & 1d overbought
-            & ((rsi_3_15m_gt_15) | (roc_9_4h < 60.0) | (roc_9_1d_lt_80))
+            & ((rsi_3_15m_gt_15) | (roc_9_4h_lt_60) | (roc_9_1d_lt_80))
             # 15m down move, 1h & 4h high
             & ((rsi_3_15m_gt_20) | (aroonu_14_1h_lt_60) | aroonu_14_4h_lt_100)
             # 15m down move, 4h high, 1h overbought
             & ((rsi_3_15m_gt_20) | (stochrsi_k_4h_lt_80) | (roc_9_1h_lt_10))
             # 15m down move, 4h & 1d overbought
-            & ((rsi_3_15m_gt_20) | (roc_9_4h < 80.0) | (roc_9_1d < 200.0))
+            & ((rsi_3_15m_gt_20) | (roc_9_4h_lt_80) | (roc_9_1d_lt_200))
             # 15m & 1h down move, 1d overbought
             & ((rsi_3_15m_gt_25) | (rsi_3_1h_gt_25) | (roc_9_1d_lt_80))
             # 15m & 1h down move, 1h high
@@ -16496,41 +16533,41 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 1h & 4h high
             & ((rsi_3_15m_gt_25) | (aroonu_14_1h_lt_90) | aroonu_14_4h_lt_100)
             # 15m down move, 4h high, 1h overbought
-            & ((rsi_3_15m_gt_25) | (aroonu_14_4h_lt_100) | (roc_9_1h < 20.0))
+            & ((rsi_3_15m_gt_25) | (aroonu_14_4h_lt_100) | (roc_9_1h_lt_20))
             # 15m down move, 4h high, 1d overbought
-            & ((rsi_3_15m_gt_25) | (aroonu_14_4h_lt_100) | (roc_9_1d < 100.0))
+            & ((rsi_3_15m_gt_25) | (aroonu_14_4h_lt_100) | (roc_9_1d_lt_100))
             # 15m down move, 1h high & overbought
-            & ((rsi_3_15m_gt_25) | (stochrsi_k_1h_lt_90) | (roc_9_1h < 20.0))
+            & ((rsi_3_15m_gt_25) | (stochrsi_k_1h_lt_90) | (roc_9_1h_lt_20))
             # 15m down move, 1h & 4h overbought
-            & ((rsi_3_15m_gt_25) | (roc_9_1h < 40.0) | (roc_9_4h_lt_40))
+            & ((rsi_3_15m_gt_25) | (roc_9_1h_lt_40) | (roc_9_4h_lt_40))
             # 15m & 4h & 1d down move, 4h & 1d high
             & ((rsi_3_15m_gt_30) | (rsi_3_4h_gt_50) | (rsi_3_1d_gt_55) | (aroonu_14_4h_lt_70) | (aroonu_14_1d_lt_100))
             # 15m down move, 4h high & overbought
             & ((rsi_3_15m_gt_30) | (stochrsi_k_4h_lt_90) | (roc_9_4h < 200.0))
             # 15m down move, 1h & 4h overbought
-            & ((rsi_3_15m_gt_30) | (roc_9_1h < 60.0) | (roc_9_4h < 80.0))
+            & ((rsi_3_15m_gt_30) | (roc_9_1h_lt_60) | (roc_9_4h_lt_80))
             # 15m down move, 4h & 1d overbought
-            & ((rsi_3_15m_gt_40) | (roc_9_4h < 100.0) | (roc_9_1d_lt_100))
+            & ((rsi_3_15m_gt_40) | (roc_9_4h_lt_100) | (roc_9_1d_lt_100))
             # 1h down move, 4h overbought, 1d downtrend
-            & ((rsi_3_1h_gt_15) | (roc_9_4h < 50.0) | (roc_9_1d > -30.0))
+            & ((rsi_3_1h_gt_15) | (roc_9_4h_lt_50) | (roc_9_1d > -30.0))
             # 1h & 4h down move, 4h high
-            & ((rsi_3_1h_gt_20) | (roc_9_4h < 50.0) | aroonu_14_4h_lt_80)
+            & ((rsi_3_1h_gt_20) | (roc_9_4h_lt_50) | aroonu_14_4h_lt_80)
             # 1h & 4h down move, 1h still high
-            & ((rsi_3_1h_gt_20) | (roc_9_4h < 50.0) | (stochrsi_k_1h_lt_40))
+            & ((rsi_3_1h_gt_20) | (roc_9_4h_lt_50) | (stochrsi_k_1h_lt_40))
             # 1h & 4h down move, 4h overbought
-            & ((rsi_3_1h_gt_20) | (roc_9_4h < 50.0) | (roc_9_4h_lt_10))
+            & ((rsi_3_1h_gt_20) | (roc_9_4h_lt_50) | (roc_9_4h_lt_10))
             # 1h down move, 1h & 4h high
             & ((rsi_3_1h_gt_20) | (aroonu_14_1h_lt_80) | (aroonu_14_4h_lt_100))
             # 1h down move, 4h high & overbought
             & ((rsi_3_1h_gt_20) | (aroonu_14_4h_lt_80) | (roc_9_4h_lt_10))
             # 1h down move, 4h high & overbought
-            & ((rsi_3_1h_gt_20) | (aroonu_14_4h_lt_100) | (roc_9_4h < 50.0))
+            & ((rsi_3_1h_gt_20) | (aroonu_14_4h_lt_100) | (roc_9_4h_lt_50))
             # 1h down move, 1h still high, 1d overbought
             & ((rsi_3_1h_gt_20) | (stochrsi_k_1h_lt_40) | (roc_9_4h_lt_10))
             # 1h down move, 4h & 1d overbought
             & ((rsi_3_1h_gt_20) | (roc_9_4h_lt_40) | (roc_9_1d_lt_100))
             # 1h down move, 1d high, 4h overbought
-            & ((rsi_3_1h_gt_25) | aroonu_14_1d_lt_100 | (roc_9_4h < 60.0))
+            & ((rsi_3_1h_gt_25) | aroonu_14_1d_lt_100 | (roc_9_4h_lt_60))
             # 1h down move, 4h high & overbought
             & ((rsi_3_1h_gt_30) | aroonu_14_4h_lt_80 | (roc_9_4h_lt_30))
             # 1h down move, 1h high, 1d downtrend
@@ -16538,11 +16575,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 4h high, 1d downtrend
             & ((rsi_3_1h_gt_35) | (stochrsi_k_4h_lt_80) | roc_9_1d_gt_neg_50)
             # 1h down move, 1h & 1d overbought
-            & ((rsi_3_1h_gt_40) | (roc_9_1h < 30.0) | (roc_9_1d < 60.0))
+            & ((rsi_3_1h_gt_40) | (roc_9_1h_lt_30) | (roc_9_1d_lt_60))
             # 1h down move, 1h high, 4h overbought
-            & ((rsi_3_1h_gt_45) | aroonu_14_1h_lt_80 | (roc_9_4h < 25.0))
+            & ((rsi_3_1h_gt_45) | aroonu_14_1h_lt_80 | (roc_9_4h_lt_25))
             # 1h down move, 4h high, 1h overbought
-            & ((rsi_3_1h_gt_45) | (aroonu_14_4h_lt_90) | (roc_9_1h < 20.0))
+            & ((rsi_3_1h_gt_45) | (aroonu_14_4h_lt_90) | (roc_9_1h_lt_20))
             # 1h down move, 4h high, 1h overbought
             & ((rsi_3_1h_gt_45) | aroonu_14_4h_lt_100 | (roc_9_1h_lt_10))
             # 1h down move, 1d high, 1d downtrend
@@ -16552,33 +16589,33 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h high, 1d downtrend
             & ((rsi_3_1h_gt_50) | (stochrsi_k_1h_lt_70) | (roc_9_1d_gt_neg_20))
             # 1h down move, 1h & 1d overbought
-            & ((rsi_3_1h_gt_50) | (roc_9_1h < 25.0) | (roc_9_1d < 200.0))
+            & ((rsi_3_1h_gt_50) | (roc_9_1h_lt_25) | (roc_9_1d_lt_200))
             # 1h down move, 1h high, 4h overbought
             & ((rsi_3_1h_gt_55) | aroonu_14_1h_lt_70 | (roc_9_4h_lt_40))
             # 1h down move, 4h high & overbought
-            & ((rsi_3_1h_gt_55) | (aroonu_14_4h_lt_85) | (roc_9_4h < 80.0))
+            & ((rsi_3_1h_gt_55) | (aroonu_14_4h_lt_85) | (roc_9_4h_lt_80))
             # 1h down move, 4h high & overbought
-            & ((rsi_3_1h_gt_60) | aroonu_14_4h_lt_80 | (roc_9_4h < 100.0))
+            & ((rsi_3_1h_gt_60) | aroonu_14_4h_lt_80 | (roc_9_4h_lt_100))
             # 1h down move, 1h & 1d overbought
             & ((rsi_3_1h_gt_60) | (roc_9_1h_lt_10) | (roc_9_1d < 250.0))
             # 1h down move, 1h high, 4h overbought
             & ((rsi_3_1h_gt_65) | aroonu_14_1h_lt_80 | (roc_9_4h_lt_30))
             # 1h down move, 1h overbought
-            & ((rsi_3_1h_gt_65) | (roc_9_1h < 40.0))
+            & ((rsi_3_1h_gt_65) | (roc_9_1h_lt_40))
             # 4h down move, 1h high & overbought
-            & ((rsi_3_4h_gt_3) | (aroonu_14_1h_lt_85) | (roc_9_1h < 60.0))
+            & ((rsi_3_4h_gt_3) | (aroonu_14_1h_lt_85) | (roc_9_1h_lt_60))
             # 1d down move, 4h high & overbought
-            & ((rsi_3_1d_gt_5) | (aroonu_14_4h_lt_90) | (roc_9_4h < 50.0))
+            & ((rsi_3_1d_gt_5) | (aroonu_14_4h_lt_90) | (roc_9_4h_lt_50))
             # 1d down move, 1h high
             & ((rsi_3_1d_gt_10) | aroonu_14_1h_lt_70)
             # 1d down move, 4h high, 1h overbought
-            & ((rsi_3_1d_gt_20) | aroonu_14_4h_lt_100 | (roc_9_1h < 25.0))
+            & ((rsi_3_1d_gt_20) | aroonu_14_4h_lt_100 | (roc_9_1h_lt_25))
             # 1d down move, 4h high, 4h overbought
             & ((rsi_3_1d_gt_20) | aroonu_14_4h_lt_100 | (roc_9_4h_lt_40))
             # 1d down move, 1h & 4h overbought
-            & ((rsi_3_1d_gt_30) | (roc_9_1h < 30.0) | (roc_9_4h < 60.0))
+            & ((rsi_3_1d_gt_30) | (roc_9_1h_lt_30) | (roc_9_4h_lt_60))
             # 1d down move, 4h high & overbought
-            & ((rsi_3_1d_gt_35) | aroonu_14_4h_lt_100 | (roc_9_4h < 20.0))
+            & ((rsi_3_1d_gt_35) | aroonu_14_4h_lt_100 | (roc_9_4h_lt_20))
             # 1d down move, 1h & 4h high
             & ((rsi_3_1d_gt_40) | aroonu_14_1h_lt_80 | aroonu_14_4h_lt_100)
             # 1d down move, 4h & 1d high
@@ -16592,23 +16629,23 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1d downtrend, 1d high & overbought
             & ((cmf_20_1d > -0.40) | (aroonu_14_1d_lt_85) | (roc_9_1d_lt_20))
             # 15m not low enough, 1h high, 1d overbought
-            & ((aroonu_14_15m_lt_25) | (stochrsi_k_1h_lt_90) | (roc_9_1d < 200.0))
+            & ((aroonu_14_15m_lt_25) | (stochrsi_k_1h_lt_90) | (roc_9_1d_lt_200))
             # 1h still high, 1h & 4h overbought
-            & ((aroonu_14_1h_lt_50) | (roc_9_1h < 40.0) | (roc_9_4h_lt_40))
+            & ((aroonu_14_1h_lt_50) | (roc_9_1h_lt_40) | (roc_9_4h_lt_40))
             # 1h & 4h high, 4h overbought
-            & (aroonu_14_1h_lt_70 | aroonu_14_4h_lt_100 | (roc_9_4h < 20.0))
+            & (aroonu_14_1h_lt_70 | aroonu_14_4h_lt_100 | (roc_9_4h_lt_20))
             # 1h & 4h high, 4h overbought
             & (aroonu_14_1h_lt_80 | aroonu_14_4h_lt_80 | (roc_9_4h_lt_30))
             # 1h & 4h high, 1h overbought
-            & (aroonu_14_1h_lt_80 | (aroonu_14_4h_lt_90) | (roc_9_1h < 30.0))
+            & (aroonu_14_1h_lt_80 | (aroonu_14_4h_lt_90) | (roc_9_1h_lt_30))
             # 1h & 4h high, 1d overbought
-            & (aroonu_14_1h_lt_80 | (aroonu_14_4h_lt_90) | (roc_9_1d < 100.0))
+            & (aroonu_14_1h_lt_80 | (aroonu_14_4h_lt_90) | (roc_9_1d_lt_100))
             # 1h & 1d high, 4h overbought
             & ((aroonu_14_1h_lt_90) | (aroonu_14_1d_lt_90) | (roc_9_4h_lt_30))
             # 1h & 4h high, 1h overbought
             & (aroonu_14_1h_lt_80 | (stochrsi_k_4h_lt_90) | (roc_9_1h_lt_10))
             # 1h high & overbought
-            & (aroonu_14_1h_lt_80 | (roc_9_1h < 80.0))
+            & (aroonu_14_1h_lt_80 | (roc_9_1h_lt_80))
             # 1h high, 1h & 4h overbought
             & (aroonu_14_1h_lt_80 | (roc_9_1h_lt_10) | (roc_9_4h_lt_10))
             # 1h high, 4h overbought, 1d downtrend
@@ -16618,27 +16655,27 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h high, 1h overbought
             & ((aroonu_14_1h_lt_90) | (aroonu_14_4h_lt_90) | (roc_9_1h_lt_10))
             # 4h high, 1h overbought, 1d downtrend
-            & (aroonu_14_4h_lt_80 | (roc_9_1h < 30.0) | (roc_9_1d > -30.0))
+            & (aroonu_14_4h_lt_80 | (roc_9_1h_lt_30) | (roc_9_1d > -30.0))
             # 4h & 1d high, 4h downtrend
             & ((aroonu_14_4h_lt_85) | aroonu_14_1d_lt_100 | (cmf_20_4h > -0.30))
             # 4h & 1d high, 1h overbought
-            & ((aroonu_14_4h_lt_85) | (aroonu_14_1d_lt_90) | (roc_9_1h < 20.0))
+            & ((aroonu_14_4h_lt_85) | (aroonu_14_1d_lt_90) | (roc_9_1h_lt_20))
             # 4h & 1d high, 4h overbought
-            & ((aroonu_14_4h_lt_85) | (aroonu_14_1d_lt_90) | (roc_9_4h < 60.0))
+            & ((aroonu_14_4h_lt_85) | (aroonu_14_1d_lt_90) | (roc_9_4h_lt_60))
             # 4h high, 1h & 4h overbought
             & ((aroonu_14_4h_lt_85) | (roc_9_1h_lt_10) | (roc_9_4h_lt_20))
             # 4h high, 1d high & overbought
             & ((aroonu_14_4h_lt_90) | aroonu_14_1d_lt_100 | (roc_9_1d_lt_30))
             # 4h high, 1h & 4h overbought
-            & ((aroonu_14_4h_lt_90) | (roc_9_1h < 40.0) | (roc_9_4h_lt_40))
+            & ((aroonu_14_4h_lt_90) | (roc_9_1h_lt_40) | (roc_9_4h_lt_40))
             # 4h high, 4h & 1d overbought
             & ((aroonu_14_4h_lt_90) | (roc_9_4h_lt_30) | (roc_9_1d_lt_100))
             # 4h high, 1h & 4h overbought
-            & (aroonu_14_4h_lt_100 | (roc_9_1h < 40.0) | (roc_9_4h < 80.0))
+            & (aroonu_14_4h_lt_100 | (roc_9_1h_lt_40) | (roc_9_4h_lt_80))
             # 1d high, 1h & 4h overbought
-            & (aroonu_14_1d_lt_100 | (roc_9_1h_lt_10) | (roc_9_4h < 20.0))
+            & (aroonu_14_1d_lt_100 | (roc_9_1h_lt_10) | (roc_9_4h_lt_20))
             # 1h high, 1h & 4h overbought
-            & ((stochrsi_k_1h_lt_60) | (roc_9_1h < 40.0) | (roc_9_4h_lt_40))
+            & ((stochrsi_k_1h_lt_60) | (roc_9_1h_lt_40) | (roc_9_4h_lt_40))
             # 1h high, 1h overbought
             & ((stochrsi_k_1h_lt_80) | (roc_9_1h_lt_10))
             # 1h high, 4h overbought. 1d downtrend
@@ -16648,9 +16685,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h high & 4h & 1d overbought
             & ((stochrsi_k_4h_lt_90) | (roc_9_4h_lt_20) | (roc_9_1d_lt_20))
             # 1d high, 1h & 4h overbought
-            & ((stochrsi_k_1d < 80.0) | (roc_9_1h_lt_10) | (roc_9_4h_lt_20))
+            & ((stochrsi_k_1d_lt_80) | (roc_9_1h_lt_10) | (roc_9_4h_lt_20))
             # 1d hihg, 1h & 1d overbought
-            & ((stochrsi_k_1d_lt_90) | (roc_9_1h < 30.0) | (roc_9_1d_lt_100))
+            & ((stochrsi_k_1d_lt_90) | (roc_9_1h_lt_30) | (roc_9_1d_lt_100))
             # 1d high, 4h & 1d overbought
             & ((stochrsi_k_1d_lt_90) | (roc_9_4h_lt_40) | (roc_9_1d_lt_100))
           )
@@ -16674,7 +16711,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 5m & 1d down move, 4h still high
             ((rsi_3_gt_15) | (rsi_3_1d_gt_30) | (aroonu_14_4h_lt_40))
             # 15m & 1h down move, 1d still high
-            & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_3) | (stochrsi_k_1d < 50.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_3) | (stochrsi_k_1d_lt_50))
             # 15m & 1h down move, 1h still not low enough
             & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_5) | (stochrsi_k_1h_lt_30))
             # 15m & 1h & 4h down move, 4h still not low enough
@@ -16752,13 +16789,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 5m down move, 4h high, 1d downtrend
             & ((rsi_3_15m_gt_5) | (stochrsi_k_4h_lt_80) | (roc_9_1d_gt_neg_40))
             # 15m down move, 1h & 4h overbought
-            & ((rsi_3_15m_gt_5) | (roc_9_1h < 25.0) | (roc_9_4h < 25.0))
+            & ((rsi_3_15m_gt_5) | (roc_9_1h_lt_25) | (roc_9_4h_lt_25))
             # 15m down move, 4h & 1d overbought
             & ((rsi_3_15m_gt_5) | (roc_9_4h_lt_30) | (roc_9_1d_lt_100))
             # 15m & 1h down move, 1h high
             & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_10) | (aroonu_14_1h_lt_70))
             # 15m & 1h down move, 1d high
-            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_10) | (stochrsi_k_1d < 70.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_10) | (stochrsi_k_1d_lt_70))
             # 15m & 1h down move, 1d downtrend
             & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_10) | (roc_9_1d > -30.0))
             # 15m & 1h down move, 1h high
@@ -16800,7 +16837,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 4h high, 15m downtrend
             & ((rsi_3_15m_gt_10) | (aroonu_14_4h_lt_100) | (roc_9_15m > -30.0))
             # 15m down move, 1h high & overbought
-            & ((rsi_3_15m_gt_10) | aroonu_14_1d_lt_100 | (roc_9_1d < 60.0))
+            & ((rsi_3_15m_gt_10) | aroonu_14_1d_lt_100 | (roc_9_1d_lt_60))
             # 15m down move, 1d high, 1d downtrend
             & ((rsi_3_15m_gt_10) | (aroonu_14_1d_lt_85) | (cmf_20_1d > -0.40))
             # 15m down move, 1h high, 15m downtrend
@@ -16842,7 +16879,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 1d high, 4h overbought
             & ((rsi_3_15m_gt_15) | (stochrsi_k_1d_lt_90) | (roc_9_4h_lt_40))
             # 15m down move, 1h downtrend, 4h overbought
-            & ((rsi_3_15m_gt_15) | (roc_9_1h > -20.0) | (roc_9_4h < 80.0))
+            & ((rsi_3_15m_gt_15) | (roc_9_1h > -20.0) | (roc_9_4h_lt_80))
             # 15m down move, 4h & 1d downtrend
             & ((rsi_3_15m_gt_15) | (roc_9_4h > -10.0) | (roc_9_1d_gt_neg_40))
             # 15m & 1h down move, 1h high
@@ -16862,11 +16899,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 1h high, 4h downtrend
             & ((rsi_3_15m_gt_20) | aroonu_14_1h_lt_80 | (roc_9_4h > -15.0))
             # 15m down move, 1h high & overbought
-            & ((rsi_3_15m_gt_20) | (aroonu_14_1h_lt_100) | (roc_9_1h < 50.0))
+            & ((rsi_3_15m_gt_20) | (aroonu_14_1h_lt_100) | (roc_9_1h_lt_50))
             # 15m down move, 4h high & overbought
             & ((rsi_3_15m_gt_20) | aroonu_14_4h_lt_70 | (roc_9_4h_lt_20))
             # 15m down move, 4h high, 1d overbought
-            & ((rsi_3_15m_gt_20) | aroonu_14_4h_lt_80 | (roc_9_1d < 60.0))
+            & ((rsi_3_15m_gt_20) | aroonu_14_4h_lt_80 | (roc_9_1d_lt_60))
             # 15m & 4h down move, 4h high
             & ((rsi_3_15m_gt_25) | (rsi_3_4h_gt_25) | (stochrsi_k_4h_lt_60))
             # 15m & 1d down move, 1h high
@@ -16878,7 +16915,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 1h high, 4h overbought
             & ((rsi_3_15m_gt_25) | (aroonu_14_1h_lt_90) | (roc_9_4h_lt_30))
             # 15m down move, 1h high, 4h overbought
-            & ((rsi_3_15m_gt_25) | (aroonu_14_1h_lt_100) | (roc_9_4h < 15.0))
+            & ((rsi_3_15m_gt_25) | (aroonu_14_1h_lt_100) | (roc_9_4h_lt_15))
             # 15m down move, 1h high, 1d overbought
             & ((rsi_3_15m_gt_25) | (aroonu_14_1h_lt_100) | (roc_9_1d_lt_20))
             # 15m down move, 4h high & overbought
@@ -16886,7 +16923,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 1h & 4h high
             & ((rsi_3_15m_gt_30) | (aroonu_14_1h_lt_90) | (aroonu_14_4h_lt_90))
             # 1h & 4h down move, 1d still high
-            & ((rsi_3_1h_gt_3) | (rsi_3_4h_gt_3) | (stochrsi_k_1d < 50.0))
+            & ((rsi_3_1h_gt_3) | (rsi_3_4h_gt_3) | (stochrsi_k_1d_lt_50))
             # 1h & 4h down move, 1h still high
             & ((rsi_3_1h_gt_3) | (rsi_3_4h_gt_25) | (aroonu_14_1h_lt_40))
             # 1h & 4h down move, 4h high
@@ -16904,11 +16941,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 4h still high, 1d downtrend
             & ((rsi_3_1h_gt_3) | (stochrsi_k_4h_lt_50) | (roc_9_1h > -20.0))
             # 1h down move, 1d high & overbought
-            & ((rsi_3_1h_gt_3) | (stochrsi_k_1d < 60.0) | (roc_9_1d_lt_20))
+            & ((rsi_3_1h_gt_3) | (stochrsi_k_1d_lt_60) | (roc_9_1d_lt_20))
             # 1h & 4h & 1d down move
             & ((rsi_3_1h_gt_5) | (rsi_3_4h_gt_10) | (rsi_3_1d_gt_20))
             # 1h & 4h down move, 1d overbought
-            & ((rsi_3_1h_gt_5) | (rsi_3_4h_gt_10) | (roc_9_1d < 100.0))
+            & ((rsi_3_1h_gt_5) | (rsi_3_4h_gt_10) | (roc_9_1d_lt_100))
             # 1h & 4h down move, 4h still not low enough
             & ((rsi_3_1h_gt_5) | (rsi_3_4h_gt_15) | (aroonu_14_4h_lt_20))
             # 1h & 4h down move, 4h still high
@@ -16920,7 +16957,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 1d down move, 1h still high
             & ((rsi_3_1h_gt_5) | (rsi_3_1d_gt_10) | (stochrsi_k_1h_lt_50))
             # 1h down move, 1h high, 1d high
-            & ((rsi_3_1h_gt_5) | (aroonu_14_1h_lt_70) | (stochrsi_k_1d < 80.0))
+            & ((rsi_3_1h_gt_5) | (aroonu_14_1h_lt_70) | (stochrsi_k_1d_lt_80))
             # 1h down move, 1d high, 1h downtrend
             & ((rsi_3_1h_gt_5) | (aroonu_14_1d_lt_85) | (roc_9_1h > -50.0))
             # 1h down move, 1d high, 4h downtrend
@@ -16942,7 +16979,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 4h still high
             & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_10) | (stochrsi_k_4h_lt_50))
             # 1h & 4h down move, 1d still not low enough
-            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_10) | (stochrsi_k_1d < 20.0))
+            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_10) | (stochrsi_k_1d_lt_20))
             # 1h & 4h down move, 4h downtrend
             & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_10) | (roc_9_4h > -35.0))
             # 1h & 4h down move, 1d downtrend
@@ -16974,7 +17011,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1d downtrend, 4h high
             & ((rsi_3_1h_gt_10) | (cmf_20_1d > -0.30) | (stochrsi_k_4h_lt_90))
             # 1h down move, 1h still high, 4h overbought
-            & ((rsi_3_1h_gt_10) | (aroonu_14_1h_lt_50) | (roc_9_4h < 20.0))
+            & ((rsi_3_1h_gt_10) | (aroonu_14_1h_lt_50) | (roc_9_4h_lt_20))
             # 1h down move, 1h & 4h high
             & ((rsi_3_1h_gt_10) | (aroonu_14_1h_lt_60) | (aroonu_14_4h_lt_60))
             # 1h down move, 1h high, 1d high
@@ -17000,7 +17037,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h downtrend, 1h still high
             & ((rsi_3_1h_gt_15) | (cmf_20_1h > -0.30) | (stochrsi_k_1h_lt_40))
             # 1h down move, 1d downtrend, 1d high
-            & ((rsi_3_1h_gt_15) | (cmf_20_1d > -0.30) | (stochrsi_k_1d < 80.0))
+            & ((rsi_3_1h_gt_15) | (cmf_20_1d > -0.30) | (stochrsi_k_1d_lt_80))
             # 1h down move, 1h & 1d high
             & ((rsi_3_1h_gt_15) | (aroonu_14_1h_lt_70) | (aroonu_14_1d_lt_90))
             # 1h down move, 1h high, 1d overbought
@@ -17010,7 +17047,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h high, 4h downtrend
             & ((rsi_3_1h_gt_15) | (aroonu_14_1h_lt_80) | (roc_9_4h_gt_neg_30))
             # 1h down move, 4h still high, 1d overbought
-            & ((rsi_3_1h_gt_15) | (aroonu_14_4h_lt_50) | (roc_9_1d < 60.0))
+            & ((rsi_3_1h_gt_15) | (aroonu_14_4h_lt_50) | (roc_9_1d_lt_60))
             # 1h down move, 4h high, 15m downtrend
             & ((rsi_3_1h_gt_15) | (aroonu_14_4h_lt_85) | (roc_9_15m > -15.0))
             # 1h down move, 4h high, 1h downtrend
@@ -17020,11 +17057,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 4h still not low enough, 1d downtrend
             & ((rsi_3_1h_gt_15) | (stochrsi_k_4h_lt_30) | (roc_9_1d > -30.0))
             # 1h down move, 4h high & overbought
-            & ((rsi_3_1h_gt_15) | (stochrsi_k_4h_lt_80) | (roc_9_4h < 100.0))
+            & ((rsi_3_1h_gt_15) | (stochrsi_k_4h_lt_80) | (roc_9_4h_lt_100))
             # 1h down move, 1h downtrend, 1d overbought
-            & ((rsi_3_1h_gt_15) | (roc_9_1h > -30.0) | (roc_9_1d < 35.0))
+            & ((rsi_3_1h_gt_15) | (roc_9_1h > -30.0) | (roc_9_1d_lt_35))
             # 1h down move, 4h downtrend, 1d overbought
-            & ((rsi_3_1h_gt_15) | (roc_9_4h > -25.0) | (roc_9_1d < 100.0))
+            & ((rsi_3_1h_gt_15) | (roc_9_4h > -25.0) | (roc_9_1d_lt_100))
             # 1h & 4h down move, 1d high
             & (rsi_3_1h_gt_20 | rsi_3_4h_gt_20 | (aroonu_14_1d_lt_80))
             # 1h & 4h down move, 4h high
@@ -17038,17 +17075,17 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h still high, 4h high
             & (rsi_3_1h_gt_20 | (aroonu_14_1h_lt_50) | (aroonu_14_4h_lt_90))
             # 1h down move, 1h high, 1d overbought
-            & (rsi_3_1h_gt_20 | aroonu_14_1h_lt_70 | (roc_9_1d < 100.0))
+            & (rsi_3_1h_gt_20 | aroonu_14_1h_lt_70 | (roc_9_1d_lt_100))
             # 1h down move, 1d high & overbought
-            & (rsi_3_1h_gt_20 | aroonu_14_1d_lt_100 | (roc_9_1d < 60.0))
+            & (rsi_3_1h_gt_20 | aroonu_14_1d_lt_100 | (roc_9_1d_lt_60))
             # 1h down move, 1h high, 4h overbought
             & (rsi_3_1h_gt_20 | (stochrsi_k_1h_lt_70) | (roc_9_4h_lt_10))
             # 1h down move, 1d high, 1d downtrend
-            & (rsi_3_1h_gt_20 | (stochrsi_k_1d < 80.0) | roc_9_1d_gt_neg_50)
+            & (rsi_3_1h_gt_20 | (stochrsi_k_1d_lt_80) | roc_9_1d_gt_neg_50)
             # 1h down move, 1d high & overbought
             & (rsi_3_1h_gt_20 | (stochrsi_k_1d_lt_90) | (roc_9_1d_lt_40))
             # 1h down move, 1h & 4h overbought
-            & (rsi_3_1h_gt_20 | (roc_9_1h < 20.0) | (roc_9_4h_lt_40))
+            & (rsi_3_1h_gt_20 | (roc_9_1h_lt_20) | (roc_9_4h_lt_40))
             # 1h down move, 4h & 1d downtrend
             & (rsi_3_1h_gt_20 | (roc_9_4h_gt_neg_30) | (roc_9_1d_gt_neg_40))
             # 1h & 4h down move, 1d overbought
@@ -17056,11 +17093,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 15m still high, 1h high
             & ((rsi_3_1h_gt_25) | (aroonu_14_15m_lt_50) | (aroonu_14_1h_lt_90))
             # 1h down move, 1h high, 1d overbought
-            & ((rsi_3_1h_gt_25) | aroonu_14_1h_lt_70 | (roc_9_1d < 200.0))
+            & ((rsi_3_1h_gt_25) | aroonu_14_1h_lt_70 | (roc_9_1d_lt_200))
             # 1h down move, 1h & 1d high
             & ((rsi_3_1h_gt_25) | aroonu_14_1h_lt_70 | (aroonu_14_1d_lt_90))
             # 1h down move, 1h high, 4h overbought
-            & ((rsi_3_1h_gt_25) | aroonu_14_1h_lt_80 | (roc_9_4h < 20.0))
+            & ((rsi_3_1h_gt_25) | aroonu_14_1h_lt_80 | (roc_9_4h_lt_20))
             # 1h down move, 1h high, 1d overbought
             & ((rsi_3_1h_gt_25) | (aroonu_14_1h_lt_85) | roc_9_1d_lt_50)
             # 1h down move, 4h high
@@ -17074,9 +17111,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h & 1d downtrend
             & ((rsi_3_1h_gt_25) | (roc_9_1h > -50.0) | roc_9_1d_gt_neg_50)
             # 1h down move, 1h downtrend, 4h overbought
-            & ((rsi_3_1h_gt_25) | (roc_9_1h > -25.0) | (roc_9_4h < 50.0))
+            & ((rsi_3_1h_gt_25) | (roc_9_1h > -25.0) | (roc_9_4h_lt_50))
             # 1h down move, 1h & 4h overbought
-            & ((rsi_3_1h_gt_25) | (roc_9_1h < 30.0) | (roc_9_4h < 100.0))
+            & ((rsi_3_1h_gt_25) | (roc_9_1h_lt_30) | (roc_9_4h_lt_100))
             # 1h & 4h down move, 1h high
             & ((rsi_3_1h_gt_30) | (rsi_3_4h_gt_30) | (aroonu_14_1h_lt_90))
             # 1h & 4h down move, 4h downtrend
@@ -17090,7 +17127,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h high, 1d downtrend
             & ((rsi_3_1h_gt_30) | aroonu_14_1h_lt_70 | (roc_9_1d > -60.0))
             # 1h down move, 4h high, 1h overbought
-            & ((rsi_3_1h_gt_30) | aroonu_14_4h_lt_80 | (roc_9_1h < 50.0))
+            & ((rsi_3_1h_gt_30) | aroonu_14_4h_lt_80 | (roc_9_1h_lt_50))
             # 1h down move, 4h high, 1d downtrend
             & ((rsi_3_1h_gt_30) | (aroonu_14_4h_lt_90) | (roc_9_1d_gt_neg_30))
             # 1h down move, 4h high, 1d overbought
@@ -17108,15 +17145,15 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h high, 4h overbought
             & ((rsi_3_1h_gt_35) | (aroonu_14_1h_lt_90) | (roc_9_4h_lt_10))
             # 1h down move, 4h high, 1d overbought
-            & ((rsi_3_1h_gt_35) | aroonu_14_4h_lt_70 | (roc_9_1d < 200.0))
+            & ((rsi_3_1h_gt_35) | aroonu_14_4h_lt_70 | (roc_9_1d_lt_200))
             # 1h down move, 4h high & overbought
-            & ((rsi_3_1h_gt_35) | aroonu_14_4h_lt_100 | (roc_9_4h < 20.0))
+            & ((rsi_3_1h_gt_35) | aroonu_14_4h_lt_100 | (roc_9_4h_lt_20))
             # 1h down move, 4h high & overbought
             & ((rsi_3_1h_gt_35) | (stochrsi_k_4h_lt_80) | (roc_9_4h_lt_30))
             # 1h down move, 1h downtrend, 4h overbought
-            & ((rsi_3_1h_gt_35) | (roc_9_1h > -30.0) | (roc_9_4h < 100.0))
+            & ((rsi_3_1h_gt_35) | (roc_9_1h > -30.0) | (roc_9_4h_lt_100))
             # 1h down move, 4h & 1d overbought
-            & ((rsi_3_1h_gt_35) | (roc_9_4h_lt_20) | (roc_9_1d < 70.0))
+            & ((rsi_3_1h_gt_35) | (roc_9_4h_lt_20) | (roc_9_1d_lt_70))
             # 1h down move, 1h & 4h high
             & ((rsi_3_1h_gt_40) | aroonu_14_1h_lt_70 | aroonu_14_4h_lt_100)
             # 1h down move, 1h high & overbought
@@ -17132,9 +17169,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 4h & 1d overbought
             & ((rsi_3_1h_gt_40) | (roc_9_4h_lt_30) | (roc_9_1d_lt_40))
             # 1h down move, 1h high, 1d overbought
-            & ((rsi_3_1h_gt_45) | (aroonu_14_1h_lt_100) | (roc_9_1d < 200.0))
+            & ((rsi_3_1h_gt_45) | (aroonu_14_1h_lt_100) | (roc_9_1d_lt_200))
             # 1h down move, 4h high & overbought
-            & ((rsi_3_1h_gt_45) | (stochrsi_k_4h_lt_80) | (roc_9_4h < 100.0))
+            & ((rsi_3_1h_gt_45) | (stochrsi_k_4h_lt_80) | (roc_9_4h_lt_100))
             # 1h down move, 1h high, 1d downtrend
             & ((rsi_3_1h_gt_50) | (aroonu_14_1h_lt_60) | (roc_9_1d > -70.0))
             # 1h down move, 1h high, 1d overbought
@@ -17144,9 +17181,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h high
             & ((rsi_3_1h_gt_60) | (stochrsi_k_1h_lt_80))
             # 1h down move, 1h overbought
-            & ((rsi_3_1h_gt_60) | (roc_9_1h < 30.0))
+            & ((rsi_3_1h_gt_60) | (roc_9_1h_lt_30))
             # 1h down move, 4h & 1d overbought
-            & ((rsi_3_1h_gt_60) | (roc_9_4h_lt_30) | (roc_9_1d < 60.0))
+            & ((rsi_3_1h_gt_60) | (roc_9_4h_lt_30) | (roc_9_1d_lt_60))
             # 4h & 1d down move, 1d still not low enough
             & ((rsi_3_4h_gt_3) | (rsi_3_1d_gt_30) | (aroonu_14_1d_lt_30))
             # 4h down move, 4h high, 1h downtrend
@@ -17164,7 +17201,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 1h & 4h downtrend
             & ((rsi_3_4h_gt_10) | (roc_9_1h > -30.0) | (roc_9_4h_gt_neg_30))
             # 4h down move, 1d high & overbought
-            & ((rsi_3_4h_gt_10) | (stochrsi_k_1d < 70.0) | (roc_9_1d < 35.0))
+            & ((rsi_3_4h_gt_10) | (stochrsi_k_1d_lt_70) | (roc_9_1d_lt_35))
             # 4h down move, 4h & 1d downtrend
             & ((rsi_3_4h_gt_10) | (roc_9_4h > -15.0) | (roc_9_1d > -35.0))
             # 4h down move, 4h still high, 1d overbought
@@ -17172,9 +17209,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 1h still not low enough, 1d downtrend
             & ((rsi_3_4h_gt_15) | (stochrsi_k_1h_lt_20) | (roc_9_1d > -20.0))
             # 4h & 1d down move, 1d high
-            & (rsi_3_4h_gt_20 | (rsi_3_1d_gt_20) | (stochrsi_k_1d < 70.0))
+            & (rsi_3_4h_gt_20 | (rsi_3_1d_gt_20) | (stochrsi_k_1d_lt_70))
             # 4h down move, 1d high & overbought
-            & (rsi_3_4h_gt_20 | (aroonu_14_1d_lt_80) | (roc_9_1d < 200.0))
+            & (rsi_3_4h_gt_20 | (aroonu_14_1d_lt_80) | (roc_9_1d_lt_200))
             # 4h down move, 4h & 1d downtrend
             & (rsi_3_4h_gt_20 | (roc_9_4h_gt_neg_20) | (roc_9_1d_gt_neg_30))
             # 4h down move, 15m high, 1d overbought
@@ -17186,11 +17223,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 4h still high, 1d downtrend
             & ((rsi_3_4h_gt_30) | (aroonu_14_4h_lt_50) | (roc_9_1d_gt_neg_40))
             # 4h down move, 4h still high, 1d overbought
-            & ((rsi_3_4h_gt_30) | (aroonu_14_4h_lt_50) | (roc_9_1d < 200.0))
+            & ((rsi_3_4h_gt_30) | (aroonu_14_4h_lt_50) | (roc_9_1d_lt_200))
             # 4h down move, 4h still not low enough, 1d overbought
-            & ((rsi_3_4h_gt_30) | (stochrsi_k_4h_lt_20) | (roc_9_1d < 60.0))
+            & ((rsi_3_4h_gt_30) | (stochrsi_k_4h_lt_20) | (roc_9_1d_lt_60))
             # 4h down move, 1d high, 1d downtrend
-            & ((rsi_3_4h_gt_35) | (stochrsi_k_1d < 60.0) | (roc_9_1d_gt_neg_30))
+            & ((rsi_3_4h_gt_35) | (stochrsi_k_1d_lt_60) | (roc_9_1d_gt_neg_30))
             # 1h & 4h down move, 1d high & overbought
             & ((rsi_3_1h_gt_45) | (rsi_3_4h_gt_55) | (aroonu_14_1d_lt_80) | (roc_9_1d_lt_50))
             # 4h down move, 1h high, 1d overbought
@@ -17198,7 +17235,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 1d high, 1d downtrend
             & ((rsi_3_4h_gt_45) | (aroonu_14_1d_lt_80) | (roc_9_1d > -15.0))
             # 4h down move, 1d high & overbought
-            & ((rsi_3_4h_gt_45) | (stochrsi_k_1d_lt_90) | (roc_9_1d < 25.0))
+            & ((rsi_3_4h_gt_45) | (stochrsi_k_1d_lt_90) | (roc_9_1d_lt_25))
             # 4h down move, 4h still high, 1d downtrend
             & ((rsi_3_4h_gt_50) | (rsi_14_4h < 40.0) | (roc_9_1d_gt_neg_30))
             # 4h down move, 4h high & overbought
@@ -17226,25 +17263,25 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m downtrend, 4h & 1d high
             & ((cmf_20_15m > -0.30) | aroonu_14_4h_lt_80 | aroonu_14_1d_lt_100)
             # 15m & 1h high, 1h overbought
-            & ((aroonu_14_15m_lt_70) | (aroonu_14_1h_lt_100) | (roc_9_1h < 50.0))
+            & ((aroonu_14_15m_lt_70) | (aroonu_14_1h_lt_100) | (roc_9_1h_lt_50))
             # 15m & 1d high, 1d overbought
             & ((aroonu_14_15m_lt_70) | (aroonu_14_1d_lt_90) | (roc_9_1d_lt_30))
             # 1h & 4h high, 1h downtrend
             & (aroonu_14_1h_lt_70 | aroonu_14_4h_lt_100 | (cmf_20_1h > -0.30))
             # 1h high, 4h high, 1h overbought
-            & (aroonu_14_1h_lt_70 | aroonu_14_4h_lt_100 | (roc_9_1h < 20.0))
+            & (aroonu_14_1h_lt_70 | aroonu_14_4h_lt_100 | (roc_9_1h_lt_20))
             # 1h & 1d high, 1h overbought
-            & (aroonu_14_1h_lt_70 | (aroonu_14_1d_lt_70) | (roc_9_1h < 20.0))
+            & (aroonu_14_1h_lt_70 | (aroonu_14_1d_lt_70) | (roc_9_1h_lt_20))
             # 1h high, 1d high & overbought
-            & (aroonu_14_1h_lt_70 | aroonu_14_1d_lt_100 | (roc_9_1d < 200.0))
+            & (aroonu_14_1h_lt_70 | aroonu_14_1d_lt_100 | (roc_9_1d_lt_200))
             # 1h high, 1h & 1d overbought
-            & (aroonu_14_1h_lt_70 | (roc_9_1h < 20.0) | (roc_9_1d < 200.0))
+            & (aroonu_14_1h_lt_70 | (roc_9_1h_lt_20) | (roc_9_1d_lt_200))
             # 1h high, 4h downtrend, 1d overbought
-            & (aroonu_14_1h_lt_70 | (roc_9_4h > -40.0) | (roc_9_1d < 100.0))
+            & (aroonu_14_1h_lt_70 | (roc_9_4h > -40.0) | (roc_9_1d_lt_100))
             # 1h high, 1h & 1d overbought
-            & (aroonu_14_1h_lt_80 | (roc_9_1h < 20.0) | (roc_9_1d_lt_20))
+            & (aroonu_14_1h_lt_80 | (roc_9_1h_lt_20) | (roc_9_1d_lt_20))
             # 1h high, 1h overbought, 1d downtrend
-            & (aroonu_14_1h_lt_80 | (roc_9_1h < 30.0) | (roc_9_1d_gt_neg_40))
+            & (aroonu_14_1h_lt_80 | (roc_9_1h_lt_30) | (roc_9_1d_gt_neg_40))
             # 1h high, 4h & 1d overbought
             & (aroonu_14_1h_lt_80 | (roc_9_4h_lt_10) | (roc_9_1d_lt_40))
             # 1h high, 4h & 1d downtrend
@@ -17252,17 +17289,17 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h high, 1h overbought
             & ((aroonu_14_1h_lt_100) | aroonu_14_4h_lt_100 | (roc_9_1h_lt_10))
             # 4h high, 4h & 1d overbought
-            & ((aroonu_14_4h_lt_60) | (roc_9_4h_lt_30) | (roc_9_1d < 60.0))
+            & ((aroonu_14_4h_lt_60) | (roc_9_4h_lt_30) | (roc_9_1d_lt_60))
             # 4h & 1d high, 4h overbought
             & (aroonu_14_4h_lt_80 | aroonu_14_1d_lt_100 | (roc_9_4h_lt_30))
             # 4h high, 4h & 1d overbought
-            & (aroonu_14_4h_lt_80 | (roc_9_4h < 20.0) | (roc_9_1d_lt_20))
+            & (aroonu_14_4h_lt_80 | (roc_9_4h_lt_20) | (roc_9_1d_lt_20))
             # 4h high, 15m downtrend, 4h overbought
             & (aroonu_14_4h_lt_100 | (roc_9_15m > -30.0) | (roc_9_4h_lt_30))
             # 4h high, 1h & 4h overbought
-            & (aroonu_14_4h_lt_100 | (roc_9_1h < 30.0) | (roc_9_4h < 70.0))
+            & (aroonu_14_4h_lt_100 | (roc_9_1h_lt_30) | (roc_9_4h_lt_70))
             # 4h & 1d high, 1h overbought
-            & (aroonu_14_4h_lt_100 | aroonu_14_1d_lt_100 | (roc_9_1h < 50.0))
+            & (aroonu_14_4h_lt_100 | aroonu_14_1d_lt_100 | (roc_9_1h_lt_50))
             # 1d still high, 4h & 1d downtrend
             & ((aroonu_14_1d_lt_50) | (roc_9_4h > -50.0) | roc_9_1d_gt_neg_50)
             # 1d high, 1h & 4h downtrend
@@ -17274,17 +17311,17 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h high, 1d overbought
             & ((stochrsi_k_1h_lt_70) | (roc_9_1d_lt_40))
             # 1h high, 4h overbought
-            & ((stochrsi_k_1h_lt_80) | (roc_9_4h < 80.0))
+            & ((stochrsi_k_1h_lt_80) | (roc_9_4h_lt_80))
             # 1h high, 1h overbought, 4h downtrend
             & ((stochrsi_k_1h_lt_90) | (roc_9_1h_lt_10) | (roc_9_4h > -15.0))
             # 4h high, 1h & 4h overbought
-            & ((stochrsi_k_4h_lt_90) | (roc_9_1h < 20.0) | (roc_9_4h < 50.0))
+            & ((stochrsi_k_4h_lt_90) | (roc_9_1h_lt_20) | (roc_9_4h_lt_50))
             # 1d high, 4h & 1d overbought
-            & ((stochrsi_k_1d_lt_90) | (roc_9_4h < 100.0) | (roc_9_1d_lt_100))
+            & ((stochrsi_k_1d_lt_90) | (roc_9_4h_lt_100) | (roc_9_1d_lt_100))
             # 1d P&D, 4h overbought
             & ((change_pct_1d > -10.0) | (change_pct_1d.shift(288) < 30.0) | (roc_9_4h_lt_10))
             # big drop in the last 20 days, 1d high, 1d downtrend
-            & ((close > (high_max_20_1d * 0.20)) | (stochrsi_k_1d < 70.0) | (roc_9_1d > -15.0))
+            & ((close > (high_max_20_1d * 0.20)) | (stochrsi_k_1d_lt_70) | (roc_9_1d > -15.0))
           )
 
           # Logic
@@ -17300,15 +17337,15 @@ class NostalgiaForInfinityX7(IStrategy):
 
           long_entry_logic.append(
             # 5m & 1h down move, 1d still high
-            ((rsi_3_gt_3) | (rsi_3_1h_gt_3) | (stochrsi_k_1d < 40.0))
+            ((rsi_3_gt_3) | (rsi_3_1h_gt_3) | (stochrsi_k_1d_lt_40))
             # 5m & 1h down move, 1d high
-            & ((rsi_3_gt_3) | (rsi_3_1h_gt_25) | (stochrsi_k_1d < 70.0))
+            & ((rsi_3_gt_3) | (rsi_3_1h_gt_25) | (stochrsi_k_1d_lt_70))
             # 15m & 1h down move, 4h high
             & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_3) | (stochrsi_k_4h_lt_70))
             # 15m & 1h down move, 1h downtrend
             & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_3) | (roc_9_1h > -50.0))
             # 15m & 1h down move, 1d still not low enough
-            & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_5) | (stochrsi_k_1d < 30.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_5) | (stochrsi_k_1d_lt_30))
             # 15m & 1h down move, 4h still high
             & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_10) | (aroonu_14_4h_lt_50))
             # 15m & 1h down move, 1d high
@@ -17352,7 +17389,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 4h high
             & ((rsi_3_15m_gt_10) | rsi_3_1h_gt_20 | aroonu_14_4h_lt_100)
             # 15m & 1h down move, 1d overbought
-            & ((rsi_3_15m_gt_10) | rsi_3_1h_gt_20 | (roc_9_1d < 10.0))
+            & ((rsi_3_15m_gt_10) | rsi_3_1h_gt_20 | (roc_9_1d_lt_10))
             # 15m & 4h down move, 1d high
             & ((rsi_3_15m_gt_10) | (rsi_3_4h_gt_30) | (stochrsi_k_1d_lt_90))
             # 15m & 1d down move, 4h still high
@@ -17360,11 +17397,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 4h down move, 4h still high
             & ((rsi_3_15m_gt_10) | (rsi_3_4h_gt_10) | (stochrsi_k_4h_lt_40))
             # 15m & 4h down move, 1d high
-            & ((rsi_3_15m_gt_10) | rsi_3_4h_gt_20 | (stochrsi_k_1d < 70.0))
+            & ((rsi_3_15m_gt_10) | rsi_3_4h_gt_20 | (stochrsi_k_1d_lt_70))
             # 15m & 4h down move, 4h still not low enough
             & ((rsi_3_15m_gt_10) | rsi_3_4h_gt_20 | (stochrsi_k_4h_lt_30))
             # 15m & 4h down move, 1d high
-            & ((rsi_3_15m_gt_10) | rsi_3_4h_gt_20 | (stochrsi_k_1d < 80.0))
+            & ((rsi_3_15m_gt_10) | rsi_3_4h_gt_20 | (stochrsi_k_1d_lt_80))
             # 15m & 1h down move, 1h high
             & ((rsi_3_15m_gt_15) | (rsi_3_1h_gt_15) | (aroonu_14_1h_lt_70))
             # 15m & 1h down move, 15m still high
@@ -17374,7 +17411,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 4h down move, 4h high
             & ((rsi_3_15m_gt_15) | rsi_3_4h_gt_20 | (aroonu_14_4h_lt_60))
             # 15m & 1d down move, 1d high
-            & ((rsi_3_15m_gt_15) | (rsi_3_1d_gt_40) | (stochrsi_k_1d < 70.0))
+            & ((rsi_3_15m_gt_15) | (rsi_3_1d_gt_40) | (stochrsi_k_1d_lt_70))
             # 15m down move, 15m high
             & ((rsi_3_15m_gt_15) | (aroonu_14_15m_lt_70))
             # 15m & 4h down move, 4h high
@@ -17398,7 +17435,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 1d still high
             & ((rsi_3_1h_gt_3) | (rsi_3_4h_gt_15) | (aroonu_14_1d_lt_50))
             # 1h & 4h down move, 1d still high
-            & ((rsi_3_1h_gt_3) | (rsi_3_4h_gt_15) | (stochrsi_k_1d < 50.0))
+            & ((rsi_3_1h_gt_3) | (rsi_3_4h_gt_15) | (stochrsi_k_1d_lt_50))
             # 1h & 4h down move, 1h still high
             & ((rsi_3_1h_gt_3) | rsi_3_4h_gt_20 | (aroonu_14_1h_lt_40))
             # 1h & 4h down move, 4h still not low enough
@@ -17420,7 +17457,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 1h high
             & ((rsi_3_1h_gt_5) | (rsi_3_4h_gt_25) | aroonu_14_1h_lt_70)
             # 1h & 4h down move, 1d high
-            & ((rsi_3_1h_gt_5) | (rsi_3_4h_gt_25) | (stochrsi_k_1d < 80.0))
+            & ((rsi_3_1h_gt_5) | (rsi_3_4h_gt_25) | (stochrsi_k_1d_lt_80))
             # 1h & 4h down move, 1d overbought
             & ((rsi_3_1h_gt_5) | (rsi_3_4h_gt_35) | (roc_9_1d_lt_40))
             # 1h & 1d down move, 1h still high
@@ -17430,13 +17467,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 1d high
             & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_10) | (aroonu_14_1d_lt_75))
             # 1h & 4h down move, 1d high
-            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_10) | (stochrsi_k_1d < 80.0))
+            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_10) | (stochrsi_k_1d_lt_80))
             # 1h & 4h down move, 4h downtrend
             & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_10) | (roc_9_4h > -20.0))
             # 1h & 4h down move, 1d downtrend
             & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_10) | (roc_9_1d > -20.0))
             # 1h & 4h down move, 1d overbought
-            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_10) | (roc_9_1d < 10.0))
+            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_10) | (roc_9_1d_lt_10))
             # 1h & 4h down move, 1d high
             & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_15) | (aroonu_14_1d_lt_80))
             # 1h & 4h down move, 4h still not low enough
@@ -17456,7 +17493,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 4h high
             & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_35) | (stochrsi_k_4h_lt_70))
             # 1h & 1d down move, 1d still high
-            & ((rsi_3_1h_gt_10) | (rsi_3_1d_gt_10) | (stochrsi_k_1d < 50.0))
+            & ((rsi_3_1h_gt_10) | (rsi_3_1d_gt_10) | (stochrsi_k_1d_lt_50))
             # 1h & 1d down move, 1d still high
             & ((rsi_3_1h_gt_10) | (rsi_3_1d_gt_25) | (rsi_14_1d < 50.0))
             # 1h & 1d down move, 1h high
@@ -17492,19 +17529,19 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 4h still not low enough
             & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_15) | (stochrsi_k_4h_lt_20))
             # 1h & 4h down move, 1d high
-            & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_15) | (stochrsi_k_1d < 70.0))
+            & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_15) | (stochrsi_k_1d_lt_70))
             # 1h & 4h down move, 1d downtrend
             & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_25) | (roc_9_1d_gt_neg_40))
             # 1h & 4h down move, 4h high
             & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_30) | (aroonu_14_4h_lt_60))
             # 1h & 4h down move, 1d high
-            & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_30) | (stochrsi_k_1d < 80.0))
+            & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_30) | (stochrsi_k_1d_lt_80))
             # 1h & 4h down move, 4h overbought
             & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_35) | (roc_9_4h_lt_10))
             # 1h & 1d down move, 4h high
             & ((rsi_3_1h_gt_15) | (rsi_3_1d_gt_20) | (stochrsi_k_4h_lt_60))
             # 1h & 1d down move, 1d overbought
-            & ((rsi_3_1h_gt_15) | (rsi_3_1d_gt_35) | (roc_9_1d < 10.0))
+            & ((rsi_3_1h_gt_15) | (rsi_3_1d_gt_35) | (roc_9_1d_lt_10))
             # 1h down move, 1h downtrend, 1h high
             & ((rsi_3_1h_gt_15) | (cmf_20_1h > -0.30) | (aroonu_14_1h_lt_70))
             # 1h down move, 1h still high, 4h downtrend
@@ -17528,13 +17565,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 15m high
             & ((rsi_3_1h_gt_20) | (rsi_3_4h_gt_20) | (stochrsi_k_15m_lt_60))
             # 1h & 4h down move, 15m still not low enough, 1d still not low enough
-            & ((rsi_3_1h_gt_20) | (rsi_3_4h_gt_20) | (stochrsi_k_15m_lt_30) | (stochrsi_k_1d < 30.0))
+            & ((rsi_3_1h_gt_20) | (rsi_3_4h_gt_20) | (stochrsi_k_15m_lt_30) | (stochrsi_k_1d_lt_30))
             # 1h & 4h down move, 1d overbought
             & ((rsi_3_1h_gt_20) | (rsi_3_4h_gt_20) | (roc_9_1d_lt_30))
             # 1h & 4h down move, 4h high
             & ((rsi_3_1h_gt_20) | (rsi_3_4h_gt_50) | (stochrsi_k_4h_lt_80))
             # 1h & 1d down move, 1d high
-            & ((rsi_3_1h_gt_20) | (rsi_3_1d_gt_20) | (stochrsi_k_1d < 60.0))
+            & ((rsi_3_1h_gt_20) | (rsi_3_1d_gt_20) | (stochrsi_k_1d_lt_60))
             # 1h & 1d down move, 1d high
             & ((rsi_3_1h_gt_20) | (rsi_3_1d_gt_30) | (aroonu_14_1d_lt_100))
             # 1h & 1d down move, 1d overbought
@@ -17546,7 +17583,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1d high & overbought
             & ((rsi_3_1h_gt_20) | (aroonu_14_1d_lt_100) | (roc_9_1d_lt_30))
             # 1h down move, 1d high, 4h downtrend
-            & ((rsi_3_1h_gt_20) | (stochrsi_k_1d < 80.0) | (roc_9_4h_gt_neg_20))
+            & ((rsi_3_1h_gt_20) | (stochrsi_k_1d_lt_80) | (roc_9_4h_gt_neg_20))
             # 1h & 4h down move, 15m high
             & ((rsi_3_1h_gt_25) | (rsi_3_4h_gt_25) | (stochrsi_k_15m_lt_70))
             # 1h & 4h down move, 4h high
@@ -17554,7 +17591,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 1d down move, 1h high
             & ((rsi_3_1h_gt_25) | (rsi_3_1d_gt_25) | aroonu_14_1h_lt_80)
             # 1h & 1d down move, 1d high
-            & ((rsi_3_1h_gt_25) | (rsi_3_1d_gt_45) | (stochrsi_k_1d < 80.0))
+            & ((rsi_3_1h_gt_25) | (rsi_3_1d_gt_45) | (stochrsi_k_1d_lt_80))
             # 1h down move, 4h downtrend, 4h high
             & ((rsi_3_1h_gt_25) | (cmf_20_4h > -0.50) | aroonu_14_4h_lt_70)
             # 1h down move, 1h high, 1d overbought
@@ -17564,7 +17601,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 4h high & overbought
             & ((rsi_3_1h_gt_25) | aroonu_14_4h_lt_70 | (roc_9_4h_lt_10))
             # 1h down move, 1d high & overbought
-            & ((rsi_3_1h_gt_25) | (aroonu_14_1d_lt_80) | (roc_9_1d < 200.0))
+            & ((rsi_3_1h_gt_25) | (aroonu_14_1d_lt_80) | (roc_9_1d_lt_200))
             # 1h down move, 1d high, 4h overbought
             & ((rsi_3_1h_gt_25) | (aroonu_14_1d_lt_100) | (roc_9_4h_lt_10))
             # 1h down move, 1h high & overbought
@@ -17622,7 +17659,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 4h high & overbought
             & ((rsi_3_1h_gt_40) | (stochrsi_k_4h_lt_70) | (roc_9_4h_lt_40))
             # 1h down move, 4h high & overbought
-            & ((rsi_3_1h_gt_45) | aroonu_14_4h_lt_80 | (roc_9_4h < 100.0))
+            & ((rsi_3_1h_gt_45) | aroonu_14_4h_lt_80 | (roc_9_4h_lt_100))
             # 1h down move, 4h high & overbought
             & ((rsi_3_1h_gt_50) | aroonu_14_4h_lt_100 | (roc_9_4h_lt_40))
             # 1h down move, 1d high & overbought
@@ -17632,7 +17669,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h & 1d down move
             & ((rsi_3_4h_gt_3) | (rsi_3_1d_gt_15))
             # 4h & 1d down move, 1d high
-            & ((rsi_3_4h_gt_3) | (rsi_3_1d_gt_25) | (stochrsi_k_1d < 60.0))
+            & ((rsi_3_4h_gt_3) | (rsi_3_1d_gt_25) | (stochrsi_k_1d_lt_60))
             # 4h down move, 1h downtrend, 4h still high
             & ((rsi_3_4h_gt_3) | (cmf_20_1h > -0.30) | (aroonu_14_4h_lt_40))
             # 4h & 1d down move, 4h downtrend
@@ -17642,7 +17679,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h & 1d down move, 1d still high
             & ((rsi_3_4h_gt_5) | (rsi_3_1d_gt_20) | (aroonu_14_1d_lt_40))
             # 4h & 1d down move, 1d still high
-            & ((rsi_3_4h_gt_5) | (rsi_3_1d_gt_20) | (stochrsi_k_1d < 50.0))
+            & ((rsi_3_4h_gt_5) | (rsi_3_1d_gt_20) | (stochrsi_k_1d_lt_50))
             # 4h & 1d down move, 4h still not low enough
             & ((rsi_3_4h_gt_5) | (rsi_3_1d_gt_30) | (aroonu_14_4h_lt_20))
             # 4h & 1d down move, 1d high
@@ -17662,7 +17699,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h & 1d down move, 4h downtrend
             & ((rsi_3_4h_gt_10) | (rsi_3_1d_gt_30) | (roc_9_4h > -20.0))
             # 4h & 1d down move, 1d overbought
-            & ((rsi_3_4h_gt_10) | (rsi_3_1d_gt_45) | (roc_9_1d < 10.0))
+            & ((rsi_3_4h_gt_10) | (rsi_3_1d_gt_45) | (roc_9_1d_lt_10))
             # 4h & 1d down move, 4h still not low enough
             & ((rsi_3_4h_gt_10) | (rsi_3_1d > 50.0) | (stochrsi_k_4h_lt_20))
             # 4h down move, 15m high, 1h downtrend
@@ -17702,7 +17739,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 1h & 4h downtrend
             & ((rsi_3_4h_gt_15) | (roc_9_1h > -40.0) | (roc_9_4h > -40.0))
             # 4h & 1d down move, 1d high
-            & (rsi_3_4h_gt_20 | (rsi_3_1d_gt_20) | (stochrsi_k_1d < 80.0))
+            & (rsi_3_4h_gt_20 | (rsi_3_1d_gt_20) | (stochrsi_k_1d_lt_80))
             # 4h & 1d down move, 15m high
             & (rsi_3_4h_gt_20 | (rsi_3_1d_gt_30) | (stochrsi_k_15m_lt_80))
             # 4h & 1d down move, 1d high
@@ -17712,7 +17749,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 4h high
             & (rsi_3_4h_gt_20 | aroonu_14_4h_lt_100)
             # 4h down move, 1d high & overbought
-            & (rsi_3_4h_gt_20 | (aroonu_14_1d_lt_70) | (roc_9_1d < 70.0))
+            & (rsi_3_4h_gt_20 | (aroonu_14_1d_lt_70) | (roc_9_1d_lt_70))
             # 4h down move, 1d high, 4h downtrend
             & (rsi_3_4h_gt_20 | (aroonu_14_1d_lt_90) | (roc_9_4h > -50.0))
             # 4h down move, 1d high & overbought
@@ -17724,7 +17761,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 4h & 1d downtrend
             & (rsi_3_4h_gt_20 | (roc_9_4h_gt_neg_20) | (roc_9_1d_gt_neg_20))
             # 4h down move, 1d high, 4h downtrend
-            & (rsi_3_4h_gt_20 | (stochrsi_k_1d < 80.0) | (roc_9_4h_gt_neg_20))
+            & (rsi_3_4h_gt_20 | (stochrsi_k_1d_lt_80) | (roc_9_4h_gt_neg_20))
             # 4h & 1d down move, 1h high
             & ((rsi_3_4h_gt_25) | (rsi_3_1d_gt_25) | (aroonu_14_1h_lt_90))
             # 4h & 1d down move, 1d high
@@ -17752,7 +17789,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 4h high
             & ((rsi_3_4h_gt_30) | aroonu_14_4h_lt_100)
             # 4h down move, 1d high & overbought
-            & ((rsi_3_4h_gt_30) | (aroonu_14_1d_lt_70) | (roc_9_1d < 60.0))
+            & ((rsi_3_4h_gt_30) | (aroonu_14_1d_lt_70) | (roc_9_1d_lt_60))
             # 4h down move, 15m still high, 4h high
             & ((rsi_3_4h_gt_35) | (aroonu_14_15m_lt_50) | aroonu_14_4h_lt_80)
             # 4h down move, 1h high
@@ -17764,7 +17801,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 1d high & overbought
             & ((rsi_3_4h_gt_35) | aroonu_14_1d_lt_100 | (roc_9_1d_lt_20))
             # 4h down move, 4h still high, 1d overbought
-            & ((rsi_3_4h_gt_35) | (stochrsi_k_4h_lt_50) | (roc_9_1d < 200.0))
+            & ((rsi_3_4h_gt_35) | (stochrsi_k_4h_lt_50) | (roc_9_1d_lt_200))
             # 4h down move, 4h & 1d high
             & ((rsi_3_4h_gt_40) | aroonu_14_4h_lt_70 | aroonu_14_1d_lt_100)
             # 4h down move, 4h high, 1d overbought
@@ -17774,7 +17811,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 4h overbought, 1d downtrend
             & ((rsi_3_4h_gt_40) | (roc_9_4h_lt_10) | (roc_9_1d_gt_neg_40))
             # 4h down move, 4h & 1d overbought
-            & ((rsi_3_4h_gt_40) | (roc_9_4h < 60.0) | (roc_9_1d_lt_80))
+            & ((rsi_3_4h_gt_40) | (roc_9_4h_lt_60) | (roc_9_1d_lt_80))
             # 4h down move, 4h & 1d high
             & ((rsi_3_4h_gt_45) | aroonu_14_4h_lt_80 | aroonu_14_1d_lt_100)
             # 4h down move, 4h overbought
@@ -17784,7 +17821,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1d down move, 1d high, 1d downtrend
             & ((rsi_3_1d_gt_15) | (aroonu_14_1d_lt_70) | (roc_9_1d_gt_neg_20))
             # 1d down move, 1d still high
-            & ((rsi_3_1d_gt_15) | (stochrsi_k_1d < 40.0))
+            & ((rsi_3_1d_gt_15) | (stochrsi_k_1d_lt_40))
             # 1d down move, 4h & 1d downtrend
             & ((rsi_3_1d_gt_15) | (roc_9_4h > -10.0) | (roc_9_1d_gt_neg_40))
             # 1d down move, 15m high
@@ -17794,7 +17831,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1d down move, 1d high, 1d downtrend
             & ((rsi_3_1d_gt_25) | (aroonu_14_1d_lt_80) | (roc_9_1d_gt_neg_30))
             # 1d down move, 1d still high, 1d downtrend
-            & ((rsi_3_1d_gt_25) | (stochrsi_k_1d < 50.0) | (roc_9_1d_gt_neg_20))
+            & ((rsi_3_1d_gt_25) | (stochrsi_k_1d_lt_50) | (roc_9_1d_gt_neg_20))
             # 1d down move, 4h & 1d high
             & ((rsi_3_1d_gt_30) | (aroonu_14_4h_lt_90) | (aroonu_14_1d_lt_90))
             # 1h & 4h downtrend, 4h high
@@ -17802,7 +17839,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h & 1d downtrend, 1d high
             & ((cmf_20_4h > -0.50) | (cmf_20_1d > -0.50) | (aroonu_14_1d_lt_85))
             # 15m & 1d high, 4h overbought
-            & ((aroonu_14_15m_lt_70) | aroonu_14_1d_lt_100 | (roc_9_4h < 20.0))
+            & ((aroonu_14_15m_lt_70) | aroonu_14_1d_lt_100 | (roc_9_4h_lt_20))
             # 15m & 4h high, 1d downtrend
             & ((aroonu_14_15m_lt_85) | (aroonu_14_4h_lt_85) | (roc_9_1d_gt_neg_20))
             # 1h still high, 1h & 4h downtrend
@@ -17816,27 +17853,27 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h & 1d high, 1d overbought
             & (aroonu_14_4h_lt_70 | aroonu_14_1d_lt_100 | (roc_9_1d_lt_80))
             # 4h high, 4h & 1d overbought
-            & ((aroonu_14_4h_lt_90) | (roc_9_4h_lt_10) | (roc_9_1d < 10.0))
+            & ((aroonu_14_4h_lt_90) | (roc_9_4h_lt_10) | (roc_9_1d_lt_10))
             # 1d high, 4h & 1d overbought
-            & ((aroonu_14_1d_lt_70) | (roc_9_4h_lt_30) | (roc_9_1d < 200.0))
+            & ((aroonu_14_1d_lt_70) | (roc_9_4h_lt_30) | (roc_9_1d_lt_200))
             # 1d high, 4h downtrend, 1d overbought
-            & ((aroonu_14_1d_lt_85) | (roc_9_4h_gt_neg_20) | (roc_9_1d < 200.0))
+            & ((aroonu_14_1d_lt_85) | (roc_9_4h_gt_neg_20) | (roc_9_1d_lt_200))
             # 1d high, 1h & 4h downtrend
             & (aroonu_14_1d_lt_100 | (roc_9_1h > -30.0) | (roc_9_4h_gt_neg_30))
             # 1d high, 1h & 1d overbought
             & (aroonu_14_1d_lt_100 | (roc_9_1h_lt_10) | (roc_9_1d_lt_30))
             # 1d high, 4h & 1d overbought
-            & (aroonu_14_1d_lt_100 | (roc_9_4h_lt_30) | (roc_9_1d < 60.0))
+            & (aroonu_14_1d_lt_100 | (roc_9_4h_lt_30) | (roc_9_1d_lt_60))
             # 15m still high, 1h & 4h downtrend
             & ((stochrsi_k_15m_lt_50) | (roc_9_1h > -20.0) | (roc_9_4h_gt_neg_20))
             # 4h high, 1h & 4h overbought
-            & ((stochrsi_k_4h_lt_90) | (roc_9_1h < 20.0) | (roc_9_4h_lt_30))
+            & ((stochrsi_k_4h_lt_90) | (roc_9_1h_lt_20) | (roc_9_4h_lt_30))
             # 4h high, 4h & 1d overbought
             & ((stochrsi_k_4h_lt_90) | (roc_9_4h_lt_20) | (roc_9_1d_lt_80))
             # 1d still high, 4h & 1d downtrend
-            & ((stochrsi_k_1d < 50.0) | (roc_9_4h_gt_neg_30) | (roc_9_1d_gt_neg_30))
+            & ((stochrsi_k_1d_lt_50) | (roc_9_4h_gt_neg_30) | (roc_9_1d_gt_neg_30))
             # big drop in the last 20 days, 1d high, 1d downtrend
-            & ((close > (high_max_20_1d * 0.20)) | (stochrsi_k_1d < 70.0) | (roc_9_1d > -15.0))
+            & ((close > (high_max_20_1d * 0.20)) | (stochrsi_k_1d_lt_70) | (roc_9_1d > -15.0))
           )
 
           # Logic
@@ -17869,7 +17906,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 5m down move, 1h & 4h high
             & ((rsi_3_gt_3) | aroonu_14_1h_lt_80 | aroonu_14_4h_lt_100)
             # 5m down move, 4h high & overbought
-            & ((rsi_3_gt_3) | aroonu_14_4h_lt_100 | (roc_9_4h < 20.0))
+            & ((rsi_3_gt_3) | aroonu_14_4h_lt_100 | (roc_9_4h_lt_20))
             # 5m down move, 1h high, 4h overbought
             & ((rsi_3_gt_3) | (stochrsi_k_1h_lt_80) | (roc_9_4h_lt_20))
             # 5m down move, 1d high & overbought
@@ -17893,7 +17930,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 1d high
             & ((rsi_3_15m_gt_3) | (rsi_3_1h_gt_10) | (aroonu_14_1d_lt_70))
             # 15m & 1d down move, 1d overbought
-            & ((rsi_3_15m_gt_3) | (rsi_3_1h_gt_10) | (roc_9_1d < 10.0))
+            & ((rsi_3_15m_gt_3) | (rsi_3_1h_gt_10) | (roc_9_1d_lt_10))
             # 15m & 1h down move, 1h still high
             & ((rsi_3_15m_gt_3) | (rsi_3_1h_gt_15) | (aroonu_14_1h_lt_40))
             # 15m & 1h down move, 1d high
@@ -17909,7 +17946,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 1d high
             & ((rsi_3_15m_gt_3) | (rsi_3_1h_gt_30) | (stochrsi_k_1d_lt_90))
             # 15m & 1h down move, 1d overbought
-            & ((rsi_3_15m_gt_3) | (rsi_3_1h_gt_30) | (roc_9_1d < 200.0))
+            & ((rsi_3_15m_gt_3) | (rsi_3_1h_gt_30) | (roc_9_1d_lt_200))
             # 15m & 1h down move, 1h still high
             & ((rsi_3_15m_gt_3) | (rsi_3_1h_gt_35) | (stochrsi_k_1h_lt_40))
             # 15m & 1h down move, 4h high
@@ -17919,7 +17956,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 4h down move, 15m high
             & ((rsi_3_15m_gt_3) | (rsi_3_4h_gt_20) | (aroonu_14_15m_lt_70))
             # 15m & 4h down move, 1d overbought
-            & ((rsi_3_15m_gt_3) | (rsi_3_4h_gt_35) | (roc_9_1d < 60.0))
+            & ((rsi_3_15m_gt_3) | (rsi_3_4h_gt_35) | (roc_9_1d_lt_60))
             # 15m & 1d down move, 1d still high
             & ((rsi_3_15m_gt_3) | (rsi_3_1d_gt_10) | (aroonu_14_1d_lt_40))
             # 15m & 1d down move, 4h still high
@@ -17927,7 +17964,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1d down move, 1d high
             & ((rsi_3_15m_gt_3) | (rsi_3_1d_gt_45) | (aroonu_14_1d_lt_70))
             # 15m down move, 4h high & overbought
-            & ((rsi_3_15m_gt_3) | (aroonu_14_4h_lt_90) | (roc_9_4h < 100.0))
+            & ((rsi_3_15m_gt_3) | (aroonu_14_4h_lt_90) | (roc_9_4h_lt_100))
             # 15m down move, 1d high & overbought
             & ((rsi_3_15m_gt_3) | (aroonu_14_1d_lt_100) | (roc_9_1d_lt_40))
             # 15m down move, 1h high, 1d downtrend
@@ -17935,9 +17972,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 4h high & overbought
             & ((rsi_3_15m_gt_3) | (stochrsi_k_4h_lt_80) | (roc_9_4h_lt_40))
             # 15m down move, 4h high, 1d overbought
-            & ((rsi_3_15m_gt_3) | (stochrsi_k_4h_lt_80) | (roc_9_1d < 10.0))
+            & ((rsi_3_15m_gt_3) | (stochrsi_k_4h_lt_80) | (roc_9_1d_lt_10))
             # 15m down move, 1h downtrend, 4h overbought
-            & ((rsi_3_15m_gt_3) | (roc_9_1h > -30.0) | (roc_9_4h < 100.0))
+            & ((rsi_3_15m_gt_3) | (roc_9_1h > -30.0) | (roc_9_4h_lt_100))
             # 15m down move, 4h & 1d downtrend
             & ((rsi_3_15m_gt_3) | (roc_9_4h > -70.0) | (roc_9_1d > -70.0))
             # 15m & 1h down move, 4h still high
@@ -17945,9 +17982,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 1h still not low enough
             & ((rsi_3_15m_gt_5) | (rsi_3_1h_gt_15) | (stochrsi_k_1h_lt_20))
             # 15m & 1h down move, 1d still high
-            & ((rsi_3_15m_gt_5) | rsi_3_1h_gt_20 | (stochrsi_k_1d < 50.0))
+            & ((rsi_3_15m_gt_5) | rsi_3_1h_gt_20 | (stochrsi_k_1d_lt_50))
             # 15m & 1h down move, 1d overbought
-            & ((rsi_3_15m_gt_5) | (rsi_3_1h_gt_25) | (roc_9_1d < 70.0))
+            & ((rsi_3_15m_gt_5) | (rsi_3_1h_gt_25) | (roc_9_1d_lt_70))
             # 15m & 1h down move, 4h high
             & ((rsi_3_15m_gt_5) | (rsi_3_1h_gt_30) | (aroonu_14_4h_lt_70))
             # 15m & 1h down move, 1h high
@@ -17973,9 +18010,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 1h high, 4h overbought
             & ((rsi_3_15m_gt_5) | (aroonu_14_1h_lt_80) | (roc_9_4h_lt_10))
             # 15m down move, 4h high & overbought
-            & ((rsi_3_15m_gt_5) | (aroonu_14_4h_lt_80) | (roc_9_4h < 50.0))
+            & ((rsi_3_15m_gt_5) | (aroonu_14_4h_lt_80) | (roc_9_4h_lt_50))
             # 15m down move, 1d still high, 1d downtrend
-            & ((rsi_3_15m_gt_5) | (stochrsi_k_1d < 50.0) | (roc_9_1d_gt_neg_20))
+            & ((rsi_3_15m_gt_5) | (stochrsi_k_1d_lt_50) | (roc_9_1d_gt_neg_20))
             # 15m down move, 1d downtrend
             & ((rsi_3_15m_gt_5) | (roc_9_1d > -60.0))
             # 15m down move, 1h & 1d high
@@ -18043,11 +18080,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 4h & 1d high
             & ((rsi_3_15m_gt_10) | (aroonu_14_4h_lt_90) | aroonu_14_1d_lt_100)
             # 15m down move, 1d high & overbought
-            & ((rsi_3_15m_gt_10) | aroonu_14_1d_lt_100 | (roc_9_1d < 100.0))
+            & ((rsi_3_15m_gt_10) | aroonu_14_1d_lt_100 | (roc_9_1d_lt_100))
             # 15m down move, 4h still high, 1d overbought
             & ((rsi_3_15m_gt_10) | (stochrsi_k_4h_lt_50) | (roc_9_1d_lt_30))
             # 15m down move, 4h & 1d overbought
-            & ((rsi_3_15m_gt_10) | (roc_9_4h_lt_10) | (roc_9_1d < 200.0))
+            & ((rsi_3_15m_gt_10) | (roc_9_4h_lt_10) | (roc_9_1d_lt_200))
             # 15m & 1h down move, 1h high
             & ((rsi_3_15m_gt_15) | (rsi_3_1h_gt_15) | (aroonu_14_1h_lt_90))
             # 15m & 1h down move, 1d high
@@ -18067,13 +18104,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 4h high & overbought
             & ((rsi_3_15m_gt_15) | (aroonu_14_4h_lt_60) | (roc_9_4h_lt_30))
             # 15m down move, 4h high, 1d overbought
-            & ((rsi_3_15m_gt_15) | (aroonu_14_4h_lt_70) | (roc_9_1d < 200.0))
+            & ((rsi_3_15m_gt_15) | (aroonu_14_4h_lt_70) | (roc_9_1d_lt_200))
             # 15m down move, 4h high, 1d overbought
-            & ((rsi_3_15m_gt_15) | (aroonu_14_4h_lt_100) | (roc_9_1d < 100.0))
+            & ((rsi_3_15m_gt_15) | (aroonu_14_4h_lt_100) | (roc_9_1d_lt_100))
             # 15m down move, 1h high, 4h downtrend
             & ((rsi_3_15m_gt_15) | (stochrsi_k_1h_lt_70) | (roc_9_4h_gt_neg_30))
             # 15m down move, 4h high & overbought
-            & ((rsi_3_15m_gt_15) | (stochrsi_k_4h_lt_90) | (roc_9_4h < 25.0))
+            & ((rsi_3_15m_gt_15) | (stochrsi_k_4h_lt_90) | (roc_9_4h_lt_25))
             # 15m down move, 4h high, 1d downtrend
             & ((rsi_3_15m_gt_15) | (stochrsi_k_4h_lt_90) | (roc_9_1d_gt_neg_40))
             # 15m down move, 4h high, 1d overbought
@@ -18093,7 +18130,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 1h high, 4h overbought
             & ((rsi_3_15m_gt_20) | aroonu_14_1h_lt_80 | (roc_9_4h_lt_10))
             # 15m down move, 1h high, 1d overbought
-            & ((rsi_3_15m_gt_20) | aroonu_14_1h_lt_80 | (roc_9_1d < 10.0))
+            & ((rsi_3_15m_gt_20) | aroonu_14_1h_lt_80 | (roc_9_1d_lt_10))
             # 15m down move, 4h high & overbought
             & ((rsi_3_15m_gt_20) | aroonu_14_4h_lt_80 | (roc_9_4h_lt_10))
             # 15m & 1h down move, 15m high
@@ -18105,7 +18142,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 1d high & overbought
             & ((rsi_3_15m_gt_30) | aroonu_14_1d_lt_100 | roc_9_1d_lt_50)
             # 1h & 4h down move, 1d still high
-            & ((rsi_3_1h_gt_3) | (rsi_3_4h_gt_10) | (stochrsi_k_1d < 40.0))
+            & ((rsi_3_1h_gt_3) | (rsi_3_4h_gt_10) | (stochrsi_k_1d_lt_40))
             # 1h & 4h down move, 4h still high
             & ((rsi_3_1h_gt_3) | (rsi_3_4h_gt_15) | (aroonu_14_4h_lt_40))
             # 1h & 4h down move, 1d still high
@@ -18145,7 +18182,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 1d down move, 4h high
             & ((rsi_3_1h_gt_10) | (rsi_3_1d_gt_15) | (stochrsi_k_4h_lt_70))
             # 1h & 1d down move, 1d still high
-            & ((rsi_3_1h_gt_10) | (rsi_3_1d_gt_30) | (stochrsi_k_1d < 50.0))
+            & ((rsi_3_1h_gt_10) | (rsi_3_1d_gt_30) | (stochrsi_k_1d_lt_50))
             # 1h down move, 15m downtrend, 1d high
             & ((rsi_3_1h_gt_10) | (cmf_20_15m > -0.40) | (aroonu_14_1d_lt_70))
             # 1h down move, 1h high, 4h overbought
@@ -18161,7 +18198,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 1h downtrend
             & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_15) | (roc_9_1h > -15.0))
             # 1h & 4h down move, 1d overbought
-            & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_15) | (roc_9_1d < 10.0))
+            & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_15) | (roc_9_1d_lt_10))
             # 1h & 4h down move, 4h still high
             & ((rsi_3_1h_gt_15) | rsi_3_4h_gt_20 | (rsi_14_4h < 40.0))
             # 1h & 4h down move, 1h high
@@ -18183,7 +18220,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h high, 4h overbought
             & (rsi_3_1h_gt_20 | aroonu_14_1h_lt_70 | (roc_9_4h_lt_10))
             # 1h down move, 1h high & overbought
-            & (rsi_3_1h_gt_20 | aroonu_14_1d_lt_100 | (roc_9_1d < 100.0))
+            & (rsi_3_1h_gt_20 | aroonu_14_1d_lt_100 | (roc_9_1d_lt_100))
             # 1h down move, 4h downtrend, 1d overbought
             & (rsi_3_1h_gt_20 | (roc_9_4h > -40.0) | roc_9_1d_lt_50)
             # 1h & 4h down move, 1d high
@@ -18201,7 +18238,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h high & overbought
             & ((rsi_3_1h_gt_25) | (aroonu_14_1h_lt_80) | (roc_9_1h_lt_10))
             # 1h down move, 1h high, 4h overbought
-            & ((rsi_3_1h_gt_25) | (aroonu_14_1h_lt_80) | (roc_9_4h < 50.0))
+            & ((rsi_3_1h_gt_25) | (aroonu_14_1h_lt_80) | (roc_9_4h_lt_50))
             # 1h down move, 4h & 1d high
             & ((rsi_3_1h_gt_25) | (aroonu_14_4h_lt_90) | (aroonu_14_1d_lt_100))
             # 1h down move, 1d high, 4h downtrend
@@ -18215,7 +18252,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 15m & 4h high
             & ((rsi_3_1h_gt_30) | (rsi_3_4h_gt_50) | (aroonu_14_15m_lt_70) | (aroonu_14_1h_lt_70))
             # 1h down move, 1h high, 1d overbought
-            & ((rsi_3_1h_gt_30) | (aroonu_14_1h_lt_80) | (roc_9_1d < 10.0))
+            & ((rsi_3_1h_gt_30) | (aroonu_14_1h_lt_80) | (roc_9_1d_lt_10))
             # 1h down move, 4h high, 1d overbought
             & ((rsi_3_1h_gt_30) | (aroonu_14_4h_lt_70) | (roc_9_1d_lt_40))
             # 1h down move, 4h high & overbought
@@ -18225,7 +18262,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1d high, 4h overbought
             & ((rsi_3_1h_gt_30) | (aroonu_14_1d_lt_100) | (roc_9_4h_lt_30))
             # 1h down move, 4h & 1d overbought
-            & ((rsi_3_1h_gt_30) | (roc_9_4h_lt_30) | (roc_9_1d < 200.0))
+            & ((rsi_3_1h_gt_30) | (roc_9_4h_lt_30) | (roc_9_1d_lt_200))
             # 1h & 4h down move, 1d high
             & ((rsi_3_1h_gt_35) | (rsi_3_4h_gt_35) | (aroonu_14_1d_lt_90))
             # 1h down move, 1h high, 1d overbought
@@ -18233,7 +18270,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h & 4h high
             & ((rsi_3_1h_gt_35) | (aroonu_14_1h_lt_100) | (aroonu_14_4h_lt_100))
             # 1h down move, 1d high & overbought
-            & ((rsi_3_1h_gt_35) | (aroonu_14_1d_lt_100) | (roc_9_1d < 200.0))
+            & ((rsi_3_1h_gt_35) | (aroonu_14_1d_lt_100) | (roc_9_1d_lt_200))
             # 1h down move, 1h high, 4h downtrend
             & ((rsi_3_1h_gt_35) | (stochrsi_k_1h_lt_70) | (roc_9_4h_gt_neg_20))
             # 1h & 1d down move, 1h high
@@ -18263,7 +18300,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 1h still high, 4h downtrend
             & ((rsi_3_4h_gt_3) | (stochrsi_k_1h_lt_50) | (roc_9_4h_gt_neg_30))
             # 4h & 1d down move, 1d still high
-            & ((rsi_3_4h_gt_5) | (rsi_3_1d_gt_30) | (stochrsi_k_1d < 40.0))
+            & ((rsi_3_4h_gt_5) | (rsi_3_1d_gt_30) | (stochrsi_k_1d_lt_40))
             # 4h down move, 1h & 4h downtrend
             & ((rsi_3_4h_gt_5) | (roc_9_1h > -10.0) | (roc_9_4h > -10.0))
             # 4h & 1d down move, 4h downtrend
@@ -18293,7 +18330,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 4h still high, 1d downtrend
             & ((rsi_3_4h_gt_30) | (aroonu_14_4h_lt_50) | (roc_9_1d_gt_neg_40))
             # 4h down move, 1d high, 1d downtrend
-            & ((rsi_3_4h_gt_35) | (stochrsi_k_1d < 60.0) | (roc_9_1d_gt_neg_30))
+            & ((rsi_3_4h_gt_35) | (stochrsi_k_1d_lt_60) | (roc_9_1d_gt_neg_30))
             # 4h down move, 1d high, 1d downtrend
             & ((rsi_3_4h_gt_45) | (aroonu_14_1d_lt_80) | (roc_9_1d > -15.0))
             # 4h down move, 4h still high, 1d downtrend
@@ -18307,7 +18344,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h downtrend, 1h & 4h high
             & ((cmf_20_4h > -0.30) | aroonu_14_1h_lt_70 | aroonu_14_4h_lt_100)
             # 15m still high, 1h & 4h overbought
-            & ((aroonu_14_15m_lt_50) | (roc_9_1h < 100.0) | (roc_9_4h < 100.0))
+            & ((aroonu_14_15m_lt_50) | (roc_9_1h_lt_100) | (roc_9_4h_lt_100))
             # 15m & 1d high, 1d overbought
             & ((aroonu_14_15m_lt_70) | (aroonu_14_1d_lt_90) | (roc_9_1d_lt_30))
             # 1h still high, 4h & 1d downtrend
@@ -18317,23 +18354,23 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h high, 1d overbought
             & (aroonu_14_1h_lt_70 | aroonu_14_4h_lt_100 | (roc_9_1d_lt_20))
             # 1h & 1d high, 1d overbought
-            & (aroonu_14_1h_lt_70 | (aroonu_14_1d_lt_90) | (roc_9_1d < 200.0))
+            & (aroonu_14_1h_lt_70 | (aroonu_14_1d_lt_90) | (roc_9_1d_lt_200))
             # 1h high, 4h downtrend, 1d overbought
-            & (aroonu_14_1h_lt_70 | (roc_9_4h > -40.0) | (roc_9_1d < 100.0))
+            & (aroonu_14_1h_lt_70 | (roc_9_4h > -40.0) | (roc_9_1d_lt_100))
             # 1h & 4h high, 4h overbought
             & (aroonu_14_1h_lt_80 | aroonu_14_4h_lt_100 | (roc_9_4h_lt_30))
             # 1h high, 1d downtrend
             & (aroonu_14_1h_lt_80 | (roc_9_1d > -60.0))
             # 1h high, 1h & 4h overbought
-            & ((aroonu_14_1h_lt_100) | (roc_9_1h < 100.0) | (roc_9_4h < 100.0))
+            & ((aroonu_14_1h_lt_100) | (roc_9_1h_lt_100) | (roc_9_4h_lt_100))
             # 4h & 1d high, 1d overbought
-            & ((aroonu_14_4h_lt_60) | aroonu_14_1d_lt_100 | (roc_9_1d < 70.0))
+            & ((aroonu_14_4h_lt_60) | aroonu_14_1d_lt_100 | (roc_9_1d_lt_70))
             # 4h high, 1h & 4h overbought
-            & ((aroonu_14_4h_lt_85) | (roc_9_1h < 80.0) | (roc_9_4h < 80.0))
+            & ((aroonu_14_4h_lt_85) | (roc_9_1h_lt_80) | (roc_9_4h_lt_80))
             # 4h high, 1h downtrend, 4h overbought
-            & ((aroonu_14_4h_lt_90) | (roc_9_1h > -40.0) | (roc_9_4h < 100.0))
+            & ((aroonu_14_4h_lt_90) | (roc_9_1h > -40.0) | (roc_9_4h_lt_100))
             # 4h & 1d high, 4h overbought
-            & ((aroonu_14_4h_lt_90) | aroonu_14_1d_lt_100 | (roc_9_4h < 100.0))
+            & ((aroonu_14_4h_lt_90) | aroonu_14_1d_lt_100 | (roc_9_4h_lt_100))
             # 4h high, 1h & 4h overbought
             & ((aroonu_14_4h_lt_90) | (roc_9_1h_lt_10) | (roc_9_4h_lt_20))
             # 4h & 1d high, 4h overbought
@@ -18343,25 +18380,25 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1d high, 1h & 4h downtrend
             & (aroonu_14_1d_lt_100 | (roc_9_1h > -30.0) | (roc_9_4h_gt_neg_30))
             # 1d high, 4h & 1d overbought
-            & (aroonu_14_1d_lt_100 | (roc_9_4h < 20.0) | (roc_9_1d < 100.0))
+            & (aroonu_14_1d_lt_100 | (roc_9_4h_lt_20) | (roc_9_1d_lt_100))
             # 1h high, 1d overbought
             & ((stochrsi_k_1h_lt_70) | (roc_9_1d_lt_40))
             # 1h high, 4h overbought
-            & ((stochrsi_k_1h_lt_80) | (roc_9_4h < 80.0))
+            & ((stochrsi_k_1h_lt_80) | (roc_9_4h_lt_80))
             # 1h high, 4h & 1d downtrend
             & ((stochrsi_k_1h < 85.0) | (roc_9_4h > -70.0) | (roc_9_1d > -70.0))
             # 4h high, 1h & 4h overbought
-            & ((stochrsi_k_4h_lt_80) | (roc_9_1h < 40.0) | (roc_9_4h < 100.0))
+            & ((stochrsi_k_4h_lt_80) | (roc_9_1h_lt_40) | (roc_9_4h_lt_100))
             # 1d high, 4h & 1d overbought
             & ((stochrsi_k_1d_lt_90) | (roc_9_4h_lt_20) | (roc_9_1d_lt_100))
             # 1h & 4h overbought, 1d downtrend
-            & ((roc_9_1h < 40.0) | (roc_9_4h < 50.0) | (roc_9_1d_gt_neg_30))
+            & ((roc_9_1h_lt_40) | (roc_9_4h_lt_50) | (roc_9_1d_gt_neg_30))
             # big drop in last hour, 15m high
             & ((close > (close_max_12 * 0.60)) | (aroonu_14_15m_lt_70))
             # big drop in last hour, 4h high
             & ((close > (close_max_12 * 0.60)) | (aroonu_14_4h_lt_70))
             # big drop in the last 20 days, 1d high, 1d downtrend
-            & ((close > (high_max_20_1d * 0.20)) | (stochrsi_k_1d < 70.0) | (roc_9_1d > -15.0))
+            & ((close > (high_max_20_1d * 0.20)) | (stochrsi_k_1d_lt_70) | (roc_9_1d > -15.0))
           )
 
           # Logic
@@ -18408,9 +18445,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 4h down move, 1h still high
             & ((rsi_3_15m_gt_3) | (rsi_3_4h_gt_40) | (stochrsi_k_1h_lt_40))
             # 15m down move, 1h still high, 1d overbought
-            & ((rsi_3_15m_gt_3) | (aroonu_14_1h_lt_40) | (roc_9_1d < 70.0))
+            & ((rsi_3_15m_gt_3) | (aroonu_14_1h_lt_40) | (roc_9_1d_lt_70))
             # 15m down move, 4h high & overbought
-            & ((rsi_3_15m_gt_3) | (aroonu_14_4h_lt_100) | (roc_9_4h < 100.0))
+            & ((rsi_3_15m_gt_3) | (aroonu_14_4h_lt_100) | (roc_9_4h_lt_100))
             # 15m down move, 1h high
             & ((rsi_3_15m_gt_3) | (stochrsi_k_1h_lt_70))
             # 15m down move, 4h high, 15m downtrend
@@ -18440,7 +18477,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 1d still high
             & ((rsi_3_1h_gt_3) | (rsi_3_4h_gt_10) | (aroonu_14_1d_lt_50))
             # 1h & 4h down move, 1d high
-            & ((rsi_3_1h_gt_3) | (rsi_3_4h_gt_10) | (stochrsi_k_1d < 60.0))
+            & ((rsi_3_1h_gt_3) | (rsi_3_4h_gt_10) | (stochrsi_k_1d_lt_60))
             # 1h & 4h down move, 1d high
             & ((rsi_3_1h_gt_3) | (rsi_3_4h_gt_20) | (aroonu_14_1d_lt_60))
             # 1h & 4h down move, 4h high
@@ -18516,15 +18553,15 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 4h & 1d high
             & ((rsi_3_1h_gt_10) | (aroonu_14_4h_lt_60) | (aroonu_14_1d_lt_100))
             # 1h down move, 4h high, 1d overbought
-            & ((rsi_3_1h_gt_10) | (aroonu_14_4h_lt_90) | (roc_9_1d < 100.0))
+            & ((rsi_3_1h_gt_10) | (aroonu_14_4h_lt_90) | (roc_9_1d_lt_100))
             # 1h down move, 4h high
             & ((rsi_3_1h_gt_10) | (aroonu_14_4h_lt_100))
             # 1h down move, 1d high & overbought
-            & ((rsi_3_1h_gt_10) | (aroonu_14_1d_lt_100) | (roc_9_1d < 60.0))
+            & ((rsi_3_1h_gt_10) | (aroonu_14_1d_lt_100) | (roc_9_1d_lt_60))
             # 1h down move, 4h overbought
             & ((rsi_3_1h_gt_10) | (roc_9_4h_lt_10))
             # 1h down move, 4h high & overbought
-            & ((rsi_3_1h_gt_10) | (stochrsi_k_4h_lt_80) | (roc_9_4h < 20.0))
+            & ((rsi_3_1h_gt_10) | (stochrsi_k_4h_lt_80) | (roc_9_4h_lt_20))
             # 1h down move, 4h & 1d downtrend
             & ((rsi_3_1h_gt_10) | (roc_9_4h_gt_neg_30) | (roc_9_1d_gt_neg_50))
             # 1h & 4h down move, 4h high
@@ -18540,15 +18577,15 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h high, 4h downtrend
             & ((rsi_3_1h_gt_15) | (aroonu_14_1h_lt_70) | (roc_9_4h > -10.0))
             # 1h down move, 4h high & overbought
-            & ((rsi_3_1h_gt_15) | (aroonu_14_4h_lt_80) | (roc_9_4h < 100.0))
+            & ((rsi_3_1h_gt_15) | (aroonu_14_4h_lt_80) | (roc_9_4h_lt_100))
             # 1h down move, 1d high & overbought
-            & ((rsi_3_1h_gt_15) | (aroonu_14_1d_lt_80) | (roc_9_1d < 100.0))
+            & ((rsi_3_1h_gt_15) | (aroonu_14_1d_lt_80) | (roc_9_1d_lt_100))
             # 1h down move, 1h & 4h downtrend
             & ((rsi_3_1h_gt_15) | (roc_9_1h > -30.0) | (roc_9_4h_gt_neg_30))
             # 1h down move, 1h & 4h overbought
             & ((rsi_3_1h_gt_15) | (roc_9_4h_lt_10) | (roc_9_1d_lt_50))
             # 1h down move, 1h & 4h overbought
-            & ((rsi_3_1h_gt_15) | (roc_9_4h < 20.0) | (roc_9_1d_lt_20))
+            & ((rsi_3_1h_gt_15) | (roc_9_4h_lt_20) | (roc_9_1d_lt_20))
             # 1h & 4h down move, 4h high
             & (rsi_3_1h_gt_20 | (rsi_3_4h_gt_50) | (aroonu_14_4h_lt_90))
             # 1h down move, 1h still high, 4h downtrend
@@ -18572,7 +18609,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h downtrend, 4h overbought
             & ((rsi_3_1h_gt_25) | (roc_9_1h > -20.0) | (roc_9_4h_lt_20))
             # 1h down move, 1d overbought
-            & ((rsi_3_1h_gt_25) | (roc_9_1d < 200.0))
+            & ((rsi_3_1h_gt_25) | (roc_9_1d_lt_200))
             # 1h down move, 4h high
             & ((rsi_3_1h_gt_30) | (aroonu_14_4h_lt_100))
             # 1h down move, 4h high & overbought
@@ -18580,9 +18617,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 4h still high, 1d high
             & ((rsi_3_4h_gt_3) | (aroonu_14_4h_lt_50) | (aroonu_14_1d_lt_100))
             # 4h down move, 1d still high, 4h downtrend
-            & ((rsi_3_4h_gt_3) | (stochrsi_k_1d < 50.0) | (roc_9_4h_gt_neg_30))
+            & ((rsi_3_4h_gt_3) | (stochrsi_k_1d_lt_50) | (roc_9_4h_gt_neg_30))
             # 4h down move, 1d overbought
-            & ((rsi_3_4h_gt_3) | (roc_9_1d < 200.0))
+            & ((rsi_3_4h_gt_3) | (roc_9_1d_lt_200))
             # 4h down move, 1h still high
             & ((rsi_3_4h_gt_5) | (stochrsi_k_1h_lt_40))
             # 4h down move, 1h & 4h downtrend
@@ -18620,7 +18657,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 4h high
             & ((rsi_3_4h_gt_50) | (stochrsi_k_4h_lt_70))
             # 4h down move, 4h overbought
-            & ((rsi_3_4h_gt_50) | (roc_9_4h < 60.0))
+            & ((rsi_3_4h_gt_50) | (roc_9_4h_lt_60))
             # 4h downtrend, 4h high
             & ((cmf_20_4h > -0.50) | aroonu_14_4h_lt_70)
             # 1h & 1d high, 4h downtrend
@@ -18644,7 +18681,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h high, 1h downtrend
             & (aroonu_14_4h_lt_80 | (roc_9_1h > -40.0))
             # 4h high & overbought
-            & (aroonu_14_4h_lt_80 | (roc_9_4h < 100.0))
+            & (aroonu_14_4h_lt_80 | (roc_9_4h_lt_100))
             # 4h high, 1d downtrend
             & (aroonu_14_4h_lt_80 | (roc_9_1d > -30.0))
             # 1d still high, 1d downtrend
@@ -18658,9 +18695,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1d high, 4h downtrend
             & ((aroonu_14_1d_lt_90) | (roc_9_4h > -40.0))
             # 1d high & overbought
-            & ((aroonu_14_1d_lt_90) | (roc_9_1d < 200.0))
+            & ((aroonu_14_1d_lt_90) | (roc_9_1d_lt_200))
             # 1d high, 4h & 1d overbought
-            & (aroonu_14_1d_lt_100 | (roc_9_4h < 20.0) | (roc_9_1d_lt_80))
+            & (aroonu_14_1d_lt_100 | (roc_9_4h_lt_20) | (roc_9_1d_lt_80))
             # 1h still high, 4h & 1d downtrend
             & ((stochrsi_k_1h_lt_50) | (roc_9_4h_gt_neg_20) | roc_9_1d_gt_neg_50)
             # 1h high, 15m downtrend
@@ -18670,13 +18707,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1d high, 1h downtrend
             & ((stochrsi_k_1d_lt_90) | (roc_9_1h > -20.0))
             # 1d high, 1d downtrend
-            & ((stochrsi_k_1d < 60.0) | (roc_9_1d_gt_neg_30))
+            & ((stochrsi_k_1d_lt_60) | (roc_9_1d_gt_neg_30))
             # 15m downtrend, 1d overbought
-            & ((roc_9_15m > -60.0) | (roc_9_1d < 200.0))
+            & ((roc_9_15m > -60.0) | (roc_9_1d_lt_200))
             # 1h downtrend, 1d overbought
-            & ((roc_9_1h > -60.0) | (roc_9_1d < 200.0))
+            & ((roc_9_1h > -60.0) | (roc_9_1d_lt_200))
             # big drop in the last 20 days, 1d high, 1d downtrend
-            & ((close > (high_max_20_1d * 0.20)) | (stochrsi_k_1d < 70.0) | (roc_9_1d > -15.0))
+            & ((close > (high_max_20_1d * 0.20)) | (stochrsi_k_1d_lt_70) | (roc_9_1d > -15.0))
           )
 
           # Logic
@@ -18734,7 +18771,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 4h down move, 4h still not low enough
             & ((rsi_3_15m_gt_10) | (rsi_3_4h_gt_10) | (stochrsi_k_4h_lt_30))
             # 15m & 4h down move, 1d high
-            & ((rsi_3_15m_gt_10) | (rsi_3_4h_gt_10) | (stochrsi_k_1d < 80.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_4h_gt_10) | (stochrsi_k_1d_lt_80))
             # 15m & 4h down move, 4h still high
             & ((rsi_3_15m_gt_10) | (rsi_3_4h_gt_30) | (stochrsi_k_4h_lt_40))
             # 15m down move, 1h & 4h high
@@ -18742,7 +18779,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 1h high & overbought
             & ((rsi_3_15m_gt_10) | aroonu_14_1h_lt_70 | (roc_9_1h_lt_10))
             # 15m down move, 1h high, 4h overbought
-            & ((rsi_3_15m_gt_10) | aroonu_14_1h_lt_70 | (roc_9_4h < 20.0))
+            & ((rsi_3_15m_gt_10) | aroonu_14_1h_lt_70 | (roc_9_4h_lt_20))
             # 15m down move, 4h & 1d high
             & ((rsi_3_15m_gt_10) | (aroonu_14_4h_lt_75) | aroonu_14_1d_lt_100)
             # 15m down move, 4h high, 1h overbought
@@ -18784,7 +18821,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 1d down move, 4h still high
             & ((rsi_3_1h_gt_10) | (rsi_3_1d_gt_30) | (aroonu_14_4h_lt_50))
             # 15m & 1d down move, 1d high
-            & ((rsi_3_15m_gt_10) | (rsi_3_1d_gt_30) | (stochrsi_k_1d < 70.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_1d_gt_30) | (stochrsi_k_1d_lt_70))
             # 1h & 4h down move, 4h still not low enough
             & ((rsi_3_1h_gt_3) | (rsi_3_4h_gt_25) | (stochrsi_k_4h_lt_30))
             # 1h down move, 1h still not low enough, 1d high
@@ -18796,11 +18833,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1d high & overbought
             & ((rsi_3_1h_gt_10) | (aroonu_14_1d_lt_70) | roc_9_1d_lt_50)
             # 1h down move, 1d overbought
-            & ((rsi_3_1h_gt_10) | (roc_9_1d < 100.0))
+            & ((rsi_3_1h_gt_10) | (roc_9_1d_lt_100))
             # 1h & 4h down move, 4h still high
             & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_15) | (aroonu_14_4h_lt_40))
             # 1h & 4h down move, 1d high
-            & ((rsi_3_1h_gt_15) | rsi_3_4h_gt_20 | (stochrsi_k_1d < 70.0))
+            & ((rsi_3_1h_gt_15) | rsi_3_4h_gt_20 | (stochrsi_k_1d_lt_70))
             # 1h & 4h & 1d down move
             & ((rsi_3_1h_gt_15) | rsi_3_4h_gt_20 | (rsi_3_1d_gt_30))
             # 1h & 4h down move, 1d high
@@ -18836,7 +18873,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 4h high
             & ((rsi_3_1h_gt_30) | (stochrsi_k_4h_lt_80))
             # 1h down move, 4h & 1d high
-            & ((rsi_3_1h_gt_35) | (stochrsi_k_4h_lt_80) | (stochrsi_k_1d < 80.0))
+            & ((rsi_3_1h_gt_35) | (stochrsi_k_4h_lt_80) | (stochrsi_k_1d_lt_80))
             # 1h down move, 1h still high, 1d overbought
             & ((rsi_3_1h_gt_40) | (aroonu_14_1h_lt_50) | roc_9_1d_lt_50)
             # 1h down move, 1h & 4h high
@@ -18846,7 +18883,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 1d high
             & ((rsi_3_4h_gt_5) | aroonu_14_1d_lt_100)
             # 4h & 1d down move, 1d still high
-            & ((rsi_3_4h_gt_10) | (rsi_3_1d_gt_25) | (stochrsi_k_1d < 50.0))
+            & ((rsi_3_4h_gt_10) | (rsi_3_1d_gt_25) | (stochrsi_k_1d_lt_50))
             # 4h downmove, 4h still high
             & ((rsi_3_4h_gt_10) | (aroonu_14_4h_lt_40))
             # 4h down move, 1h still high, 1d downtrend
@@ -18886,7 +18923,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m still high, 1h & 4h high
             & ((rsi_14_15m < 40.0) | aroonu_14_1h_lt_80 | (aroonu_14_4h_lt_90))
             # 1h & 4h high, 4h overbought
-            & (aroonu_14_1h_lt_70 | aroonu_14_4h_lt_100 | (roc_9_4h < 20.0))
+            & (aroonu_14_1h_lt_70 | aroonu_14_4h_lt_100 | (roc_9_4h_lt_20))
             # 4h high, 1d overbought
             & (aroonu_14_4h_lt_70 | (roc_9_1d_lt_80))
             # 4h high, 1h & 1d downtrend
@@ -18894,11 +18931,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h high, 1h & 4h overbought
             & (aroonu_14_4h_lt_80 | (roc_9_1h_lt_10) | (roc_9_4h_lt_10))
             # 4h high & overbought
-            & ((aroonu_14_4h_lt_90) | (roc_9_4h < 80.0))
+            & ((aroonu_14_4h_lt_90) | (roc_9_4h_lt_80))
             # 1d high, 4h & 1d downtrend
             & ((aroonu_14_1d_lt_80) | (roc_9_4h_gt_neg_20) | (roc_9_1d_gt_neg_20))
             # 1h high, 4h overbought
-            & ((stochrsi_k_1h_lt_80) | (roc_9_4h < 80.0))
+            & ((stochrsi_k_1h_lt_80) | (roc_9_4h_lt_80))
             # 4h high, 1h & 1d downtrend
             & ((stochrsi_k_4h_lt_70) | (roc_9_1h > -20.0) | (roc_9_1d_gt_neg_20))
             # 4h high, 1h & 4h overbought
@@ -18942,7 +18979,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # big drop in the last 20 days, 1h down move
             & ((close > (high_max_20_1d * 0.10)) | rsi_3_1h_gt_20)
             # big drop in the last 20 days, 1d high, 1d downtrend
-            & ((close > (high_max_20_1d * 0.20)) | (stochrsi_k_1d < 70.0) | (roc_9_1d > -15.0))
+            & ((close > (high_max_20_1d * 0.20)) | (stochrsi_k_1d_lt_70) | (roc_9_1d > -15.0))
             # big drop in the last 30 days, 4h down move, 4h still high
             & ((close > (high_max_30_1d * 0.25)) | (rsi_3_4h_gt_45) | (rsi_14_4h < 40.0))
           )
@@ -19007,7 +19044,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 1h & 4h still high
             & ((rsi_3_15m_gt_20) | (aroonu_14_1h_lt_40) | (stochrsi_k_4h_lt_50))
             # 15m & 1h & 4h down move, 1d high
-            & ((rsi_3_15m_gt_25) | (rsi_3_1h_gt_25) | (rsi_3_4h_gt_25) | (roc_9_1d < 70.0))
+            & ((rsi_3_15m_gt_25) | (rsi_3_1h_gt_25) | (rsi_3_4h_gt_25) | (roc_9_1d_lt_70))
             # 15m & 4h down move, 4h high
             & ((rsi_3_15m_gt_25) | (rsi_3_4h_gt_45) | (aroonu_14_4h_lt_85))
             # 15m & 1h down move, 15m still not low enough
@@ -19029,7 +19066,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 4h high
             & ((rsi_3_1h_gt_5) | aroonu_14_4h_lt_70)
             # 1h down move, 1d still high
-            & ((rsi_3_1h_gt_5) | (stochrsi_k_1d < 50.0))
+            & ((rsi_3_1h_gt_5) | (stochrsi_k_1d_lt_50))
             # 1h & 4h down move, 4h still not low enough
             & ((rsi_3_1h_gt_10) | rsi_3_4h_gt_20 | (rsi_14_4h < 30.0))
             # 1h & 4h down move, 4h still not low enough
@@ -19067,7 +19104,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h & 1d down move
             & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_25) | (rsi_3_1d_gt_25))
             # 1h & 4h down move, 1d high
-            & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_30) | (stochrsi_k_1d < 80.0))
+            & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_30) | (stochrsi_k_1d_lt_80))
             # 1h & 4h down move, 1h & 4h still high
             & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_40) | (rsi_14_1h < 40.0) | (rsi_14_4h < 50.0))
             # 1h & 4h down move, 4h still high
@@ -19105,7 +19142,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 4h still high, 1d downtrend
             & (rsi_3_1h_gt_20 | (stochrsi_k_4h_lt_40) | (roc_9_1d > -25.0))
             # 1h down move, 4h & 1d high
-            & (rsi_3_1h_gt_20 | (stochrsi_k_4h_lt_50) | (stochrsi_k_1d < 80.0))
+            & (rsi_3_1h_gt_20 | (stochrsi_k_4h_lt_50) | (stochrsi_k_1d_lt_80))
             # 1h & 4h down move, 1h still high
             & ((rsi_3_1h_gt_25) | (rsi_3_4h_gt_35) | (aroonu_14_1h_lt_40))
             # 1h & 4h down move, 4h high
@@ -19141,7 +19178,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h & 4h high
             & ((rsi_3_1h_gt_50) | (aroonu_14_1h_lt_70) | (aroonu_14_4h_lt_100))
             # 1h down move, 1h overbought
-            & ((rsi_3_1h_gt_50) | (roc_9_1h < 40.0))
+            & ((rsi_3_1h_gt_50) | (roc_9_1h_lt_40))
             # 4h & 1d down move, 1d high
             & ((rsi_3_4h_gt_5) | (rsi_3_1d_gt_30) | (aroonu_14_1d_lt_70))
             # 4h down move, 1h & 4h downtrend
@@ -19177,13 +19214,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1d down move, 1d high, 1d downtrend
             & ((rsi_3_1d_gt_25) | (aroonu_14_1d_lt_80) | (roc_9_1d_gt_neg_30))
             # 4h & 1d high, 4h overbought
-            & (aroonu_14_4h_lt_80 | aroonu_14_1d_lt_100 | (roc_9_4h < 20.0))
+            & (aroonu_14_4h_lt_80 | aroonu_14_1d_lt_100 | (roc_9_4h_lt_20))
             # 4h high, 1h overbought
-            & (aroonu_14_4h_lt_80 | (roc_9_1h < 40.0))
+            & (aroonu_14_4h_lt_80 | (roc_9_1h_lt_40))
             # 4h high, 4h overbought
             & (aroonu_14_4h_lt_80 | (roc_9_4h_lt_40))
             # 4h high, 1h overbought
-            & ((stochrsi_k_4h_lt_70) | (roc_9_1h < 40.0))
+            & ((stochrsi_k_4h_lt_70) | (roc_9_1h_lt_40))
             # 4h high, 4h overbought
             & ((stochrsi_k_4h_lt_70) | (roc_9_4h_lt_40))
             # 4h high, 4h overbought, 1d downtrend
@@ -19265,7 +19302,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 4h downtrend
             & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_10) | (cmf_20_4h > -0.30))
             # 15m & 1h down move, 1d still high
-            & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_10) | (stochrsi_k_1d < 50.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_10) | (stochrsi_k_1d_lt_50))
             # 15m & 1h down move, 1d overbought
             & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_10) | (roc_9_1d_lt_40))
             # 15m & 1h down move, 1d overbought
@@ -19295,7 +19332,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 4h down move, 1h downtrend
             & ((rsi_3_15m_gt_5) | (rsi_3_4h_gt_10) | (roc_9_1h > -20.0))
             # 15m & 4h down move, 1d overbought
-            & ((rsi_3_15m_gt_5) | (rsi_3_4h_gt_15) | (roc_9_1d < 70.0))
+            & ((rsi_3_15m_gt_5) | (rsi_3_4h_gt_15) | (roc_9_1d_lt_70))
             # 15m & 4h down move, 1h high
             & ((rsi_3_15m_gt_5) | rsi_3_4h_gt_20 | (stochrsi_k_1h_lt_80))
             # 15m down move, 15m still low, 4h still high
@@ -19307,7 +19344,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 1h & 1d high
             & ((rsi_3_15m_gt_5) | (roc_9_1h_lt_10) | (roc_9_1d_lt_40))
             # 15m & 1h down move, 1d high
-            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_10) | (stochrsi_k_1d < 70.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_10) | (stochrsi_k_1d_lt_70))
             # 15m & 1h down move, 4h downtrend
             & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_10) | (roc_9_4h > -50.0))
             # 15m & 1h down move, 1d overbought
@@ -19315,15 +19352,15 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 15m still high
             & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_30) | (aroonu_14_15m_lt_50))
             # 15m & 1h down move, 4h overbought
-            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_30) | (roc_9_4h < 50.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_30) | (roc_9_4h_lt_50))
             # 15m & 4h down move, 4h still not low enough
             & ((rsi_3_15m_gt_10) | (rsi_3_4h_gt_10) | (stochrsi_k_4h_lt_30))
             # 15m & 4h down move, 4h still high, 1d high & overbought
-            & ((rsi_3_15m_gt_10) | (rsi_3_4h_gt_15) | (aroonu_14_4h_lt_40) | (aroonu_14_1d_lt_70) | (roc_9_1d < 10.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_4h_gt_15) | (aroonu_14_4h_lt_40) | (aroonu_14_1d_lt_70) | (roc_9_1d_lt_10))
             # 15m & 4h down move, 4h high
             & ((rsi_3_15m_gt_10) | (rsi_3_4h_gt_25) | (aroonu_14_4h_lt_70))
             # 15m & 4h down move, 4h overbought
-            & ((rsi_3_15m_gt_10) | (rsi_3_4h_gt_55) | (roc_9_4h < 50.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_4h_gt_55) | (roc_9_4h_lt_50))
             # 15m down move, 15m still not low enough, 1d downtrend
             & ((rsi_3_15m_gt_10) | (aroonu_14_15m_lt_30) | (roc_9_1d_gt_neg_30))
             # 15m down move, 15m still high, 1d overbought
@@ -19333,7 +19370,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 1d high, 1d downtrend
             & ((rsi_3_15m_gt_10) | (aroonu_14_1d_lt_85) | (cmf_20_1d > -0.40))
             # 15m down move, 1h high & overbought
-            & ((rsi_3_15m_gt_10) | (stochrsi_k_1h_lt_90) | (roc_9_1h < 20.0))
+            & ((rsi_3_15m_gt_10) | (stochrsi_k_1h_lt_90) | (roc_9_1h_lt_20))
             # 15m down move, 4h high
             & ((rsi_3_15m_gt_10) | (stochrsi_k_4h_lt_70))
             # 15m down move, 4h & 1d overbought
@@ -19353,11 +19390,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 1d high, 4h overbought
             & ((rsi_3_15m_gt_15) | (stochrsi_k_1d_lt_90) | (roc_9_4h_lt_40))
             # 15m down move, 1h & 4h overbought
-            & ((rsi_3_15m_gt_15) | (roc_9_1h < 20.0) | (roc_9_4h_lt_40))
+            & ((rsi_3_15m_gt_15) | (roc_9_1h_lt_20) | (roc_9_4h_lt_40))
             # 15m down move, 4h & 1d downtrend
             & ((rsi_3_15m_gt_15) | (roc_9_4h > -10.0) | (roc_9_1d_gt_neg_40))
             # 15m down move, 4h & 1d overbought
-            & ((rsi_3_15m_gt_15) | (roc_9_4h_lt_20) | (roc_9_1d < 60.0))
+            & ((rsi_3_15m_gt_15) | (roc_9_4h_lt_20) | (roc_9_1d_lt_60))
             # 15m & 1h down move, 15m high
             & ((rsi_3_15m_gt_20) | rsi_3_1h_gt_20 | (aroonu_14_15m_lt_60))
             # 15m & 1h down move, 1h high
@@ -19387,7 +19424,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 15m stil high
             & ((rsi_3_1h_gt_3) | (rsi_3_4h_gt_10) | (stochrsi_k_15m_lt_50))
             # 1h & 4h down move, 1d still high
-            & ((rsi_3_1h_gt_3) | (rsi_3_4h_gt_10) | (stochrsi_k_1d < 40.0))
+            & ((rsi_3_1h_gt_3) | (rsi_3_4h_gt_10) | (stochrsi_k_1d_lt_40))
             # 1h down move, 1h still not low enough
             & ((rsi_3_1h_gt_3) | (aroonu_14_1h_lt_20))
             # 1h & 4h down move, 1d downtrend
@@ -19399,7 +19436,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 4h still not low enough
             & ((rsi_3_1h_gt_5) | rsi_3_4h_gt_20 | (stochrsi_k_4h_lt_30))
             # 1h down move, 4h high, 1d overbought
-            & ((rsi_3_1h_gt_5) | (aroonu_14_4h_lt_60) | (roc_9_1d < 10.0))
+            & ((rsi_3_1h_gt_5) | (aroonu_14_4h_lt_60) | (roc_9_1d_lt_10))
             # 1h down move, 1d high, 4h downtrend
             & ((rsi_3_1h_gt_5) | (aroonu_14_1d_lt_90) | (roc_9_4h_gt_neg_30))
             # 1h down move, 1d high, 1d downtrend
@@ -19417,17 +19454,17 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 15m still high, 4h high
             & ((rsi_3_1h_gt_10) | (aroonu_14_15m_lt_40) | (stochrsi_k_4h_lt_90))
             # 1h down move, 1d high & overbought
-            & ((rsi_3_1h_gt_10) | (aroonu_14_1d_lt_100) | (roc_9_1d < 10.0))
+            & ((rsi_3_1h_gt_10) | (aroonu_14_1d_lt_100) | (roc_9_1d_lt_10))
             # 1h down move, 4h still high, 4d downtrend
             & ((rsi_3_1h_gt_10) | (stochrsi_k_4h_lt_50) | roc_9_1d_gt_neg_50)
             # 1h down move, 4h downtrend, 1d overbought
             & ((rsi_3_1h_gt_10) | (roc_9_4h > -10.0) | (roc_9_1d_lt_40))
             # 1h down move, 1d overbought
-            & ((rsi_3_1h_gt_10) | (roc_9_1d < 100.0))
+            & ((rsi_3_1h_gt_10) | (roc_9_1d_lt_100))
             # 1h & 4h down move, 4h high
             & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_40) | (aroonu_14_4h_lt_80))
             # 1h down move, 1d downtrend, 1d high
-            & ((rsi_3_1h_gt_15) | (cmf_20_1d > -0.30) | (stochrsi_k_1d < 80.0))
+            & ((rsi_3_1h_gt_15) | (cmf_20_1d > -0.30) | (stochrsi_k_1d_lt_80))
             # 1h down move, 1h still high
             & ((rsi_3_1h_gt_15) | (aroonu_14_1h_lt_50))
             # 1h down move, 4h high, 1d overbought
@@ -19455,7 +19492,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h high, 4h downtrend
             & ((rsi_3_1h_gt_35) | aroonu_14_1h_lt_80 | (roc_9_4h > -40.0))
             # 1h down move, 1h still high, 1d overbought
-            & ((rsi_3_1h_gt_35) | (stochrsi_k_1h_lt_50) | (roc_9_1d < 200.0))
+            & ((rsi_3_1h_gt_35) | (stochrsi_k_1h_lt_50) | (roc_9_1d_lt_200))
             # 1h down move, 1h high, 4h downtrend
             & ((rsi_3_1h_gt_35) | (stochrsi_k_1h_lt_70) | (roc_9_4h_gt_neg_20))
             # 1h down move, 4h & 1d overbought
@@ -19467,11 +19504,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h high, 4h downtrend
             & ((rsi_3_1h_gt_40) | (stochrsi_k_1h_lt_80) | (roc_9_4h_gt_neg_20))
             # 1h down move, 1h high, 1h overbought
-            & ((rsi_3_1h_gt_50) | aroonu_14_1h_lt_70 | (roc_9_1h < 25.0))
+            & ((rsi_3_1h_gt_50) | aroonu_14_1h_lt_70 | (roc_9_1h_lt_25))
             # 1h down move, 4h high, 1d downtrend
             & ((rsi_3_1h_gt_50) | (stochrsi_k_4h_lt_60) | (roc_9_1d > -60.0))
             # 1h down move, 4h & 1d overbought
-            & ((rsi_3_1h_gt_60) | (roc_9_4h_lt_30) | (roc_9_1d < 60.0))
+            & ((rsi_3_1h_gt_60) | (roc_9_4h_lt_30) | (roc_9_1d_lt_60))
             # 4h & 1d down move, 15m still high
             & ((rsi_3_4h_gt_3) | (rsi_3_1d_gt_15) | (stochrsi_k_15m_lt_40))
             # 4h & 1d down move, 1h still not low enough
@@ -19489,7 +19526,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 1d overbought
             & ((rsi_3_4h_gt_3) | (roc_9_1d_lt_40))
             # 4h & 1d down move, 1d still high
-            & ((rsi_3_4h_gt_5) | (rsi_3_1d_gt_30) | (stochrsi_k_1d < 40.0))
+            & ((rsi_3_4h_gt_5) | (rsi_3_1d_gt_30) | (stochrsi_k_1d_lt_40))
             # 4h down move, 4h downtrend, 4h still high
             & ((rsi_3_4h_gt_5) | (cmf_20_4h > -0.20) | (aroonu_14_4h_lt_40))
             # 4h & 1d down move, 1d downtrend
@@ -19537,37 +19574,37 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m high, 1h high & overbought
             & ((aroonu_14_15m_lt_60) | (aroonu_14_1h_lt_85) | (roc_9_1h_lt_10))
             # 1h high, 4h high, 1h overbought
-            & (aroonu_14_1h_lt_70 | aroonu_14_4h_lt_100 | (roc_9_1h < 20.0))
+            & (aroonu_14_1h_lt_70 | aroonu_14_4h_lt_100 | (roc_9_1h_lt_20))
             # 1h & 1d high, 1h overbought
-            & (aroonu_14_1h_lt_70 | (aroonu_14_1d_lt_70) | (roc_9_1h < 20.0))
+            & (aroonu_14_1h_lt_70 | (aroonu_14_1d_lt_70) | (roc_9_1h_lt_20))
             # 1h & 4h high, 1d downtrend
             & ((aroonu_14_1h_lt_85) | aroonu_14_4h_lt_100 | (roc_9_1d > -80.0))
             # 4h still high, 5m downtrend
             & ((aroonu_14_4h_lt_40) | (roc_9 > -40.0))
             # 4h high, 4h & 1d overbought
-            & ((aroonu_14_4h_lt_60) | (roc_9_4h_lt_30) | (roc_9_1d < 60.0))
+            & ((aroonu_14_4h_lt_60) | (roc_9_4h_lt_30) | (roc_9_1d_lt_60))
             # 4h & 1d high, 4h overbought
             & (aroonu_14_4h_lt_80 | aroonu_14_1d_lt_100 | (roc_9_4h_lt_30))
             # 4h & 1d high, 1d overbought
             & (aroonu_14_4h_lt_80 | aroonu_14_1d_lt_100 | roc_9_1d_lt_50)
             # 4h high, 4h & 1d overbought
-            & (aroonu_14_4h_lt_80 | (roc_9_4h < 20.0) | (roc_9_1d_lt_20))
+            & (aroonu_14_4h_lt_80 | (roc_9_4h_lt_20) | (roc_9_1d_lt_20))
             # 1d high, 1h & 4h downtrend
             & ((aroonu_14_1d_lt_85) | (roc_9_1h > -30.0) | (roc_9_4h > -50.0))
             # 1d high, 1h & 1d overbought
-            & ((aroonu_14_1d_lt_85) | (roc_9_1h < 20.0) | (roc_9_1d_lt_100))
+            & ((aroonu_14_1d_lt_85) | (roc_9_1h_lt_20) | (roc_9_1d_lt_100))
             # 1d high, 4h & 1d overbought
-            & ((aroonu_14_1d_lt_90) | (roc_9_4h_lt_30) | (roc_9_1d < 60.0))
+            & ((aroonu_14_1d_lt_90) | (roc_9_4h_lt_30) | (roc_9_1d_lt_60))
             # 1h high, 1d overbought
             & ((stochrsi_k_1h_lt_70) | (roc_9_1d_lt_40))
             # 4h high, 1h overbought, 1d downtrend
-            & ((stochrsi_k_4h_lt_80) | (roc_9_1h < 40.0) | (roc_9_1d > -70.0))
+            & ((stochrsi_k_4h_lt_80) | (roc_9_1h_lt_40) | (roc_9_1d > -70.0))
             # 4h high, 1h & 4h overbought
-            & ((stochrsi_k_4h_lt_90) | (roc_9_1h < 20.0) | (roc_9_4h < 50.0))
+            & ((stochrsi_k_4h_lt_90) | (roc_9_1h_lt_20) | (roc_9_4h_lt_50))
             # 1h & 4h overbought
-            & ((roc_9_1h < 100.0) | (roc_9_4h < 100.0))
+            & ((roc_9_1h_lt_100) | (roc_9_4h_lt_100))
             # big drop in the last 20 days, 1d high, 1d downtrend
-            & ((close > (high_max_20_1d * 0.20)) | (stochrsi_k_1d < 70.0) | (roc_9_1d > -15.0))
+            & ((close > (high_max_20_1d * 0.20)) | (stochrsi_k_1d_lt_70) | (roc_9_1d > -15.0))
           )
 
           # Logic
@@ -19648,13 +19685,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 4h down move, 4h still not low enough
             & ((rsi_3_15m_gt_10) | rsi_3_4h_gt_20 | (stochrsi_k_4h_lt_30))
             # 15m & 4h down move, 1d high
-            & ((rsi_3_15m_gt_10) | rsi_3_4h_gt_20 | (stochrsi_k_1d < 70.0))
+            & ((rsi_3_15m_gt_10) | rsi_3_4h_gt_20 | (stochrsi_k_1d_lt_70))
             # 15m & 4h down move, 4h downtrend
             & ((rsi_3_15m_gt_10) | (rsi_3_4h_gt_25) | (cmf_20_4h > -0.30))
             # 15m & 4h down move, 1d high
             & ((rsi_3_15m_gt_10) | (rsi_3_4h_gt_30) | (stochrsi_k_1d_lt_90))
             # 15m & 4h down move, 1d overbought
-            & ((rsi_3_15m_gt_10) | (rsi_3_4h_gt_40) | (roc_9_1d < 200.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_4h_gt_40) | (roc_9_1d_lt_200))
             # 15m & 1d down move, 1d high
             & ((rsi_3_15m_gt_10) | (rsi_3_1d_gt_20) | (aroonu_14_1d_lt_75))
             # 15m down move, 4h high, 1d downtrend
@@ -19690,7 +19727,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 15m still high, 4h high
             & ((rsi_3_15m_gt_35) | (aroonu_14_15m_lt_50) | aroonu_14_4h_lt_80)
             # 1h & 4h down move, 1d still high
-            & ((rsi_3_1h_gt_3) | (rsi_3_4h_gt_10) | (stochrsi_k_1d < 40.0))
+            & ((rsi_3_1h_gt_3) | (rsi_3_4h_gt_10) | (stochrsi_k_1d_lt_40))
             # 1h & 4h down move, 4h still high
             & ((rsi_3_1h_gt_3) | (rsi_3_4h_gt_40) | (stochrsi_k_4h_lt_50))
             # 1h & 4h down move, 4h high
@@ -19722,7 +19759,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 1d downtrend
             & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_10) | (roc_9_1d > -20.0))
             # 1h & 4h down move, 1d overbought
-            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_10) | (roc_9_1d < 10.0))
+            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_10) | (roc_9_1d_lt_10))
             # 1h & 4h down move, 4h still high
             & ((rsi_3_1h_gt_10) | rsi_3_4h_gt_20 | (aroonu_14_4h_lt_40))
             # 1h & 4h down move, 4h high
@@ -19740,25 +19777,25 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 4h still high
             & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_15) | (aroonu_14_4h_lt_40))
             # 1h & 4h down move, 1d high
-            & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_15) | (stochrsi_k_1d < 70.0))
+            & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_15) | (stochrsi_k_1d_lt_70))
             # 1h & 4h down move, 4h still high
             & ((rsi_3_1h_gt_15) | rsi_3_4h_gt_20 | (stochrsi_k_4h_lt_40))
             # 1h & 4h down move, 1d high
             & ((rsi_3_1h_gt_15) | rsi_3_4h_gt_20 | (stochrsi_k_1d_lt_90))
             # 1h & 4h down move, 1d high
-            & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_30) | (stochrsi_k_1d < 80.0))
+            & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_30) | (stochrsi_k_1d_lt_80))
             # 1h & 4h down move, 1d downtrend
             & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_45) | (roc_9_1d_gt_neg_40))
             # 1h & 1d down move, 4h high
             & ((rsi_3_1h_gt_15) | (rsi_3_1d_gt_15) | (stochrsi_k_4h_lt_80))
             # 1h down move, 4h high, 1d overbought
-            & ((rsi_3_1h_gt_15) | aroonu_14_4h_lt_70 | (roc_9_1d < 100.0))
+            & ((rsi_3_1h_gt_15) | aroonu_14_4h_lt_70 | (roc_9_1d_lt_100))
             # 1h down move, 1d high, 4h downtrend
             & ((rsi_3_1h_gt_15) | (aroonu_14_1d_lt_90) | (roc_9_4h > -20.0))
             # 1h & 4h down move, 4h & 1d still not low enough, 15m still not low enough
             & (rsi_3_1h_gt_20 | (rsi_3_4h_gt_20) | (rsi_14_4h < 30.0) | (rsi_14_1d < 30.0) | (stochrsi_k_15m_lt_30))
             # 1h & 4h down move, 1d high
-            & (rsi_3_1h_gt_20 | (rsi_3_4h_gt_25) | (stochrsi_k_1d < 70.0))
+            & (rsi_3_1h_gt_20 | (rsi_3_4h_gt_25) | (stochrsi_k_1d_lt_70))
             # 1h & 4h down move, 4h high
             & (rsi_3_1h_gt_20 | (rsi_3_4h_gt_40) | (stochrsi_k_4h_lt_70))
             # 1h & 4h down move, 4h overbought
@@ -19778,7 +19815,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 4h still high, 1d downtrend
             & (rsi_3_1h_gt_20 | (stochrsi_k_4h_lt_40) | (roc_9_1d_gt_neg_40))
             # 1h down move, 1d high, 4h downtrend
-            & (rsi_3_1h_gt_20 | (stochrsi_k_1d < 80.0) | (roc_9_4h_gt_neg_20))
+            & (rsi_3_1h_gt_20 | (stochrsi_k_1d_lt_80) | (roc_9_4h_gt_neg_20))
             # 1h down move, 4h high
             & (rsi_3_1h_gt_20 | (stochrsi_k_4h_lt_80))
             # 1h & 4h down move, 1h still not low enough
@@ -19810,7 +19847,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1d high, 4h downtrend
             & ((rsi_3_1h_gt_30) | (aroonu_14_1d_lt_80) | (roc_9_4h_gt_neg_30))
             # 1h down move, 1d high, 4h overbought
-            & ((rsi_3_1h_gt_30) | aroonu_14_1d_lt_100 | (roc_9_4h < 20.0))
+            & ((rsi_3_1h_gt_30) | aroonu_14_1d_lt_100 | (roc_9_4h_lt_20))
             # 1h down move, 4h still high, 1d downtrend
             & ((rsi_3_1h_gt_30) | (stochrsi_k_4h_lt_40) | (roc_9_1d > -80.0))
             # 1h down move, 4h high & overbought
@@ -19828,9 +19865,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 4h high & overbought
             & ((rsi_3_1h_gt_40) | (stochrsi_k_4h_lt_70) | (roc_9_4h_lt_30))
             # 1h down move, 4h high & overbought
-            & ((rsi_3_1h_gt_45) | aroonu_14_4h_lt_80 | (roc_9_4h < 100.0))
+            & ((rsi_3_1h_gt_45) | aroonu_14_4h_lt_80 | (roc_9_4h_lt_100))
             # 1h down move, 1h overbought
-            & ((rsi_3_1h_gt_50) | (roc_9_1h < 40.0))
+            & ((rsi_3_1h_gt_50) | (roc_9_1h_lt_40))
             # 1h down move, 4h & 1d overbought
             & ((rsi_3_1h_gt_60) | (roc_9_4h_lt_30) | (roc_9_1d_lt_100))
             # 4h & 1d down move, 1d still high
@@ -19852,7 +19889,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 1h downtrend, 1d downtrend
             & ((rsi_3_4h_gt_15) | (cmf_20_1h > -0.40) | (roc_9_1d > -20.0))
             # 4h down move, 15m high, 1d overbought
-            & ((rsi_3_4h_gt_15) | (aroonu_14_15m_lt_70) | (roc_9_1d < 100.0))
+            & ((rsi_3_4h_gt_15) | (aroonu_14_15m_lt_70) | (roc_9_1d_lt_100))
             # 4h down move, 4h still high, 4h downtrend
             & ((rsi_3_4h_gt_15) | (aroonu_14_4h_lt_40) | (roc_9_4h > -20.0))
             # 4h down move, 15m still not low enough, 1d downtrend
@@ -19866,7 +19903,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 1d high & overbought
             & (rsi_3_4h_gt_20 | (aroonu_14_1d_lt_80) | (roc_9_1d_lt_30))
             # 4h & 1d down move, 1d overbought
-            & ((rsi_3_4h_gt_25) | (rsi_3_1d_gt_45) | (roc_9_1d < 10.0))
+            & ((rsi_3_4h_gt_25) | (rsi_3_1d_gt_45) | (roc_9_1d_lt_10))
             # 4h down move, 15m high, 4h high
             & ((rsi_3_4h_gt_25) | (aroonu_14_15m_lt_70) | aroonu_14_4h_lt_80)
             # 4h down move, 4h still high, 1d downtrend
@@ -19874,7 +19911,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 4h still high, 4h downtrend
             & ((rsi_3_4h_gt_25) | (aroonu_14_4h_lt_50) | (cmf_20_4h > -0.40))
             # 4h down move, 4h high, 1d high
-            & ((rsi_3_4h_gt_30) | aroonu_14_4h_lt_70 | (stochrsi_k_1d < 80.0))
+            & ((rsi_3_4h_gt_30) | aroonu_14_4h_lt_70 | (stochrsi_k_1d_lt_80))
             # 4h down move, 1d still high, 1d downtrend
             & ((rsi_3_4h_gt_30) | (aroonu_14_1d_lt_40) | (roc_9_1d_gt_neg_20))
             # 4h down move, 1d high & overbought
@@ -19886,7 +19923,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 15m & 4h still high
             & ((rsi_3_4h_gt_40) | (stochrsi_k_15m_lt_50) | (stochrsi_k_4h_lt_50))
             # 4h down move, 1d high & overbought
-            & ((rsi_3_4h_gt_40) | (stochrsi_k_1d_lt_90) | (roc_9_1d < 200.0))
+            & ((rsi_3_4h_gt_40) | (stochrsi_k_1d_lt_90) | (roc_9_1d_lt_200))
             # 4h down move, 4h high
             & ((rsi_3_4h_gt_40) | aroonu_14_4h_lt_100)
             # 4h down move, 4h still high, 1d downtrend
@@ -19912,13 +19949,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h & 1d high, 1d overbought
             & (aroonu_14_4h_lt_70 | aroonu_14_1d_lt_100 | (roc_9_1d_lt_80))
             # 4h high, 1h & 4h overbought
-            & (aroonu_14_4h_lt_80 | (roc_9_1h < 40.0) | (roc_9_4h_lt_40))
+            & (aroonu_14_4h_lt_80 | (roc_9_1h_lt_40) | (roc_9_4h_lt_40))
             # 1d high, 4h downtrend, 1d overbought
-            & ((aroonu_14_1d_lt_85) | (roc_9_4h_gt_neg_20) | (roc_9_1d < 200.0))
+            & ((aroonu_14_1d_lt_85) | (roc_9_4h_gt_neg_20) | (roc_9_1d_lt_200))
             # 1d high, 4h & 1d overbought
-            & ((aroonu_14_1d_lt_90) | (roc_9_4h_lt_30) | (roc_9_1d < 60.0))
+            & ((aroonu_14_1d_lt_90) | (roc_9_4h_lt_30) | (roc_9_1d_lt_60))
             # 4h high, 1h & 4h overbought
-            & ((stochrsi_k_4h_lt_70) | (roc_9_1h < 40.0) | (roc_9_4h_lt_40))
+            & ((stochrsi_k_4h_lt_70) | (roc_9_1h_lt_40) | (roc_9_4h_lt_40))
             # 4h high, 4h & 1d overbought
             & ((stochrsi_k_4h_lt_80) | (roc_9_4h_lt_20) | (roc_9_1d_lt_20))
             # 1d green, 4h down move, 4h still high
@@ -19970,7 +20007,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 4h down move, 4h still not low enough
             & ((rsi_3_15m_gt_10) | (rsi_3_4h_gt_10) | (stochrsi_k_4h_lt_30))
             # 15m & 4h down move, 1d high
-            & ((rsi_3_15m_gt_10) | (rsi_3_4h_gt_10) | (stochrsi_k_1d < 80.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_4h_gt_10) | (stochrsi_k_1d_lt_80))
             # 15m & 4h down move, 4h still not low enough
             & ((rsi_3_15m_gt_10) | (rsi_3_4h_gt_15) | (stochrsi_k_4h_lt_30))
             # 15m & 4h down move, 1d downtrend
@@ -19986,9 +20023,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 15m still high, 4h high
             & ((rsi_3_15m_gt_10) | (aroonu_14_15m_lt_50) | aroonu_14_4h_lt_80)
             # 15m down move, 1h still high, 1d overbought
-            & ((rsi_3_15m_gt_10) | (aroonu_14_1h_lt_50) | (roc_9_1d < 60.0))
+            & ((rsi_3_15m_gt_10) | (aroonu_14_1h_lt_50) | (roc_9_1d_lt_60))
             # 15m down move, 4h high, 1d overbought
-            & ((rsi_3_15m_gt_10) | (aroonu_14_4h_lt_60) | (roc_9_1d < 60.0))
+            & ((rsi_3_15m_gt_10) | (aroonu_14_4h_lt_60) | (roc_9_1d_lt_60))
             # 15m down move, 1d high & overbought
             & ((rsi_3_15m_gt_10) | (aroonu_14_1d_lt_90) | (roc_9_1d_lt_20))
             # 15m down move, 1d high, 4h overbought
@@ -20016,7 +20053,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 15m still not low enough, 1h still high
             & ((rsi_3_15m_gt_15) | (stochrsi_k_15m_lt_30) | (stochrsi_k_1h_lt_50))
             # 15m down move, 4h & 1d overbought
-            & ((rsi_3_15m_gt_15) | (roc_9_4h_lt_20) | (roc_9_1d < 60.0))
+            & ((rsi_3_15m_gt_15) | (roc_9_4h_lt_20) | (roc_9_1d_lt_60))
             # 15m & 1h down move, 1h high
             & ((rsi_3_15m_gt_20) | rsi_3_1h_gt_20 | (stochrsi_k_1h_lt_70))
             # 15m & 4h down move, 4h high
@@ -20048,7 +20085,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 15m downtrend, 4h high
             & ((rsi_3_15m_gt_30) | (cmf_20_15m > -0.30) | aroonu_14_4h_lt_100)
             # 15m down move, 15m still high, 1d high
-            & ((rsi_3_15m_gt_30) | (aroonu_14_15m_lt_50) | (stochrsi_k_1d < 70.0))
+            & ((rsi_3_15m_gt_30) | (aroonu_14_15m_lt_50) | (stochrsi_k_1d_lt_70))
             # 15m down move, 15m high, 4h high
             & ((rsi_3_15m_gt_30) | (aroonu_14_15m_lt_60) | (stochrsi_k_4h_lt_70))
             # 15m down move, 4h high, 1h downtrend
@@ -20078,7 +20115,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 4h still high
             & ((rsi_3_1h_gt_3) | (rsi_3_4h_gt_10) | (stochrsi_k_4h_lt_40))
             # 1h & 4h down move, 1d still high
-            & ((rsi_3_1h_gt_3) | (rsi_3_4h_gt_10) | (stochrsi_k_1d < 40.0))
+            & ((rsi_3_1h_gt_3) | (rsi_3_4h_gt_10) | (stochrsi_k_1d_lt_40))
             # 1h & 4h down move, 4h stil high
             & ((rsi_3_1h_gt_3) | rsi_3_4h_gt_20 | (rsi_14_4h < 40.0))
             # 1h ^ 4h down move, 1d downtrend
@@ -20098,7 +20135,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 4h high
             & ((rsi_3_1h_gt_3) | (stochrsi_k_4h_lt_70))
             # 1h & 4h down move, 1d high
-            & ((rsi_3_1h_gt_5) | (rsi_3_4h_gt_5) | (stochrsi_k_1d < 60.0))
+            & ((rsi_3_1h_gt_5) | (rsi_3_4h_gt_5) | (stochrsi_k_1d_lt_60))
             # 1h & 4h down move, 4h still not low enough
             & ((rsi_3_1h_gt_5) | (rsi_3_4h_gt_10) | (aroonu_14_4h_lt_20))
             # 1h & 4h down move, 4h downtrend
@@ -20132,13 +20169,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 4h still high
             & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_30) | (stochrsi_k_4h_lt_50))
             # 1h & 4h down move, 1d overbought
-            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_35) | (roc_9_1d < 70.0))
+            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_35) | (roc_9_1d_lt_70))
             # 1h & 1d down move, 1h still high
             & ((rsi_3_1h_gt_10) | (rsi_3_1d_gt_10) | (stochrsi_k_1h_lt_40))
             # 1h & 1d down move, 4h high
             & ((rsi_3_1h_gt_10) | (rsi_3_1d_gt_15) | (stochrsi_k_4h_lt_70))
             # 1h & 1d downtrend, 1d overbought
-            & ((rsi_3_1h_gt_10) | (rsi_3_1d_gt_45) | (roc_9_1d < 10.0))
+            & ((rsi_3_1h_gt_10) | (rsi_3_1d_gt_45) | (roc_9_1d_lt_10))
             # 1h down move, 1h downtrend, 1h still not low enough
             & ((rsi_3_1h_gt_10) | (cmf_20_1h > -0.20) | (aroonu_14_1h_lt_30))
             # 1h down move, 1h downtrend, 1h still not low enough
@@ -20150,7 +20187,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 4h still not low enough
             & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_10) | (stochrsi_k_4h_lt_20))
             # 1h down move, 1d overbought
-            & ((rsi_3_1h_gt_10) | (roc_9_1d < 100.0))
+            & ((rsi_3_1h_gt_10) | (roc_9_1d_lt_100))
             # 1h & 4h down move, 1h still not low enough
             & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_15) | (stochrsi_k_1h_lt_30))
             # 1h & 4h down move, 15m high
@@ -20158,9 +20195,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 1d downtrend
             & ((rsi_3_1h_gt_15) | rsi_3_4h_gt_20 | (roc_9_1d_gt_neg_40))
             # 1h & 4h down mov, 1d overbought
-            & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_30) | (roc_9_1d < 100.0))
+            & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_30) | (roc_9_1d_lt_100))
             # 1h down move, 1d downtrend, 1d high
-            & ((rsi_3_1h_gt_15) | (cmf_20_1d > -0.30) | (stochrsi_k_1d < 80.0))
+            & ((rsi_3_1h_gt_15) | (cmf_20_1d > -0.30) | (stochrsi_k_1d_lt_80))
             # 1h down move, 1h still high
             & ((rsi_3_1h_gt_15) | (aroonu_14_1h_lt_50))
             # 1h down move, 1d high, 4h downtrend
@@ -20176,9 +20213,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 1h high
             & ((rsi_3_1h_gt_20) | (rsi_3_4h_gt_45) | (aroonu_14_1h_lt_60))
             # 1h & 1d down move, 1d high & overbought
-            & ((rsi_3_1h_gt_20) | (rsi_3_1d_gt_55) | (aroonu_14_1d_lt_90) | (roc_9_1d < 20.0))
+            & ((rsi_3_1h_gt_20) | (rsi_3_1d_gt_55) | (aroonu_14_1d_lt_90) | (roc_9_1d_lt_20))
             # 1h down move, 1h high, 1d overbought
-            & ((rsi_3_1h_gt_20) | (aroonu_14_1h_lt_70) | (roc_9_1d < 100.0))
+            & ((rsi_3_1h_gt_20) | (aroonu_14_1h_lt_70) | (roc_9_1d_lt_100))
             # 1h down move, 4h still high
             & ((rsi_3_1h_gt_20) | (aroonu_14_4h_lt_40))
             # 1h down move, 4h still high, 1d downtrend
@@ -20206,7 +20243,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 4h high & overbought
             & ((rsi_3_1h_gt_25) | (stochrsi_k_4h_lt_80) | (roc_9_4h_lt_20))
             # 1h down move, 4h high, 1d overbought
-            & ((rsi_3_1h_gt_25) | (stochrsi_k_4h_lt_80) | (roc_9_1d < 70.0))
+            & ((rsi_3_1h_gt_25) | (stochrsi_k_4h_lt_80) | (roc_9_1d_lt_70))
             # 1h & 4h down move, 1h high
             & ((rsi_3_1h_gt_30) | (rsi_3_4h_gt_30) | (stochrsi_k_1h_lt_60))
             # 1h & 4h down move, 4h still high
@@ -20224,17 +20261,17 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 4h high & overbought
             & ((rsi_3_1h_gt_30) | (aroonu_14_4h_lt_90) | (roc_9_4h_lt_20))
             # 1h down move, 1d high & overbought
-            & ((rsi_3_1h_gt_30) | (aroonu_14_1d_lt_80) | (roc_9_1d < 200.0))
+            & ((rsi_3_1h_gt_30) | (aroonu_14_1d_lt_80) | (roc_9_1d_lt_200))
             # 1h down move, 1d high, 4h downtrend
             & ((rsi_3_1h_gt_30) | (aroonu_14_1d_lt_90) | (roc_9_4h > -40.0))
             # 1h down move, 1d high, 4h overbought
-            & ((rsi_3_1h_gt_30) | (aroonu_14_1d_lt_100) | (roc_9_4h < 80.0))
+            & ((rsi_3_1h_gt_30) | (aroonu_14_1d_lt_100) | (roc_9_4h_lt_80))
             # 1h down move, 1h & 4h still high
             & ((rsi_3_1h_gt_30) | (stochrsi_k_1h_lt_40) | (stochrsi_k_4h_lt_50))
             # 1h down move, 1h highm 1d overbought
             & ((rsi_3_1h_gt_30) | (stochrsi_k_1h_lt_60) | (roc_9_1d_lt_30))
             # 1h down move, 4h overbought
-            & ((rsi_3_1h_gt_30) | (roc_9_4h < 50.0))
+            & ((rsi_3_1h_gt_30) | (roc_9_4h_lt_50))
             # 4h down move, 1d downtrend
             & ((rsi_3_4h_gt_30) | (roc_9_1d_gt_neg_50))
             # 1h down move, 1h high, 4h overbought
@@ -20242,17 +20279,17 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h high, 1d downtrend
             & ((rsi_3_1h_gt_35) | (aroonu_14_1h_lt_70) | (roc_9_1d > -25.0))
             # 1h down move, 4h high & overbought
-            & ((rsi_3_1h_gt_35) | (aroonu_14_4h_lt_85) | (roc_9_4h < 100.0))
+            & ((rsi_3_1h_gt_35) | (aroonu_14_4h_lt_85) | (roc_9_4h_lt_100))
             # 1h down move, 4h high & overbought
-            & ((rsi_3_1h_gt_35) | (aroonu_14_4h_lt_100) | (roc_9_4h < 20.0))
+            & ((rsi_3_1h_gt_35) | (aroonu_14_4h_lt_100) | (roc_9_4h_lt_20))
             # 1h down move, 4h high & overbought
             & ((rsi_3_1h_gt_35) | (stochrsi_k_4h_lt_70) | (roc_9_4h_lt_10))
             # 1h down move, 1d high & overbought
-            & ((rsi_3_1h_gt_35) | (aroonu_14_1d_lt_100) | (roc_9_1d < 100.0))
+            & ((rsi_3_1h_gt_35) | (aroonu_14_1d_lt_100) | (roc_9_1d_lt_100))
             # 1h down move, 1h still high, 1d overbought
-            & ((rsi_3_1h_gt_35) | (stochrsi_k_1h_lt_50) | (roc_9_1d < 200.0))
+            & ((rsi_3_1h_gt_35) | (stochrsi_k_1h_lt_50) | (roc_9_1d_lt_200))
             # 1h down move, 1d high & overbought
-            & ((rsi_3_1h_gt_40) | (rsi_14_1d < 80.0) | (roc_9_1d < 150.0))
+            & ((rsi_3_1h_gt_40) | (rsi_14_1d < 80.0) | (roc_9_1d_lt_150))
             # 1h down move, 15m high, 1h high
             & ((rsi_3_1h_gt_40) | (aroonu_14_15m_lt_60) | aroonu_14_1h_lt_70)
             # 1h down move, 1h high, 1d overbought
@@ -20262,7 +20299,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h & 4h overbought
             & ((rsi_3_1h_gt_40) | (roc_9_1h_lt_10) | (roc_9_4h_lt_10))
             # 1h & 4h down move, 1d overbought
-            & ((rsi_3_1h_gt_45) | (rsi_3_4h_gt_65) | (roc_9_1d < 200.0))
+            & ((rsi_3_1h_gt_45) | (rsi_3_4h_gt_65) | (roc_9_1d_lt_200))
             # 1h down move, 1h high & overbought
             & ((rsi_3_1h_gt_45) | aroonu_14_1h_lt_70 | (roc_9_1h_lt_10))
             # 1h down move, 4h high & overbought
@@ -20270,7 +20307,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h high, 1d downtrend
             & ((rsi_3_1h_gt_50) | (aroonu_14_1h_lt_90) | (roc_9_1d_gt_neg_30))
             # 1h down move, 4h high & overbought
-            & ((rsi_3_1h_gt_50) | aroonu_14_4h_lt_100 | (roc_9_4h < 100.0))
+            & ((rsi_3_1h_gt_50) | aroonu_14_4h_lt_100 | (roc_9_4h_lt_100))
             # 1h down move, 4h high, 1d downtrend
             & ((rsi_3_1h_gt_50) | (stochrsi_k_4h_lt_60) | (roc_9_1d > -60.0))
             # 1h down move, 15m high, 1h high
@@ -20290,7 +20327,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 4h & 1d downtrend
             & ((rsi_3_4h_gt_5) | (roc_9_4h > -15.0) | (roc_9_1d_gt_neg_20))
             # 4h & 1d down move, 1d overbought
-            & ((rsi_3_4h_gt_10) | (rsi_3_1d_gt_45) | (roc_9_1d < 10.0))
+            & ((rsi_3_4h_gt_10) | (rsi_3_1d_gt_45) | (roc_9_1d_lt_10))
             # 4h down move, 1d still high, 1d downtrend
             & ((rsi_3_4h_gt_10) | (aroonu_14_1d_lt_50) | (roc_9_1d > -30.0))
             # 4h down move, 1d high, 4h downtrend
@@ -20362,15 +20399,15 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h downtrend, 1h high
             & ((cmf_20_1h > -0.20) | aroonu_14_1h_lt_80)
             # 4h & 1d downtrend, 1d high
-            & ((cmf_20_4h > -0.30) | (cmf_20_1d > -0.30) | (stochrsi_k_1d < 60.0))
+            & ((cmf_20_4h > -0.30) | (cmf_20_1d > -0.30) | (stochrsi_k_1d_lt_60))
             # 1d downtrend, 1d high & overbought
             & ((cmf_20_1d > -0.30) | (aroonu_14_1d_lt_85) | (roc_9_1d_lt_100))
             # 1d downtrend, 1d high & overbought
             & ((cmf_20_1d > -0.40) | (aroonu_14_1d_lt_85) | (roc_9_1d_lt_20))
             # 15m still high, 1h overbought
-            & ((aroonu_14_15m_lt_40) | (roc_9_1h < 40.0))
+            & ((aroonu_14_15m_lt_40) | (roc_9_1h_lt_40))
             # 15m still high, 4h overbought
-            & ((aroonu_14_15m_lt_40) | (roc_9_4h < 80.0))
+            & ((aroonu_14_15m_lt_40) | (roc_9_4h_lt_80))
             # 15m still high, 1h high
             & ((aroonu_14_15m_lt_50) | (aroonu_14_1h_lt_85))
             # 15m still high, 4h high & overbought
@@ -20380,11 +20417,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h still high, 4h & 1d downtrend
             & ((aroonu_14_1h_lt_40) | (roc_9_4h_gt_neg_20) | (roc_9_1d_gt_neg_40))
             # 1h high, 4h high, 1h overbought
-            & (aroonu_14_1h_lt_70 | aroonu_14_4h_lt_100 | (roc_9_1h < 20.0))
+            & (aroonu_14_1h_lt_70 | aroonu_14_4h_lt_100 | (roc_9_1h_lt_20))
             # 1h & 4h high, 4h overbought
             & (aroonu_14_1h_lt_70 | aroonu_14_4h_lt_100 | (roc_9_4h_lt_40))
             # 1h & 1d high, 1h overbought
-            & (aroonu_14_1h_lt_70 | (aroonu_14_1d_lt_70) | (roc_9_1h < 20.0))
+            & (aroonu_14_1h_lt_70 | (aroonu_14_1d_lt_70) | (roc_9_1h_lt_20))
             # 1h high, 1h & 4h overbought
             & (aroonu_14_1h_lt_70 | (roc_9_1h_lt_10) | (roc_9_4h_lt_40))
             # 1h high, 1d downtrend
@@ -20406,11 +20443,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1d high, 1h & 4h downtrend
             & ((aroonu_14_1d_lt_85) | (roc_9_1h > -30.0) | (roc_9_4h > -50.0))
             # 1d high, 1h & 1d overbought
-            & ((aroonu_14_1d_lt_85) | (roc_9_1h < 20.0) | (roc_9_1d_lt_100))
+            & ((aroonu_14_1d_lt_85) | (roc_9_1h_lt_20) | (roc_9_1d_lt_100))
             # 1d high, 1h & 4h down move
-            & (aroonu_14_1d_lt_100 | (roc_9_1h < 25.0) | (roc_9_4h < 60.0))
+            & (aroonu_14_1d_lt_100 | (roc_9_1h_lt_25) | (roc_9_4h_lt_60))
             # 1d high, 4h & 1d overbought
-            & (aroonu_14_1d_lt_100 | (roc_9_4h < 20.0) | (roc_9_1d_lt_30))
+            & (aroonu_14_1d_lt_100 | (roc_9_4h_lt_20) | (roc_9_1d_lt_30))
             # 1h high, 4h & 1d overbought
             & ((stochrsi_k_1h_lt_90) | (roc_9_4h_lt_20) | (roc_9_1d_lt_100))
             # 4h still high, 4h & 1d downtrend
@@ -20420,25 +20457,25 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h high, 4h & 1d overbought
             & ((stochrsi_k_4h_lt_70) | (roc_9_4h_lt_20) | (roc_9_1d_lt_30))
             # 4h high, 1h overbought, 1d downtrend
-            & ((stochrsi_k_4h_lt_80) | (roc_9_1h < 40.0) | (roc_9_1d > -70.0))
+            & ((stochrsi_k_4h_lt_80) | (roc_9_1h_lt_40) | (roc_9_1d > -70.0))
             # 4h high, 4h overbought
             & ((stochrsi_k_4h_lt_80) | (roc_9_4h_lt_10))
             # 4h high, 1h & 4h overbought
-            & ((stochrsi_k_4h_lt_90) | (roc_9_1h < 20.0) | (roc_9_4h < 50.0))
+            & ((stochrsi_k_4h_lt_90) | (roc_9_1h_lt_20) | (roc_9_4h_lt_50))
             # 1d high, 4h & 1d overbought
             & ((stochrsi_k_1d_lt_90) | (roc_9_4h_lt_40) | (roc_9_1d_lt_100))
             # 1h & 4h overbought
-            & ((roc_9_1h < 30.0) | (roc_9_4h < 80.0))
+            & ((roc_9_1h_lt_30) | (roc_9_4h_lt_80))
             # 1d green with top wick, 4h high
             & ((change_pct_1d < 30.0) | (top_wick_pct_1d < 20.0) | aroonu_14_4h_lt_80)
             # 1d top wick, 4h down move, 1d overbought
-            & ((top_wick_pct_1d < 50.0) | (rsi_3_4h_gt_35) | (roc_9_1d < 60.0))
+            & ((top_wick_pct_1d < 50.0) | (rsi_3_4h_gt_35) | (roc_9_1d_lt_60))
             # drop in last 20 days, 4h high
             & ((close > (high_max_20_1d * 0.10)) | (stochrsi_k_4h_lt_90))
             # drop in last 20 days, 1h high, 1d downtrend
             & ((close > (high_max_20_1d * 0.20)) | aroonu_14_1h_lt_70 | (roc_9_1d > -70.0))
             # drop in last 20 days, 1d high, 1d downtrend
-            & ((close > (high_max_20_1d * 0.20)) | (stochrsi_k_1d < 70.0) | (roc_9_1d > -15.0))
+            & ((close > (high_max_20_1d * 0.20)) | (stochrsi_k_1d_lt_70) | (roc_9_1d > -15.0))
           )
 
           # Logic
@@ -20514,7 +20551,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 4h high
             & ((rsi_3_15m_gt_5) | (rsi_3_1h_gt_50) | (stochrsi_k_4h_lt_90))
             # 15m & 4h down move, 1d still high
-            & ((rsi_3_15m_gt_5) | (rsi_3_4h_gt_5) | (stochrsi_k_1d < 40.0))
+            & ((rsi_3_15m_gt_5) | (rsi_3_4h_gt_5) | (stochrsi_k_1d_lt_40))
             # 15m & 4h down move, 4h still high
             & ((rsi_3_15m_gt_5) | (rsi_3_4h_gt_40) | (stochrsi_k_4h_lt_50))
             # 15m & 1d down move
@@ -20530,7 +20567,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 4h still high
             & ((rsi_3_15m_gt_10) | rsi_3_1h_gt_20 | (stochrsi_k_4h_lt_50))
             # 15m & 1h & 4h down move, 1d high
-            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_25) | (rsi_3_4h_gt_25) | (stochrsi_k_1d < 70.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_25) | (rsi_3_4h_gt_25) | (stochrsi_k_1d_lt_70))
             # 15m & 1h down move, 1h still not low enough
             & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_25) | (aroonu_14_1h_lt_25))
             # 15m & 1h down move, 1h still high
@@ -20582,7 +20619,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 4h down move, 4h still high
             & ((rsi_3_15m_gt_15) | (rsi_3_4h_gt_50) | (aroonu_14_4h_lt_50))
             # 1h & 1d down move, 1d overbought
-            & ((rsi_3_1h_gt_15) | (rsi_3_1d_gt_35) | (roc_9_1d < 10.0))
+            & ((rsi_3_1h_gt_15) | (rsi_3_1d_gt_35) | (roc_9_1d_lt_10))
             # 15m down move, 15m still not low enough, 1h high
             & ((rsi_3_15m_gt_15) | (aroonu_14_15m_lt_25) | (stochrsi_k_1h_lt_80))
             # 15m down move, 4h high & overbought
@@ -20648,7 +20685,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 1h still high
             & ((rsi_3_1h_gt_25) | (rsi_3_4h_gt_25) | (stochrsi_k_1h_lt_50))
             # 1h & 4h down move, 1d high
-            & ((rsi_3_1h_gt_25) | (rsi_3_4h_gt_30) | (stochrsi_k_1d < 80.0))
+            & ((rsi_3_1h_gt_25) | (rsi_3_4h_gt_30) | (stochrsi_k_1d_lt_80))
             # 1h & 4h down move, 1h high
             & ((rsi_3_1h_gt_25) | (rsi_3_4h_gt_60) | (stochrsi_k_4h_lt_80))
             # 1h & 4h down move, 1h still high
@@ -20664,7 +20701,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h & 4h high
             & ((rsi_3_1h_gt_40) | aroonu_14_1h_lt_80 | aroonu_14_4h_lt_100)
             # 1h down move, 1h high, 1d high & overbought
-            & ((rsi_3_1h_gt_45) | (stochrsi_k_1h_lt_60) | (stochrsi_k_1d < 70.0) | (roc_9_1d < 40.0))
+            & ((rsi_3_1h_gt_45) | (stochrsi_k_1h_lt_60) | (stochrsi_k_1d_lt_70) | (roc_9_1d_lt_40))
             # 1h down move, 1h high & overbought
             & ((rsi_3_1h_gt_55) | (stochrsi_k_1h_lt_80) | (roc_9_1h_lt_10))
             # 1h down move, 4h high
@@ -20704,23 +20741,23 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1d down move, 1h high & overbought
             & ((rsi_3_1d_gt_35) | (stochrsi_k_1h_lt_90) | (roc_9_1h_lt_10))
             # 1d down move, 4h high, 1d overbought
-            & ((rsi_3_1d_gt_45) | (stochrsi_k_4h_lt_90) | (roc_9_1d < 10.0))
+            & ((rsi_3_1d_gt_45) | (stochrsi_k_4h_lt_90) | (roc_9_1d_lt_10))
             # 4h still high, 4h moving lower, 4h overbought
             & ((aroonu_14_4h_lt_50) | (aroonu_14_4h > aroonu_14_4h.shift(48)) | (roc_9_4h_lt_40))
             # 1h high, 1d downtrend
             & ((aroonu_14_1d_lt_70) | (roc_9_1d_gt_neg_30))
             # 1d high, 4h & 1d overbought
-            & ((aroonu_14_1d_lt_85) | (roc_9_4h < 60.0) | (roc_9_1d < 60.0))
+            & ((aroonu_14_1d_lt_85) | (roc_9_4h_lt_60) | (roc_9_1d_lt_60))
             # 1d high, 4h & 1d overbought
             & (aroonu_14_1d_lt_100 | (roc_9_4h_lt_10) | (roc_9_1d_lt_20))
             # 1h high, 4h downtrend
             & ((stochrsi_k_1h_lt_80) | (roc_9_4h_gt_neg_20))
             # 1h high, 4h overbought
-            & ((stochrsi_k_1h_lt_80) | (roc_9_4h < 80.0))
+            & ((stochrsi_k_1h_lt_80) | (roc_9_4h_lt_80))
             # 4h high, 4h & 1d overbought
             & ((stochrsi_k_4h_lt_80) | (roc_9_4h_lt_30) | (roc_9_1d_lt_30))
             # 1d high, 4h & 1d overbought
-            & ((stochrsi_k_1d < 80.0) | (roc_9_4h < 60.0) | (roc_9_1d < 60.0))
+            & ((stochrsi_k_1d_lt_80) | (roc_9_4h_lt_60) | (roc_9_1d_lt_60))
             # 1d red, 4h down move, 1h still high
             & ((change_pct_1d > -30.0) | (rsi_3_4h_gt_30) | (stochrsi_k_1h_lt_50))
             # pump, drop but not yet near the previous lows
@@ -20752,7 +20789,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # big drop in the last 20 days, 1h still high
             & ((close > (high_max_20_1d * 0.05)) | (aroonu_14_1h_lt_50))
             # big drop in the last 20 days, 1d high, 1d downtrend
-            & ((close > (high_max_20_1d * 0.20)) | (stochrsi_k_1d < 70.0) | (roc_9_1d > -15.0))
+            & ((close > (high_max_20_1d * 0.20)) | (stochrsi_k_1d_lt_70) | (roc_9_1d > -15.0))
             # big drop in the last 30 days, 1h down move
             & ((close > (high_max_30_1d * 0.25)) | (rsi_3_1h_gt_15))
           )
@@ -20809,7 +20846,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 5m & 15m down move, 4h high
             & ((rsi_3_gt_10) | (rsi_3_15m_gt_20) | (aroonu_14_4h_lt_90))
             # 5m & 15m down move, 1d high
-            & ((rsi_3_gt_10) | (rsi_3_15m_gt_20) | (stochrsi_k_1d < 80.0))
+            & ((rsi_3_gt_10) | (rsi_3_15m_gt_20) | (stochrsi_k_1d_lt_80))
             # 5m & 15m down move, 1h high
             & ((rsi_3_gt_10) | (rsi_3_15m_gt_25) | (stochrsi_k_1h_lt_90))
             # 5m & 1h down move, 4h still high
@@ -20829,7 +20866,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 1h still not low enough
             & ((rsi_3_15m_gt_10) | rsi_3_1h_gt_20 | (stochrsi_k_1h_lt_20))
             # 15m & 1h & 4h down move, 1d high
-            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_25) | (rsi_3_4h_gt_25) | (stochrsi_k_1d < 70.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_25) | (rsi_3_4h_gt_25) | (stochrsi_k_1d_lt_70))
             # 15m & 1h down move, 1h still not low enough
             & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_25) | (aroonu_14_1h_lt_30))
             # 15m & 1h down move, 1h still high
@@ -20863,13 +20900,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 15m still not low enough, 1h high
             & ((rsi_3_15m_gt_10) | (aroonu_14_15m_lt_30) | (stochrsi_k_1h_lt_80))
             # 15m down move, 1h high, 4h overbought
-            & ((rsi_3_15m_gt_10) | aroonu_14_1h_lt_70 | (roc_9_4h < 50.0))
+            & ((rsi_3_15m_gt_10) | aroonu_14_1h_lt_70 | (roc_9_4h_lt_50))
             # 15m down move, 1d high & overbought
             & ((rsi_3_15m_gt_10) | (aroonu_14_1d_lt_80) | (roc_9_1d_lt_20))
             # 15m & 1h down move, 1h still high
             & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_30) | (aroonu_14_1h_lt_40))
             # 15m & 1h & 4h & 1d down move, 1d high
-            & ((rsi_3_15m_gt_15) | (rsi_3_1h_gt_30) | (rsi_3_4h_gt_40) | (rsi_3_1d_gt_50) | (stochrsi_k_1d < 70.0))
+            & ((rsi_3_15m_gt_15) | (rsi_3_1h_gt_30) | (rsi_3_4h_gt_40) | (rsi_3_1d_gt_50) | (stochrsi_k_1d_lt_70))
             # 15m & 1h down move, 1h still high
             & ((rsi_3_15m_gt_15) | (rsi_3_1h_gt_40) | (aroonu_14_1h_lt_50))
             # 15m & 1h down move, 1h still high
@@ -20963,7 +21000,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 15m still not low enough, 1h high
             & ((rsi_3_15m_gt_30) | (stochrsi_k_15m_lt_30) | (stochrsi_k_1h_lt_80))
             # 15m down move, 15m still high, 1d high, 1d downtrend
-            & ((rsi_3_15m_gt_30) | (aroonu_14_15m_lt_50) | (stochrsi_k_1d < 70.0) | (roc_9_1d > -15.0))
+            & ((rsi_3_15m_gt_30) | (aroonu_14_15m_lt_50) | (stochrsi_k_1d_lt_70) | (roc_9_1d > -15.0))
             # 15m down move, 1h still high, 4h high
             & ((rsi_3_15m_gt_30) | (aroonu_14_1h_lt_50) | (aroonu_14_4h_lt_90))
             # 15m down move, 15m & 1h high
@@ -20997,7 +21034,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h still not low enough, 4h high
             & ((rsi_3_1h_gt_25) | (stochrsi_k_1h_lt_30) | (stochrsi_k_4h_lt_70))
             # 1h down move, 1d still high, 1d downtrend
-            & ((rsi_3_1h_gt_25) | (stochrsi_k_1d < 50.0) | (roc_9_1d_gt_neg_20))
+            & ((rsi_3_1h_gt_25) | (stochrsi_k_1d_lt_50) | (roc_9_1d_gt_neg_20))
             # 1h down move, 4h high & overbought
             & ((rsi_3_1h_gt_30) | aroonu_14_4h_lt_70 | (roc_9_4h_lt_10))
             # 1h down move, 4h high, 1d downtrend
@@ -21023,7 +21060,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1d high, 1h overbought
             & ((rsi_3_1h_gt_60) | (aroonu_14_1d_lt_90) | (roc_9_1h_lt_10))
             # 4h down move, 4h still not low enough, 1d overbought
-            & ((rsi_3_4h_gt_15) | (aroonu_14_4h_lt_30) | (roc_9_1d < 100.0))
+            & ((rsi_3_4h_gt_15) | (aroonu_14_4h_lt_30) | (roc_9_1d_lt_100))
             # 4h down move, 15m still high, 1d downtrend
             & ((rsi_3_4h_gt_15) | (stochrsi_k_15m_lt_50) | (roc_9_1d > -20.0))
             # 4h & 1d down move, 15m still not low enough
@@ -21071,9 +21108,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h high
             & ((aroonu_14_15m_lt_90) | (aroonu_14_1h_lt_90))
             # 1h still high, 4h high & overbought
-            & ((aroonu_14_1h_lt_50) | (aroonu_14_4h_lt_90) | (roc_9_4h < 80.0))
+            & ((aroonu_14_1h_lt_50) | (aroonu_14_4h_lt_90) | (roc_9_4h_lt_80))
             # 1h & 4h high, 1h overbought
-            & (aroonu_14_1h_lt_80 | aroonu_14_4h_lt_100 | (roc_9_1h < 40.0))
+            & (aroonu_14_1h_lt_80 | aroonu_14_4h_lt_100 | (roc_9_1h_lt_40))
             # 1h & 1d high, 1d overbought
             & (aroonu_14_1h_lt_80 | aroonu_14_1d_lt_100 | (roc_9_1d_lt_30))
             # 1h high, 4h & 1d overbought
@@ -21081,13 +21118,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h & 1d high, 4h overbought
             & (aroonu_14_4h_lt_80 | aroonu_14_1d_lt_100 | (roc_9_4h_lt_30))
             # 4h & 1d high, 1d overbought
-            & (aroonu_14_4h_lt_70 | aroonu_14_1d_lt_100 | (roc_9_1d < 10.0))
+            & (aroonu_14_4h_lt_70 | aroonu_14_1d_lt_100 | (roc_9_1d_lt_10))
             # 4h high & overbought
-            & ((aroonu_14_4h_lt_90) | (stochrsi_k_4h < 85.0) | (roc_9_4h < 50.0))
+            & ((aroonu_14_4h_lt_90) | (stochrsi_k_4h < 85.0) | (roc_9_4h_lt_50))
             # 1d high, 4h & 1d overbought
             & (aroonu_14_1d_lt_100 | (roc_9_4h_lt_10) | roc_9_1d_lt_50)
             # 1d high, 4h & 1d overbought
-            & (aroonu_14_1d_lt_100 | (roc_9_4h < 20.0) | (roc_9_1d_lt_40))
+            & (aroonu_14_1d_lt_100 | (roc_9_4h_lt_20) | (roc_9_1d_lt_40))
             # 4h high, 4h & 1d overbought
             & ((stochrsi_k_4h_lt_70) | (roc_9_4h_lt_30) | (roc_9_1d_lt_30))
             # 5m red, 1h still high
@@ -21158,7 +21195,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 15m & 1h still high
             & ((rsi_3_15m_gt_20) | (stochrsi_k_15m_lt_50) | (stochrsi_k_1h_lt_50))
             # 15m down move, 4h overbought
-            & ((rsi_3_15m_gt_20) | (roc_9_4h < 70.0))
+            & ((rsi_3_15m_gt_20) | (roc_9_4h_lt_70))
             # 15m down move, 15m still high, 1h high
             & ((rsi_3_15m_gt_25) | (aroonu_14_15m_lt_50) | aroonu_14_1h_lt_80)
             # 15m down move, 4h & 1d high
@@ -21166,7 +21203,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 1h & 1d high
             & ((rsi_3_15m_gt_25) | (stochrsi_k_1h_lt_80) | (stochrsi_k_1d_lt_90))
             # 15m down move, 1h high & overbought
-            & ((rsi_3_15m_gt_25) | (stochrsi_k_1h_lt_80) | (roc_9_1h < 20.0))
+            & ((rsi_3_15m_gt_25) | (stochrsi_k_1h_lt_80) | (roc_9_1h_lt_20))
             # 15m & 1h down move, 15m high
             & ((rsi_3_15m_gt_30) | (rsi_3_1h_gt_30) | (aroonu_14_15m_lt_70))
             # 15m & 4h & 1d down move, 4h & 1d high
@@ -21182,13 +21219,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 15m & 1h high
             & ((rsi_3_15m_gt_35) | (aroonu_14_15m_lt_70) | (stochrsi_k_1h_lt_80))
             # 15m down move, 1h high, 4h overbought
-            & ((rsi_3_15m_gt_35) | (aroonu_14_1h_lt_85) | (roc_9_4h < 80.0))
+            & ((rsi_3_15m_gt_35) | (aroonu_14_1h_lt_85) | (roc_9_4h_lt_80))
             # 1h & 4h down move, 1h still high
             & ((rsi_3_1h_gt_10) | rsi_3_4h_gt_20 | (aroonu_14_1h_lt_40))
             # 1h & 4h down move, 15m still not low enough
             & ((rsi_3_1h_gt_10) | rsi_3_4h_gt_20 | (stochrsi_k_15m_lt_20))
             # 1h down move, 1d high & overbought
-            & ((rsi_3_1h_gt_10) | (aroonu_14_1d_lt_90) | (roc_9_1d < 10.0))
+            & ((rsi_3_1h_gt_10) | (aroonu_14_1d_lt_90) | (roc_9_1d_lt_10))
             # 1h & 4h down move, 4h still high
             & ((rsi_3_1h_gt_15) | rsi_3_4h_gt_20 | (aroonu_14_4h_lt_40))
             # 1h down move, 4h still high, 4h downtrend
@@ -21196,7 +21233,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 15m still not low enough, 4h high
             & (rsi_3_1h_gt_20 | (aroonu_14_15m_lt_25) | aroonu_14_4h_lt_80)
             # 1h down move, 4h & 1d high
-            & ((rsi_3_1h_gt_30) | aroonu_14_4h_lt_70 | (stochrsi_k_1d < 80.0))
+            & ((rsi_3_1h_gt_30) | aroonu_14_4h_lt_70 | (stochrsi_k_1d_lt_80))
             # 1h down move, 4h high & overbought
             & ((rsi_3_1h_gt_30) | aroonu_14_4h_lt_70 | (roc_9_4h_lt_10))
             # 1h down move, 4h high, 1d overbought
@@ -21212,7 +21249,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h high, 4h overbought
             & ((rsi_3_1h_gt_40) | aroonu_14_1h_lt_70 | (roc_9_4h_lt_30))
             # 1h down move, 1h overbought
-            & ((rsi_3_1h_gt_40) | (roc_9_1h < 30.0))
+            & ((rsi_3_1h_gt_40) | (roc_9_1h_lt_30))
             # 1h down move, 1d high & overbought
             & ((rsi_3_1h_gt_45) | aroonu_14_1d_lt_100 | (roc_9_1d_lt_30))
             # 1h down move, 15m & 1h still high
@@ -21240,7 +21277,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 4h still high, 1d downtrend
             & ((rsi_3_4h_gt_50) | (rsi_14_4h < 40.0) | (roc_9_1d_gt_neg_30))
             # 4h down move, 4h high & overbought
-            & ((rsi_3_4h_gt_50) | (aroonu_14_4h_lt_80) | (roc_9_4h < 20.0))
+            & ((rsi_3_4h_gt_50) | (aroonu_14_4h_lt_80) | (roc_9_4h_lt_20))
             # 4h down move, 4h still high, 1d downtrend
             & ((rsi_3_4h_gt_50) | (stochrsi_k_4h_lt_50) | (roc_9_1d_gt_neg_30))
             # 4h down move, 15m still high, 1h high
@@ -21254,13 +21291,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1d down move, 15m still high, 1h high
             & ((rsi_3_1d_gt_15) | (aroonu_14_15m_lt_50) | (aroonu_14_1h_lt_85))
             # 1d down move, 1h & 1d overbought
-            & ((rsi_3_1d_gt_45) | (roc_9_1h < 80.0) | (roc_9_1d_lt_80))
+            & ((rsi_3_1d_gt_45) | (roc_9_1h_lt_80) | (roc_9_1d_lt_80))
             # 15m still high, 1h & 4h high
             & ((rsi_14_15m < 40.0) | aroonu_14_1h_lt_80 | (aroonu_14_4h_lt_90))
             # 15m & 1h still high, 4h high
             & ((rsi_14_15m < 45.0) | (aroonu_14_1h_lt_40) | (stochrsi_k_4h_lt_70))
             # 15m still high, 4h high & overbought
-            & ((rsi_14_15m < 50.0) | (aroonu_14_4h_lt_90) | (roc_9_4h < 80.0))
+            & ((rsi_14_15m < 50.0) | (aroonu_14_4h_lt_90) | (roc_9_4h_lt_80))
             # 15m still high, 1h high, 4h still high
             & ((aroonu_14_15m_lt_50) | (aroonu_14_1h_lt_90) | (stochrsi_k_4h_lt_50))
             # 15m still high, 1d high
@@ -21276,9 +21313,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h high, 1h & 1d overbought
             & ((aroonu_14_1h_lt_90) | (roc_9_1h_lt_10) | (roc_9_1d_lt_30))
             # 4h & 1d high, 1d overbought
-            & (aroonu_14_4h_lt_70 | aroonu_14_1d_lt_100 | (roc_9_1d < 10.0))
+            & (aroonu_14_4h_lt_70 | aroonu_14_1d_lt_100 | (roc_9_1d_lt_10))
             # 4h high, 4h & 1d overbought
-            & (aroonu_14_4h_lt_80 | (roc_9_4h < 80.0) | (roc_9_1d < 100.0))
+            & (aroonu_14_4h_lt_80 | (roc_9_4h_lt_80) | (roc_9_1d_lt_100))
             # 1d high, 4h & 1d overbought
             & (aroonu_14_1d_lt_100 | (roc_9_4h_lt_10) | roc_9_1d_lt_50)
             # 15m still high, 1h high
@@ -21292,7 +21329,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1d top wick, 4h high
             & ((top_wick_pct_1d < 30.0) | (aroonu_14_4h_lt_90))
             # pump, 4h overbought
-            & ((((df["high_max_6_1h"] - df["low_min_6_1h"]) / df["low_min_6_1h"]) < 0.5) | (roc_9_4h < 50.0))
+            & ((((df["high_max_6_1h"] - df["low_min_6_1h"]) / df["low_min_6_1h"]) < 0.5) | (roc_9_4h_lt_50))
             # pump, drop but not yet near the previous lows
             & (
               (((high_max_24_4h - low_min_24_4h) / low_min_24_4h) < 2.0)
@@ -21363,7 +21400,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m & 1h down move, 4h still high
           long_entry_logic.append((rsi_3_15m_gt_10) | rsi_3_1h_gt_20 | (stochrsi_k_4h_lt_50))
           # 15m & 1h down move, 4h overbought
-          long_entry_logic.append((rsi_3_15m_gt_10) | (rsi_3_1h_gt_40) | (roc_9_4h < 50.0))
+          long_entry_logic.append((rsi_3_15m_gt_10) | (rsi_3_1h_gt_40) | (roc_9_4h_lt_50))
           # 15m & 1h down move, 1h high
           long_entry_logic.append((rsi_3_15m_gt_10) | (rsi_3_1h_gt_25) | aroonu_14_1h_lt_80)
           # 15m & 4h down move, 1h & 4h downtrend
@@ -21395,7 +21432,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m down move, 4h still high, 4h downtrend
           long_entry_logic.append((rsi_3_15m_gt_15) | (aroonu_14_4h_lt_40) | (roc_9_4h_gt_neg_20))
           # 15m down move, 1d high, 4h overbought
-          long_entry_logic.append((rsi_3_15m_gt_15) | aroonu_14_1d_lt_100 | (roc_9_4h < 50.0))
+          long_entry_logic.append((rsi_3_15m_gt_15) | aroonu_14_1d_lt_100 | (roc_9_4h_lt_50))
           # 15m & 3h down move, 15m still not low enough
           long_entry_logic.append((rsi_3_15m_gt_20) | rsi_3_4h_gt_20 | (stochrsi_k_15m_lt_20))
           # 15m & 1h down move, 1h still high
@@ -21423,7 +21460,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1h & 4h down move, 4h still not low enough
           long_entry_logic.append((rsi_3_1h_gt_10) | (rsi_3_4h_gt_15) | (stochrsi_k_4h_lt_30))
           # 1h & 4h down move, 1d still high
-          long_entry_logic.append((rsi_3_1h_gt_10) | (rsi_3_4h_gt_15) | (stochrsi_k_1d < 50.0))
+          long_entry_logic.append((rsi_3_1h_gt_10) | (rsi_3_4h_gt_15) | (stochrsi_k_1d_lt_50))
           # 1h & 1d down move, 1h still moving lower
           long_entry_logic.append((rsi_3_1h_gt_10) | (rsi_3_1d_gt_15) | (cci_20_change_pct_1h > -0.0))
           # 1h down move, 1d high, 4h downtrend
@@ -21443,7 +21480,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1h & 1d down move, 1d high
           long_entry_logic.append((rsi_3_1h_gt_15) | (rsi_3_1d_gt_25) | (aroonu_14_1d_lt_70))
           # 1h & 1d down move, 1d high
-          long_entry_logic.append((rsi_3_1h_gt_15) | (rsi_3_1d_gt_25) | (stochrsi_k_1d < 70.0))
+          long_entry_logic.append((rsi_3_1h_gt_15) | (rsi_3_1d_gt_25) | (stochrsi_k_1d_lt_70))
           # 1h down move, 1h & 4h high
           long_entry_logic.append((rsi_3_1h_gt_15) | (aroonu_14_1h_lt_60) | (aroonu_14_4h_lt_60))
           # 1h & 4h down move, 1d overbought
@@ -21489,7 +21526,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 4h down move, 4h still high, 1d downtrend
           long_entry_logic.append((rsi_3_4h_gt_5) | (stochrsi_k_4h_lt_40) | (roc_9_1d_gt_neg_20))
           # 4h down move, 1d still not low enough, 1d downtrend
-          long_entry_logic.append((rsi_3_4h_gt_5) | (stochrsi_k_1d < 30.0) | (roc_9_1d_gt_neg_20))
+          long_entry_logic.append((rsi_3_4h_gt_5) | (stochrsi_k_1d_lt_30) | (roc_9_1d_gt_neg_20))
           # 4h down move, 1h downtrend, 1h still not low enough
           long_entry_logic.append((rsi_3_4h_gt_10) | (cmf_20_1h > -0.25) | (aroonu_14_1h_lt_30))
           # 4h down move, 1h & 1d downtrend
@@ -21497,7 +21534,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 4h & 1d down move, 4h still high
           long_entry_logic.append((rsi_3_4h_gt_15) | (rsi_3_1d_gt_45) | (stochrsi_k_4h_lt_40))
           # 4h & 1d down move, 1d high
-          long_entry_logic.append(rsi_3_4h_gt_20 | (rsi_3_1d_gt_25) | (stochrsi_k_1d < 60.0))
+          long_entry_logic.append(rsi_3_4h_gt_20 | (rsi_3_1d_gt_25) | (stochrsi_k_1d_lt_60))
           # 4h down move, 1d high & overbought
           long_entry_logic.append(rsi_3_4h_gt_20 | (aroonu_14_1d_lt_70) | roc_9_1d_lt_50)
           # 4h down move, 1h still high, 1d downtrend
@@ -21505,7 +21542,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 4h down move, 1h high
           long_entry_logic.append(rsi_3_4h_gt_20 | (stochrsi_k_1h_lt_80))
           # 4h down move, 1d high, 1h downtrend
-          long_entry_logic.append(rsi_3_4h_gt_20 | (stochrsi_k_1d < 70.0) | (roc_9_1h > -10.0))
+          long_entry_logic.append(rsi_3_4h_gt_20 | (stochrsi_k_1d_lt_70) | (roc_9_1h > -10.0))
           # 4h down move, 4h still high, 1d overbought
           long_entry_logic.append((rsi_3_4h_gt_30) | (aroonu_14_4h_lt_40) | (roc_9_1d_lt_100))
           # 4h down move, 4h high, 1h downtrend
@@ -21623,17 +21660,17 @@ class NostalgiaForInfinityX7(IStrategy):
             # 5m down move, 1h & 1d high
             & ((rsi_3_gt_10) | aroonu_14_1h_lt_80 | aroonu_14_1d_lt_100)
             # 15m & 1h down move, 1d overbought
-            & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_10) | (roc_9_1d < 100.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_10) | (roc_9_1d_lt_100))
             # 15m & 1h down move, 1h still not low enough
             & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_10) | (stochrsi_k_1h_lt_20))
             # 15m & 1h down move, 1d overbought
-            & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_10) | (roc_9_1d < 60.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_10) | (roc_9_1d_lt_60))
             # 15m & 1h down move, 4h still high
             & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_15) | (aroonu_14_4h_lt_40))
             # 15m & 1h down move, 4h high
             & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_15) | (stochrsi_k_4h_lt_90))
             # 15m & 1h down move, 1d still high
-            & (rsi_3_15m_gt_3 | rsi_3_1h_gt_20 | (stochrsi_k_1d < 50.0))
+            & (rsi_3_15m_gt_3 | rsi_3_1h_gt_20 | (stochrsi_k_1d_lt_50))
             # 15m & 1h & 4h down move, 1d downtrend
             & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_25) | (rsi_14_4h < 40.0) | (roc_9_1d > -10.0))
             # 15m & 1h down move, 15m still high
@@ -21647,7 +21684,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 1h high
             & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_45) | (stochrsi_k_1h_lt_80))
             # 15m & 1h down move, 1d high
-            & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_45) | (stochrsi_k_1d < 80.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_45) | (stochrsi_k_1d_lt_80))
             # 15m & 4h down move, 15m downtrend
             & (rsi_3_15m_gt_3 | (rsi_3_4h_gt_3) | (cmf_20_15m > -0.30))
             # 15m & 4h down move, 4h still high
@@ -21655,7 +21692,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 1h high, 4h overbought
             & (rsi_3_15m_gt_3 | aroonu_14_1h_lt_70 | (roc_9_4h_lt_10))
             # 15m down move, 1d high & overbought
-            & (rsi_3_15m_gt_3 | (aroonu_14_1d_lt_70) | (roc_9_1d < 10.0))
+            & (rsi_3_15m_gt_3 | (aroonu_14_1d_lt_70) | (roc_9_1d_lt_10))
             # 15m & 1h down move, 4h still high
             & ((rsi_3_15m_gt_5) | (rsi_3_1h_gt_10) | (stochrsi_k_4h_lt_50))
             # 15m & 1h down move, 1h still high
@@ -21683,7 +21720,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 1h still high
             & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_15) | (stochrsi_k_1h_lt_50))
             # 15m & 1h down move, 1d still high
-            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_15) | (stochrsi_k_1d < 50.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_15) | (stochrsi_k_1d_lt_50))
             # 15m & 1h down move, 15m high
             & ((rsi_3_15m_gt_10) | rsi_3_1h_gt_20 | (aroonu_14_15m_lt_60))
             # 15m & 1h down move, 1h high
@@ -21691,7 +21728,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 1h high
             & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_30) | (stochrsi_k_1h_lt_70))
             # 15m & 1h down move, 1d overbought
-            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_30) | (roc_9_1d < 60.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_30) | (roc_9_1d_lt_60))
             # 15m & 4h down move, 15m still high
             & ((rsi_3_15m_gt_10) | (rsi_3_4h_gt_10) | (aroonu_14_15m_lt_40))
             # 15m & 4h down move, 1d high
@@ -21711,7 +21748,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 4h down move, 1h high
             & ((rsi_3_15m_gt_10) | rsi_3_4h_gt_20 | (stochrsi_k_1h_lt_70))
             # 15m & 4h down move, 1d high
-            & ((rsi_3_15m_gt_10) | rsi_3_4h_gt_20 | (stochrsi_k_1d < 80.0))
+            & ((rsi_3_15m_gt_10) | rsi_3_4h_gt_20 | (stochrsi_k_1d_lt_80))
             # 15m & 4h down move, 1d overbought
             & ((rsi_3_15m_gt_10) | rsi_3_4h_gt_20 | roc_9_1d_lt_50)
             # 15m & 4h down move, 1d high
@@ -21725,7 +21762,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1d down move, 1h still high
             & ((rsi_3_15m_gt_10) | (rsi_3_1d_gt_10) | (stochrsi_k_1h_lt_50))
             # 15m & 1d down move, 1d high
-            & ((rsi_3_15m_gt_10) | (rsi_3_1d_gt_30) | (stochrsi_k_1d < 60.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_1d_gt_30) | (stochrsi_k_1d_lt_60))
             # 15m down move, 15m & 1h high
             & ((rsi_3_15m_gt_10) | (aroonu_14_15m_lt_60) | (aroonu_14_1h_lt_100))
             # 15m down move, 15m & 4h high
@@ -21775,7 +21812,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 4h high & overbought
             & ((rsi_3_15m_gt_20) | (rsi_3_1h_gt_30) | (stochrsi_k_4h_lt_80) | (roc_9_4h_lt_10))
             # 15m down move, 1h high, 1d overbought
-            & ((rsi_3_15m_gt_20) | (aroonu_14_1h_lt_80) | (roc_9_1d < 10.0))
+            & ((rsi_3_15m_gt_20) | (aroonu_14_1h_lt_80) | (roc_9_1d_lt_10))
             # 15m down move, 1h high, 1d downtrend
             & ((rsi_3_15m_gt_20) | (stochrsi_k_1h_lt_80) | (roc_9_1d_gt_neg_20))
             # 15m down move, 4h high, 1d downtrend
@@ -21801,11 +21838,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 4h still not low enough
             & ((rsi_3_1h_gt_3) | (rsi_3_4h_gt_10) | (stochrsi_k_4h_lt_10))
             # 1h & 4h down move, 1d still high
-            & ((rsi_3_1h_gt_3) | (rsi_3_4h_gt_10) | (stochrsi_k_1d < 40.0))
+            & ((rsi_3_1h_gt_3) | (rsi_3_4h_gt_10) | (stochrsi_k_1d_lt_40))
             # 1h & 4h down move, 1d overbought
-            & ((rsi_3_1h_gt_3) | (rsi_3_4h_gt_25) | (roc_9_1d < 10.0))
+            & ((rsi_3_1h_gt_3) | (rsi_3_4h_gt_25) | (roc_9_1d_lt_10))
             # 1h & 1d down move, 1d still high
-            & ((rsi_3_1h_gt_3) | (rsi_3_1d_gt_25) | (stochrsi_k_1d < 40.0))
+            & ((rsi_3_1h_gt_3) | (rsi_3_1d_gt_25) | (stochrsi_k_1d_lt_40))
             # 1h & 4h down move, 15m still not low enough
             & ((rsi_3_1h_gt_5) | (rsi_3_4h_gt_5) | (stochrsi_k_15m_lt_20))
             # 1h & 4h down move, 4h downtrend
@@ -21845,7 +21882,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 1d down move, 1d high
             & ((rsi_3_1h_gt_15) | (rsi_3_1d_gt_35) | (aroonu_14_1d_lt_70))
             # 1h down move, 1h still high, 1d high
-            & ((rsi_3_1h_gt_15) | (aroonu_14_1h_lt_50) | (stochrsi_k_1d < 80.0))
+            & ((rsi_3_1h_gt_15) | (aroonu_14_1h_lt_50) | (stochrsi_k_1d_lt_80))
             # 1h down move, 1h still high, 4h overbought
             & ((rsi_3_1h_gt_15) | (aroonu_14_1h_lt_50) | (roc_9_4h_lt_10))
             # 1h down move, 1h still high, 1d downtrend
@@ -21867,7 +21904,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 15m still high, 1d high
             & (rsi_3_1h_gt_20 | (aroonu_14_15m_lt_40) | (aroonu_14_1d_lt_90))
             # 1h down move, 1h high, 1d overbought
-            & (rsi_3_1h_gt_20 | (aroonu_14_1h_lt_60) | (roc_9_1d < 10.0))
+            & (rsi_3_1h_gt_20 | (aroonu_14_1h_lt_60) | (roc_9_1d_lt_10))
             # 1h & 4h down move, 15m high
             & ((rsi_3_1h_gt_25) | (rsi_3_4h_gt_25) | (stochrsi_k_15m_lt_70))
             # 1h & 4h down move, 1h high
@@ -21879,7 +21916,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1d high & overbought
             & ((rsi_3_1h_gt_30) | (aroonu_14_1d_lt_85) | (roc_9_1d_lt_40))
             # 1h down move, 1d high & overbought
-            & ((rsi_3_1h_gt_30) | (stochrsi_k_1d < 80.0) | (roc_9_1d_lt_20))
+            & ((rsi_3_1h_gt_30) | (stochrsi_k_1d_lt_80) | (roc_9_1d_lt_20))
             # 1h down move, 15m still high, 1h high
             & ((rsi_3_1h_gt_30) | (aroonu_14_15m_lt_50) | (aroonu_14_1h_lt_85))
             # 1h down move, 4h high, 1d overbought
@@ -21897,9 +21934,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h & 4h high
             & ((rsi_3_1h_gt_45) | (aroonu_14_1h_lt_75) | aroonu_14_4h_lt_100)
             # 1h down move, 1h high, 1d high & overbought
-            & ((rsi_3_1h_gt_45) | (stochrsi_k_1h_lt_60) | (stochrsi_k_1d < 70.0) | (roc_9_1d < 40.0))
+            & ((rsi_3_1h_gt_45) | (stochrsi_k_1h_lt_60) | (stochrsi_k_1d_lt_70) | (roc_9_1d_lt_40))
             # 1h down move, 4h high & overbought
-            & ((rsi_3_1h_gt_50) | (stochrsi_k_4h_lt_90) | (roc_9_4h < 25.0))
+            & ((rsi_3_1h_gt_50) | (stochrsi_k_4h_lt_90) | (roc_9_4h_lt_25))
             # 1h & 1d down move, 1h high
             & ((rsi_3_1h_gt_60) | (rsi_3_1d_gt_60) | aroonu_14_1h_lt_70)
             # 4h & 1d down move, 1d still high
@@ -21907,7 +21944,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 1h still not low enough, 4h downtrend
             & ((rsi_3_4h_gt_3) | (aroonu_14_1h_lt_20) | (roc_9_4h > -10.0))
             # 4h & 1d down move, 1d still high
-            & ((rsi_3_4h_gt_5) | (rsi_3_1d_gt_30) | (stochrsi_k_1d < 40.0))
+            & ((rsi_3_4h_gt_5) | (rsi_3_1d_gt_30) | (stochrsi_k_1d_lt_40))
             # 4h down move, 1h high
             & ((rsi_3_4h_gt_5) | (stochrsi_k_1h_lt_90))
             # 4h down move, 4h & 1d downtrend
@@ -21953,11 +21990,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 4h still not low enough, 1d downtrend
             & ((rsi_3_4h_gt_15) | (stochrsi_k_4h_lt_20) | (roc_9_1d > -20.0))
             # 4h down move, 1h downtrend, 1d overbought
-            & ((rsi_3_4h_gt_15) | (roc_9_1h > -10.0) | (roc_9_1d < 200.0))
+            & ((rsi_3_4h_gt_15) | (roc_9_1h > -10.0) | (roc_9_1d_lt_200))
             # 4h down move, 4h high, 4h downtrend
             & (rsi_3_4h_gt_20 | (aroonu_14_4h_lt_60) | (roc_9_4h_gt_neg_20))
             # 4h down move, 1d high & overbought
-            & (rsi_3_4h_gt_20 | (aroonu_14_1d_lt_80) | (roc_9_1d < 70.0))
+            & (rsi_3_4h_gt_20 | (aroonu_14_1d_lt_80) | (roc_9_1d_lt_70))
             # 4h down move, 4h & 1d downtrend
             & ((rsi_3_4h_gt_25) | (roc_9_4h > -10.0) | (roc_9_1d > -10.0))
             # 1h down move, 4h still not low enough, 1d downtrend
@@ -21981,7 +22018,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 4h still high, 1d downtrend
             & ((rsi_3_4h_gt_35) | (stochrsi_k_4h_lt_40) | (roc_9_1d_gt_neg_30))
             # 4h down move, 1d high & overbought
-            & ((rsi_3_4h_gt_35) | (stochrsi_k_1d < 80.0) | (roc_9_1d_lt_20))
+            & ((rsi_3_4h_gt_35) | (stochrsi_k_1d_lt_80) | (roc_9_1d_lt_20))
             # 4h down move, 15m still high, 1h high
             & ((rsi_3_4h_gt_35) | (aroonu_14_15m_lt_50) | (aroonu_14_1h_lt_100))
             # 4h down move, 1h high
@@ -21995,13 +22032,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1d down move, 1h & 4h high
             & ((rsi_3_1d_gt_30) | aroonu_14_1h_lt_70 | aroonu_14_4h_lt_100)
             # 1d down move, 4h high, 1d overbought
-            & ((rsi_3_1d_gt_45) | (stochrsi_k_4h_lt_90) | (roc_9_1d < 10.0))
+            & ((rsi_3_1d_gt_45) | (stochrsi_k_4h_lt_90) | (roc_9_1d_lt_10))
             # 1d down move, 1d high & overbought
-            & ((rsi_3_1d_gt_55) | (stochrsi_k_1d < 80.0) | (roc_9_1d < 10.0))
+            & ((rsi_3_1d_gt_55) | (stochrsi_k_1d_lt_80) | (roc_9_1d_lt_10))
             # 1d down move, 1d overbought
-            & ((rsi_3_1d_gt_60) | (roc_9_1d < 200.0))
+            & ((rsi_3_1d_gt_60) | (roc_9_1d_lt_200))
             # 15m & 1h high, 4h overbought
-            & ((aroonu_14_15m_lt_70) | (aroonu_14_1h_lt_100) | (roc_9_4h < 15.0))
+            & ((aroonu_14_15m_lt_70) | (aroonu_14_1h_lt_100) | (roc_9_4h_lt_15))
             # 15m & 1h high, 1d overbought
             & ((aroonu_14_15m_lt_70) | (aroonu_14_1h_lt_100) | (roc_9_1d_lt_100))
             # 15m & 1h high, 1d downtrend
@@ -22019,13 +22056,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 1d high, 1d overbought
             & ((aroonu_14_1h_lt_100) | aroonu_14_1d_lt_100 | (roc_9_1d_lt_40))
             # 4h & 1d high, 4h overbought
-            & (aroonu_14_4h_lt_100 | aroonu_14_1d_lt_100 | (roc_9_4h < 50.0))
+            & (aroonu_14_4h_lt_100 | aroonu_14_1d_lt_100 | (roc_9_4h_lt_50))
             # 4h & 1d high, 1d overbought
             & ((aroonu_14_4h_lt_90) | aroonu_14_1d_lt_100 | roc_9_1d_lt_50)
             # 1h high, 1h & 4h overbought
-            & ((stochrsi_k_1h_lt_80) | (roc_9_1h < 20.0) | (roc_9_4h_lt_20))
+            & ((stochrsi_k_1h_lt_80) | (roc_9_1h_lt_20) | (roc_9_4h_lt_20))
             # 4h & 1d overbought
-            & ((roc_9_4h < 100.0) | (roc_9_1d < 200.0))
+            & ((roc_9_4h_lt_100) | (roc_9_1d_lt_200))
           )
 
           # Logic
@@ -22058,7 +22095,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 1h still high
             & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_10) | (stochrsi_k_1h_lt_40))
             # 15m & 1h down move, 1d overbought
-            & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_10) | (roc_9_1d < 60.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_10) | (roc_9_1d_lt_60))
             # 15m & 1h down move, 1h still high
             & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_15) | (aroonu_14_1h_lt_50))
             # 15m & 1h down move, 4h still high
@@ -22118,7 +22155,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 1h high
             & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_30) | (stochrsi_k_1h_lt_70))
             # 15m & 1h down move, 1d overbought
-            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_30) | (roc_9_1d < 60.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_30) | (roc_9_1d_lt_60))
             # 15m & 4h down move, 1d still high
             & ((rsi_3_15m_gt_10) | (rsi_3_4h_gt_10) | (aroonu_14_1d_lt_50))
             # 15m & 4h down move, 15m still high
@@ -22136,7 +22173,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 4h down move, 1h high
             & ((rsi_3_15m_gt_10) | rsi_3_4h_gt_20 | (stochrsi_k_1h_lt_70))
             # 15m & 4h down move, 1d high
-            & ((rsi_3_15m_gt_10) | rsi_3_4h_gt_20 | (stochrsi_k_1d < 80.0))
+            & ((rsi_3_15m_gt_10) | rsi_3_4h_gt_20 | (stochrsi_k_1d_lt_80))
             # 15m & 4h down move, 1d overbought
             & ((rsi_3_15m_gt_10) | rsi_3_4h_gt_20 | roc_9_1d_lt_50)
             # 15m & 4h down move, 15m high
@@ -22182,7 +22219,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 15m still high, 4h high
             & ((rsi_3_15m_gt_15) | (aroonu_14_15m_lt_50) | (stochrsi_k_4h_lt_80))
             # 15m down move, 15m high, 1d overbought
-            & ((rsi_3_15m_gt_15) | (aroonu_14_15m_lt_70) | (roc_9_1d < 10.0))
+            & ((rsi_3_15m_gt_15) | (aroonu_14_15m_lt_70) | (roc_9_1d_lt_10))
             # 15m down move, 1h & 4h high
             & ((rsi_3_15m_gt_15) | (aroonu_14_1h_lt_100) | aroonu_14_4h_lt_100)
             # 15m down move, 1d high & overbought
@@ -22220,11 +22257,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 15m high, 1d overbought
             & ((rsi_3_15m_gt_35) | (aroonu_14_15m_lt_80) | roc_9_1d_lt_50)
             # 15m down move, 1d high, 1h overbought
-            & ((rsi_3_15m_gt_40) | (stochrsi_k_1d < 80.0) | (roc_9_1h < 20.0))
+            & ((rsi_3_15m_gt_40) | (stochrsi_k_1d_lt_80) | (roc_9_1h_lt_20))
             # 1h & 4h down move, 1d still high
             & ((rsi_3_1h_gt_3) | (rsi_3_4h_gt_10) | (aroonu_14_1d_lt_50))
             # 1h & 4h down move, 1d overbought
-            & ((rsi_3_1h_gt_3) | (rsi_3_4h_gt_25) | (roc_9_1d < 10.0))
+            & ((rsi_3_1h_gt_3) | (rsi_3_4h_gt_25) | (roc_9_1d_lt_10))
             # 1h & 4h down move, 1d still high
             & ((rsi_3_1h_gt_5) | (rsi_3_4h_gt_15) | (aroonu_14_1d_lt_40))
             # 1h & 4h & 1d down move
@@ -22234,13 +22271,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h & 1d down move
             & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_10) | (rsi_3_1d_gt_15))
             # 1h & 4h down move, 1d still not low enough
-            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_10) | (stochrsi_k_1d < 20.0))
+            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_10) | (stochrsi_k_1d_lt_20))
             # 1h & 4h down move, 15m still high
             & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_15) | (stochrsi_k_15m_lt_50))
             # 1h & 4h down move, 1h still not low enough
             & ((rsi_3_1h_gt_10) | rsi_3_4h_gt_20 | (aroonu_14_1h_lt_30))
             # 1h & 4h down move, 1d overbought
-            & ((rsi_3_1h_gt_10) | rsi_3_4h_gt_20 | (roc_9_1d < 100.0))
+            & ((rsi_3_1h_gt_10) | rsi_3_4h_gt_20 | (roc_9_1d_lt_100))
             # 1h & 1d downtrend, 1d high
             & ((rsi_3_1h_gt_10) | (rsi_3_1d_gt_45) | (aroonu_14_1d_lt_70))
             # 1h & 4h down move, 1h still not low enough
@@ -22256,7 +22293,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 4h still high
             & ((rsi_3_1h_gt_15) | rsi_3_4h_gt_20 | (stochrsi_k_4h_lt_40))
             # 1h & 1d down move, 1d still high
-            & ((rsi_3_1h_gt_15) | (rsi_3_1d_gt_20) | (stochrsi_k_1d < 40.0))
+            & ((rsi_3_1h_gt_15) | (rsi_3_1d_gt_20) | (stochrsi_k_1d_lt_40))
             # 1h & 1d down move, 1d high
             & ((rsi_3_1h_gt_15) | (rsi_3_1d_gt_35) | (aroonu_14_1d_lt_70))
             # 1h down move, 15m & 1d high
@@ -22278,7 +22315,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 4h high
             & (rsi_3_1h_gt_20 | (rsi_3_4h_gt_50) | aroonu_14_4h_lt_100)
             # 1h down move, 1d high, 4h & 1d overbought
-            & ((rsi_3_1h_gt_20) | (aroonu_14_1d_lt_80) | (roc_9_4h < 10.0) | (roc_9_1d < 40.0))
+            & ((rsi_3_1h_gt_20) | (aroonu_14_1d_lt_80) | (roc_9_4h_lt_10) | (roc_9_1d_lt_40))
             # 1h down move, 4h high & overbought, 1d downtrend
             & ((rsi_3_1h_gt_20) | (stochrsi_k_4h_lt_80) | (roc_9_4h_lt_10) | (roc_9_1d_gt_neg_20))
             # 1h & 4h down move, 15m high
@@ -22286,9 +22323,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 4h high
             & ((rsi_3_1h_gt_25) | (rsi_3_4h_gt_30) | (aroonu_14_4h_lt_60))
             # 1h down move, 4h & 1d overbought
-            & ((rsi_3_1h_gt_25) | (roc_9_4h_lt_30) | (roc_9_1d < 60.0))
+            & ((rsi_3_1h_gt_25) | (roc_9_4h_lt_30) | (roc_9_1d_lt_60))
             # 1h & 1d down move, 1d still high
-            & ((rsi_3_1h_gt_25) | (rsi_3_1d_gt_25) | (stochrsi_k_1d < 50.0))
+            & ((rsi_3_1h_gt_25) | (rsi_3_1d_gt_25) | (stochrsi_k_1d_lt_50))
             # 1h & 4h down move, 1h high
             & ((rsi_3_1h_gt_30) | (rsi_3_4h_gt_30) | (stochrsi_k_1h_lt_60))
             # 1h & 4g down move, 4h still high
@@ -22306,9 +22343,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h & 4h high
             & ((rsi_3_1h_gt_45) | (aroonu_14_1h_lt_75) | aroonu_14_4h_lt_100)
             # 1h down move, 1h high, 1d high & overbought
-            & ((rsi_3_1h_gt_45) | (stochrsi_k_1h_lt_60) | (stochrsi_k_1d < 70.0) | (roc_9_1d < 40.0))
+            & ((rsi_3_1h_gt_45) | (stochrsi_k_1h_lt_60) | (stochrsi_k_1d_lt_70) | (roc_9_1d_lt_40))
             # 1h down move, 4h high & overbought
-            & ((rsi_3_1h_gt_50) | (stochrsi_k_4h_lt_90) | (roc_9_4h < 25.0))
+            & ((rsi_3_1h_gt_50) | (stochrsi_k_4h_lt_90) | (roc_9_4h_lt_25))
             # 4h & 1d down move, 1d downtrend
             & ((rsi_3_4h_gt_3) | (rsi_3_1d_gt_10) | (roc_9_1d_gt_neg_20))
             # 4h & 1d down move, 1d still high
@@ -22360,7 +22397,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 4h high
             & ((rsi_3_4h_gt_20) | (aroonu_14_4h_lt_80))
             # 4h down move, 1d high & overbought
-            & ((rsi_3_4h_gt_20) | (aroonu_14_1d_lt_80) | (roc_9_1d < 70.0))
+            & ((rsi_3_4h_gt_20) | (aroonu_14_1d_lt_80) | (roc_9_1d_lt_70))
             # 4h down move, 4h still high, 4h downtrend
             & ((rsi_3_4h_gt_20) | (stochrsi_k_4h_lt_50) | (roc_9_4h_gt_neg_20))
             # 4h down move, 4h high, 1d downtrend
@@ -22368,19 +22405,19 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 1d overbought
             & ((rsi_3_4h_gt_20) | (roc_9_1d_lt_80))
             # 4h & 1d down move, 4h overbought
-            & ((rsi_3_4h_gt_25) | (rsi_3_1d_gt_45) | (roc_9_4h < 5.0))
+            & ((rsi_3_4h_gt_25) | (rsi_3_1d_gt_45) | (roc_9_4h_lt_5))
             # 4h & 1d down move, 1d overbought
-            & ((rsi_3_4h_gt_25) | (rsi_3_1d_gt_45) | (roc_9_1d < 10.0))
+            & ((rsi_3_4h_gt_25) | (rsi_3_1d_gt_45) | (roc_9_1d_lt_10))
             # 4h down move, 15m still not low enough, 4h still high
             & ((rsi_3_4h_gt_25) | (aroonu_14_15m_lt_30) | (stochrsi_k_4h_lt_40))
             # 4h down move, 1d high, 4h overbought
-            & ((rsi_3_4h_gt_25) | (aroonu_14_1d_lt_80) | (roc_9_4h < 5.0))
+            & ((rsi_3_4h_gt_25) | (aroonu_14_1d_lt_80) | (roc_9_4h_lt_5))
             # 4h & 1d down move, 4h still high
             & ((rsi_3_4h_gt_30) | (rsi_3_1d_gt_30) | (stochrsi_k_4h_lt_50))
             # 4h & 1d down move, 1d high
             & ((rsi_3_4h_gt_30) | (rsi_3_1d_gt_60) | (aroonu_14_1d_lt_90))
             # 4h down move, 4h high, 1d high
-            & ((rsi_3_4h_gt_30) | (aroonu_14_4h_lt_70) | (stochrsi_k_1d < 80.0))
+            & ((rsi_3_4h_gt_30) | (aroonu_14_4h_lt_70) | (stochrsi_k_1d_lt_80))
             # 4h down move, 1d stil high, 1d downtrend
             & ((rsi_3_4h_gt_30) | (aroonu_14_1d_lt_40) | (roc_9_1d_gt_neg_30))
             # 4h down move, 1h high, 1d downtrend
@@ -22392,7 +22429,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 4h still high, 1d downtrend
             & ((rsi_3_4h_gt_35) | (stochrsi_k_4h_lt_40) | (roc_9_1d_gt_neg_30))
             # 4h down move, 1d high & overbought
-            & ((rsi_3_4h_gt_35) | (stochrsi_k_1d < 80.0) | (roc_9_1d_lt_20))
+            & ((rsi_3_4h_gt_35) | (stochrsi_k_1d_lt_80) | (roc_9_1d_lt_20))
             # 4h down move, 1h high
             & ((rsi_3_4h_gt_40) | (aroonu_14_1h_lt_80))
             # 4h down move, 1d high & overbought
@@ -22400,7 +22437,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 4h high, 1d downtrend
             & ((rsi_3_4h_gt_45) | (stochrsi_k_4h_lt_40) | (roc_9_1d > -25.0))
             # 4h down move, 1d high & overbought
-            & ((rsi_3_4h_gt_50) | (aroonu_14_1d_lt_85) | (roc_9_1d < 200.0))
+            & ((rsi_3_4h_gt_50) | (aroonu_14_1d_lt_85) | (roc_9_1d_lt_200))
             # 4h down move, 4h high & overbought
             & ((rsi_3_4h_gt_50) | (stochrsi_k_4h_lt_70) | (roc_9_4h_lt_10))
             # 4h down move, 4h still high, 1d downtrend
@@ -22416,7 +22453,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1d down move, 1h & 4h high
             & ((rsi_3_1d_gt_30) | aroonu_14_1h_lt_70 | aroonu_14_4h_lt_100)
             # 15m & 1h high, 4h overbought
-            & ((aroonu_14_15m_lt_70) | (aroonu_14_1h_lt_100) | (roc_9_4h < 15.0))
+            & ((aroonu_14_15m_lt_70) | (aroonu_14_1h_lt_100) | (roc_9_4h_lt_15))
             # 15m & 1h high, 1d overbought
             & ((aroonu_14_15m_lt_70) | (aroonu_14_1h_lt_100) | (roc_9_1d_lt_100))
             # 15m & 1h high, 1d downtrend
@@ -22434,29 +22471,29 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 4h high
             & ((aroonu_14_15m_lt_90) | aroonu_14_4h_lt_100)
             # 1h & 1d high, 1d overbought
-            & ((aroonu_14_1h_lt_100) | aroonu_14_1d_lt_100 | (roc_9_1d < 10.0))
+            & ((aroonu_14_1h_lt_100) | aroonu_14_1d_lt_100 | (roc_9_1d_lt_10))
             # 1h & 4h high, 1h overbought
             & ((aroonu_14_1h_lt_100) | aroonu_14_4h_lt_100 | (roc_9_1h_lt_10))
             # 1h & 4h high, 4h overbought
             & ((aroonu_14_1h_lt_100) | aroonu_14_4h_lt_100 | (roc_9_4h_lt_10))
             # 4h & 1d high, 4h overbought
-            & (aroonu_14_4h_lt_100 | aroonu_14_1d_lt_100 | (roc_9_4h < 20.0))
+            & (aroonu_14_4h_lt_100 | aroonu_14_1d_lt_100 | (roc_9_4h_lt_20))
             # 4h & 1d high, 1d overbought
             & (aroonu_14_4h_lt_100 | aroonu_14_1d_lt_100 | (roc_9_1d_lt_30))
             # 4h high, 1h & 4h overbought
-            & (aroonu_14_4h_lt_100 | (roc_9_1h < 20.0) | (roc_9_4h_lt_40))
+            & (aroonu_14_4h_lt_100 | (roc_9_1h_lt_20) | (roc_9_4h_lt_40))
             # 1d high, 4h & 1d downtrend
             & ((aroonu_14_1d_lt_60) | (roc_9_4h_gt_neg_20) | (roc_9_1d_gt_neg_30))
             # 1d high, 4h & 1d overbought
-            & (aroonu_14_1d_lt_100 | (roc_9_4h < 60.0) | (roc_9_1d < 100.0))
+            & (aroonu_14_1d_lt_100 | (roc_9_4h_lt_60) | (roc_9_1d_lt_100))
             # 15m high, 4h & 1d overbought
             & ((stochrsi_k_15m_lt_70) | (roc_9_4h_lt_20) | (roc_9_1d_lt_20))
             # 1h high, 1h & 1d overbought
-            & ((stochrsi_k_1h_lt_80) | (roc_9_1h < 20.0) | (roc_9_1d_lt_100))
+            & ((stochrsi_k_1h_lt_80) | (roc_9_1h_lt_20) | (roc_9_1d_lt_100))
             # 4h high, 4h overbought, 1d downtrend
             & ((stochrsi_k_4h_lt_90) | (roc_9_4h_lt_20) | (roc_9_1d_gt_neg_20))
             # 1d high, 1h & 4h overbought
-            & ((stochrsi_k_1d < 80.0) | (roc_9_1h < 20.0) | (roc_9_4h_lt_20))
+            & ((stochrsi_k_1d_lt_80) | (roc_9_1h_lt_20) | (roc_9_4h_lt_20))
           )
 
           # Logic
@@ -22549,7 +22586,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 4h down move, 1h still high
             & ((rsi_3_15m_gt_10) | (rsi_3_4h_gt_10) | (stochrsi_k_1h_lt_50))
             # 15m & 4h down move, 4h still high, 1d high & overbought
-            & ((rsi_3_15m_gt_10) | (rsi_3_4h_gt_15) | (aroonu_14_4h_lt_40) | (aroonu_14_1d_lt_70) | (roc_9_1d < 10.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_4h_gt_15) | (aroonu_14_4h_lt_40) | (aroonu_14_1d_lt_70) | (roc_9_1d_lt_10))
             # 15m & 4h down move, 1h high
             & ((rsi_3_15m_gt_10) | (rsi_3_4h_gt_20) | (stochrsi_k_1h_lt_70))
             # 15m & 4h down move, 4h overbought
@@ -22569,13 +22606,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 1h still high, 1d downtrend
             & ((rsi_3_15m_gt_10) | (stochrsi_k_1h_lt_50) | (roc_9_1d_gt_neg_20))
             # 15m & 1h down move, 1h high, 1d high & overbought
-            & ((rsi_3_15m_gt_15) | (rsi_3_1h_gt_15) | (aroonu_14_1h_lt_70) | (aroonu_14_1d_lt_100) | (roc_9_1d < 10.0))
+            & ((rsi_3_15m_gt_15) | (rsi_3_1h_gt_15) | (aroonu_14_1h_lt_70) | (aroonu_14_1d_lt_100) | (roc_9_1d_lt_10))
             # 15m & 4h down move, 1h high
             & ((rsi_3_15m_gt_15) | (rsi_3_4h_gt_35) | (aroonu_14_1h_lt_90))
             # 15m & 1h & 1d down move, 4h still high, 4h downtrend
             & ((rsi_3_15m_gt_20) | (rsi_3_1h_gt_25) | (rsi_3_1d_gt_25) | (aroonu_14_4h_lt_40) | (roc_9_4h_gt_neg_20))
             # 1h & 1d down move, 1d still high
-            & ((rsi_3_1h_gt_3) | (rsi_3_1d_gt_25) | (stochrsi_k_1d < 40.0))
+            & ((rsi_3_1h_gt_3) | (rsi_3_1d_gt_25) | (stochrsi_k_1d_lt_40))
             # 1h & 4h down move, 1d downtrend
             & ((rsi_3_1h_gt_5) | (rsi_3_4h_gt_5) | (roc_9_1d_gt_neg_30))
             # 1h & 4h down move, 1d still high
@@ -22587,7 +22624,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 4h & 1d downtrend
             & ((rsi_3_1h_gt_5) | (roc_9_4h > -10.0) | (roc_9_1d_gt_neg_20))
             # 1h & 4h down move, 1d still not low enough
-            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_10) | (stochrsi_k_1d < 20.0))
+            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_10) | (stochrsi_k_1d_lt_20))
             # 1h & 4h down move, 15m still not low enough
             & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_3) | (stochrsi_k_15m_lt_30))
             # 1h & 4h down move, 4h high
@@ -22611,7 +22648,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1d high, 1d downtrend
             & (rsi_3_1h_gt_20 | (aroonu_14_1d_lt_70) | (roc_9_1d_gt_neg_20))
             # 1h down move, 1d high, 4h & 1d overbought
-            & ((rsi_3_1h_gt_20) | (aroonu_14_1d_lt_80) | (roc_9_4h < 10.0) | (roc_9_1d < 40.0))
+            & ((rsi_3_1h_gt_20) | (aroonu_14_1d_lt_80) | (roc_9_4h_lt_10) | (roc_9_1d_lt_40))
             # 1h down move, 4h high & overbought, 1d downtrend
             & ((rsi_3_1h_gt_20) | (stochrsi_k_4h_lt_80) | (roc_9_4h_lt_10) | (roc_9_1d_gt_neg_20))
             # 1h down move, 1h & 4h high
@@ -22639,7 +22676,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h & 1d down move, 15m still high
             & ((rsi_3_4h_gt_10) | (rsi_3_1d_gt_20) | (stochrsi_k_15m_lt_40))
             # 4h down move, 1d high & overbought
-            & ((rsi_3_4h_gt_10) | (aroonu_14_1d_lt_100) | (roc_9_1d < 10.0))
+            & ((rsi_3_4h_gt_10) | (aroonu_14_1d_lt_100) | (roc_9_1d_lt_10))
             # 4h down move, 1h high, 1d downtrend
             & ((rsi_3_4h_gt_10) | (stochrsi_k_1h_lt_50) | (roc_9_1d > -30.0))
             # 4h down move, 4h & 1d downtrend
@@ -22659,13 +22696,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 1h high
             & ((rsi_3_4h_gt_15) | (stochrsi_k_1h_lt_80))
             # 4h down move, 1h downtrend, 1d overbought
-            & ((rsi_3_4h_gt_15) | (roc_9_1h > -10.0) | (roc_9_1d < 200.0))
+            & ((rsi_3_4h_gt_15) | (roc_9_1h > -10.0) | (roc_9_1d_lt_200))
             # 4h & 1d down move, 1d still high
             & (rsi_3_4h_gt_20 | (rsi_3_1d_gt_20) | (aroonu_14_1d_lt_50))
             # 4h down move, 4h & 1d high
             & (rsi_3_4h_gt_20 | aroonu_14_4h_lt_70 | (aroonu_14_1d_lt_70))
             # 4h down move, 1d high & overbought
-            & (rsi_3_4h_gt_20 | (aroonu_14_1d_lt_80) | (roc_9_1d < 70.0))
+            & (rsi_3_4h_gt_20 | (aroonu_14_1d_lt_80) | (roc_9_1d_lt_70))
             # 4h down move, 4h high, 1d downtrend
             & (rsi_3_4h_gt_20 | (stochrsi_k_4h_lt_60) | (roc_9_1d_gt_neg_20))
             # 4h & 1d down move, 1d overbought
@@ -22752,13 +22789,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 4h down move, 15m still high
             & ((rsi_3_15m_gt_15) | (rsi_3_4h_gt_15) | (aroonu_14_15m_lt_40))
             # 15m down move, 4h & 1d overbought
-            & ((rsi_3_15m_gt_15) | (roc_9_4h_lt_20) | (roc_9_1d < 200.0))
+            & ((rsi_3_15m_gt_15) | (roc_9_4h_lt_20) | (roc_9_1d_lt_200))
             # 15m & 1h down move, 4h high
             & ((rsi_3_15m_gt_25) | (rsi_3_1h_gt_30) | aroonu_14_4h_lt_100)
             # 15m & 1h down move, 4h high
             & ((rsi_3_15m_gt_25) | (rsi_3_1h_gt_40) | (stochrsi_k_4h_lt_90))
             # 15m down move, 4h & 1d high, 4h overbought
-            & ((rsi_3_15m_gt_25) | (aroonu_14_4h_lt_80) | (aroonu_14_1d_lt_100) | (roc_9_4h < 30.0))
+            & ((rsi_3_15m_gt_25) | (aroonu_14_4h_lt_80) | (aroonu_14_1d_lt_100) | (roc_9_4h_lt_30))
             # 15m down move, 4h high, 1d downtrend
             & ((rsi_3_15m_gt_25) | (stochrsi_k_4h_lt_80) | (roc_9_1d_gt_neg_30))
             # 15m & 1h down move, 15m high
@@ -22786,7 +22823,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 1h downtrend
             & ((rsi_3_1h_gt_3) | (rsi_3_4h_gt_10) | (cmf_20_1h > -0.20))
             # 1h & 4h down move, 1d still high
-            & ((rsi_3_1h_gt_3) | (rsi_3_4h_gt_10) | (stochrsi_k_1d < 40.0))
+            & ((rsi_3_1h_gt_3) | (rsi_3_4h_gt_10) | (stochrsi_k_1d_lt_40))
             # 1h & 4h down move, 4h still high
             & ((rsi_3_1h_gt_3) | rsi_3_4h_gt_20 | (stochrsi_k_4h_lt_40))
             # 1h & 4h down move, 15m still high
@@ -22832,9 +22869,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1d high, 4h downtrend
             & ((rsi_3_1h_gt_15) | (aroonu_14_1d_lt_70) | (roc_9_4h > -20.0))
             # 1h down move, 1d high & overbought
-            & ((rsi_3_1h_gt_15) | (aroonu_14_1d_lt_80) | (roc_9_1d < 10.0))
+            & ((rsi_3_1h_gt_15) | (aroonu_14_1d_lt_80) | (roc_9_1d_lt_10))
             # 1h down move, 4h high & overbought
-            & ((rsi_3_1h_gt_15) | (stochrsi_k_4h_lt_80) | (roc_9_4h < 20.0))
+            & ((rsi_3_1h_gt_15) | (stochrsi_k_4h_lt_80) | (roc_9_4h_lt_20))
             # 1h down move, 4h high, 1d downtrend
             & ((rsi_3_1h_gt_15) | (stochrsi_k_4h_lt_80) | (roc_9_1d > -30.0))
             # 1h & 4h down move, 4h still high
@@ -22850,7 +22887,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 1d down move, 1h still high
             & (rsi_3_1h_gt_20 | (rsi_3_1d_gt_25) | (aroonu_14_1h_lt_50))
             # 1h down move, 4h high & overbought
-            & (rsi_3_1h_gt_20 | (aroonu_14_4h_lt_80) | (roc_9_4h < 70.0))
+            & (rsi_3_1h_gt_20 | (aroonu_14_4h_lt_80) | (roc_9_4h_lt_70))
             # 1h down move, 1h high, 1h still not low enough
             & (rsi_3_1h_gt_20 | (aroonu_14_1d_lt_80) | (stochrsi_k_1h_lt_20))
             # 1h down move, 1d high & overbought
@@ -22884,7 +22921,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h & 1d down move, 15m still not low enough
             & ((rsi_3_4h_gt_3) | (rsi_3_1d_gt_15) | (aroonu_14_15m_lt_20))
             # 4h & 1d down move, 1d still high
-            & ((rsi_3_4h_gt_3) | (rsi_3_1d_gt_20) | (stochrsi_k_1d < 40.0))
+            & ((rsi_3_4h_gt_3) | (rsi_3_1d_gt_20) | (stochrsi_k_1d_lt_40))
             # 4h & 1d down move, 1d high
             & ((rsi_3_4h_gt_3) | (rsi_3_1d_gt_25) | (aroonu_14_1d_lt_70))
             # 4h down move, 15m high
@@ -22920,15 +22957,15 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h & 1d down move, 1d downtrend
             & (rsi_3_4h_gt_20 | (rsi_3_1d_gt_25) | (roc_9_1d_gt_neg_30))
             # 4h down move, 1d high & overbought
-            & (rsi_3_4h_gt_20 | (aroonu_14_1d_lt_80) | (roc_9_1d < 70.0))
+            & (rsi_3_4h_gt_20 | (aroonu_14_1d_lt_80) | (roc_9_1d_lt_70))
             # 4h & 1d down move, 4h overbought
-            & ((rsi_3_4h_gt_25) | (rsi_3_1d_gt_45) | (roc_9_4h < 5.0))
+            & ((rsi_3_4h_gt_25) | (rsi_3_1d_gt_45) | (roc_9_4h_lt_5))
             # 4h & 1d down move, 1d overbought
-            & ((rsi_3_4h_gt_25) | (rsi_3_1d_gt_45) | (roc_9_1d < 10.0))
+            & ((rsi_3_4h_gt_25) | (rsi_3_1d_gt_45) | (roc_9_1d_lt_10))
             # 4h & 1d down move, 1d overbought
             & ((rsi_3_4h_gt_30) | (rsi_3_1d > 70.0) | (roc_9_1d_lt_20))
             # 4h down move, 4h high, 1d high
-            & ((rsi_3_4h_gt_30) | (aroonu_14_4h_lt_70) | (stochrsi_k_1d < 80.0))
+            & ((rsi_3_4h_gt_30) | (aroonu_14_4h_lt_70) | (stochrsi_k_1d_lt_80))
             # 4h down move, 1d stil high, 1d downtrend
             & ((rsi_3_4h_gt_30) | (aroonu_14_1d_lt_40) | (roc_9_1d_gt_neg_30))
             # 4h down move, 4h still high, 4h downtrend
@@ -22954,17 +22991,17 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h & 1d high, 1h overbought
             & ((aroonu_14_4h_lt_85) | aroonu_14_1d_lt_100 | (roc_9_1h_lt_10))
             # 4h high, 4h & 1d overbought
-            & ((aroonu_14_4h_lt_90) | (roc_9_4h_lt_30) | (roc_9_1d < 60.0))
+            & ((aroonu_14_4h_lt_90) | (roc_9_4h_lt_30) | (roc_9_1d_lt_60))
             # 15m high, 4h & 1d overbought
             & ((stochrsi_k_15m_lt_80) | (roc_9_4h_lt_20) | (roc_9_1d_lt_20))
             # 15m still high, 4h & 1d overbought
             & ((stochrsi_k_15m_lt_50) | (roc_9_4h_lt_40) | (roc_9_1d_lt_100))
             # 4h high, 4h & 1d overbought
-            & ((stochrsi_k_4h_lt_90) | (roc_9_4h_lt_30) | (roc_9_1d < 60.0))
+            & ((stochrsi_k_4h_lt_90) | (roc_9_4h_lt_30) | (roc_9_1d_lt_60))
             # 1d high, 4h & 1d overbought
             & ((stochrsi_k_1d_lt_90) | (roc_9_4h_lt_30) | (roc_9_1d_lt_100))
             # 4h & 1d overbought
-            & ((roc_9_4h < 100.0) | (roc_9_1d < 200.0))
+            & ((roc_9_4h_lt_100) | (roc_9_1d_lt_200))
             # 1d P&D, 4h overbought
             & ((change_pct_1d > -10.0) | (change_pct_1d.shift(288) < 50.0) | (roc_9_4h_lt_30))
           )
@@ -23102,7 +23139,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h high, 1d overbought
             & ((rsi_3_1h_gt_20) | (aroonu_14_1h_lt_70) | (roc_9_1d_lt_20))
             # 1h down move, 4h high & overbought
-            & ((rsi_3_1h_gt_20) | (aroonu_14_4h_lt_80) | (roc_9_4h < 60.0))
+            & ((rsi_3_1h_gt_20) | (aroonu_14_4h_lt_80) | (roc_9_4h_lt_60))
             # 1h down move, 1h still not low enough, 1d downtrend
             & ((rsi_3_1h_gt_20) | (stochrsi_k_1h_lt_30) | (roc_9_1d_gt_neg_30))
             # 1h & 4h down move, 1h high
@@ -23124,7 +23161,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h still high, 1d overbought
             & ((rsi_3_1h_gt_35) | (aroonu_14_1h_lt_40) | (roc_9_1d_lt_40))
             # 1h down move, 4h high & overbought
-            & ((rsi_3_1h_gt_35) | (aroonu_14_4h_lt_90) | (roc_9_4h < 60.0))
+            & ((rsi_3_1h_gt_35) | (aroonu_14_4h_lt_90) | (roc_9_4h_lt_60))
             # 1h down move, 4h high, 1d downtrend
             & ((rsi_3_1h_gt_35) | (stochrsi_k_4h_lt_90) | (roc_9_1d_gt_neg_20))
             # 1h down move, 1h high, 1d downtrend
@@ -23136,11 +23173,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h high, 4h overbought
             & ((rsi_3_1h_gt_50) | aroonu_14_1h_lt_80 | (roc_9_4h_lt_10))
             # 1h down move, 4h high & overbought
-            & ((rsi_3_1h_gt_50) | (stochrsi_k_4h_lt_90) | (roc_9_4h < 25.0))
+            & ((rsi_3_1h_gt_50) | (stochrsi_k_4h_lt_90) | (roc_9_4h_lt_25))
             # 4h down move, 4h & 1d downtrend
             & ((rsi_3_4h_gt_5) | (roc_9_4h > -15.0) | (roc_9_1d_gt_neg_20))
             # 4h & 1d down move, 1d still high
-            & ((rsi_3_4h_gt_10) | (rsi_3_1d_gt_30) | (stochrsi_k_1d < 50.0))
+            & ((rsi_3_4h_gt_10) | (rsi_3_1d_gt_30) | (stochrsi_k_1d_lt_50))
             # 4h down move, 4h & 1d high
             & ((rsi_3_4h_gt_10) | (aroonu_14_4h_lt_60) | (aroonu_14_1d_lt_70))
             # 4h down move, 1d still high, 1d downtrend
@@ -23164,11 +23201,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 1d high & overbought
             & (rsi_3_4h_gt_20 | (aroonu_14_1d_lt_90) | (roc_9_1d_lt_30))
             # 4h & 1d down move, 1d overbought
-            & ((rsi_3_4h_gt_25) | (rsi_3_1d_gt_40) | (roc_9_1d < 10.0))
+            & ((rsi_3_4h_gt_25) | (rsi_3_1d_gt_40) | (roc_9_1d_lt_10))
             # 4h & 1d down move, 1d high
             & ((rsi_3_4h_gt_25) | (rsi_3_1d_gt_45) | (aroonu_14_1d_lt_80))
             # 4h down move, 15m high, 1d overbought
-            & ((rsi_3_4h_gt_30) | (stochrsi_k_15m < 90.0) | (roc_9_1d < 10.0))
+            & ((rsi_3_4h_gt_30) | (stochrsi_k_15m < 90.0) | (roc_9_1d_lt_10))
             # 4h down move, 4h still high, 1d downtrend
             & ((rsi_3_4h_gt_35) | (stochrsi_k_4h_lt_40) | (roc_9_1d_gt_neg_30))
             # 4h down move, 4h high, 1d overbought
@@ -23188,7 +23225,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1d down move, 4h high, 1d overbought
             & ((rsi_3_1d_gt_60) | aroonu_14_4h_lt_70 | (roc_9_1d_lt_40))
             # 15m high, 1d high & overbought
-            & ((aroonu_14_15m_lt_70) | aroonu_14_1d_lt_100 | (roc_9_1d < 100.0))
+            & ((aroonu_14_15m_lt_70) | aroonu_14_1d_lt_100 | (roc_9_1d_lt_100))
             # 15m high, 4h overbought, 1d downtrend
             & ((aroonu_14_15m_lt_80) | (roc_9_4h_lt_20) | (roc_9_1d_gt_neg_30))
             # 1h & 4h high, 4h overbought
@@ -23198,7 +23235,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h high, 4h & 1d downtrend
             & ((aroonu_14_1h_lt_100) | (roc_9_4h > -10.0) | (roc_9_1d > -25.0))
             # 4h & 1d high, 1d overbought
-            & (aroonu_14_4h_lt_100 | aroonu_14_1d_lt_100 | (roc_9_1d < 60.0))
+            & (aroonu_14_4h_lt_100 | aroonu_14_1d_lt_100 | (roc_9_1d_lt_60))
             # 1h high, 4h & 1d downtrend
             & ((stochrsi_k_1h_lt_80) | (roc_9_4h > -10.0) | (roc_9_1d > -25.0))
           )
@@ -23307,7 +23344,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1h down move, 15m & 1h high
           long_entry_logic.append((rsi_3_1h_gt_50) | (stochrsi_k_15m_lt_60) | (aroonu_14_1h_lt_60))
           # 1h down move, 1h & 1d high
-          long_entry_logic.append((rsi_3_1h_gt_50) | aroonu_14_1h_lt_70 | (stochrsi_k_1d < 80.0))
+          long_entry_logic.append((rsi_3_1h_gt_50) | aroonu_14_1h_lt_70 | (stochrsi_k_1d_lt_80))
           # 1h down move, 4h still high, 1d high
           long_entry_logic.append((rsi_3_1h_gt_50) | (stochrsi_k_4h_lt_50) | (stochrsi_k_1d_lt_90))
           # 1h down move, 1h still high, 1d high
@@ -23347,11 +23384,11 @@ class NostalgiaForInfinityX7(IStrategy):
           # 4h down move, 15m & 4h still high
           long_entry_logic.append((rsi_3_4h_gt_30) | (aroonu_14_15m_lt_50) | (aroonu_14_4h_lt_50))
           # 4h down move, 15m still high, 1d overbought
-          long_entry_logic.append((rsi_3_4h_gt_30) | (stochrsi_k_15m_lt_50) | (roc_9_1d < 10.0))
+          long_entry_logic.append((rsi_3_4h_gt_30) | (stochrsi_k_15m_lt_50) | (roc_9_1d_lt_10))
           # 4h down move, 1h & 4h still high
           long_entry_logic.append((rsi_3_4h_gt_35) | (stochrsi_k_1h_lt_50) | (aroonu_14_4h_lt_50))
           # 4h down move, 1d high & overbought
-          long_entry_logic.append((rsi_3_4h_gt_35) | (stochrsi_k_1d < 80.0) | (roc_9_1d_lt_40))
+          long_entry_logic.append((rsi_3_4h_gt_35) | (stochrsi_k_1d_lt_80) | (roc_9_1d_lt_40))
           # 4h down move, 15m & 1h high
           long_entry_logic.append((rsi_3_4h_gt_40) | (aroonu_14_15m_lt_80) | (stochrsi_k_1h_lt_70))
           # 4h down move, 1d high & overbought
@@ -23363,7 +23400,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 4h down move, 1h still high, 4h still moving down
           long_entry_logic.append((rsi_3_4h_gt_40) | (stochrsi_k_1h_lt_50) | (cci_20_change_pct_4h > -0.0))
           # 4h down move, 1d high & overbought
-          long_entry_logic.append((rsi_3_4h_gt_40) | (stochrsi_k_1d < 80.0) | (roc_9_1d < 10.0))
+          long_entry_logic.append((rsi_3_4h_gt_40) | (stochrsi_k_1d_lt_80) | (roc_9_1d_lt_10))
           # 4h down move, 1h high, 4h still high
           long_entry_logic.append((rsi_3_4h_gt_45) | aroonu_14_1h_lt_70 | (aroonu_14_4h_lt_50))
           # 4h down move, 15m high, 4h still high
@@ -23393,9 +23430,9 @@ class NostalgiaForInfinityX7(IStrategy):
           # 4h down move, 1h & 4h high
           long_entry_logic.append((rsi_3_4h_gt_60) | (stochrsi_k_1h_lt_70) | aroonu_14_4h_lt_70)
           # 4h down move, 4h still high, 1d high
-          long_entry_logic.append((rsi_3_4h_gt_60) | (stochrsi_k_4h_lt_50) | (stochrsi_k_1d < 80.0))
+          long_entry_logic.append((rsi_3_4h_gt_60) | (stochrsi_k_4h_lt_50) | (stochrsi_k_1d_lt_80))
           # 15m still high, 1d high & overbought
-          long_entry_logic.append((aroonu_14_15m_lt_50) | aroonu_14_1d_lt_100 | (roc_9_1d < 100.0))
+          long_entry_logic.append((aroonu_14_15m_lt_50) | aroonu_14_1d_lt_100 | (roc_9_1d_lt_100))
           # 15m high, 4h high
           long_entry_logic.append((aroonu_14_15m_lt_70) | (aroonu_14_4h_lt_85))
           # 15m & 1d high, 1d overbought
@@ -23413,17 +23450,17 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1d high, 4h overbought
           long_entry_logic.append((aroonu_14_1d_lt_90) | (roc_9_4h_lt_40))
           # 1d high & overbought
-          long_entry_logic.append(aroonu_14_1d_lt_100 | (roc_9_1d < 200.0))
+          long_entry_logic.append(aroonu_14_1d_lt_100 | (roc_9_1d_lt_200))
           # 15m high, 1h still high
           long_entry_logic.append((stochrsi_k_15m_lt_70) | (stochrsi_k_1h_lt_40))
           # 15m & 4h high
           long_entry_logic.append((stochrsi_k_15m_lt_70) | aroonu_14_4h_lt_70)
           # 15m high, 1d overbought
-          long_entry_logic.append((stochrsi_k_15m_lt_70) | (roc_9_1d < 10.0))
+          long_entry_logic.append((stochrsi_k_15m_lt_70) | (roc_9_1d_lt_10))
           # 15m high, 1h still not low enough
           long_entry_logic.append((stochrsi_k_15m_lt_80) | (stochrsi_k_1h_lt_30))
           # 1d high, 4h overbought
-          long_entry_logic.append((stochrsi_k_1d < 80.0) | (roc_9_4h_lt_40))
+          long_entry_logic.append((stochrsi_k_1d_lt_80) | (roc_9_4h_lt_40))
           # 1d high & overbought
           long_entry_logic.append((stochrsi_k_1d_lt_90) | (roc_9_1d_lt_30))
           # 4h & 1d overbought
@@ -23455,7 +23492,7 @@ class NostalgiaForInfinityX7(IStrategy):
           long_entry_logic.append(num_empty_288 <= allowed_empty_candles_288)
           long_entry_logic.append(protections_long_global == True)
 
-          long_entry_logic.append((rsi_3_gt_5) & (rsi_3_15m_gt_5) & (roc_9_15m > -10.0) & (roc_9_1d < 200.0))
+          long_entry_logic.append((rsi_3_gt_5) & (rsi_3_15m_gt_5) & (roc_9_15m > -10.0) & (roc_9_1d_lt_200))
 
           long_entry_logic.append(
             # 15m & 1h down move, 4h high
@@ -23493,9 +23530,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 4h high
             & ((rsi_3_15m_gt_25) | (rsi_3_1h_gt_25) | (stochrsi_k_4h_lt_90))
             # 15m down move, 15m high, 1d overbought
-            & ((rsi_3_15m_gt_25) | (aroonu_14_15m_lt_60) | (roc_9_1d < 150.0))
+            & ((rsi_3_15m_gt_25) | (aroonu_14_15m_lt_60) | (roc_9_1d_lt_150))
             # 15m down move, 15m still high, 1d high, 1d downtrend
-            & ((rsi_3_15m_gt_30) | (aroonu_14_15m_lt_50) | (stochrsi_k_1d < 70.0) | (roc_9_1d > -15.0))
+            & ((rsi_3_15m_gt_30) | (aroonu_14_15m_lt_50) | (stochrsi_k_1d_lt_70) | (roc_9_1d > -15.0))
             # 15m down move, 1h & 4h high
             & ((rsi_3_15m_gt_35) | aroonu_14_1h_lt_80 | (rsi_14_4h < 80.0))
             # 1h & 4h down move, 15m stil high
@@ -23507,7 +23544,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 4h high
             & ((rsi_3_1h_gt_5) | (rsi_3_4h_gt_30) | (aroonu_14_4h_lt_90))
             # 1h down move, 4h high, 1d overbought
-            & ((rsi_3_1h_gt_5) | (aroonu_14_4h_lt_60) | (roc_9_1d < 10.0))
+            & ((rsi_3_1h_gt_5) | (aroonu_14_4h_lt_60) | (roc_9_1d_lt_10))
             # 1h & 4h down move, 4h still high
             & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_10) | (aroonu_14_4h_lt_50))
             # 1h & 3h down move, 1d high
@@ -23535,7 +23572,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 15m & 4h high
             & ((rsi_3_1h_gt_30) | (rsi_3_4h_gt_50) | (aroonu_14_15m_lt_70) | (aroonu_14_1h_lt_70))
             # 1h down move, 1h high, 4h overbought
-            & ((rsi_3_1h_gt_30) | (aroonu_14_1h_lt_60) | (roc_9_4h < 50.0))
+            & ((rsi_3_1h_gt_30) | (aroonu_14_1h_lt_60) | (roc_9_4h_lt_50))
             # 1h down move, 1h high, 1d overbought
             & ((rsi_3_1h_gt_30) | (aroonu_14_1h_lt_80) | (roc_9_1d_lt_80))
             # 1h down move, 1h & 4h high
@@ -23549,7 +23586,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 4h & 1d overbought
             & ((rsi_3_1h_gt_45) | (roc_9_4h_lt_10) | (roc_9_1d_lt_50))
             # 1h down move,  4h high, 1d overbought
-            & ((rsi_3_1h_gt_50) | (stochrsi_k_4h_lt_90) | (roc_9_1d < 150.0))
+            & ((rsi_3_1h_gt_50) | (stochrsi_k_4h_lt_90) | (roc_9_1d_lt_150))
             # 4h down move, 1d high
             & ((rsi_3_4h_gt_3) | (aroonu_14_1d_lt_90))
             # 4h down move, 15m still high
@@ -23595,19 +23632,19 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h & 1d high, 4h overbought
             & (aroonu_14_4h_lt_80 | aroonu_14_1d_lt_100 | (roc_9_4h_lt_30))
             # 4h high, 4h & 1d overbought
-            & (aroonu_14_4h_lt_80 | (roc_9_4h < 20.0) | (roc_9_1d_lt_20))
+            & (aroonu_14_4h_lt_80 | (roc_9_4h_lt_20) | (roc_9_1d_lt_20))
             # 1d still high, 1h & 4h downtrend
             & ((aroonu_14_1d_lt_50) | (roc_9_1h > -20.0) | (roc_9_4h_gt_neg_20))
             # 1h high, 1h overbought
-            & ((stochrsi_k_1h_lt_80) | (roc_9_1h < 50.0))
+            & ((stochrsi_k_1h_lt_80) | (roc_9_1h_lt_50))
             # 1h high, 1d downtrend
             & ((stochrsi_k_1h_lt_80) | (roc_9_1d > -60.0))
             # 4h high, 1h overbought, 1d downtrend
             & ((stochrsi_k_4h_lt_80) | (roc_9_1h_lt_10) | (roc_9_1d > -70.0))
             # 4h high, 1h & 4h overbought
-            & ((stochrsi_k_4h_lt_90) | (roc_9_1h < 20.0) | (roc_9_4h < 50.0))
+            & ((stochrsi_k_4h_lt_90) | (roc_9_1h_lt_20) | (roc_9_4h_lt_50))
             # 1h & 4h overbought
-            & ((roc_9_1h < 100.0) | (roc_9_4h < 100.0))
+            & ((roc_9_1h_lt_100) | (roc_9_4h_lt_100))
             # 1h P&D, 1h down move
             & ((change_pct_1h > -10.0) | (change_pct_1h.shift(12) < 10.0) | (rsi_3_1h_gt_50))
             # 4h P&D, 4h high
@@ -23703,7 +23740,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 15m still not low enough, 1h & 4h high
             & ((rsi_3_15m_gt_15) | (rsi_3_1h_gt_40) | (aroonu_14_15m_lt_30) | aroonu_14_1h_lt_80 | aroonu_14_4h_lt_80)
             # 15m & 1h down move, 4h high & overbought
-            & ((rsi_3_15m_gt_15) | (rsi_3_1h_gt_45) | (rsi_14_4h < 70.0) | (roc_9_4h < 50.0))
+            & ((rsi_3_15m_gt_15) | (rsi_3_1h_gt_45) | (rsi_14_4h < 70.0) | (roc_9_4h_lt_50))
             # 15m & 1h down move, 1h high
             & ((rsi_3_15m_gt_15) | (rsi_3_1h_gt_50) | (stochrsi_k_1h_lt_90))
             # 15m & 4h down move, 15m high
@@ -23733,7 +23770,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1d down move, 1d high
             & ((rsi_3_15m_gt_15) | (rsi_3_1d > 50.0) | (aroonu_14_1d_lt_70))
             # 15m & 1d down move, 1d high
-            & ((rsi_3_15m_gt_15) | (rsi_3_1d_gt_60) | (stochrsi_k_1d < 80.0))
+            & ((rsi_3_15m_gt_15) | (rsi_3_1d_gt_60) | (stochrsi_k_1d_lt_80))
             # 15m down move, 15m & 4h high
             & ((rsi_3_15m_gt_15) | (aroonu_14_15m_lt_70) | (aroonu_14_4h_lt_80))
             # 15m down move, 15m & 1h high
@@ -23745,7 +23782,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 4h still high, 4h downtrend
             & ((rsi_3_15m_gt_15) | (aroonu_14_4h_lt_40) | (roc_9_4h_gt_neg_20))
             # 15m down move, 1d high & overbought
-            & ((rsi_3_15m_gt_15) | (aroonu_14_1d_lt_100) | (roc_9_1d < 100.0))
+            & ((rsi_3_15m_gt_15) | (aroonu_14_1d_lt_100) | (roc_9_1d_lt_100))
             # 15m down move, 15m still not low enough, 4h high
             & ((rsi_3_15m_gt_15) | (stochrsi_k_15m_lt_30) | (stochrsi_k_4h_lt_50))
             # 15m down move, 15m & 1h high
@@ -23753,15 +23790,15 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 1h high, 1d overbought
             & ((rsi_3_15m_gt_15) | (stochrsi_k_1h_lt_70) | (roc_9_1d_lt_30))
             # 15m down move, 1h high, 1d overbought
-            & ((rsi_3_15m_gt_15) | (stochrsi_k_1h_lt_70) | (roc_9_1d < 150.0))
+            & ((rsi_3_15m_gt_15) | (stochrsi_k_1h_lt_70) | (roc_9_1d_lt_150))
             # 15m down move, 1h high & overbought
-            & ((rsi_3_15m_gt_15) | (stochrsi_k_1h_lt_80) | (roc_9_1h < 20.0))
+            & ((rsi_3_15m_gt_15) | (stochrsi_k_1h_lt_80) | (roc_9_1h_lt_20))
             # 15m down move, 1h high, 1d overbought
             & ((rsi_3_15m_gt_15) | (stochrsi_k_1h_lt_80) | (roc_9_1d_lt_100))
             # 15m down move, 4h high, 1d overbought
-            & ((rsi_3_15m_gt_15) | (stochrsi_k_4h_lt_80) | (roc_9_1d < 25.0))
+            & ((rsi_3_15m_gt_15) | (stochrsi_k_4h_lt_80) | (roc_9_1d_lt_25))
             # 15m down move, 4h high & overbought
-            & ((rsi_3_15m_gt_15) | (stochrsi_k_4h_lt_90) | (roc_9_4h < 25.0))
+            & ((rsi_3_15m_gt_15) | (stochrsi_k_4h_lt_90) | (roc_9_4h_lt_25))
             # 15m down move, 4h high
             & ((rsi_3_15m_gt_15) | (rsi_14_4h < 70.0) | (stochrsi_k_4h_lt_90) | (ema_9 < (ema_26 * 0.972)))
             # 15m down move, 4h high and downtrend
@@ -23777,7 +23814,7 @@ class NostalgiaForInfinityX7(IStrategy):
               (rsi_3_15m_gt_20) | (rsi_3_1h_gt_35) | (cmf_20_1h > -0.10) | (aroonu_14_15m_lt_40) | (aroonu_14_1h_lt_85)
             )
             # 15m & 1h down move, 4h high & overbought
-            & ((rsi_3_15m_gt_20) | (rsi_3_1h_gt_45) | (rsi_14_4h < 70.0) | (roc_9_4h < 50.0))
+            & ((rsi_3_15m_gt_20) | (rsi_3_1h_gt_45) | (rsi_14_4h < 70.0) | (roc_9_4h_lt_50))
             # 15m & 1h down move, 1h high, 1d overbought
             & ((rsi_3_15m_gt_20) | (rsi_3_1h_gt_45) | (aroonu_14_1h_lt_90) | (roc_9_1d_lt_40))
             # 15m & 4h down move, 15m high
@@ -23816,11 +23853,11 @@ class NostalgiaForInfinityX7(IStrategy):
               | aroonu_14_4h_lt_100
             )
             # 15m & 4h down move, 4h overbought
-            & ((rsi_3_15m_gt_30) | (rsi_3_4h_gt_60) | (roc_9_4h < 60.0))
+            & ((rsi_3_15m_gt_30) | (rsi_3_4h_gt_60) | (roc_9_4h_lt_60))
             # 15m & 4h down move, 4h high
             & ((rsi_3_15m_gt_35) | (rsi_3_4h_gt_35) | (stochrsi_k_4h_lt_80))
             # 1h & 4h down move, 1d high
-            & ((rsi_3_1h_gt_25) | (rsi_3_4h_gt_30) | (stochrsi_k_1d < 80.0))
+            & ((rsi_3_1h_gt_25) | (rsi_3_4h_gt_30) | (stochrsi_k_1d_lt_80))
             # 1h & 4h down move, 4h high
             & ((rsi_3_1h_gt_25) | (rsi_3_4h_gt_40) | aroonu_14_4h_lt_70)
             # 1h & 4h down move, 4h high
@@ -23844,9 +23881,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h still not low enough, 1d downtrend
             & ((rsi_3_1h_gt_25) | (stochrsi_k_1h_lt_30) | (roc_9_1d_gt_neg_40))
             # 1h down move, 4h high, 1d overbought
-            & ((rsi_3_1h_gt_25) | (stochrsi_k_4h_lt_90) | (roc_9_1d < 25.0))
+            & ((rsi_3_1h_gt_25) | (stochrsi_k_4h_lt_90) | (roc_9_1d_lt_25))
             # 1h & 4h & 1d down move, 1d high & overbought
-            & ((rsi_3_1h_gt_30) | (rsi_3_4h_gt_30) | (rsi_3_1d_gt_55) | (aroonu_14_1d_lt_80) | (roc_9_1d < 20.0))
+            & ((rsi_3_1h_gt_30) | (rsi_3_4h_gt_30) | (rsi_3_1d_gt_55) | (aroonu_14_1d_lt_80) | (roc_9_1d_lt_20))
             # 1h & 4h down move, 1h still high
             & ((rsi_3_1h_gt_30) | (rsi_3_4h_gt_30) | (aroonu_14_1h_lt_40))
             # 1h & 1d down move, 1d still high
@@ -23868,7 +23905,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 4h high & overbought
             & ((rsi_3_1h_gt_30) | aroonu_14_4h_lt_100 | (roc_9_4h_lt_30))
             # 1h down move, 1d high, 4h overbought
-            & ((rsi_3_1h_gt_30) | aroonu_14_1d_lt_100 | (roc_9_4h < 20.0))
+            & ((rsi_3_1h_gt_30) | aroonu_14_1d_lt_100 | (roc_9_4h_lt_20))
             # 1h & 4h down move, 1h still high, 4h high
             & ((rsi_3_1h_gt_35) | (rsi_3_4h_gt_60) | (rsi_14_1h < 50.0) | (rsi_14_4h < 70.0))
             # 1h down move, 1d downtrend, 15m still high, 1d high
@@ -23878,7 +23915,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h & 1d high
             & ((rsi_3_1h_gt_35) | (aroonu_14_1h_lt_60) | aroonu_14_1d_lt_100)
             # 1h down move, 1h high, 4h overbought
-            & ((rsi_3_1h_gt_35) | (aroonu_14_1h_lt_70) | (roc_9_4h < 25.0))
+            & ((rsi_3_1h_gt_35) | (aroonu_14_1h_lt_70) | (roc_9_4h_lt_25))
             # 1h down move, 1h & 4h high
             & ((rsi_3_1h_gt_35) | (aroonu_14_1h_lt_70) | (aroonu_14_4h_lt_90))
             # 1h down move, 1h & 1d high
@@ -23898,7 +23935,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h high, 1d downtrend
             & ((rsi_3_1h_gt_40) | (stochrsi_k_1h_lt_80) | (roc_9_1d_gt_neg_40))
             # 1h & 4h down move, 1d overbought
-            & ((rsi_3_1h_gt_45) | (rsi_3_4h_gt_65) | (roc_9_1d < 200.0))
+            & ((rsi_3_1h_gt_45) | (rsi_3_4h_gt_65) | (roc_9_1d_lt_200))
             # 1h & 1d down move, 4h high
             & ((rsi_3_1h_gt_45) | (rsi_3_1d > 50.0) | (stochrsi_k_4h_lt_90))
             # 1h down move, 1h high, 4h overbought
@@ -23910,7 +23947,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 4h & 1d high
             & ((rsi_3_1h_gt_50) | (aroonu_14_4h_lt_90) | (aroonu_14_1d_lt_90))
             # 1h down move, 4h high, 1h overbought
-            & ((rsi_3_1h_gt_55) | aroonu_14_4h_lt_100 | (roc_9_1h < 20.0))
+            & ((rsi_3_1h_gt_55) | aroonu_14_4h_lt_100 | (roc_9_1h_lt_20))
             # 1h down move, 15m & 1h high, 1d downtrend
             & ((rsi_3_1h_gt_60) | (aroonu_14_15m < 65.0) | (stochrsi_k_1h_lt_80) | (cmf_20_1d > -0.0))
             # 1h down move, 1h high, 1d downtrend
@@ -23940,7 +23977,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 4h still high 1d downtrend
             & ((rsi_3_4h_gt_25) | (aroonu_14_4h_lt_50) | (roc_9_1d_gt_neg_20))
             # 4h down move, 1d high & overbought
-            & ((rsi_3_4h_gt_25) | (stochrsi_k_1d < 80.0) | (roc_9_1d < 25.0))
+            & ((rsi_3_4h_gt_25) | (stochrsi_k_1d_lt_80) | (roc_9_1d_lt_25))
             # 4h down move, 4h & 1d high
             & ((rsi_3_4h_gt_35) | aroonu_14_4h_lt_70 | aroonu_14_1d_lt_100)
             # 4h down move, 15m still high, 1d overbought
@@ -23976,7 +24013,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1d down move, 1h & 4h still high
             & ((rsi_3_1d_gt_10) | (stochrsi_k_1h_lt_40) | (aroonu_14_4h_lt_40))
             # 1d down move, 1h high & overbought
-            & ((rsi_3_1d_gt_20) | (stochrsi_k_1h_lt_80) | (roc_9_1h < 20.0))
+            & ((rsi_3_1d_gt_20) | (stochrsi_k_1h_lt_80) | (roc_9_1h_lt_20))
             # 1d down move, 1d high & overbought
             & ((rsi_3_1d_gt_40) | (aroonu_14_1d_lt_70) | (roc_9_1d_lt_20))
             # 1d down move, 4h high & overbought
@@ -23986,7 +24023,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1d down move, 15m still high, 1d overbought
             & ((rsi_3_1d_gt_65) | (aroonu_14_15m_lt_40) | (roc_9_1d_lt_100))
             # 1d down move, 4h & 1d high
-            & ((rsi_3_1d_gt_65) | (roc_9_4h_lt_10) | (roc_9_1d < 10.0))
+            & ((rsi_3_1d_gt_65) | (roc_9_4h_lt_10) | (roc_9_1d_lt_10))
             # 5m still high, 1h down move, 15m still high, 1h high
             & ((rsi_3 < 40.0) | (rsi_3_1h_gt_30) | (aroonu_14_15m_lt_50) | (aroonu_14_4h_lt_90))
             # 5m still high, 15m high
@@ -23996,15 +24033,15 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 1h high
             & ((rsi_14_15m > 25.0) | (stochrsi_k_1h_lt_80))
             # 15m down move, 4h & 1d high
-            & ((rsi_14_15m > 30.0) | (stochrsi_k_4h_lt_90) | (stochrsi_k_1d < 70.0))
+            & ((rsi_14_15m > 30.0) | (stochrsi_k_4h_lt_90) | (stochrsi_k_1d_lt_70))
             # 1h downtrend, 4h high, 1d downtrend
             & ((cmf_20_1h > -0.2) | (stochrsi_k_4h_lt_90) | (cmf_20_1d > -0.25))
             # 15m & 1h high, 1d overbought
             & ((aroonu_14_15m_lt_60) | (aroonu_14_1h_lt_100) | (roc_9_1d_lt_20))
             # 4h high, 4h & 1d overbought
-            & (aroonu_14_4h_lt_80 | (roc_9_4h < 20.0) | (roc_9_1d_lt_20))
+            & (aroonu_14_4h_lt_80 | (roc_9_4h_lt_20) | (roc_9_1d_lt_20))
             # 4h & 1d high, 1d overbought
-            & ((aroonu_14_4h_lt_85) | (aroonu_14_1d_lt_85) | (roc_9_1d < 60.0))
+            & ((aroonu_14_4h_lt_85) | (aroonu_14_1d_lt_85) | (roc_9_1d_lt_60))
             # 4h & 1d high, 1d overbought
             & (aroonu_14_4h_lt_100 | aroonu_14_1d_lt_100 | (roc_9_1d_lt_30))
             # 1d still high, 4h & 1d downtrend
@@ -24040,7 +24077,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # big drop in the last 20 days, 1h down move, 1h high
             & ((close > (high_max_20_1d * 0.30)) | (rsi_3_1h_gt_30) | (stochrsi_k_1h < 75.0))
             # big drop in the last 20 days, 1d high, 1d downtrend
-            & ((close > (high_max_20_1d * 0.20)) | (stochrsi_k_1d < 70.0) | (roc_9_1d > -15.0))
+            & ((close > (high_max_20_1d * 0.20)) | (stochrsi_k_1d_lt_70) | (roc_9_1d > -15.0))
           )
 
           # Logic
@@ -24140,7 +24177,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 5m & 15m strong up move
           short_entry_logic.append((rsi_3 < 95.0) | (rsi_3_15m_lt_95))
           # 5m & 1h up move, 1d uptrend
-          short_entry_logic.append((rsi_3 < 95.0) | (rsi_3_1h_lt_90) | (roc_9_1d < 100.0))
+          short_entry_logic.append((rsi_3 < 95.0) | (rsi_3_1h_lt_90) | (roc_9_1d_lt_100))
           # 5m up move, 15m & 1h still not high enough
           short_entry_logic.append((rsi_3 < 95.0) | (aroond_14_15m < 25.0) | (aroond_14_1h < 25.0))
           # 4m up move, 1h & 4h still low
@@ -24200,7 +24237,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m & 4h up move, 4h not high enough
           short_entry_logic.append((rsi_3_15m_lt_90) | (rsi_3_4h_lt_90) | (aroond_14_4h < 50.0))
           # 15m & 4h up move, 1d low
-          short_entry_logic.append((rsi_3_15m_lt_90) | (rsi_3_4h_lt_85) | (stochrsi_k_1d > 30.0))
+          short_entry_logic.append((rsi_3_15m_lt_90) | (rsi_3_4h_lt_85) | (stochrsi_k_1d_gt_30))
           # 15m & 4h up move, 1h low
           short_entry_logic.append((rsi_3_15m_lt_90) | (rsi_3_4h < 70.0) | (stochrsi_k_1h_gt_20))
           # 15m & 4h up move, 4h low
@@ -24212,11 +24249,11 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m up move, 1h low, 4h still not high enough
           short_entry_logic.append((rsi_3_15m_lt_90) | (stochrsi_k_1h_gt_30) | (stochrsi_k_4h_gt_70))
           # 15m & 4h up move, 1d low
-          short_entry_logic.append((rsi_3_15m_lt_90) | (rsi_3_4h < 70.0) | (stochrsi_k_1d > 20.0))
+          short_entry_logic.append((rsi_3_15m_lt_90) | (rsi_3_4h < 70.0) | (stochrsi_k_1d_gt_20))
           # 15m & 1h up move, 4h low
           short_entry_logic.append((rsi_3_15m_lt_85) | (rsi_3_1h_lt_85) | (stochrsi_k_4h > 20.0))
           # 15m & 1h up move, 1d still low
-          short_entry_logic.append((rsi_3_15m_lt_85) | (rsi_3_1h_lt_85) | (stochrsi_k_1d > 60.0))
+          short_entry_logic.append((rsi_3_15m_lt_85) | (rsi_3_1h_lt_85) | (stochrsi_k_1d_gt_60))
           # 15m & 1h up move, 1h low
           short_entry_logic.append((rsi_3_15m_lt_85) | (rsi_3_1h < 70.0) | (stochrsi_k_1h_gt_30))
           # 15m & 1h up move, 4h low
@@ -24228,7 +24265,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m down move, 15m still not high enough, 4h low
           short_entry_logic.append((rsi_3_15m_lt_85) | (rsi_14_15m > 70.0) | (stochrsi_k_4h > 40.0))
           # 15m up move, 4h overbought
-          short_entry_logic.append((rsi_3_15m_lt_85) | (roc_9_4h < 50.0))
+          short_entry_logic.append((rsi_3_15m_lt_85) | (roc_9_4h_lt_50))
           # 15m & 1h up move, 1h still not high enough
           short_entry_logic.append((rsi_3_15m < 80.0) | (rsi_3_1h < 70.0) | (aroonu_14_1h > 60.0))
           # 15m & 4h up move, 15m still low
@@ -24254,29 +24291,29 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1h up move, 4h still low
           short_entry_logic.append((rsi_3_1h_lt_95) | (rsi_14_4h > 60.0))
           # 1h up move, 1d still low, 1h uptrend
-          short_entry_logic.append((rsi_3_1h_lt_95) | (rsi_14_1d > 50.0) | (roc_9_1h < 30.0))
+          short_entry_logic.append((rsi_3_1h_lt_95) | (rsi_14_1d > 50.0) | (roc_9_1h_lt_30))
           # 1h & 4h strong up move
           short_entry_logic.append((rsi_3_1h_lt_95) | (mfi_14_1h < 95.0) | (rsi_3_4h_lt_95))
           # 1h up move, 1d still low, 1h uptrend
-          short_entry_logic.append((rsi_3_1h_lt_95) | (stochrsi_k_1d > 50.0) | (roc_9_1h < 20.0))
+          short_entry_logic.append((rsi_3_1h_lt_95) | (stochrsi_k_1d_gt_50) | (roc_9_1h_lt_20))
           # 1h strong up move, 15m still move higher
           short_entry_logic.append((rsi_3_1h_lt_95) | (df["CCI_20_change_pct_15m"] < -0.0))
           # 1h & 4h up move, 1h still low
           short_entry_logic.append((rsi_3_1h_lt_90) | (rsi_3_4h_lt_90) | (stochrsi_k_1h_gt_50))
           # 1h & 4h up move, 1d still not high enough
-          short_entry_logic.append((rsi_3_1h_lt_90) | (rsi_3_4h_lt_90) | (stochrsi_k_1d > 70.0))
+          short_entry_logic.append((rsi_3_1h_lt_90) | (rsi_3_4h_lt_90) | (stochrsi_k_1d_gt_70))
           # 1h up move, 4h low, 1d overbought
           short_entry_logic.append((rsi_3_1h_lt_90) | (aroonu_14_4h > 20.0) | roc_9_1d_lt_50)
           # 1h up move, 1h still low, 1d uptrend
           short_entry_logic.append((rsi_3_1h_lt_90) | (stochrsi_k_1h_gt_60) | roc_9_1d_lt_50)
           # 1h up move, 1h still not high enough, 1d low
-          short_entry_logic.append((rsi_3_1h_lt_90) | (stochrsi_k_1h_gt_70) | (stochrsi_k_1d > 30.0))
+          short_entry_logic.append((rsi_3_1h_lt_90) | (stochrsi_k_1h_gt_70) | (stochrsi_k_1d_gt_30))
           # 1h up move, 4h low, 1h uptrend
           short_entry_logic.append((rsi_3_1h_lt_90) | (stochrsi_k_4h > 20.0) | (roc_9_1h_lt_10))
           # 1h up move, 4h low, 1h overbought
-          short_entry_logic.append((rsi_3_1h_lt_90) | (stochrsi_k_4h > 40.0) | (roc_9_1h < 30.0))
+          short_entry_logic.append((rsi_3_1h_lt_90) | (stochrsi_k_4h > 40.0) | (roc_9_1h_lt_30))
           # 1h up move, 15m & 1h uptrend
-          short_entry_logic.append((rsi_3_1h_lt_90) | (roc_9_15m < 15.0) | (roc_9_1h < 15.0))
+          short_entry_logic.append((rsi_3_1h_lt_90) | (roc_9_15m < 15.0) | (roc_9_1h_lt_15))
           # 1h up move, 15m & 4h still low
           short_entry_logic.append((rsi_3_1h_lt_85) | (stochrsi_k_15m_gt_50) | (stochrsi_k_4h_gt_50))
           # 1h & 4h up move, 15m still not high enough
@@ -24292,13 +24329,13 @@ class NostalgiaForInfinityX7(IStrategy):
           # 4h up move, 15m still low, 1h not high enough
           short_entry_logic.append((rsi_3_4h_lt_95) | (stochrsi_k_15m_gt_50) | (aroond_14_1h < 25.0))
           # 4h up move, 15m still not high enough, 4h overbought
-          short_entry_logic.append((rsi_3_4h_lt_95) | (stochrsi_k_15m > 70.0) | (roc_9_4h < 60.0))
+          short_entry_logic.append((rsi_3_4h_lt_95) | (stochrsi_k_15m > 70.0) | (roc_9_4h_lt_60))
           # 4h up move, 15m uptrend
           short_entry_logic.append((rsi_3_4h_lt_95) | (roc_9_15m < 20.0))
           # 4h up move, 1h uptrend
-          short_entry_logic.append((rsi_3_4h_lt_95) | (roc_9_1h < 20.0))
+          short_entry_logic.append((rsi_3_4h_lt_95) | (roc_9_1h_lt_20))
           # 4h up move, 1h & 4h overbought
-          short_entry_logic.append((rsi_3_4h_lt_95) | (roc_9_1h < 30.0) | (roc_9_4h < 60.0))
+          short_entry_logic.append((rsi_3_4h_lt_95) | (roc_9_1h_lt_30) | (roc_9_4h_lt_60))
           # 4h up move, 1h still low
           short_entry_logic.append((rsi_3_4h_lt_90) | (aroonu_14_1h > 40.0))
           # 4h up move, 1d still low, 4h uptrend
@@ -24312,7 +24349,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 4h up move, 1h low
           short_entry_logic.append((rsi_3_4h < 70.0) | (stochrsi_k_1h_gt_20))
           # 4h up move, 1d low
-          short_entry_logic.append((rsi_3_4h < 70.0) | (stochrsi_k_1d > 20.0))
+          short_entry_logic.append((rsi_3_4h < 70.0) | (stochrsi_k_1d_gt_20))
           # 1d up move, 1h & 4h still not low enough
           short_entry_logic.append((rsi_3_1d < 90.0) | (stochrsi_k_1h_gt_80) | (stochrsi_k_4h_gt_50))
           # 4h still not high enough, 4h overbought, 4h uptrend
@@ -24330,13 +24367,13 @@ class NostalgiaForInfinityX7(IStrategy):
           # 4h uptrend, 15m uptrend
           short_entry_logic.append(aroonu_14_4h_lt_100 | (roc_9_15m < 10.0))
           # 4h uptrend, 1h uptrend
-          short_entry_logic.append(aroonu_14_4h_lt_100 | (roc_9_1h < 20.0))
+          short_entry_logic.append(aroonu_14_4h_lt_100 | (roc_9_1h_lt_20))
           # 1d uptrend, 15m uptrend
           short_entry_logic.append(aroonu_14_1d_lt_100 | (roc_9_15m < 20.0))
           # 1d uptrend, 1h uptrend
-          short_entry_logic.append(aroonu_14_1d_lt_100 | (roc_9_1h < 20.0))
+          short_entry_logic.append(aroonu_14_1d_lt_100 | (roc_9_1h_lt_20))
           # 15m still not high enough, 1h & 4h overbought
-          short_entry_logic.append((stochrsi_k_15m > 70.0) | (roc_9_1h < 30.0) | (roc_9_4h < 60.0))
+          short_entry_logic.append((stochrsi_k_15m > 70.0) | (roc_9_1h_lt_30) | (roc_9_4h_lt_60))
           # 1h & 4h overbought, 1h uptrend
           short_entry_logic.append((roc_9_1h_lt_10) | (roc_9_4h_lt_40) | (cci_20_change_pct_1h < 0.0))
           # 1h & 4h overbought, 4h uptrend
@@ -24412,7 +24449,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 4h up move, 1d low
             & ((rsi_3_15m_lt_90) | (rsi_3_4h_lt_85) | (rsi_14_1d > 40.0))
             # 15m & 4h up move, 1d low
-            & ((rsi_3_15m_lt_90) | (rsi_3_4h_lt_85) | (stochrsi_k_1d > 30.0))
+            & ((rsi_3_15m_lt_90) | (rsi_3_4h_lt_85) | (stochrsi_k_1d_gt_30))
             # 15m up move, 1h still low, 1d low
             & ((rsi_3_15m_lt_90) | (aroonu_14_1h > 50.0) | (aroonu_14_1d > 30.0))
             # 15m up move, 1h high
@@ -24436,7 +24473,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m up move, 4h low
             & ((rsi_3_15m < 80.0) | (stochrsi_k_4h > 40.0))
             # 15m up move, 1h uptrend
-            & ((rsi_3_15m < 75.0) | (roc_9_1h < 40.0))
+            & ((rsi_3_15m < 75.0) | (roc_9_1h_lt_40))
             # 1h & 1d strong up move
             & ((rsi_3_1h_lt_95) | (rsi_3_1d < 95.0))
             # 1h up move, 1h still not high enough
@@ -24454,13 +24491,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h up move, 1d low
             & ((rsi_3_1h_lt_90) | (stochrsi_k_1d > 10.0))
             # 1h up move, 1h & 4h uptrend
-            & ((rsi_3_1h_lt_90) | (roc_9_1h < 30.0) | (roc_9_4h_lt_30))
+            & ((rsi_3_1h_lt_90) | (roc_9_1h_lt_30) | (roc_9_4h_lt_30))
             # 1h up move, 4h uptrend
             & ((rsi_3_1h_lt_90) | (roc_9_4h_lt_20))
             # 1h up move, 4h still low
             & ((rsi_3_1h_lt_85) | (aroonu_14_4h > 50.0))
             # 1h & 4h up move, 1d low
-            & ((rsi_3_1h_lt_80) | (rsi_3_4h_lt_80) | (stochrsi_k_1d > 30.0))
+            & ((rsi_3_1h_lt_80) | (rsi_3_4h_lt_80) | (stochrsi_k_1d_gt_30))
             # 1h up move, 1h still not high enough
             & ((rsi_3_1h_lt_80) | (stochrsi_k_1h_gt_70))
             # 1h up move, 4h still low, 1h still moving higher
@@ -24476,7 +24513,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h up move, 4h low
             & ((rsi_3_1h < 70.0) | (stochrsi_k_4h > 40.0))
             # 1h up move, 1h uptrend
-            & ((rsi_3_1h < 70.0) | (roc_9_1h < 40.0))
+            & ((rsi_3_1h < 70.0) | (roc_9_1h_lt_40))
             # 1h up move, 1h low
             & ((rsi_3_1h < 60.0) | (stochrsi_k_1h_gt_20))
             # 4h up move, 1d still low
@@ -24524,9 +24561,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h low
             & ((aroonu_14_1h > 20.0) | (stochrsi_k_4h > 20.0))
             # 1h low, 1d low
-            & ((aroonu_14_1h > 30.0) | (stochrsi_k_1d > 30.0))
+            & ((aroonu_14_1h > 30.0) | (stochrsi_k_1d_gt_30))
             # 4h still not high enough, 4h & 1d uptrend
-            & ((aroonu_14_4h > 70.0) | (roc_9_4h < 60.0) | (roc_9_1d < 200.0))
+            & ((aroonu_14_4h > 70.0) | (roc_9_4h_lt_60) | (roc_9_1d_lt_200))
             # 1h & 4h low
             & ((stochrsi_k_1h_gt_20) | (aroonu_14_4h > 20.0))
             # 1d big green, 1d still not high enough
@@ -24570,7 +24607,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 5m & 4h strong down move, 4h still not low enough
           short_entry_logic.append((rsi_3 < 95.0) | (rsi_3_1h_lt_95) | (stochrsi_k_4h > 60.0))
           # 5m down move, 1h high, 1d overbought
-          short_entry_logic.append((rsi_3_lt_90) | (roc_9_1h < 15.0) | (roc_9_1d_gt_neg_40))
+          short_entry_logic.append((rsi_3_lt_90) | (roc_9_1h_lt_15) | (roc_9_1d_gt_neg_40))
           # 5m down move, 1h & 4h high
           short_entry_logic.append((rsi_3_lt_90) | (df["UO_7_14_28_1h"] > 40.0) | (stochrsi_k_4h_gt_30))
           # 5m down move, 1h high, 4h downtrend
@@ -24681,7 +24718,7 @@ class NostalgiaForInfinityX7(IStrategy):
           )
           # 4h red, 4h still not low enough, 1h downtrend, 1h overbought
           short_entry_logic.append(
-            (change_pct_4h < 10.0) | (aroond_14_4h < 25.0) | (roc_9_1h < 20.0) | (roc_9_1d_gt_neg_40)
+            (change_pct_4h < 10.0) | (aroond_14_4h < 25.0) | (roc_9_1h_lt_20) | (roc_9_1d_gt_neg_40)
           )
           # 4h red, 4h still high, 1d downtrend
           short_entry_logic.append((change_pct_4h < 10.0) | (stochrsi_k_4h_gt_30) | (roc_9_1d_lt_40))
@@ -24769,7 +24806,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m down move, 1h & 4h still high
           short_entry_logic.append((rsi_3_15m_lt_85) | (stochrsi_k_1h_gt_50) | (stochrsi_k_4h_gt_50))
           # 15m down move, 1h downtrend, 4h still high
-          short_entry_logic.append((rsi_3_15m_lt_90) | (roc_9_1h < 20.0) | (stochrsi_k_4h_gt_50))
+          short_entry_logic.append((rsi_3_15m_lt_90) | (roc_9_1h_lt_20) | (stochrsi_k_4h_gt_50))
           # 15m & 1h down move, 4h high
           short_entry_logic.append((rsi_3_15m_lt_90) | (rsi_3_1h_lt_85) | (stochrsi_k_4h_gt_30))
           # 15m down move, 1h down move, 4h high
@@ -24794,16 +24831,16 @@ class NostalgiaForInfinityX7(IStrategy):
           short_entry_logic.append((rsi_3_1h_lt_90) | (rsi_3_change_pct_4h < 70.0) | (rsi_14_4h.shift(48) > 30.0))
           # 1h & 4h down move, 4h still not low enough, 1d still high
           short_entry_logic.append(
-            (rsi_3_1h_lt_90) | (rsi_3_change_pct_4h < 50.0) | (aroond_14_4h < 25.0) | (stochrsi_k_1d > 60.0)
+            (rsi_3_1h_lt_90) | (rsi_3_change_pct_4h < 50.0) | (aroond_14_4h < 25.0) | (stochrsi_k_1d_gt_60)
           )
           # 1h down move, 1h still high, 1d going down
           short_entry_logic.append((rsi_3_1h_lt_85) | (stochrsi_k_1h_gt_50) | (roc_2_1d > -50.0))
           # 4h downtrend, 4h still high, 1d strong downtrend
-          short_entry_logic.append((rsi_3_4h_lt_85) | (stochrsi_k_4h_gt_70) | (roc_9_1d < 60.0))
+          short_entry_logic.append((rsi_3_4h_lt_85) | (stochrsi_k_4h_gt_70) | (roc_9_1d_lt_60))
           # 15m down move, 1h strong down move, 1d overbought
           short_entry_logic.append((mfi_14_15m < 80.0) | (rsi_3_change_pct_1h < 80.0) | roc_9_1d_gt_neg_50)
           # 1h not low enough, 4h high, 1d strong downtrend
-          short_entry_logic.append((stochrsi_k_1h_gt_70) | (stochrsi_k_4h > 10.0) | (roc_9_1d < 60.0))
+          short_entry_logic.append((stochrsi_k_1h_gt_70) | (stochrsi_k_4h > 10.0) | (roc_9_1d_lt_60))
           # 1h down move, 4h still high, 1d downtrend
           short_entry_logic.append((rsi_3_change_pct_1h < 65.0) | (stochrsi_k_4h_gt_30) | roc_9_1d_lt_50)
           # 15m strong down move, 1h still high
@@ -24815,7 +24852,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1h P&D, 4h still high
           short_entry_logic.append((df["ROC_2_1h"] < 10.0) | (roc_9_1h > -5.0) | (stochrsi_k_4h_gt_30))
           # 1h downtrend, 4h down move, 1d downtrend
-          short_entry_logic.append((roc_9_1h < 40.0) | (rsi_3_4h_lt_90) | roc_9_1d_lt_50)
+          short_entry_logic.append((roc_9_1h_lt_40) | (rsi_3_4h_lt_90) | roc_9_1d_lt_50)
           short_entry_logic.append((roc_9_4h > -200.0) | (rsi_14_4h > 20.0))
           # 4h down move, 1d P&D
           short_entry_logic.append((roc_9_4h_lt_20) | (roc_2_1d < 20.0) | roc_9_1d_gt_neg_50)
@@ -24873,7 +24910,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m up move, 15m still not high enough, 4h still low
           short_entry_logic.append((rsi_3_15m_lt_85) | (stochrsi_k_15m > 80.0) | (aroonu_14_4h > 50.0))
           # 15m up move, 4h overbought
-          short_entry_logic.append((rsi_3_15m_lt_85) | (roc_9_4h < 50.0))
+          short_entry_logic.append((rsi_3_15m_lt_85) | (roc_9_4h_lt_50))
           # 15m & 1h up move, 15m still low
           short_entry_logic.append((rsi_3_15m < 70.0) | (rsi_3_1h < 70.0) | (aroonu_14_15m > 40.0))
           # 15m & 1h up move, 15m still low
@@ -24885,7 +24922,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1h & 4h up move, 15m still not high enough
           short_entry_logic.append((rsi_3_1h_lt_95) | (rsi_3_4h_lt_95) | (stochrsi_k_15m > 80.0))
           # 1h & 4h up move, 1d uptrend
-          short_entry_logic.append((rsi_3_1h_lt_95) | (rsi_3_4h_lt_95) | (roc_9_1d < 100.0))
+          short_entry_logic.append((rsi_3_1h_lt_95) | (rsi_3_4h_lt_95) | (roc_9_1d_lt_100))
           # 1h & 4h up move, 1d still low
           short_entry_logic.append((rsi_3_1h_lt_95) | (rsi_3_4h_lt_85) | (rsi_14_1d > 50.0))
           # 1h up move, 4h still low, 1h still moving higher
@@ -24919,11 +24956,11 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1h & 4h up move, 1d still low
           short_entry_logic.append((rsi_3_1h_lt_80) | (rsi_3_4h_lt_80) | (aroonu_14_1d > 50.0))
           # 1h & 4h up move, 1d low
-          short_entry_logic.append((rsi_3_1h_lt_80) | (rsi_3_4h < 70.0) | (stochrsi_k_1d > 30.0))
+          short_entry_logic.append((rsi_3_1h_lt_80) | (rsi_3_4h < 70.0) | (stochrsi_k_1d_gt_30))
           # 1h up move, 1d still low, 1d uptrend
           short_entry_logic.append((rsi_3_1h_lt_80) | (aroonu_14_1d > 50.0) | (roc_9_1d_lt_30))
           # 1h up move, 1d low
-          short_entry_logic.append((rsi_3_1h_lt_80) | (stochrsi_k_1d > 20.0))
+          short_entry_logic.append((rsi_3_1h_lt_80) | (stochrsi_k_1d_gt_20))
           # 1h up move, 4h & 1d uptrend
           short_entry_logic.append((rsi_3_1h_lt_80) | (roc_9_4h_lt_20) | (roc_9_1d_lt_40))
           # 4h up move, 1d low
@@ -24931,7 +24968,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 4h down move, 15m still not high enough, 1d low
           short_entry_logic.append((rsi_3_4h_lt_95) | (stochrsi_k_15m > 80.0) | (df["AROOND_14_1d"] < 75.0))
           # 4h up move, 1h & 4h uptrend
-          short_entry_logic.append((rsi_3_4h_lt_95) | (roc_9_1h < 20.0) | (roc_9_4h_lt_20))
+          short_entry_logic.append((rsi_3_4h_lt_95) | (roc_9_1h_lt_20) | (roc_9_4h_lt_20))
           # 4h up move, 15m low
           short_entry_logic.append((rsi_3_4h_lt_90) | (stochrsi_k_15m > 45.0))
           # 4h up move, 4h & 1d uptrend
@@ -24953,13 +24990,13 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m & 1h high, 4h uptrend
           short_entry_logic.append((aroonu_14_15m_lt_100) | (aroonu_14_1h_lt_100) | (roc_9_4h_lt_20))
           # 15m & 4h high, 1h uptrend
-          short_entry_logic.append((aroonu_14_15m_lt_100) | aroonu_14_4h_lt_100 | (roc_9_1h < 20.0))
+          short_entry_logic.append((aroonu_14_15m_lt_100) | aroonu_14_4h_lt_100 | (roc_9_1h_lt_20))
           # 15m high, 1d low
-          short_entry_logic.append((aroonu_14_15m_lt_100) | (stochrsi_k_1d > 20.0))
+          short_entry_logic.append((aroonu_14_15m_lt_100) | (stochrsi_k_1d_gt_20))
           # 15m high & uptrend
           short_entry_logic.append((aroonu_14_15m_lt_100) | (roc_9_15m < 30.0))
           # 15m high, 1h & 4h uptrend
-          short_entry_logic.append((aroonu_14_15m_lt_100) | (roc_9_1h < 20.0) | (roc_9_4h_lt_20))
+          short_entry_logic.append((aroonu_14_15m_lt_100) | (roc_9_1h_lt_20) | (roc_9_4h_lt_20))
           # 1h high, 15m uptrend
           short_entry_logic.append((aroonu_14_1h_lt_100) | (roc_9_15m < 20.0))
           # 15m & 4h still not high enough
@@ -25044,7 +25081,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 4h down move, 4h still high, 1d downtrend
           short_entry_logic.append((rsi_3_4h < 75.0) | (stochrsi_k_4h_gt_50) | roc_9_1d_lt_50)
           # 4h & 1d down move, 1d strong downtrend
-          short_entry_logic.append((rsi_3_4h_lt_90) | (rsi_3_1d < 90.0) | (roc_9_1d < 60.0))
+          short_entry_logic.append((rsi_3_4h_lt_90) | (rsi_3_1d < 90.0) | (roc_9_1d_lt_60))
           # 4h overbought, 1h still high, 1d downtrend
           short_entry_logic.append((roc_9_4h > -50.0) | (stochrsi_k_1h_gt_70) | roc_9_1d_lt_50)
           # 4h red, previous 4h green, 4h overbought
@@ -25105,7 +25142,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m down move, 15m still not low enough, 1h still high
           short_entry_logic.append((rsi_3_15m_lt_95) | (aroond_14_15m < 25.0) | (stochrsi_k_1h_gt_50))
           # 15m & 1h down move, 1d still not low enough
-          short_entry_logic.append((rsi_3_15m_lt_95) | (rsi_3_1h_lt_95) | (stochrsi_k_1d > 70.0))
+          short_entry_logic.append((rsi_3_15m_lt_95) | (rsi_3_1h_lt_95) | (stochrsi_k_1d_gt_70))
           # 15m & 1h down move, 1h still not low enough
           short_entry_logic.append((rsi_3_15m_lt_85) | (rsi_3_1h_lt_85) | (stochrsi_k_1h_gt_70))
           # 15m down move, 1h high, 4h still high
@@ -25157,7 +25194,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m & 1h down move, 1h still not low enough
           short_entry_logic.append((rsi_3_15m_lt_95) | (rsi_3_1h_lt_95) | (stochrsi_k_1h_gt_90))
           # 15m & 1h down move, 1d still not low enough
-          short_entry_logic.append((rsi_3_15m_lt_95) | (rsi_3_1h_lt_95) | (stochrsi_k_1d > 70.0))
+          short_entry_logic.append((rsi_3_15m_lt_95) | (rsi_3_1h_lt_95) | (stochrsi_k_1d_gt_70))
           # 15m strong down move, 4h high
           short_entry_logic.append((rsi_3_15m_lt_95) | (stochrsi_k_4h > 20.0))
           # 15m & 1h down move, 1h still not low enough
@@ -25171,9 +25208,9 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m down move, 15m still not low enough, 4h high
           short_entry_logic.append((rsi_3_15m_lt_85) | (stochrsi_k_15m > 80.0) | (stochrsi_k_4h > 20.0))
           # 15m down move, 4h still high, 1d high
-          short_entry_logic.append((rsi_3_15m_lt_85) | (stochrsi_k_4h > 60.0) | (stochrsi_k_1d > 30.0))
+          short_entry_logic.append((rsi_3_15m_lt_85) | (stochrsi_k_4h > 60.0) | (stochrsi_k_1d_gt_30))
           # 15m & 4h down move, 1d still high
-          short_entry_logic.append((rsi_3_15m_lt_85) | (rsi_3_4h < 75.0) | (stochrsi_k_1d > 50.0))
+          short_entry_logic.append((rsi_3_15m_lt_85) | (rsi_3_4h < 75.0) | (stochrsi_k_1d_gt_50))
           # 15m & 1h down move, 4h still not low enough
           short_entry_logic.append((rsi_3_15m < 80.0) | (rsi_3_1h_lt_80) | (stochrsi_k_4h_gt_70))
           # 15m & 1h down move, 4h still not low enough
@@ -25187,7 +25224,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m down move, 1h high, 4h still not low enough
           short_entry_logic.append((rsi_3_15m < 75.0) | (stochrsi_k_1h_gt_20) | (stochrsi_k_4h > 90.0))
           # 15m down move, 4h high, 1d stil high
-          short_entry_logic.append((rsi_3_15m < 75.0) | (stochrsi_k_4h > 20.0) | (stochrsi_k_1d > 50.0))
+          short_entry_logic.append((rsi_3_15m < 75.0) | (stochrsi_k_4h > 20.0) | (stochrsi_k_1d_gt_50))
           # 15m & 4h down move, 1h still not low enough
           short_entry_logic.append((rsi_3_15m < 70.0) | (rsi_3_4h_lt_85) | (stochrsi_k_1h_gt_70))
           # 15m & 4h down move, 1h still high
@@ -25207,11 +25244,11 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1h & 4h down move, 1h still not low enough
           short_entry_logic.append((rsi_3_1h_lt_90) | (rsi_3_4h_lt_85) | (stochrsi_k_1h > 85.0))
           # 1h & 4h down move, 1d still high
-          short_entry_logic.append((rsi_3_1h_lt_90) | (rsi_3_4h_lt_85) | (stochrsi_k_1d > 50.0))
+          short_entry_logic.append((rsi_3_1h_lt_90) | (rsi_3_4h_lt_85) | (stochrsi_k_1d_gt_50))
           # 1h & 4h down move, 4h still not low enough
           short_entry_logic.append((rsi_3_1h_lt_85) | (rsi_3_4h < 75.0) | (stochrsi_k_4h > 85.0))
           # 1h down move, 4h still high, 1d high
-          short_entry_logic.append((rsi_3_1h_lt_80) | (stochrsi_k_4h > 60.0) | (stochrsi_k_1d > 30.0))
+          short_entry_logic.append((rsi_3_1h_lt_80) | (stochrsi_k_4h > 60.0) | (stochrsi_k_1d_gt_30))
           # 1h & 4h down move, 1h still not low enough
           short_entry_logic.append((rsi_3_1h_lt_80) | (rsi_3_4h_lt_85) | (stochrsi_k_1h_gt_75))
           # 1h & 4h down move, 15m still high
@@ -25227,11 +25264,11 @@ class NostalgiaForInfinityX7(IStrategy):
           # 4h down move, 15m still high, 4h still not low enough
           short_entry_logic.append((rsi_3_4h < 75.0) | (stochrsi_k_15m_gt_50) | (stochrsi_k_4h > 75.0))
           # 4h down move, 1h still not low enough, 1d still high
-          short_entry_logic.append((rsi_3_4h < 25.0) | (stochrsi_k_1h_gt_70) | (stochrsi_k_1d > 50.0))
+          short_entry_logic.append((rsi_3_4h < 25.0) | (stochrsi_k_1h_gt_70) | (stochrsi_k_1d_gt_50))
           # 15m & 1h still high, 4h high
           short_entry_logic.append((stochrsi_k_15m > 70.0) | (stochrsi_k_1h_gt_70) | (stochrsi_k_4h > 10.0))
           # 15m still high, 1h & 1d high
-          short_entry_logic.append((stochrsi_k_15m > 60.0) | (stochrsi_k_1h_gt_30) | (stochrsi_k_1d > 30.0))
+          short_entry_logic.append((stochrsi_k_15m > 60.0) | (stochrsi_k_1h_gt_30) | (stochrsi_k_1d_gt_30))
           # 15m & 4h high
           short_entry_logic.append((stochrsi_k_15m_gt_50) | (stochrsi_k_4h > 20.0))
           # 15m high, 1h & 4h still not low enough
@@ -25239,19 +25276,17 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m & 4h high
           short_entry_logic.append((stochrsi_k_15m > 30.0) | (stochrsi_k_4h_gt_30))
           # 1h & 4h still high, 1d high
-          short_entry_logic.append((stochrsi_k_1h_gt_70) | (stochrsi_k_4h_gt_70) | (stochrsi_k_1d > 50.0))
+          short_entry_logic.append((stochrsi_k_1h_gt_70) | (stochrsi_k_4h_gt_70) | (stochrsi_k_1d_gt_50))
           # 1h & 4h high
           short_entry_logic.append((stochrsi_k_1h_gt_30) | (stochrsi_k_4h > 10.0))
           # 1h & 4h high
           short_entry_logic.append((stochrsi_k_1h_gt_20) | (stochrsi_k_4h > 20.0))
           # 4h & 1d high
-          short_entry_logic.append((stochrsi_k_4h > 20.0) | (stochrsi_k_1d > 20.0))
+          short_entry_logic.append((stochrsi_k_4h > 20.0) | (stochrsi_k_1d_gt_20))
           # 1d red, 1d high
-          short_entry_logic.append((change_pct_1d < 5.0) | (stochrsi_k_1d > 20.0))
+          short_entry_logic.append((change_pct_1d < 5.0) | (stochrsi_k_1d_gt_20))
           # 1d P&D, 1d high
-          short_entry_logic.append(
-            (change_pct_1d < 10.0) | (change_pct_1d.shift(288) > -10.0) | (stochrsi_k_1d > 50.0)
-          )
+          short_entry_logic.append((change_pct_1d < 10.0) | (change_pct_1d.shift(288) > -10.0) | (stochrsi_k_1d_gt_50))
 
           # Logic
           short_entry_logic.append(rsi_4 > 54.0)
@@ -25319,7 +25354,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1h down move, 15m & 1h high
           short_entry_logic.append((rsi_3_1h < 50.0) | (stochrsi_k_15m > 40.0) | (aroond_14_1h < 60.0))
           # 1h down move, 1h & 1d high
-          short_entry_logic.append((rsi_3_1h < 50.0) | (aroond_14_1h < 70.0) | (stochrsi_k_1d > 20.0))
+          short_entry_logic.append((rsi_3_1h < 50.0) | (aroond_14_1h < 70.0) | (stochrsi_k_1d_gt_20))
           # 1h down move, 4h still high, 1d high
           short_entry_logic.append((rsi_3_1h < 50.0) | (stochrsi_k_4h_gt_50) | (stochrsi_k_1d > 10.0))
           # 1h down move, 5m up move, 1h still high
@@ -25377,7 +25412,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 4h down move, 1h & 4h high
           short_entry_logic.append((rsi_3_4h < 40.0) | (stochrsi_k_1h_gt_30) | (aroond_14_4h < 70.0))
           # 4h down move, 4h still high, 1d high
-          short_entry_logic.append((rsi_3_4h < 40.0) | (stochrsi_k_4h_gt_50) | (stochrsi_k_1d > 20.0))
+          short_entry_logic.append((rsi_3_4h < 40.0) | (stochrsi_k_4h_gt_50) | (stochrsi_k_1d_gt_20))
           # 15m high, 4h high
           short_entry_logic.append((aroond_14_15m < 70.0) | (aroond_14_4h < 85.0))
           # 15m high, 4h still high


### PR DESCRIPTION
## Summary
- Reuses repeated STOCHRSI 1d and ROC 1h/4h/1d entry masks inside `populate_entry_trend()`.
- Consolidates the split entry-mask PRs into one latest-main branch to avoid repeated rebase/apply conflicts.
- Independent on latest upstream `main`.

## Safety
- Behavior is preserved: this only reuses named boolean Series masks for comparisons that were already evaluated inline in the same function.
- No indicator formulas, candle selection, order classification, profit arithmetic, thresholds, condition order, return values, or signal behavior are changed.
- Touched function: `populate_entry_trend()`.
- No v3 grind-entry code is touched.

## Backtest scope
- Full backtesting was not required for this patch type because it does not change formulas, thresholds, condition ordering, or trading outputs; it only reuses equivalent local boolean masks inside the same call.
- The validation scope is static/parity-by-construction plus targeted diff review for the touched function.

## Checks
- `python3 ~/.codex/skills/nfi-upstream-pr/scripts/validate_nfi_pr.py --base origin/main`
- `git merge-tree` conflict simulation against `origin/main`
- targeted `git diff origin/main...HEAD -- NostalgiaForInfinityX7.py` review
- `git diff --check origin/main...HEAD`
- `ruff format --check NostalgiaForInfinityX7.py`
- `ruff check NostalgiaForInfinityX7.py`
- `PYTHONDONTWRITEBYTECODE=1 python3 -m py_compile NostalgiaForInfinityX7.py`
- AST self-reference scan for accidental `x = x` assignments
