### PR TITLE
Reuse X7 entry RSI14 threshold masks

### DIFF
--- a/NostalgiaForInfinityX7.py
+++ b/NostalgiaForInfinityX7.py
@@ -13037,6 +13037,34 @@ class NostalgiaForInfinityX7(IStrategy):
     rsi_3_1d_gt_55 = rsi_3_1d > 55.0
     rsi_3_1d_gt_60 = rsi_3_1d > 60.0
     rsi_3_1d_gt_65 = rsi_3_1d > 65.0
+    rsi_14_15m_lt_30 = rsi_14_15m < 30.0
+    rsi_14_15m_lt_35 = rsi_14_15m < 35.0
+    rsi_14_15m_lt_40 = rsi_14_15m < 40.0
+    rsi_14_15m_lt_50 = rsi_14_15m < 50.0
+    rsi_14_1h_gt_20 = rsi_14_1h > 20.0
+    rsi_14_1h_lt_40 = rsi_14_1h < 40.0
+    rsi_14_1h_lt_50 = rsi_14_1h < 50.0
+    rsi_14_1h_lt_80 = rsi_14_1h < 80.0
+    rsi_14_4h_gt_20 = rsi_14_4h > 20.0
+    rsi_14_4h_gt_30 = rsi_14_4h > 30.0
+    rsi_14_4h_gt_40 = rsi_14_4h > 40.0
+    rsi_14_4h_gt_50 = rsi_14_4h > 50.0
+    rsi_14_4h_gt_60 = rsi_14_4h > 60.0
+    rsi_14_4h_gt_80 = rsi_14_4h > 80.0
+    rsi_14_4h_lt_30 = rsi_14_4h < 30.0
+    rsi_14_4h_lt_40 = rsi_14_4h < 40.0
+    rsi_14_4h_lt_50 = rsi_14_4h < 50.0
+    rsi_14_4h_lt_70 = rsi_14_4h < 70.0
+    rsi_14_4h_lt_75 = rsi_14_4h < 75.0
+    rsi_14_4h_lt_80 = rsi_14_4h < 80.0
+    rsi_14_1d_gt_10 = rsi_14_1d > 10.0
+    rsi_14_1d_gt_40 = rsi_14_1d > 40.0
+    rsi_14_1d_gt_50 = rsi_14_1d > 50.0
+    rsi_14_1d_lt_40 = rsi_14_1d < 40.0
+    rsi_14_1d_lt_50 = rsi_14_1d < 50.0
+    rsi_14_1d_lt_60 = rsi_14_1d < 60.0
+    rsi_14_1d_lt_70 = rsi_14_1d < 70.0
+    rsi_14_1d_lt_80 = rsi_14_1d < 80.0
 
     aroonu_14_lt_25 = aroonu_14 < 25.0
     aroonu_14_lt_30 = aroonu_14 < 30.0
@@ -13337,7 +13365,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 1d downtrend
             & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_15) | (roc_9_1d_gt_neg_40))
             # 15m & 1h down move, 4h high
-            & ((rsi_3_15m_gt_10) | rsi_3_1h_gt_20 | (rsi_14_4h < 80.0))
+            & ((rsi_3_15m_gt_10) | rsi_3_1h_gt_20 | (rsi_14_4h_lt_80))
             # 15m & 1h down move, 15m still high
             & ((rsi_3_15m_gt_10) | rsi_3_1h_gt_20 | (aroonu_14_15m_lt_50))
             # 15m & 1h down move, 4h overbought
@@ -13381,7 +13409,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 1h high
             & ((rsi_3_15m_gt_15) | rsi_3_1h_gt_20 | aroonu_14_1h_lt_80)
             # 15m down move, 15m still high, 4h overbought
-            & ((rsi_3_15m_gt_15) | (rsi_14_15m < 50.0) | (roc_9_4h_lt_50))
+            & ((rsi_3_15m_gt_15) | (rsi_14_15m_lt_50) | (roc_9_4h_lt_50))
             # 15m down move, 15m & 1h high
             & ((rsi_3_15m_gt_15) | (aroonu_14_15m_lt_70) | (aroonu_14_1h_lt_100))
             # 15m down move, 15m & 1h high
@@ -13433,11 +13461,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 1h still high
             & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_10) | (stochrsi_k_1h_lt_50))
             # 1h & 4h & 1d down move, 4h downtrend, 1d still high
-            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_15) | (rsi_3_1d_gt_25) | (rsi_14_4h > 30.0) | (aroonu_14_1d_lt_40))
+            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_15) | (rsi_3_1d_gt_25) | (rsi_14_4h_gt_30) | (aroonu_14_1d_lt_40))
             # 1h & 1d down move, 4h high
             & ((rsi_3_1h_gt_10) | (rsi_3_1d_gt_20) | (aroonu_14_4h_lt_80))
             # 1h down move, 4h high
-            & ((rsi_3_1h_gt_10) | (rsi_14_4h < 75.0))
+            & ((rsi_3_1h_gt_10) | (rsi_14_4h_lt_75))
             # 1h down move, 15m downtrend, 1d high
             & ((rsi_3_1h_gt_10) | (cmf_20_15m > -0.40) | (aroonu_14_1d_lt_70))
             # 1h down move, 1h high, 4h overbought
@@ -13690,7 +13718,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h & 4h down move
             & ((rsi_3_15m_gt_3) | (rsi_3_1h_gt_10) | (rsi_3_4h_gt_10))
             # 15m & 1h & 4h down move, 4h still not low enough, 1d still high
-            & ((rsi_3_15m_gt_3) | (rsi_3_1h_gt_10) | (rsi_3_4h_gt_20) | (aroonu_14_4h_lt_20) | (rsi_14_1d < 50.0))
+            & ((rsi_3_15m_gt_3) | (rsi_3_1h_gt_10) | (rsi_3_4h_gt_20) | (aroonu_14_4h_lt_20) | (rsi_14_1d_lt_50))
             # 15m & 1h down move, 1h high
             & ((rsi_3_15m_gt_3) | (rsi_3_1h_gt_10) | (stochrsi_k_1h_lt_30))
             # 15m & 1h down move, 1d downtrend
@@ -13722,7 +13750,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 1h high
             & ((rsi_3_15m_gt_3) | (rsi_3_1h_gt_60) | (stochrsi_k_1h_lt_80))
             # 15m & 4h down move, 4h still not low enough
-            & ((rsi_3_15m_gt_3) | (rsi_3_4h_gt_5) | (rsi_14_4h < 30.0))
+            & ((rsi_3_15m_gt_3) | (rsi_3_4h_gt_5) | (rsi_14_4h_lt_30))
             # 15m & 4h down move, 4h downtrend
             & ((rsi_3_15m_gt_3) | (rsi_3_4h_gt_5) | (cmf_20_4h > -0.35))
             # 15m & 4h down move, 1d high
@@ -13748,7 +13776,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h & 4h down move
             & ((rsi_3_15m_gt_5) | (rsi_3_1h_gt_5) | (rsi_3_4h_gt_10))
             # 15m & 1h down move, 4h still high
-            & ((rsi_3_15m_gt_5) | (rsi_3_1h_gt_10) | (rsi_14_4h < 40.0))
+            & ((rsi_3_15m_gt_5) | (rsi_3_1h_gt_10) | (rsi_14_4h_lt_40))
             # 15m & 1h down move, 1h still high
             & ((rsi_3_15m_gt_5) | (rsi_3_1h_gt_10) | (aroonu_14_1h_lt_40))
             # 15m & 1h down move, 4h high
@@ -13820,7 +13848,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 1d overbought
             & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_30) | (roc_9_1d_lt_30))
             # 15m & 1h down move, 4h still high
-            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_35) | (rsi_14_4h < 50.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_35) | (rsi_14_4h_lt_50))
             # 15m & 1h down move, 1h high
             & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_35) | (stochrsi_k_1h_lt_60))
             # 15m & 1h down move, 4h high
@@ -13852,7 +13880,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 4h down move, 4h overbought
             & ((rsi_3_15m_gt_10) | (rsi_3_4h_gt_55) | (roc_9_4h_lt_50))
             # 15m & 1d down move, 1d still high
-            & ((rsi_3_15m_gt_10) | (rsi_3_1d_gt_10) | (rsi_14_1d < 40.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_1d_gt_10) | (rsi_14_1d_lt_40))
             # 15m & 1d down move, 1h high
             & ((rsi_3_15m_gt_10) | (rsi_3_1d_gt_10) | (stochrsi_k_1h_lt_90))
             # 15m & 1d down move, 4h high
@@ -13954,7 +13982,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 1h high & overbought
             & ((rsi_3_15m_gt_20) | (stochrsi_k_1h_lt_90) | (roc_9_1h_lt_10))
             # 15m & 1h & 4h & 1d down move, 4h still high
-            & ((rsi_3_15m_gt_25) | (rsi_3_1h_gt_25) | (rsi_3_4h_gt_25) | (rsi_3_1d_gt_30) | (rsi_14_4h < 40.0))
+            & ((rsi_3_15m_gt_25) | (rsi_3_1h_gt_25) | (rsi_3_4h_gt_25) | (rsi_3_1d_gt_30) | (rsi_14_4h_lt_40))
             # 15m & 1h down move, 1d overbought
             & ((rsi_3_15m_gt_25) | (rsi_3_1h_gt_40) | (roc_9_1d_lt_80))
             # 15m & 4h down move, 1h overbought
@@ -13996,7 +14024,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 1d still high
             & ((rsi_3_1h_gt_3) | (rsi_3_4h_gt_10) | (stochrsi_k_1d_lt_40))
             # 1h & 4h down move, 4h still high
-            & ((rsi_3_1h_gt_3) | (rsi_3_4h_gt_15) | (rsi_14_4h < 40.0))
+            & ((rsi_3_1h_gt_3) | (rsi_3_4h_gt_15) | (rsi_14_4h_lt_40))
             # 1h & 4h down move, 1h still not low enough
             & ((rsi_3_1h_gt_3) | rsi_3_4h_gt_20 | (aroonu_14_1h_lt_20))
             # 1h & 4h down move, 1d high
@@ -14034,7 +14062,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 1d downtrend
             & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_10) | (roc_9_1d > -20.0))
             # 1h & 4h & 1d down move, 4h downtrend, 1d still high
-            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_15) | (rsi_3_1d_gt_25) | (rsi_14_4h > 30.0) | (aroonu_14_1d_lt_40))
+            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_15) | (rsi_3_1d_gt_25) | (rsi_14_4h_gt_30) | (aroonu_14_1d_lt_40))
             # 1h & 4h down move, 15m high
             & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_15) | (stochrsi_k_15m_lt_70))
             # 1h & 4h down move, 1d downtrend
@@ -14044,11 +14072,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 1d down move, 15m still high
             & ((rsi_3_1h_gt_10) | (rsi_3_1d_gt_15) | (stochrsi_k_15m_lt_40))
             # 1h & 4h down move, 4h still high
-            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_35) | (rsi_14_4h < 40.0))
+            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_35) | (rsi_14_4h_lt_40))
             # 1h down move, 1h still not low enough 1d overbought
             & ((rsi_3_1h_gt_10) | (aroonu_14_1h_lt_30) | (roc_9_1d_lt_100))
             # 1h & 4h down move, 1d high
-            & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_15) | (rsi_14_1d < 60.0))
+            & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_15) | (rsi_14_1d_lt_60))
             # 1h & 4h down move, 1h still not low enough
             & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_15) | (aroonu_14_1h_lt_20))
             # 1h & 4h down move, 15m still high
@@ -14056,7 +14084,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 4h downtrend
             & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_15) | (roc_9_4h > -20.0))
             # 1h & 4h down move, 4h still high
-            & ((rsi_3_1h_gt_15) | rsi_3_4h_gt_20 | (rsi_14_4h < 40.0))
+            & ((rsi_3_1h_gt_15) | rsi_3_4h_gt_20 | (rsi_14_4h_lt_40))
             # 1h & 4h down move, 4h still not low enough
             & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_25) | (stochrsi_k_4h < 30.0))
             # 1h & 4h down move, 1d high
@@ -14284,7 +14312,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1d down move, 4h high & overbought
             & ((rsi_3_1d_gt_45) | (stochrsi_k_4h_lt_90) | (roc_9_4h_lt_60))
             # 1d down move, 1d still high, 4h still high
-            & ((rsi_3_1d_gt_50) | (rsi_14_1d < 50.0) | (stochrsi_k_4h_lt_50))
+            & ((rsi_3_1d_gt_50) | (rsi_14_1d_lt_50) | (stochrsi_k_4h_lt_50))
             # 1d downtrend, 1d high & overbought
             & ((cmf_20_1d > -0.40) | (aroonu_14_1d_lt_85) | (roc_9_1d_lt_20))
             # 1h high, 4h & 1d overbought
@@ -14555,7 +14583,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 4h down move, 4h high
             & ((rsi_3_15m_gt_30) | (rsi_3_4h_gt_35) | (aroonu_14_4h_lt_70))
             # 15m down move, 1d high, 15m high
-            & ((rsi_3_15m_gt_30) | (rsi_14_1d < 70.0) | (aroonu_14_15m_lt_70))
+            & ((rsi_3_15m_gt_30) | (rsi_14_1d_lt_70) | (aroonu_14_15m_lt_70))
             # 15m down move, 15m high, 1d downtrend
             & ((rsi_3_15m_gt_30) | (aroonu_14_15m_lt_60) | (roc_9_1d_gt_neg_40))
             # 15m down move, 15m high, 15m downtrend
@@ -14601,7 +14629,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 4h high & overbought
             & ((rsi_3_1h_gt_10) | aroonu_14_4h_lt_70 | (roc_9_4h_lt_20))
             # 1h & 4h down move, 1d high
-            & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_15) | (rsi_14_1d < 60.0))
+            & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_15) | (rsi_14_1d_lt_60))
             # 1h & 4h down move, 15m high
             & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_15) | (aroonu_14_15m_lt_70))
             # 1h & 4h down move, 1d downtrend
@@ -15174,13 +15202,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h & 1d down move
             & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_10) | (rsi_3_1d_gt_15))
             # 1h & 4h down move, 4h still high
-            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_15) | (rsi_14_4h < 40.0))
+            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_15) | (rsi_14_4h_lt_40))
             # 1h & 4h down move, 1h downtrend
             & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_15) | (roc_9_1h > -20.0))
             # 1h & 4h down move, 1h still high
             & ((rsi_3_1h_gt_10) | rsi_3_4h_gt_20 | (aroonu_14_1h_lt_50))
             # 1h & 4h down move, 4h still high
-            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_35) | (rsi_14_4h < 40.0))
+            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_35) | (rsi_14_4h_lt_40))
             # 1h & 3h down move, 1d high
             & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_40) | (aroonu_14_1d_lt_80))
             # 1h & 1d down move, 1d high
@@ -15192,7 +15220,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 4h & 1d downtrend
             & ((rsi_3_1h_gt_10) | (roc_9_4h > -15.0) | (roc_9_1d > -30.0))
             # 1h & 4h down move, 4h still high
-            & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_15) | (rsi_14_4h < 40.0))
+            & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_15) | (rsi_14_4h_lt_40))
             # 1h & 4h down move, 1h still not low enough
             & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_15) | (aroonu_14_1h_lt_20))
             # 1h & 4h down move, 4h still not low enough
@@ -15481,7 +15509,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 1d down move, 1h still high
             & (rsi_3_1h_gt_20 | (rsi_3_1d_gt_30) | (stochrsi_k_1h_lt_50))
             # 15m & 1h & 4h & 1d down move, 4h still high
-            & ((rsi_3_15m_gt_25) | (rsi_3_1h_gt_25) | (rsi_3_4h_gt_25) | (rsi_3_1d_gt_30) | (rsi_14_4h < 40.0))
+            & ((rsi_3_15m_gt_25) | (rsi_3_1h_gt_25) | (rsi_3_4h_gt_25) | (rsi_3_1d_gt_30) | (rsi_14_4h_lt_40))
             # 1h & 4h down move, 15m high
             & ((rsi_3_1h_gt_25) | (rsi_3_4h_gt_25) | (aroonu_14_15m_lt_70))
             # 1h down move, 4h downtrend, 4h high
@@ -15752,7 +15780,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 4h still not low enough
             & ((rsi_3_15m_gt_3) | (rsi_3_1h_gt_20) | (aroonu_14_4h_lt_20))
             # 15m & 1h & 4h down move, 1d downtrend
-            & ((rsi_3_15m_gt_3) | (rsi_3_1h_gt_25) | (rsi_14_4h < 40.0) | (roc_9_1d > -10.0))
+            & ((rsi_3_15m_gt_3) | (rsi_3_1h_gt_25) | (rsi_14_4h_lt_40) | (roc_9_1d > -10.0))
             # 15m & 1h down move, 1h still not low enough
             & ((rsi_3_15m_gt_3) | (rsi_3_1h_gt_25) | (aroonu_14_1h_lt_20))
             # 15m & 1h down move, 4h still high
@@ -15842,7 +15870,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 4h down move, 1d high
             & ((rsi_3_15m_gt_10) | (rsi_3_4h_gt_10) | (stochrsi_k_1d_lt_70))
             # 15m & 4h down move, 1d high
-            & ((rsi_3_15m_gt_10) | (rsi_3_4h_gt_15) | (rsi_14_1d < 60.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_4h_gt_15) | (rsi_14_1d_lt_60))
             # 15m & 4h down move, 4h still high
             & ((rsi_3_15m_gt_10) | (rsi_3_4h_gt_20) | (aroonu_14_4h_lt_40))
             # 15m & 4h down move, 1d high
@@ -16174,7 +16202,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1d still high, 1d downtrend
             & ((rsi_3_1h_gt_25) | (stochrsi_k_1d_lt_50) | (roc_9_1d_gt_neg_20))
             # 1h & 4h down move, 1d high
-            & ((rsi_3_1h_gt_30) | (rsi_3_4h_gt_35) | (rsi_14_1d < 80.0))
+            & ((rsi_3_1h_gt_30) | (rsi_3_4h_gt_35) | (rsi_14_1d_lt_80))
             # 1h & 4h down move, 4h high
             & ((rsi_3_1h_gt_30) | (rsi_3_4h_gt_40) | (aroonu_14_4h_lt_60))
             # 1h & 4h & 1d down move, 1d still high
@@ -16292,7 +16320,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h & 1d down move, 4h still high
             & ((rsi_3_4h_gt_15) | (rsi_3_1d > 50.0) | (stochrsi_k_4h_lt_40))
             # 4h down move, 1d still high, 4h still not low enough
-            & ((rsi_3_4h_gt_15) | (rsi_14_1d < 40.0) | (stochrsi_k_4h_lt_30))
+            & ((rsi_3_4h_gt_15) | (rsi_14_1d_lt_40) | (stochrsi_k_4h_lt_30))
             # 4h down move, 4h still not low enough, 1d downtrend
             & ((rsi_3_4h_gt_15) | (stochrsi_k_4h_lt_20) | (roc_9_1d > -20.0))
             # 4h down move, 1h & 4h downtrend
@@ -16949,7 +16977,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 4h still not low enough
             & ((rsi_3_1h_gt_5) | (rsi_3_4h_gt_15) | (aroonu_14_4h_lt_20))
             # 1h & 4h down move, 4h still high
-            & ((rsi_3_1h_gt_5) | (rsi_3_4h_gt_30) | (rsi_14_4h < 40.0))
+            & ((rsi_3_1h_gt_5) | (rsi_3_4h_gt_30) | (rsi_14_4h_lt_40))
             # 1h & 4h down move, 1h downtrend
             & ((rsi_3_1h_gt_5) | (rsi_3_4h_gt_30) | (cmf_20_1h > -0.30))
             # 1h & 4h down move, 4h high
@@ -17025,7 +17053,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 1d downtrend
             & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_15) | (roc_9_1d > -70.0))
             # 1h & 4h down move, 4h still high
-            & ((rsi_3_1h_gt_15) | rsi_3_4h_gt_20 | (rsi_14_4h < 40.0))
+            & ((rsi_3_1h_gt_15) | rsi_3_4h_gt_20 | (rsi_14_4h_lt_40))
             # 1h & 4h down move, 4h high
             & ((rsi_3_1h_gt_15) | rsi_3_4h_gt_20 | aroonu_14_4h_lt_70)
             # 1h & 4h down move, 1d high
@@ -17237,7 +17265,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 1d high & overbought
             & ((rsi_3_4h_gt_45) | (stochrsi_k_1d_lt_90) | (roc_9_1d_lt_25))
             # 4h down move, 4h still high, 1d downtrend
-            & ((rsi_3_4h_gt_50) | (rsi_14_4h < 40.0) | (roc_9_1d_gt_neg_30))
+            & ((rsi_3_4h_gt_50) | (rsi_14_4h_lt_40) | (roc_9_1d_gt_neg_30))
             # 4h down move, 4h high & overbought
             & ((rsi_3_4h_gt_50) | aroonu_14_4h_lt_80 | (roc_9_4h_lt_10))
             # 4h down move, 4h still high, 1d downtrend
@@ -17495,7 +17523,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 1d down move, 1d still high
             & ((rsi_3_1h_gt_10) | (rsi_3_1d_gt_10) | (stochrsi_k_1d_lt_50))
             # 1h & 1d down move, 1d still high
-            & ((rsi_3_1h_gt_10) | (rsi_3_1d_gt_25) | (rsi_14_1d < 50.0))
+            & ((rsi_3_1h_gt_10) | (rsi_3_1d_gt_25) | (rsi_14_1d_lt_50))
             # 1h & 1d down move, 1h high
             & ((rsi_3_1h_gt_10) | (rsi_3_1d_gt_25) | (aroonu_14_1h_lt_70))
             # 1h & 1d down move, 1d high
@@ -17521,7 +17549,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 4h & 1d downtrend
             & ((rsi_3_1h_gt_10) | (roc_9_4h > -20.0) | (roc_9_1d_gt_neg_40))
             # 1h & 4h down move, 1d still high, 1d downtrend
-            & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_15) | (rsi_14_1d < 40.0) | (roc_9_1d > -15.0))
+            & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_15) | (rsi_14_1d_lt_40) | (roc_9_1d > -15.0))
             # 1h & 4h down move, 4h still high
             & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_15) | (aroonu_14_4h_lt_50))
             # 1h & 4h down move, 15m still high
@@ -17721,7 +17749,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h & 1d down move, 4h still high
             & ((rsi_3_4h_gt_15) | (rsi_3_1d_gt_30) | (stochrsi_k_4h_lt_50))
             # 4h & 1d down move, 1d still high
-            & ((rsi_3_4h_gt_15) | (rsi_3_1d_gt_35) | (rsi_14_1d < 50.0))
+            & ((rsi_3_4h_gt_15) | (rsi_3_1d_gt_35) | (rsi_14_1d_lt_50))
             # 4h & 1d down move, 1d overbought
             & ((rsi_3_4h_gt_15) | (rsi_3_1d_gt_45) | (roc_9_1d_lt_30))
             # 4h & 1d down move, 1d still high
@@ -17924,7 +17952,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h & 1d down move
             & ((rsi_3_15m_gt_3) | (rsi_3_1h_gt_10) | (rsi_3_1d_gt_25))
             # 15m & 1h down move, 1d still high
-            & ((rsi_3_15m_gt_3) | (rsi_3_1h_gt_10) | (rsi_14_1d < 50.0))
+            & ((rsi_3_15m_gt_3) | (rsi_3_1h_gt_10) | (rsi_14_1d_lt_50))
             # 15m & 1h down move, 15m still high
             & ((rsi_3_15m_gt_3) | (rsi_3_1h_gt_10) | (aroonu_14_15m_lt_50))
             # 15m & 1h down move, 1d high
@@ -17978,7 +18006,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 4h & 1d downtrend
             & ((rsi_3_15m_gt_3) | (roc_9_4h > -70.0) | (roc_9_1d > -70.0))
             # 15m & 1h down move, 4h still high
-            & ((rsi_3_15m_gt_5) | (rsi_3_1h_gt_5) | (rsi_14_4h < 40.0))
+            & ((rsi_3_15m_gt_5) | (rsi_3_1h_gt_5) | (rsi_14_4h_lt_40))
             # 15m & 1h down move, 1h still not low enough
             & ((rsi_3_15m_gt_5) | (rsi_3_1h_gt_15) | (stochrsi_k_1h_lt_20))
             # 15m & 1h down move, 1d still high
@@ -18162,7 +18190,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 1d high
             & ((rsi_3_1h_gt_5) | rsi_3_4h_gt_20 | aroonu_14_1d_lt_100)
             # 1h & 4h down move, 4h still high
-            & ((rsi_3_1h_gt_5) | (rsi_3_4h_gt_35) | (rsi_14_4h < 40.0))
+            & ((rsi_3_1h_gt_5) | (rsi_3_4h_gt_35) | (rsi_14_4h_lt_40))
             # 1h down move, 4h high, 1d downtrend
             & ((rsi_3_1h_gt_5) | aroonu_14_4h_lt_70 | (roc_9_1d_gt_neg_30))
             # 1h down move, 1d high, 1h downtrend
@@ -18200,7 +18228,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 1d overbought
             & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_15) | (roc_9_1d_lt_10))
             # 1h & 4h down move, 4h still high
-            & ((rsi_3_1h_gt_15) | rsi_3_4h_gt_20 | (rsi_14_4h < 40.0))
+            & ((rsi_3_1h_gt_15) | rsi_3_4h_gt_20 | (rsi_14_4h_lt_40))
             # 1h & 4h down move, 1h high
             & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_30) | (aroonu_14_1h_lt_70))
             # 1h & 4h down move, 1d high
@@ -18334,7 +18362,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 1d high, 1d downtrend
             & ((rsi_3_4h_gt_45) | (aroonu_14_1d_lt_80) | (roc_9_1d > -15.0))
             # 4h down move, 4h still high, 1d downtrend
-            & ((rsi_3_4h_gt_50) | (rsi_14_4h < 40.0) | (roc_9_1d_gt_neg_30))
+            & ((rsi_3_4h_gt_50) | (rsi_14_4h_lt_40) | (roc_9_1d_gt_neg_30))
             # 1d down move, 4h high, 1d downtrend
             & ((rsi_3_1d_gt_15) | (stochrsi_k_4h_lt_70) | (roc_9_1d > -70.0))
             # 1d down move, 1h high & overbought
@@ -18499,7 +18527,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 1d high
             & ((rsi_3_1h_gt_5) | (rsi_3_4h_gt_10) | (stochrsi_k_1d_lt_90))
             # 1h & 4h down move, 4h still high
-            & ((rsi_3_1h_gt_5) | (rsi_3_4h_gt_30) | (rsi_14_4h < 40.0))
+            & ((rsi_3_1h_gt_5) | (rsi_3_4h_gt_30) | (rsi_14_4h_lt_40))
             # 1h & 1d down move, 1d downtrend
             & ((rsi_3_1h_gt_5) | (rsi_3_1d_gt_5) | (roc_9_1d_gt_neg_20))
             # 1h down move, 1h high
@@ -18515,7 +18543,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 1d downtrend
             & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_10) | (roc_9_1d > -20.0))
             # 1h & 4h down move, 4h still high
-            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_15) | (rsi_14_4h < 40.0))
+            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_15) | (rsi_14_4h_lt_40))
             # 1h & 4h down move, 1h still high
             & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_15) | (aroonu_14_1h_lt_50))
             # 1h & 4h down move, 4h still high
@@ -18651,7 +18679,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 1h high & overbought
             & ((rsi_3_4h_gt_35) | (aroonu_14_1d_lt_90) | (roc_9_1d_lt_100))
             # 4h down move, 4h still high, 1d downtrend
-            & ((rsi_3_4h_gt_50) | (rsi_14_4h < 40.0) | (roc_9_1d_gt_neg_30))
+            & ((rsi_3_4h_gt_50) | (rsi_14_4h_lt_40) | (roc_9_1d_gt_neg_30))
             # 4h down move, 4h high, 1d overbought
             & ((rsi_3_4h_gt_50) | aroonu_14_4h_lt_70 | (roc_9_1d_lt_40))
             # 4h down move, 4h high
@@ -18811,7 +18839,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 4h still high
             & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_25) | (aroonu_14_4h_lt_50))
             # 1h & 4h down move, 4h still not low enough
-            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_30) | (rsi_14_4h < 40.0))
+            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_30) | (rsi_14_4h_lt_40))
             # 1h & 4h down move, 4h high
             & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_40) | (aroonu_14_4h_lt_60))
             # 1h & 1d down move, 4h still high
@@ -18865,7 +18893,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 1d down move, 1h still high
             & ((rsi_3_1h_gt_30) | (rsi_3_1d > 50.0) | (stochrsi_k_1h_lt_50))
             # 1h down move, 4h high
-            & ((rsi_3_1h_gt_30) | (rsi_14_4h < 80.0))
+            & ((rsi_3_1h_gt_30) | (rsi_14_4h_lt_80))
             # 14 down move, 1h high
             & ((rsi_3_1h_gt_30) | aroonu_14_1h_lt_80)
             # 1h down move, 4h high
@@ -18891,7 +18919,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 1h & 1d downtrend
             & ((rsi_3_4h_gt_10) | (roc_9_1h > -20.0) | (roc_9_1d > -20.0))
             # 4h & 1d down move, 1d still high
-            & ((rsi_3_4h_gt_15) | (rsi_3_1d_gt_35) | (rsi_14_1d < 50.0))
+            & ((rsi_3_4h_gt_15) | (rsi_3_1d_gt_35) | (rsi_14_1d_lt_50))
             # 4h down move, 1h still not low enough
             & ((rsi_3_4h_gt_15) | (aroonu_14_1h_lt_30))
             # 4h & 1d down move, 1d high
@@ -18921,7 +18949,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1d down move, 1h high & overbought
             & ((rsi_3_1d_gt_35) | (stochrsi_k_1h_lt_90) | (roc_9_1h_lt_10))
             # 15m still high, 1h & 4h high
-            & ((rsi_14_15m < 40.0) | aroonu_14_1h_lt_80 | (aroonu_14_4h_lt_90))
+            & ((rsi_14_15m_lt_40) | aroonu_14_1h_lt_80 | (aroonu_14_4h_lt_90))
             # 1h & 4h high, 4h overbought
             & (aroonu_14_1h_lt_70 | aroonu_14_4h_lt_100 | (roc_9_4h_lt_20))
             # 4h high, 1d overbought
@@ -18981,7 +19009,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # big drop in the last 20 days, 1d high, 1d downtrend
             & ((close > (high_max_20_1d * 0.20)) | (stochrsi_k_1d_lt_70) | (roc_9_1d > -15.0))
             # big drop in the last 30 days, 4h down move, 4h still high
-            & ((close > (high_max_30_1d * 0.25)) | (rsi_3_4h_gt_45) | (rsi_14_4h < 40.0))
+            & ((close > (high_max_30_1d * 0.25)) | (rsi_3_4h_gt_45) | (rsi_14_4h_lt_40))
           )
 
           # Logic
@@ -19012,7 +19040,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h & 4h down move
             & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_10) | (rsi_3_4h_gt_30))
             # 15m & 1h down move, 4h still not low enough
-            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_10) | (rsi_14_4h < 30.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_10) | (rsi_14_4h_lt_30))
             # 15m & 1h & 4h down move
             & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_20) | (rsi_3_4h_gt_20))
             # 15m & 1h down move, 1h still high
@@ -19068,9 +19096,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1d still high
             & ((rsi_3_1h_gt_5) | (stochrsi_k_1d_lt_50))
             # 1h & 4h down move, 4h still not low enough
-            & ((rsi_3_1h_gt_10) | rsi_3_4h_gt_20 | (rsi_14_4h < 30.0))
+            & ((rsi_3_1h_gt_10) | rsi_3_4h_gt_20 | (rsi_14_4h_lt_30))
             # 1h & 4h down move, 4h still not low enough
-            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_30) | (rsi_14_4h < 40.0))
+            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_30) | (rsi_14_4h_lt_40))
             # 1h & 4h down move, 4h still not low enough
             & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_30) | (aroonu_14_4h_lt_30))
             # 1h & 4h & 1d down move
@@ -19086,7 +19114,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 1d down move, 4h still high
             & ((rsi_3_1h_gt_10) | (rsi_3_1d_gt_30) | (aroonu_14_4h_lt_50))
             # 1h & 1d down move, 4h still high
-            & ((rsi_3_1h_gt_10) | (rsi_3_1d_gt_45) | (rsi_14_4h < 40.0))
+            & ((rsi_3_1h_gt_10) | (rsi_3_1d_gt_45) | (rsi_14_4h_lt_40))
             # 1h down move, 1h still high
             & ((rsi_3_1h_gt_10) | (aroonu_14_1h_lt_50))
             # 1h down move, 4h still high, 1d high
@@ -19094,7 +19122,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1d high & overbought
             & ((rsi_3_1h_gt_10) | (aroonu_14_1d_lt_80) | (roc_9_1d_lt_30))
             # 1h & 4h down move, 1d stll high
-            & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_15) | (rsi_14_1d < 40.0))
+            & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_15) | (rsi_14_1d_lt_40))
             # 1h & 4h & 1d down move
             & ((rsi_3_1h_gt_15) | rsi_3_4h_gt_20 | (rsi_3_1d_gt_30))
             # 1h & 4h down move, 4h still not low enough
@@ -19106,7 +19134,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 1d high
             & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_30) | (stochrsi_k_1d_lt_80))
             # 1h & 4h down move, 1h & 4h still high
-            & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_40) | (rsi_14_1h < 40.0) | (rsi_14_4h < 50.0))
+            & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_40) | (rsi_14_1h_lt_40) | (rsi_14_4h_lt_50))
             # 1h & 4h down move, 4h still high
             & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_45) | (stochrsi_k_4h_lt_50))
             # 1h & 4h down move, 4h still high
@@ -19124,7 +19152,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 1h still not low enough
             & (rsi_3_1h_gt_20 | rsi_3_4h_gt_20 | (aroonu_14_1h_lt_30))
             # 1h & 4h down move, 4h still high
-            & (rsi_3_1h_gt_20 | rsi_3_4h_gt_20 | (rsi_14_4h < 40.0))
+            & (rsi_3_1h_gt_20 | rsi_3_4h_gt_20 | (rsi_14_4h_lt_40))
             # 1h & 4h down move, 4h still high
             & (rsi_3_1h_gt_20 | rsi_3_4h_gt_20 | (aroonu_14_4h_lt_50))
             # 1h & 4h down move, 1d downtrend
@@ -19148,7 +19176,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 4h high
             & ((rsi_3_1h_gt_25) | (rsi_3_4h_gt_40) | aroonu_14_4h_lt_70)
             # 1h down move, 15m still not low enough, 4h high
-            & ((rsi_3_1h_gt_25) | (rsi_14_15m < 30.0) | (stochrsi_k_4h_lt_60))
+            & ((rsi_3_1h_gt_25) | (rsi_14_15m_lt_30) | (stochrsi_k_4h_lt_60))
             # 1h & 4h down move, 4h still high
             & ((rsi_3_1h_gt_25) | (rsi_3_4h_gt_35) | (stochrsi_k_4h_lt_50))
             # 1h down move, 1h high
@@ -19290,7 +19318,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h & 4h down move
             & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_3) | (rsi_3_4h_gt_10))
             # 15m & 1h down move, 4h still high
-            & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_3) | (rsi_14_4h < 40.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_3) | (rsi_14_4h_lt_40))
             # 15m & 1h down move, 4h still high
             & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_3) | (aroonu_14_4h_lt_40))
             # 15m & 1h down move, 4h still not low enough
@@ -19298,7 +19326,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h & 4h down move
             & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_10) | (rsi_3_4h_gt_3))
             # 15m & 1h down move, 1d still high
-            & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_10) | (rsi_14_1d < 50.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_10) | (rsi_14_1d_lt_50))
             # 15m & 1h down move, 4h downtrend
             & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_10) | (cmf_20_4h > -0.30))
             # 15m & 1h down move, 1d still high
@@ -19316,7 +19344,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 1h high
             & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_60) | (stochrsi_k_1h_lt_80))
             # 15m & 4h down move, 4h still high
-            & (rsi_3_15m_gt_3 | (rsi_3_4h_gt_40) | (rsi_14_4h < 40.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_4h_gt_40) | (rsi_14_4h_lt_40))
             # 15m down move, 15m downtrend. 4h high
             & (rsi_3_15m_gt_3 | (cmf_20_15m > -0.50) | (aroonu_14_4h_lt_60))
             # 15m down move, 15m still not low enough
@@ -19448,7 +19476,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 3h down move, 4h downtrend
             & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_10) | (roc_9_4h > -50.0))
             # 1h & 4h down move, 4h still high
-            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_15) | (rsi_14_4h < 40.0))
+            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_15) | (rsi_14_4h_lt_40))
             # 1h & 4h down move, 1d overbought
             & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_30) | (roc_9_1d_lt_80))
             # 1h down move, 15m still high, 4h high
@@ -19556,7 +19584,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 1h high, 1d overbought
             & ((rsi_3_4h_gt_45) | (aroonu_14_1h_lt_85) | roc_9_1d_lt_50)
             # 4h down move, 4h still high, 1d downtrend
-            & ((rsi_3_4h_gt_50) | (rsi_14_4h < 40.0) | (roc_9_1d_gt_neg_30))
+            & ((rsi_3_4h_gt_50) | (rsi_14_4h_lt_40) | (roc_9_1d_gt_neg_30))
             # 4h down move, 4h high & overbought
             & ((rsi_3_4h_gt_50) | aroonu_14_4h_lt_80 | (roc_9_4h_lt_10))
             # 4h down move, 4h still high, 1d downtrend
@@ -19635,11 +19663,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 1h still not low enough
             & ((rsi_3_15m_gt_3) | (rsi_3_1h_gt_10) | (aroonu_14_1h_lt_20))
             # 15m & 1h down move, 4h still not low enough
-            & ((rsi_3_15m_gt_3) | (rsi_3_1h_gt_10) | (rsi_14_4h < 30.0))
+            & ((rsi_3_15m_gt_3) | (rsi_3_1h_gt_10) | (rsi_14_4h_lt_30))
             # 15m & 1h & 4h down move, 1d high
             & ((rsi_3_15m_gt_3) | (rsi_3_1h_gt_15) | (rsi_3_4h_gt_15) | (aroonu_14_1d_lt_80))
             # 15m & 1h down move, 4h still high
-            & ((rsi_3_15m_gt_3) | (rsi_3_1h_gt_15) | (rsi_14_4h < 50.0))
+            & ((rsi_3_15m_gt_3) | (rsi_3_1h_gt_15) | (rsi_14_4h_lt_50))
             # 15m & 1h down move, 4h still high
             & ((rsi_3_15m_gt_3) | (rsi_3_1h_gt_20) | (stochrsi_k_4h_lt_40))
             # 15m & 1h down move, 4h still high
@@ -19661,7 +19689,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 4h down move, 1d overbought
             & ((rsi_3_15m_gt_5) | (rsi_3_4h_gt_10) | (roc_9_1d_lt_20))
             # 15m & 4h down move, 4h still high
-            & ((rsi_3_15m_gt_5) | (rsi_3_4h_gt_15) | (rsi_14_4h < 40.0))
+            & ((rsi_3_15m_gt_5) | (rsi_3_4h_gt_15) | (rsi_14_4h_lt_40))
             # 15m & 1h down move, 4h still high
             & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_10) | (stochrsi_k_4h_lt_40))
             # 15m & 1h down move, 1d downtrend
@@ -19745,7 +19773,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 4h downtrend
             & ((rsi_3_1h_gt_5) | (rsi_3_4h_gt_15) | (roc_9_4h_gt_neg_30))
             # 1h & 4h down move, 4h still not low enough
-            & ((rsi_3_1h_gt_5) | rsi_3_4h_gt_20 | (rsi_14_4h < 30.0))
+            & ((rsi_3_1h_gt_5) | rsi_3_4h_gt_20 | (rsi_14_4h_lt_30))
             # 1h & 4h down move, 4h still high
             & ((rsi_3_1h_gt_5) | (rsi_3_4h_gt_30) | (aroonu_14_4h_lt_40))
             # 1h & 4h & 1d down move
@@ -19773,7 +19801,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 1d down move, 1d high
             & ((rsi_3_1h_gt_10) | (rsi_3_1d_gt_60) | (aroonu_14_1d_lt_80))
             # 1h & 4h down move, 1d high
-            & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_15) | (rsi_14_1d < 60.0))
+            & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_15) | (rsi_14_1d_lt_60))
             # 1h & 4h down move, 4h still high
             & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_15) | (aroonu_14_4h_lt_40))
             # 1h & 4h down move, 1d high
@@ -19793,7 +19821,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1d high, 4h downtrend
             & ((rsi_3_1h_gt_15) | (aroonu_14_1d_lt_90) | (roc_9_4h > -20.0))
             # 1h & 4h down move, 4h & 1d still not low enough, 15m still not low enough
-            & (rsi_3_1h_gt_20 | (rsi_3_4h_gt_20) | (rsi_14_4h < 30.0) | (rsi_14_1d < 30.0) | (stochrsi_k_15m_lt_30))
+            & (rsi_3_1h_gt_20 | (rsi_3_4h_gt_20) | (rsi_14_4h_lt_30) | (rsi_14_1d < 30.0) | (stochrsi_k_15m_lt_30))
             # 1h & 4h down move, 1d high
             & (rsi_3_1h_gt_20 | (rsi_3_4h_gt_25) | (stochrsi_k_1d_lt_70))
             # 1h & 4h down move, 4h high
@@ -19885,7 +19913,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 15m still high
             & ((rsi_3_4h_gt_10) | (stochrsi_k_15m_lt_40))
             # 4h down move, 1d still high, 1d downtrend
-            & ((rsi_3_4h_gt_15) | (rsi_14_1d < 40.0) | (roc_9_1d > -15.0))
+            & ((rsi_3_4h_gt_15) | (rsi_14_1d_lt_40) | (roc_9_1d > -15.0))
             # 4h down move, 1h downtrend, 1d downtrend
             & ((rsi_3_4h_gt_15) | (cmf_20_1h > -0.40) | (roc_9_1d > -20.0))
             # 4h down move, 15m high, 1d overbought
@@ -19927,7 +19955,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 4h high
             & ((rsi_3_4h_gt_40) | aroonu_14_4h_lt_100)
             # 4h down move, 4h still high, 1d downtrend
-            & ((rsi_3_4h_gt_50) | (rsi_14_4h < 40.0) | (roc_9_1d_gt_neg_30))
+            & ((rsi_3_4h_gt_50) | (rsi_14_4h_lt_40) | (roc_9_1d_gt_neg_30))
             # 4h down move, 4h still high, 1d downtrend
             & ((rsi_3_4h_gt_50) | (stochrsi_k_4h_lt_50) | (roc_9_1d_gt_neg_30))
             # 4h down move, 4h overbought
@@ -20067,7 +20095,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 4h overbought
             & ((rsi_3_15m_gt_20) | (roc_9_4h_lt_40))
             # 15m & 1h & 4h & 1d down move, 4h still high
-            & ((rsi_3_15m_gt_25) | (rsi_3_1h_gt_25) | (rsi_3_4h_gt_25) | (rsi_3_1d_gt_30) | (rsi_14_4h < 40.0))
+            & ((rsi_3_15m_gt_25) | (rsi_3_1h_gt_25) | (rsi_3_4h_gt_25) | (rsi_3_1d_gt_30) | (rsi_14_4h_lt_40))
             # 15m & 1h down move, 1h high
             & ((rsi_3_15m_gt_25) | (rsi_3_1h_gt_25) | aroonu_14_1h_lt_70)
             # 15m & 1h down move, 1d overbought
@@ -20107,7 +20135,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m still high, 4h high
             & ((rsi_3_15m < 40.0) | (aroonu_14_4h_lt_85))
             # 1h & 4h down move, 4h still not low enough
-            & ((rsi_3_1h > 2.0) | (rsi_3_4h_gt_15) | (rsi_14_4h < 30.0))
+            & ((rsi_3_1h > 2.0) | (rsi_3_4h_gt_15) | (rsi_14_4h_lt_30))
             # 1h & 4h down move, 15m still not low enough
             & ((rsi_3_1h_gt_3) | (rsi_3_4h_gt_3) | (stochrsi_k_15m_lt_30))
             # 1h & 4h down move, 15m downtrend
@@ -20117,7 +20145,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 1d still high
             & ((rsi_3_1h_gt_3) | (rsi_3_4h_gt_10) | (stochrsi_k_1d_lt_40))
             # 1h & 4h down move, 4h stil high
-            & ((rsi_3_1h_gt_3) | rsi_3_4h_gt_20 | (rsi_14_4h < 40.0))
+            & ((rsi_3_1h_gt_3) | rsi_3_4h_gt_20 | (rsi_14_4h_lt_40))
             # 1h ^ 4h down move, 1d downtrend
             & ((rsi_3_1h_gt_3) | (rsi_3_4h_gt_25) | roc_9_1d_gt_neg_50)
             # 1h & 1d down move, 4h still high
@@ -20145,7 +20173,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 4h down move, 4h still not low enough, 15m still not low enough
             & ((rsi_3_1h_gt_5) | (rsi_3_4h_gt_20) | (aroonu_14_4h_lt_20) | (stochrsi_k_15m_lt_20))
             # 1h & 4h down move, 4h still high
-            & ((rsi_3_1h_gt_5) | (rsi_3_4h_gt_35) | (rsi_14_4h < 40.0))
+            & ((rsi_3_1h_gt_5) | (rsi_3_4h_gt_35) | (rsi_14_4h_lt_40))
             # 1h down move, 1d high, 4h downtrend
             & ((rsi_3_1h_gt_5) | (aroonu_14_1d_lt_90) | (roc_9_4h_gt_neg_30))
             # 1h down move, 4h downtrend
@@ -20153,7 +20181,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h, 1d downtrend
             & ((rsi_3_1h_gt_5) | roc_9_1d_gt_neg_50)
             # 1h & 4h down move, 4h still not low enough
-            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_10) | (rsi_14_4h < 30.0))
+            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_10) | (rsi_14_4h_lt_30))
             # 1h & 4h down move, 4h still not low enough
             & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_10) | (aroonu_14_4h_lt_30))
             # 1h & 4h down move, 15m still high
@@ -20289,7 +20317,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h still high, 1d overbought
             & ((rsi_3_1h_gt_35) | (stochrsi_k_1h_lt_50) | (roc_9_1d_lt_200))
             # 1h down move, 1d high & overbought
-            & ((rsi_3_1h_gt_40) | (rsi_14_1d < 80.0) | (roc_9_1d_lt_150))
+            & ((rsi_3_1h_gt_40) | (rsi_14_1d_lt_80) | (roc_9_1d_lt_150))
             # 1h down move, 15m high, 1h high
             & ((rsi_3_1h_gt_40) | (aroonu_14_15m_lt_60) | aroonu_14_1h_lt_70)
             # 1h down move, 1h high, 1d overbought
@@ -20379,7 +20407,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 4h & 1d overbought
             & ((rsi_3_4h_gt_40) | (roc_9_4h_lt_10) | roc_9_1d_lt_50)
             # 4h down move, 4h still high, 1d downtrend
-            & ((rsi_3_4h_gt_50) | (rsi_14_4h < 40.0) | (roc_9_1d_gt_neg_30))
+            & ((rsi_3_4h_gt_50) | (rsi_14_4h_lt_40) | (roc_9_1d_gt_neg_30))
             # 4h down move, 4h high, 1d overbought
             & ((rsi_3_4h_gt_50) | aroonu_14_4h_lt_70 | (roc_9_1d_lt_40))
             # 4h down move, 4h still high, 1d downtrend
@@ -20494,9 +20522,9 @@ class NostalgiaForInfinityX7(IStrategy):
           long_entry_logic.append(num_empty_288 <= allowed_empty_candles_288)
           long_entry_logic.append(protections_long_global == True)
 
-          long_entry_logic.append(rsi_14_1h < 80.0)
-          long_entry_logic.append(rsi_14_4h < 80.0)
-          long_entry_logic.append(rsi_14_1d < 80.0)
+          long_entry_logic.append(rsi_14_1h_lt_80)
+          long_entry_logic.append(rsi_14_4h_lt_80)
+          long_entry_logic.append(rsi_14_1d_lt_80)
           # big drop in the last hour
           long_entry_logic.append(
             (close > (close_max_12 * 0.50))
@@ -20509,15 +20537,15 @@ class NostalgiaForInfinityX7(IStrategy):
             # 5m down move, 1h & 4h high
             & ((rsi_3_gt_10) | (aroonu_14_1h_lt_85) | (aroonu_14_4h_lt_90))
             # 15m & 1h & 4h & 1d down move, 1d still high
-            & ((rsi_3_15m_gt_3) | (rsi_3_1h_gt_3) | (rsi_3_4h_gt_15) | (rsi_3_1d_gt_50) | (rsi_14_1d < 40.0))
+            & ((rsi_3_15m_gt_3) | (rsi_3_1h_gt_3) | (rsi_3_4h_gt_15) | (rsi_3_1d_gt_50) | (rsi_14_1d_lt_40))
             # 15m & 1h down move, 4h still not low enough
             & ((rsi_3_15m_gt_3) | (rsi_3_1h_gt_5) | (stochrsi_k_4h_lt_30))
             # 15m & 1h down move, 1d still high
             & ((rsi_3_15m_gt_3) | (rsi_3_1h_gt_5) | (aroonu_14_1d_lt_40))
             # 15m & 1h & 4h down move, 4h still not low enough, 1d still high
-            & ((rsi_3_15m_gt_3) | (rsi_3_1h_gt_10) | (rsi_3_4h_gt_20) | (aroonu_14_4h_lt_20) | (rsi_14_1d < 50.0))
+            & ((rsi_3_15m_gt_3) | (rsi_3_1h_gt_10) | (rsi_3_4h_gt_20) | (aroonu_14_4h_lt_20) | (rsi_14_1d_lt_50))
             # 15m & 1h down move, 4h still high
-            & ((rsi_3_15m_gt_3) | (rsi_3_1h_gt_15) | (rsi_14_4h < 40.0))
+            & ((rsi_3_15m_gt_3) | (rsi_3_1h_gt_15) | (rsi_14_4h_lt_40))
             # 15m & 4h down move, 4h high
             & ((rsi_3_15m_gt_3) | (rsi_3_1h_gt_30) | (aroonu_14_4h_lt_75))
             # 15m & 1h down move, 1h still not low enough
@@ -20838,7 +20866,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 5m & 4h down move, 4h high
             & ((rsi_3_gt_5) | (rsi_3_4h_gt_50) | aroonu_14_4h_lt_70)
             # 5m down move, 15m still high, 1h high
-            & ((rsi_3_gt_5) | (rsi_14_15m < 40.0) | aroonu_14_1h_lt_80)
+            & ((rsi_3_gt_5) | (rsi_14_15m_lt_40) | aroonu_14_1h_lt_80)
             # 5m down move, 15m still high, 1h high
             & ((rsi_3_gt_5) | (aroonu_14_15m_lt_40) | (stochrsi_k_1h_lt_50))
             # 5m down move, 15m & 4h high
@@ -20856,9 +20884,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 5m down move, 4h high, 1d high
             & ((rsi_3_gt_10) | (aroonu_14_4h_lt_60) | (stochrsi_k_1d_lt_90))
             # 5m down move, 15m still high, 1h high
-            & ((rsi_3_gt_15) | (rsi_14_15m < 40.0) | (stochrsi_k_1h_lt_90))
+            & ((rsi_3_gt_15) | (rsi_14_15m_lt_40) | (stochrsi_k_1h_lt_90))
             # 5m down move, 15m still high, 4h high
-            & ((rsi_3_gt_15) | (rsi_14_15m < 40.0) | (stochrsi_k_4h_lt_90))
+            & ((rsi_3_gt_15) | (rsi_14_15m_lt_40) | (stochrsi_k_4h_lt_90))
             # 15m down move, 15m still not low enough, 1h high
             & (rsi_3_15m_gt_3 | (aroonu_14_15m_lt_20) | (stochrsi_k_1h_lt_60))
             # 15m & 1h down move, 1d high
@@ -20928,7 +20956,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 4h down move, 4h still high
             & ((rsi_3_15m_gt_15) | (rsi_3_4h_gt_45) | (stochrsi_k_4h_lt_50))
             # 15m down move, 15m still not low enough, 4h high
-            & ((rsi_3_15m_gt_15) | (rsi_14_15m < 35.0) | (stochrsi_k_4h_lt_90))
+            & ((rsi_3_15m_gt_15) | (rsi_14_15m_lt_35) | (stochrsi_k_4h_lt_90))
             # 15m down move, 15m still not low enough, 4h high
             & ((rsi_3_15m_gt_15) | (aroonu_14_15m_lt_30) | (stochrsi_k_4h_lt_90))
             # 15m down move, 15m & 4h still high
@@ -20952,7 +20980,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1d down move, 4h high
             & ((rsi_3_15m_gt_20) | (rsi_3_1d_gt_20) | (stochrsi_k_4h_lt_90))
             # 15m down move, 15m still not low enough, 4h high
-            & ((rsi_3_15m_gt_20) | (rsi_14_15m < 35.0) | (rsi_14_4h < 85.0))
+            & ((rsi_3_15m_gt_20) | (rsi_14_15m_lt_35) | (rsi_14_4h < 85.0))
             # 15m down move, 15m still not low enough, 1h high
             & ((rsi_3_15m_gt_20) | (aroonu_14_15m_lt_30) | (stochrsi_k_1h_lt_80))
             # 15m down move, 15m still not low enough, 4h high
@@ -21012,13 +21040,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 4h still high, 4h overbought
             & ((rsi_3_15m_gt_35) | (stochrsi_k_4h_lt_50) | (roc_9_4h_lt_20))
             # 15m down move, 15m still high, 1h high
-            & ((rsi_3_15m_gt_40) | (rsi_14_15m < 50.0) | aroonu_14_1h_lt_80)
+            & ((rsi_3_15m_gt_40) | (rsi_14_15m_lt_50) | aroonu_14_1h_lt_80)
             # 15m down move, 15m high, 1h high
             & ((rsi_3_15m_gt_40) | (aroonu_14_15m_lt_70) | (aroonu_14_1h_lt_90))
             # 15m down move, 15m high
             & ((rsi_3_15m_gt_45) | (aroonu_14_15m_lt_90))
             # 1h & 4h down move, 4h still high
-            & ((rsi_3_1h_gt_15) | rsi_3_4h_gt_20 | (rsi_14_4h < 40.0))
+            & ((rsi_3_1h_gt_15) | rsi_3_4h_gt_20 | (rsi_14_4h_lt_40))
             # 1h & 4h down move, 1h still high
             & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_30) | (stochrsi_k_1h_lt_50))
             # 1h & 4h down move, 4h still high
@@ -21048,7 +21076,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h high, 1d overbought
             & ((rsi_3_1h_gt_35) | aroonu_14_1h_lt_70 | (roc_9_1d_lt_20))
             # 1h down move, 4h high, 1d overbought
-            & ((rsi_3_1h_gt_40) | (rsi_14_4h < 75.0) | (roc_9_1d_lt_100))
+            & ((rsi_3_1h_gt_40) | (rsi_14_4h_lt_75) | (roc_9_1d_lt_100))
             # 1h down move, 1h still high, 1d high
             & ((rsi_3_1h_gt_40) | (aroonu_14_1h_lt_50) | (aroonu_14_1d_lt_85))
             # 1h down move, 1h still high, 1d overbought
@@ -21150,7 +21178,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # big drop in the last 20 days, 1d down move
             & ((close > (high_max_20_1d * 0.40)) | (rsi_3_1d_gt_30))
             # big drop in the last 30 days, 4h down move, 4h still high
-            & ((close > (high_max_30_1d * 0.25)) | (rsi_3_4h_gt_45) | (rsi_14_4h < 40.0))
+            & ((close > (high_max_30_1d * 0.25)) | (rsi_3_4h_gt_45) | (rsi_14_4h_lt_40))
             # big drop in the last 30 days, 1h high
             & ((close > (high_max_30_1d * 0.20)) | (stochrsi_k_1h_lt_80))
           )
@@ -21183,9 +21211,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 4h down move, 15m still high
             & ((rsi_3_15m_gt_20) | rsi_3_4h_gt_20 | (stochrsi_k_15m_lt_50))
             # 15m down move, 15m still high, 1h high
-            & ((rsi_3_15m_gt_20) | (rsi_14_15m < 40.0) | (stochrsi_k_1h_lt_70))
+            & ((rsi_3_15m_gt_20) | (rsi_14_15m_lt_40) | (stochrsi_k_1h_lt_70))
             # 15m down move, 15m still high, 4h high
-            & ((rsi_3_15m_gt_20) | (rsi_14_15m < 40.0) | (aroonu_14_4h_lt_90))
+            & ((rsi_3_15m_gt_20) | (rsi_14_15m_lt_40) | (aroonu_14_4h_lt_90))
             # 15m down move, 15m still high, 4h high
             & ((rsi_3_15m_gt_20) | (aroonu_14_15m_lt_50) | (aroonu_14_4h_lt_90))
             # 15m down move, 15m & 1h high
@@ -21275,7 +21303,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1d down move, 4h & 1d high
             & ((rsi_3_1d_gt_55) | (aroonu_14_4h_lt_100) | (aroonu_14_1d_lt_100))
             # 4h down move, 4h still high, 1d downtrend
-            & ((rsi_3_4h_gt_50) | (rsi_14_4h < 40.0) | (roc_9_1d_gt_neg_30))
+            & ((rsi_3_4h_gt_50) | (rsi_14_4h_lt_40) | (roc_9_1d_gt_neg_30))
             # 4h down move, 4h high & overbought
             & ((rsi_3_4h_gt_50) | (aroonu_14_4h_lt_80) | (roc_9_4h_lt_20))
             # 4h down move, 4h still high, 1d downtrend
@@ -21293,11 +21321,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1d down move, 1h & 1d overbought
             & ((rsi_3_1d_gt_45) | (roc_9_1h_lt_80) | (roc_9_1d_lt_80))
             # 15m still high, 1h & 4h high
-            & ((rsi_14_15m < 40.0) | aroonu_14_1h_lt_80 | (aroonu_14_4h_lt_90))
+            & ((rsi_14_15m_lt_40) | aroonu_14_1h_lt_80 | (aroonu_14_4h_lt_90))
             # 15m & 1h still high, 4h high
             & ((rsi_14_15m < 45.0) | (aroonu_14_1h_lt_40) | (stochrsi_k_4h_lt_70))
             # 15m still high, 4h high & overbought
-            & ((rsi_14_15m < 50.0) | (aroonu_14_4h_lt_90) | (roc_9_4h_lt_80))
+            & ((rsi_14_15m_lt_50) | (aroonu_14_4h_lt_90) | (roc_9_4h_lt_80))
             # 15m still high, 1h high, 4h still high
             & ((aroonu_14_15m_lt_50) | (aroonu_14_1h_lt_90) | (stochrsi_k_4h_lt_50))
             # 15m still high, 1d high
@@ -21382,7 +21410,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m & 1h down move, 1h still not low enough
           long_entry_logic.append(rsi_3_15m_gt_3 | (rsi_3_1h_gt_15) | (stochrsi_k_1h_lt_30))
           # 15m & 4h down move, 4h still high
-          long_entry_logic.append(rsi_3_15m_gt_3 | (rsi_3_4h_gt_30) | (rsi_14_4h < 40.0))
+          long_entry_logic.append(rsi_3_15m_gt_3 | (rsi_3_4h_gt_30) | (rsi_14_4h_lt_40))
           # 15m & 1h & 4h down move
           long_entry_logic.append((rsi_3_15m_gt_5) | (rsi_3_1h_gt_15) | (rsi_3_4h_gt_15))
           # 15m & 1h & 4h down move, 15m downtrend
@@ -21436,7 +21464,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m & 3h down move, 15m still not low enough
           long_entry_logic.append((rsi_3_15m_gt_20) | rsi_3_4h_gt_20 | (stochrsi_k_15m_lt_20))
           # 15m & 1h down move, 1h still high
-          long_entry_logic.append((rsi_3_15m_gt_25) | (rsi_3_1h_gt_25) | (rsi_14_1h < 40.0))
+          long_entry_logic.append((rsi_3_15m_gt_25) | (rsi_3_1h_gt_25) | (rsi_14_1h_lt_40))
           # 15m & 4h down move, 4h high
           long_entry_logic.append((rsi_3_15m_gt_25) | (rsi_3_4h_gt_25) | aroonu_14_4h_lt_70)
           # 15m down move, 15m still not low enough, 1d overbought
@@ -21584,7 +21612,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # big drop in the last 20 days, 1d down move
           long_entry_logic.append((close > (high_max_20_1d * 0.25)) | (rsi_3_1d_gt_30))
           # big drop in the last 20 days, 4h still not low enough
-          long_entry_logic.append((close > (high_max_20_1d * 0.10)) | (rsi_14_4h < 30.0))
+          long_entry_logic.append((close > (high_max_20_1d * 0.10)) | (rsi_14_4h_lt_30))
           # big drop in the last 30 days, 4h down move
           long_entry_logic.append((close > (high_max_30_1d * 0.25)) | rsi_3_4h_gt_20)
 
@@ -21607,9 +21635,9 @@ class NostalgiaForInfinityX7(IStrategy):
           long_entry_logic.append(rsi_3_15m >= 20.0)
           long_entry_logic.append(rsi_3_1h >= 10.0)
           long_entry_logic.append(rsi_3_4h >= 10.0)
-          long_entry_logic.append(rsi_14_1h < 80.0)
-          long_entry_logic.append(rsi_14_4h < 80.0)
-          long_entry_logic.append(rsi_14_1d < 80.0)
+          long_entry_logic.append(rsi_14_1h_lt_80)
+          long_entry_logic.append(rsi_14_4h_lt_80)
+          long_entry_logic.append(rsi_14_1d_lt_80)
           long_entry_logic.append(aroonu_14_15m_lt_70)
           long_entry_logic.append(aroonu_14_1h_lt_100)
           long_entry_logic.append(aroonu_14_4h_lt_100)
@@ -21672,7 +21700,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 1d still high
             & (rsi_3_15m_gt_3 | rsi_3_1h_gt_20 | (stochrsi_k_1d_lt_50))
             # 15m & 1h & 4h down move, 1d downtrend
-            & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_25) | (rsi_14_4h < 40.0) | (roc_9_1d > -10.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_25) | (rsi_14_4h_lt_40) | (roc_9_1d > -10.0))
             # 15m & 1h down move, 15m still high
             & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_30) | (aroonu_14_15m_lt_50))
             # 15m & 1h down move, 1d high
@@ -21738,7 +21766,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 4h down move, 1d overbought
             & ((rsi_3_15m_gt_10) | (rsi_3_4h_gt_15) | (roc_9_1d_lt_20))
             # 15m & 4h down move, 1d high
-            & ((rsi_3_15m_gt_10) | rsi_3_4h_gt_20 | (rsi_14_1d < 70.0))
+            & ((rsi_3_15m_gt_10) | rsi_3_4h_gt_20 | (rsi_14_1d_lt_70))
             # 15m & 4h down move, 15m high
             & ((rsi_3_15m_gt_10) | rsi_3_4h_gt_20 | (aroonu_14_15m_lt_60))
             # 15m & 4h down move, 4h still high
@@ -21912,7 +21940,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 4h high
             & ((rsi_3_1h_gt_25) | (rsi_3_4h_gt_30) | (aroonu_14_4h_lt_60))
             # 1h & 4h down move, 1d high
-            & ((rsi_3_1h_gt_30) | (rsi_3_4h_gt_35) | (rsi_14_1d < 80.0))
+            & ((rsi_3_1h_gt_30) | (rsi_3_4h_gt_35) | (rsi_14_1d_lt_80))
             # 1h down move, 1d high & overbought
             & ((rsi_3_1h_gt_30) | (aroonu_14_1d_lt_85) | (roc_9_1d_lt_40))
             # 1h down move, 1d high & overbought
@@ -21940,7 +21968,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 1d down move, 1h high
             & ((rsi_3_1h_gt_60) | (rsi_3_1d_gt_60) | aroonu_14_1h_lt_70)
             # 4h & 1d down move, 1d still high
-            & ((rsi_3_4h_gt_3) | (rsi_3_1d_gt_20) | (rsi_14_1d < 40.0))
+            & ((rsi_3_4h_gt_3) | (rsi_3_1d_gt_20) | (rsi_14_1d_lt_40))
             # 4h down move, 1h still not low enough, 4h downtrend
             & ((rsi_3_4h_gt_3) | (aroonu_14_1h_lt_20) | (roc_9_4h > -10.0))
             # 4h & 1d down move, 1d still high
@@ -21982,7 +22010,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h & 1d down move, 4h still high
             & ((rsi_3_4h_gt_15) | (rsi_3_1d > 50.0) | (stochrsi_k_4h_lt_40))
             # 4h down move, 1d still high, 4h still not low enough
-            & ((rsi_3_4h_gt_15) | (rsi_14_1d < 40.0) | (stochrsi_k_4h_lt_30))
+            & ((rsi_3_4h_gt_15) | (rsi_14_1d_lt_40) | (stochrsi_k_4h_lt_30))
             # 4h down move, 4h still high, 4h downtrend
             & ((rsi_3_4h_gt_15) | (aroonu_14_4h_lt_50) | (roc_9_4h > -10.0))
             # 4h down move, 1d still high, 1d downtrend
@@ -22165,7 +22193,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 4h down move, 1d overbought
             & ((rsi_3_15m_gt_10) | (rsi_3_4h_gt_15) | (roc_9_1d_lt_20))
             # 15m & 4h down move, 1d high
-            & ((rsi_3_15m_gt_10) | rsi_3_4h_gt_20 | (rsi_14_1d < 70.0))
+            & ((rsi_3_15m_gt_10) | rsi_3_4h_gt_20 | (rsi_14_1d_lt_70))
             # 15m & 4h down move, 4h still high
             & ((rsi_3_15m_gt_10) | rsi_3_4h_gt_20 | (aroonu_14_4h_lt_50))
             # 14m & 4h down move, 1d high
@@ -22349,7 +22377,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h & 1d down move, 1d downtrend
             & ((rsi_3_4h_gt_3) | (rsi_3_1d_gt_10) | (roc_9_1d_gt_neg_20))
             # 4h & 1d down move, 1d still high
-            & ((rsi_3_4h_gt_3) | (rsi_3_1d_gt_20) | (rsi_14_1d < 40.0))
+            & ((rsi_3_4h_gt_3) | (rsi_3_1d_gt_20) | (rsi_14_1d_lt_40))
             # 4h & 1d down move, 1d high
             & ((rsi_3_4h_gt_5) | (rsi_3_1d_gt_45) | (aroonu_14_1d_lt_70))
             # 4h down move, 4h still high, 4h downtrend
@@ -22385,7 +22413,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h & 1d down move, 4h still high
             & ((rsi_3_4h_gt_15) | (rsi_3_1d > 50.0) | (stochrsi_k_4h_lt_40))
             # 4h down move, 1d still high, 4h still not low enough
-            & ((rsi_3_4h_gt_15) | (rsi_14_1d < 40.0) | (stochrsi_k_4h_lt_30))
+            & ((rsi_3_4h_gt_15) | (rsi_14_1d_lt_40) | (stochrsi_k_4h_lt_30))
             # 4h down move, 15m still not low enough, 1d high
             & ((rsi_3_4h_gt_15) | (aroonu_14_15m_lt_30) | (aroonu_14_1d_lt_70))
             # 4h down move, 4h still high, 4h downtrend
@@ -22544,9 +22572,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1d down move, 4h still high
             & (rsi_3_15m_gt_3 | (rsi_3_1d_gt_20) | (stochrsi_k_4h_lt_50))
             # 15m & 4h down move, 1d still high
-            & ((rsi_3_15m_gt_5) | (rsi_3_4h_gt_5) | (rsi_14_1d < 40.0))
+            & ((rsi_3_15m_gt_5) | (rsi_3_4h_gt_5) | (rsi_14_1d_lt_40))
             # 15m & 1h down move, 4h still high
-            & ((rsi_3_15m_gt_5) | (rsi_3_1h_gt_10) | (rsi_14_4h < 40.0))
+            & ((rsi_3_15m_gt_5) | (rsi_3_1h_gt_10) | (rsi_14_4h_lt_40))
             # 15m & 1h down move, 1d high
             & ((rsi_3_15m_gt_5) | (rsi_3_1h_gt_15) | (aroonu_14_1d_lt_100))
             # 15m & 4h down move, 15m still not low enough
@@ -22686,7 +22714,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h & 1d down move, 4h high
             & ((rsi_3_4h_gt_15) | (rsi_3_1d_gt_30) | (stochrsi_k_4h_lt_60))
             # 4h down move, 1d still high, 4h still not low enough
-            & ((rsi_3_4h_gt_15) | (rsi_14_1d < 40.0) | (stochrsi_k_4h_lt_30))
+            & ((rsi_3_4h_gt_15) | (rsi_14_1d_lt_40) | (stochrsi_k_4h_lt_30))
             # 1h down move, 1h still high, 1d downtrend
             & ((rsi_3_1h_gt_15) | (aroonu_14_1h_lt_50) | (roc_9_1d > -30.0))
             # 4h down move, 4h & 1d high
@@ -22839,7 +22867,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1d high & overbought
             & ((rsi_3_1h_gt_5) | (aroonu_14_1d_lt_90) | (roc_9_1d_lt_20))
             # 1h & 4h & 1d down move, 4h downtrend, 1d still high
-            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_15) | (rsi_3_1d_gt_25) | (rsi_14_4h > 30.0) | (aroonu_14_1d_lt_40))
+            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_15) | (rsi_3_1d_gt_25) | (rsi_14_4h_gt_30) | (aroonu_14_1d_lt_40))
             # 1h & 4h down move, 4h still not low enough
             & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_15) | (stochrsi_k_4h_lt_30))
             # 1h & 4h down move, 15m still high
@@ -22909,7 +22937,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 4h & 1d high
             & ((rsi_3_1h_gt_25) | aroonu_14_4h_lt_70 | aroonu_14_1d_lt_100)
             # 1h & 4h down move, 1d high
-            & ((rsi_3_1h_gt_30) | (rsi_3_4h_gt_35) | (rsi_14_1d < 80.0))
+            & ((rsi_3_1h_gt_30) | (rsi_3_4h_gt_35) | (rsi_14_1d_lt_80))
             # 1h down move, 1h & 4h high
             & ((rsi_3_1h_gt_30) | aroonu_14_1h_lt_70 | aroonu_14_4h_lt_100)
             # 1h down move, 1h high, 4h high
@@ -23113,7 +23141,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 15m still high
             & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_15) | (aroonu_14_15m_lt_50))
             # 1h & 4h & 1d down move, 1d still high
-            & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_25) | (rsi_3_1d_gt_45) | (rsi_14_1d < 50.0))
+            & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_25) | (rsi_3_1d_gt_45) | (rsi_14_1d_lt_50))
             # 1h & 4h down move, 4h high
             & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_25) | (aroonu_14_4h_lt_60))
             # 1h & 4h down move, 1d downtrend
@@ -23374,7 +23402,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1h down move, 1h & 1d high
           long_entry_logic.append((rsi_3_1h_gt_60) | (stochrsi_k_1h_lt_70) | (aroonu_14_1d_lt_90))
           # 1h down move, 4h & 1d high
-          long_entry_logic.append((rsi_3_1h_gt_60) | (rsi_14_4h < 70.0) | (rsi_14_1d < 80.0))
+          long_entry_logic.append((rsi_3_1h_gt_60) | (rsi_14_4h_lt_70) | (rsi_14_1d_lt_80))
           # 15m & 1h & 4h down move, 4h high
           long_entry_logic.append((rsi_3_15m_gt_50) | (rsi_3_1h_gt_65) | (rsi_3_4h_gt_65) | (aroonu_14_4h_lt_85))
           # 4h down move, 15m high
@@ -23396,7 +23424,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 4h down move, 15m still high, 1h high
           long_entry_logic.append((rsi_3_4h_gt_40) | (stochrsi_k_15m_lt_40) | (stochrsi_k_1h_lt_80))
           # 4h down move, 1h & 4h still high
-          long_entry_logic.append((rsi_3_4h_gt_40) | (stochrsi_k_1h_lt_50) | (rsi_14_4h < 50.0))
+          long_entry_logic.append((rsi_3_4h_gt_40) | (stochrsi_k_1h_lt_50) | (rsi_14_4h_lt_50))
           # 4h down move, 1h still high, 4h still moving down
           long_entry_logic.append((rsi_3_4h_gt_40) | (stochrsi_k_1h_lt_50) | (cci_20_change_pct_4h > -0.0))
           # 4h down move, 1d high & overbought
@@ -23498,7 +23526,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 4h high
             ((rsi_3_15m_gt_10) | rsi_3_1h_gt_20 | (stochrsi_k_4h_lt_70))
             # 15m & 4h down move, 1h still high
-            & ((rsi_3_15m_gt_10) | (rsi_3_4h_gt_40) | (rsi_14_1h < 50.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_4h_gt_40) | (rsi_14_1h_lt_50))
             # 15m & 1d down move, 4h high
             & ((rsi_3_15m_gt_10) | (rsi_3_1d_gt_20) | (aroonu_14_4h_lt_90))
             # 15m down move, 15m still high, 1h high
@@ -23534,7 +23562,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 15m still high, 1d high, 1d downtrend
             & ((rsi_3_15m_gt_30) | (aroonu_14_15m_lt_50) | (stochrsi_k_1d_lt_70) | (roc_9_1d > -15.0))
             # 15m down move, 1h & 4h high
-            & ((rsi_3_15m_gt_35) | aroonu_14_1h_lt_80 | (rsi_14_4h < 80.0))
+            & ((rsi_3_15m_gt_35) | aroonu_14_1h_lt_80 | (rsi_14_4h_lt_80))
             # 1h & 4h down move, 15m stil high
             & ((rsi_3_1h_gt_3) | (rsi_3_4h_gt_10) | (stochrsi_k_15m_lt_50))
             # 1h & 4h down move, 1h still high
@@ -23620,7 +23648,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1d down move, 1h & 4h high
             & ((rsi_3_1d_gt_10) | aroonu_14_1h_lt_70 | (aroonu_14_4h_lt_90))
             # 1d down move, 4h high
-            & ((rsi_3_1d_gt_20) | (rsi_14_4h < 80.0))
+            & ((rsi_3_1d_gt_20) | (rsi_14_4h_lt_80))
             # 1d downtrend, 1d high & overbought
             & ((cmf_20_1d > -0.30) | (aroonu_14_1d_lt_85) | (roc_9_1d_lt_100))
             # 1h & 4h high, 1d overbought
@@ -23700,7 +23728,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 5m & 15m & 1d down move, 1h high
             & ((rsi_3_gt_15) | (rsi_3_15m_gt_25) | (rsi_3_1d_gt_25) | (aroonu_14_1h_lt_90))
             # 5m & 1h down move, 15m still high, 4h high
-            & ((rsi_3 > 20.0) | (rsi_3_1h_gt_40) | (rsi_14_15m < 40.0) | aroonu_14_4h_lt_100)
+            & ((rsi_3 > 20.0) | (rsi_3_1h_gt_40) | (rsi_14_15m_lt_40) | aroonu_14_4h_lt_100)
             # 5m & 1h & 15m down move, 1h still not low enough
             & ((rsi_3_gt_15) | (rsi_3_1h_gt_30) | (rsi_3_1d_gt_15) | (aroonu_14_1h_lt_30))
             # 15m & 4h down move, 4h high
@@ -23740,7 +23768,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 15m still not low enough, 1h & 4h high
             & ((rsi_3_15m_gt_15) | (rsi_3_1h_gt_40) | (aroonu_14_15m_lt_30) | aroonu_14_1h_lt_80 | aroonu_14_4h_lt_80)
             # 15m & 1h down move, 4h high & overbought
-            & ((rsi_3_15m_gt_15) | (rsi_3_1h_gt_45) | (rsi_14_4h < 70.0) | (roc_9_4h_lt_50))
+            & ((rsi_3_15m_gt_15) | (rsi_3_1h_gt_45) | (rsi_14_4h_lt_70) | (roc_9_4h_lt_50))
             # 15m & 1h down move, 1h high
             & ((rsi_3_15m_gt_15) | (rsi_3_1h_gt_50) | (stochrsi_k_1h_lt_90))
             # 15m & 4h down move, 15m high
@@ -23800,7 +23828,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 4h high & overbought
             & ((rsi_3_15m_gt_15) | (stochrsi_k_4h_lt_90) | (roc_9_4h_lt_25))
             # 15m down move, 4h high
-            & ((rsi_3_15m_gt_15) | (rsi_14_4h < 70.0) | (stochrsi_k_4h_lt_90) | (ema_9 < (ema_26 * 0.972)))
+            & ((rsi_3_15m_gt_15) | (rsi_14_4h_lt_70) | (stochrsi_k_4h_lt_90) | (ema_9 < (ema_26 * 0.972)))
             # 15m down move, 4h high and downtrend
             & ((rsi_3_15m_gt_15) | (cmf_20_4h > -0.2) | aroonu_14_4h_lt_80)
             # 15m down move, 1h high, 4h overbought
@@ -23814,7 +23842,7 @@ class NostalgiaForInfinityX7(IStrategy):
               (rsi_3_15m_gt_20) | (rsi_3_1h_gt_35) | (cmf_20_1h > -0.10) | (aroonu_14_15m_lt_40) | (aroonu_14_1h_lt_85)
             )
             # 15m & 1h down move, 4h high & overbought
-            & ((rsi_3_15m_gt_20) | (rsi_3_1h_gt_45) | (rsi_14_4h < 70.0) | (roc_9_4h_lt_50))
+            & ((rsi_3_15m_gt_20) | (rsi_3_1h_gt_45) | (rsi_14_4h_lt_70) | (roc_9_4h_lt_50))
             # 15m & 1h down move, 1h high, 1d overbought
             & ((rsi_3_15m_gt_20) | (rsi_3_1h_gt_45) | (aroonu_14_1h_lt_90) | (roc_9_1d_lt_40))
             # 15m & 4h down move, 15m high
@@ -23824,11 +23852,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1d down move, 4h high
             & ((rsi_3_15m_gt_20) | (rsi_3_1d_gt_20) | (stochrsi_k_4h_lt_70))
             # 15m down move, 15m still high, 4h high
-            & ((rsi_3_15m_gt_20) | (rsi_14_15m < 40.0) | (rsi_14_4h < 75.0) | aroonu_14_4h_lt_100)
+            & ((rsi_3_15m_gt_20) | (rsi_14_15m_lt_40) | (rsi_14_4h_lt_75) | aroonu_14_4h_lt_100)
             # 15m down move, 4h downtrend, 4h overbought
             & ((rsi_3_15m_gt_20) | (cmf_20_4h > -0.0) | (roc_9_4h_lt_40))
             # 15m down move, 1h & 4h high, 1f overbought
-            & ((rsi_3_15m_gt_20) | (aroonu_14_1h_lt_85) | (rsi_14_4h < 70.0) | (roc_9_1d_lt_80))
+            & ((rsi_3_15m_gt_20) | (aroonu_14_1h_lt_85) | (rsi_14_4h_lt_70) | (roc_9_1d_lt_80))
             # 15m down move, 1h & 4h high
             & ((rsi_3_15m_gt_20) | (aroonu_14_1h_lt_90) | (aroonu_14_4h_lt_100))
             # 15m down move, 1d high, 4h overbought
@@ -23836,7 +23864,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 1h high & overbought
             & ((rsi_3_15m_gt_20) | (stochrsi_k_1h_lt_80) | (roc_9_1h_lt_10))
             # 15m & 1h down move, 15m still high, 4h high
-            & ((rsi_3_15m_gt_25) | (rsi_3_1h_gt_45) | (rsi_14_15m < 40.0) | (aroonu_14_4h_lt_100))
+            & ((rsi_3_15m_gt_25) | (rsi_3_1h_gt_45) | (rsi_14_15m_lt_40) | (aroonu_14_4h_lt_100))
             # 15m & 1d down move, 1d high
             & ((rsi_3_15m_gt_25) | (rsi_3_1d_gt_40) | (aroonu_14_1d_lt_80))
             # 15m down move, 4h high, 1d downtrend
@@ -23845,9 +23873,9 @@ class NostalgiaForInfinityX7(IStrategy):
             & (
               (rsi_3_15m_gt_30)
               | (rsi_3_1h_gt_45)
-              | (rsi_14_15m < 30.0)
-              | (rsi_14_1h < 50.0)
-              | (rsi_14_4h < 70.0)
+              | (rsi_14_15m_lt_30)
+              | (rsi_14_1h_lt_50)
+              | (rsi_14_4h_lt_70)
               | (aroonu_14_15m_lt_20)
               | (aroonu_14_1h_lt_60)
               | aroonu_14_4h_lt_100
@@ -23907,7 +23935,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1d high, 4h overbought
             & ((rsi_3_1h_gt_30) | aroonu_14_1d_lt_100 | (roc_9_4h_lt_20))
             # 1h & 4h down move, 1h still high, 4h high
-            & ((rsi_3_1h_gt_35) | (rsi_3_4h_gt_60) | (rsi_14_1h < 50.0) | (rsi_14_4h < 70.0))
+            & ((rsi_3_1h_gt_35) | (rsi_3_4h_gt_60) | (rsi_14_1h_lt_50) | (rsi_14_4h_lt_70))
             # 1h down move, 1d downtrend, 15m still high, 1d high
             & ((rsi_3_1h_gt_35) | (cmf_20_1d > -0.0) | (aroonu_14_15m_lt_50) | (aroonu_14_1d_lt_90))
             # 1h down move, 15m still not low enough, 1h high
@@ -23965,7 +23993,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 1h still high, 4h downtrend
             & ((rsi_3_4h_gt_10) | (stochrsi_k_1h_lt_50) | (cmf_20_4h > -0.3))
             # 4h down move, 1d still high, 1d downtrend
-            & ((rsi_3_4h_gt_15) | (rsi_14_1d < 40.0) | (roc_9_1d > -10.0))
+            & ((rsi_3_4h_gt_15) | (rsi_14_1d_lt_40) | (roc_9_1d > -10.0))
             # 4h down move, 4h high
             & ((rsi_3_4h_gt_15) | (aroonu_14_4h_lt_60))
             # 4h down move, 1d high & overbought
@@ -23993,7 +24021,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 1d high, 4h overbought
             & ((rsi_3_4h_gt_45) | (aroonu_14_1d_lt_90) | (roc_9_4h_lt_10))
             # 4h down move, 4h still high, 1d downtrend
-            & ((rsi_3_4h_gt_50) | (rsi_14_4h < 40.0) | (roc_9_1d_gt_neg_30))
+            & ((rsi_3_4h_gt_50) | (rsi_14_4h_lt_40) | (roc_9_1d_gt_neg_30))
             # 4h down move, 4h high & overbought
             & ((rsi_3_4h_gt_50) | aroonu_14_4h_lt_70 | (roc_9_4h_lt_10))
             # 4h down move, 15m still high, 1d overbought
@@ -24007,7 +24035,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1d down move, 1h high
             & ((rsi_3_1d_gt_5) | (stochrsi_k_1h_lt_80))
             # 1d down move, 15m & 1h still high
-            & ((rsi_3_1d_gt_10) | (rsi_14_15m < 40.0) | (stochrsi_k_1h_lt_50))
+            & ((rsi_3_1d_gt_10) | (rsi_14_15m_lt_40) | (stochrsi_k_1h_lt_50))
             # 1d down move, 1h & 4h high
             & ((rsi_3_1d_gt_10) | aroonu_14_1h_lt_80 | (aroonu_14_4h_lt_90))
             # 1d down move, 1h & 4h still high
@@ -24167,9 +24195,9 @@ class NostalgiaForInfinityX7(IStrategy):
           short_entry_logic.append(rsi_3_1h >= 5.0)
           short_entry_logic.append(rsi_3_4h >= 20.0)
           short_entry_logic.append(rsi_3_1d >= 20.0)
-          short_entry_logic.append(rsi_14_1h > 20.0)
-          short_entry_logic.append(rsi_14_4h > 20.0)
-          short_entry_logic.append(rsi_14_1d > 10.0)
+          short_entry_logic.append(rsi_14_1h_gt_20)
+          short_entry_logic.append(rsi_14_4h_gt_20)
+          short_entry_logic.append(rsi_14_1d_gt_10)
           # 5m up move, 4h still not high enough
           short_entry_logic.append((rsi_3 < 97.0) | (aroonu_14_4h > 60.0))
           # 5m up move, 4h still low
@@ -24205,7 +24233,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m & 4h up move, 1h still not high enough
           short_entry_logic.append((rsi_3_15m_lt_95) | (rsi_3_4h_lt_95) | (stochrsi_k_1h_gt_75))
           # 15m up move, 1d lost, 1h low
-          short_entry_logic.append((rsi_3_15m_lt_95) | (rsi_14_1d > 40.0) | (aroonu_14_1h > 40.0))
+          short_entry_logic.append((rsi_3_15m_lt_95) | (rsi_14_1d_gt_40) | (aroonu_14_1h > 40.0))
           # 15m up move, 15m & 4h uptrend
           short_entry_logic.append((rsi_3_15m_lt_95) | (aroonu_14_15m_lt_90) | (aroonu_14_4h_lt_90))
           # 15m up move, 15m stil not high enough, 1h low
@@ -24289,9 +24317,9 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1h & 1d strong up move
           short_entry_logic.append((rsi_3_1h_lt_95) | (rsi_3_1d < 95.0))
           # 1h up move, 4h still low
-          short_entry_logic.append((rsi_3_1h_lt_95) | (rsi_14_4h > 60.0))
+          short_entry_logic.append((rsi_3_1h_lt_95) | (rsi_14_4h_gt_60))
           # 1h up move, 1d still low, 1h uptrend
-          short_entry_logic.append((rsi_3_1h_lt_95) | (rsi_14_1d > 50.0) | (roc_9_1h_lt_30))
+          short_entry_logic.append((rsi_3_1h_lt_95) | (rsi_14_1d_gt_50) | (roc_9_1h_lt_30))
           # 1h & 4h strong up move
           short_entry_logic.append((rsi_3_1h_lt_95) | (mfi_14_1h < 95.0) | (rsi_3_4h_lt_95))
           # 1h up move, 1d still low, 1h uptrend
@@ -24339,7 +24367,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 4h up move, 1h still low
           short_entry_logic.append((rsi_3_4h_lt_90) | (aroonu_14_1h > 40.0))
           # 4h up move, 1d still low, 4h uptrend
-          short_entry_logic.append((rsi_3_4h_lt_85) | (rsi_14_1d > 40.0) | (roc_9_4h_lt_20))
+          short_entry_logic.append((rsi_3_4h_lt_85) | (rsi_14_1d_gt_40) | (roc_9_4h_lt_20))
           # 4h up move, 4h still low
           short_entry_logic.append((rsi_3_4h_lt_80) | (stochrsi_k_4h_gt_50))
           # 4h up move, 1h low
@@ -24353,7 +24381,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1d up move, 1h & 4h still not low enough
           short_entry_logic.append((rsi_3_1d < 90.0) | (stochrsi_k_1h_gt_80) | (stochrsi_k_4h_gt_50))
           # 4h still not high enough, 4h overbought, 4h uptrend
-          short_entry_logic.append((rsi_14_4h > 80.0) | (roc_9_4h_lt_40) | (cci_20_change_pct_4h < 0.0))
+          short_entry_logic.append((rsi_14_4h_gt_80) | (roc_9_4h_lt_40) | (cci_20_change_pct_4h < 0.0))
           # 15m & 1h uptrend, 4h still low
           short_entry_logic.append((cmf_20_15m < 0.30) | (cmf_20_1h < 0.30) | (stochrsi_k_4h > 60.0))
           # 15m uptrend, 1h low
@@ -24447,7 +24475,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h up move, 4h stil low
             & ((rsi_3_15m_lt_90) | (rsi_3_1h_lt_80) | (aroonu_14_4h > 50.0))
             # 15m & 4h up move, 1d low
-            & ((rsi_3_15m_lt_90) | (rsi_3_4h_lt_85) | (rsi_14_1d > 40.0))
+            & ((rsi_3_15m_lt_90) | (rsi_3_4h_lt_85) | (rsi_14_1d_gt_40))
             # 15m & 4h up move, 1d low
             & ((rsi_3_15m_lt_90) | (rsi_3_4h_lt_85) | (stochrsi_k_1d_gt_30))
             # 15m up move, 1h still low, 1d low
@@ -24481,7 +24509,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h up move, 4h still low, 1h moving higher
             & ((rsi_3_1h_lt_95) | (stochrsi_k_4h > 60.0) | (cci_20_change_pct_1h < -0.0))
             # 1h up move, 1d low
-            & ((rsi_3_1h_lt_95) | (rsi_14_1d > 40.0))
+            & ((rsi_3_1h_lt_95) | (rsi_14_1d_gt_40))
             # 1h strong up move, 15m still move higher
             & ((rsi_3_1h_lt_95) | (df["CCI_20_change_pct_15m"] < -0.0))
             # 1h up move, relative stable before the hour
@@ -24501,7 +24529,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h up move, 1h still not high enough
             & ((rsi_3_1h_lt_80) | (stochrsi_k_1h_gt_70))
             # 1h up move, 4h still low, 1h still moving higher
-            & ((rsi_3_1h_lt_80) | (rsi_14_4h > 60.0) | (cci_20_change_pct_1h < -0.0))
+            & ((rsi_3_1h_lt_80) | (rsi_14_4h_gt_60) | (cci_20_change_pct_1h < -0.0))
             # 1h up move, 4h low
             & ((rsi_3_1h_lt_80) | (stochrsi_k_4h > 20.0))
             # 1h up move, 4h low
@@ -24509,7 +24537,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h up move, 1h still low
             & ((rsi_3_1h < 75.0) | (stochrsi_k_1h_gt_50))
             # 1h up move, 4h low
-            & ((rsi_3_1h < 70.0) | (rsi_14_4h > 40.0))
+            & ((rsi_3_1h < 70.0) | (rsi_14_4h_gt_40))
             # 1h up move, 4h low
             & ((rsi_3_1h < 70.0) | (stochrsi_k_4h > 40.0))
             # 1h up move, 1h uptrend
@@ -24517,7 +24545,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h up move, 1h low
             & ((rsi_3_1h < 60.0) | (stochrsi_k_1h_gt_20))
             # 4h up move, 1d still low
-            & ((rsi_3_4h < 97.0) | (rsi_14_1d > 50.0))
+            & ((rsi_3_4h < 97.0) | (rsi_14_1d_gt_50))
             # 4h up move, 1h still not high enough
             & ((rsi_3_4h_lt_95) | (stochrsi_k_1h_gt_70))
             # 4h up move, 4h still not high enough
@@ -24533,7 +24561,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h up move, 4h still not high enough
             & ((rsi_3_4h_lt_85) | (stochrsi_k_4h_gt_70))
             # 4h up move, 1d still low, 4h uptrend
-            & ((rsi_3_4h_lt_85) | (rsi_14_1d > 50.0) | (roc_9_4h_lt_20))
+            & ((rsi_3_4h_lt_85) | (rsi_14_1d_gt_50) | (roc_9_4h_lt_20))
             # 4h up move, 4h high, 4h & 1d uptrend
             & ((rsi_3_4h_lt_80) | (aroonu_14_4h_lt_100) | (roc_9_4h_lt_10) | (roc_9_1d_lt_40))
             # 4h up move, 4h uptrend
@@ -24593,9 +24621,9 @@ class NostalgiaForInfinityX7(IStrategy):
           short_entry_logic.append(rsi_3_1h >= 5.0)
           short_entry_logic.append(rsi_3_4h >= 20.0)
           short_entry_logic.append(rsi_3_1d >= 20.0)
-          short_entry_logic.append(rsi_14_1h > 20.0)
-          short_entry_logic.append(rsi_14_4h > 20.0)
-          short_entry_logic.append(rsi_14_1d > 10.0)
+          short_entry_logic.append(rsi_14_1h_gt_20)
+          short_entry_logic.append(rsi_14_4h_gt_20)
+          short_entry_logic.append(rsi_14_1d_gt_10)
           # 5m strong down move
           short_entry_logic.append((rsi_3 < 98.0) | (roc_9 < 50.0))
           # 5m down move, 4h still high
@@ -24631,7 +24659,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m & 4h down move, 4h still not low enough
           short_entry_logic.append((rsi_3_15m_lt_95) | (rsi_3_4h_lt_80) | (stochrsi_k_4h > 60.0))
           # 15m down move, 1h & 4h still high
-          short_entry_logic.append((rsi_3_15m_lt_95) | (stochrsi_k_1h_gt_50) | (rsi_14_4h > 50.0))
+          short_entry_logic.append((rsi_3_15m_lt_95) | (stochrsi_k_1h_gt_50) | (rsi_14_4h_gt_50))
           # 15m & 1h & 4h down move
           short_entry_logic.append((rsi_3_15m_lt_90) | (rsi_3_change_pct_1h > -60.0) | (rsi_3_change_pct_4h > -40.0))
           # 15m down move, 1d downtrend, 1h still high
@@ -24675,9 +24703,9 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1h down move, 4h still not low enough, 1d overbought
           short_entry_logic.append((rsi_3_1h_lt_90) | (aroond_14_4h < 25.0) | (roc_9_1d > -120.0))
           # 1h down move, 1h still not low enough, 4h still not low
-          short_entry_logic.append((rsi_3_1h_lt_90) | (stochrsi_k_1h_gt_70) | (rsi_14_4h > 50.0))
+          short_entry_logic.append((rsi_3_1h_lt_90) | (stochrsi_k_1h_gt_70) | (rsi_14_4h_gt_50))
           # 1h down move, 4h still high
-          short_entry_logic.append((rsi_3_1h_lt_95) | (rsi_14_4h > 60.0))
+          short_entry_logic.append((rsi_3_1h_lt_95) | (rsi_14_4h_gt_60))
           # 1h down move, 4h still high, 1d downtrend
           short_entry_logic.append((rsi_3_1h_lt_80) | (stochrsi_k_4h_gt_30) | roc_9_1d_lt_50)
           # 1h down move, 4h still high, 1d downtrend
@@ -24742,9 +24770,9 @@ class NostalgiaForInfinityX7(IStrategy):
           short_entry_logic.append(rsi_3_1h >= 5.0)
           short_entry_logic.append(rsi_3_4h >= 20.0)
           short_entry_logic.append(rsi_3_1d >= 20.0)
-          short_entry_logic.append(rsi_14_1h > 20.0)
-          short_entry_logic.append(rsi_14_4h > 20.0)
-          short_entry_logic.append(rsi_14_1d > 10.0)
+          short_entry_logic.append(rsi_14_1h_gt_20)
+          short_entry_logic.append(rsi_14_4h_gt_20)
+          short_entry_logic.append(rsi_14_1d_gt_10)
           # 15m & 1h down move, 4h still high
           short_entry_logic.append((rsi_3_15m_lt_95) | (mfi_14_15m < 90.0) | (rsi_3_1h_lt_80) | (stochrsi_k_4h_gt_50))
           # 15m & 1h down move, 4h still high
@@ -24778,7 +24806,7 @@ class NostalgiaForInfinityX7(IStrategy):
           short_entry_logic.append(num_empty_288 <= allowed_empty_candles_288)
 
           # 5m & 15m down move, 4h still high
-          short_entry_logic.append((rsi_3 < 95.0) | (df["RSI_3_change_pct_15m"] < 50.0) | (rsi_14_4h > 50.0))
+          short_entry_logic.append((rsi_3 < 95.0) | (df["RSI_3_change_pct_15m"] < 50.0) | (rsi_14_4h_gt_50))
           # 5m & 15m & 1h down move
           short_entry_logic.append((rsi_3 < 95.0) | (rsi_3_15m_lt_95) | (rsi_3_1h_lt_95))
           # 5m strong down move
@@ -24812,7 +24840,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m down move, 1h down move, 4h high
           short_entry_logic.append((rsi_3_15m_lt_85) | (rsi_3_change_pct_1h < 30.0) | (stochrsi_k_4h > 10.0))
           # 1m down move, 1h still dropping, 4h overbought
-          short_entry_logic.append((rsi_3_15m_lt_90) | (cci_20_change_pct_1h < 0.0) | (rsi_14_4h > 20.0))
+          short_entry_logic.append((rsi_3_15m_lt_90) | (cci_20_change_pct_1h < 0.0) | (rsi_14_4h_gt_20))
           # 15m down move, 1h high
           short_entry_logic.append((df["RSI_3_change_pct_15m"] < 70.0) | (stochrsi_k_1h_gt_10))
           # 1h strong down move, 4h high
@@ -24820,7 +24848,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1h down move, 4h downtrend, 4h not low enough
           short_entry_logic.append((rsi_3_1h_lt_95) | (cmf_20_4h > -0.25) | (stochrsi_k_4h_gt_70))
           # 1h down move, 4h high, 1d overbought
-          short_entry_logic.append((rsi_3_1h_lt_90) | (rsi_14_4h > 40.0) | roc_9_1d_gt_neg_50)
+          short_entry_logic.append((rsi_3_1h_lt_90) | (rsi_14_4h_gt_40) | roc_9_1d_gt_neg_50)
           # 1h down move, 4h strong down move
           short_entry_logic.append((rsi_3_1h_lt_95) | (df["RSI_14_change_pct_4h"] < 40.0))
           # 1h & 4h down move, 4h still going down
@@ -24848,16 +24876,16 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m downtrend, 4h down move, 4h stil high
           short_entry_logic.append((roc_9_15m < 15.0) | (rsi_3_4h < 75.0) | (stochrsi_k_4h_gt_30))
           # 1h downtrend, 4h overbought
-          short_entry_logic.append((df["ROC_2_1h"] < 5.0) | (rsi_14_4h > 20.0) | (roc_9_4h > -25.0))
+          short_entry_logic.append((df["ROC_2_1h"] < 5.0) | (rsi_14_4h_gt_20) | (roc_9_4h > -25.0))
           # 1h P&D, 4h still high
           short_entry_logic.append((df["ROC_2_1h"] < 10.0) | (roc_9_1h > -5.0) | (stochrsi_k_4h_gt_30))
           # 1h downtrend, 4h down move, 1d downtrend
           short_entry_logic.append((roc_9_1h_lt_40) | (rsi_3_4h_lt_90) | roc_9_1d_lt_50)
-          short_entry_logic.append((roc_9_4h > -200.0) | (rsi_14_4h > 20.0))
+          short_entry_logic.append((roc_9_4h > -200.0) | (rsi_14_4h_gt_20))
           # 4h down move, 1d P&D
           short_entry_logic.append((roc_9_4h_lt_20) | (roc_2_1d < 20.0) | roc_9_1d_gt_neg_50)
           # 1h P&D, 4h overbought
-          short_entry_logic.append((change_pct_1h < 2.0) | (change_pct_1h.shift(12) > 2.0) | (rsi_14_4h > 20.0))
+          short_entry_logic.append((change_pct_1h < 2.0) | (change_pct_1h.shift(12) > 2.0) | (rsi_14_4h_gt_20))
           # 1h P&D, 1d overbought
           short_entry_logic.append((change_pct_1h < 5.0) | (change_pct_1h.shift(12) > -5.0) | (roc_9_1d > -100.0))
           # 1h & 4h red, 1h not low enough
@@ -24888,7 +24916,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 5m & 15m up move, 15m stil low
           short_entry_logic.append((rsi_3_lt_90) | (rsi_3_15m < 80.0) | (aroonu_14_15m > 60.0))
           # 15m & 1h up move, 4h still low
-          short_entry_logic.append((rsi_3_15m_lt_95) | (rsi_3_1h_lt_95) | (rsi_14_4h > 60.0))
+          short_entry_logic.append((rsi_3_15m_lt_95) | (rsi_3_1h_lt_95) | (rsi_14_4h_gt_60))
           # 15m & 1h up move, 4h still not high enough
           short_entry_logic.append((rsi_3_15m_lt_95) | (rsi_3_1h_lt_95) | (stochrsi_k_4h > 80.0))
           # 15m & 1h up move, 1h still moving higher
@@ -24906,7 +24934,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m & 4h up move, 1d uptrend
           short_entry_logic.append((rsi_3_15m_lt_85) | (rsi_3_4h_lt_85) | roc_9_1d_lt_50)
           # 15m & 4h up move, 4h still not high enough
-          short_entry_logic.append((rsi_3_15m_lt_85) | (rsi_3_4h_lt_80) | (rsi_14_4h > 60.0))
+          short_entry_logic.append((rsi_3_15m_lt_85) | (rsi_3_4h_lt_80) | (rsi_14_4h_gt_60))
           # 15m up move, 15m still not high enough, 4h still low
           short_entry_logic.append((rsi_3_15m_lt_85) | (stochrsi_k_15m > 80.0) | (aroonu_14_4h > 50.0))
           # 15m up move, 4h overbought
@@ -24924,9 +24952,9 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1h & 4h up move, 1d uptrend
           short_entry_logic.append((rsi_3_1h_lt_95) | (rsi_3_4h_lt_95) | (roc_9_1d_lt_100))
           # 1h & 4h up move, 1d still low
-          short_entry_logic.append((rsi_3_1h_lt_95) | (rsi_3_4h_lt_85) | (rsi_14_1d > 50.0))
+          short_entry_logic.append((rsi_3_1h_lt_95) | (rsi_3_4h_lt_85) | (rsi_14_1d_gt_50))
           # 1h up move, 4h still low, 1h still moving higher
-          short_entry_logic.append((rsi_3_1h_lt_95) | (rsi_14_4h > 60.0) | (cci_20_change_pct_1h < -0.0))
+          short_entry_logic.append((rsi_3_1h_lt_95) | (rsi_14_4h_gt_60) | (cci_20_change_pct_1h < -0.0))
           # 1h up move, 4h low
           short_entry_logic.append((rsi_3_1h_lt_95) | (aroonu_14_4h > 10.0))
           # 1h & 4h up move, 1h still moving higher
@@ -24950,7 +24978,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1h up move, 15m low
           short_entry_logic.append((rsi_3_1h_lt_85) | (aroonu_14_15m > 40.0))
           # 1h up move, 4h still not high enough, 1d low
-          short_entry_logic.append((rsi_3_1h_lt_85) | (aroonu_14_4h > 80.0) | (rsi_14_1d > 40.0))
+          short_entry_logic.append((rsi_3_1h_lt_85) | (aroonu_14_4h > 80.0) | (rsi_14_1d_gt_40))
           # 1h & 4h up move, 4h still low
           short_entry_logic.append((rsi_3_1h_lt_80) | (rsi_3_4h_lt_80) | (aroonu_14_4h > 50.0))
           # 1h & 4h up move, 1d still low
@@ -24964,7 +24992,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1h up move, 4h & 1d uptrend
           short_entry_logic.append((rsi_3_1h_lt_80) | (roc_9_4h_lt_20) | (roc_9_1d_lt_40))
           # 4h up move, 1d low
-          short_entry_logic.append((rsi_3_4h_lt_95) | (rsi_14_1d > 40.0))
+          short_entry_logic.append((rsi_3_4h_lt_95) | (rsi_14_1d_gt_40))
           # 4h down move, 15m still not high enough, 1d low
           short_entry_logic.append((rsi_3_4h_lt_95) | (stochrsi_k_15m > 80.0) | (df["AROOND_14_1d"] < 75.0))
           # 4h up move, 1h & 4h uptrend
@@ -24986,7 +25014,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1d up move, 4h low
           short_entry_logic.append((rsi_3_1d < 85.0) | (stochrsi_k_4h > 40.0))
           # 4h still not high enough, 4h overbought, 4h uptrend
-          short_entry_logic.append((rsi_14_4h > 80.0) | (roc_9_4h_lt_40) | (cci_20_change_pct_4h < 0.0))
+          short_entry_logic.append((rsi_14_4h_gt_80) | (roc_9_4h_lt_40) | (cci_20_change_pct_4h < 0.0))
           # 15m & 1h high, 4h uptrend
           short_entry_logic.append((aroonu_14_15m_lt_100) | (aroonu_14_1h_lt_100) | (roc_9_4h_lt_20))
           # 15m & 4h high, 1h uptrend
@@ -25029,9 +25057,9 @@ class NostalgiaForInfinityX7(IStrategy):
           # Protections
           short_entry_logic.append(num_empty_288 <= allowed_empty_candles_288)
 
-          short_entry_logic.append(rsi_14_1h > 20.0)
-          short_entry_logic.append(rsi_14_4h > 20.0)
-          short_entry_logic.append(rsi_14_1d > 10.0)
+          short_entry_logic.append(rsi_14_1h_gt_20)
+          short_entry_logic.append(rsi_14_4h_gt_20)
+          short_entry_logic.append(rsi_14_1d_gt_10)
           # 5m strong down move
           short_entry_logic.append((rsi_3 < 98.0) | (roc_9 < 50.0))
           # 15m down move, 1h down move, 1h still not low enough
@@ -25073,7 +25101,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1h & 4h down move, 4h still not low enough
           short_entry_logic.append((rsi_3_1h_lt_95) | (rsi_3_change_pct_4h < 65.0) | (stochrsi_k_4h_gt_70))
           # 1h down move, 1h still not low enough, 4h still not low
-          short_entry_logic.append((rsi_3_1h_lt_90) | (stochrsi_k_1h_gt_70) | (rsi_14_4h > 50.0))
+          short_entry_logic.append((rsi_3_1h_lt_90) | (stochrsi_k_1h_gt_70) | (rsi_14_4h_gt_50))
           # 1h down move, 1h not low enough, 1h still high
           short_entry_logic.append((rsi_3_1h_lt_85) | (aroond_14_1h < 50.0) | (stochrsi_k_4h_gt_50))
           # 4h down move, 15m still not low enough, 1h still high
@@ -25132,9 +25160,9 @@ class NostalgiaForInfinityX7(IStrategy):
           short_entry_logic.append(rsi_3_1h >= 5.0)
           short_entry_logic.append(rsi_3_4h >= 20.0)
           short_entry_logic.append(rsi_3_1d >= 20.0)
-          short_entry_logic.append(rsi_14_1h > 20.0)
-          short_entry_logic.append(rsi_14_4h > 20.0)
-          short_entry_logic.append(rsi_14_1d > 10.0)
+          short_entry_logic.append(rsi_14_1h_gt_20)
+          short_entry_logic.append(rsi_14_4h_gt_20)
+          short_entry_logic.append(rsi_14_1d_gt_10)
           # 5m down move, 1h still not low enough, 4h high
           short_entry_logic.append((rsi_3_lt_90) | (stochrsi_k_1h_gt_90) | (stochrsi_k_4h_gt_30))
           # 5m down move, 1h high, 4h still not low enough
@@ -25376,7 +25404,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1h down move, 1h & 1d high
           short_entry_logic.append((rsi_3_1h < 40.0) | (stochrsi_k_1h_gt_30) | (df["AROOND_14_1d"] < 90.0))
           # 1h down move, 4h & 1d high
-          short_entry_logic.append((rsi_3_1h < 40.0) | (rsi_14_4h > 30.0) | (rsi_14_1d > 20.0))
+          short_entry_logic.append((rsi_3_1h < 40.0) | (rsi_14_4h_gt_30) | (rsi_14_1d > 20.0))
           # 4h down move, 15m high
           short_entry_logic.append((rsi_3_4h_lt_80) | (aroond_14_15m < 80.0))
           # 4h down move, 1h high


### PR DESCRIPTION
## Summary
- Reuse repeated RSI14 threshold comparisons in `populate_entry_trend()` through named entry masks.
- Independent on latest upstream `main`.

## Safety
- Behavior-preserving Series mask reuse only.
- Touched function: `populate_entry_trend()`.
- Indicator formulas, candle selection, thresholds, condition order, profit arithmetic, order classification, return values, and signal behavior are unchanged.
- No v3 grind-entry code is touched.

## Backtest scope
- Full backtesting was not required because this patch only aliases Series comparisons that are already used by the same condition ladder.
- Indicator formulas, candle selection, thresholds, and condition order are unchanged.

## Checks
- `python3 /home/user/.codex/skills/nfi-upstream-pr/scripts/validate_nfi_pr.py --base origin/main`
- `git merge-tree $(git merge-base origin/main HEAD) origin/main HEAD | grep -E '<<<<<<<|>>>>>>>|changed in both|removed in|added in both' && echo CONFLICT || echo NO_CONFLICT`\n- `git diff --check`\n- `ruff format --check NostalgiaForInfinityX7.py`\n- `ruff check NostalgiaForInfinityX7.py`\n- `PYTHONDONTWRITEBYTECODE=1 python3 -m py_compile NostalgiaForInfinityX7.py`