### PR TITLE
Reuse X7 entry ROC 4h downtrend masks

### DIFF
--- a/NostalgiaForInfinityX7.py
+++ b/NostalgiaForInfinityX7.py
@@ -13142,6 +13142,13 @@ class NostalgiaForInfinityX7(IStrategy):
     roc_9_1h_lt_80 = roc_9_1h < 80.0
     roc_9_1h_lt_100 = roc_9_1h < 100.0
     roc_9_4h_gt_neg_30 = roc_9_4h > -30.0
+    roc_9_4h_gt_neg_70 = roc_9_4h > -70.0
+    roc_9_4h_gt_neg_50 = roc_9_4h > -50.0
+    roc_9_4h_gt_neg_40 = roc_9_4h > -40.0
+    roc_9_4h_gt_neg_35 = roc_9_4h > -35.0
+    roc_9_4h_gt_neg_25 = roc_9_4h > -25.0
+    roc_9_4h_gt_neg_15 = roc_9_4h > -15.0
+    roc_9_4h_gt_neg_10 = roc_9_4h > -10.0
     roc_9_4h_gt_neg_20 = roc_9_4h > -20.0
     roc_9_4h_lt_5 = roc_9_4h < 5.0
     roc_9_4h_lt_10 = roc_9_4h < 10.0
@@ -13369,7 +13376,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 1h high, 1d overbought
             & ((rsi_3_15m_gt_10) | (aroonu_14_1h_lt_100) | (roc_9_1d_lt_80))
             # 15m down move, 1h high, 4h downtrend
-            & ((rsi_3_15m_gt_10) | (stochrsi_k_1h_lt_70) | (roc_9_4h > -25.0))
+            & ((rsi_3_15m_gt_10) | (stochrsi_k_1h_lt_70) | (roc_9_4h_gt_neg_25))
             # 15m down move, 1h high, 1d downtrend
             & ((rsi_3_15m_gt_10) | (stochrsi_k_1h_lt_70) | roc_9_1d_gt_neg_50)
             # 15m down move, 1h high & overbought
@@ -13399,7 +13406,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 4h down move, 15m high
             & ((rsi_3_15m_gt_40) | (rsi_3_4h_gt_45) | (stochrsi_k_15m_lt_70))
             # 1h & 4h down move, 4h downtrend
-            & ((rsi_3_1h_gt_3) | (rsi_3_4h_gt_10) | (roc_9_4h > -10.0))
+            & ((rsi_3_1h_gt_3) | (rsi_3_4h_gt_10) | (roc_9_4h_gt_neg_10))
             # 1h & 4h down move, 1h still high
             & ((rsi_3_1h_gt_3) | (rsi_3_4h_gt_15) | (aroonu_14_1h_lt_50))
             # 1h & 4h down move, 1d high
@@ -13569,7 +13576,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h high, 1d downtrend
             & (aroonu_14_4h_lt_80 | (roc_9_1d_gt_neg_40))
             # 1d high, 4h downtrend, 1d overbought
-            & ((aroonu_14_1d_lt_85) | (roc_9_4h > -25.0) | roc_9_1d_lt_50)
+            & ((aroonu_14_1d_lt_85) | (roc_9_4h_gt_neg_25) | roc_9_1d_lt_50)
             # 1d high, 1h & 4h downtrend
             & ((aroonu_14_1d_lt_90) | (roc_9_1h > -10.0) | (roc_9_4h_gt_neg_20))
             # 1d high, 4h & 1d overbought
@@ -14092,7 +14099,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 1d down move, 1h still high
             & (rsi_3_1h_gt_20 | (rsi_3_1d_gt_30) | (stochrsi_k_1h_lt_50))
             # 1h down move, 1h high, 4h downtrend
-            & (rsi_3_1h_gt_20 | aroonu_14_1h_lt_70 | (roc_9_4h > -10.0))
+            & (rsi_3_1h_gt_20 | aroonu_14_1h_lt_70 | (roc_9_4h_gt_neg_10))
             # 1h down move, 1h high, 4h overbought
             & (rsi_3_1h_gt_20 | aroonu_14_1h_lt_70 | (roc_9_4h_lt_10))
             # 1h down move, 1h high, 1h still not low enough
@@ -14128,7 +14135,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 4h downtrend, 1d overbought
             & ((rsi_3_1h_gt_30) | (roc_9_4h_gt_neg_30) | (roc_9_1d_lt_200))
             # 1h down move, 4h & 1d downtrend
-            & ((rsi_3_1h_gt_30) | (roc_9_4h > -25.0) | (roc_9_1d > -60.0))
+            & ((rsi_3_1h_gt_30) | (roc_9_4h_gt_neg_25) | (roc_9_1d > -60.0))
             # 1h & 4h down move, 1h still high
             & ((rsi_3_1h_gt_35) | (rsi_3_4h_gt_35) | (stochrsi_k_1h_lt_40))
             # 1h down move, 1h still high, 4h downtrend
@@ -14320,7 +14327,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1d high, 1d downtrend
             & ((aroonu_14_1d_lt_80) | (roc_9_1d_gt_neg_30))
             # 1d high, 1h & 4h downtrend
-            & ((aroonu_14_1d_lt_85) | (roc_9_1h > -30.0) | (roc_9_4h > -50.0))
+            & ((aroonu_14_1d_lt_85) | (roc_9_1h > -30.0) | (roc_9_4h_gt_neg_50))
             # 1d high, 4h & 1d overbought
             & ((aroonu_14_1d_lt_85) | (roc_9_4h_lt_60) | (roc_9_1d_lt_60))
             # 1d high, 1h & 4h down move
@@ -14373,7 +14380,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 5m down move, 15m still high, 1d downtrend
             & ((rsi_3_gt_5) | (stochrsi_k_15m_lt_50) | (roc_9_1d_gt_neg_20))
             # 5m down move, 1h still high, 4h downtrend
-            & ((rsi_3_gt_5) | (stochrsi_k_1h_lt_50) | (roc_9_4h > -10.0))
+            & ((rsi_3_gt_5) | (stochrsi_k_1h_lt_50) | (roc_9_4h_gt_neg_10))
             # 5m down move, 1h high. 1d downtrend
             & ((rsi_3_gt_5) | (stochrsi_k_1h_lt_80) | (roc_9_1d_gt_neg_30))
             # 5m down move, 15m & 1h high
@@ -14481,13 +14488,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 15m still high, 1d overbought
             & ((rsi_3_15m_gt_20) | (aroonu_14_15m_lt_50) | roc_9_1d_lt_50)
             # 15m down move, 15m high, 4h downtrend
-            & ((rsi_3_15m_gt_20) | (aroonu_14_15m_lt_60) | (roc_9_4h > -40.0))
+            & ((rsi_3_15m_gt_20) | (aroonu_14_15m_lt_60) | (roc_9_4h_gt_neg_40))
             # 15m down move, 15m high, 4h overbought
             & ((rsi_3_15m_gt_20) | (aroonu_14_15m_lt_60) | (roc_9_4h_lt_10))
             # 15m down move, 15m high, 4h overbought
             & ((rsi_3_15m_gt_20) | (aroonu_14_15m_lt_70) | (roc_9_4h_lt_20))
             # 15m down move, 15m high, 4h downtrend
-            & ((rsi_3_15m_gt_20) | (aroonu_14_15m_lt_70) | (roc_9_4h > -10.0))
+            & ((rsi_3_15m_gt_20) | (aroonu_14_15m_lt_70) | (roc_9_4h_gt_neg_10))
             # 15m down move, 15m high, 1d downtrend
             & ((rsi_3_15m_gt_20) | (aroonu_14_15m_lt_70) | (roc_9_1d_gt_neg_20))
             # 15m down move, 15m high, 1d overbought
@@ -14533,7 +14540,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 1h & 4h high
             & ((rsi_3_15m_gt_25) | (aroonu_14_1h_lt_70) | (aroonu_14_4h_lt_70))
             # 15m down move, 1h high, 1d downtrend
-            & ((rsi_3_15m_gt_25) | (aroonu_14_1h_lt_70) | (roc_9_4h > -10.0))
+            & ((rsi_3_15m_gt_25) | (aroonu_14_1h_lt_70) | (roc_9_4h_gt_neg_10))
             # 15m down move, 1h high, 1d overbought
             & ((rsi_3_15m_gt_25) | (aroonu_14_1h_lt_90) | (roc_9_1d_lt_20))
             # 15m down move, 4h high, 1d high
@@ -14629,7 +14636,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 4h high, 1d downtrend
             & ((rsi_3_1h_gt_25) | (stochrsi_k_4h_lt_60) | (roc_9_1d_gt_neg_20))
             # 1h down move, 4h downtrend, 1d overbought
-            & ((rsi_3_1h_gt_25) | (roc_9_4h > -40.0) | roc_9_1d_lt_50)
+            & ((rsi_3_1h_gt_25) | (roc_9_4h_gt_neg_40) | roc_9_1d_lt_50)
             # 1h down move, 15m & 1h still high
             & ((rsi_3_1h_gt_30) | (aroonu_14_15m_lt_40) | (aroonu_14_1h_lt_50))
             # 1h down move, 1h still high 1d overbought
@@ -14669,7 +14676,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 4h high
             & ((rsi_3_1h_gt_40) | (rsi_3_4h_gt_50) | (stochrsi_k_4h_lt_60))
             # 1h down move, 15m still high, 4h downtrend
-            & ((rsi_3_1h_gt_40) | (stochrsi_k_15m_lt_40) | (roc_9_4h > -15.0))
+            & ((rsi_3_1h_gt_40) | (stochrsi_k_15m_lt_40) | (roc_9_4h_gt_neg_15))
             # 1h down move, 15m still high, 1d overbought
             & ((rsi_3_1h_gt_40) | (aroonu_14_15m_lt_50) | roc_9_1d_lt_50)
             # 1h down move, 15m & 4h high
@@ -14749,7 +14756,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 15m still not low enough, 1d downtrend
             & ((rsi_3_4h_gt_10) | (stochrsi_k_15m_lt_30) | (roc_9_1d_gt_neg_40))
             # 4h down move, 15m high, 4h downtrend
-            & ((rsi_3_4h_gt_10) | (stochrsi_k_15m_lt_60) | (roc_9_4h > -50.0))
+            & ((rsi_3_4h_gt_10) | (stochrsi_k_15m_lt_60) | (roc_9_4h_gt_neg_50))
             # 4h down move, 15m high
             & ((rsi_3_4h_gt_10) | (stochrsi_k_15m_lt_70))
             # 4h & 1d down move, 15m high
@@ -14783,11 +14790,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 1d high & overbought
             & (rsi_3_4h_gt_20 | (aroonu_14_1d_lt_90) | (roc_9_1d_lt_10))
             # 4h down move, 15m high, 4h downtrend
-            & (rsi_3_4h_gt_20 | (stochrsi_k_15m_lt_80) | (roc_9_4h > -50.0))
+            & (rsi_3_4h_gt_20 | (stochrsi_k_15m_lt_80) | (roc_9_4h_gt_neg_50))
             # 4h down move, 1h high, 1d downtrend
             & (rsi_3_4h_gt_20 | (stochrsi_k_1h_lt_60) | (roc_9_1d_gt_neg_40))
             # 4h down move, 4h still not low enough, 4h downtrend
-            & (rsi_3_4h_gt_20 | (stochrsi_k_4h_lt_30) | (roc_9_4h > -10.0))
+            & (rsi_3_4h_gt_20 | (stochrsi_k_4h_lt_30) | (roc_9_4h_gt_neg_10))
             # 4h down move, 4h high, 1d downtrend
             & (rsi_3_4h_gt_20 | (stochrsi_k_4h_lt_60) | (roc_9_1d > -60.0))
             # 4h & 1d down move, 1d overbought
@@ -14911,7 +14918,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 4h high & overbought
             & ((rsi_3_4h_gt_65) | aroonu_14_4h_lt_80 | (roc_9_4h_lt_10))
             # 1d down move, 4h & 1d downtrend
-            & ((rsi_3_1d_gt_3) | (roc_9_4h > -40.0) | roc_9_1d_gt_neg_50)
+            & ((rsi_3_1d_gt_3) | (roc_9_4h_gt_neg_40) | roc_9_1d_gt_neg_50)
             # 1d down move, 15m still high, 4h high
             & ((rsi_3_1d_gt_10) | (aroonu_14_15m_lt_70) | (stochrsi_k_4h_lt_80))
             # 1d down move, 4h & 1d downtrend
@@ -14921,7 +14928,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1d down move, 1h high, 1d downtrend
             & ((rsi_3_1d_gt_15) | (aroonu_14_1h_lt_85) | (roc_9_1d_gt_neg_30))
             # 1d down move, 4h & 1d downtrend
-            & ((rsi_3_1d_gt_15) | (roc_9_4h > -10.0) | (roc_9_1d_gt_neg_40))
+            & ((rsi_3_1d_gt_15) | (roc_9_4h_gt_neg_10) | (roc_9_1d_gt_neg_40))
             # 1d down move, 15m high, 1h high
             & ((rsi_3_1d_gt_20) | (aroonu_14_15m_lt_60) | (stochrsi_k_1h_lt_80))
             # 1d down move, 15m high, 1h high
@@ -14991,7 +14998,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1d high, 4h & 1d downtrend
             & ((aroonu_14_1d_lt_80) | (roc_9_4h_gt_neg_20) | (roc_9_1d_gt_neg_20))
             # 1d high, 1h & 4h downtrend
-            & ((aroonu_14_1d_lt_85) | (roc_9_1h > -30.0) | (roc_9_4h > -50.0))
+            & ((aroonu_14_1d_lt_85) | (roc_9_1h > -30.0) | (roc_9_4h_gt_neg_50))
             # 1d high, 4h downtrend
             & ((aroonu_14_1d_lt_85) | (roc_9_4h_gt_neg_30))
             # 1d high, 4h downtrend, 1d overbought
@@ -15100,7 +15107,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 15m stil high
             & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_10) | (stochrsi_k_15m_lt_50))
             # 15m & 1h down move, 4h downtrend
-            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_10) | (roc_9_4h > -40.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_10) | (roc_9_4h_gt_neg_40))
             # 15m & 1h down move, 1h still high
             & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_15) | (stochrsi_k_1h_lt_50))
             # 15m & 1h down move, 4h high
@@ -15128,7 +15135,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 4h high & overbought
             & ((rsi_3_15m_gt_15) | (stochrsi_k_4h_lt_90) | (roc_9_4h_lt_10))
             # 15m down move, 4h & 1d downtrend
-            & ((rsi_3_15m_gt_15) | (roc_9_4h > -10.0) | (roc_9_1d_gt_neg_40))
+            & ((rsi_3_15m_gt_15) | (roc_9_4h_gt_neg_10) | (roc_9_1d_gt_neg_40))
             # 15m & 1h down move, 1h high
             & ((rsi_3_15m_gt_20) | (rsi_3_1h_gt_20) | (aroonu_14_1h_lt_70))
             # 15m down move, 4h high, 1d overbought
@@ -15190,7 +15197,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1d high, 15m downtrend
             & ((rsi_3_1h_gt_10) | (aroonu_14_1d_lt_70) | (roc_9_15m > -50.0))
             # 1h down move, 4h & 1d downtrend
-            & ((rsi_3_1h_gt_10) | (roc_9_4h > -15.0) | (roc_9_1d > -30.0))
+            & ((rsi_3_1h_gt_10) | (roc_9_4h_gt_neg_15) | (roc_9_1d > -30.0))
             # 1h & 4h down move, 4h still high
             & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_15) | (rsi_14_4h < 40.0))
             # 1h & 4h down move, 1h still not low enough
@@ -15208,7 +15215,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1d high & overbought
             & ((rsi_3_1h_gt_15) | (stochrsi_k_1d_lt_90) | (roc_9_1d_lt_40))
             # 1h down move, 1h still high, 4h downtrend
-            & (rsi_3_1h_gt_20 | (aroonu_14_1h_lt_50) | (roc_9_4h > -50.0))
+            & (rsi_3_1h_gt_20 | (aroonu_14_1h_lt_50) | (roc_9_4h_gt_neg_50))
             # 1h down move, 1h high
             & (rsi_3_1h_gt_20 | aroonu_14_1h_lt_80)
             # 1h & 4h down move, 1d overbought
@@ -15232,7 +15239,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h still high, 4h high
             & ((rsi_3_1h_gt_30) | (stochrsi_k_1h_lt_40) | (stochrsi_k_4h_lt_70))
             # 1h down move, 4h & 1d downtrend
-            & ((rsi_3_1h_gt_30) | (roc_9_4h > -25.0) | (roc_9_1d > -60.0))
+            & ((rsi_3_1h_gt_30) | (roc_9_4h_gt_neg_25) | (roc_9_1d > -60.0))
             # 1h down move, 4h & 1d overbought
             & ((rsi_3_1h_gt_30) | (roc_9_4h_lt_20) | (roc_9_1d_lt_100))
             # 1h down move, 1h high, 1d overbought
@@ -15258,13 +15265,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h & 1d down move, 4h still not low enough
             & ((rsi_3_4h_gt_3) | (rsi_3_1d_gt_15) | (aroonu_14_4h < 20.0))
             # 4h down move, 4h high, 4h downtrend
-            & ((rsi_3_4h_gt_3) | (aroonu_14_4h_lt_50) | (roc_9_4h > -40.0))
+            & ((rsi_3_4h_gt_3) | (aroonu_14_4h_lt_50) | (roc_9_4h_gt_neg_40))
             # 4h & 1d down move, 1h still not low enough
             & ((rsi_3_4h_gt_5) | (rsi_3_1d_gt_10) | (stochrsi_k_1h_lt_30))
             # 4h & 1d down move, 1d high
             & ((rsi_3_4h_gt_5) | (rsi_3_1d_gt_45) | (aroonu_14_1d_lt_70))
             # 4h down move, 4h & 1d downtrend
-            & ((rsi_3_4h_gt_5) | (roc_9_4h > -15.0) | (roc_9_1d_gt_neg_20))
+            & ((rsi_3_4h_gt_5) | (roc_9_4h_gt_neg_15) | (roc_9_1d_gt_neg_20))
             # 4h & 1d down move, 1h still high
             & ((rsi_3_4h_gt_10) | (rsi_3_1d_gt_10) | (aroonu_14_1h_lt_40))
             # 4h & 1d down move, 1h high
@@ -15306,7 +15313,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 1d high, 1h overbought
             & (aroonu_14_1h_lt_80 | (aroonu_14_1d_lt_90) | (roc_9_1h_lt_30))
             # 4h still not low enough, 4h & 1d downtrend
-            & ((aroonu_14_4h_lt_30) | (roc_9_4h > -40.0) | (roc_9_1d_gt_neg_40))
+            & ((aroonu_14_4h_lt_30) | (roc_9_4h_gt_neg_40) | (roc_9_1d_gt_neg_40))
             # 4h still high, 5m downtrend
             & ((aroonu_14_4h_lt_40) | (roc_9 > -40.0))
             # 4h high, 4h & 1d overbought
@@ -15318,7 +15325,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h high, 1h & 4h high
             & (aroonu_14_4h_lt_100 | (roc_9_1h_lt_50) | (roc_9_4h_lt_100))
             # 1d high, 4h & 1d downtrend
-            & ((aroonu_14_1d_lt_70) | (roc_9_4h > -40.0) | (roc_9_1d_gt_neg_40))
+            & ((aroonu_14_1d_lt_70) | (roc_9_4h_gt_neg_40) | (roc_9_1d_gt_neg_40))
             # 1d high, 1h & 1d overbought
             & ((aroonu_14_1d_lt_80) | (roc_9_1h_lt_30) | (roc_9_1d_lt_200))
             # 1d high, 4h & 1d overbought
@@ -15411,7 +15418,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 1d overbought
             & ((rsi_3_1h_gt_3) | (rsi_3_4h_gt_10) | (roc_9_1d_lt_15))
             # 1h & 4h down move, 4h downtrend
-            & ((rsi_3_1h_gt_3) | (rsi_3_4h_gt_15) | (roc_9_4h > -40.0))
+            & ((rsi_3_1h_gt_3) | (rsi_3_4h_gt_15) | (roc_9_4h_gt_neg_40))
             # 1h & 4h down move, 1d downtrend
             & ((rsi_3_1h_gt_3) | (rsi_3_4h_gt_25) | roc_9_1d_gt_neg_50)
             # 1h & 1d down move, 1d high
@@ -15439,7 +15446,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 15m still high, 4h high
             & ((rsi_3_1h_gt_10) | (aroonu_14_15m_lt_40) | (stochrsi_k_4h_lt_90))
             # 1h down move, 15m high, 4h downtrend
-            & ((rsi_3_1h_gt_10) | (aroonu_14_15m_lt_70) | (roc_9_4h > -10.0))
+            & ((rsi_3_1h_gt_10) | (aroonu_14_15m_lt_70) | (roc_9_4h_gt_neg_10))
             # 1h down move, 1h still high, 15m downtrend
             & ((rsi_3_1h_gt_10) | (aroonu_14_1h_lt_40) | (cmf_20_15m > -0.30))
             # 1h down move, 1d high, 4h overbought
@@ -15565,7 +15572,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h & 1d down move, 1h still not low enough
             & ((rsi_3_4h_gt_5) | (rsi_3_1d_gt_10) | (stochrsi_k_1h_lt_30))
             # 4h down move, 1d high, 4h downtrend
-            & ((rsi_3_4h_gt_5) | (aroonu_14_1d_lt_80) | (roc_9_4h > -10.0))
+            & ((rsi_3_4h_gt_5) | (aroonu_14_1d_lt_80) | (roc_9_4h_gt_neg_10))
             # 4h & 1d down move, 15m high
             & ((rsi_3_4h_gt_10) | (rsi_3_1d_gt_15) | (stochrsi_k_15m_lt_80))
             # 4h & 1d down move, 1d downtrend
@@ -15585,7 +15592,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 4h downtrend, 1d overbought
             & ((rsi_3_4h_gt_10) | (roc_9_4h > -20.0) | (roc_9_1d_lt_40))
             # 4h & 1d down move, 4h downtrend
-            & ((rsi_3_4h_gt_15) | (rsi_3_1d_gt_20) | (roc_9_4h > -40.0))
+            & ((rsi_3_4h_gt_15) | (rsi_3_1d_gt_20) | (roc_9_4h_gt_neg_40))
             # 4h down move, 1h high, 1d downtrend
             & ((rsi_3_4h_gt_15) | (aroonu_14_1h_lt_90) | (roc_9_1d > -10.0))
             # 4h down move, 4h still high, 1d downtrend
@@ -15605,7 +15612,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 4h high, 1d downtrend
             & ((rsi_3_4h_gt_25) | (stochrsi_k_4h_lt_60) | (roc_9_1d > -70.0))
             # 4h down move, 1h high, 4h downtrend
-            & ((rsi_3_4h_gt_30) | aroonu_14_1h_lt_70 | (roc_9_4h > -10.0))
+            & ((rsi_3_4h_gt_30) | aroonu_14_1h_lt_70 | (roc_9_4h_gt_neg_10))
             # 4h down move, 1h high, 1d downtrend
             & ((rsi_3_4h_gt_30) | (stochrsi_k_1h_lt_60) | (roc_9_1d_gt_neg_40))
             # 4h down move, 4h & 1d high
@@ -15625,7 +15632,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1d downtrend, 1d high & overbought
             & ((cmf_20_1d > -0.40) | (aroonu_14_1d_lt_85) | (roc_9_1d_lt_20))
             # 15m not low enough, 1h & 4h downtrend
-            & ((aroonu_14_15m_lt_20) | (roc_9_1h > -30.0) | (roc_9_4h > -50.0))
+            & ((aroonu_14_15m_lt_20) | (roc_9_1h > -30.0) | (roc_9_4h_gt_neg_50))
             # 15m high, 1h high & overbought
             & ((aroonu_14_15m_lt_70) | (aroonu_14_1h_lt_85) | (roc_9_1h_lt_10))
             # 4h high, 4h & 1d overbought
@@ -16016,7 +16023,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 1d high, 1d overbought
             & ((rsi_3_15m_gt_20) | aroonu_14_1d_lt_100 | (roc_9_1d_lt_20))
             # 15m down move, 15m high, 4h downtrend
-            & ((rsi_3_15m_gt_20) | (stochrsi_k_15m_lt_60) | (roc_9_4h > -50.0))
+            & ((rsi_3_15m_gt_20) | (stochrsi_k_15m_lt_60) | (roc_9_4h_gt_neg_50))
             # 15 down move, 1h high, 1d overbought
             & ((rsi_3_15m_gt_20) | (stochrsi_k_1h_lt_70) | (roc_9_1d_lt_10))
             # 15m down move, 4h high, 15m downtrend
@@ -16158,7 +16165,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1d high, 4h downtrend
             & (rsi_3_1h_gt_20 | (stochrsi_k_1d_lt_80) | (roc_9_4h_gt_neg_20))
             # 1h down move, 4h downtrend, 1d overbought
-            & (rsi_3_1h_gt_20 | (roc_9_4h > -10.0) | (roc_9_1d_lt_20))
+            & (rsi_3_1h_gt_20 | (roc_9_4h_gt_neg_10) | (roc_9_1d_lt_20))
             # 1h & 4h down move, 1h still high
             & ((rsi_3_1h_gt_25) | (rsi_3_4h_gt_10) | (stochrsi_k_1h_lt_40))
             # 1h & 4h down move, 15m high
@@ -16194,7 +16201,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1d high & overbought
             & ((rsi_3_1h_gt_30) | (stochrsi_k_1d_lt_90) | (roc_9_1d_lt_20))
             # 1h down move, 4h & 1d downtrend
-            & ((rsi_3_1h_gt_30) | (roc_9_4h > -25.0) | (roc_9_1d > -60.0))
+            & ((rsi_3_1h_gt_30) | (roc_9_4h_gt_neg_25) | (roc_9_1d > -60.0))
             # 1h & 1d down move, 1h high
             & ((rsi_3_1h_gt_35) | (rsi_3_1d_gt_35) | (aroonu_14_1h_lt_75))
             # 1h down move, 1h & 4h high
@@ -16264,9 +16271,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h high, 1d overbought
             & ((rsi_3_1h_gt_65) | (stochrsi_k_1h_lt_90) | (roc_9_1d_lt_20))
             # 4h down move, 1h still not low enough, 4h downtrend
-            & ((rsi_3_4h_gt_3) | (aroonu_14_1h_lt_20) | (roc_9_4h > -10.0))
+            & ((rsi_3_4h_gt_3) | (aroonu_14_1h_lt_20) | (roc_9_4h_gt_neg_10))
             # 4h down move, 4h & 1d downtrend
-            & ((rsi_3_4h_gt_3) | (roc_9_4h > -10.0) | (roc_9_1d > -10.0))
+            & ((rsi_3_4h_gt_3) | (roc_9_4h_gt_neg_10) | (roc_9_1d > -10.0))
             # 4h & 1d down move, 15m still high
             & ((rsi_3_4h_gt_5) | (rsi_3_1d_gt_25) | (stochrsi_k_15m_lt_40))
             # 4h & 1d down move, 1h still not low enough
@@ -16316,7 +16323,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 1h high, 1h downtrend
             & ((rsi_3_4h_gt_30) | aroonu_14_1h_lt_70 | (roc_9_1h > -10.0))
             # 4h down move, 1h high, 4h downtrend
-            & ((rsi_3_4h_gt_30) | aroonu_14_1h_lt_70 | (roc_9_4h > -10.0))
+            & ((rsi_3_4h_gt_30) | aroonu_14_1h_lt_70 | (roc_9_4h_gt_neg_10))
             # 4h down move, 1h still high, 1d overbought
             & ((rsi_3_4h_gt_30) | (stochrsi_k_1h_lt_40) | (roc_9_1d_lt_30))
             # 4h & 1d down move, 1d overbought
@@ -16418,7 +16425,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1d high, 1d downtrend
             & ((aroonu_14_1d_lt_80) | (roc_9_1d_gt_neg_30))
             # 1d high, 1h & 4h downtrend
-            & ((aroonu_14_1d_lt_85) | (roc_9_1h > -30.0) | (roc_9_4h > -50.0))
+            & ((aroonu_14_1d_lt_85) | (roc_9_1h > -30.0) | (roc_9_4h_gt_neg_50))
             # 1d high, 1h & 1d overbought
             & ((aroonu_14_1d_lt_90) | (roc_9_1h_lt_10) | roc_9_1d_lt_50)
             # 1d high, 4h & 1d overbought
@@ -16430,7 +16437,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h high, 1d overbought
             & ((stochrsi_k_1h_lt_70) | (roc_9_1d_lt_40))
             # 1h high, 1h overbought, 4h downtrend
-            & ((stochrsi_k_1h_lt_80) | (roc_9_1h_lt_10) | (roc_9_4h > -10.0))
+            & ((stochrsi_k_1h_lt_80) | (roc_9_1h_lt_10) | (roc_9_4h_gt_neg_10))
             # 1h high, 4h & 1d downtrend
             & ((stochrsi_k_1h_lt_80) | (roc_9_4h_gt_neg_20) | (roc_9_1d > -80.0))
             # 1h down move, 1h & 1d overbought
@@ -16881,7 +16888,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 1h downtrend, 4h overbought
             & ((rsi_3_15m_gt_15) | (roc_9_1h > -20.0) | (roc_9_4h_lt_80))
             # 15m down move, 4h & 1d downtrend
-            & ((rsi_3_15m_gt_15) | (roc_9_4h > -10.0) | (roc_9_1d_gt_neg_40))
+            & ((rsi_3_15m_gt_15) | (roc_9_4h_gt_neg_10) | (roc_9_1d_gt_neg_40))
             # 15m & 1h down move, 1h high
             & ((rsi_3_15m_gt_20) | (rsi_3_1h_gt_20) | (aroonu_14_1h_lt_70))
             # 15m & 1h down move, 1d overbought
@@ -16897,7 +16904,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 15m high, 1d overbought
             & ((rsi_3_15m_gt_20) | (aroonu_14_15m_lt_70) | (roc_9_1d_lt_40))
             # 15m down move, 1h high, 4h downtrend
-            & ((rsi_3_15m_gt_20) | aroonu_14_1h_lt_80 | (roc_9_4h > -15.0))
+            & ((rsi_3_15m_gt_20) | aroonu_14_1h_lt_80 | (roc_9_4h_gt_neg_15))
             # 15m down move, 1h high & overbought
             & ((rsi_3_15m_gt_20) | (aroonu_14_1h_lt_100) | (roc_9_1h_lt_50))
             # 15m down move, 4h high & overbought
@@ -16969,7 +16976,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 4h still high, 1d downtrend
             & ((rsi_3_1h_gt_5) | (stochrsi_k_4h_lt_50) | (roc_9_1d_gt_neg_50))
             # 1h down move, 4h & 1d downtrend
-            & ((rsi_3_1h_gt_5) | (roc_9_4h > -25.0) | (roc_9_1d_gt_neg_50))
+            & ((rsi_3_1h_gt_5) | (roc_9_4h_gt_neg_25) | (roc_9_1d_gt_neg_50))
             # 1h & 4h & 1d down move
             & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_10) | (rsi_3_1d_gt_15))
             # 1h & 4h down move, 1h high
@@ -16981,7 +16988,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 1d still not low enough
             & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_10) | (stochrsi_k_1d_lt_20))
             # 1h & 4h down move, 4h downtrend
-            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_10) | (roc_9_4h > -35.0))
+            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_10) | (roc_9_4h_gt_neg_35))
             # 1h & 4h down move, 1d downtrend
             & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_10) | (roc_9_1d > -20.0))
             # 1h & 4h down move, 15m downtrend
@@ -17021,7 +17028,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 1h downtrend
             & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_15) | (roc_9_1h > -15.0))
             # 1h & 4h down move, 4h downtrend
-            & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_15) | (roc_9_4h > -25.0))
+            & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_15) | (roc_9_4h_gt_neg_25))
             # 1h & 4h down move, 1d downtrend
             & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_15) | (roc_9_1d > -70.0))
             # 1h & 4h down move, 4h still high
@@ -17061,7 +17068,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h downtrend, 1d overbought
             & ((rsi_3_1h_gt_15) | (roc_9_1h > -30.0) | (roc_9_1d_lt_35))
             # 1h down move, 4h downtrend, 1d overbought
-            & ((rsi_3_1h_gt_15) | (roc_9_4h > -25.0) | (roc_9_1d_lt_100))
+            & ((rsi_3_1h_gt_15) | (roc_9_4h_gt_neg_25) | (roc_9_1d_lt_100))
             # 1h & 4h down move, 1d high
             & (rsi_3_1h_gt_20 | rsi_3_4h_gt_20 | (aroonu_14_1d_lt_80))
             # 1h & 4h down move, 4h high
@@ -17137,7 +17144,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 15m & 1h high
             & ((rsi_3_1h_gt_35) | (aroonu_14_15m_lt_70) | (aroonu_14_1h_lt_100))
             # 1h down move, 1h high, 4h downtrend
-            & ((rsi_3_1h_gt_35) | aroonu_14_1h_lt_70 | (roc_9_4h > -40.0))
+            & ((rsi_3_1h_gt_35) | aroonu_14_1h_lt_70 | (roc_9_4h_gt_neg_40))
             # 1h down move, 1h & 4h high
             & ((rsi_3_1h_gt_35) | aroonu_14_1h_lt_80 | aroonu_14_4h_lt_100)
             # 1h down move, 1h high, 1d downtrend
@@ -17203,7 +17210,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 1d high & overbought
             & ((rsi_3_4h_gt_10) | (stochrsi_k_1d_lt_70) | (roc_9_1d_lt_35))
             # 4h down move, 4h & 1d downtrend
-            & ((rsi_3_4h_gt_10) | (roc_9_4h > -15.0) | (roc_9_1d > -35.0))
+            & ((rsi_3_4h_gt_10) | (roc_9_4h_gt_neg_15) | (roc_9_1d > -35.0))
             # 4h down move, 4h still high, 1d overbought
             & ((rsi_3_4h_gt_15) | (aroonu_14_4h_lt_40) | (roc_9_1d_lt_40))
             # 4h down move, 1h still not low enough, 1d downtrend
@@ -17277,7 +17284,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h high, 1h & 1d overbought
             & (aroonu_14_1h_lt_70 | (roc_9_1h_lt_20) | (roc_9_1d_lt_200))
             # 1h high, 4h downtrend, 1d overbought
-            & (aroonu_14_1h_lt_70 | (roc_9_4h > -40.0) | (roc_9_1d_lt_100))
+            & (aroonu_14_1h_lt_70 | (roc_9_4h_gt_neg_40) | (roc_9_1d_lt_100))
             # 1h high, 1h & 1d overbought
             & (aroonu_14_1h_lt_80 | (roc_9_1h_lt_20) | (roc_9_1d_lt_20))
             # 1h high, 1h overbought, 1d downtrend
@@ -17301,11 +17308,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h & 1d high, 1h overbought
             & (aroonu_14_4h_lt_100 | aroonu_14_1d_lt_100 | (roc_9_1h_lt_50))
             # 1d still high, 4h & 1d downtrend
-            & ((aroonu_14_1d_lt_50) | (roc_9_4h > -50.0) | roc_9_1d_gt_neg_50)
+            & ((aroonu_14_1d_lt_50) | (roc_9_4h_gt_neg_50) | roc_9_1d_gt_neg_50)
             # 1d high, 1h & 4h downtrend
-            & ((aroonu_14_1d_lt_85) | (roc_9_1h > -30.0) | (roc_9_4h > -50.0))
+            & ((aroonu_14_1d_lt_85) | (roc_9_1h > -30.0) | (roc_9_4h_gt_neg_50))
             # 1d high, 4h downtrend, 1d overbought
-            & ((aroonu_14_1d_lt_85) | (roc_9_4h > -25.0) | roc_9_1d_lt_50)
+            & ((aroonu_14_1d_lt_85) | (roc_9_4h_gt_neg_25) | roc_9_1d_lt_50)
             # 1d high, 4h & 1d overbought
             & ((aroonu_14_1d_lt_90) | (roc_9_4h_lt_10) | roc_9_1d_lt_50)
             # 1h high, 1d overbought
@@ -17313,7 +17320,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h high, 4h overbought
             & ((stochrsi_k_1h_lt_80) | (roc_9_4h_lt_80))
             # 1h high, 1h overbought, 4h downtrend
-            & ((stochrsi_k_1h_lt_90) | (roc_9_1h_lt_10) | (roc_9_4h > -15.0))
+            & ((stochrsi_k_1h_lt_90) | (roc_9_1h_lt_10) | (roc_9_4h_gt_neg_15))
             # 4h high, 1h & 4h overbought
             & ((stochrsi_k_4h_lt_90) | (roc_9_1h_lt_20) | (roc_9_4h_lt_50))
             # 1d high, 4h & 1d overbought
@@ -17651,7 +17658,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 4h high & overbought
             & ((rsi_3_1h_gt_35) | (stochrsi_k_4h_lt_90) | (roc_9_4h_lt_10))
             # 1h down move, 4h & 1d downtrend
-            & ((rsi_3_1h_gt_35) | (roc_9_4h > -10.0) | (roc_9_1d > -60.0))
+            & ((rsi_3_1h_gt_35) | (roc_9_4h_gt_neg_10) | (roc_9_1d > -60.0))
             # 1h down move, 4h high & overbought
             & ((rsi_3_1h_gt_40) | (aroonu_14_4h_lt_90) | (roc_9_4h_lt_20))
             # 1h down move, 4h high, 1d downtrend
@@ -17673,7 +17680,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 1h downtrend, 4h still high
             & ((rsi_3_4h_gt_3) | (cmf_20_1h > -0.30) | (aroonu_14_4h_lt_40))
             # 4h & 1d down move, 4h downtrend
-            & ((rsi_3_4h_gt_5) | (rsi_3_1d_gt_15) | (roc_9_4h > -10.0))
+            & ((rsi_3_4h_gt_5) | (rsi_3_1d_gt_15) | (roc_9_4h_gt_neg_10))
             # 4h & 1d down move, 1d downtrend
             & ((rsi_3_4h_gt_5) | (rsi_3_1d_gt_15) | (roc_9_1d_gt_neg_20))
             # 4h & 1d down move, 1d still high
@@ -17695,7 +17702,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1d down move, 15m still high
             & ((rsi_3_4h_gt_10) | (rsi_3_1d_gt_15) | (stochrsi_k_15m_lt_50))
             # 4h & 1d down move, 4d & 1d downtrend
-            & ((rsi_3_4h_gt_10) | (rsi_3_1d_gt_30) | (roc_9_4h > -10.0) | (roc_9_1d > -20.0))
+            & ((rsi_3_4h_gt_10) | (rsi_3_1d_gt_30) | (roc_9_4h_gt_neg_10) | (roc_9_1d > -20.0))
             # 4h & 1d down move, 4h downtrend
             & ((rsi_3_4h_gt_10) | (rsi_3_1d_gt_30) | (roc_9_4h > -20.0))
             # 4h & 1d down move, 1d overbought
@@ -17737,7 +17744,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 4h still high, 1d downtrend
             & ((rsi_3_4h_gt_15) | (aroonu_14_4h_lt_50) | (roc_9_1d > -20.0))
             # 4h down move, 1h & 4h downtrend
-            & ((rsi_3_4h_gt_15) | (roc_9_1h > -40.0) | (roc_9_4h > -40.0))
+            & ((rsi_3_4h_gt_15) | (roc_9_1h > -40.0) | (roc_9_4h_gt_neg_40))
             # 4h & 1d down move, 1d high
             & (rsi_3_4h_gt_20 | (rsi_3_1d_gt_20) | (stochrsi_k_1d_lt_80))
             # 4h & 1d down move, 15m high
@@ -17751,7 +17758,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 1d high & overbought
             & (rsi_3_4h_gt_20 | (aroonu_14_1d_lt_70) | (roc_9_1d_lt_70))
             # 4h down move, 1d high, 4h downtrend
-            & (rsi_3_4h_gt_20 | (aroonu_14_1d_lt_90) | (roc_9_4h > -50.0))
+            & (rsi_3_4h_gt_20 | (aroonu_14_1d_lt_90) | (roc_9_4h_gt_neg_50))
             # 4h down move, 1d high & overbought
             & (rsi_3_4h_gt_20 | (aroonu_14_1d_lt_90) | (roc_9_1d_lt_40))
             # 4h down move, 15m high
@@ -17781,7 +17788,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 1d overbought
             & ((rsi_3_4h_gt_25) | (roc_9_1d_lt_100))
             # 4h down move, 1h high, 4h downtrend
-            & ((rsi_3_4h_gt_30) | (aroonu_14_1h_lt_60) | (roc_9_4h > -10.0))
+            & ((rsi_3_4h_gt_30) | (aroonu_14_1h_lt_60) | (roc_9_4h_gt_neg_10))
             # 4h down move, 4h still high, 1d high
             & ((rsi_3_4h_gt_30) | (aroonu_14_4h_lt_50) | aroonu_14_1d_lt_100)
             # 4h down move, 4h high, 1h downtrend
@@ -17823,11 +17830,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1d down move, 1d still high
             & ((rsi_3_1d_gt_15) | (stochrsi_k_1d_lt_40))
             # 1d down move, 4h & 1d downtrend
-            & ((rsi_3_1d_gt_15) | (roc_9_4h > -10.0) | (roc_9_1d_gt_neg_40))
+            & ((rsi_3_1d_gt_15) | (roc_9_4h_gt_neg_10) | (roc_9_1d_gt_neg_40))
             # 1d down move, 15m high
             & ((rsi_3_1d_gt_20) | (aroonu_14_15m_lt_80))
             # 1d down move, 4h high, 4h downtrend
-            & ((rsi_3_1d_gt_20) | (aroonu_14_4h_lt_50) | (roc_9_4h > -40.0))
+            & ((rsi_3_1d_gt_20) | (aroonu_14_4h_lt_50) | (roc_9_4h_gt_neg_40))
             # 1d down move, 1d high, 1d downtrend
             & ((rsi_3_1d_gt_25) | (aroonu_14_1d_lt_80) | (roc_9_1d_gt_neg_30))
             # 1d down move, 1d still high, 1d downtrend
@@ -17976,7 +17983,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 1h downtrend, 4h overbought
             & ((rsi_3_15m_gt_3) | (roc_9_1h > -30.0) | (roc_9_4h_lt_100))
             # 15m down move, 4h & 1d downtrend
-            & ((rsi_3_15m_gt_3) | (roc_9_4h > -70.0) | (roc_9_1d > -70.0))
+            & ((rsi_3_15m_gt_3) | (roc_9_4h_gt_neg_70) | (roc_9_1d > -70.0))
             # 15m & 1h down move, 4h still high
             & ((rsi_3_15m_gt_5) | (rsi_3_1h_gt_5) | (rsi_14_4h < 40.0))
             # 15m & 1h down move, 1h still not low enough
@@ -18072,7 +18079,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 15m high, 1h high
             & ((rsi_3_15m_gt_10) | (aroonu_14_15m_lt_60) | aroonu_14_1h_lt_80)
             # 15m down move, 15m high, 4h downtrend
-            & ((rsi_3_15m_gt_10) | (aroonu_14_15m_lt_60) | (roc_9_4h > -10.0))
+            & ((rsi_3_15m_gt_10) | (aroonu_14_15m_lt_60) | (roc_9_4h_gt_neg_10))
             # 15m down move, 1h & 4h high
             & ((rsi_3_15m_gt_10) | (aroonu_14_1h_lt_90) | aroonu_14_4h_lt_100)
             # 15m down move, 1h high, 1d downtrend
@@ -18118,7 +18125,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 1d high & overbought
             & ((rsi_3_15m_gt_15) | (stochrsi_k_1d_lt_90) | (roc_9_1d_lt_100))
             # 15m down move, 4h & 1d downtrend
-            & ((rsi_3_15m_gt_15) | (roc_9_4h > -10.0) | (roc_9_1d_gt_neg_40))
+            & ((rsi_3_15m_gt_15) | (roc_9_4h_gt_neg_10) | (roc_9_1d_gt_neg_40))
             # 15m & 1h down move, 4h high
             & ((rsi_3_15m_gt_20) | rsi_3_1h_gt_20 | (stochrsi_k_4h_lt_80))
             # 15m & 1h down move, 1d overbought
@@ -18222,7 +18229,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h high & overbought
             & (rsi_3_1h_gt_20 | aroonu_14_1d_lt_100 | (roc_9_1d_lt_100))
             # 1h down move, 4h downtrend, 1d overbought
-            & (rsi_3_1h_gt_20 | (roc_9_4h > -40.0) | roc_9_1d_lt_50)
+            & (rsi_3_1h_gt_20 | (roc_9_4h_gt_neg_40) | roc_9_1d_lt_50)
             # 1h & 4h down move, 1d high
             & ((rsi_3_1h_gt_25) | (rsi_3_4h_gt_30) | (aroonu_14_1d_lt_80))
             # 1h & 4h down move, 1d overbought
@@ -18242,7 +18249,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 4h & 1d high
             & ((rsi_3_1h_gt_25) | (aroonu_14_4h_lt_90) | (aroonu_14_1d_lt_100))
             # 1h down move, 1d high, 4h downtrend
-            & ((rsi_3_1h_gt_25) | (aroonu_14_1d_lt_80) | (roc_9_4h > -70.0))
+            & ((rsi_3_1h_gt_25) | (aroonu_14_1d_lt_80) | (roc_9_4h_gt_neg_70))
             # 1h down move, 4h high, 1d downtrend
             & ((rsi_3_1h_gt_25) | (stochrsi_k_4h_lt_80) | (roc_9_1d_gt_neg_30))
             # 1h down move, 4h & 1d downtrend
@@ -18258,7 +18265,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 4h high & overbought
             & ((rsi_3_1h_gt_30) | (aroonu_14_4h_lt_80) | (roc_9_4h_lt_30))
             # 1h down move, 1d high, 4h downtrend
-            & ((rsi_3_1h_gt_30) | (aroonu_14_1d_lt_90) | (roc_9_4h > -40.0))
+            & ((rsi_3_1h_gt_30) | (aroonu_14_1d_lt_90) | (roc_9_4h_gt_neg_40))
             # 1h down move, 1d high, 4h overbought
             & ((rsi_3_1h_gt_30) | (aroonu_14_1d_lt_100) | (roc_9_4h_lt_30))
             # 1h down move, 4h & 1d overbought
@@ -18302,7 +18309,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h & 1d down move, 1d still high
             & ((rsi_3_4h_gt_5) | (rsi_3_1d_gt_30) | (stochrsi_k_1d_lt_40))
             # 4h down move, 1h & 4h downtrend
-            & ((rsi_3_4h_gt_5) | (roc_9_1h > -10.0) | (roc_9_4h > -10.0))
+            & ((rsi_3_4h_gt_5) | (roc_9_1h > -10.0) | (roc_9_4h_gt_neg_10))
             # 4h & 1d down move, 4h downtrend
             & ((rsi_3_4h_gt_10) | (rsi_3_1d_gt_10) | (roc_9_4h > -20.0))
             # 4h & 1d down move, 1d downtrend
@@ -18356,7 +18363,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 1d high, 1d overbought
             & (aroonu_14_1h_lt_70 | (aroonu_14_1d_lt_90) | (roc_9_1d_lt_200))
             # 1h high, 4h downtrend, 1d overbought
-            & (aroonu_14_1h_lt_70 | (roc_9_4h > -40.0) | (roc_9_1d_lt_100))
+            & (aroonu_14_1h_lt_70 | (roc_9_4h_gt_neg_40) | (roc_9_1d_lt_100))
             # 1h & 4h high, 4h overbought
             & (aroonu_14_1h_lt_80 | aroonu_14_4h_lt_100 | (roc_9_4h_lt_30))
             # 1h high, 1d downtrend
@@ -18386,7 +18393,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h high, 4h overbought
             & ((stochrsi_k_1h_lt_80) | (roc_9_4h_lt_80))
             # 1h high, 4h & 1d downtrend
-            & ((stochrsi_k_1h < 85.0) | (roc_9_4h > -70.0) | (roc_9_1d > -70.0))
+            & ((stochrsi_k_1h < 85.0) | (roc_9_4h_gt_neg_70) | (roc_9_1d > -70.0))
             # 4h high, 1h & 4h overbought
             & ((stochrsi_k_4h_lt_80) | (roc_9_1h_lt_40) | (roc_9_4h_lt_100))
             # 1d high, 4h & 1d overbought
@@ -18467,7 +18474,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 4h down move, 4h high
             & ((rsi_3_15m_gt_15) | (rsi_3_4h_gt_45) | (aroonu_14_4h_lt_90))
             # 15m down move, 4h & 1d downtrend
-            & ((rsi_3_15m_gt_15) | (roc_9_4h > -10.0) | (roc_9_1d_gt_neg_40))
+            & ((rsi_3_15m_gt_15) | (roc_9_4h_gt_neg_10) | (roc_9_1d_gt_neg_40))
             # 15m down move, 1h high & overbought
             & ((rsi_3_15m_gt_25) | (aroonu_14_1d_lt_90) | (roc_9_1d_lt_100))
             # 1h & 4h down move, 1h still not low enough
@@ -18575,7 +18582,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h high, 1d overbought
             & ((rsi_3_1h_gt_15) | (aroonu_14_1h_lt_60) | roc_9_1d_lt_50)
             # 1h down move, 1h high, 4h downtrend
-            & ((rsi_3_1h_gt_15) | (aroonu_14_1h_lt_70) | (roc_9_4h > -10.0))
+            & ((rsi_3_1h_gt_15) | (aroonu_14_1h_lt_70) | (roc_9_4h_gt_neg_10))
             # 1h down move, 4h high & overbought
             & ((rsi_3_1h_gt_15) | (aroonu_14_4h_lt_80) | (roc_9_4h_lt_100))
             # 1h down move, 1d high & overbought
@@ -18625,7 +18632,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 1h & 4h downtrend
             & ((rsi_3_4h_gt_5) | (roc_9_1h > -15.0) | (roc_9_4h_gt_neg_20))
             # 4h down move, 4h downtrend
-            & ((rsi_3_4h_gt_5) | (roc_9_4h > -40.0))
+            & ((rsi_3_4h_gt_5) | (roc_9_4h_gt_neg_40))
             # 4h & 1d down move, 1d high
             & ((rsi_3_4h_gt_10) | (rsi_3_1d_gt_20) | (aroonu_14_1d_lt_80))
             # 4h down move, 1d high, 4h downtrend
@@ -18669,7 +18676,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h high, 4h & 1d downtrend
             & (aroonu_14_1h_lt_70 | (roc_9_4h > -20.0) | roc_9_1d_gt_neg_50)
             # 1h high, 4h downtrend
-            & (aroonu_14_1h_lt_70 | (roc_9_4h > -40.0))
+            & (aroonu_14_1h_lt_70 | (roc_9_4h_gt_neg_40))
             # 1h & 1d high, 1d overbought
             & (aroonu_14_1h_lt_80 | (aroonu_14_1d_lt_90) | (roc_9_1d_lt_80))
             # 1h & 1d high, 1h downtrend
@@ -18691,9 +18698,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1d high, 1h downtrend
             & ((aroonu_14_1d_lt_70) | (roc_9_1h > -70.0))
             # 1d high, 4h downtrend
-            & ((aroonu_14_1d_lt_80) | (roc_9_4h > -70.0))
+            & ((aroonu_14_1d_lt_80) | (roc_9_4h_gt_neg_70))
             # 1d high, 4h downtrend
-            & ((aroonu_14_1d_lt_90) | (roc_9_4h > -40.0))
+            & ((aroonu_14_1d_lt_90) | (roc_9_4h_gt_neg_40))
             # 1d high & overbought
             & ((aroonu_14_1d_lt_90) | (roc_9_1d_lt_200))
             # 1d high, 4h & 1d overbought
@@ -19346,7 +19353,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 1d high
             & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_10) | (stochrsi_k_1d_lt_70))
             # 15m & 1h down move, 4h downtrend
-            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_10) | (roc_9_4h > -50.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_10) | (roc_9_4h_gt_neg_50))
             # 15m & 1h down move, 1d overbought
             & ((rsi_3_15m_gt_10) | rsi_3_1h_gt_20 | (roc_9_1d_lt_80))
             # 15m & 1h down move, 15m still high
@@ -19392,7 +19399,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 1h & 4h overbought
             & ((rsi_3_15m_gt_15) | (roc_9_1h_lt_20) | (roc_9_4h_lt_40))
             # 15m down move, 4h & 1d downtrend
-            & ((rsi_3_15m_gt_15) | (roc_9_4h > -10.0) | (roc_9_1d_gt_neg_40))
+            & ((rsi_3_15m_gt_15) | (roc_9_4h_gt_neg_10) | (roc_9_1d_gt_neg_40))
             # 15m down move, 4h & 1d overbought
             & ((rsi_3_15m_gt_15) | (roc_9_4h_lt_20) | (roc_9_1d_lt_60))
             # 15m & 1h down move, 15m high
@@ -19446,7 +19453,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 15m downtrend
             & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_10) | (roc_9_15m > -15.0))
             # 1h & 3h down move, 4h downtrend
-            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_10) | (roc_9_4h > -50.0))
+            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_10) | (roc_9_4h_gt_neg_50))
             # 1h & 4h down move, 4h still high
             & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_15) | (rsi_14_4h < 40.0))
             # 1h & 4h down move, 1d overbought
@@ -19458,7 +19465,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 4h still high, 4d downtrend
             & ((rsi_3_1h_gt_10) | (stochrsi_k_4h_lt_50) | roc_9_1d_gt_neg_50)
             # 1h down move, 4h downtrend, 1d overbought
-            & ((rsi_3_1h_gt_10) | (roc_9_4h > -10.0) | (roc_9_1d_lt_40))
+            & ((rsi_3_1h_gt_10) | (roc_9_4h_gt_neg_10) | (roc_9_1d_lt_40))
             # 1h down move, 1d overbought
             & ((rsi_3_1h_gt_10) | (roc_9_1d_lt_100))
             # 1h & 4h down move, 4h high
@@ -19490,7 +19497,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 15m & 4h high
             & ((rsi_3_1h_gt_30) | (rsi_3_4h_gt_50) | (aroonu_14_15m_lt_70) | (aroonu_14_1h_lt_70))
             # 1h down move, 1h high, 4h downtrend
-            & ((rsi_3_1h_gt_35) | aroonu_14_1h_lt_80 | (roc_9_4h > -40.0))
+            & ((rsi_3_1h_gt_35) | aroonu_14_1h_lt_80 | (roc_9_4h_gt_neg_40))
             # 1h down move, 1h still high, 1d overbought
             & ((rsi_3_1h_gt_35) | (stochrsi_k_1h_lt_50) | (roc_9_1d_lt_200))
             # 1h down move, 1h high, 4h downtrend
@@ -19590,7 +19597,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h high, 4h & 1d overbought
             & (aroonu_14_4h_lt_80 | (roc_9_4h_lt_20) | (roc_9_1d_lt_20))
             # 1d high, 1h & 4h downtrend
-            & ((aroonu_14_1d_lt_85) | (roc_9_1h > -30.0) | (roc_9_4h > -50.0))
+            & ((aroonu_14_1d_lt_85) | (roc_9_1h > -30.0) | (roc_9_4h_gt_neg_50))
             # 1d high, 1h & 1d overbought
             & ((aroonu_14_1d_lt_85) | (roc_9_1h_lt_20) | (roc_9_1d_lt_100))
             # 1d high, 4h & 1d overbought
@@ -19839,7 +19846,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & dh down move, 4h high
             & ((rsi_3_1h_gt_30) | (rsi_3_4h_gt_50) | (aroonu_14_4h_lt_85))
             # 1h down move, 4h & 1d downtrend
-            & ((rsi_3_1h_gt_30) | (roc_9_4h > -25.0) | (roc_9_1d > -60.0))
+            & ((rsi_3_1h_gt_30) | (roc_9_4h_gt_neg_25) | (roc_9_1d > -60.0))
             # 1h down move, 4h & 1h overbought
             & ((rsi_3_1h_gt_30) | (roc_9_4h_lt_30) | (roc_9_1d_lt_40))
             # 1h down move, 4h high, 4h downtrend
@@ -19939,7 +19946,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1d down move, 1d high, 1d downtrend
             & ((rsi_3_1d_gt_15) | (aroonu_14_1d_lt_70) | (roc_9_1d_gt_neg_20))
             # 1d down move, 4h & 1d downtrend
-            & ((rsi_3_1d_gt_15) | (roc_9_4h > -10.0) | (roc_9_1d_gt_neg_40))
+            & ((rsi_3_1d_gt_15) | (roc_9_4h_gt_neg_10) | (roc_9_1d_gt_neg_40))
             # 4h & 1d downtrend, 1d high
             & ((cmf_20_4h > -0.50) | (cmf_20_1d > -0.50) | (aroonu_14_1d_lt_85))
             # 4h still not low enough, 4h & 1d downtrend
@@ -20063,7 +20070,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 1d high & overbought
             & ((rsi_3_15m_gt_20) | (aroonu_14_1d_lt_90) | (roc_9_1d_lt_80))
             # 15m down move, 15m high, 4h downtrend
-            & ((rsi_3_15m_gt_20) | (stochrsi_k_15m_lt_60) | (roc_9_4h > -50.0))
+            & ((rsi_3_15m_gt_20) | (stochrsi_k_15m_lt_60) | (roc_9_4h_gt_neg_50))
             # 15m down move, 4h overbought
             & ((rsi_3_15m_gt_20) | (roc_9_4h_lt_40))
             # 15m & 1h & 4h & 1d down move, 4h still high
@@ -20263,7 +20270,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1d high & overbought
             & ((rsi_3_1h_gt_30) | (aroonu_14_1d_lt_80) | (roc_9_1d_lt_200))
             # 1h down move, 1d high, 4h downtrend
-            & ((rsi_3_1h_gt_30) | (aroonu_14_1d_lt_90) | (roc_9_4h > -40.0))
+            & ((rsi_3_1h_gt_30) | (aroonu_14_1d_lt_90) | (roc_9_4h_gt_neg_40))
             # 1h down move, 1d high, 4h overbought
             & ((rsi_3_1h_gt_30) | (aroonu_14_1d_lt_100) | (roc_9_4h_lt_80))
             # 1h down move, 1h & 4h still high
@@ -20321,11 +20328,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 1h & 4h downtrend
             & ((rsi_3_4h_gt_3) | (roc_9_1h > -30.0) | (roc_9_4h_gt_neg_30))
             # 4h down move, 1d high, 4h downtrend
-            & ((rsi_3_4h_gt_5) | (aroonu_14_1d_lt_80) | (roc_9_4h > -10.0))
+            & ((rsi_3_4h_gt_5) | (aroonu_14_1d_lt_80) | (roc_9_4h_gt_neg_10))
             # 4h down move, 1h still high
             & ((rsi_3_4h_gt_5) | (stochrsi_k_1h_lt_50))
             # 4h down move, 4h & 1d downtrend
-            & ((rsi_3_4h_gt_5) | (roc_9_4h > -15.0) | (roc_9_1d_gt_neg_20))
+            & ((rsi_3_4h_gt_5) | (roc_9_4h_gt_neg_15) | (roc_9_1d_gt_neg_20))
             # 4h & 1d down move, 1d overbought
             & ((rsi_3_4h_gt_10) | (rsi_3_1d_gt_45) | (roc_9_1d_lt_10))
             # 4h down move, 1d still high, 1d downtrend
@@ -20369,7 +20376,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 4h high, 1d overbought
             & ((rsi_3_4h_gt_30) | aroonu_14_4h_lt_80 | roc_9_1d_lt_50)
             # 4h down move, 1h high, 4h downtrend
-            & ((rsi_3_4h_gt_30) | aroonu_14_1h_lt_70 | (roc_9_4h > -10.0))
+            & ((rsi_3_4h_gt_30) | aroonu_14_1h_lt_70 | (roc_9_4h_gt_neg_10))
             # 4h down move, 4h & 1d downtrend
             & ((rsi_3_4h_gt_40) | aroonu_14_4h_lt_70 | aroonu_14_1d_lt_100)
             # 4h down move, 1d high & overbought
@@ -20441,7 +20448,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1d high, 4h & 1d downtrend
             & ((aroonu_14_1d_lt_80) | (roc_9_4h_gt_neg_20) | (roc_9_1d_gt_neg_20))
             # 1d high, 1h & 4h downtrend
-            & ((aroonu_14_1d_lt_85) | (roc_9_1h > -30.0) | (roc_9_4h > -50.0))
+            & ((aroonu_14_1d_lt_85) | (roc_9_1h > -30.0) | (roc_9_4h_gt_neg_50))
             # 1d high, 1h & 1d overbought
             & ((aroonu_14_1d_lt_85) | (roc_9_1h_lt_20) | (roc_9_1d_lt_100))
             # 1d high, 1h & 4h down move
@@ -20721,7 +20728,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 1d high & overbought
             & ((rsi_3_4h_gt_15) | (stochrsi_k_1d_lt_90) | (roc_9_1d_lt_20))
             # 4h down move, 4h & 1d downtrend
-            & ((rsi_3_4h_gt_15) | (roc_9_4h > -10.0) | (roc_9_1d > -15.0))
+            & ((rsi_3_4h_gt_15) | (roc_9_4h_gt_neg_10) | (roc_9_1d > -15.0))
             # 4h down move, 4h & 1d downtrend
             & (rsi_3_4h_gt_20 | (roc_9_4h_gt_neg_20) | (roc_9_1d_gt_neg_30))
             # 4h dowqn move, 4h still high, 1d downtrend
@@ -21269,7 +21276,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 15m still high, 4h high
             & ((rsi_3_4h_gt_25) | (stochrsi_k_15m_lt_50) | (aroonu_14_4h_lt_70))
             # 4h down move, 1h high, 4h downtrend
-            & ((rsi_3_4h_gt_30) | (aroonu_14_1h_lt_70) | (roc_9_4h > -10.0))
+            & ((rsi_3_4h_gt_30) | (aroonu_14_1h_lt_70) | (roc_9_4h_gt_neg_10))
             # 4h down move, 15m still not low enough, 4h high
             & ((rsi_3_4h_gt_35) | (aroonu_14_15m_lt_30) | (aroonu_14_4h_lt_70))
             # 1d down move, 4h & 1d high
@@ -21464,7 +21471,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1h & 1d down move, 1h still moving lower
           long_entry_logic.append((rsi_3_1h_gt_10) | (rsi_3_1d_gt_15) | (cci_20_change_pct_1h > -0.0))
           # 1h down move, 1d high, 4h downtrend
-          long_entry_logic.append((rsi_3_1h_gt_10) | (aroonu_14_1d_lt_85) | (roc_9_4h > -10.0))
+          long_entry_logic.append((rsi_3_1h_gt_10) | (aroonu_14_1d_lt_85) | (roc_9_4h_gt_neg_10))
           # 1h & 4h down move, 1h still high
           long_entry_logic.append((rsi_3_1h_gt_15) | (rsi_3_4h_gt_15) | (aroonu_14_1h_lt_50))
           # 1h & 4h & 1d down move
@@ -21846,7 +21853,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 15m still not low enough
             & ((rsi_3_1h_gt_5) | (rsi_3_4h_gt_5) | (stochrsi_k_15m_lt_20))
             # 1h & 4h down move, 4h downtrend
-            & ((rsi_3_1h_gt_5) | (rsi_3_4h_gt_10) | (roc_9_4h > -10.0))
+            & ((rsi_3_1h_gt_5) | (rsi_3_4h_gt_10) | (roc_9_4h_gt_neg_10))
             # 1h & 4h down move, 15m high
             & ((rsi_3_1h_gt_5) | (rsi_3_4h_gt_25) | (stochrsi_k_15m_lt_60))
             # 1h & 4h down move, 1d still high
@@ -21942,13 +21949,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h & 1d down move, 1d still high
             & ((rsi_3_4h_gt_3) | (rsi_3_1d_gt_20) | (rsi_14_1d < 40.0))
             # 4h down move, 1h still not low enough, 4h downtrend
-            & ((rsi_3_4h_gt_3) | (aroonu_14_1h_lt_20) | (roc_9_4h > -10.0))
+            & ((rsi_3_4h_gt_3) | (aroonu_14_1h_lt_20) | (roc_9_4h_gt_neg_10))
             # 4h & 1d down move, 1d still high
             & ((rsi_3_4h_gt_5) | (rsi_3_1d_gt_30) | (stochrsi_k_1d_lt_40))
             # 4h down move, 1h high
             & ((rsi_3_4h_gt_5) | (stochrsi_k_1h_lt_90))
             # 4h down move, 4h & 1d downtrend
-            & ((rsi_3_4h_gt_5) | (roc_9_4h > -10.0) | (roc_9_1d > -10.0))
+            & ((rsi_3_4h_gt_5) | (roc_9_4h_gt_neg_10) | (roc_9_1d > -10.0))
             # 4h & 1d down move, 1h high
             & ((rsi_3_4h_gt_10) | (rsi_3_1d_gt_10) | (stochrsi_k_1h_lt_60))
             # 4h & 1d down move, 4h downtrend
@@ -21984,7 +21991,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 1d still high, 4h still not low enough
             & ((rsi_3_4h_gt_15) | (rsi_14_1d < 40.0) | (stochrsi_k_4h_lt_30))
             # 4h down move, 4h still high, 4h downtrend
-            & ((rsi_3_4h_gt_15) | (aroonu_14_4h_lt_50) | (roc_9_4h > -10.0))
+            & ((rsi_3_4h_gt_15) | (aroonu_14_4h_lt_50) | (roc_9_4h_gt_neg_10))
             # 4h down move, 1d still high, 1d downtrend
             & ((rsi_3_4h_gt_15) | (aroonu_14_1d_lt_50) | (roc_9_1d > -20.0))
             # 4h down move, 4h still not low enough, 1d downtrend
@@ -21996,7 +22003,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 1d high & overbought
             & (rsi_3_4h_gt_20 | (aroonu_14_1d_lt_80) | (roc_9_1d_lt_70))
             # 4h down move, 4h & 1d downtrend
-            & ((rsi_3_4h_gt_25) | (roc_9_4h > -10.0) | (roc_9_1d > -10.0))
+            & ((rsi_3_4h_gt_25) | (roc_9_4h_gt_neg_10) | (roc_9_1d > -10.0))
             # 1h down move, 4h still not low enough, 1d downtrend
             & (rsi_3_4h_gt_20 | (stochrsi_k_4h_lt_30) | (roc_9_1d_gt_neg_20))
             # 4h & 1d down move, 1h high
@@ -22028,7 +22035,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 1d high & overbought
             & ((rsi_3_4h_gt_55) | (stochrsi_k_1d_lt_90) | (roc_9_1d_lt_80))
             # 1d down move, 1d high, 4h downtrend
-            & ((rsi_3_1d_gt_15) | (aroonu_14_1d_lt_70) | (roc_9_4h > -40.0))
+            & ((rsi_3_1d_gt_15) | (aroonu_14_1d_lt_70) | (roc_9_4h_gt_neg_40))
             # 1d down move, 1h & 4h high
             & ((rsi_3_1d_gt_30) | aroonu_14_1h_lt_70 | aroonu_14_4h_lt_100)
             # 1d down move, 4h high, 1d overbought
@@ -22353,7 +22360,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h & 1d down move, 1d high
             & ((rsi_3_4h_gt_5) | (rsi_3_1d_gt_45) | (aroonu_14_1d_lt_70))
             # 4h down move, 4h still high, 4h downtrend
-            & ((rsi_3_4h_gt_5) | (aroonu_14_4h_lt_40) | (roc_9_4h > -10.0))
+            & ((rsi_3_4h_gt_5) | (aroonu_14_4h_lt_40) | (roc_9_4h_gt_neg_10))
             # 4h down move, 1h high
             & ((rsi_3_4h_gt_5) | (stochrsi_k_1h_lt_90))
             # 4h & 1d down move, 1h still high
@@ -22373,7 +22380,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 1h high, 4h downtrend
             & ((rsi_3_4h_gt_10) | (stochrsi_k_1h_lt_70) | (roc_9_4h > -20.0))
             # 4h down move, 4h & 1d downtrend
-            & ((rsi_3_4h_gt_10) | (roc_9_4h > -15.0) | (roc_9_1d > -20.0))
+            & ((rsi_3_4h_gt_10) | (roc_9_4h_gt_neg_15) | (roc_9_1d > -20.0))
             # 4h & 1d down move, 1d still high
             & ((rsi_3_4h_gt_15) | (rsi_3_1d_gt_15) | (aroonu_14_1d_lt_50))
             # 4h & 1d down move, 4h still high
@@ -22389,7 +22396,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 15m still not low enough, 1d high
             & ((rsi_3_4h_gt_15) | (aroonu_14_15m_lt_30) | (aroonu_14_1d_lt_70))
             # 4h down move, 4h still high, 4h downtrend
-            & ((rsi_3_4h_gt_15) | (aroonu_14_4h_lt_50) | (roc_9_4h > -10.0))
+            & ((rsi_3_4h_gt_15) | (aroonu_14_4h_lt_50) | (roc_9_4h_gt_neg_10))
             # 4h down move, 4h still not low enough, 1d downtrend
             & ((rsi_3_4h_gt_15) | (stochrsi_k_4h_lt_20) | (roc_9_1d > -20.0))
             # 4h down move, 4h & 1d high
@@ -22447,7 +22454,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 1d high & overbought
             & ((rsi_3_4h_gt_55) | (stochrsi_k_1d_lt_90) | (roc_9_1d_lt_80))
             # 1d down move, 1d high, 4h downtrend
-            & ((rsi_3_1d_gt_15) | (aroonu_14_1d_lt_70) | (roc_9_4h > -40.0))
+            & ((rsi_3_1d_gt_15) | (aroonu_14_1d_lt_70) | (roc_9_4h_gt_neg_40))
             # 1d down move, 1d high, 1d downtrend
             & ((rsi_3_1d_gt_15) | (aroonu_14_1d_lt_70) | (roc_9_1d_gt_neg_20))
             # 1d down move, 1h & 4h high
@@ -22622,7 +22629,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 4h still not low enough
             & ((rsi_3_1h_gt_5) | (rsi_3_4h_gt_15) | (aroonu_14_4h_lt_30))
             # 1h down move, 4h & 1d downtrend
-            & ((rsi_3_1h_gt_5) | (roc_9_4h > -10.0) | (roc_9_1d_gt_neg_20))
+            & ((rsi_3_1h_gt_5) | (roc_9_4h_gt_neg_10) | (roc_9_1d_gt_neg_20))
             # 1h & 4h down move, 1d still not low enough
             & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_10) | (stochrsi_k_1d_lt_20))
             # 1h & 4h down move, 15m still not low enough
@@ -22939,9 +22946,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 1d high, 15m high
             & ((rsi_3_4h_gt_10) | (aroonu_14_1d_lt_80) | (stochrsi_k_15m_lt_60))
             # 4h down move, 1d high, 4h downtrend
-            & ((rsi_3_4h_gt_10) | (aroonu_14_1d_lt_100) | (roc_9_4h > -10.0))
+            & ((rsi_3_4h_gt_10) | (aroonu_14_1d_lt_100) | (roc_9_4h_gt_neg_10))
             # 4h down move, 4h & 1d downtrend
-            & ((rsi_3_4h_gt_10) | (roc_9_4h > -10.0) | (roc_9_1d > -20.0))
+            & ((rsi_3_4h_gt_10) | (roc_9_4h_gt_neg_10) | (roc_9_1d > -20.0))
             # 4h & 1d down move, 1d still high
             & ((rsi_3_4h_gt_15) | (rsi_3_1d_gt_15) | (aroonu_14_1d_lt_50))
             # 4h & 1d down move, 4h still high
@@ -22969,7 +22976,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 1d stil high, 1d downtrend
             & ((rsi_3_4h_gt_30) | (aroonu_14_1d_lt_40) | (roc_9_1d_gt_neg_30))
             # 4h down move, 4h still high, 4h downtrend
-            & ((rsi_3_4h_gt_30) | (stochrsi_k_4h_lt_40) | (roc_9_4h > -15.0))
+            & ((rsi_3_4h_gt_30) | (stochrsi_k_4h_lt_40) | (roc_9_4h_gt_neg_15))
             # 4h & 1d down move, 4h still high, 1d high
             & ((rsi_3_4h_gt_35) | (rsi_3_1d_gt_35) | (stochrsi_k_4h_lt_50) | (aroonu_14_1d_lt_60))
             # 4h down move, 4h still high, 1d downtrend
@@ -22977,7 +22984,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 1d high & overbought
             & ((rsi_3_4h_gt_55) | (stochrsi_k_1d_lt_90) | (roc_9_1d_lt_100))
             # 1d down move, 4h still not low enough, 4h downtrend
-            & ((rsi_3_1d_gt_10) | (stochrsi_k_4h_lt_30) | (roc_9_4h > -15.0))
+            & ((rsi_3_1d_gt_10) | (stochrsi_k_4h_lt_30) | (roc_9_4h_gt_neg_15))
             # 1d down move, 4h & 1d downtrend
             & ((rsi_3_1d_gt_10) | (roc_9_4h_gt_neg_20) | (roc_9_1d_gt_neg_20))
             # 1d down move, 1d high, 4h downtrend
@@ -23089,7 +23096,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 4h still high
             & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_10) | (aroonu_14_4h_lt_40))
             # 1h & 4h down move, 4h downtrend
-            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_10) | (roc_9_4h > -10.0))
+            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_10) | (roc_9_4h_gt_neg_10))
             # 1h & 4h down move, 1d downtrend
             & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_10) | (roc_9_1d > -30.0))
             # 1h & 4h down move, 15m high
@@ -23175,7 +23182,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 4h high & overbought
             & ((rsi_3_1h_gt_50) | (stochrsi_k_4h_lt_90) | (roc_9_4h_lt_25))
             # 4h down move, 4h & 1d downtrend
-            & ((rsi_3_4h_gt_5) | (roc_9_4h > -15.0) | (roc_9_1d_gt_neg_20))
+            & ((rsi_3_4h_gt_5) | (roc_9_4h_gt_neg_15) | (roc_9_1d_gt_neg_20))
             # 4h & 1d down move, 1d still high
             & ((rsi_3_4h_gt_10) | (rsi_3_1d_gt_30) | (stochrsi_k_1d_lt_50))
             # 4h down move, 4h & 1d high
@@ -23221,7 +23228,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1d down move, 1h high, 1d downtrend
             & ((rsi_3_1d_gt_25) | (stochrsi_k_1h_lt_60) | (roc_9_1d_gt_neg_30))
             # 1d down move, 1d high, 4h downtrend
-            & ((rsi_3_1d_gt_35) | (aroonu_14_1d_lt_70) | (roc_9_4h > -10.0))
+            & ((rsi_3_1d_gt_35) | (aroonu_14_1d_lt_70) | (roc_9_4h_gt_neg_10))
             # 1d down move, 4h high, 1d overbought
             & ((rsi_3_1d_gt_60) | aroonu_14_4h_lt_70 | (roc_9_1d_lt_40))
             # 15m high, 1d high & overbought
@@ -23233,11 +23240,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h high, 1d overbought
             & ((aroonu_14_1h_lt_85) | (roc_9_1d_lt_80))
             # 1h high, 4h & 1d downtrend
-            & ((aroonu_14_1h_lt_100) | (roc_9_4h > -10.0) | (roc_9_1d > -25.0))
+            & ((aroonu_14_1h_lt_100) | (roc_9_4h_gt_neg_10) | (roc_9_1d > -25.0))
             # 4h & 1d high, 1d overbought
             & (aroonu_14_4h_lt_100 | aroonu_14_1d_lt_100 | (roc_9_1d_lt_60))
             # 1h high, 4h & 1d downtrend
-            & ((stochrsi_k_1h_lt_80) | (roc_9_4h > -10.0) | (roc_9_1d > -25.0))
+            & ((stochrsi_k_1h_lt_80) | (roc_9_4h_gt_neg_10) | (roc_9_1d > -25.0))
           )
 
           # Logic
@@ -23522,7 +23529,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 4h high, 4h downtrend
             & ((rsi_3_15m_gt_15) | (aroonu_14_4h_lt_60) | (roc_9_4h_gt_neg_20))
             # 15m down move, 4h & 1d downtrend
-            & ((rsi_3_15m_gt_15) | (roc_9_4h > -10.0) | (roc_9_1d_gt_neg_40))
+            & ((rsi_3_15m_gt_15) | (roc_9_4h_gt_neg_10) | (roc_9_1d_gt_neg_40))
             # 15m & 1h down move, 1h high
             & ((rsi_3_15m_gt_20) | (rsi_3_1h_gt_25) | aroonu_14_1h_lt_70)
             # 15m down move, 4h high & overbought
@@ -23602,7 +23609,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 1d high, 1h downtrend
             & ((rsi_3_4h_gt_10) | (aroonu_14_1d_lt_85) | (roc_9_1h > -30.0))
             # 4h down move, 1h & 4h downtrend
-            & ((rsi_3_4h_gt_10) | (roc_9_1h > -40.0) | (roc_9_4h > -40.0))
+            & ((rsi_3_4h_gt_10) | (roc_9_1h > -40.0) | (roc_9_4h_gt_neg_40))
             # 4h & 1d down move, 4h still not low enough
             & ((rsi_3_4h_gt_20) | (rsi_3_1d_gt_20) | (stochrsi_k_4h_lt_30))
             # 4h down move, 4h still high, 1d downtrend
@@ -24691,7 +24698,7 @@ class NostalgiaForInfinityX7(IStrategy):
             (aroond_14_15m < 50.0) | (rsi_3_1h_lt_85) | (rsi_3_4h_lt_80) | (stochrsi_k_4h > 80.0)
           )
           # 15m & 1h still high, 4h overbought
-          short_entry_logic.append((aroond_14_15m < 50.0) | (aroond_14_1h < 50.0) | (roc_9_4h > -40.0))
+          short_entry_logic.append((aroond_14_15m < 50.0) | (aroond_14_1h < 50.0) | (roc_9_4h_gt_neg_40))
           # 15m still high, 1h down move, 1d downtrend
           short_entry_logic.append((stochrsi_k_15m > 30.0) | (rsi_3_4h_lt_90) | roc_9_1d_lt_50)
           # 1h & 4h still high, 1d strong down move
@@ -24709,7 +24716,7 @@ class NostalgiaForInfinityX7(IStrategy):
             (change_pct_1h < 1.0) | (change_pct_1h.shift(12) > -5.0) | (rsi_14_1h.shift(12) < 80.0)
           )
           # 1h red, 1h stil high, 4h downtrend
-          short_entry_logic.append((change_pct_1h < 5.0) | (stochrsi_k_1h_gt_50) | (roc_9_4h > -25.0))
+          short_entry_logic.append((change_pct_1h < 5.0) | (stochrsi_k_1h_gt_50) | (roc_9_4h_gt_neg_25))
           # 4h red, 15m down move, 4h still high
           short_entry_logic.append((change_pct_4h < 5.0) | (rsi_3_15m_lt_90) | (stochrsi_k_4h_gt_30))
           # 4h red, previous 4h green, 4h overbought
@@ -24848,7 +24855,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m downtrend, 4h down move, 4h stil high
           short_entry_logic.append((roc_9_15m < 15.0) | (rsi_3_4h < 75.0) | (stochrsi_k_4h_gt_30))
           # 1h downtrend, 4h overbought
-          short_entry_logic.append((df["ROC_2_1h"] < 5.0) | (rsi_14_4h > 20.0) | (roc_9_4h > -25.0))
+          short_entry_logic.append((df["ROC_2_1h"] < 5.0) | (rsi_14_4h > 20.0) | (roc_9_4h_gt_neg_25))
           # 1h P&D, 4h still high
           short_entry_logic.append((df["ROC_2_1h"] < 10.0) | (roc_9_1h > -5.0) | (stochrsi_k_4h_gt_30))
           # 1h downtrend, 4h down move, 1d downtrend
@@ -25065,7 +25072,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m down move, 15m still not low enoug, 1h high
           short_entry_logic.append((rsi_3_15m_lt_85) | (aroond_14_15m < 25.0) | (stochrsi_k_1h_gt_10))
           # 15m down move, 1h downtrend, 4h overbought
-          short_entry_logic.append((rsi_3_15m_lt_85) | (roc_9_1h < 5.0) | (roc_9_4h > -35.0))
+          short_entry_logic.append((rsi_3_15m_lt_85) | (roc_9_1h < 5.0) | (roc_9_4h_gt_neg_35))
           # 1h & 4h down move, 4h still not low enough
           short_entry_logic.append((rsi_3_1h_lt_95) | (rsi_3_4h_lt_90) | (stochrsi_k_4h > 75.0))
           # 1h & 4h down move, 4h still high
@@ -25083,7 +25090,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 4h & 1d down move, 1d strong downtrend
           short_entry_logic.append((rsi_3_4h_lt_90) | (rsi_3_1d < 90.0) | (roc_9_1d_lt_60))
           # 4h overbought, 1h still high, 1d downtrend
-          short_entry_logic.append((roc_9_4h > -50.0) | (stochrsi_k_1h_gt_70) | roc_9_1d_lt_50)
+          short_entry_logic.append((roc_9_4h_gt_neg_50) | (stochrsi_k_1h_gt_70) | roc_9_1d_lt_50)
           # 4h red, previous 4h green, 4h overbought
           short_entry_logic.append(
             (change_pct_4h < 5.0) | (change_pct_4h.shift(48) > -5.0) | (rsi_14_4h.shift(48) > 20.0)


### PR DESCRIPTION
## Summary
- Reuse repeated ROC 4h downtrend comparisons in `populate_entry_trend()` through named entry masks.
- Independent on latest upstream `main`.

## Safety
- Behavior-preserving Series mask reuse only.
- Touched function: `populate_entry_trend()`.
- Indicator formulas, candle selection, thresholds, condition order, profit arithmetic, order classification, return values, and signal behavior are unchanged.
- No v3 grind-entry code is touched.

## Backtest scope
- Full backtesting was not required because this patch only aliases Series comparisons that are already used by the same condition ladder.
- Indicator formulas, candle selection, thresholds, and condition order are unchanged.

## Checks
- `python3 /home/user/.codex/skills/nfi-upstream-pr/scripts/validate_nfi_pr.py --base origin/main`
- `git merge-tree \9f25e22bd594c7b51672063310f7e3a76474f673 origin/main HEAD | grep -E '\''<<<<<<<|>>>>>>>|changed in both|removed in|added in both'\'' && echo CONFLICT || echo NO_CONFLICT`
- `git diff --check`
- `ruff format --check NostalgiaForInfinityX7.py`
- `ruff check NostalgiaForInfinityX7.py`
- `PYTHONDONTWRITEBYTECODE=1 python3 -m py_compile NostalgiaForInfinityX7.py`