### PR TITLE
Reuse X7 entry ROC 1h downtrend masks

### DIFF
--- a/NostalgiaForInfinityX7.py
+++ b/NostalgiaForInfinityX7.py
@@ -13132,6 +13132,13 @@ class NostalgiaForInfinityX7(IStrategy):
     stochrsi_k_1d_lt_90 = stochrsi_k_1d < 90.0
 
     roc_9_1h_lt_10 = roc_9_1h < 10.0
+    roc_9_1h_gt_neg_50 = roc_9_1h > -50.0
+    roc_9_1h_gt_neg_40 = roc_9_1h > -40.0
+    roc_9_1h_gt_neg_30 = roc_9_1h > -30.0
+    roc_9_1h_gt_neg_25 = roc_9_1h > -25.0
+    roc_9_1h_gt_neg_20 = roc_9_1h > -20.0
+    roc_9_1h_gt_neg_15 = roc_9_1h > -15.0
+    roc_9_1h_gt_neg_10 = roc_9_1h > -10.0
     roc_9_1h_lt_15 = roc_9_1h < 15.0
     roc_9_1h_lt_20 = roc_9_1h < 20.0
     roc_9_1h_lt_25 = roc_9_1h < 25.0
@@ -13461,7 +13468,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1d high & overbought
             & ((rsi_3_1h_gt_15) | (aroonu_14_1d_lt_80) | (roc_9_1d_lt_40))
             # 1h down move, 1h & 4h downtrend
-            & ((rsi_3_1h_gt_15) | (roc_9_1h > -30.0) | (roc_9_4h_gt_neg_30))
+            & ((rsi_3_1h_gt_15) | (roc_9_1h_gt_neg_30) | (roc_9_4h_gt_neg_30))
             # 1h & 4h down move, 4h overbought
             & (rsi_3_1h_gt_20 | (rsi_3_4h_gt_50) | (roc_9_4h_lt_80))
             # 1h down move, 1h still high, 4h downtrend
@@ -13521,7 +13528,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 4h still not low enough, 1d downtrend
             & ((rsi_3_4h_gt_10) | (stochrsi_k_4h_lt_30) | (roc_9_1d > -20.0))
             # 4h down move, 1h & 4h downtrend
-            & ((rsi_3_4h_gt_10) | (roc_9_1h > -30.0) | (roc_9_4h_gt_neg_30))
+            & ((rsi_3_4h_gt_10) | (roc_9_1h_gt_neg_30) | (roc_9_4h_gt_neg_30))
             # 4h down move, 4h & 1d downtrend
             & ((rsi_3_4h_gt_15) | (roc_9_4h > -20.0) | (roc_9_1d > -30.0))
             # 4h down move, 1d high & overbought
@@ -13555,7 +13562,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m high, 1d overbought
             & ((aroonu_14_15m_lt_70) | (roc_9_1d_lt_80))
             # 1h still high, 1h & 4h downtrend
-            & ((aroonu_14_1h_lt_40) | (roc_9_1h > -20.0) | (roc_9_4h_gt_neg_30))
+            & ((aroonu_14_1h_lt_40) | (roc_9_1h_gt_neg_20) | (roc_9_4h_gt_neg_30))
             # 1h & 4h high, 1h overbought
             & ((aroonu_14_1h_lt_85) | (aroonu_14_4h_lt_90) | (roc_9_1h_lt_20))
             # 1h high, 1h & 4h overbought
@@ -13565,19 +13572,19 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h & 1d high, 1d overbought
             & (aroonu_14_4h_lt_80 | aroonu_14_1d_lt_100 | roc_9_1d_lt_50)
             # 4h high, 1h downtrend
-            & (aroonu_14_4h_lt_80 | (roc_9_1h > -15.0))
+            & (aroonu_14_4h_lt_80 | (roc_9_1h_gt_neg_15))
             # 4h high, 1d downtrend
             & (aroonu_14_4h_lt_80 | (roc_9_1d_gt_neg_40))
             # 1d high, 4h downtrend, 1d overbought
             & ((aroonu_14_1d_lt_85) | (roc_9_4h > -25.0) | roc_9_1d_lt_50)
             # 1d high, 1h & 4h downtrend
-            & ((aroonu_14_1d_lt_90) | (roc_9_1h > -10.0) | (roc_9_4h_gt_neg_20))
+            & ((aroonu_14_1d_lt_90) | (roc_9_1h_gt_neg_10) | (roc_9_4h_gt_neg_20))
             # 1d high, 4h & 1d overbought
             & ((aroonu_14_1d_lt_90) | (roc_9_4h_lt_40) | (roc_9_1d_lt_80))
             # 1h high, 4h overbought
             & ((stochrsi_k_1h_lt_80) | (roc_9_4h_lt_80))
             # 4h high, 1h downtrend
-            & ((stochrsi_k_4h_lt_70) | (roc_9_1h > -15.0))
+            & ((stochrsi_k_4h_lt_70) | (roc_9_1h_gt_neg_15))
             # 4h high, 1d downtrend
             & ((stochrsi_k_4h_lt_70) | (roc_9_1d_gt_neg_40))
             # 5m down move, 15m still not low enough, 1h high
@@ -13589,7 +13596,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 5m down move, 4h down move, 15m downtrend, 1h high
             & ((roc_9 > -15.0) | (rsi_3_4h_gt_45) | (cmf_20_15m > -0.3) | (aroonu_14_1h_lt_60))
             # 1h downtrend, 4h high & overbought
-            & ((roc_9_1h > -25.0) | aroonu_14_4h_lt_80 | (roc_9_4h_lt_80))
+            & ((roc_9_1h_gt_neg_25) | aroonu_14_4h_lt_80 | (roc_9_4h_lt_80))
             # 1h & 4h overbought, 1d downtrend
             & ((roc_9_1h_lt_20) | (roc_9_4h_lt_20) | (roc_9_1d_gt_neg_40))
             # 1d P&D, 1d downtrend
@@ -14320,7 +14327,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1d high, 1d downtrend
             & ((aroonu_14_1d_lt_80) | (roc_9_1d_gt_neg_30))
             # 1d high, 1h & 4h downtrend
-            & ((aroonu_14_1d_lt_85) | (roc_9_1h > -30.0) | (roc_9_4h > -50.0))
+            & ((aroonu_14_1d_lt_85) | (roc_9_1h_gt_neg_30) | (roc_9_4h > -50.0))
             # 1d high, 4h & 1d overbought
             & ((aroonu_14_1d_lt_85) | (roc_9_4h_lt_60) | (roc_9_1d_lt_60))
             # 1d high, 1h & 4h down move
@@ -14587,7 +14594,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 15m high, 1d high & overbought
             & ((rsi_3_15m_gt_40) | (aroonu_14_15m_lt_70) | (aroonu_14_1d_lt_85) | (rsi_3_1d_gt_35))
             # 15m down move, 15m high, 1h downtrend
-            & ((rsi_3_15m_gt_40) | (aroonu_14_15m_lt_70) | (roc_9_1h > -20.0))
+            & ((rsi_3_15m_gt_40) | (aroonu_14_15m_lt_70) | (roc_9_1h_gt_neg_20))
             # 15m down move, 15m & 4h high
             & ((rsi_3_15m_gt_40) | (aroonu_14_15m_lt_75) | (aroonu_14_4h_lt_75))
             # 15m down move, 4h high & overbought
@@ -14767,7 +14774,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 1d high
             & ((rsi_3_4h_gt_15) | (stochrsi_k_1d_lt_80))
             # 4h down move, 1h & 4h downtrend
-            & ((rsi_3_4h_gt_15) | (roc_9_1h > -30.0) | (roc_9_4h_gt_neg_30))
+            & ((rsi_3_4h_gt_15) | (roc_9_1h_gt_neg_30) | (roc_9_4h_gt_neg_30))
             # 4h & 1d down move, 1h still high
             & (rsi_3_4h_gt_20 | (rsi_3_1d_gt_20) | (aroonu_14_1h_lt_40))
             # 4h & 1d down move, 15m high
@@ -14815,7 +14822,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 4h high, 1d downtrend
             & ((rsi_3_4h_gt_25) | (stochrsi_k_4h_lt_80) | roc_9_1d_gt_neg_50)
             # 4h down move, 1h high, 1h downtrend
-            & ((rsi_3_4h_gt_30) | aroonu_14_1h_lt_70 | (roc_9_1h > -10.0))
+            & ((rsi_3_4h_gt_30) | aroonu_14_1h_lt_70 | (roc_9_1h_gt_neg_10))
             # 4h & 1d down move, 1d overbought
             & ((rsi_3_4h_gt_30) | (rsi_3_1d > 50.0) | (roc_9_1d_lt_100))
             # 4h down move, 1d downtrend, 1d overbought
@@ -14953,7 +14960,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m still high, 4h high, 1d overbought
             & ((aroonu_14_15m_lt_50) | (rsi_14_4h < 60.0) | (roc_9_1d_lt_70))
             # 15m still high, 1h downtrend, 4h overbought
-            & ((aroonu_14_15m_lt_50) | (roc_9_1h > -10.0) | (roc_9_4h_lt_40))
+            & ((aroonu_14_15m_lt_50) | (roc_9_1h_gt_neg_10) | (roc_9_4h_lt_40))
             # 15m high, 4h high & overbought
             & ((aroonu_14_15m_lt_60) | aroonu_14_4h_lt_70 | (roc_9_4h_lt_20))
             # 15m & 4h high, 1d overbought
@@ -14991,7 +14998,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1d high, 4h & 1d downtrend
             & ((aroonu_14_1d_lt_80) | (roc_9_4h_gt_neg_20) | (roc_9_1d_gt_neg_20))
             # 1d high, 1h & 4h downtrend
-            & ((aroonu_14_1d_lt_85) | (roc_9_1h > -30.0) | (roc_9_4h > -50.0))
+            & ((aroonu_14_1d_lt_85) | (roc_9_1h_gt_neg_30) | (roc_9_4h > -50.0))
             # 1d high, 4h downtrend
             & ((aroonu_14_1d_lt_85) | (roc_9_4h_gt_neg_30))
             # 1d high, 4h downtrend, 1d overbought
@@ -15160,11 +15167,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h & 1d down move
             & ((rsi_3_1h_gt_5) | (rsi_3_4h_gt_5) | (rsi_3_1d_gt_10))
             # 1h & 4h down move, 1h downtrend
-            & ((rsi_3_1h_gt_5) | (rsi_3_4h_gt_5) | (roc_9_1h > -20.0))
+            & ((rsi_3_1h_gt_5) | (rsi_3_4h_gt_5) | (roc_9_1h_gt_neg_20))
             # 1h & 4h down move, 1d downtrend
             & ((rsi_3_1h_gt_5) | (rsi_3_4h_gt_10) | (roc_9_1d_gt_neg_40))
             # 1h down move, 4h high, 1h downtrend
-            & ((rsi_3_1h_gt_5) | (stochrsi_k_4h_lt_70) | (roc_9_1h > -40.0))
+            & ((rsi_3_1h_gt_5) | (stochrsi_k_4h_lt_70) | (roc_9_1h_gt_neg_40))
             # 1h down move, 4h high, 1h downtrend
             & ((rsi_3_1h_gt_5) | (stochrsi_k_4h_lt_70) | (cmf_20_1h > -0.40))
             # 1h down move, 1d high & overbought
@@ -15176,7 +15183,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 4h still high
             & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_15) | (rsi_14_4h < 40.0))
             # 1h & 4h down move, 1h downtrend
-            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_15) | (roc_9_1h > -20.0))
+            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_15) | (roc_9_1h_gt_neg_20))
             # 1h & 4h down move, 1h still high
             & ((rsi_3_1h_gt_10) | rsi_3_4h_gt_20 | (aroonu_14_1h_lt_50))
             # 1h & 4h down move, 4h still high
@@ -15389,7 +15396,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 4h & 1d high
             & ((rsi_3_15m_gt_30) | aroonu_14_4h_lt_80 | aroonu_14_1d_lt_100)
             # 15m down move, 4h high, 1h downtrend
-            & ((rsi_3_15m < 30.0) | (aroonu_14_4h_lt_85) | (roc_9_1h > -40.0))
+            & ((rsi_3_15m < 30.0) | (aroonu_14_4h_lt_85) | (roc_9_1h_gt_neg_40))
             # 15m down move, 4h high & overbought
             & ((rsi_3_15m_gt_30) | aroonu_14_4h_lt_100 | (roc_9_4h_lt_25))
             # 15m & 4h down move, 4h high
@@ -15417,13 +15424,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 1d down move, 1d high
             & ((rsi_3_1h_gt_3) | (rsi_3_1d_gt_25) | (aroonu_14_1d_lt_80))
             # 1h & 4h down move, 1h downtrend
-            & ((rsi_3_1h_gt_5) | rsi_3_4h_gt_20 | (roc_9_1h > -15.0))
+            & ((rsi_3_1h_gt_5) | rsi_3_4h_gt_20 | (roc_9_1h_gt_neg_15))
             # 1h & 4h down move, 4h still high
             & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_10) | (aroonu_14_4h_lt_50))
             # 1h & 4h down move, 15m still high
             & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_10) | (stochrsi_k_15m_lt_50))
             # 1h & 4h down move, 1h downtrend
-            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_10) | (roc_9_1h > -20.0))
+            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_10) | (roc_9_1h_gt_neg_20))
             # 1h & 4h & 1d down move
             & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_15) | (rsi_3_1d_gt_15))
             # 1h & 4h down move, 15m high
@@ -15471,7 +15478,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1d high & overbought
             & ((rsi_3_1h_gt_15) | (aroonu_14_1d_lt_100) | (roc_9_1d_lt_10))
             # 1h down move, 1h downtrend, 1d overbought
-            & ((rsi_3_1h_gt_15) | (roc_9_1h > -30.0) | (roc_9_1d_lt_80))
+            & ((rsi_3_1h_gt_15) | (roc_9_1h_gt_neg_30) | (roc_9_1d_lt_80))
             # 1h down move, 4h & 1d overbought
             & ((rsi_3_1h_gt_15) | (roc_9_4h_lt_10) | (roc_9_1d_lt_60))
             # 1h & 4h down move, 4h high
@@ -15591,7 +15598,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 4h still high, 1d downtrend
             & ((rsi_3_4h_gt_15) | (stochrsi_k_4h_lt_50) | (roc_9_1d > -20.0))
             # 4h down move, 1h & 4h downtrend
-            & ((rsi_3_4h_gt_15) | (roc_9_1h > -30.0) | (roc_9_4h_gt_neg_30))
+            & ((rsi_3_4h_gt_15) | (roc_9_1h_gt_neg_30) | (roc_9_4h_gt_neg_30))
             # 4h & 1ddown move, 1d high
             & (rsi_3_4h_gt_20 | (rsi_3_1d_gt_20) | (aroonu_14_1d_lt_80))
             # 4h & 1d down move, 1h still high, 4h still high
@@ -15625,7 +15632,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1d downtrend, 1d high & overbought
             & ((cmf_20_1d > -0.40) | (aroonu_14_1d_lt_85) | (roc_9_1d_lt_20))
             # 15m not low enough, 1h & 4h downtrend
-            & ((aroonu_14_15m_lt_20) | (roc_9_1h > -30.0) | (roc_9_4h > -50.0))
+            & ((aroonu_14_15m_lt_20) | (roc_9_1h_gt_neg_30) | (roc_9_4h > -50.0))
             # 15m high, 1h high & overbought
             & ((aroonu_14_15m_lt_70) | (aroonu_14_1h_lt_85) | (roc_9_1h_lt_10))
             # 4h high, 4h & 1d overbought
@@ -15655,7 +15662,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1d high, 1h & 4h down move
             & (aroonu_14_1d_lt_100 | (roc_9_1h_lt_25) | (roc_9_4h_lt_60))
             # 1d high, 1h downtrend, 1d overbought
-            & (aroonu_14_1d_lt_100 | (roc_9_1h > -30.0) | (roc_9_1d_lt_100))
+            & (aroonu_14_1d_lt_100 | (roc_9_1h_gt_neg_30) | (roc_9_1d_lt_100))
             # 1d high, 4h & 1d overbought
             & (aroonu_14_1d_lt_100 | (roc_9_4h_lt_20) | (roc_9_1d_lt_80))
             # 15m high, 4h & 1d downtrend
@@ -16296,7 +16303,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 4h still not low enough, 1d downtrend
             & ((rsi_3_4h_gt_15) | (stochrsi_k_4h_lt_20) | (roc_9_1d > -20.0))
             # 4h down move, 1h & 4h downtrend
-            & ((rsi_3_4h_gt_15) | (roc_9_1h > -30.0) | (roc_9_4h_gt_neg_30))
+            & ((rsi_3_4h_gt_15) | (roc_9_1h_gt_neg_30) | (roc_9_4h_gt_neg_30))
             # 4h & 1d down move, 1d high
             & (rsi_3_4h_gt_20 | (rsi_3_1d_gt_20) | (aroonu_14_1d_lt_60))
             # 4h & 1d down move, 4h still high
@@ -16314,7 +16321,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h & 1d down move, 1d high
             & ((rsi_3_4h_gt_30) | (rsi_3_1d > 50.0) | (aroonu_14_1d_lt_90))
             # 4h down move, 1h high, 1h downtrend
-            & ((rsi_3_4h_gt_30) | aroonu_14_1h_lt_70 | (roc_9_1h > -10.0))
+            & ((rsi_3_4h_gt_30) | aroonu_14_1h_lt_70 | (roc_9_1h_gt_neg_10))
             # 4h down move, 1h high, 4h downtrend
             & ((rsi_3_4h_gt_30) | aroonu_14_1h_lt_70 | (roc_9_4h > -10.0))
             # 4h down move, 1h still high, 1d overbought
@@ -16418,7 +16425,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1d high, 1d downtrend
             & ((aroonu_14_1d_lt_80) | (roc_9_1d_gt_neg_30))
             # 1d high, 1h & 4h downtrend
-            & ((aroonu_14_1d_lt_85) | (roc_9_1h > -30.0) | (roc_9_4h > -50.0))
+            & ((aroonu_14_1d_lt_85) | (roc_9_1h_gt_neg_30) | (roc_9_4h > -50.0))
             # 1d high, 1h & 1d overbought
             & ((aroonu_14_1d_lt_90) | (roc_9_1h_lt_10) | roc_9_1d_lt_50)
             # 1d high, 4h & 1d overbought
@@ -16831,7 +16838,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 1h & 4h high
             & ((rsi_3_15m_gt_10) | (aroonu_14_1h_lt_100) | aroonu_14_4h_lt_100)
             # 15m down move, 4h high, 1h downtrend
-            & ((rsi_3_15m_gt_10) | (aroonu_14_4h_lt_85) | (roc_9_1h > -25.0))
+            & ((rsi_3_15m_gt_10) | (aroonu_14_4h_lt_85) | (roc_9_1h_gt_neg_25))
             # 15m down move, 4h & 1d high
             & ((rsi_3_15m_gt_10) | (aroonu_14_4h_lt_90) | aroonu_14_1d_lt_100)
             # 15m down move, 4h high, 15m downtrend
@@ -16879,7 +16886,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 1d high, 4h overbought
             & ((rsi_3_15m_gt_15) | (stochrsi_k_1d_lt_90) | (roc_9_4h_lt_40))
             # 15m down move, 1h downtrend, 4h overbought
-            & ((rsi_3_15m_gt_15) | (roc_9_1h > -20.0) | (roc_9_4h_lt_80))
+            & ((rsi_3_15m_gt_15) | (roc_9_1h_gt_neg_20) | (roc_9_4h_lt_80))
             # 15m down move, 4h & 1d downtrend
             & ((rsi_3_15m_gt_15) | (roc_9_4h > -10.0) | (roc_9_1d_gt_neg_40))
             # 15m & 1h down move, 1h high
@@ -16931,7 +16938,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 15m & 1h downtrend
             & ((rsi_3_1h_gt_3) | (cmf_20_15m > -0.30) | (cmf_20_1h > -0.30))
             # 1h down move, 1h still high, 1h downtrend
-            & ((rsi_3_1h_gt_3) | (aroonu_14_1h_lt_50) | (roc_9_1h > -20.0))
+            & ((rsi_3_1h_gt_3) | (aroonu_14_1h_lt_50) | (roc_9_1h_gt_neg_20))
             # 1h down move, 1h high
             & ((rsi_3_1h_gt_3) | aroonu_14_1h_lt_70)
             # 1h down move, 4h high
@@ -16939,7 +16946,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1d high
             & ((rsi_3_1h_gt_3) | (aroonu_14_1d_lt_70))
             # 1h down move, 4h still high, 1d downtrend
-            & ((rsi_3_1h_gt_3) | (stochrsi_k_4h_lt_50) | (roc_9_1h > -20.0))
+            & ((rsi_3_1h_gt_3) | (stochrsi_k_4h_lt_50) | (roc_9_1h_gt_neg_20))
             # 1h down move, 1d high & overbought
             & ((rsi_3_1h_gt_3) | (stochrsi_k_1d_lt_60) | (roc_9_1d_lt_20))
             # 1h & 4h & 1d down move
@@ -16959,7 +16966,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h high, 1d high
             & ((rsi_3_1h_gt_5) | (aroonu_14_1h_lt_70) | (stochrsi_k_1d_lt_80))
             # 1h down move, 1d high, 1h downtrend
-            & ((rsi_3_1h_gt_5) | (aroonu_14_1d_lt_85) | (roc_9_1h > -50.0))
+            & ((rsi_3_1h_gt_5) | (aroonu_14_1d_lt_85) | (roc_9_1h_gt_neg_50))
             # 1h down move, 1d high, 4h downtrend
             & ((rsi_3_1h_gt_5) | (aroonu_14_1d_lt_90) | (roc_9_4h_gt_neg_30))
             # 1h down move, 1d high, 1d downtrend
@@ -17019,7 +17026,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1d overbought
             & ((rsi_3_1h_gt_10) | roc_9_1d_lt_50)
             # 1h & 4h down move, 1h downtrend
-            & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_15) | (roc_9_1h > -15.0))
+            & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_15) | (roc_9_1h_gt_neg_15))
             # 1h & 4h down move, 4h downtrend
             & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_15) | (roc_9_4h > -25.0))
             # 1h & 4h down move, 1d downtrend
@@ -17051,7 +17058,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 4h high, 15m downtrend
             & ((rsi_3_1h_gt_15) | (aroonu_14_4h_lt_85) | (roc_9_15m > -15.0))
             # 1h down move, 4h high, 1h downtrend
-            & ((rsi_3_1h_gt_15) | (aroonu_14_4h_lt_85) | (roc_9_1h > -30.0))
+            & ((rsi_3_1h_gt_15) | (aroonu_14_4h_lt_85) | (roc_9_1h_gt_neg_30))
             # 1h down move, 1d high, 4h overbought
             & ((rsi_3_1h_gt_15) | (aroonu_14_1d_lt_100) | (roc_9_4h_lt_10))
             # 1h down move, 4h still not low enough, 1d downtrend
@@ -17059,7 +17066,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 4h high & overbought
             & ((rsi_3_1h_gt_15) | (stochrsi_k_4h_lt_80) | (roc_9_4h_lt_100))
             # 1h down move, 1h downtrend, 1d overbought
-            & ((rsi_3_1h_gt_15) | (roc_9_1h > -30.0) | (roc_9_1d_lt_35))
+            & ((rsi_3_1h_gt_15) | (roc_9_1h_gt_neg_30) | (roc_9_1d_lt_35))
             # 1h down move, 4h downtrend, 1d overbought
             & ((rsi_3_1h_gt_15) | (roc_9_4h > -25.0) | (roc_9_1d_lt_100))
             # 1h & 4h down move, 1d high
@@ -17109,9 +17116,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 15m downtrend, 4h overbought
             & ((rsi_3_1h_gt_25) | (roc_9_15m > -25.0) | (roc_9_4h_lt_30))
             # 1h down move, 1h & 1d downtrend
-            & ((rsi_3_1h_gt_25) | (roc_9_1h > -50.0) | roc_9_1d_gt_neg_50)
+            & ((rsi_3_1h_gt_25) | (roc_9_1h_gt_neg_50) | roc_9_1d_gt_neg_50)
             # 1h down move, 1h downtrend, 4h overbought
-            & ((rsi_3_1h_gt_25) | (roc_9_1h > -25.0) | (roc_9_4h_lt_50))
+            & ((rsi_3_1h_gt_25) | (roc_9_1h_gt_neg_25) | (roc_9_4h_lt_50))
             # 1h down move, 1h & 4h overbought
             & ((rsi_3_1h_gt_25) | (roc_9_1h_lt_30) | (roc_9_4h_lt_100))
             # 1h & 4h down move, 1h high
@@ -17151,7 +17158,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 4h high & overbought
             & ((rsi_3_1h_gt_35) | (stochrsi_k_4h_lt_80) | (roc_9_4h_lt_30))
             # 1h down move, 1h downtrend, 4h overbought
-            & ((rsi_3_1h_gt_35) | (roc_9_1h > -30.0) | (roc_9_4h_lt_100))
+            & ((rsi_3_1h_gt_35) | (roc_9_1h_gt_neg_30) | (roc_9_4h_lt_100))
             # 1h down move, 4h & 1d overbought
             & ((rsi_3_1h_gt_35) | (roc_9_4h_lt_20) | (roc_9_1d_lt_70))
             # 1h down move, 1h & 4h high
@@ -17187,7 +17194,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h & 1d down move, 1d still not low enough
             & ((rsi_3_4h_gt_3) | (rsi_3_1d_gt_30) | (aroonu_14_1d_lt_30))
             # 4h down move, 4h high, 1h downtrend
-            & ((rsi_3_4h_gt_3) | aroonu_14_4h_lt_70 | (roc_9_1h > -40.0))
+            & ((rsi_3_4h_gt_3) | aroonu_14_4h_lt_70 | (roc_9_1h_gt_neg_40))
             # 4h down move, 1h still high, 4h downtrend
             & ((rsi_3_4h_gt_3) | (stochrsi_k_1h_lt_50) | (roc_9_4h_gt_neg_30))
             # 4h & 1d down move, 1d still high
@@ -17199,7 +17206,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 1d high & overbought
             & ((rsi_3_4h_gt_10) | (aroonu_14_1d_lt_80) | (roc_9_1d_lt_80))
             # 4h down move, 1h & 4h downtrend
-            & ((rsi_3_4h_gt_10) | (roc_9_1h > -30.0) | (roc_9_4h_gt_neg_30))
+            & ((rsi_3_4h_gt_10) | (roc_9_1h_gt_neg_30) | (roc_9_4h_gt_neg_30))
             # 4h down move, 1d high & overbought
             & ((rsi_3_4h_gt_10) | (stochrsi_k_1d_lt_70) | (roc_9_1d_lt_35))
             # 4h down move, 4h & 1d downtrend
@@ -17219,7 +17226,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 4h high
             & ((rsi_3_4h_gt_25) | aroonu_14_4h_lt_80)
             # 4h down move, 1d high, 1h downtrend
-            & ((rsi_3_4h_gt_25) | aroonu_14_1d_lt_100 | (roc_9_1h > -40.0))
+            & ((rsi_3_4h_gt_25) | aroonu_14_1d_lt_100 | (roc_9_1h_gt_neg_40))
             # 4h down move, 4h still high, 1d downtrend
             & ((rsi_3_4h_gt_30) | (aroonu_14_4h_lt_50) | (roc_9_1d_gt_neg_40))
             # 4h down move, 4h still high, 1d overbought
@@ -17303,7 +17310,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1d still high, 4h & 1d downtrend
             & ((aroonu_14_1d_lt_50) | (roc_9_4h > -50.0) | roc_9_1d_gt_neg_50)
             # 1d high, 1h & 4h downtrend
-            & ((aroonu_14_1d_lt_85) | (roc_9_1h > -30.0) | (roc_9_4h > -50.0))
+            & ((aroonu_14_1d_lt_85) | (roc_9_1h_gt_neg_30) | (roc_9_4h > -50.0))
             # 1d high, 4h downtrend, 1d overbought
             & ((aroonu_14_1d_lt_85) | (roc_9_4h > -25.0) | roc_9_1d_lt_50)
             # 1d high, 4h & 1d overbought
@@ -17343,7 +17350,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 4h high
             & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_3) | (stochrsi_k_4h_lt_70))
             # 15m & 1h down move, 1h downtrend
-            & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_3) | (roc_9_1h > -50.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_3) | (roc_9_1h_gt_neg_50))
             # 15m & 1h down move, 1d still not low enough
             & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_5) | (stochrsi_k_1d_lt_30))
             # 15m & 1h down move, 4h still high
@@ -17369,7 +17376,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h & 4h down move
             & ((rsi_3_15m_gt_5) | (rsi_3_1h_gt_10) | (rsi_3_4h_gt_15))
             # 15m & 4h down move, 1h downtrend
-            & ((rsi_3_15m_gt_5) | (rsi_3_4h_gt_10) | (roc_9_1h > -20.0))
+            & ((rsi_3_15m_gt_5) | (rsi_3_4h_gt_10) | (roc_9_1h_gt_neg_20))
             # 15m & 4h down move, 1d downtrend
             & ((rsi_3_15m_gt_5) | (rsi_3_4h_gt_10) | (roc_9_1d > -30.0))
             # 15m & 4h down move, 4h still high
@@ -17447,7 +17454,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 4h high
             & ((rsi_3_1h_gt_3) | (rsi_3_4h_gt_25) | (stochrsi_k_4h_lt_60))
             # 1h down move, 1d high, 1d downtrend
-            & ((rsi_3_1h_gt_3) | (aroonu_14_1d_lt_70) | (roc_9_1h > -50.0))
+            & ((rsi_3_1h_gt_3) | (aroonu_14_1d_lt_70) | (roc_9_1h_gt_neg_50))
             # 1h & 4h down move, 15m still not low enough
             & ((rsi_3_1h_gt_5) | (rsi_3_4h_gt_5) | (stochrsi_k_15m_lt_20))
             # 1h & 4h down move, 1d downtrend
@@ -17685,7 +17692,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h & 1d down move, 1d high
             & ((rsi_3_4h_gt_5) | (rsi_3_1d_gt_30) | (aroonu_14_1d_lt_70))
             # 4h down move, 1h & 4h downtrend
-            & ((rsi_3_4h_gt_5) | (roc_9_1h > -15.0) | (roc_9_4h_gt_neg_20))
+            & ((rsi_3_4h_gt_5) | (roc_9_1h_gt_neg_15) | (roc_9_4h_gt_neg_20))
             # 4h down move, 4h & 1d downtrend
             & ((rsi_3_4h_gt_5) | (roc_9_4h_gt_neg_20) | (roc_9_1d_gt_neg_20))
             # 4h & 1d down move, 15m still not low enough
@@ -17703,7 +17710,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h & 1d down move, 4h still not low enough
             & ((rsi_3_4h_gt_10) | (rsi_3_1d > 50.0) | (stochrsi_k_4h_lt_20))
             # 4h down move, 15m high, 1h downtrend
-            & ((rsi_3_4h_gt_10) | (stochrsi_k_15m_lt_60) | (roc_9_1h > -10.0))
+            & ((rsi_3_4h_gt_10) | (stochrsi_k_15m_lt_60) | (roc_9_1h_gt_neg_10))
             # 4h down move, 15m high
             & ((rsi_3_4h_gt_10) | (stochrsi_k_15m_lt_80))
             # 4h down move, 4h still not low e nough, 1d downtrend
@@ -17737,7 +17744,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 4h still high, 1d downtrend
             & ((rsi_3_4h_gt_15) | (aroonu_14_4h_lt_50) | (roc_9_1d > -20.0))
             # 4h down move, 1h & 4h downtrend
-            & ((rsi_3_4h_gt_15) | (roc_9_1h > -40.0) | (roc_9_4h > -40.0))
+            & ((rsi_3_4h_gt_15) | (roc_9_1h_gt_neg_40) | (roc_9_4h > -40.0))
             # 4h & 1d down move, 1d high
             & (rsi_3_4h_gt_20 | (rsi_3_1d_gt_20) | (stochrsi_k_1d_lt_80))
             # 4h & 1d down move, 15m high
@@ -17769,7 +17776,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 4h still high, 1d downtrend
             & ((rsi_3_4h_gt_25) | (aroonu_14_4h_lt_40) | (roc_9_1d_gt_neg_20))
             # 4h down move, 4h high, 1h downtrend
-            & ((rsi_3_4h_gt_25) | (aroonu_14_4h_lt_60) | (roc_9_1h > -10.0))
+            & ((rsi_3_4h_gt_25) | (aroonu_14_4h_lt_60) | (roc_9_1h_gt_neg_10))
             # 4h down move, 1d high & overbought
             & ((rsi_3_4h_gt_25) | (aroonu_14_1d_lt_80) | (roc_9_1d_lt_30))
             # 4h down move, 1d high, 4h downtrend
@@ -17785,7 +17792,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 4h still high, 1d high
             & ((rsi_3_4h_gt_30) | (aroonu_14_4h_lt_50) | aroonu_14_1d_lt_100)
             # 4h down move, 4h high, 1h downtrend
-            & ((rsi_3_4h_gt_30) | aroonu_14_4h_lt_80 | (roc_9_1h > -40.0))
+            & ((rsi_3_4h_gt_30) | aroonu_14_4h_lt_80 | (roc_9_1h_gt_neg_40))
             # 4h down move, 4h high
             & ((rsi_3_4h_gt_30) | aroonu_14_4h_lt_100)
             # 4h down move, 1d high & overbought
@@ -17843,7 +17850,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 4h high, 1d downtrend
             & ((aroonu_14_15m_lt_85) | (aroonu_14_4h_lt_85) | (roc_9_1d_gt_neg_20))
             # 1h still high, 1h & 4h downtrend
-            & ((aroonu_14_1h_lt_50) | (roc_9_1h > -20.0) | (roc_9_4h_gt_neg_30))
+            & ((aroonu_14_1h_lt_50) | (roc_9_1h_gt_neg_20) | (roc_9_4h_gt_neg_30))
             # 1h & 4h high, 4h overbought
             & (aroonu_14_1h_lt_80 | aroonu_14_4h_lt_100 | (roc_9_4h_lt_10))
             # 4h high, 4h & 1d downtrend
@@ -17859,13 +17866,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1d high, 4h downtrend, 1d overbought
             & ((aroonu_14_1d_lt_85) | (roc_9_4h_gt_neg_20) | (roc_9_1d_lt_200))
             # 1d high, 1h & 4h downtrend
-            & (aroonu_14_1d_lt_100 | (roc_9_1h > -30.0) | (roc_9_4h_gt_neg_30))
+            & (aroonu_14_1d_lt_100 | (roc_9_1h_gt_neg_30) | (roc_9_4h_gt_neg_30))
             # 1d high, 1h & 1d overbought
             & (aroonu_14_1d_lt_100 | (roc_9_1h_lt_10) | (roc_9_1d_lt_30))
             # 1d high, 4h & 1d overbought
             & (aroonu_14_1d_lt_100 | (roc_9_4h_lt_30) | (roc_9_1d_lt_60))
             # 15m still high, 1h & 4h downtrend
-            & ((stochrsi_k_15m_lt_50) | (roc_9_1h > -20.0) | (roc_9_4h_gt_neg_20))
+            & ((stochrsi_k_15m_lt_50) | (roc_9_1h_gt_neg_20) | (roc_9_4h_gt_neg_20))
             # 4h high, 1h & 4h overbought
             & ((stochrsi_k_4h_lt_90) | (roc_9_1h_lt_20) | (roc_9_4h_lt_30))
             # 4h high, 4h & 1d overbought
@@ -17974,7 +17981,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 4h high, 1d overbought
             & ((rsi_3_15m_gt_3) | (stochrsi_k_4h_lt_80) | (roc_9_1d_lt_10))
             # 15m down move, 1h downtrend, 4h overbought
-            & ((rsi_3_15m_gt_3) | (roc_9_1h > -30.0) | (roc_9_4h_lt_100))
+            & ((rsi_3_15m_gt_3) | (roc_9_1h_gt_neg_30) | (roc_9_4h_lt_100))
             # 15m down move, 4h & 1d downtrend
             & ((rsi_3_15m_gt_3) | (roc_9_4h > -70.0) | (roc_9_1d > -70.0))
             # 15m & 1h down move, 4h still high
@@ -17992,7 +17999,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 4h down move, 1h still high
             & ((rsi_3_15m_gt_5) | (rsi_3_4h_gt_10) | (stochrsi_k_1h_lt_50))
             # 15m & 4h down move, 1h downtrend
-            & ((rsi_3_15m_gt_5) | (rsi_3_4h_gt_10) | (roc_9_1h > -20.0))
+            & ((rsi_3_15m_gt_5) | (rsi_3_4h_gt_10) | (roc_9_1h_gt_neg_20))
             # 15m & 4h down move, 15m still high
             & ((rsi_3_15m_gt_5) | (rsi_3_4h_gt_15) | (stochrsi_k_15m_lt_50))
             # 15m & 4h down move, 4h still high
@@ -18136,7 +18143,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 15m high
             & ((rsi_3_15m_gt_25) | (rsi_3_1h_gt_25) | (stochrsi_k_15m_lt_70))
             # 15m & 1h down move, 1h downtrend
-            & ((rsi_3_15m_gt_25) | (rsi_3_1h_gt_25) | (roc_9_1h > -30.0))
+            & ((rsi_3_15m_gt_25) | (rsi_3_1h_gt_25) | (roc_9_1h_gt_neg_30))
             # 15m & 4h down move, 15m & 4h high
             & ((rsi_3_15m_gt_25) | (rsi_3_4h_gt_25) | (aroonu_14_15m_lt_70) | (aroonu_14_4h_lt_70))
             # 15m down move, 1d high & overbought
@@ -18166,7 +18173,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 4h high, 1d downtrend
             & ((rsi_3_1h_gt_5) | aroonu_14_4h_lt_70 | (roc_9_1d_gt_neg_30))
             # 1h down move, 1d high, 1h downtrend
-            & ((rsi_3_1h_gt_5) | (aroonu_14_1d_lt_90) | (roc_9_1h > -40.0))
+            & ((rsi_3_1h_gt_5) | (aroonu_14_1d_lt_90) | (roc_9_1h_gt_neg_40))
             # 1h down move, 4h & 1d downtrend
             & ((rsi_3_1h_gt_5) | (roc_9_4h_gt_neg_20) | (roc_9_1d_gt_neg_20))
             # 1h & 4h & 1d down move
@@ -18196,7 +18203,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 4h high
             & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_15) | (aroonu_14_4h_lt_60))
             # 1h & 4h down move, 1h downtrend
-            & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_15) | (roc_9_1h > -15.0))
+            & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_15) | (roc_9_1h_gt_neg_15))
             # 1h & 4h down move, 1d overbought
             & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_15) | (roc_9_1d_lt_10))
             # 1h & 4h down move, 4h still high
@@ -18302,7 +18309,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h & 1d down move, 1d still high
             & ((rsi_3_4h_gt_5) | (rsi_3_1d_gt_30) | (stochrsi_k_1d_lt_40))
             # 4h down move, 1h & 4h downtrend
-            & ((rsi_3_4h_gt_5) | (roc_9_1h > -10.0) | (roc_9_4h > -10.0))
+            & ((rsi_3_4h_gt_5) | (roc_9_1h_gt_neg_10) | (roc_9_4h > -10.0))
             # 4h & 1d down move, 4h downtrend
             & ((rsi_3_4h_gt_10) | (rsi_3_1d_gt_10) | (roc_9_4h > -20.0))
             # 4h & 1d down move, 1d downtrend
@@ -18368,7 +18375,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h high, 1h & 4h overbought
             & ((aroonu_14_4h_lt_85) | (roc_9_1h_lt_80) | (roc_9_4h_lt_80))
             # 4h high, 1h downtrend, 4h overbought
-            & ((aroonu_14_4h_lt_90) | (roc_9_1h > -40.0) | (roc_9_4h_lt_100))
+            & ((aroonu_14_4h_lt_90) | (roc_9_1h_gt_neg_40) | (roc_9_4h_lt_100))
             # 4h & 1d high, 4h overbought
             & ((aroonu_14_4h_lt_90) | aroonu_14_1d_lt_100 | (roc_9_4h_lt_100))
             # 4h high, 1h & 4h overbought
@@ -18378,7 +18385,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h & 1d high, 1d overbought
             & (aroonu_14_4h_lt_100 | aroonu_14_1d_lt_100 | (roc_9_1d_lt_40))
             # 1d high, 1h & 4h downtrend
-            & (aroonu_14_1d_lt_100 | (roc_9_1h > -30.0) | (roc_9_4h_gt_neg_30))
+            & (aroonu_14_1d_lt_100 | (roc_9_1h_gt_neg_30) | (roc_9_4h_gt_neg_30))
             # 1d high, 4h & 1d overbought
             & (aroonu_14_1d_lt_100 | (roc_9_4h_lt_20) | (roc_9_1d_lt_100))
             # 1h high, 1d overbought
@@ -18439,7 +18446,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 4h down move, 15m downtrend
             & ((rsi_3_15m_gt_3) | (rsi_3_4h_gt_10) | (roc_9_15m > -30.0))
             # 15m & 4h down move, 1h downtrend
-            & ((rsi_3_15m_gt_3) | (rsi_3_4h_gt_10) | (roc_9_1h > -20.0))
+            & ((rsi_3_15m_gt_3) | (rsi_3_4h_gt_10) | (roc_9_1h_gt_neg_20))
             # 15m & 4h down move, 1h still high
             & ((rsi_3_15m_gt_3) | (rsi_3_4h_gt_15) | (aroonu_14_1h_lt_50))
             # 15m & 4h down move, 1h still high
@@ -18455,7 +18462,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 1h high
             & ((rsi_3_15m_gt_5) | (rsi_3_1h_gt_15) | (aroonu_14_1h_lt_70))
             # 15m & 1h down move, 1h downtrend
-            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_10) | (roc_9_1h > -20.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_10) | (roc_9_1h_gt_neg_20))
             # 15m & 4h down move, 1h still not low enough
             & ((rsi_3_15m_gt_10) | (rsi_3_4h_gt_10) | (stochrsi_k_1h_lt_30))
             # 15m down move, 4h overbought
@@ -18487,13 +18494,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h & 4h still high
             & ((rsi_3_1h_gt_3) | (aroonu_14_1h_lt_50) | (aroonu_14_4h_lt_50))
             # 1h down move, 1h still high, 1h downtrend
-            & ((rsi_3_1h_gt_3) | (aroonu_14_1h_lt_50) | (roc_9_1h > -20.0))
+            & ((rsi_3_1h_gt_3) | (aroonu_14_1h_lt_50) | (roc_9_1h_gt_neg_20))
             # 1h down move, 4h still high, 1d downtrend
-            & ((rsi_3_1h_gt_3) | (stochrsi_k_4h_lt_50) | (roc_9_1h > -15.0))
+            & ((rsi_3_1h_gt_3) | (stochrsi_k_4h_lt_50) | (roc_9_1h_gt_neg_15))
             # 1h downtrend, 4h high
             & ((rsi_3_1h_gt_3) | (stochrsi_k_4h_lt_70))
             # 1h down move, 1h & 4h downtrend
-            & ((rsi_3_1h_gt_3) | (roc_9_1h > -20.0) | (roc_9_4h_gt_neg_20))
+            & ((rsi_3_1h_gt_3) | (roc_9_1h_gt_neg_20) | (roc_9_4h_gt_neg_20))
             # 1h & 4h down move, 4h still high
             & ((rsi_3_1h_gt_5) | (rsi_3_4h_gt_10) | (aroonu_14_4h_lt_50))
             # 1h & 4h down move, 1d high
@@ -18523,7 +18530,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 1d downtrend
             & ((rsi_3_1h_gt_10) | rsi_3_4h_gt_20 | (roc_9_1d_gt_neg_40))
             # 1h & 4h down move, 1h downtrend
-            & ((rsi_3_1h_gt_10) | rsi_3_4h_gt_20 | (roc_9_1h > -25.0))
+            & ((rsi_3_1h_gt_10) | rsi_3_4h_gt_20 | (roc_9_1h_gt_neg_25))
             # 1h & 4h down move, 4h high
             & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_25) | aroonu_14_4h_lt_70)
             # 1h & 4h down move, 1h high
@@ -18539,7 +18546,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h still high, 1d high
             & ((rsi_3_1h_gt_10) | (aroonu_14_1h_lt_50) | (aroonu_14_1d_lt_90))
             # 1h down move, 1h high, 1h downtrend
-            & ((rsi_3_1h_gt_10) | (aroonu_14_1h_lt_60) | (roc_9_1h > -10.0))
+            & ((rsi_3_1h_gt_10) | (aroonu_14_1h_lt_60) | (roc_9_1h_gt_neg_10))
             # 1h down move, 1h high, 1d downtrend
             & ((rsi_3_1h_gt_10) | (aroonu_14_1h_lt_70) | (roc_9_1d > -30.0))
             # 1h down move, 1h high
@@ -18581,7 +18588,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1d high & overbought
             & ((rsi_3_1h_gt_15) | (aroonu_14_1d_lt_80) | (roc_9_1d_lt_100))
             # 1h down move, 1h & 4h downtrend
-            & ((rsi_3_1h_gt_15) | (roc_9_1h > -30.0) | (roc_9_4h_gt_neg_30))
+            & ((rsi_3_1h_gt_15) | (roc_9_1h_gt_neg_30) | (roc_9_4h_gt_neg_30))
             # 1h down move, 1h & 4h overbought
             & ((rsi_3_1h_gt_15) | (roc_9_4h_lt_10) | (roc_9_1d_lt_50))
             # 1h down move, 1h & 4h overbought
@@ -18607,7 +18614,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h still high, 1d overbought
             & ((rsi_3_1h_gt_25) | (stochrsi_k_1h_lt_50) | (roc_9_1d_lt_40))
             # 1h down move, 1h downtrend, 4h overbought
-            & ((rsi_3_1h_gt_25) | (roc_9_1h > -20.0) | (roc_9_4h_lt_20))
+            & ((rsi_3_1h_gt_25) | (roc_9_1h_gt_neg_20) | (roc_9_4h_lt_20))
             # 1h down move, 1d overbought
             & ((rsi_3_1h_gt_25) | (roc_9_1d_lt_200))
             # 1h down move, 4h high
@@ -18623,7 +18630,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 1h still high
             & ((rsi_3_4h_gt_5) | (stochrsi_k_1h_lt_40))
             # 4h down move, 1h & 4h downtrend
-            & ((rsi_3_4h_gt_5) | (roc_9_1h > -15.0) | (roc_9_4h_gt_neg_20))
+            & ((rsi_3_4h_gt_5) | (roc_9_1h_gt_neg_15) | (roc_9_4h_gt_neg_20))
             # 4h down move, 4h downtrend
             & ((rsi_3_4h_gt_5) | (roc_9_4h > -40.0))
             # 4h & 1d down move, 1d high
@@ -18631,7 +18638,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 1d high, 4h downtrend
             & ((rsi_3_4h_gt_10) | (aroonu_14_1d_lt_90) | (roc_9_4h > -20.0))
             # 4h down move, 1h & 4h downtrend
-            & ((rsi_3_4h_gt_10) | (roc_9_1h > -30.0) | (roc_9_4h_gt_neg_30))
+            & ((rsi_3_4h_gt_10) | (roc_9_1h_gt_neg_30) | (roc_9_4h_gt_neg_30))
             # 4h down move, 4h still not low enough, 1d overbought
             & ((rsi_3_4h_gt_15) | (aroonu_14_4h_lt_30) | roc_9_1d_lt_50)
             # 4h down move, 4h high
@@ -18663,7 +18670,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 1d high, 4h downtrend
             & ((aroonu_14_1h_lt_40) | (aroonu_14_1d_lt_70) | (roc_9_4h_gt_neg_20))
             # 1h still high, 1h & 4h downtrend
-            & ((aroonu_14_1h_lt_40) | (roc_9_1h > -20.0) | (roc_9_4h_gt_neg_30))
+            & ((aroonu_14_1h_lt_40) | (roc_9_1h_gt_neg_20) | (roc_9_4h_gt_neg_30))
             # 1h & 4h high, 1d overbought
             & (aroonu_14_1h_lt_70 | aroonu_14_4h_lt_100 | (roc_9_1d_lt_20))
             # 1h high, 4h & 1d downtrend
@@ -18673,13 +18680,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 1d high, 1d overbought
             & (aroonu_14_1h_lt_80 | (aroonu_14_1d_lt_90) | (roc_9_1d_lt_80))
             # 1h & 1d high, 1h downtrend
-            & (aroonu_14_1h_lt_80 | aroonu_14_1d_lt_100 | (roc_9_1h > -20.0))
+            & (aroonu_14_1h_lt_80 | aroonu_14_1d_lt_100 | (roc_9_1h_gt_neg_20))
             # 4h & 1d high, 1h downtrend
-            & (aroonu_14_4h_lt_80 | aroonu_14_1d_lt_100 | (roc_9_1h > -30.0))
+            & (aroonu_14_4h_lt_80 | aroonu_14_1d_lt_100 | (roc_9_1h_gt_neg_30))
             # 4h & 1d high, 4h overbought
             & (aroonu_14_4h_lt_80 | aroonu_14_1d_lt_100 | (roc_9_4h_lt_40))
             # 4h high, 1h downtrend
-            & (aroonu_14_4h_lt_80 | (roc_9_1h > -40.0))
+            & (aroonu_14_4h_lt_80 | (roc_9_1h_gt_neg_40))
             # 4h high & overbought
             & (aroonu_14_4h_lt_80 | (roc_9_4h_lt_100))
             # 4h high, 1d downtrend
@@ -18705,7 +18712,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h high, 1d downtrend
             & ((stochrsi_k_4h_lt_70) | (roc_9_1d > -70.0))
             # 1d high, 1h downtrend
-            & ((stochrsi_k_1d_lt_90) | (roc_9_1h > -20.0))
+            & ((stochrsi_k_1d_lt_90) | (roc_9_1h_gt_neg_20))
             # 1d high, 1d downtrend
             & ((stochrsi_k_1d_lt_60) | (roc_9_1d_gt_neg_30))
             # 15m downtrend, 1d overbought
@@ -18889,7 +18896,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 1h still high, 1d downtrend
             & ((rsi_3_4h_gt_10) | (stochrsi_k_1h_lt_40) | (roc_9_1d > -20.0))
             # 4h down move, 1h & 1d downtrend
-            & ((rsi_3_4h_gt_10) | (roc_9_1h > -20.0) | (roc_9_1d > -20.0))
+            & ((rsi_3_4h_gt_10) | (roc_9_1h_gt_neg_20) | (roc_9_1d > -20.0))
             # 4h & 1d down move, 1d still high
             & ((rsi_3_4h_gt_15) | (rsi_3_1d_gt_35) | (rsi_14_1d < 50.0))
             # 4h down move, 1h still not low enough
@@ -18927,7 +18934,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h high, 1d overbought
             & (aroonu_14_4h_lt_70 | (roc_9_1d_lt_80))
             # 4h high, 1h & 1d downtrend
-            & (aroonu_14_4h_lt_70 | (roc_9_1h > -20.0) | (roc_9_1d_gt_neg_20))
+            & (aroonu_14_4h_lt_70 | (roc_9_1h_gt_neg_20) | (roc_9_1d_gt_neg_20))
             # 4h high, 1h & 4h overbought
             & (aroonu_14_4h_lt_80 | (roc_9_1h_lt_10) | (roc_9_4h_lt_10))
             # 4h high & overbought
@@ -18937,7 +18944,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h high, 4h overbought
             & ((stochrsi_k_1h_lt_80) | (roc_9_4h_lt_80))
             # 4h high, 1h & 1d downtrend
-            & ((stochrsi_k_4h_lt_70) | (roc_9_1h > -20.0) | (roc_9_1d_gt_neg_20))
+            & ((stochrsi_k_4h_lt_70) | (roc_9_1h_gt_neg_20) | (roc_9_1d_gt_neg_20))
             # 4h high, 1h & 4h overbought
             & ((stochrsi_k_4h_lt_80) | (roc_9_1h_lt_10) | (roc_9_4h_lt_10))
             # 4h high, 4h & 1d overbought
@@ -19182,7 +19189,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h & 1d down move, 1d high
             & ((rsi_3_4h_gt_5) | (rsi_3_1d_gt_30) | (aroonu_14_1d_lt_70))
             # 4h down move, 1h & 4h downtrend
-            & ((rsi_3_4h_gt_5) | (roc_9_1h > -15.0) | (roc_9_4h_gt_neg_20))
+            & ((rsi_3_4h_gt_5) | (roc_9_1h_gt_neg_15) | (roc_9_4h_gt_neg_20))
             # 4h & 1d down move
             & ((rsi_3_4h_gt_10) | (rsi_3_1d_gt_20))
             # 4h & 1d down move, 1d high
@@ -19330,7 +19337,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 1h high
             & ((rsi_3_15m_gt_5) | (rsi_3_1h_gt_30) | (stochrsi_k_1h_lt_80))
             # 15m & 4h down move, 1h downtrend
-            & ((rsi_3_15m_gt_5) | (rsi_3_4h_gt_10) | (roc_9_1h > -20.0))
+            & ((rsi_3_15m_gt_5) | (rsi_3_4h_gt_10) | (roc_9_1h_gt_neg_20))
             # 15m & 4h down move, 1d overbought
             & ((rsi_3_15m_gt_5) | (rsi_3_4h_gt_15) | (roc_9_1d_lt_70))
             # 15m & 4h down move, 1h high
@@ -19522,7 +19529,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 1d high
             & ((rsi_3_4h_gt_3) | (stochrsi_k_1d_lt_90))
             # 4h down move, 1h & 4h downtrend
-            & ((rsi_3_4h_gt_3) | (roc_9_1h > -30.0) | (roc_9_4h_gt_neg_30))
+            & ((rsi_3_4h_gt_3) | (roc_9_1h_gt_neg_30) | (roc_9_4h_gt_neg_30))
             # 4h down move, 1d overbought
             & ((rsi_3_4h_gt_3) | (roc_9_1d_lt_40))
             # 4h & 1d down move, 1d still high
@@ -19536,7 +19543,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h & 1d down move, 1d high
             & ((rsi_3_4h_gt_15) | (rsi_3_1d_gt_20) | (aroonu_14_1d_lt_60))
             # 4h down move, 4h high, 1h downtrend
-            & ((rsi_3_4h_gt_15) | (aroonu_14_4h_lt_60) | (roc_9_1h > -20.0))
+            & ((rsi_3_4h_gt_15) | (aroonu_14_4h_lt_60) | (roc_9_1h_gt_neg_20))
             # 4h down move, 4h & 1d high
             & ((rsi_3_4h_gt_15) | aroonu_14_4h_lt_70 | (aroonu_14_1d_lt_70))
             # 4h down move, 1d high & overbought
@@ -19590,7 +19597,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h high, 4h & 1d overbought
             & (aroonu_14_4h_lt_80 | (roc_9_4h_lt_20) | (roc_9_1d_lt_20))
             # 1d high, 1h & 4h downtrend
-            & ((aroonu_14_1d_lt_85) | (roc_9_1h > -30.0) | (roc_9_4h > -50.0))
+            & ((aroonu_14_1d_lt_85) | (roc_9_1h_gt_neg_30) | (roc_9_4h > -50.0))
             # 1d high, 1h & 1d overbought
             & ((aroonu_14_1d_lt_85) | (roc_9_1h_lt_20) | (roc_9_1d_lt_100))
             # 1d high, 4h & 1d overbought
@@ -19657,7 +19664,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 4h down move, 15m still not low enough
             & ((rsi_3_15m_gt_5) | (rsi_3_4h_gt_10) | (stochrsi_k_15m_lt_30))
             # 15m & 4h down move, 1h downtrend
-            & ((rsi_3_15m_gt_5) | (rsi_3_4h_gt_10) | (roc_9_1h > -20.0))
+            & ((rsi_3_15m_gt_5) | (rsi_3_4h_gt_10) | (roc_9_1h_gt_neg_20))
             # 15m & 4h down move, 1d overbought
             & ((rsi_3_15m_gt_5) | (rsi_3_4h_gt_10) | (roc_9_1d_lt_20))
             # 15m & 4h down move, 4h still high
@@ -19755,7 +19762,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 4h still not low enough
             & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_10) | (aroonu_14_4h_lt_30))
             # 1h & 4h down move, 1h downtrend
-            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_10) | (roc_9_1h > -20.0))
+            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_10) | (roc_9_1h_gt_neg_20))
             # 1h & 4h down move, 1d downtrend
             & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_10) | (roc_9_1d > -20.0))
             # 1h & 4h down move, 1d overbought
@@ -20089,7 +20096,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 15m high, 4h high
             & ((rsi_3_15m_gt_30) | (aroonu_14_15m_lt_60) | (stochrsi_k_4h_lt_70))
             # 15m down move, 4h high, 1h downtrend
-            & ((rsi_3_15m_gt_30) | (aroonu_14_4h_lt_85) | (roc_9_1h > -40.0))
+            & ((rsi_3_15m_gt_30) | (aroonu_14_4h_lt_85) | (roc_9_1h_gt_neg_40))
             # 15m down move, 4h high
             & ((rsi_3_15m_gt_30) | (stochrsi_k_4h_lt_90))
             # 15m & 1h down move, 15m high
@@ -20123,7 +20130,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 1d down move, 4h still high
             & ((rsi_3_1h_gt_3) | (rsi_3_1d_gt_10) | (stochrsi_k_4h_lt_40))
             # 1h & 1d down move, 1h downtrend
-            & ((rsi_3_1h_gt_3) | (rsi_3_1d_gt_15) | (roc_9_1h > -40.0))
+            & ((rsi_3_1h_gt_3) | (rsi_3_1d_gt_15) | (roc_9_1h_gt_neg_40))
             # 1h down move, 15m downtrend, 1h still high
             & ((rsi_3_1h_gt_3) | (cmf_20_15m > -0.40) | (aroonu_14_1h_lt_40))
             # 1h down move, 15m still not low enough, 4h still high
@@ -20235,7 +20242,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 4h high, 1d downtrend
             & ((rsi_3_1h_gt_25) | (stochrsi_k_4h_lt_80) | (roc_9_1d_gt_neg_40))
             # 1h down move, 1h still high, 1h downtrend
-            & ((rsi_3_1h_gt_25) | (aroonu_14_1h_lt_40) | (roc_9_1h > -50.0))
+            & ((rsi_3_1h_gt_25) | (aroonu_14_1h_lt_40) | (roc_9_1h_gt_neg_50))
             # 1h down move, 4h high & overbought
             & ((rsi_3_1h_gt_25) | (aroonu_14_4h_lt_90) | (roc_9_4h_lt_20))
             # 1h down move, 1h still high, 1d overbought
@@ -20319,7 +20326,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 1h still not low enough, 4h downtrend
             & ((rsi_3_4h_gt_3) | (stochrsi_k_1h_lt_20) | (roc_9_4h_gt_neg_30))
             # 4h down move, 1h & 4h downtrend
-            & ((rsi_3_4h_gt_3) | (roc_9_1h > -30.0) | (roc_9_4h_gt_neg_30))
+            & ((rsi_3_4h_gt_3) | (roc_9_1h_gt_neg_30) | (roc_9_4h_gt_neg_30))
             # 4h down move, 1d high, 4h downtrend
             & ((rsi_3_4h_gt_5) | (aroonu_14_1d_lt_80) | (roc_9_4h > -10.0))
             # 4h down move, 1h still high
@@ -20431,7 +20438,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h still high, 1d high, 4h downtrend
             & ((aroonu_14_4h_lt_50) | aroonu_14_1d_lt_100 | (roc_9_4h_gt_neg_30))
             # 4h high, 1h & 1d downtrend
-            & (aroonu_14_4h_lt_70 | (roc_9_1h > -20.0) | (roc_9_1d_gt_neg_20))
+            & (aroonu_14_4h_lt_70 | (roc_9_1h_gt_neg_20) | (roc_9_1d_gt_neg_20))
             # 4h & 1d high, 1d overbought
             & (aroonu_14_4h_lt_80 | aroonu_14_1d_lt_100 | roc_9_1d_lt_50)
             # 4h & 1d high, 4h overbought
@@ -20441,7 +20448,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1d high, 4h & 1d downtrend
             & ((aroonu_14_1d_lt_80) | (roc_9_4h_gt_neg_20) | (roc_9_1d_gt_neg_20))
             # 1d high, 1h & 4h downtrend
-            & ((aroonu_14_1d_lt_85) | (roc_9_1h > -30.0) | (roc_9_4h > -50.0))
+            & ((aroonu_14_1d_lt_85) | (roc_9_1h_gt_neg_30) | (roc_9_4h > -50.0))
             # 1d high, 1h & 1d overbought
             & ((aroonu_14_1d_lt_85) | (roc_9_1h_lt_20) | (roc_9_1d_lt_100))
             # 1d high, 1h & 4h down move
@@ -20453,7 +20460,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h still high, 4h & 1d downtrend
             & ((stochrsi_k_4h_lt_40) | (roc_9_4h_gt_neg_20) | (roc_9_1d_gt_neg_40))
             # 4h high, 1h & 1d downtrend
-            & ((stochrsi_k_4h_lt_70) | (roc_9_1h > -20.0) | (roc_9_1d_gt_neg_20))
+            & ((stochrsi_k_4h_lt_70) | (roc_9_1h_gt_neg_20) | (roc_9_1d_gt_neg_20))
             # 4h high, 4h & 1d overbought
             & ((stochrsi_k_4h_lt_70) | (roc_9_4h_lt_20) | (roc_9_1d_lt_30))
             # 4h high, 1h overbought, 1d downtrend
@@ -21259,7 +21266,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 4h high
             & ((rsi_3_1h_gt_60) | (rsi_3_4h_gt_60) | (stochrsi_k_4h_lt_80))
             # 4h down move, 1h & 4h downtrend
-            & ((rsi_3_4h_gt_5) | (roc_9_1h > -30.0) | (roc_9_4h_gt_neg_30))
+            & ((rsi_3_4h_gt_5) | (roc_9_1h_gt_neg_30) | (roc_9_4h_gt_neg_30))
             # 1h down move, 4h high & overbought
             & ((rsi_3_1h_gt_50) | (stochrsi_k_4h_lt_90) | (roc_9_4h_lt_20))
             # 4h down move, 4h still high, 1d downtrend
@@ -21530,7 +21537,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 4h down move, 1h downtrend, 1h still not low enough
           long_entry_logic.append((rsi_3_4h_gt_10) | (cmf_20_1h > -0.25) | (aroonu_14_1h_lt_30))
           # 4h down move, 1h & 1d downtrend
-          long_entry_logic.append((rsi_3_4h_gt_10) | (roc_9_1h > -20.0) | (roc_9_1d > -20.0))
+          long_entry_logic.append((rsi_3_4h_gt_10) | (roc_9_1h_gt_neg_20) | (roc_9_1d > -20.0))
           # 4h & 1d down move, 4h still high
           long_entry_logic.append((rsi_3_4h_gt_15) | (rsi_3_1d_gt_45) | (stochrsi_k_4h_lt_40))
           # 4h & 1d down move, 1d high
@@ -21542,11 +21549,11 @@ class NostalgiaForInfinityX7(IStrategy):
           # 4h down move, 1h high
           long_entry_logic.append(rsi_3_4h_gt_20 | (stochrsi_k_1h_lt_80))
           # 4h down move, 1d high, 1h downtrend
-          long_entry_logic.append(rsi_3_4h_gt_20 | (stochrsi_k_1d_lt_70) | (roc_9_1h > -10.0))
+          long_entry_logic.append(rsi_3_4h_gt_20 | (stochrsi_k_1d_lt_70) | (roc_9_1h_gt_neg_10))
           # 4h down move, 4h still high, 1d overbought
           long_entry_logic.append((rsi_3_4h_gt_30) | (aroonu_14_4h_lt_40) | (roc_9_1d_lt_100))
           # 4h down move, 4h high, 1h downtrend
-          long_entry_logic.append((rsi_3_4h_gt_30) | aroonu_14_4h_lt_80 | (roc_9_1h > -30.0))
+          long_entry_logic.append((rsi_3_4h_gt_30) | aroonu_14_4h_lt_80 | (roc_9_1h_gt_neg_30))
           # 4h down move, 4h still high, 1d overbought
           long_entry_logic.append((rsi_3_4h_gt_35) | (aroonu_14_4h_lt_50) | (roc_9_1d_lt_40))
           # 4h down move, 4h still high, 1d high
@@ -21990,7 +21997,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 4h still not low enough, 1d downtrend
             & ((rsi_3_4h_gt_15) | (stochrsi_k_4h_lt_20) | (roc_9_1d > -20.0))
             # 4h down move, 1h downtrend, 1d overbought
-            & ((rsi_3_4h_gt_15) | (roc_9_1h > -10.0) | (roc_9_1d_lt_200))
+            & ((rsi_3_4h_gt_15) | (roc_9_1h_gt_neg_10) | (roc_9_1d_lt_200))
             # 4h down move, 4h high, 4h downtrend
             & (rsi_3_4h_gt_20 | (aroonu_14_4h_lt_60) | (roc_9_4h_gt_neg_20))
             # 4h down move, 1d high & overbought
@@ -22696,7 +22703,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 1h high
             & ((rsi_3_4h_gt_15) | (stochrsi_k_1h_lt_80))
             # 4h down move, 1h downtrend, 1d overbought
-            & ((rsi_3_4h_gt_15) | (roc_9_1h > -10.0) | (roc_9_1d_lt_200))
+            & ((rsi_3_4h_gt_15) | (roc_9_1h_gt_neg_10) | (roc_9_1d_lt_200))
             # 4h & 1d down move, 1d still high
             & (rsi_3_4h_gt_20 | (rsi_3_1d_gt_20) | (aroonu_14_1d_lt_50))
             # 4h down move, 4h & 1d high
@@ -22853,7 +22860,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 1d down move, 1d high
             & ((rsi_3_1h_gt_10) | (rsi_3_1d_gt_20) | (aroonu_14_1d_lt_70))
             # 1h down move, 1d high, 1h downtrend
-            & ((rsi_3_1h_gt_10) | (aroonu_14_1d_lt_70) | (roc_9_1h > -10.0))
+            & ((rsi_3_1h_gt_10) | (aroonu_14_1d_lt_70) | (roc_9_1h_gt_neg_10))
             # 1h & 4h down move, 15m still not low enough
             & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_3) | (stochrsi_k_15m_lt_30))
             # 1h & 4h down move, 1h high
@@ -23031,7 +23038,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h & 4h down move
             & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_3) | (rsi_3_4h_gt_5))
             # 15m & 1h down move, 1h downtrend
-            & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_3) | (roc_9_1h > -20.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_3) | (roc_9_1h_gt_neg_20))
             # 15m & 1h down move, 1h still not low enough
             & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_10) | (stochrsi_k_1h_lt_20))
             # 15m & 1h down move, 4h high
@@ -23552,7 +23559,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 4h high
             & ((rsi_3_1h_gt_15) | rsi_3_4h_gt_20 | aroonu_14_4h_lt_70)
             # 1h down move, 1h downtrend, 1d overbought
-            & ((rsi_3_1h_gt_15) | (roc_9_1h > -30.0) | (roc_9_1d_lt_80))
+            & ((rsi_3_1h_gt_15) | (roc_9_1h_gt_neg_30) | (roc_9_1d_lt_80))
             # 1h & 4h down move, 4h high
             & (rsi_3_1h_gt_20 | (rsi_3_4h_gt_35) | aroonu_14_4h_lt_70)
             # 1h & 4h down move, 1d downtrend
@@ -23600,9 +23607,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h & 1d down move, 1d high & overbought
             & ((rsi_3_4h_gt_10) | (rsi_3_1d_gt_40) | (aroonu_14_1d_lt_85) | (roc_9_1d_lt_50))
             # 4h down move, 1d high, 1h downtrend
-            & ((rsi_3_4h_gt_10) | (aroonu_14_1d_lt_85) | (roc_9_1h > -30.0))
+            & ((rsi_3_4h_gt_10) | (aroonu_14_1d_lt_85) | (roc_9_1h_gt_neg_30))
             # 4h down move, 1h & 4h downtrend
-            & ((rsi_3_4h_gt_10) | (roc_9_1h > -40.0) | (roc_9_4h > -40.0))
+            & ((rsi_3_4h_gt_10) | (roc_9_1h_gt_neg_40) | (roc_9_4h > -40.0))
             # 4h & 1d down move, 4h still not low enough
             & ((rsi_3_4h_gt_20) | (rsi_3_1d_gt_20) | (stochrsi_k_4h_lt_30))
             # 4h down move, 4h still high, 1d downtrend
@@ -23634,7 +23641,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h high, 4h & 1d overbought
             & (aroonu_14_4h_lt_80 | (roc_9_4h_lt_20) | (roc_9_1d_lt_20))
             # 1d still high, 1h & 4h downtrend
-            & ((aroonu_14_1d_lt_50) | (roc_9_1h > -20.0) | (roc_9_4h_gt_neg_20))
+            & ((aroonu_14_1d_lt_50) | (roc_9_1h_gt_neg_20) | (roc_9_4h_gt_neg_20))
             # 1h high, 1h overbought
             & ((stochrsi_k_1h_lt_80) | (roc_9_1h_lt_50))
             # 1h high, 1d downtrend


### PR DESCRIPTION
## Summary
- Reuse repeated ROC 1h downtrend comparisons in `populate_entry_trend()` through named entry masks.
- Independent on latest upstream `main`.

## Safety
- Behavior-preserving Series mask reuse only.
- Touched function: `populate_entry_trend()`.
- Indicator formulas, candle selection, thresholds, condition order, profit arithmetic, order classification, return values, and signal behavior are unchanged.
- No v3 grind-entry code is touched.

## Backtest scope
- Full backtesting was not required because this patch only aliases Series comparisons that are already used by the same condition ladder.
- Indicator formulas, candle selection, thresholds, and condition order are unchanged.

## Checks
- `python3 /home/user/.codex/skills/nfi-upstream-pr/scripts/validate_nfi_pr.py --base origin/main`
- `git merge-tree \9f25e22bd594c7b51672063310f7e3a76474f673 origin/main HEAD | grep -E '\''<<<<<<<|>>>>>>>|changed in both|removed in|added in both'\'' && echo CONFLICT || echo NO_CONFLICT`
- `git diff --check`
- `ruff format --check NostalgiaForInfinityX7.py`
- `ruff check NostalgiaForInfinityX7.py`
- `PYTHONDONTWRITEBYTECODE=1 python3 -m py_compile NostalgiaForInfinityX7.py`