### PR TITLE
Reuse X7 entry RSI3 low-side masks

### DIFF
--- a/NostalgiaForInfinityX7.py
+++ b/NostalgiaForInfinityX7.py
@@ -13037,6 +13037,34 @@ class NostalgiaForInfinityX7(IStrategy):
     rsi_3_1d_gt_55 = rsi_3_1d > 55.0
     rsi_3_1d_gt_60 = rsi_3_1d > 60.0
     rsi_3_1d_gt_65 = rsi_3_1d > 65.0
+    rsi_3_lt_40 = rsi_3 < 40.0
+    rsi_3_lt_46 = rsi_3 < 46.0
+    rsi_3_lt_50 = rsi_3 < 50.0
+    rsi_3_lt_95 = rsi_3 < 95.0
+    rsi_3_lt_97 = rsi_3 < 97.0
+    rsi_3_lt_98 = rsi_3 < 98.0
+    rsi_3_15m_lt_50 = rsi_3_15m < 50.0
+    rsi_3_15m_lt_55 = rsi_3_15m < 55.0
+    rsi_3_15m_lt_60 = rsi_3_15m < 60.0
+    rsi_3_15m_lt_70 = rsi_3_15m < 70.0
+    rsi_3_15m_lt_75 = rsi_3_15m < 75.0
+    rsi_3_15m_lt_80 = rsi_3_15m < 80.0
+    rsi_3_15m_lt_97 = rsi_3_15m < 97.0
+    rsi_3_1h_lt_40 = rsi_3_1h < 40.0
+    rsi_3_1h_lt_50 = rsi_3_1h < 50.0
+    rsi_3_1h_lt_55 = rsi_3_1h < 55.0
+    rsi_3_1h_lt_60 = rsi_3_1h < 60.0
+    rsi_3_1h_lt_65 = rsi_3_1h < 65.0
+    rsi_3_1h_lt_70 = rsi_3_1h < 70.0
+    rsi_3_1h_lt_75 = rsi_3_1h < 75.0
+    rsi_3_4h_lt_40 = rsi_3_4h < 40.0
+    rsi_3_4h_lt_50 = rsi_3_4h < 50.0
+    rsi_3_4h_lt_60 = rsi_3_4h < 60.0
+    rsi_3_4h_lt_70 = rsi_3_4h < 70.0
+    rsi_3_4h_lt_75 = rsi_3_4h < 75.0
+    rsi_3_1d_lt_80 = rsi_3_1d < 80.0
+    rsi_3_1d_lt_90 = rsi_3_1d < 90.0
+    rsi_3_1d_lt_95 = rsi_3_1d < 95.0
 
     aroonu_14_lt_25 = aroonu_14 < 25.0
     aroonu_14_lt_30 = aroonu_14 < 30.0
@@ -15684,7 +15712,7 @@ class NostalgiaForInfinityX7(IStrategy):
 
           # Logic
           long_entry_logic.append(
-            (rsi_3 < 50.0)
+            (rsi_3_lt_50)
             & (aroonu_14_lt_25)
             & (stochrsi_k < 30.0)
             & (ema_26 > ema_12)
@@ -16464,7 +16492,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # Logic
           long_entry_logic.append(
             (rsi_20 < rsi_20.shift(1))
-            & (rsi_3 < 46.0)
+            & (rsi_3_lt_46)
             & (aroonu_14_lt_25)
             & (stochrsi_k < 20.0)
             & (aroonu_14_15m_lt_50)
@@ -18718,8 +18746,8 @@ class NostalgiaForInfinityX7(IStrategy):
 
           # Logic
           long_entry_logic.append(
-            (rsi_3 < 40.0)
-            & (rsi_3_15m < 50.0)
+            (rsi_3_lt_40)
+            & (rsi_3_15m_lt_50)
             & (aroonu_14_15m_lt_25)
             & (stochrsi_k_15m_lt_20)
             & (df["EMA_26_15m"] > df["EMA_12_15m"])
@@ -18986,7 +19014,7 @@ class NostalgiaForInfinityX7(IStrategy):
 
           # Logic
           long_entry_logic.append(
-            (rsi_3 < 50.0)
+            (rsi_3_lt_50)
             & (aroonu_14_15m_lt_25)
             & (stochrsi_k_15m_lt_20)
             & (df["close_15m"] < (df["EMA_20_15m"] * 0.924))
@@ -19261,8 +19289,8 @@ class NostalgiaForInfinityX7(IStrategy):
 
           # Logic
           long_entry_logic.append(
-            (rsi_3 < 40.0)
-            & (rsi_3_15m < 50.0)
+            (rsi_3_lt_40)
+            & (rsi_3_15m_lt_50)
             & (df["WILLR_14_15m"] < -50.0)
             & (aroonu_14_15m_lt_25)
             & (stochrsi_k_15m_lt_20)
@@ -19609,7 +19637,7 @@ class NostalgiaForInfinityX7(IStrategy):
 
           # Logic
           long_entry_logic.append(
-            (rsi_3 < 50.0)
+            (rsi_3_lt_50)
             & (aroonu_14_lt_25)
             & (stochrsi_k < 30.0)
             & (ema_26 > ema_12)
@@ -19964,7 +19992,7 @@ class NostalgiaForInfinityX7(IStrategy):
 
           # Logic
           long_entry_logic.append(
-            (rsi_3 < 40.0)
+            (rsi_3_lt_40)
             & (aroonu_14_lt_30)
             & (stochrsi_k < 20.0)
             & (stochrsi_k_15m_lt_70)
@@ -20481,7 +20509,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # Logic
           long_entry_logic.append(
             (rsi_3 > 0.0)
-            & (rsi_3 < 50.0)
+            & (rsi_3_lt_50)
             & (aroonu_14_lt_25)
             & (ema_26 > ema_12)
             & ((ema_26 - ema_12) > (open_rate * 0.022))
@@ -20810,7 +20838,7 @@ class NostalgiaForInfinityX7(IStrategy):
           long_entry_logic.append(num_empty_288 <= allowed_empty_candles_288)
           long_entry_logic.append(protections_long_global == True)
 
-          long_entry_logic.append(rsi_3 < 46.0)
+          long_entry_logic.append(rsi_3_lt_46)
           long_entry_logic.append(rsi_3_15m_gt_5)
           long_entry_logic.append(rsi_3_1h_gt_10)
           long_entry_logic.append(rsi_3_4h_gt_10)
@@ -21589,7 +21617,7 @@ class NostalgiaForInfinityX7(IStrategy):
           long_entry_logic.append((close > (high_max_30_1d * 0.25)) | rsi_3_4h_gt_20)
 
           # Logic
-          long_entry_logic.append(rsi_3 < 40.0)
+          long_entry_logic.append(rsi_3_lt_40)
           long_entry_logic.append(aroonu_14_lt_25)
           long_entry_logic.append(stochrsi_k < 20.0)
           long_entry_logic.append(aroonu_14_15m_lt_25)
@@ -22727,7 +22755,7 @@ class NostalgiaForInfinityX7(IStrategy):
 
           # Logic
           long_entry_logic.append(
-            (rsi_3 < 40.0)
+            (rsi_3_lt_40)
             & (stochrsi_k < 20.0)
             & (ema_26 > ema_12)
             & ((ema_26 - ema_12) > (open_rate * 0.020))
@@ -23756,7 +23784,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 4h down move, 1h high
             & ((rsi_3_15m_gt_15) | (rsi_3_4h_gt_50) | (stochrsi_k_1h_lt_80))
             # 15m down move, 4h & 1d up move, 1d downtrend
-            & ((rsi_3_15m_gt_15) | (rsi_3_4h < 90.0) | (rsi_3_1d < 80.0) | (cmf_20_1d > -0.2))
+            & ((rsi_3_15m_gt_15) | (rsi_3_4h < 90.0) | (rsi_3_1d_lt_80) | (cmf_20_1d > -0.2))
             # 15m & 1d down move, 4h high
             & ((rsi_3_15m_gt_15) | (rsi_3_1d_gt_10) | (stochrsi_k_4h_lt_70))
             # 15m & 1h down move, 1h & 4h still high
@@ -24025,11 +24053,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1d down move, 4h & 1d high
             & ((rsi_3_1d_gt_65) | (roc_9_4h_lt_10) | (roc_9_1d_lt_10))
             # 5m still high, 1h down move, 15m still high, 1h high
-            & ((rsi_3 < 40.0) | (rsi_3_1h_gt_30) | (aroonu_14_15m_lt_50) | (aroonu_14_4h_lt_90))
+            & ((rsi_3_lt_40) | (rsi_3_1h_gt_30) | (aroonu_14_15m_lt_50) | (aroonu_14_4h_lt_90))
             # 5m still high, 15m high
             & ((rsi_3 < 45.0) | (aroonu_14_15m_lt_70))
             # 5m still high, 1h down move, 4h high
-            & ((rsi_3 < 50.0) | (rsi_3_1h_gt_30) | aroonu_14_4h_lt_100)
+            & ((rsi_3_lt_50) | (rsi_3_1h_gt_30) | aroonu_14_4h_lt_100)
             # 15m down move, 1h high
             & ((rsi_14_15m > 25.0) | (stochrsi_k_1h_lt_80))
             # 15m down move, 4h & 1d high
@@ -24171,17 +24199,17 @@ class NostalgiaForInfinityX7(IStrategy):
           short_entry_logic.append(rsi_14_4h > 20.0)
           short_entry_logic.append(rsi_14_1d > 10.0)
           # 5m up move, 4h still not high enough
-          short_entry_logic.append((rsi_3 < 97.0) | (aroonu_14_4h > 60.0))
+          short_entry_logic.append((rsi_3_lt_97) | (aroonu_14_4h > 60.0))
           # 5m up move, 4h still low
-          short_entry_logic.append((rsi_3 < 97.0) | (stochrsi_k_4h_gt_50))
+          short_entry_logic.append((rsi_3_lt_97) | (stochrsi_k_4h_gt_50))
           # 5m & 15m strong up move
-          short_entry_logic.append((rsi_3 < 95.0) | (rsi_3_15m_lt_95))
+          short_entry_logic.append((rsi_3_lt_95) | (rsi_3_15m_lt_95))
           # 5m & 1h up move, 1d uptrend
-          short_entry_logic.append((rsi_3 < 95.0) | (rsi_3_1h_lt_90) | (roc_9_1d_lt_100))
+          short_entry_logic.append((rsi_3_lt_95) | (rsi_3_1h_lt_90) | (roc_9_1d_lt_100))
           # 5m up move, 15m & 1h still not high enough
-          short_entry_logic.append((rsi_3 < 95.0) | (aroond_14_15m < 25.0) | (aroond_14_1h < 25.0))
+          short_entry_logic.append((rsi_3_lt_95) | (aroond_14_15m < 25.0) | (aroond_14_1h < 25.0))
           # 4m up move, 1h & 4h still low
-          short_entry_logic.append((rsi_3 < 95.0) | (stochrsi_k_1h_gt_70) | (stochrsi_k_4h_gt_70))
+          short_entry_logic.append((rsi_3_lt_95) | (stochrsi_k_1h_gt_70) | (stochrsi_k_4h_gt_70))
           # 4m & 1h up move, 1h still low
           short_entry_logic.append((rsi_3_lt_90) | (rsi_3_1h_lt_80) | (stochrsi_k_1h_gt_50))
           # 15m & 1h up move, 4h low
@@ -24193,7 +24221,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 5m up move, 15m & 1h still not high enough
           short_entry_logic.append((rsi_3_lt_90) | (stochrsi_k_15m > 60.0) | (stochrsi_k_1h_gt_75))
           # 15m up move, 1h low
-          short_entry_logic.append((rsi_3_15m < 97.0) | (aroonu_14_1h > 30.0))
+          short_entry_logic.append((rsi_3_15m_lt_97) | (aroonu_14_1h > 30.0))
           # 15m & 1h up move, 4h still going up
           short_entry_logic.append((rsi_3_15m_lt_95) | (rsi_3_1h_lt_95) | (cci_20_change_pct_4h < -0.0))
           # 15m & 1h up move, 4h still not high enough
@@ -24201,7 +24229,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m & 1h up move, 4h still not high enough
           short_entry_logic.append((rsi_3_15m_lt_95) | (rsi_3_1h_lt_85) | (stochrsi_k_4h_gt_50))
           # 15m & 1h up move, 1h still low
-          short_entry_logic.append((rsi_3_15m_lt_95) | (rsi_3_1h < 70.0) | (stochrsi_k_1h_gt_50))
+          short_entry_logic.append((rsi_3_15m_lt_95) | (rsi_3_1h_lt_70) | (stochrsi_k_1h_gt_50))
           # 15m & 4h up move, 1h still not high enough
           short_entry_logic.append((rsi_3_15m_lt_95) | (rsi_3_4h_lt_95) | (stochrsi_k_1h_gt_75))
           # 15m up move, 1d lost, 1h low
@@ -24239,9 +24267,9 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m & 4h up move, 1d low
           short_entry_logic.append((rsi_3_15m_lt_90) | (rsi_3_4h_lt_85) | (stochrsi_k_1d_gt_30))
           # 15m & 4h up move, 1h low
-          short_entry_logic.append((rsi_3_15m_lt_90) | (rsi_3_4h < 70.0) | (stochrsi_k_1h_gt_20))
+          short_entry_logic.append((rsi_3_15m_lt_90) | (rsi_3_4h_lt_70) | (stochrsi_k_1h_gt_20))
           # 15m & 4h up move, 4h low
-          short_entry_logic.append((rsi_3_15m_lt_90) | (rsi_3_4h < 60.0) | (aroonu_14_4h > 30.0))
+          short_entry_logic.append((rsi_3_15m_lt_90) | (rsi_3_4h_lt_60) | (aroonu_14_4h > 30.0))
           # 15m up move, 1h & 4h low
           short_entry_logic.append((rsi_3_15m_lt_90) | (aroonu_14_1h > 40.0) | (aroonu_14_4h > 10.0))
           # 15m up move, 1h still low, 4h low
@@ -24249,15 +24277,15 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m up move, 1h low, 4h still not high enough
           short_entry_logic.append((rsi_3_15m_lt_90) | (stochrsi_k_1h_gt_30) | (stochrsi_k_4h_gt_70))
           # 15m & 4h up move, 1d low
-          short_entry_logic.append((rsi_3_15m_lt_90) | (rsi_3_4h < 70.0) | (stochrsi_k_1d_gt_20))
+          short_entry_logic.append((rsi_3_15m_lt_90) | (rsi_3_4h_lt_70) | (stochrsi_k_1d_gt_20))
           # 15m & 1h up move, 4h low
           short_entry_logic.append((rsi_3_15m_lt_85) | (rsi_3_1h_lt_85) | (stochrsi_k_4h > 20.0))
           # 15m & 1h up move, 1d still low
           short_entry_logic.append((rsi_3_15m_lt_85) | (rsi_3_1h_lt_85) | (stochrsi_k_1d_gt_60))
           # 15m & 1h up move, 1h low
-          short_entry_logic.append((rsi_3_15m_lt_85) | (rsi_3_1h < 70.0) | (stochrsi_k_1h_gt_30))
+          short_entry_logic.append((rsi_3_15m_lt_85) | (rsi_3_1h_lt_70) | (stochrsi_k_1h_gt_30))
           # 15m & 1h up move, 4h low
-          short_entry_logic.append((rsi_3_15m_lt_85) | (rsi_3_1h < 70.0) | (stochrsi_k_4h_gt_30))
+          short_entry_logic.append((rsi_3_15m_lt_85) | (rsi_3_1h_lt_70) | (stochrsi_k_4h_gt_30))
           # 15m & 4h down move, 4h still not high enough
           short_entry_logic.append((rsi_3_15m_lt_85) | (rsi_3_4h_lt_90) | (stochrsi_k_4h > 75.0))
           # 15m & 4h up move, 15m low
@@ -24267,15 +24295,15 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m up move, 4h overbought
           short_entry_logic.append((rsi_3_15m_lt_85) | (roc_9_4h_lt_50))
           # 15m & 1h up move, 1h still not high enough
-          short_entry_logic.append((rsi_3_15m < 80.0) | (rsi_3_1h < 70.0) | (aroonu_14_1h > 60.0))
+          short_entry_logic.append((rsi_3_15m_lt_80) | (rsi_3_1h_lt_70) | (aroonu_14_1h > 60.0))
           # 15m & 4h up move, 15m still low
-          short_entry_logic.append((rsi_3_15m < 80.0) | (rsi_3_4h_lt_80) | (aroonu_14_15m > 50.0))
+          short_entry_logic.append((rsi_3_15m_lt_80) | (rsi_3_4h_lt_80) | (aroonu_14_15m > 50.0))
           # 15m up move, 1h low
-          short_entry_logic.append((rsi_3_15m < 80.0) | (stochrsi_k_1h_gt_20))
+          short_entry_logic.append((rsi_3_15m_lt_80) | (stochrsi_k_1h_gt_20))
           # 15m & 1h up move, 1h low
-          short_entry_logic.append((rsi_3_15m < 70.0) | (rsi_3_1h < 70.0) | (aroonu_14_1h > 30.0))
+          short_entry_logic.append((rsi_3_15m_lt_70) | (rsi_3_1h_lt_70) | (aroonu_14_1h > 30.0))
           # 15m up move, 15m still not high enough, 1h still low
-          short_entry_logic.append((rsi_3_15m < 70.0) | (stochrsi_k_15m > 90.0) | (stochrsi_k_1h_gt_50))
+          short_entry_logic.append((rsi_3_15m_lt_70) | (stochrsi_k_15m > 90.0) | (stochrsi_k_1h_gt_50))
           # 1h & 4h up move, 1h still not high enough
           short_entry_logic.append((rsi_3_1h_lt_95) | (rsi_3_4h_lt_95) | (stochrsi_k_1h_gt_70))
           # 1h up move, 4h low
@@ -24287,7 +24315,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1h & 4h up move, 4h uptrend
           short_entry_logic.append((rsi_3_1h_lt_95) | (rsi_3_4h_lt_85) | (roc_9_4h_lt_40))
           # 1h & 1d strong up move
-          short_entry_logic.append((rsi_3_1h_lt_95) | (rsi_3_1d < 95.0))
+          short_entry_logic.append((rsi_3_1h_lt_95) | (rsi_3_1d_lt_95))
           # 1h up move, 4h still low
           short_entry_logic.append((rsi_3_1h_lt_95) | (rsi_14_4h > 60.0))
           # 1h up move, 1d still low, 1h uptrend
@@ -24325,7 +24353,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1h up move, 1h still low
           short_entry_logic.append((rsi_3_1h_lt_80) | (stochrsi_k_1h_gt_60))
           # 4h & 1d strong up move
-          short_entry_logic.append((rsi_3_4h_lt_95) | (rsi_3_1d < 95.0))
+          short_entry_logic.append((rsi_3_4h_lt_95) | (rsi_3_1d_lt_95))
           # 4h up move, 15m still low, 1h not high enough
           short_entry_logic.append((rsi_3_4h_lt_95) | (stochrsi_k_15m_gt_50) | (aroond_14_1h < 25.0))
           # 4h up move, 15m still not high enough, 4h overbought
@@ -24343,15 +24371,15 @@ class NostalgiaForInfinityX7(IStrategy):
           # 4h up move, 4h still low
           short_entry_logic.append((rsi_3_4h_lt_80) | (stochrsi_k_4h_gt_50))
           # 4h up move, 1h low
-          short_entry_logic.append((rsi_3_4h < 70.0) | (aroonu_14_1h > 25.0))
+          short_entry_logic.append((rsi_3_4h_lt_70) | (aroonu_14_1h > 25.0))
           # 4h up move, 1d low
-          short_entry_logic.append((rsi_3_4h < 70.0) | (aroonu_14_1d > 20.0))
+          short_entry_logic.append((rsi_3_4h_lt_70) | (aroonu_14_1d > 20.0))
           # 4h up move, 1h low
-          short_entry_logic.append((rsi_3_4h < 70.0) | (stochrsi_k_1h_gt_20))
+          short_entry_logic.append((rsi_3_4h_lt_70) | (stochrsi_k_1h_gt_20))
           # 4h up move, 1d low
-          short_entry_logic.append((rsi_3_4h < 70.0) | (stochrsi_k_1d_gt_20))
+          short_entry_logic.append((rsi_3_4h_lt_70) | (stochrsi_k_1d_gt_20))
           # 1d up move, 1h & 4h still not low enough
-          short_entry_logic.append((rsi_3_1d < 90.0) | (stochrsi_k_1h_gt_80) | (stochrsi_k_4h_gt_50))
+          short_entry_logic.append((rsi_3_1d_lt_90) | (stochrsi_k_1h_gt_80) | (stochrsi_k_4h_gt_50))
           # 4h still not high enough, 4h overbought, 4h uptrend
           short_entry_logic.append((rsi_14_4h > 80.0) | (roc_9_4h_lt_40) | (cci_20_change_pct_4h < 0.0))
           # 15m & 1h uptrend, 4h still low
@@ -24407,27 +24435,27 @@ class NostalgiaForInfinityX7(IStrategy):
 
           # 5m & 15m & 1h & 4h up move
           short_entry_logic.append(
-            ((rsi_3 < 97.0) | (rsi_3_15m_lt_90) | (rsi_3_1h_lt_90) | (rsi_3_4h_lt_80))
+            ((rsi_3_lt_97) | (rsi_3_15m_lt_90) | (rsi_3_1h_lt_90) | (rsi_3_4h_lt_80))
             # 5m & 4h up move
-            & ((rsi_3 < 97.0) | (rsi_3_4h_lt_95))
+            & ((rsi_3_lt_97) | (rsi_3_4h_lt_95))
             # 5m up move, 4h still not high enough
-            & ((rsi_3 < 97.0) | (stochrsi_k_4h > 80.0))
+            & ((rsi_3_lt_97) | (stochrsi_k_4h > 80.0))
             # 5m & 15m strong up move
-            & ((rsi_3 < 95.0) | (rsi_3_15m_lt_95))
+            & ((rsi_3_lt_95) | (rsi_3_15m_lt_95))
             # 5m & 15m up move, 4h low
-            & ((rsi_3 < 95.0) | (rsi_3_15m_lt_90) | (aroonu_14_4h > 30.0))
+            & ((rsi_3_lt_95) | (rsi_3_15m_lt_90) | (aroonu_14_4h > 30.0))
             # 5m & 1h & 4h up move
-            & ((rsi_3 < 95.0) | (rsi_3_1h_lt_90) | (rsi_3_4h_lt_90))
+            & ((rsi_3_lt_95) | (rsi_3_1h_lt_90) | (rsi_3_4h_lt_90))
             # 5m & 1h up move, 15m still not high enough
-            & ((rsi_3 < 95.0) | (rsi_3_1h_lt_85) | (stochrsi_k_15m > 70.0))
+            & ((rsi_3_lt_95) | (rsi_3_1h_lt_85) | (stochrsi_k_15m > 70.0))
             # 5m up move, 15m still low
-            & ((rsi_3 < 95.0) | (stochrsi_k_15m_gt_50))
+            & ((rsi_3_lt_95) | (stochrsi_k_15m_gt_50))
             # 5m up move, 4h low
             & ((rsi_3_lt_90) | (aroonu_14_4h > 20.0))
             # 15m & 1h down move, 4h still not high enough
-            & ((rsi_3_15m < 97.0) | (rsi_3_1h_lt_85) | (stochrsi_k_4h > 80.0))
+            & ((rsi_3_15m_lt_97) | (rsi_3_1h_lt_85) | (stochrsi_k_4h > 80.0))
             # 15m up move, 1h still low
-            & ((rsi_3_15m < 97.0) | (stochrsi_k_1h_gt_60))
+            & ((rsi_3_15m_lt_97) | (stochrsi_k_1h_gt_60))
             # 15m & 1h & 4h up move
             & ((rsi_3_15m_lt_95) | (rsi_3_1h_lt_90) | (rsi_3_4h_lt_85))
             # 15m & 1h up move, 4h still low
@@ -24459,23 +24487,23 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m up move, 4h uptrend
             & ((rsi_3_15m_lt_90) | (roc_9_4h_lt_20))
             # 15m & 1h up move, 1h still low
-            & ((rsi_3_15m_lt_85) | (rsi_3_1h < 65.0) | (stochrsi_k_1h_gt_60))
+            & ((rsi_3_15m_lt_85) | (rsi_3_1h_lt_65) | (stochrsi_k_1h_gt_60))
             # 15m up move, 1h low
             & ((rsi_3_15m_lt_85) | (stochrsi_k_1h_gt_30))
             # 15m & 1h & 4h up move, 4h uptrend
-            & ((rsi_3_15m < 80.0) | (rsi_3_1h_lt_80) | (rsi_3_4h_lt_80) | (aroonu_14_4h_lt_100))
+            & ((rsi_3_15m_lt_80) | (rsi_3_1h_lt_80) | (rsi_3_4h_lt_80) | (aroonu_14_4h_lt_100))
             # 15m & 4h up move, 15m still low
-            & ((rsi_3_15m < 80.0) | (rsi_3_4h < 75.0) | (aroonu_14_15m > 50.0))
+            & ((rsi_3_15m_lt_80) | (rsi_3_4h_lt_75) | (aroonu_14_15m > 50.0))
             # 15m up move, 1h low
-            & ((rsi_3_15m < 80.0) | (aroonu_14_1h > 10.0))
+            & ((rsi_3_15m_lt_80) | (aroonu_14_1h > 10.0))
             # 15m up move, 1h low, 1d uptrend
-            & ((rsi_3_15m < 80.0) | (aroonu_14_1h > 40.0) | (roc_9_1d_lt_100))
+            & ((rsi_3_15m_lt_80) | (aroonu_14_1h > 40.0) | (roc_9_1d_lt_100))
             # 15m up move, 4h low
-            & ((rsi_3_15m < 80.0) | (stochrsi_k_4h > 40.0))
+            & ((rsi_3_15m_lt_80) | (stochrsi_k_4h > 40.0))
             # 15m up move, 1h uptrend
-            & ((rsi_3_15m < 75.0) | (roc_9_1h_lt_40))
+            & ((rsi_3_15m_lt_75) | (roc_9_1h_lt_40))
             # 1h & 1d strong up move
-            & ((rsi_3_1h_lt_95) | (rsi_3_1d < 95.0))
+            & ((rsi_3_1h_lt_95) | (rsi_3_1d_lt_95))
             # 1h up move, 1h still not high enough
             & ((rsi_3_1h_lt_95) | (stochrsi_k_1h_gt_70))
             # 1h up move, 4h still low, 1h moving higher
@@ -24507,15 +24535,15 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h up move, 4h low
             & ((rsi_3_1h_lt_80) | (aroonu_14_4h > 10.0))
             # 1h up move, 1h still low
-            & ((rsi_3_1h < 75.0) | (stochrsi_k_1h_gt_50))
+            & ((rsi_3_1h_lt_75) | (stochrsi_k_1h_gt_50))
             # 1h up move, 4h low
-            & ((rsi_3_1h < 70.0) | (rsi_14_4h > 40.0))
+            & ((rsi_3_1h_lt_70) | (rsi_14_4h > 40.0))
             # 1h up move, 4h low
-            & ((rsi_3_1h < 70.0) | (stochrsi_k_4h > 40.0))
+            & ((rsi_3_1h_lt_70) | (stochrsi_k_4h > 40.0))
             # 1h up move, 1h uptrend
-            & ((rsi_3_1h < 70.0) | (roc_9_1h_lt_40))
+            & ((rsi_3_1h_lt_70) | (roc_9_1h_lt_40))
             # 1h up move, 1h low
-            & ((rsi_3_1h < 60.0) | (stochrsi_k_1h_gt_20))
+            & ((rsi_3_1h_lt_60) | (stochrsi_k_1h_gt_20))
             # 4h up move, 1d still low
             & ((rsi_3_4h < 97.0) | (rsi_14_1d > 50.0))
             # 4h up move, 1h still not high enough
@@ -24539,15 +24567,15 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h up move, 4h uptrend
             & ((rsi_3_4h_lt_80) | (roc_9_4h_lt_20))
             # 4h up move, 1h low
-            & ((rsi_3_4h < 75.0) | (stochrsi_k_1h_gt_20))
+            & ((rsi_3_4h_lt_75) | (stochrsi_k_1h_gt_20))
             # 4h up move, 4h low
-            & ((rsi_3_4h < 70.0) | (stochrsi_k_4h > 40.0))
+            & ((rsi_3_4h_lt_70) | (stochrsi_k_4h > 40.0))
             # 1d up move, 1h still not high enough
-            & ((rsi_3_1d < 95.0) | (stochrsi_k_1h_gt_90))
+            & ((rsi_3_1d_lt_95) | (stochrsi_k_1h_gt_90))
             # 1d up move, 1h still low
-            & ((rsi_3_1d < 90.0) | (stochrsi_k_1h_gt_50))
+            & ((rsi_3_1d_lt_90) | (stochrsi_k_1h_gt_50))
             # 1d up move, 4h still low
-            & ((rsi_3_1d < 80.0) | (stochrsi_k_4h > 40.0))
+            & ((rsi_3_1d_lt_80) | (stochrsi_k_4h > 40.0))
             # 15m low, 1h still low
             & ((aroonu_14_15m > 20.0) | (stochrsi_k_1h_gt_50))
             # 15m low, 4h low
@@ -24597,21 +24625,21 @@ class NostalgiaForInfinityX7(IStrategy):
           short_entry_logic.append(rsi_14_4h > 20.0)
           short_entry_logic.append(rsi_14_1d > 10.0)
           # 5m strong down move
-          short_entry_logic.append((rsi_3 < 98.0) | (roc_9 < 50.0))
+          short_entry_logic.append((rsi_3_lt_98) | (roc_9 < 50.0))
           # 5m down move, 4h still high
           short_entry_logic.append((rsi_3_lt_90) | (mfi_14 > 10.0) | (stochrsi_k_4h_gt_30))
           # 5m & 1h down move, 1h still high
           short_entry_logic.append((rsi_3_lt_90) | (rsi_3_1h_lt_90) | (stochrsi_k_1h_gt_70))
           # 5m down move, 4h downtrend, 1h still high
-          short_entry_logic.append((rsi_3 < 95.0) | (rsi_3_4h_lt_85) | (stochrsi_k_1h_gt_30))
+          short_entry_logic.append((rsi_3_lt_95) | (rsi_3_4h_lt_85) | (stochrsi_k_1h_gt_30))
           # 5m & 4h strong down move, 4h still not low enough
-          short_entry_logic.append((rsi_3 < 95.0) | (rsi_3_1h_lt_95) | (stochrsi_k_4h > 60.0))
+          short_entry_logic.append((rsi_3_lt_95) | (rsi_3_1h_lt_95) | (stochrsi_k_4h > 60.0))
           # 5m down move, 1h high, 1d overbought
           short_entry_logic.append((rsi_3_lt_90) | (roc_9_1h_lt_15) | (roc_9_1d_gt_neg_40))
           # 5m down move, 1h & 4h high
           short_entry_logic.append((rsi_3_lt_90) | (df["UO_7_14_28_1h"] > 40.0) | (stochrsi_k_4h_gt_30))
           # 5m down move, 1h high, 4h downtrend
-          short_entry_logic.append((rsi_3 < 98.0) | (stochrsi_k_1h_gt_10) | (roc_9_4h_lt_10))
+          short_entry_logic.append((rsi_3_lt_98) | (stochrsi_k_1h_gt_10) | (roc_9_4h_lt_10))
           # 5m & 1h down move, 4h down
           short_entry_logic.append((rsi_3_lt_90) | (rsi_3_1h_lt_85) | (cmf_20_4h > -0.2))
           # 5m down move, 1h high
@@ -24637,13 +24665,13 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m down move, 1d downtrend, 1h still high
           short_entry_logic.append((rsi_3_15m_lt_90) | (roc_9_1d > -25.0) | (stochrsi_k_1h_gt_30))
           # 15m & 1d down move, 1h still high
-          short_entry_logic.append((rsi_3_15m_lt_90) | (rsi_3_1d < 90.0) | (stochrsi_k_1h_gt_30))
+          short_entry_logic.append((rsi_3_15m_lt_90) | (rsi_3_1d_lt_90) | (stochrsi_k_1h_gt_30))
           # 15m & 4h down move, 1h still high
           short_entry_logic.append((rsi_3_15m_lt_90) | (rsi_3_4h_lt_95) | (stochrsi_k_1h_gt_50))
           # 15m down move, 15m still not low enough, 4h down move
           short_entry_logic.append((rsi_3_15m_lt_90) | (aroond_14_15m < 50.0) | (rsi_3_4h_lt_85))
           # 15m down move, 1h still high, 1d strong downtrend
-          short_entry_logic.append((rsi_3_15m < 80.0) | (aroond_14_1h < 25.0) | (df["MFI_14_1d"] < 90.0))
+          short_entry_logic.append((rsi_3_15m_lt_80) | (aroond_14_1h < 25.0) | (df["MFI_14_1d"] < 90.0))
           # 15m down move, 1h still high, 1d downtrend
           short_entry_logic.append((rsi_3_15m_lt_85) | (stochrsi_k_1h_gt_30) | roc_9_1d_lt_50)
           # 15m down move, 4h still high, 1d downtrend
@@ -24663,7 +24691,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m strong down move
           short_entry_logic.append((rsi_3_15m_lt_90) | (mfi_14_15m < 85.0) | (aroond_14_15m < 25.0))
           # 14m down move, 4h still high
-          short_entry_logic.append((rsi_3_15m < 80.0) | (aroond_14_15m < 50.0) | (uo_7_14_28_4h > 50.0))
+          short_entry_logic.append((rsi_3_15m_lt_80) | (aroond_14_15m < 50.0) | (uo_7_14_28_4h > 50.0))
           # 15m down move, 1h stil high, 1d overbought
           short_entry_logic.append((rsi_3_15m_lt_85) | (aroond_14_1h < 25.0) | (roc_9_1d > -80.0))
           # 15m down move, 1h high, 1d overbought
@@ -24695,7 +24723,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m still high, 1h down move, 1d downtrend
           short_entry_logic.append((stochrsi_k_15m > 30.0) | (rsi_3_4h_lt_90) | roc_9_1d_lt_50)
           # 1h & 4h still high, 1d strong down move
-          short_entry_logic.append((stochrsi_k_1h_gt_50) | (uo_7_14_28_4h > 55.0) | (rsi_3_1d < 90.0))
+          short_entry_logic.append((stochrsi_k_1h_gt_50) | (uo_7_14_28_4h > 55.0) | (rsi_3_1d_lt_90))
           # 1h still high, 4h & 1d downtrend
           short_entry_logic.append((aroond_14_1h < 25.0) | (roc_9_4h_lt_20) | roc_9_1d_lt_50)
           # 4h moving down, 1d P&D
@@ -24760,11 +24788,11 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1h & 4h down move, 4h still not low enough
           short_entry_logic.append((rsi_3_1h_lt_95) | (rsi_3_4h_lt_90) | (stochrsi_k_4h > 75.0))
           # 1h & 4h down move, 4h still not low enough
-          short_entry_logic.append((rsi_3_1h_lt_95) | (rsi_3_4h < 75.0) | (aroond_14_4h < 50.0))
+          short_entry_logic.append((rsi_3_1h_lt_95) | (rsi_3_4h_lt_75) | (aroond_14_4h < 50.0))
           # 15m down move, 1h strong downtrend
           short_entry_logic.append((rsi_3_15m_lt_95) | (rsi_3_1h_lt_95) | (mfi_14_1h > 5.0))
           # 15m downtrend, 4h down move, 4h stil high
-          short_entry_logic.append((roc_9_15m > -20.0) | (rsi_3_4h < 75.0) | (stochrsi_k_4h_gt_30))
+          short_entry_logic.append((roc_9_15m > -20.0) | (rsi_3_4h_lt_75) | (stochrsi_k_4h_gt_30))
 
           # Logic
           short_entry_logic.append(aroond_14 < 25.0)
@@ -24778,11 +24806,11 @@ class NostalgiaForInfinityX7(IStrategy):
           short_entry_logic.append(num_empty_288 <= allowed_empty_candles_288)
 
           # 5m & 15m down move, 4h still high
-          short_entry_logic.append((rsi_3 < 95.0) | (df["RSI_3_change_pct_15m"] < 50.0) | (rsi_14_4h > 50.0))
+          short_entry_logic.append((rsi_3_lt_95) | (df["RSI_3_change_pct_15m"] < 50.0) | (rsi_14_4h > 50.0))
           # 5m & 15m & 1h down move
-          short_entry_logic.append((rsi_3 < 95.0) | (rsi_3_15m_lt_95) | (rsi_3_1h_lt_95))
+          short_entry_logic.append((rsi_3_lt_95) | (rsi_3_15m_lt_95) | (rsi_3_1h_lt_95))
           # 5m strong down move
-          short_entry_logic.append((rsi_3 < 98.0) | (roc_9 < 50.0))
+          short_entry_logic.append((rsi_3_lt_98) | (roc_9 < 50.0))
           # 15m & 1h strong down move & downtrend
           short_entry_logic.append((rsi_3_15m_lt_95) | (rsi_3_1h_lt_95) | (mfi_14_1h > 5.0))
           # 15m strong down move, 4h high
@@ -24846,7 +24874,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m strong down move, 1h still high
           short_entry_logic.append((roc_9_15m < 15.0) | (stochrsi_k_1h_gt_30))
           # 15m downtrend, 4h down move, 4h stil high
-          short_entry_logic.append((roc_9_15m < 15.0) | (rsi_3_4h < 75.0) | (stochrsi_k_4h_gt_30))
+          short_entry_logic.append((roc_9_15m < 15.0) | (rsi_3_4h_lt_75) | (stochrsi_k_4h_gt_30))
           # 1h downtrend, 4h overbought
           short_entry_logic.append((df["ROC_2_1h"] < 5.0) | (rsi_14_4h > 20.0) | (roc_9_4h > -25.0))
           # 1h P&D, 4h still high
@@ -24863,7 +24891,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1h & 4h red, 1h not low enough
           short_entry_logic.append((change_pct_1h < 10.0) | (change_pct_4h < 10.0) | (mfi_14_1h > 50.0))
           # 1h red, 1h still not low enough, 1d down move
-          short_entry_logic.append((change_pct_1h < 15.0) | (mfi_14_1h > 50.0) | (rsi_3_1d < 90.0))
+          short_entry_logic.append((change_pct_1h < 15.0) | (mfi_14_1h > 50.0) | (rsi_3_1d_lt_90))
           # 4h red, previous 4h green, 4h overbought
           short_entry_logic.append(
             (change_pct_4h < 5.0) | (change_pct_4h.shift(48) > -5.0) | (rsi_14_4h.shift(48) > 20.0)
@@ -24886,7 +24914,7 @@ class NostalgiaForInfinityX7(IStrategy):
           short_entry_logic.append(protections_short_global == True)
 
           # 5m & 15m up move, 15m stil low
-          short_entry_logic.append((rsi_3_lt_90) | (rsi_3_15m < 80.0) | (aroonu_14_15m > 60.0))
+          short_entry_logic.append((rsi_3_lt_90) | (rsi_3_15m_lt_80) | (aroonu_14_15m > 60.0))
           # 15m & 1h up move, 4h still low
           short_entry_logic.append((rsi_3_15m_lt_95) | (rsi_3_1h_lt_95) | (rsi_14_4h > 60.0))
           # 15m & 1h up move, 4h still not high enough
@@ -24896,7 +24924,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m & 4h up move, 4h still moving higher
           short_entry_logic.append((rsi_3_15m_lt_90) | (rsi_3_4h_lt_95) | (cci_20_change_pct_4h < -0.0))
           # 15m & 1d up move, 4h uptrend
-          short_entry_logic.append((rsi_3_15m_lt_90) | (rsi_3_1d < 80.0) | (roc_9_4h_lt_20))
+          short_entry_logic.append((rsi_3_15m_lt_90) | (rsi_3_1d_lt_80) | (roc_9_4h_lt_20))
           # 15m up move, 15m & 4h high
           short_entry_logic.append((rsi_3_15m_lt_90) | (aroonu_14_15m_lt_100) | (aroonu_14_4h_lt_100))
           # 15m up move, 15m still not high enough, 1d uptrend
@@ -24912,13 +24940,13 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m up move, 4h overbought
           short_entry_logic.append((rsi_3_15m_lt_85) | (roc_9_4h_lt_50))
           # 15m & 1h up move, 15m still low
-          short_entry_logic.append((rsi_3_15m < 70.0) | (rsi_3_1h < 70.0) | (aroonu_14_15m > 40.0))
+          short_entry_logic.append((rsi_3_15m_lt_70) | (rsi_3_1h_lt_70) | (aroonu_14_15m > 40.0))
           # 15m & 1h up move, 15m still low
-          short_entry_logic.append((rsi_3_15m < 70.0) | (rsi_3_1h < 70.0) | (stochrsi_k_15m > 40.0))
+          short_entry_logic.append((rsi_3_15m_lt_70) | (rsi_3_1h_lt_70) | (stochrsi_k_15m > 40.0))
           # # 15m & 1h up move, 4h low
-          short_entry_logic.append((rsi_3_15m < 70.0) | (rsi_3_1h < 60.0) | (aroonu_14_4h > 40.0))
+          short_entry_logic.append((rsi_3_15m_lt_70) | (rsi_3_1h_lt_60) | (aroonu_14_4h > 40.0))
           # 1h & 1d up move, 1h still moving higher
-          short_entry_logic.append((rsi_3_1h < 97.0) | (rsi_3_1d < 95.0) | (cci_20_change_pct_1h < -0.0))
+          short_entry_logic.append((rsi_3_1h < 97.0) | (rsi_3_1d_lt_95) | (cci_20_change_pct_1h < -0.0))
           # 1h & 4h up move, 15m still not high enough
           short_entry_logic.append((rsi_3_1h_lt_95) | (rsi_3_4h_lt_95) | (stochrsi_k_15m > 80.0))
           # 1h & 4h up move, 1d uptrend
@@ -24932,9 +24960,9 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1h & 4h up move, 1h still moving higher
           short_entry_logic.append((rsi_3_1h_lt_90) | (rsi_3_4h_lt_85) | (cci_20_change_pct_1h < -0.0))
           # 1h & 4h up move, 4h still not high enough
-          short_entry_logic.append((rsi_3_1h_lt_90) | (rsi_3_4h < 70.0) | (stochrsi_k_4h > 80.0))
+          short_entry_logic.append((rsi_3_1h_lt_90) | (rsi_3_4h_lt_70) | (stochrsi_k_4h > 80.0))
           # 1h & 1d up move, 15m still low
-          short_entry_logic.append((rsi_3_1h_lt_90) | (rsi_3_1d < 90.0) | (stochrsi_k_15m > 60.0))
+          short_entry_logic.append((rsi_3_1h_lt_90) | (rsi_3_1d_lt_90) | (stochrsi_k_15m > 60.0))
           # 1h up move, 15m high
           short_entry_logic.append((rsi_3_1h_lt_90) | (aroonu_14_15m_lt_100))
           # 1h up move, 4h low
@@ -24956,7 +24984,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1h & 4h up move, 1d still low
           short_entry_logic.append((rsi_3_1h_lt_80) | (rsi_3_4h_lt_80) | (aroonu_14_1d > 50.0))
           # 1h & 4h up move, 1d low
-          short_entry_logic.append((rsi_3_1h_lt_80) | (rsi_3_4h < 70.0) | (stochrsi_k_1d_gt_30))
+          short_entry_logic.append((rsi_3_1h_lt_80) | (rsi_3_4h_lt_70) | (stochrsi_k_1d_gt_30))
           # 1h up move, 1d still low, 1d uptrend
           short_entry_logic.append((rsi_3_1h_lt_80) | (aroonu_14_1d > 50.0) | (roc_9_1d_lt_30))
           # 1h up move, 1d low
@@ -24982,7 +25010,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 4h up move, 15m still low, 4h still not high enough
           short_entry_logic.append((rsi_3_4h_lt_80) | (stochrsi_k_15m > 60.0) | (aroonu_14_4h > 80.0))
           # 4h up move, 15m still low, 4h still not high enough
-          short_entry_logic.append((rsi_3_4h < 75.0) | (stochrsi_k_15m > 60.0) | (stochrsi_k_4h > 80.0))
+          short_entry_logic.append((rsi_3_4h_lt_75) | (stochrsi_k_15m > 60.0) | (stochrsi_k_4h > 80.0))
           # 1d up move, 4h low
           short_entry_logic.append((rsi_3_1d < 85.0) | (stochrsi_k_4h > 40.0))
           # 4h still not high enough, 4h overbought, 4h uptrend
@@ -25033,7 +25061,7 @@ class NostalgiaForInfinityX7(IStrategy):
           short_entry_logic.append(rsi_14_4h > 20.0)
           short_entry_logic.append(rsi_14_1d > 10.0)
           # 5m strong down move
-          short_entry_logic.append((rsi_3 < 98.0) | (roc_9 < 50.0))
+          short_entry_logic.append((rsi_3_lt_98) | (roc_9 < 50.0))
           # 15m down move, 1h down move, 1h still not low enough
           short_entry_logic.append((rsi_3_15m_lt_95) | (rsi_3_change_pct_1h < 60.0) | (stochrsi_k_1h_gt_50))
           # 15m down move, 1h down move, 4h still not low enough
@@ -25061,7 +25089,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m down move, 15m still not low enough, 1h still high
           short_entry_logic.append((rsi_3_15m_lt_85) | (stochrsi_k_15m_gt_50) | (stochrsi_k_1h_gt_30))
           # 15m & 1h down move, 1h still high
-          short_entry_logic.append((rsi_3_15m_lt_85) | (rsi_3_1h < 75.0) | (stochrsi_k_1h_gt_30))
+          short_entry_logic.append((rsi_3_15m_lt_85) | (rsi_3_1h_lt_75) | (stochrsi_k_1h_gt_30))
           # 15m down move, 15m still not low enoug, 1h high
           short_entry_logic.append((rsi_3_15m_lt_85) | (aroond_14_15m < 25.0) | (stochrsi_k_1h_gt_10))
           # 15m down move, 1h downtrend, 4h overbought
@@ -25079,9 +25107,9 @@ class NostalgiaForInfinityX7(IStrategy):
           # 4h down move, 15m still not low enough, 1h still high
           short_entry_logic.append((rsi_3_4h_lt_80) | (stochrsi_k_15m > 70.0) | (stochrsi_k_1h_gt_30))
           # 4h down move, 4h still high, 1d downtrend
-          short_entry_logic.append((rsi_3_4h < 75.0) | (stochrsi_k_4h_gt_50) | roc_9_1d_lt_50)
+          short_entry_logic.append((rsi_3_4h_lt_75) | (stochrsi_k_4h_gt_50) | roc_9_1d_lt_50)
           # 4h & 1d down move, 1d strong downtrend
-          short_entry_logic.append((rsi_3_4h_lt_90) | (rsi_3_1d < 90.0) | (roc_9_1d_lt_60))
+          short_entry_logic.append((rsi_3_4h_lt_90) | (rsi_3_1d_lt_90) | (roc_9_1d_lt_60))
           # 4h overbought, 1h still high, 1d downtrend
           short_entry_logic.append((roc_9_4h > -50.0) | (stochrsi_k_1h_gt_70) | roc_9_1d_lt_50)
           # 4h red, previous 4h green, 4h overbought
@@ -25148,19 +25176,19 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m down move, 1h high, 4h still high
           short_entry_logic.append((rsi_3_15m_lt_85) | (stochrsi_k_1h_gt_30) | (stochrsi_k_4h > 75.0))
           # 15m & 1h down move, 4h still high
-          short_entry_logic.append((rsi_3_15m < 80.0) | (rsi_3_1h < 70.0) | (stochrsi_k_4h_gt_50))
+          short_entry_logic.append((rsi_3_15m_lt_80) | (rsi_3_1h_lt_70) | (stochrsi_k_4h_gt_50))
           # 15m down move, 1h still not low enough, 4h still high
-          short_entry_logic.append((rsi_3_15m < 75.0) | (stochrsi_k_1h_gt_80) | (stochrsi_k_4h > 60.0))
+          short_entry_logic.append((rsi_3_15m_lt_75) | (stochrsi_k_1h_gt_80) | (stochrsi_k_4h > 60.0))
           # 1h & 4h & 1d down move
-          short_entry_logic.append((rsi_3_1h_lt_95) | (rsi_3_4h_lt_90) | (rsi_3_1d < 80.0))
+          short_entry_logic.append((rsi_3_1h_lt_95) | (rsi_3_4h_lt_90) | (rsi_3_1d_lt_80))
           # 1h & 4h down move, 15m not low enough
           short_entry_logic.append((rsi_3_1h_lt_90) | (rsi_3_4h_lt_90) | (stochrsi_k_15m > 75.0))
           # 1h down move, 1h still not low enough, 4h still high
           short_entry_logic.append((rsi_3_1h_lt_90) | (stochrsi_k_1h_gt_90) | (stochrsi_k_4h_gt_50))
           # 1h & 4h down move, 1h still not low enough
-          short_entry_logic.append((rsi_3_1h_lt_85) | (rsi_3_4h < 75.0) | (stochrsi_k_1h_gt_90))
+          short_entry_logic.append((rsi_3_1h_lt_85) | (rsi_3_4h_lt_75) | (stochrsi_k_1h_gt_90))
           # 1h & 4h down move, 4h still high
-          short_entry_logic.append((rsi_3_1h_lt_85) | (rsi_3_4h < 75.0) | (stochrsi_k_4h_gt_50))
+          short_entry_logic.append((rsi_3_1h_lt_85) | (rsi_3_4h_lt_75) | (stochrsi_k_4h_gt_50))
           # 1h & 4h down move, 1h still not low enough
           short_entry_logic.append((rsi_3_1h_lt_80) | (rsi_3_4h_lt_85) | (stochrsi_k_1h_gt_75))
           # 1h & 4h down move, 4h still not low enough
@@ -25204,35 +25232,35 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m down move, 1h & 4h still high
           short_entry_logic.append((rsi_3_15m_lt_90) | (stochrsi_k_1h_gt_60) | (stochrsi_k_4h > 60.0))
           # 15m & 1h down move, 4h still not low enough
-          short_entry_logic.append((rsi_3_15m_lt_95) | (rsi_3_1h < 70.0) | (stochrsi_k_4h_gt_50))
+          short_entry_logic.append((rsi_3_15m_lt_95) | (rsi_3_1h_lt_70) | (stochrsi_k_4h_gt_50))
           # 15m down move, 15m still not low enough, 4h high
           short_entry_logic.append((rsi_3_15m_lt_85) | (stochrsi_k_15m > 80.0) | (stochrsi_k_4h > 20.0))
           # 15m down move, 4h still high, 1d high
           short_entry_logic.append((rsi_3_15m_lt_85) | (stochrsi_k_4h > 60.0) | (stochrsi_k_1d_gt_30))
           # 15m & 4h down move, 1d still high
-          short_entry_logic.append((rsi_3_15m_lt_85) | (rsi_3_4h < 75.0) | (stochrsi_k_1d_gt_50))
+          short_entry_logic.append((rsi_3_15m_lt_85) | (rsi_3_4h_lt_75) | (stochrsi_k_1d_gt_50))
           # 15m & 1h down move, 4h still not low enough
-          short_entry_logic.append((rsi_3_15m < 80.0) | (rsi_3_1h_lt_80) | (stochrsi_k_4h_gt_70))
+          short_entry_logic.append((rsi_3_15m_lt_80) | (rsi_3_1h_lt_80) | (stochrsi_k_4h_gt_70))
           # 15m & 1h down move, 4h still not low enough
-          short_entry_logic.append((rsi_3_15m < 75.0) | (rsi_3_1h < 75.0) | (stochrsi_k_4h_gt_70))
+          short_entry_logic.append((rsi_3_15m_lt_75) | (rsi_3_1h_lt_75) | (stochrsi_k_4h_gt_70))
           # 15m & 4h down move, 4h still not low enough
-          short_entry_logic.append((rsi_3_15m < 75.0) | (rsi_3_4h < 75.0) | (stochrsi_k_4h > 80.0))
+          short_entry_logic.append((rsi_3_15m_lt_75) | (rsi_3_4h_lt_75) | (stochrsi_k_4h > 80.0))
           # 15m down move, 1h still high, 4h still high
-          short_entry_logic.append((rsi_3_15m < 75.0) | (stochrsi_k_1h_gt_80) | (stochrsi_k_4h > 60.0))
+          short_entry_logic.append((rsi_3_15m_lt_75) | (stochrsi_k_1h_gt_80) | (stochrsi_k_4h > 60.0))
           # 15m down move, 1h still not low enough, 4h high
-          short_entry_logic.append((rsi_3_15m < 75.0) | (stochrsi_k_1h_gt_90) | (stochrsi_k_4h_gt_30))
+          short_entry_logic.append((rsi_3_15m_lt_75) | (stochrsi_k_1h_gt_90) | (stochrsi_k_4h_gt_30))
           # 15m down move, 1h high, 4h still not low enough
-          short_entry_logic.append((rsi_3_15m < 75.0) | (stochrsi_k_1h_gt_20) | (stochrsi_k_4h > 90.0))
+          short_entry_logic.append((rsi_3_15m_lt_75) | (stochrsi_k_1h_gt_20) | (stochrsi_k_4h > 90.0))
           # 15m down move, 4h high, 1d stil high
-          short_entry_logic.append((rsi_3_15m < 75.0) | (stochrsi_k_4h > 20.0) | (stochrsi_k_1d_gt_50))
+          short_entry_logic.append((rsi_3_15m_lt_75) | (stochrsi_k_4h > 20.0) | (stochrsi_k_1d_gt_50))
           # 15m & 4h down move, 1h still not low enough
-          short_entry_logic.append((rsi_3_15m < 70.0) | (rsi_3_4h_lt_85) | (stochrsi_k_1h_gt_70))
+          short_entry_logic.append((rsi_3_15m_lt_70) | (rsi_3_4h_lt_85) | (stochrsi_k_1h_gt_70))
           # 15m & 4h down move, 1h still high
-          short_entry_logic.append((rsi_3_15m < 70.0) | (rsi_3_4h_lt_80) | (stochrsi_k_1h_gt_50))
+          short_entry_logic.append((rsi_3_15m_lt_70) | (rsi_3_4h_lt_80) | (stochrsi_k_1h_gt_50))
           # 15m down move, 15m still high 4h still high
-          short_entry_logic.append((rsi_3_15m < 70.0) | (stochrsi_k_15m > 70.0) | (stochrsi_k_4h_gt_50))
+          short_entry_logic.append((rsi_3_15m_lt_70) | (stochrsi_k_15m > 70.0) | (stochrsi_k_4h_gt_50))
           # 15m down move, 1h still high, 4h high
-          short_entry_logic.append((rsi_3_15m < 70.0) | (stochrsi_k_1h_gt_50) | (stochrsi_k_4h > 10.0))
+          short_entry_logic.append((rsi_3_15m_lt_70) | (stochrsi_k_1h_gt_50) | (stochrsi_k_4h > 10.0))
           # 1h & 4h down move, 1h still not low enough
           short_entry_logic.append((rsi_3_1h_lt_95) | (rsi_3_4h_lt_95) | (stochrsi_k_1h_gt_90))
           # 1h & 4h down move, 4h still not low enough
@@ -25246,7 +25274,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1h & 4h down move, 1d still high
           short_entry_logic.append((rsi_3_1h_lt_90) | (rsi_3_4h_lt_85) | (stochrsi_k_1d_gt_50))
           # 1h & 4h down move, 4h still not low enough
-          short_entry_logic.append((rsi_3_1h_lt_85) | (rsi_3_4h < 75.0) | (stochrsi_k_4h > 85.0))
+          short_entry_logic.append((rsi_3_1h_lt_85) | (rsi_3_4h_lt_75) | (stochrsi_k_4h > 85.0))
           # 1h down move, 4h still high, 1d high
           short_entry_logic.append((rsi_3_1h_lt_80) | (stochrsi_k_4h > 60.0) | (stochrsi_k_1d_gt_30))
           # 1h & 4h down move, 1h still not low enough
@@ -25254,15 +25282,15 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1h & 4h down move, 15m still high
           short_entry_logic.append((rsi_3_1h_lt_80) | (rsi_3_4h_lt_80) | (stochrsi_k_15m_gt_50))
           # 1h & 4h down move, 4h still not low enough
-          short_entry_logic.append((rsi_3_1h < 75.0) | (rsi_3_4h_lt_90) | (stochrsi_k_1h_gt_75))
+          short_entry_logic.append((rsi_3_1h_lt_75) | (rsi_3_4h_lt_90) | (stochrsi_k_1h_gt_75))
           # 1h & 4h down move, 1h still high
-          short_entry_logic.append((rsi_3_1h < 70.0) | (rsi_3_4h_lt_85) | (stochrsi_k_1h_gt_60))
+          short_entry_logic.append((rsi_3_1h_lt_70) | (rsi_3_4h_lt_85) | (stochrsi_k_1h_gt_60))
           # 1h down move, 1h still not low enough, 4h still high
-          short_entry_logic.append((rsi_3_1h < 70.0) | (stochrsi_k_1h_gt_80) | (stochrsi_k_4h_gt_50))
+          short_entry_logic.append((rsi_3_1h_lt_70) | (stochrsi_k_1h_gt_80) | (stochrsi_k_4h_gt_50))
           # 4h down move, 15m still high, 1h still not low enough
           short_entry_logic.append((rsi_3_4h_lt_85) | (stochrsi_k_15m > 60.0) | (stochrsi_k_1h_gt_80))
           # 4h down move, 15m still high, 4h still not low enough
-          short_entry_logic.append((rsi_3_4h < 75.0) | (stochrsi_k_15m_gt_50) | (stochrsi_k_4h > 75.0))
+          short_entry_logic.append((rsi_3_4h_lt_75) | (stochrsi_k_15m_gt_50) | (stochrsi_k_4h > 75.0))
           # 4h down move, 1h still not low enough, 1d still high
           short_entry_logic.append((rsi_3_4h < 25.0) | (stochrsi_k_1h_gt_70) | (stochrsi_k_1d_gt_50))
           # 15m & 1h still high, 4h high
@@ -25299,120 +25327,120 @@ class NostalgiaForInfinityX7(IStrategy):
           short_entry_logic.append(num_empty_288 <= allowed_empty_candles_288)
 
           # 15m down move, 15m high
-          short_entry_logic.append((rsi_3_15m < 75.0) | (aroond_14_15m < 80.0))
+          short_entry_logic.append((rsi_3_15m_lt_75) | (aroond_14_15m < 80.0))
           # 15m & 1h down move, 15m still high
-          short_entry_logic.append((rsi_3_15m < 70.0) | (rsi_3_1h < 40.0) | (aroond_14_15m < 50.0))
+          short_entry_logic.append((rsi_3_15m_lt_70) | (rsi_3_1h_lt_40) | (aroond_14_15m < 50.0))
           # 15m down move, 15m & 4h still high
-          short_entry_logic.append((rsi_3_15m < 70.0) | (stochrsi_k_15m_gt_50) | (stochrsi_k_4h_gt_50))
+          short_entry_logic.append((rsi_3_15m_lt_70) | (stochrsi_k_15m_gt_50) | (stochrsi_k_4h_gt_50))
           # 15m & 1h down move, 1h high
-          short_entry_logic.append((rsi_3_15m < 60.0) | (rsi_3_1h < 60.0) | (aroond_14_1h < 70.0))
+          short_entry_logic.append((rsi_3_15m_lt_60) | (rsi_3_1h_lt_60) | (aroond_14_1h < 70.0))
           # 15m & 1h down move, 1h still high
-          short_entry_logic.append((rsi_3_15m < 60.0) | (rsi_3_1h < 60.0) | (stochrsi_k_1h_gt_50))
+          short_entry_logic.append((rsi_3_15m_lt_60) | (rsi_3_1h_lt_60) | (stochrsi_k_1h_gt_50))
           # 15m & 1h down move, 4h high
-          short_entry_logic.append((rsi_3_15m < 60.0) | (rsi_3_1h < 40.0) | (aroond_14_4h < 80.0))
+          short_entry_logic.append((rsi_3_15m_lt_60) | (rsi_3_1h_lt_40) | (aroond_14_4h < 80.0))
           # 15m & 4h down move, 15m high
-          short_entry_logic.append((rsi_3_15m < 60.0) | (rsi_3_4h < 60.0) | (stochrsi_k_15m_gt_50))
+          short_entry_logic.append((rsi_3_15m_lt_60) | (rsi_3_4h_lt_60) | (stochrsi_k_15m_gt_50))
           # 15m & 4h down move, 15m high
-          short_entry_logic.append((rsi_3_15m < 60.0) | (rsi_3_4h < 40.0) | (stochrsi_k_15m > 30.0))
+          short_entry_logic.append((rsi_3_15m_lt_60) | (rsi_3_4h_lt_40) | (stochrsi_k_15m > 30.0))
           # 15m down move, 15m & 1h still high
-          short_entry_logic.append((rsi_3_15m < 60.0) | (aroond_14_15m < 50.0) | (stochrsi_k_1h_gt_50))
+          short_entry_logic.append((rsi_3_15m_lt_60) | (aroond_14_15m < 50.0) | (stochrsi_k_1h_gt_50))
           # 15m down move, 15m & 1h still high
-          short_entry_logic.append((rsi_3_15m < 60.0) | (stochrsi_k_15m_gt_50) | (stochrsi_k_1h_gt_50))
+          short_entry_logic.append((rsi_3_15m_lt_60) | (stochrsi_k_15m_gt_50) | (stochrsi_k_1h_gt_50))
           # 15m down move, 4h still high, 1d overbought
-          short_entry_logic.append((rsi_3_15m < 60.0) | (aroond_14_4h < 50.0) | (roc_9_1d > -100.0))
+          short_entry_logic.append((rsi_3_15m_lt_60) | (aroond_14_4h < 50.0) | (roc_9_1d > -100.0))
           # 15m down move, 15m high, 4h still high
-          short_entry_logic.append((rsi_3_15m < 55.0) | (aroond_14_15m > 30.0) | (stochrsi_k_4h_gt_50))
+          short_entry_logic.append((rsi_3_15m_lt_55) | (aroond_14_15m > 30.0) | (stochrsi_k_4h_gt_50))
           # 15m down move, 15m & 1h still high
-          short_entry_logic.append((rsi_3_15m < 55.0) | (stochrsi_k_15m > 55.0) | (stochrsi_k_1h_gt_60))
+          short_entry_logic.append((rsi_3_15m_lt_55) | (stochrsi_k_15m > 55.0) | (stochrsi_k_1h_gt_60))
           # 15m down move, 15m still not low enough, 4h high
-          short_entry_logic.append((rsi_3_15m < 50.0) | (stochrsi_k_15m > 70.0) | (stochrsi_k_4h > 10.0))
+          short_entry_logic.append((rsi_3_15m_lt_50) | (stochrsi_k_15m > 70.0) | (stochrsi_k_4h > 10.0))
           # 1h down move, 4h still high, 1d high
-          short_entry_logic.append((rsi_3_1h < 75.0) | (aroond_14_4h < 50.0) | (stochrsi_k_1d > 10.0))
-          short_entry_logic.append((rsi_3_1h < 70.0) | (stochrsi_k_1h_gt_60) | (stochrsi_k_1d > 10.0))
+          short_entry_logic.append((rsi_3_1h_lt_75) | (aroond_14_4h < 50.0) | (stochrsi_k_1d > 10.0))
+          short_entry_logic.append((rsi_3_1h_lt_70) | (stochrsi_k_1h_gt_60) | (stochrsi_k_1d > 10.0))
           # 1h & 4h down move, 4h high
-          short_entry_logic.append((rsi_3_1h < 65.0) | (rsi_3_4h < 40.0) | (stochrsi_k_4h > 20.0))
+          short_entry_logic.append((rsi_3_1h_lt_65) | (rsi_3_4h_lt_40) | (stochrsi_k_4h > 20.0))
           # 1h down move, 15m & 1h still high
-          short_entry_logic.append((rsi_3_1h < 60.0) | (stochrsi_k_15m_gt_50) | (stochrsi_k_1h_gt_50))
+          short_entry_logic.append((rsi_3_1h_lt_60) | (stochrsi_k_15m_gt_50) | (stochrsi_k_1h_gt_50))
           # 1h down move, 1h still high, 4h high
-          short_entry_logic.append((rsi_3_1h < 60.0) | (stochrsi_k_1h_gt_50) | (stochrsi_k_4h_gt_70))
+          short_entry_logic.append((rsi_3_1h_lt_60) | (stochrsi_k_1h_gt_50) | (stochrsi_k_4h_gt_70))
           # 1h down move, 1h high
-          short_entry_logic.append((rsi_3_1h < 60.0) | (stochrsi_k_1h_gt_40))
+          short_entry_logic.append((rsi_3_1h_lt_60) | (stochrsi_k_1h_gt_40))
           # 1h down move, 4h & 1d high
-          short_entry_logic.append((rsi_3_1h < 60.0) | (aroond_14_4h < 85.0) | (df["AROOND_14_1d"] < 90.0))
+          short_entry_logic.append((rsi_3_1h_lt_60) | (aroond_14_4h < 85.0) | (df["AROOND_14_1d"] < 90.0))
           # 1h down move, 1h still high, 4h high
-          short_entry_logic.append((rsi_3_1h < 55.0) | (aroond_14_1h < 50.0) | (aroond_14_4h < 90.0))
+          short_entry_logic.append((rsi_3_1h_lt_55) | (aroond_14_1h < 50.0) | (aroond_14_4h < 90.0))
           # 1h down move, 1h high
-          short_entry_logic.append((rsi_3_1h < 55.0) | (stochrsi_k_1h_gt_40))
+          short_entry_logic.append((rsi_3_1h_lt_55) | (stochrsi_k_1h_gt_40))
           # 1h & 4h down move, 15m high
-          short_entry_logic.append((rsi_3_1h < 50.0) | (rsi_3_4h < 40.0) | (aroond_14_15m < 70.0))
+          short_entry_logic.append((rsi_3_1h_lt_50) | (rsi_3_4h_lt_40) | (aroond_14_15m < 70.0))
           # 1h down move, 15m still high, 4h high
-          short_entry_logic.append((rsi_3_1h < 50.0) | (aroond_14_15m < 50.0) | (aroond_14_4h < 80.0))
+          short_entry_logic.append((rsi_3_1h_lt_50) | (aroond_14_15m < 50.0) | (aroond_14_4h < 80.0))
           # 1h down move, 15m high, 1h still high
-          short_entry_logic.append((rsi_3_1h < 50.0) | (aroond_14_15m < 70.0) | (stochrsi_k_1h_gt_60))
+          short_entry_logic.append((rsi_3_1h_lt_50) | (aroond_14_15m < 70.0) | (stochrsi_k_1h_gt_60))
           # 1h down move, 15m still high, 4h high
-          short_entry_logic.append((rsi_3_1h < 50.0) | (stochrsi_k_15m_gt_50) | (stochrsi_k_4h > 20.0))
+          short_entry_logic.append((rsi_3_1h_lt_50) | (stochrsi_k_15m_gt_50) | (stochrsi_k_4h > 20.0))
           # 1h down move, 15m & 1h high
-          short_entry_logic.append((rsi_3_1h < 50.0) | (stochrsi_k_15m > 40.0) | (aroond_14_1h < 60.0))
+          short_entry_logic.append((rsi_3_1h_lt_50) | (stochrsi_k_15m > 40.0) | (aroond_14_1h < 60.0))
           # 1h down move, 1h & 1d high
-          short_entry_logic.append((rsi_3_1h < 50.0) | (aroond_14_1h < 70.0) | (stochrsi_k_1d_gt_20))
+          short_entry_logic.append((rsi_3_1h_lt_50) | (aroond_14_1h < 70.0) | (stochrsi_k_1d_gt_20))
           # 1h down move, 4h still high, 1d high
-          short_entry_logic.append((rsi_3_1h < 50.0) | (stochrsi_k_4h_gt_50) | (stochrsi_k_1d > 10.0))
+          short_entry_logic.append((rsi_3_1h_lt_50) | (stochrsi_k_4h_gt_50) | (stochrsi_k_1d > 10.0))
           # 1h down move, 5m up move, 1h still high
-          short_entry_logic.append((rsi_3_1h < 40.0) | (rsi_3 > 40.0) | (stochrsi_k_1h_gt_50))
+          short_entry_logic.append((rsi_3_1h_lt_40) | (rsi_3 > 40.0) | (stochrsi_k_1h_gt_50))
           # 1h down move, 15m still not low enough, 1h high
-          short_entry_logic.append((rsi_3_1h < 40.0) | (stochrsi_k_15m > 70.0) | (aroond_14_1h < 70.0))
+          short_entry_logic.append((rsi_3_1h_lt_40) | (stochrsi_k_15m > 70.0) | (aroond_14_1h < 70.0))
           # 1h down move, 15m still not low enough, 1h high
-          short_entry_logic.append((rsi_3_1h < 40.0) | (stochrsi_k_15m > 70.0) | (stochrsi_k_1h_gt_40))
+          short_entry_logic.append((rsi_3_1h_lt_40) | (stochrsi_k_15m > 70.0) | (stochrsi_k_1h_gt_40))
           # 1h down move, 15m & 4h still high
-          short_entry_logic.append((rsi_3_1h < 40.0) | (stochrsi_k_15m_gt_50) | (stochrsi_k_4h_gt_50))
+          short_entry_logic.append((rsi_3_1h_lt_40) | (stochrsi_k_15m_gt_50) | (stochrsi_k_4h_gt_50))
           # 1h down move, 15m & 1h high
-          short_entry_logic.append((rsi_3_1h < 40.0) | (aroond_14_15m < 70.0) | (aroond_14_1h < 90.0))
+          short_entry_logic.append((rsi_3_1h_lt_40) | (aroond_14_15m < 70.0) | (aroond_14_1h < 90.0))
           # 1h down move, 1h still high, 4h high
-          short_entry_logic.append((rsi_3_1h < 40.0) | (aroond_14_1h < 50.0) | (stochrsi_k_4h > 10.0))
+          short_entry_logic.append((rsi_3_1h_lt_40) | (aroond_14_1h < 50.0) | (stochrsi_k_4h > 10.0))
           # 1h down move, 1h high, 4h still high
-          short_entry_logic.append((rsi_3_1h < 40.0) | (aroond_14_1h < 80.0) | (aroond_14_4h < 40.0))
+          short_entry_logic.append((rsi_3_1h_lt_40) | (aroond_14_1h < 80.0) | (aroond_14_4h < 40.0))
           # 1h down move, 1h still high, 4h high
-          short_entry_logic.append((rsi_3_1h < 40.0) | (stochrsi_k_1h_gt_60) | (aroond_14_4h < 70.0))
+          short_entry_logic.append((rsi_3_1h_lt_40) | (stochrsi_k_1h_gt_60) | (aroond_14_4h < 70.0))
           # 1h down move, 1h & 1d high
-          short_entry_logic.append((rsi_3_1h < 40.0) | (stochrsi_k_1h_gt_30) | (df["AROOND_14_1d"] < 90.0))
+          short_entry_logic.append((rsi_3_1h_lt_40) | (stochrsi_k_1h_gt_30) | (df["AROOND_14_1d"] < 90.0))
           # 1h down move, 4h & 1d high
-          short_entry_logic.append((rsi_3_1h < 40.0) | (rsi_14_4h > 30.0) | (rsi_14_1d > 20.0))
+          short_entry_logic.append((rsi_3_1h_lt_40) | (rsi_14_4h > 30.0) | (rsi_14_1d > 20.0))
           # 4h down move, 15m high
           short_entry_logic.append((rsi_3_4h_lt_80) | (aroond_14_15m < 80.0))
           # 4h down move, 1h high
-          short_entry_logic.append((rsi_3_4h < 75.0) | (stochrsi_k_1h_gt_20))
+          short_entry_logic.append((rsi_3_4h_lt_75) | (stochrsi_k_1h_gt_20))
           # 4h down move, 1h & 4h still high
           short_entry_logic.append((rsi_3_4h < 65.0) | (stochrsi_k_1h_gt_50) | (aroond_14_4h < 50.0))
           # 4h down move, 15m & 1h high
-          short_entry_logic.append((rsi_3_4h < 60.0) | (aroond_14_15m < 80.0) | (stochrsi_k_1h_gt_30))
+          short_entry_logic.append((rsi_3_4h_lt_60) | (aroond_14_15m < 80.0) | (stochrsi_k_1h_gt_30))
           # 4h down move, 15m still high, 1h high
-          short_entry_logic.append((rsi_3_4h < 60.0) | (stochrsi_k_15m > 60.0) | (stochrsi_k_1h_gt_20))
+          short_entry_logic.append((rsi_3_4h_lt_60) | (stochrsi_k_15m > 60.0) | (stochrsi_k_1h_gt_20))
           # 4h down move, 1h still high, 4h still moving down
-          short_entry_logic.append((rsi_3_4h < 60.0) | (stochrsi_k_1h_gt_50) | (cci_20_change_pct_4h < 0.0))
+          short_entry_logic.append((rsi_3_4h_lt_60) | (stochrsi_k_1h_gt_50) | (cci_20_change_pct_4h < 0.0))
           # 4h down move, 1h high, 4h still high
           short_entry_logic.append((rsi_3_4h < 55.0) | (aroond_14_1h < 70.0) | (aroond_14_4h < 50.0))
           # 4h down move, 15m high, 4h still high
-          short_entry_logic.append((rsi_3_4h < 50.0) | (aroond_14_15m < 70.0) | (stochrsi_k_4h > 60.0))
+          short_entry_logic.append((rsi_3_4h_lt_50) | (aroond_14_15m < 70.0) | (stochrsi_k_4h > 60.0))
           # 4h down move, 15m still high, 1h high
-          short_entry_logic.append((rsi_3_4h < 50.0) | (stochrsi_k_15m > 60.0) | (stochrsi_k_1h_gt_30))
+          short_entry_logic.append((rsi_3_4h_lt_50) | (stochrsi_k_15m > 60.0) | (stochrsi_k_1h_gt_30))
           # 4h down move, 15m & 4h still high
-          short_entry_logic.append((rsi_3_4h < 50.0) | (stochrsi_k_15m_gt_50) | (aroond_14_4h < 50.0))
+          short_entry_logic.append((rsi_3_4h_lt_50) | (stochrsi_k_15m_gt_50) | (aroond_14_4h < 50.0))
           # 4h down move, 15m high, 4h still not low enough
-          short_entry_logic.append((rsi_3_4h < 50.0) | (stochrsi_k_15m > 30.0) | (stochrsi_k_4h_gt_70))
+          short_entry_logic.append((rsi_3_4h_lt_50) | (stochrsi_k_15m > 30.0) | (stochrsi_k_4h_gt_70))
           # 4h down move, 1h still high, 4h high
-          short_entry_logic.append((rsi_3_4h < 50.0) | (stochrsi_k_1h_gt_50) | (aroond_14_4h < 70.0))
+          short_entry_logic.append((rsi_3_4h_lt_50) | (stochrsi_k_1h_gt_50) | (aroond_14_4h < 70.0))
           # 4h down move, 15m & 4h high
-          short_entry_logic.append((rsi_3_4h < 40.0) | (aroond_14_15m < 70.0) | (aroond_14_4h < 70.0))
+          short_entry_logic.append((rsi_3_4h_lt_40) | (aroond_14_15m < 70.0) | (aroond_14_4h < 70.0))
           # 4h down move, 15m high, 4h still high
-          short_entry_logic.append((rsi_3_4h < 40.0) | (aroond_14_15m < 80.0) | (aroond_14_4h < 40.0))
+          short_entry_logic.append((rsi_3_4h_lt_40) | (aroond_14_15m < 80.0) | (aroond_14_4h < 40.0))
           # 4h down move, 15m still high, 4h high
-          short_entry_logic.append((rsi_3_4h < 40.0) | (stochrsi_k_15m_gt_50) | (stochrsi_k_4h_gt_30))
+          short_entry_logic.append((rsi_3_4h_lt_40) | (stochrsi_k_15m_gt_50) | (stochrsi_k_4h_gt_30))
           # 4h down move, 15m & 4h high
-          short_entry_logic.append((rsi_3_4h < 40.0) | (stochrsi_k_15m > 30.0) | (stochrsi_k_4h > 40.0))
+          short_entry_logic.append((rsi_3_4h_lt_40) | (stochrsi_k_15m > 30.0) | (stochrsi_k_4h > 40.0))
           # 4h down move, 1h & 4h high
-          short_entry_logic.append((rsi_3_4h < 40.0) | (stochrsi_k_1h_gt_30) | (aroond_14_4h < 70.0))
+          short_entry_logic.append((rsi_3_4h_lt_40) | (stochrsi_k_1h_gt_30) | (aroond_14_4h < 70.0))
           # 4h down move, 4h still high, 1d high
-          short_entry_logic.append((rsi_3_4h < 40.0) | (stochrsi_k_4h_gt_50) | (stochrsi_k_1d_gt_20))
+          short_entry_logic.append((rsi_3_4h_lt_40) | (stochrsi_k_4h_gt_50) | (stochrsi_k_1d_gt_20))
           # 15m high, 4h high
           short_entry_logic.append((aroond_14_15m < 70.0) | (aroond_14_4h < 85.0))
           # 15m high, 4h still high


### PR DESCRIPTION
## Summary
- Reuse repeated RSI3 low-side comparisons in `populate_entry_trend()` through named entry masks.
- Independent on latest upstream `main`.

## Safety
- Behavior-preserving Series mask reuse only.
- Touched function: `populate_entry_trend()`.
- Indicator formulas, candle selection, thresholds, condition order, profit arithmetic, order classification, return values, and signal behavior are unchanged.
- No v3 grind-entry code is touched.

## Backtest scope
- Full backtesting was not required because this patch only aliases Series comparisons that are already used by the same condition ladder.
- Indicator formulas, candle selection, thresholds, and condition order are unchanged.

## Checks
- `python3 /home/user/.codex/skills/nfi-upstream-pr/scripts/validate_nfi_pr.py --base origin/main`
- `git merge-tree \9f25e22bd594c7b51672063310f7e3a76474f673 origin/main HEAD | grep -E '\''<<<<<<<|>>>>>>>|changed in both|removed in|added in both'\'' && echo CONFLICT || echo NO_CONFLICT`
- `git diff --check`
- `ruff format --check NostalgiaForInfinityX7.py`
- `ruff check NostalgiaForInfinityX7.py`
- `PYTHONDONTWRITEBYTECODE=1 python3 -m py_compile NostalgiaForInfinityX7.py`