### PR TITLE
Reuse X7 entry STOCHRSI high-side masks

### DIFF
--- a/NostalgiaForInfinityX7.py
+++ b/NostalgiaForInfinityX7.py
@@ -13087,6 +13087,20 @@ class NostalgiaForInfinityX7(IStrategy):
     aroonu_14_1d_lt_100 = aroonu_14_1d < 100.0
 
     stochrsi_k_15m_lt_20 = stochrsi_k_15m < 20.0
+    stochrsi_k_gt_80 = stochrsi_k > 80.0
+    stochrsi_k_15m_gt_30 = stochrsi_k_15m > 30.0
+    stochrsi_k_15m_gt_40 = stochrsi_k_15m > 40.0
+    stochrsi_k_15m_gt_60 = stochrsi_k_15m > 60.0
+    stochrsi_k_15m_gt_70 = stochrsi_k_15m > 70.0
+    stochrsi_k_15m_gt_80 = stochrsi_k_15m > 80.0
+    stochrsi_k_15m_gt_90 = stochrsi_k_15m > 90.0
+    stochrsi_k_4h_gt_10 = stochrsi_k_4h > 10.0
+    stochrsi_k_4h_gt_20 = stochrsi_k_4h > 20.0
+    stochrsi_k_4h_gt_40 = stochrsi_k_4h > 40.0
+    stochrsi_k_4h_gt_60 = stochrsi_k_4h > 60.0
+    stochrsi_k_4h_gt_75 = stochrsi_k_4h > 75.0
+    stochrsi_k_4h_gt_80 = stochrsi_k_4h > 80.0
+    stochrsi_k_4h_gt_90 = stochrsi_k_4h > 90.0
     stochrsi_k_15m_lt_30 = stochrsi_k_15m < 30.0
     stochrsi_k_15m_lt_40 = stochrsi_k_15m < 40.0
     stochrsi_k_15m_lt_50 = stochrsi_k_15m < 50.0
@@ -24191,13 +24205,13 @@ class NostalgiaForInfinityX7(IStrategy):
           # 5m up move, 15m stil low
           short_entry_logic.append((rsi_3_lt_90) | (aroonu_14_15m > 50.0))
           # 5m up move, 15m & 1h still not high enough
-          short_entry_logic.append((rsi_3_lt_90) | (stochrsi_k_15m > 60.0) | (stochrsi_k_1h_gt_75))
+          short_entry_logic.append((rsi_3_lt_90) | (stochrsi_k_15m_gt_60) | (stochrsi_k_1h_gt_75))
           # 15m up move, 1h low
           short_entry_logic.append((rsi_3_15m < 97.0) | (aroonu_14_1h > 30.0))
           # 15m & 1h up move, 4h still going up
           short_entry_logic.append((rsi_3_15m_lt_95) | (rsi_3_1h_lt_95) | (cci_20_change_pct_4h < -0.0))
           # 15m & 1h up move, 4h still not high enough
-          short_entry_logic.append((rsi_3_15m_lt_95) | (rsi_3_1h_lt_90) | (stochrsi_k_4h > 80.0))
+          short_entry_logic.append((rsi_3_15m_lt_95) | (rsi_3_1h_lt_90) | (stochrsi_k_4h_gt_80))
           # 15m & 1h up move, 4h still not high enough
           short_entry_logic.append((rsi_3_15m_lt_95) | (rsi_3_1h_lt_85) | (stochrsi_k_4h_gt_50))
           # 15m & 1h up move, 1h still low
@@ -24209,11 +24223,11 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m up move, 15m & 4h uptrend
           short_entry_logic.append((rsi_3_15m_lt_95) | (aroonu_14_15m_lt_90) | (aroonu_14_4h_lt_90))
           # 15m up move, 15m stil not high enough, 1h low
-          short_entry_logic.append((rsi_3_15m_lt_95) | (stochrsi_k_15m > 70.0) | (stochrsi_k_1h_gt_10))
+          short_entry_logic.append((rsi_3_15m_lt_95) | (stochrsi_k_15m_gt_70) | (stochrsi_k_1h_gt_10))
           # 15m up move, 1h still not high enough, 4h low
           short_entry_logic.append((rsi_3_15m_lt_95) | (stochrsi_k_1h_gt_70) | (aroonu_14_4h > 20.0))
           # 15m up move, 1h & 4h still not high enough
-          short_entry_logic.append((rsi_3_15m_lt_95) | (stochrsi_k_1h_gt_70) | (stochrsi_k_4h > 80.0))
+          short_entry_logic.append((rsi_3_15m_lt_95) | (stochrsi_k_1h_gt_70) | (stochrsi_k_4h_gt_80))
           # 15m up move, 4h still not high enough
           short_entry_logic.append((rsi_3_15m_lt_95) | (aroonu_14_4h > 70.0))
           # 15m up move, 4h & 1d uptrend
@@ -24229,7 +24243,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m & 1h up move, 1d uptrend
           short_entry_logic.append((rsi_3_15m_lt_90) | (rsi_3_1h_lt_80) | (roc_9_1d_lt_40))
           # 15m & 1h up move, 15m still not high enough
-          short_entry_logic.append((rsi_3_15m_lt_90) | (rsi_3_1h_lt_80) | (stochrsi_k_15m > 60.0))
+          short_entry_logic.append((rsi_3_15m_lt_90) | (rsi_3_1h_lt_80) | (stochrsi_k_15m_gt_60))
           # 15m & 4h up move, 1h still not high enough
           short_entry_logic.append((rsi_3_15m_lt_90) | (rsi_3_4h_lt_90) | (stochrsi_k_1h_gt_80))
           # 15m & 4h up move, 1h still not high enough
@@ -24251,7 +24265,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m & 4h up move, 1d low
           short_entry_logic.append((rsi_3_15m_lt_90) | (rsi_3_4h < 70.0) | (stochrsi_k_1d_gt_20))
           # 15m & 1h up move, 4h low
-          short_entry_logic.append((rsi_3_15m_lt_85) | (rsi_3_1h_lt_85) | (stochrsi_k_4h > 20.0))
+          short_entry_logic.append((rsi_3_15m_lt_85) | (rsi_3_1h_lt_85) | (stochrsi_k_4h_gt_20))
           # 15m & 1h up move, 1d still low
           short_entry_logic.append((rsi_3_15m_lt_85) | (rsi_3_1h_lt_85) | (stochrsi_k_1d_gt_60))
           # 15m & 1h up move, 1h low
@@ -24259,11 +24273,11 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m & 1h up move, 4h low
           short_entry_logic.append((rsi_3_15m_lt_85) | (rsi_3_1h < 70.0) | (stochrsi_k_4h_gt_30))
           # 15m & 4h down move, 4h still not high enough
-          short_entry_logic.append((rsi_3_15m_lt_85) | (rsi_3_4h_lt_90) | (stochrsi_k_4h > 75.0))
+          short_entry_logic.append((rsi_3_15m_lt_85) | (rsi_3_4h_lt_90) | (stochrsi_k_4h_gt_75))
           # 15m & 4h up move, 15m low
           short_entry_logic.append((rsi_3_15m_lt_85) | (rsi_3_4h_lt_85) | (stochrsi_k_15m_gt_50))
           # 15m down move, 15m still not high enough, 4h low
-          short_entry_logic.append((rsi_3_15m_lt_85) | (rsi_14_15m > 70.0) | (stochrsi_k_4h > 40.0))
+          short_entry_logic.append((rsi_3_15m_lt_85) | (rsi_14_15m > 70.0) | (stochrsi_k_4h_gt_40))
           # 15m up move, 4h overbought
           short_entry_logic.append((rsi_3_15m_lt_85) | (roc_9_4h_lt_50))
           # 15m & 1h up move, 1h still not high enough
@@ -24275,7 +24289,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m & 1h up move, 1h low
           short_entry_logic.append((rsi_3_15m < 70.0) | (rsi_3_1h < 70.0) | (aroonu_14_1h > 30.0))
           # 15m up move, 15m still not high enough, 1h still low
-          short_entry_logic.append((rsi_3_15m < 70.0) | (stochrsi_k_15m > 90.0) | (stochrsi_k_1h_gt_50))
+          short_entry_logic.append((rsi_3_15m < 70.0) | (stochrsi_k_15m_gt_90) | (stochrsi_k_1h_gt_50))
           # 1h & 4h up move, 1h still not high enough
           short_entry_logic.append((rsi_3_1h_lt_95) | (rsi_3_4h_lt_95) | (stochrsi_k_1h_gt_70))
           # 1h up move, 4h low
@@ -24309,9 +24323,9 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1h up move, 1h still not high enough, 1d low
           short_entry_logic.append((rsi_3_1h_lt_90) | (stochrsi_k_1h_gt_70) | (stochrsi_k_1d_gt_30))
           # 1h up move, 4h low, 1h uptrend
-          short_entry_logic.append((rsi_3_1h_lt_90) | (stochrsi_k_4h > 20.0) | (roc_9_1h_lt_10))
+          short_entry_logic.append((rsi_3_1h_lt_90) | (stochrsi_k_4h_gt_20) | (roc_9_1h_lt_10))
           # 1h up move, 4h low, 1h overbought
-          short_entry_logic.append((rsi_3_1h_lt_90) | (stochrsi_k_4h > 40.0) | (roc_9_1h_lt_30))
+          short_entry_logic.append((rsi_3_1h_lt_90) | (stochrsi_k_4h_gt_40) | (roc_9_1h_lt_30))
           # 1h up move, 15m & 1h uptrend
           short_entry_logic.append((rsi_3_1h_lt_90) | (roc_9_15m < 15.0) | (roc_9_1h_lt_15))
           # 1h up move, 15m & 4h still low
@@ -24319,9 +24333,9 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1h & 4h up move, 15m still not high enough
           short_entry_logic.append((rsi_3_1h_lt_85) | (rsi_3_4h_lt_85) | (aroond_14_15m < 50.0))
           # 1h & 4h up move, 15m still not high enough
-          short_entry_logic.append((rsi_3_1h_lt_85) | (rsi_3_4h_lt_85) | (stochrsi_k_15m > 90.0))
+          short_entry_logic.append((rsi_3_1h_lt_85) | (rsi_3_4h_lt_85) | (stochrsi_k_15m_gt_90))
           # 1h up move, 15m still not high enough, 1h still low
-          short_entry_logic.append((rsi_3_1h_lt_80) | (stochrsi_k_15m > 80.0) | (stochrsi_k_1h_gt_50))
+          short_entry_logic.append((rsi_3_1h_lt_80) | (stochrsi_k_15m_gt_80) | (stochrsi_k_1h_gt_50))
           # 1h up move, 1h still low
           short_entry_logic.append((rsi_3_1h_lt_80) | (stochrsi_k_1h_gt_60))
           # 4h & 1d strong up move
@@ -24329,7 +24343,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 4h up move, 15m still low, 1h not high enough
           short_entry_logic.append((rsi_3_4h_lt_95) | (stochrsi_k_15m_gt_50) | (aroond_14_1h < 25.0))
           # 4h up move, 15m still not high enough, 4h overbought
-          short_entry_logic.append((rsi_3_4h_lt_95) | (stochrsi_k_15m > 70.0) | (roc_9_4h_lt_60))
+          short_entry_logic.append((rsi_3_4h_lt_95) | (stochrsi_k_15m_gt_70) | (roc_9_4h_lt_60))
           # 4h up move, 15m uptrend
           short_entry_logic.append((rsi_3_4h_lt_95) | (roc_9_15m < 20.0))
           # 4h up move, 1h uptrend
@@ -24355,7 +24369,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 4h still not high enough, 4h overbought, 4h uptrend
           short_entry_logic.append((rsi_14_4h > 80.0) | (roc_9_4h_lt_40) | (cci_20_change_pct_4h < 0.0))
           # 15m & 1h uptrend, 4h still low
-          short_entry_logic.append((cmf_20_15m < 0.30) | (cmf_20_1h < 0.30) | (stochrsi_k_4h > 60.0))
+          short_entry_logic.append((cmf_20_15m < 0.30) | (cmf_20_1h < 0.30) | (stochrsi_k_4h_gt_60))
           # 15m uptrend, 1h low
           short_entry_logic.append((aroonu_14_15m_lt_100) | (stochrsi_k_1h_gt_20))
           # 1h & 4h uptrend
@@ -24373,7 +24387,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1d uptrend, 1h uptrend
           short_entry_logic.append(aroonu_14_1d_lt_100 | (roc_9_1h_lt_20))
           # 15m still not high enough, 1h & 4h overbought
-          short_entry_logic.append((stochrsi_k_15m > 70.0) | (roc_9_1h_lt_30) | (roc_9_4h_lt_60))
+          short_entry_logic.append((stochrsi_k_15m_gt_70) | (roc_9_1h_lt_30) | (roc_9_4h_lt_60))
           # 1h & 4h overbought, 1h uptrend
           short_entry_logic.append((roc_9_1h_lt_10) | (roc_9_4h_lt_40) | (cci_20_change_pct_1h < 0.0))
           # 1h & 4h overbought, 4h uptrend
@@ -24383,11 +24397,11 @@ class NostalgiaForInfinityX7(IStrategy):
           # 5m green, 15m still not high enough
           short_entry_logic.append((df["change_pct"] < 5.0) | (aroond_14_15m < 50.0))
           # 5m green, 15m still not high enough
-          short_entry_logic.append((df["change_pct"] < 5.0) | (stochrsi_k_15m > 90.0))
+          short_entry_logic.append((df["change_pct"] < 5.0) | (stochrsi_k_15m_gt_90))
           # pump in the last half hour, 1h low
           short_entry_logic.append((close < (df["close_min_6"] * 1.20)) | (aroonu_14_1h > 30.0))
           # pump in the last half hour, 15m still low
-          short_entry_logic.append((close < (df["close_min_6"] * 1.20)) | (stochrsi_k_15m > 40.0))
+          short_entry_logic.append((close < (df["close_min_6"] * 1.20)) | (stochrsi_k_15m_gt_40))
           # pump in the last half hour, 1d uptrend
           short_entry_logic.append((close < (df["close_min_6"] * 1.20)) | (roc_9_1d_lt_20))
           # big pump in the last 4 hours, 15m still low
@@ -24411,7 +24425,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 5m & 4h up move
             & ((rsi_3 < 97.0) | (rsi_3_4h_lt_95))
             # 5m up move, 4h still not high enough
-            & ((rsi_3 < 97.0) | (stochrsi_k_4h > 80.0))
+            & ((rsi_3 < 97.0) | (stochrsi_k_4h_gt_80))
             # 5m & 15m strong up move
             & ((rsi_3 < 95.0) | (rsi_3_15m_lt_95))
             # 5m & 15m up move, 4h low
@@ -24419,19 +24433,19 @@ class NostalgiaForInfinityX7(IStrategy):
             # 5m & 1h & 4h up move
             & ((rsi_3 < 95.0) | (rsi_3_1h_lt_90) | (rsi_3_4h_lt_90))
             # 5m & 1h up move, 15m still not high enough
-            & ((rsi_3 < 95.0) | (rsi_3_1h_lt_85) | (stochrsi_k_15m > 70.0))
+            & ((rsi_3 < 95.0) | (rsi_3_1h_lt_85) | (stochrsi_k_15m_gt_70))
             # 5m up move, 15m still low
             & ((rsi_3 < 95.0) | (stochrsi_k_15m_gt_50))
             # 5m up move, 4h low
             & ((rsi_3_lt_90) | (aroonu_14_4h > 20.0))
             # 15m & 1h down move, 4h still not high enough
-            & ((rsi_3_15m < 97.0) | (rsi_3_1h_lt_85) | (stochrsi_k_4h > 80.0))
+            & ((rsi_3_15m < 97.0) | (rsi_3_1h_lt_85) | (stochrsi_k_4h_gt_80))
             # 15m up move, 1h still low
             & ((rsi_3_15m < 97.0) | (stochrsi_k_1h_gt_60))
             # 15m & 1h & 4h up move
             & ((rsi_3_15m_lt_95) | (rsi_3_1h_lt_90) | (rsi_3_4h_lt_85))
             # 15m & 1h up move, 4h still low
-            & ((rsi_3_15m_lt_95) | (rsi_3_1h_lt_85) | (stochrsi_k_4h > 60.0))
+            & ((rsi_3_15m_lt_95) | (rsi_3_1h_lt_85) | (stochrsi_k_4h_gt_60))
             # 15m up move, 1h still low
             & ((rsi_3_15m_lt_95) | (stochrsi_k_1h_gt_40))
             # 15m up move, 4h still not high enough
@@ -24439,7 +24453,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h & 4h up move
             & ((rsi_3_15m_lt_90) | (rsi_3_1h_lt_90) | (rsi_3_4h_lt_90))
             # 15m & 1h up move, 15m still not high enough
-            & ((rsi_3_15m_lt_90) | (rsi_3_1h_lt_90) | (stochrsi_k_15m > 80.0))
+            & ((rsi_3_15m_lt_90) | (rsi_3_1h_lt_90) | (stochrsi_k_15m_gt_80))
             # 15m & 1h up move, 1d low
             & ((rsi_3_15m_lt_90) | (rsi_3_1h_lt_90) | (stochrsi_k_1d > 40.0))
             # 15m & 1h up move, 1h still not high enough
@@ -24471,7 +24485,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m up move, 1h low, 1d uptrend
             & ((rsi_3_15m < 80.0) | (aroonu_14_1h > 40.0) | (roc_9_1d_lt_100))
             # 15m up move, 4h low
-            & ((rsi_3_15m < 80.0) | (stochrsi_k_4h > 40.0))
+            & ((rsi_3_15m < 80.0) | (stochrsi_k_4h_gt_40))
             # 15m up move, 1h uptrend
             & ((rsi_3_15m < 75.0) | (roc_9_1h_lt_40))
             # 1h & 1d strong up move
@@ -24479,7 +24493,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h up move, 1h still not high enough
             & ((rsi_3_1h_lt_95) | (stochrsi_k_1h_gt_70))
             # 1h up move, 4h still low, 1h moving higher
-            & ((rsi_3_1h_lt_95) | (stochrsi_k_4h > 60.0) | (cci_20_change_pct_1h < -0.0))
+            & ((rsi_3_1h_lt_95) | (stochrsi_k_4h_gt_60) | (cci_20_change_pct_1h < -0.0))
             # 1h up move, 1d low
             & ((rsi_3_1h_lt_95) | (rsi_14_1d > 40.0))
             # 1h strong up move, 15m still move higher
@@ -24503,7 +24517,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h up move, 4h still low, 1h still moving higher
             & ((rsi_3_1h_lt_80) | (rsi_14_4h > 60.0) | (cci_20_change_pct_1h < -0.0))
             # 1h up move, 4h low
-            & ((rsi_3_1h_lt_80) | (stochrsi_k_4h > 20.0))
+            & ((rsi_3_1h_lt_80) | (stochrsi_k_4h_gt_20))
             # 1h up move, 4h low
             & ((rsi_3_1h_lt_80) | (aroonu_14_4h > 10.0))
             # 1h up move, 1h still low
@@ -24511,7 +24525,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h up move, 4h low
             & ((rsi_3_1h < 70.0) | (rsi_14_4h > 40.0))
             # 1h up move, 4h low
-            & ((rsi_3_1h < 70.0) | (stochrsi_k_4h > 40.0))
+            & ((rsi_3_1h < 70.0) | (stochrsi_k_4h_gt_40))
             # 1h up move, 1h uptrend
             & ((rsi_3_1h < 70.0) | (roc_9_1h_lt_40))
             # 1h up move, 1h low
@@ -24521,15 +24535,15 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h up move, 1h still not high enough
             & ((rsi_3_4h_lt_95) | (stochrsi_k_1h_gt_70))
             # 4h up move, 4h still not high enough
-            & ((rsi_3_4h_lt_95) | (stochrsi_k_4h > 80.0))
+            & ((rsi_3_4h_lt_95) | (stochrsi_k_4h_gt_80))
             # 4h up move, 15m still not high enough, 4h moving higher
-            & ((rsi_3_4h_lt_90) | (stochrsi_k_15m > 80.0) | (cci_20_change_pct_4h < 0.0))
+            & ((rsi_3_4h_lt_90) | (stochrsi_k_15m_gt_80) | (cci_20_change_pct_4h < 0.0))
             # 4h up move, 15m still low
             & ((rsi_3_4h_lt_90) | (stochrsi_k_15m_gt_50))
             # 4h up move, 1h still low
             & ((rsi_3_4h_lt_90) | (aroonu_14_1h > 40.0))
             # 4h up move, 4h still not high enough
-            & ((rsi_3_4h_lt_90) | (stochrsi_k_4h > 75.0))
+            & ((rsi_3_4h_lt_90) | (stochrsi_k_4h_gt_75))
             # 4h up move, 4h still not high enough
             & ((rsi_3_4h_lt_85) | (stochrsi_k_4h_gt_70))
             # 4h up move, 1d still low, 4h uptrend
@@ -24541,25 +24555,25 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h up move, 1h low
             & ((rsi_3_4h < 75.0) | (stochrsi_k_1h_gt_20))
             # 4h up move, 4h low
-            & ((rsi_3_4h < 70.0) | (stochrsi_k_4h > 40.0))
+            & ((rsi_3_4h < 70.0) | (stochrsi_k_4h_gt_40))
             # 1d up move, 1h still not high enough
             & ((rsi_3_1d < 95.0) | (stochrsi_k_1h_gt_90))
             # 1d up move, 1h still low
             & ((rsi_3_1d < 90.0) | (stochrsi_k_1h_gt_50))
             # 1d up move, 4h still low
-            & ((rsi_3_1d < 80.0) | (stochrsi_k_4h > 40.0))
+            & ((rsi_3_1d < 80.0) | (stochrsi_k_4h_gt_40))
             # 15m low, 1h still low
             & ((aroonu_14_15m > 20.0) | (stochrsi_k_1h_gt_50))
             # 15m low, 4h low
-            & ((aroonu_14_15m > 20.0) | (stochrsi_k_4h > 20.0))
+            & ((aroonu_14_15m > 20.0) | (stochrsi_k_4h_gt_20))
             # 15m still low, 1h low
             & ((aroonu_14_15m > 50.0) | (stochrsi_k_1h_gt_30))
             # 15m still not high enough, 4h low
-            & ((stochrsi_k_15m > 70.0) | (aroonu_14_4h > 10.0))
+            & ((stochrsi_k_15m_gt_70) | (aroonu_14_4h > 10.0))
             # 1h & 4h low
             & ((aroonu_14_1h > 20.0) | (aroonu_14_4h > 20.0))
             # 1h & 4h low
-            & ((aroonu_14_1h > 20.0) | (stochrsi_k_4h > 20.0))
+            & ((aroonu_14_1h > 20.0) | (stochrsi_k_4h_gt_20))
             # 1h low, 1d low
             & ((aroonu_14_1h > 30.0) | (stochrsi_k_1d_gt_30))
             # 4h still not high enough, 4h & 1d uptrend
@@ -24571,7 +24585,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # rise in the last hour, relatively stable before the hour
             & ((close < (df["close_min_12"] * 1.10)) | (df["close_min_12"] > (df["close_min_48"] * 1.10)))
             # big pump in the last 6 days, 4h still not high enough
-            & ((close < (df["low_min_6_1d"] * 4.0)) | (stochrsi_k_4h > 80.0))
+            & ((close < (df["low_min_6_1d"] * 4.0)) | (stochrsi_k_4h_gt_80))
             # big pump in the last 20 days, 1h up move
             & ((close < (df["low_min_20_1d"] * 6.0)) | (rsi_3_1h_lt_90))
           )
@@ -24579,7 +24593,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # Logic
           short_entry_logic.append(
             (aroond_14 < 25.0)
-            & (stochrsi_k > 80.0)
+            & (stochrsi_k_gt_80)
             & (close > (ema_20 * 1.060))
             & (close > (bbu_20_2_0 * 0.995))
             & (aroond_14_15m < 25.0)
@@ -24605,7 +24619,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 5m down move, 4h downtrend, 1h still high
           short_entry_logic.append((rsi_3 < 95.0) | (rsi_3_4h_lt_85) | (stochrsi_k_1h_gt_30))
           # 5m & 4h strong down move, 4h still not low enough
-          short_entry_logic.append((rsi_3 < 95.0) | (rsi_3_1h_lt_95) | (stochrsi_k_4h > 60.0))
+          short_entry_logic.append((rsi_3 < 95.0) | (rsi_3_1h_lt_95) | (stochrsi_k_4h_gt_60))
           # 5m down move, 1h high, 1d overbought
           short_entry_logic.append((rsi_3_lt_90) | (roc_9_1h_lt_15) | (roc_9_1d_gt_neg_40))
           # 5m down move, 1h & 4h high
@@ -24629,7 +24643,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m & 4h down move, 1h still not low
           short_entry_logic.append((rsi_3_15m_lt_95) | (rsi_3_4h_lt_90) | (stochrsi_k_1h_gt_70))
           # 15m & 4h down move, 4h still not low enough
-          short_entry_logic.append((rsi_3_15m_lt_95) | (rsi_3_4h_lt_80) | (stochrsi_k_4h > 60.0))
+          short_entry_logic.append((rsi_3_15m_lt_95) | (rsi_3_4h_lt_80) | (stochrsi_k_4h_gt_60))
           # 15m down move, 1h & 4h still high
           short_entry_logic.append((rsi_3_15m_lt_95) | (stochrsi_k_1h_gt_50) | (rsi_14_4h > 50.0))
           # 15m & 1h & 4h down move
@@ -24651,9 +24665,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m & 4h down move, 1d downtrend
           short_entry_logic.append((rsi_3_15m_lt_85) | (rsi_3_4h_lt_85) | (roc_9_1d > -70.0))
           # 15m down move, 15m not low enough, 1h overbought
-          short_entry_logic.append(
-            (df["RSI_14_change_pct_15m"] > -40.0) | (stochrsi_k_15m > 90.0) | (rsi_14_1h > 30.0)
-          )
+          short_entry_logic.append((df["RSI_14_change_pct_15m"] > -40.0) | (stochrsi_k_15m_gt_90) | (rsi_14_1h > 30.0))
           # 15m strong down move, 1h still high
           short_entry_logic.append((roc_9_15m < 15.0) | (stochrsi_k_1h_gt_50))
           # 15m downtrend, 1h & 4h still high
@@ -24688,12 +24700,12 @@ class NostalgiaForInfinityX7(IStrategy):
           short_entry_logic.append((aroond_14_15m < 50.0) | (rsi_3_change_pct_1h < 50.0) | (stochrsi_k_4h_gt_30))
           # 15m still high, 1h & 4h down move, 4h still high
           short_entry_logic.append(
-            (aroond_14_15m < 50.0) | (rsi_3_1h_lt_85) | (rsi_3_4h_lt_80) | (stochrsi_k_4h > 80.0)
+            (aroond_14_15m < 50.0) | (rsi_3_1h_lt_85) | (rsi_3_4h_lt_80) | (stochrsi_k_4h_gt_80)
           )
           # 15m & 1h still high, 4h overbought
           short_entry_logic.append((aroond_14_15m < 50.0) | (aroond_14_1h < 50.0) | (roc_9_4h > -40.0))
           # 15m still high, 1h down move, 1d downtrend
-          short_entry_logic.append((stochrsi_k_15m > 30.0) | (rsi_3_4h_lt_90) | roc_9_1d_lt_50)
+          short_entry_logic.append((stochrsi_k_15m_gt_30) | (rsi_3_4h_lt_90) | roc_9_1d_lt_50)
           # 1h & 4h still high, 1d strong down move
           short_entry_logic.append((stochrsi_k_1h_gt_50) | (uo_7_14_28_4h > 55.0) | (rsi_3_1d < 90.0))
           # 1h still high, 4h & 1d downtrend
@@ -24750,7 +24762,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m & 1h down move, 4h still high
           short_entry_logic.append((rsi_3_15m_lt_90) | (mfi_14_15m < 85.0) | (stochrsi_k_4h_gt_30))
           # 14m & 4h down move, 4h still high
-          short_entry_logic.append((rsi_3_15m_lt_90) | (rsi_3_4h_lt_85) | (stochrsi_k_4h > 60.0))
+          short_entry_logic.append((rsi_3_15m_lt_90) | (rsi_3_4h_lt_85) | (stochrsi_k_4h_gt_60))
           # 15m down move, 1h & 4h still high
           short_entry_logic.append((rsi_3_15m_lt_90) | (df["UO_7_14_28_1h"] < 45.0) | (stochrsi_k_4h_gt_30))
           # 1h strong down move, 4h still high
@@ -24758,7 +24770,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1h strong down move, 4h down move, 4h still high
           short_entry_logic.append((rsi_3_1h_lt_95) | (rsi_3_change_pct_4h < 50.0) | (stochrsi_k_4h_gt_50))
           # 1h & 4h down move, 4h still not low enough
-          short_entry_logic.append((rsi_3_1h_lt_95) | (rsi_3_4h_lt_90) | (stochrsi_k_4h > 75.0))
+          short_entry_logic.append((rsi_3_1h_lt_95) | (rsi_3_4h_lt_90) | (stochrsi_k_4h_gt_75))
           # 1h & 4h down move, 4h still not low enough
           short_entry_logic.append((rsi_3_1h_lt_95) | (rsi_3_4h < 75.0) | (aroond_14_4h < 50.0))
           # 15m down move, 1h strong downtrend
@@ -24786,7 +24798,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m & 1h strong down move & downtrend
           short_entry_logic.append((rsi_3_15m_lt_95) | (rsi_3_1h_lt_95) | (mfi_14_1h > 5.0))
           # 15m strong down move, 4h high
-          short_entry_logic.append((rsi_3_15m_lt_95) | (stochrsi_k_4h > 10.0))
+          short_entry_logic.append((rsi_3_15m_lt_95) | (stochrsi_k_4h_gt_10))
           # 15m & 1h down move
           short_entry_logic.append((rsi_3_15m_lt_95) | (rsi_3_1h_lt_95) | (cci_20_change_pct_1h > 0.0))
           # 15m & 1h down move, 4h high
@@ -24810,13 +24822,13 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m & 1h down move, 4h high
           short_entry_logic.append((rsi_3_15m_lt_90) | (rsi_3_1h_lt_85) | (stochrsi_k_4h_gt_30))
           # 15m down move, 1h down move, 4h high
-          short_entry_logic.append((rsi_3_15m_lt_85) | (rsi_3_change_pct_1h < 30.0) | (stochrsi_k_4h > 10.0))
+          short_entry_logic.append((rsi_3_15m_lt_85) | (rsi_3_change_pct_1h < 30.0) | (stochrsi_k_4h_gt_10))
           # 1m down move, 1h still dropping, 4h overbought
           short_entry_logic.append((rsi_3_15m_lt_90) | (cci_20_change_pct_1h < 0.0) | (rsi_14_4h > 20.0))
           # 15m down move, 1h high
           short_entry_logic.append((df["RSI_3_change_pct_15m"] < 70.0) | (stochrsi_k_1h_gt_10))
           # 1h strong down move, 4h high
-          short_entry_logic.append((rsi_3_1h_lt_95) | (stochrsi_k_4h > 10.0))
+          short_entry_logic.append((rsi_3_1h_lt_95) | (stochrsi_k_4h_gt_10))
           # 1h down move, 4h downtrend, 4h not low enough
           short_entry_logic.append((rsi_3_1h_lt_95) | (cmf_20_4h > -0.25) | (stochrsi_k_4h_gt_70))
           # 1h down move, 4h high, 1d overbought
@@ -24840,7 +24852,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m down move, 1h strong down move, 1d overbought
           short_entry_logic.append((mfi_14_15m < 80.0) | (rsi_3_change_pct_1h < 80.0) | roc_9_1d_gt_neg_50)
           # 1h not low enough, 4h high, 1d strong downtrend
-          short_entry_logic.append((stochrsi_k_1h_gt_70) | (stochrsi_k_4h > 10.0) | (roc_9_1d_lt_60))
+          short_entry_logic.append((stochrsi_k_1h_gt_70) | (stochrsi_k_4h_gt_10) | (roc_9_1d_lt_60))
           # 1h down move, 4h still high, 1d downtrend
           short_entry_logic.append((rsi_3_change_pct_1h < 65.0) | (stochrsi_k_4h_gt_30) | roc_9_1d_lt_50)
           # 15m strong down move, 1h still high
@@ -24890,7 +24902,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m & 1h up move, 4h still low
           short_entry_logic.append((rsi_3_15m_lt_95) | (rsi_3_1h_lt_95) | (rsi_14_4h > 60.0))
           # 15m & 1h up move, 4h still not high enough
-          short_entry_logic.append((rsi_3_15m_lt_95) | (rsi_3_1h_lt_95) | (stochrsi_k_4h > 80.0))
+          short_entry_logic.append((rsi_3_15m_lt_95) | (rsi_3_1h_lt_95) | (stochrsi_k_4h_gt_80))
           # 15m & 1h up move, 1h still moving higher
           short_entry_logic.append((rsi_3_15m_lt_95) | (rsi_3_1h_lt_90) | (cci_20_change_pct_1h < -0.0))
           # 15m & 4h up move, 4h still moving higher
@@ -24900,27 +24912,27 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m up move, 15m & 4h high
           short_entry_logic.append((rsi_3_15m_lt_90) | (aroonu_14_15m_lt_100) | (aroonu_14_4h_lt_100))
           # 15m up move, 15m still not high enough, 1d uptrend
-          short_entry_logic.append((rsi_3_15m_lt_90) | (stochrsi_k_15m > 80.0) | (roc_9_1d_lt_80))
+          short_entry_logic.append((rsi_3_15m_lt_90) | (stochrsi_k_15m_gt_80) | (roc_9_1d_lt_80))
           # 15m & 4h up move, 15m still not high enough
-          short_entry_logic.append((rsi_3_15m_lt_85) | (rsi_3_4h_lt_90) | (stochrsi_k_15m > 70.0))
+          short_entry_logic.append((rsi_3_15m_lt_85) | (rsi_3_4h_lt_90) | (stochrsi_k_15m_gt_70))
           # 15m & 4h up move, 1d uptrend
           short_entry_logic.append((rsi_3_15m_lt_85) | (rsi_3_4h_lt_85) | roc_9_1d_lt_50)
           # 15m & 4h up move, 4h still not high enough
           short_entry_logic.append((rsi_3_15m_lt_85) | (rsi_3_4h_lt_80) | (rsi_14_4h > 60.0))
           # 15m up move, 15m still not high enough, 4h still low
-          short_entry_logic.append((rsi_3_15m_lt_85) | (stochrsi_k_15m > 80.0) | (aroonu_14_4h > 50.0))
+          short_entry_logic.append((rsi_3_15m_lt_85) | (stochrsi_k_15m_gt_80) | (aroonu_14_4h > 50.0))
           # 15m up move, 4h overbought
           short_entry_logic.append((rsi_3_15m_lt_85) | (roc_9_4h_lt_50))
           # 15m & 1h up move, 15m still low
           short_entry_logic.append((rsi_3_15m < 70.0) | (rsi_3_1h < 70.0) | (aroonu_14_15m > 40.0))
           # 15m & 1h up move, 15m still low
-          short_entry_logic.append((rsi_3_15m < 70.0) | (rsi_3_1h < 70.0) | (stochrsi_k_15m > 40.0))
+          short_entry_logic.append((rsi_3_15m < 70.0) | (rsi_3_1h < 70.0) | (stochrsi_k_15m_gt_40))
           # # 15m & 1h up move, 4h low
           short_entry_logic.append((rsi_3_15m < 70.0) | (rsi_3_1h < 60.0) | (aroonu_14_4h > 40.0))
           # 1h & 1d up move, 1h still moving higher
           short_entry_logic.append((rsi_3_1h < 97.0) | (rsi_3_1d < 95.0) | (cci_20_change_pct_1h < -0.0))
           # 1h & 4h up move, 15m still not high enough
-          short_entry_logic.append((rsi_3_1h_lt_95) | (rsi_3_4h_lt_95) | (stochrsi_k_15m > 80.0))
+          short_entry_logic.append((rsi_3_1h_lt_95) | (rsi_3_4h_lt_95) | (stochrsi_k_15m_gt_80))
           # 1h & 4h up move, 1d uptrend
           short_entry_logic.append((rsi_3_1h_lt_95) | (rsi_3_4h_lt_95) | (roc_9_1d_lt_100))
           # 1h & 4h up move, 1d still low
@@ -24932,15 +24944,15 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1h & 4h up move, 1h still moving higher
           short_entry_logic.append((rsi_3_1h_lt_90) | (rsi_3_4h_lt_85) | (cci_20_change_pct_1h < -0.0))
           # 1h & 4h up move, 4h still not high enough
-          short_entry_logic.append((rsi_3_1h_lt_90) | (rsi_3_4h < 70.0) | (stochrsi_k_4h > 80.0))
+          short_entry_logic.append((rsi_3_1h_lt_90) | (rsi_3_4h < 70.0) | (stochrsi_k_4h_gt_80))
           # 1h & 1d up move, 15m still low
-          short_entry_logic.append((rsi_3_1h_lt_90) | (rsi_3_1d < 90.0) | (stochrsi_k_15m > 60.0))
+          short_entry_logic.append((rsi_3_1h_lt_90) | (rsi_3_1d < 90.0) | (stochrsi_k_15m_gt_60))
           # 1h up move, 15m high
           short_entry_logic.append((rsi_3_1h_lt_90) | (aroonu_14_15m_lt_100))
           # 1h up move, 4h low
           short_entry_logic.append((rsi_3_1h_lt_90) | (stochrsi_k_4h_gt_30))
           # 1h up move, 4h still low, 1h still moving higher
-          short_entry_logic.append((rsi_3_1h_lt_90) | (stochrsi_k_4h > 60.0) | (cci_20_change_pct_1h < -0.0))
+          short_entry_logic.append((rsi_3_1h_lt_90) | (stochrsi_k_4h_gt_60) | (cci_20_change_pct_1h < -0.0))
           # 1h up move, 15m uptrend
           short_entry_logic.append((rsi_3_1h_lt_90) | (roc_9_15m < 30.0))
           # 1h up move, 15m & 4h uptrend
@@ -24966,7 +24978,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 4h up move, 1d low
           short_entry_logic.append((rsi_3_4h_lt_95) | (rsi_14_1d > 40.0))
           # 4h down move, 15m still not high enough, 1d low
-          short_entry_logic.append((rsi_3_4h_lt_95) | (stochrsi_k_15m > 80.0) | (df["AROOND_14_1d"] < 75.0))
+          short_entry_logic.append((rsi_3_4h_lt_95) | (stochrsi_k_15m_gt_80) | (df["AROOND_14_1d"] < 75.0))
           # 4h up move, 1h & 4h uptrend
           short_entry_logic.append((rsi_3_4h_lt_95) | (roc_9_1h_lt_20) | (roc_9_4h_lt_20))
           # 4h up move, 15m low
@@ -24976,15 +24988,15 @@ class NostalgiaForInfinityX7(IStrategy):
           # 4h up move, 15m still not high enough
           short_entry_logic.append((rsi_3_4h_lt_85) | (aroonu_14_15m > 60.0))
           # 4h up move, 15m low
-          short_entry_logic.append((rsi_3_4h_lt_85) | (stochrsi_k_15m > 30.0))
+          short_entry_logic.append((rsi_3_4h_lt_85) | (stochrsi_k_15m_gt_30))
           # 4h up move, 4h uptrend
           short_entry_logic.append((rsi_3_4h_lt_80) | (aroonu_14_4h_lt_100) | (roc_9_4h_lt_20))
           # 4h up move, 15m still low, 4h still not high enough
-          short_entry_logic.append((rsi_3_4h_lt_80) | (stochrsi_k_15m > 60.0) | (aroonu_14_4h > 80.0))
+          short_entry_logic.append((rsi_3_4h_lt_80) | (stochrsi_k_15m_gt_60) | (aroonu_14_4h > 80.0))
           # 4h up move, 15m still low, 4h still not high enough
-          short_entry_logic.append((rsi_3_4h < 75.0) | (stochrsi_k_15m > 60.0) | (stochrsi_k_4h > 80.0))
+          short_entry_logic.append((rsi_3_4h < 75.0) | (stochrsi_k_15m_gt_60) | (stochrsi_k_4h_gt_80))
           # 1d up move, 4h low
-          short_entry_logic.append((rsi_3_1d < 85.0) | (stochrsi_k_4h > 40.0))
+          short_entry_logic.append((rsi_3_1d < 85.0) | (stochrsi_k_4h_gt_40))
           # 4h still not high enough, 4h overbought, 4h uptrend
           short_entry_logic.append((rsi_14_4h > 80.0) | (roc_9_4h_lt_40) | (cci_20_change_pct_4h < 0.0))
           # 15m & 1h high, 4h uptrend
@@ -25000,13 +25012,13 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1h high, 15m uptrend
           short_entry_logic.append((aroonu_14_1h_lt_100) | (roc_9_15m < 20.0))
           # 15m & 4h still not high enough
-          short_entry_logic.append((stochrsi_k_15m > 70.0) | (stochrsi_k_4h_gt_70))
+          short_entry_logic.append((stochrsi_k_15m_gt_70) | (stochrsi_k_4h_gt_70))
           # 1h & 4h overbought, 1h uptrend
           short_entry_logic.append((roc_9_1h_lt_10) | (roc_9_4h_lt_40) | (cci_20_change_pct_1h < 0.0))
           # 1h & 4h overbought, 4h uptrend
           short_entry_logic.append((roc_9_1h_lt_10) | (roc_9_4h_lt_40) | (cci_20_change_pct_4h < 0.0))
           # 1d bot wick, 4h still not high enough
-          short_entry_logic.append((df["bot_wick_pct_1d"] < 30.0) | (stochrsi_k_4h > 80.0))
+          short_entry_logic.append((df["bot_wick_pct_1d"] < 30.0) | (stochrsi_k_4h_gt_80))
           # rise in the last 12 hours, relatively stable before the 12 hours
           short_entry_logic.append(
             (close < (df["low_min_12_1h"] * 1.30)) | (df["low_min_12_1h"] > (df["low_min_24_1h"] * 1.10))
@@ -25018,7 +25030,7 @@ class NostalgiaForInfinityX7(IStrategy):
           short_entry_logic.append(willr_14 > -50.0)
           short_entry_logic.append(aroonu_14 > 75.0)
           short_entry_logic.append(aroond_14 < 25.0)
-          short_entry_logic.append(stochrsi_k > 80.0)
+          short_entry_logic.append(stochrsi_k_gt_80)
           short_entry_logic.append(willr_84_1h > -30.0)
           short_entry_logic.append(stochrsi_k_1h_gt_80)
           short_entry_logic.append(bbb_20_2_0_1h > 20.0)
@@ -25041,7 +25053,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 5m down move, 1h down, 4h high
           short_entry_logic.append((rsi_3_15m_lt_95) | (cmf_20_1h < 0.2) | (stochrsi_k_4h_gt_50))
           # 15m down move, 1h still not low enough, 4h high
-          short_entry_logic.append((rsi_3_15m_lt_95) | (aroond_14_1h < 25.0) | (stochrsi_k_4h > 10.0))
+          short_entry_logic.append((rsi_3_15m_lt_95) | (aroond_14_1h < 25.0) | (stochrsi_k_4h_gt_10))
           # 15m down move, 1h still high
           short_entry_logic.append((rsi_3_15m_lt_90) | (df["OBV_change_pct_15m"] < 50.0) | (stochrsi_k_1h_gt_30))
           # 5m & 1h strong down move, 1h still not low enough
@@ -25067,7 +25079,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m down move, 1h downtrend, 4h overbought
           short_entry_logic.append((rsi_3_15m_lt_85) | (roc_9_1h < 5.0) | (roc_9_4h > -35.0))
           # 1h & 4h down move, 4h still not low enough
-          short_entry_logic.append((rsi_3_1h_lt_95) | (rsi_3_4h_lt_90) | (stochrsi_k_4h > 75.0))
+          short_entry_logic.append((rsi_3_1h_lt_95) | (rsi_3_4h_lt_90) | (stochrsi_k_4h_gt_75))
           # 1h & 4h down move, 4h still high
           short_entry_logic.append((rsi_3_1h_lt_95) | (rsi_3_change_pct_4h < 50.0) | (stochrsi_k_4h_gt_50))
           # 1h & 4h down move, 4h still not low enough
@@ -25077,7 +25089,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1h down move, 1h not low enough, 1h still high
           short_entry_logic.append((rsi_3_1h_lt_85) | (aroond_14_1h < 50.0) | (stochrsi_k_4h_gt_50))
           # 4h down move, 15m still not low enough, 1h still high
-          short_entry_logic.append((rsi_3_4h_lt_80) | (stochrsi_k_15m > 70.0) | (stochrsi_k_1h_gt_30))
+          short_entry_logic.append((rsi_3_4h_lt_80) | (stochrsi_k_15m_gt_70) | (stochrsi_k_1h_gt_30))
           # 4h down move, 4h still high, 1d downtrend
           short_entry_logic.append((rsi_3_4h < 75.0) | (stochrsi_k_4h_gt_50) | roc_9_1d_lt_50)
           # 4h & 1d down move, 1d strong downtrend
@@ -25118,7 +25130,7 @@ class NostalgiaForInfinityX7(IStrategy):
         #   short_entry_logic.append(close_max_48 >= (df["close"] * 1.10))
 
         #   # Logic
-        #   short_entry_logic.append(stochrsi_k > 80.0)
+        #   short_entry_logic.append(stochrsi_k_gt_80)
         #   short_entry_logic.append(willr_14 > -20.0)
         #   short_entry_logic.append(aroond_14 < 25.0)
 
@@ -25138,7 +25150,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 5m down move, 1h still not low enough, 4h high
           short_entry_logic.append((rsi_3_lt_90) | (stochrsi_k_1h_gt_90) | (stochrsi_k_4h_gt_30))
           # 5m down move, 1h high, 4h still not low enough
-          short_entry_logic.append((rsi_3_lt_90) | (stochrsi_k_1h_gt_20) | (stochrsi_k_4h > 90.0))
+          short_entry_logic.append((rsi_3_lt_90) | (stochrsi_k_1h_gt_20) | (stochrsi_k_4h_gt_90))
           # 15m down move, 15m still not low enough, 1h still high
           short_entry_logic.append((rsi_3_15m_lt_95) | (aroond_14_15m < 25.0) | (stochrsi_k_1h_gt_50))
           # 15m & 1h down move, 1d still not low enough
@@ -25146,11 +25158,11 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m & 1h down move, 1h still not low enough
           short_entry_logic.append((rsi_3_15m_lt_85) | (rsi_3_1h_lt_85) | (stochrsi_k_1h_gt_70))
           # 15m down move, 1h high, 4h still high
-          short_entry_logic.append((rsi_3_15m_lt_85) | (stochrsi_k_1h_gt_30) | (stochrsi_k_4h > 75.0))
+          short_entry_logic.append((rsi_3_15m_lt_85) | (stochrsi_k_1h_gt_30) | (stochrsi_k_4h_gt_75))
           # 15m & 1h down move, 4h still high
           short_entry_logic.append((rsi_3_15m < 80.0) | (rsi_3_1h < 70.0) | (stochrsi_k_4h_gt_50))
           # 15m down move, 1h still not low enough, 4h still high
-          short_entry_logic.append((rsi_3_15m < 75.0) | (stochrsi_k_1h_gt_80) | (stochrsi_k_4h > 60.0))
+          short_entry_logic.append((rsi_3_15m < 75.0) | (stochrsi_k_1h_gt_80) | (stochrsi_k_4h_gt_60))
           # 1h & 4h & 1d down move
           short_entry_logic.append((rsi_3_1h_lt_95) | (rsi_3_4h_lt_90) | (rsi_3_1d < 80.0))
           # 1h & 4h down move, 15m not low enough
@@ -25164,13 +25176,13 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1h & 4h down move, 1h still not low enough
           short_entry_logic.append((rsi_3_1h_lt_80) | (rsi_3_4h_lt_85) | (stochrsi_k_1h_gt_75))
           # 1h & 4h down move, 4h still not low enough
-          short_entry_logic.append((rsi_3_1h_lt_80) | (rsi_3_4h_lt_85) | (stochrsi_k_4h > 75.0))
+          short_entry_logic.append((rsi_3_1h_lt_80) | (rsi_3_4h_lt_85) | (stochrsi_k_4h_gt_75))
           # 1h down move, 1h & 4h still not low enough
           short_entry_logic.append((rsi_3_1h_lt_80) | (stochrsi_k_1h_gt_90) | (stochrsi_k_4h_gt_70))
           # 4h down move, 15m still high, 1h still not low enough
           short_entry_logic.append((rsi_3_4h_lt_85) | (stochrsi_k_15m_gt_50) | (stochrsi_k_1h_gt_75))
           # 4h down move, 15m & 4h still not low enough
-          short_entry_logic.append((rsi_3_4h < 15.0) | (stochrsi_k_15m > 30.0) | (stochrsi_k_4h > 80.0))
+          short_entry_logic.append((rsi_3_4h < 15.0) | (stochrsi_k_15m_gt_30) | (stochrsi_k_4h_gt_80))
 
           # Logic
           short_entry_logic.append(rsi_20 > rsi_20.shift(1))
@@ -25188,7 +25200,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 5m & 1h & 4h down move
           short_entry_logic.append((rsi_3_lt_90) | (rsi_3_1h_lt_95) | (rsi_3_4h_lt_90))
           # 5m down move, 15m & 4h still high
-          short_entry_logic.append((rsi_3_lt_90) | (stochrsi_k_15m > 60.0) | (stochrsi_k_4h > 60.0))
+          short_entry_logic.append((rsi_3_lt_90) | (stochrsi_k_15m_gt_60) | (stochrsi_k_4h_gt_60))
           # 5m down move, 15m still high, 1h high
           short_entry_logic.append((rsi_3 < 85.0) | (aroond_14_15m < 50.0) | (stochrsi_k_1h_gt_20))
           # 15m & 1h down move, 1h still not low enough
@@ -25196,19 +25208,19 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m & 1h down move, 1d still not low enough
           short_entry_logic.append((rsi_3_15m_lt_95) | (rsi_3_1h_lt_95) | (stochrsi_k_1d_gt_70))
           # 15m strong down move, 4h high
-          short_entry_logic.append((rsi_3_15m_lt_95) | (stochrsi_k_4h > 20.0))
+          short_entry_logic.append((rsi_3_15m_lt_95) | (stochrsi_k_4h_gt_20))
           # 15m & 1h down move, 1h still not low enough
           short_entry_logic.append((rsi_3_15m_lt_95) | (rsi_3_1h_lt_80) | (stochrsi_k_1h_gt_80))
           # 15m down move, 15m stil high, 1h still not low enough
           short_entry_logic.append((rsi_3_15m_lt_90) | (stochrsi_k_15m_gt_50) | (stochrsi_k_1h_gt_80))
           # 15m down move, 1h & 4h still high
-          short_entry_logic.append((rsi_3_15m_lt_90) | (stochrsi_k_1h_gt_60) | (stochrsi_k_4h > 60.0))
+          short_entry_logic.append((rsi_3_15m_lt_90) | (stochrsi_k_1h_gt_60) | (stochrsi_k_4h_gt_60))
           # 15m & 1h down move, 4h still not low enough
           short_entry_logic.append((rsi_3_15m_lt_95) | (rsi_3_1h < 70.0) | (stochrsi_k_4h_gt_50))
           # 15m down move, 15m still not low enough, 4h high
-          short_entry_logic.append((rsi_3_15m_lt_85) | (stochrsi_k_15m > 80.0) | (stochrsi_k_4h > 20.0))
+          short_entry_logic.append((rsi_3_15m_lt_85) | (stochrsi_k_15m_gt_80) | (stochrsi_k_4h_gt_20))
           # 15m down move, 4h still high, 1d high
-          short_entry_logic.append((rsi_3_15m_lt_85) | (stochrsi_k_4h > 60.0) | (stochrsi_k_1d_gt_30))
+          short_entry_logic.append((rsi_3_15m_lt_85) | (stochrsi_k_4h_gt_60) | (stochrsi_k_1d_gt_30))
           # 15m & 4h down move, 1d still high
           short_entry_logic.append((rsi_3_15m_lt_85) | (rsi_3_4h < 75.0) | (stochrsi_k_1d_gt_50))
           # 15m & 1h down move, 4h still not low enough
@@ -25216,31 +25228,31 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m & 1h down move, 4h still not low enough
           short_entry_logic.append((rsi_3_15m < 75.0) | (rsi_3_1h < 75.0) | (stochrsi_k_4h_gt_70))
           # 15m & 4h down move, 4h still not low enough
-          short_entry_logic.append((rsi_3_15m < 75.0) | (rsi_3_4h < 75.0) | (stochrsi_k_4h > 80.0))
+          short_entry_logic.append((rsi_3_15m < 75.0) | (rsi_3_4h < 75.0) | (stochrsi_k_4h_gt_80))
           # 15m down move, 1h still high, 4h still high
-          short_entry_logic.append((rsi_3_15m < 75.0) | (stochrsi_k_1h_gt_80) | (stochrsi_k_4h > 60.0))
+          short_entry_logic.append((rsi_3_15m < 75.0) | (stochrsi_k_1h_gt_80) | (stochrsi_k_4h_gt_60))
           # 15m down move, 1h still not low enough, 4h high
           short_entry_logic.append((rsi_3_15m < 75.0) | (stochrsi_k_1h_gt_90) | (stochrsi_k_4h_gt_30))
           # 15m down move, 1h high, 4h still not low enough
-          short_entry_logic.append((rsi_3_15m < 75.0) | (stochrsi_k_1h_gt_20) | (stochrsi_k_4h > 90.0))
+          short_entry_logic.append((rsi_3_15m < 75.0) | (stochrsi_k_1h_gt_20) | (stochrsi_k_4h_gt_90))
           # 15m down move, 4h high, 1d stil high
-          short_entry_logic.append((rsi_3_15m < 75.0) | (stochrsi_k_4h > 20.0) | (stochrsi_k_1d_gt_50))
+          short_entry_logic.append((rsi_3_15m < 75.0) | (stochrsi_k_4h_gt_20) | (stochrsi_k_1d_gt_50))
           # 15m & 4h down move, 1h still not low enough
           short_entry_logic.append((rsi_3_15m < 70.0) | (rsi_3_4h_lt_85) | (stochrsi_k_1h_gt_70))
           # 15m & 4h down move, 1h still high
           short_entry_logic.append((rsi_3_15m < 70.0) | (rsi_3_4h_lt_80) | (stochrsi_k_1h_gt_50))
           # 15m down move, 15m still high 4h still high
-          short_entry_logic.append((rsi_3_15m < 70.0) | (stochrsi_k_15m > 70.0) | (stochrsi_k_4h_gt_50))
+          short_entry_logic.append((rsi_3_15m < 70.0) | (stochrsi_k_15m_gt_70) | (stochrsi_k_4h_gt_50))
           # 15m down move, 1h still high, 4h high
-          short_entry_logic.append((rsi_3_15m < 70.0) | (stochrsi_k_1h_gt_50) | (stochrsi_k_4h > 10.0))
+          short_entry_logic.append((rsi_3_15m < 70.0) | (stochrsi_k_1h_gt_50) | (stochrsi_k_4h_gt_10))
           # 1h & 4h down move, 1h still not low enough
           short_entry_logic.append((rsi_3_1h_lt_95) | (rsi_3_4h_lt_95) | (stochrsi_k_1h_gt_90))
           # 1h & 4h down move, 4h still not low enough
-          short_entry_logic.append((rsi_3_1h_lt_95) | (rsi_3_4h_lt_85) | (stochrsi_k_4h > 80.0))
+          short_entry_logic.append((rsi_3_1h_lt_95) | (rsi_3_4h_lt_85) | (stochrsi_k_4h_gt_80))
           # 1h & 4h down move, 1h still not low enough
           short_entry_logic.append((rsi_3_1h_lt_90) | (rsi_3_4h_lt_90) | (stochrsi_k_1h_gt_90))
           # 1h & 4h down move, 4h still not low enough
-          short_entry_logic.append((rsi_3_1h_lt_90) | (rsi_3_4h_lt_90) | (stochrsi_k_4h > 80.0))
+          short_entry_logic.append((rsi_3_1h_lt_90) | (rsi_3_4h_lt_90) | (stochrsi_k_4h_gt_80))
           # 1h & 4h down move, 1h still not low enough
           short_entry_logic.append((rsi_3_1h_lt_90) | (rsi_3_4h_lt_85) | (stochrsi_k_1h > 85.0))
           # 1h & 4h down move, 1d still high
@@ -25248,7 +25260,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1h & 4h down move, 4h still not low enough
           short_entry_logic.append((rsi_3_1h_lt_85) | (rsi_3_4h < 75.0) | (stochrsi_k_4h > 85.0))
           # 1h down move, 4h still high, 1d high
-          short_entry_logic.append((rsi_3_1h_lt_80) | (stochrsi_k_4h > 60.0) | (stochrsi_k_1d_gt_30))
+          short_entry_logic.append((rsi_3_1h_lt_80) | (stochrsi_k_4h_gt_60) | (stochrsi_k_1d_gt_30))
           # 1h & 4h down move, 1h still not low enough
           short_entry_logic.append((rsi_3_1h_lt_80) | (rsi_3_4h_lt_85) | (stochrsi_k_1h_gt_75))
           # 1h & 4h down move, 15m still high
@@ -25260,29 +25272,29 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1h down move, 1h still not low enough, 4h still high
           short_entry_logic.append((rsi_3_1h < 70.0) | (stochrsi_k_1h_gt_80) | (stochrsi_k_4h_gt_50))
           # 4h down move, 15m still high, 1h still not low enough
-          short_entry_logic.append((rsi_3_4h_lt_85) | (stochrsi_k_15m > 60.0) | (stochrsi_k_1h_gt_80))
+          short_entry_logic.append((rsi_3_4h_lt_85) | (stochrsi_k_15m_gt_60) | (stochrsi_k_1h_gt_80))
           # 4h down move, 15m still high, 4h still not low enough
-          short_entry_logic.append((rsi_3_4h < 75.0) | (stochrsi_k_15m_gt_50) | (stochrsi_k_4h > 75.0))
+          short_entry_logic.append((rsi_3_4h < 75.0) | (stochrsi_k_15m_gt_50) | (stochrsi_k_4h_gt_75))
           # 4h down move, 1h still not low enough, 1d still high
           short_entry_logic.append((rsi_3_4h < 25.0) | (stochrsi_k_1h_gt_70) | (stochrsi_k_1d_gt_50))
           # 15m & 1h still high, 4h high
-          short_entry_logic.append((stochrsi_k_15m > 70.0) | (stochrsi_k_1h_gt_70) | (stochrsi_k_4h > 10.0))
+          short_entry_logic.append((stochrsi_k_15m_gt_70) | (stochrsi_k_1h_gt_70) | (stochrsi_k_4h_gt_10))
           # 15m still high, 1h & 1d high
-          short_entry_logic.append((stochrsi_k_15m > 60.0) | (stochrsi_k_1h_gt_30) | (stochrsi_k_1d_gt_30))
+          short_entry_logic.append((stochrsi_k_15m_gt_60) | (stochrsi_k_1h_gt_30) | (stochrsi_k_1d_gt_30))
           # 15m & 4h high
-          short_entry_logic.append((stochrsi_k_15m_gt_50) | (stochrsi_k_4h > 20.0))
+          short_entry_logic.append((stochrsi_k_15m_gt_50) | (stochrsi_k_4h_gt_20))
           # 15m high, 1h & 4h still not low enough
-          short_entry_logic.append((stochrsi_k_15m > 30.0) | (stochrsi_k_1h_gt_75) | (stochrsi_k_4h > 75.0))
+          short_entry_logic.append((stochrsi_k_15m_gt_30) | (stochrsi_k_1h_gt_75) | (stochrsi_k_4h_gt_75))
           # 15m & 4h high
-          short_entry_logic.append((stochrsi_k_15m > 30.0) | (stochrsi_k_4h_gt_30))
+          short_entry_logic.append((stochrsi_k_15m_gt_30) | (stochrsi_k_4h_gt_30))
           # 1h & 4h still high, 1d high
           short_entry_logic.append((stochrsi_k_1h_gt_70) | (stochrsi_k_4h_gt_70) | (stochrsi_k_1d_gt_50))
           # 1h & 4h high
-          short_entry_logic.append((stochrsi_k_1h_gt_30) | (stochrsi_k_4h > 10.0))
+          short_entry_logic.append((stochrsi_k_1h_gt_30) | (stochrsi_k_4h_gt_10))
           # 1h & 4h high
-          short_entry_logic.append((stochrsi_k_1h_gt_20) | (stochrsi_k_4h > 20.0))
+          short_entry_logic.append((stochrsi_k_1h_gt_20) | (stochrsi_k_4h_gt_20))
           # 4h & 1d high
-          short_entry_logic.append((stochrsi_k_4h > 20.0) | (stochrsi_k_1d_gt_20))
+          short_entry_logic.append((stochrsi_k_4h_gt_20) | (stochrsi_k_1d_gt_20))
           # 1d red, 1d high
           short_entry_logic.append((change_pct_1d < 5.0) | (stochrsi_k_1d_gt_20))
           # 1d P&D, 1d high
@@ -25313,7 +25325,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m & 4h down move, 15m high
           short_entry_logic.append((rsi_3_15m < 60.0) | (rsi_3_4h < 60.0) | (stochrsi_k_15m_gt_50))
           # 15m & 4h down move, 15m high
-          short_entry_logic.append((rsi_3_15m < 60.0) | (rsi_3_4h < 40.0) | (stochrsi_k_15m > 30.0))
+          short_entry_logic.append((rsi_3_15m < 60.0) | (rsi_3_4h < 40.0) | (stochrsi_k_15m_gt_30))
           # 15m down move, 15m & 1h still high
           short_entry_logic.append((rsi_3_15m < 60.0) | (aroond_14_15m < 50.0) | (stochrsi_k_1h_gt_50))
           # 15m down move, 15m & 1h still high
@@ -25325,12 +25337,12 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m down move, 15m & 1h still high
           short_entry_logic.append((rsi_3_15m < 55.0) | (stochrsi_k_15m > 55.0) | (stochrsi_k_1h_gt_60))
           # 15m down move, 15m still not low enough, 4h high
-          short_entry_logic.append((rsi_3_15m < 50.0) | (stochrsi_k_15m > 70.0) | (stochrsi_k_4h > 10.0))
+          short_entry_logic.append((rsi_3_15m < 50.0) | (stochrsi_k_15m_gt_70) | (stochrsi_k_4h_gt_10))
           # 1h down move, 4h still high, 1d high
           short_entry_logic.append((rsi_3_1h < 75.0) | (aroond_14_4h < 50.0) | (stochrsi_k_1d > 10.0))
           short_entry_logic.append((rsi_3_1h < 70.0) | (stochrsi_k_1h_gt_60) | (stochrsi_k_1d > 10.0))
           # 1h & 4h down move, 4h high
-          short_entry_logic.append((rsi_3_1h < 65.0) | (rsi_3_4h < 40.0) | (stochrsi_k_4h > 20.0))
+          short_entry_logic.append((rsi_3_1h < 65.0) | (rsi_3_4h < 40.0) | (stochrsi_k_4h_gt_20))
           # 1h down move, 15m & 1h still high
           short_entry_logic.append((rsi_3_1h < 60.0) | (stochrsi_k_15m_gt_50) | (stochrsi_k_1h_gt_50))
           # 1h down move, 1h still high, 4h high
@@ -25350,9 +25362,9 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1h down move, 15m high, 1h still high
           short_entry_logic.append((rsi_3_1h < 50.0) | (aroond_14_15m < 70.0) | (stochrsi_k_1h_gt_60))
           # 1h down move, 15m still high, 4h high
-          short_entry_logic.append((rsi_3_1h < 50.0) | (stochrsi_k_15m_gt_50) | (stochrsi_k_4h > 20.0))
+          short_entry_logic.append((rsi_3_1h < 50.0) | (stochrsi_k_15m_gt_50) | (stochrsi_k_4h_gt_20))
           # 1h down move, 15m & 1h high
-          short_entry_logic.append((rsi_3_1h < 50.0) | (stochrsi_k_15m > 40.0) | (aroond_14_1h < 60.0))
+          short_entry_logic.append((rsi_3_1h < 50.0) | (stochrsi_k_15m_gt_40) | (aroond_14_1h < 60.0))
           # 1h down move, 1h & 1d high
           short_entry_logic.append((rsi_3_1h < 50.0) | (aroond_14_1h < 70.0) | (stochrsi_k_1d_gt_20))
           # 1h down move, 4h still high, 1d high
@@ -25360,15 +25372,15 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1h down move, 5m up move, 1h still high
           short_entry_logic.append((rsi_3_1h < 40.0) | (rsi_3 > 40.0) | (stochrsi_k_1h_gt_50))
           # 1h down move, 15m still not low enough, 1h high
-          short_entry_logic.append((rsi_3_1h < 40.0) | (stochrsi_k_15m > 70.0) | (aroond_14_1h < 70.0))
+          short_entry_logic.append((rsi_3_1h < 40.0) | (stochrsi_k_15m_gt_70) | (aroond_14_1h < 70.0))
           # 1h down move, 15m still not low enough, 1h high
-          short_entry_logic.append((rsi_3_1h < 40.0) | (stochrsi_k_15m > 70.0) | (stochrsi_k_1h_gt_40))
+          short_entry_logic.append((rsi_3_1h < 40.0) | (stochrsi_k_15m_gt_70) | (stochrsi_k_1h_gt_40))
           # 1h down move, 15m & 4h still high
           short_entry_logic.append((rsi_3_1h < 40.0) | (stochrsi_k_15m_gt_50) | (stochrsi_k_4h_gt_50))
           # 1h down move, 15m & 1h high
           short_entry_logic.append((rsi_3_1h < 40.0) | (aroond_14_15m < 70.0) | (aroond_14_1h < 90.0))
           # 1h down move, 1h still high, 4h high
-          short_entry_logic.append((rsi_3_1h < 40.0) | (aroond_14_1h < 50.0) | (stochrsi_k_4h > 10.0))
+          short_entry_logic.append((rsi_3_1h < 40.0) | (aroond_14_1h < 50.0) | (stochrsi_k_4h_gt_10))
           # 1h down move, 1h high, 4h still high
           short_entry_logic.append((rsi_3_1h < 40.0) | (aroond_14_1h < 80.0) | (aroond_14_4h < 40.0))
           # 1h down move, 1h still high, 4h high
@@ -25386,19 +25398,19 @@ class NostalgiaForInfinityX7(IStrategy):
           # 4h down move, 15m & 1h high
           short_entry_logic.append((rsi_3_4h < 60.0) | (aroond_14_15m < 80.0) | (stochrsi_k_1h_gt_30))
           # 4h down move, 15m still high, 1h high
-          short_entry_logic.append((rsi_3_4h < 60.0) | (stochrsi_k_15m > 60.0) | (stochrsi_k_1h_gt_20))
+          short_entry_logic.append((rsi_3_4h < 60.0) | (stochrsi_k_15m_gt_60) | (stochrsi_k_1h_gt_20))
           # 4h down move, 1h still high, 4h still moving down
           short_entry_logic.append((rsi_3_4h < 60.0) | (stochrsi_k_1h_gt_50) | (cci_20_change_pct_4h < 0.0))
           # 4h down move, 1h high, 4h still high
           short_entry_logic.append((rsi_3_4h < 55.0) | (aroond_14_1h < 70.0) | (aroond_14_4h < 50.0))
           # 4h down move, 15m high, 4h still high
-          short_entry_logic.append((rsi_3_4h < 50.0) | (aroond_14_15m < 70.0) | (stochrsi_k_4h > 60.0))
+          short_entry_logic.append((rsi_3_4h < 50.0) | (aroond_14_15m < 70.0) | (stochrsi_k_4h_gt_60))
           # 4h down move, 15m still high, 1h high
-          short_entry_logic.append((rsi_3_4h < 50.0) | (stochrsi_k_15m > 60.0) | (stochrsi_k_1h_gt_30))
+          short_entry_logic.append((rsi_3_4h < 50.0) | (stochrsi_k_15m_gt_60) | (stochrsi_k_1h_gt_30))
           # 4h down move, 15m & 4h still high
           short_entry_logic.append((rsi_3_4h < 50.0) | (stochrsi_k_15m_gt_50) | (aroond_14_4h < 50.0))
           # 4h down move, 15m high, 4h still not low enough
-          short_entry_logic.append((rsi_3_4h < 50.0) | (stochrsi_k_15m > 30.0) | (stochrsi_k_4h_gt_70))
+          short_entry_logic.append((rsi_3_4h < 50.0) | (stochrsi_k_15m_gt_30) | (stochrsi_k_4h_gt_70))
           # 4h down move, 1h still high, 4h high
           short_entry_logic.append((rsi_3_4h < 50.0) | (stochrsi_k_1h_gt_50) | (aroond_14_4h < 70.0))
           # 4h down move, 15m & 4h high
@@ -25408,7 +25420,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 4h down move, 15m still high, 4h high
           short_entry_logic.append((rsi_3_4h < 40.0) | (stochrsi_k_15m_gt_50) | (stochrsi_k_4h_gt_30))
           # 4h down move, 15m & 4h high
-          short_entry_logic.append((rsi_3_4h < 40.0) | (stochrsi_k_15m > 30.0) | (stochrsi_k_4h > 40.0))
+          short_entry_logic.append((rsi_3_4h < 40.0) | (stochrsi_k_15m_gt_30) | (stochrsi_k_4h_gt_40))
           # 4h down move, 1h & 4h high
           short_entry_logic.append((rsi_3_4h < 40.0) | (stochrsi_k_1h_gt_30) | (aroond_14_4h < 70.0))
           # 4h down move, 4h still high, 1d high
@@ -25418,9 +25430,9 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m high, 4h still high
           short_entry_logic.append((aroond_14_15m < 80.0) | (stochrsi_k_4h_gt_50))
           # 15m high, 1h still high
-          short_entry_logic.append((stochrsi_k_15m > 30.0) | (stochrsi_k_1h_gt_60))
+          short_entry_logic.append((stochrsi_k_15m_gt_30) | (stochrsi_k_1h_gt_60))
           # 15m & 4h high
-          short_entry_logic.append((stochrsi_k_15m > 30.0) | (aroond_14_4h < 70.0))
+          short_entry_logic.append((stochrsi_k_15m_gt_30) | (aroond_14_4h < 70.0))
           # 15m high, 1h still not low enough
           short_entry_logic.append((stochrsi_k_15m > 20.0) | (stochrsi_k_1h_gt_70))
 


### PR DESCRIPTION
## Summary
- Reuse repeated STOCHRSI high-side comparisons in `populate_entry_trend()` through named entry masks.
- Independent on latest upstream `main`.

## Safety
- Behavior-preserving Series mask reuse only.
- Touched function: `populate_entry_trend()`.
- Indicator formulas, candle selection, thresholds, condition order, profit arithmetic, order classification, return values, and signal behavior are unchanged.
- No v3 grind-entry code is touched.

## Backtest scope
- Full backtesting was not required because this patch only aliases Series comparisons that are already used by the same condition ladder.
- Indicator formulas, candle selection, thresholds, and condition order are unchanged.

## Checks
- `python3 /home/user/.codex/skills/nfi-upstream-pr/scripts/validate_nfi_pr.py --base origin/main`
- `git merge-tree $(git merge-base origin/main HEAD) origin/main HEAD | grep -E '<<<<<<<|>>>>>>>|changed in both|removed in|added in both' && echo CONFLICT || echo NO_CONFLICT`\n- `git diff --check`\n- `ruff format --check NostalgiaForInfinityX7.py`\n- `ruff check NostalgiaForInfinityX7.py`\n- `PYTHONDONTWRITEBYTECODE=1 python3 -m py_compile NostalgiaForInfinityX7.py`