### PR TITLE
Reuse X7 entry AROON threshold masks

### DIFF
--- a/NostalgiaForInfinityX7.py
+++ b/NostalgiaForInfinityX7.py
@@ -13039,6 +13039,29 @@ class NostalgiaForInfinityX7(IStrategy):
     rsi_3_1d_gt_65 = rsi_3_1d > 65.0
 
     aroonu_14_lt_25 = aroonu_14 < 25.0
+    aroond_14_15m_lt_25 = aroond_14_15m < 25.0
+    aroond_14_15m_lt_50 = aroond_14_15m < 50.0
+    aroond_14_15m_lt_70 = aroond_14_15m < 70.0
+    aroond_14_15m_lt_80 = aroond_14_15m < 80.0
+    aroond_14_1h_lt_25 = aroond_14_1h < 25.0
+    aroond_14_1h_lt_50 = aroond_14_1h < 50.0
+    aroond_14_1h_lt_70 = aroond_14_1h < 70.0
+    aroond_14_4h_lt_25 = aroond_14_4h < 25.0
+    aroond_14_4h_lt_40 = aroond_14_4h < 40.0
+    aroond_14_4h_lt_50 = aroond_14_4h < 50.0
+    aroond_14_4h_lt_70 = aroond_14_4h < 70.0
+    aroond_14_4h_lt_80 = aroond_14_4h < 80.0
+    aroond_14_4h_lt_85 = aroond_14_4h < 85.0
+    aroonu_14_1h_gt_20 = aroonu_14_1h > 20.0
+    aroonu_14_1h_gt_30 = aroonu_14_1h > 30.0
+    aroonu_14_1h_gt_40 = aroonu_14_1h > 40.0
+    aroonu_14_1h_gt_60 = aroonu_14_1h > 60.0
+    aroonu_14_4h_gt_10 = aroonu_14_4h > 10.0
+    aroonu_14_4h_gt_20 = aroonu_14_4h > 20.0
+    aroonu_14_4h_gt_30 = aroonu_14_4h > 30.0
+    aroonu_14_4h_gt_50 = aroonu_14_4h > 50.0
+    aroonu_14_4h_gt_70 = aroonu_14_4h > 70.0
+    aroonu_14_4h_gt_80 = aroonu_14_4h > 80.0
     aroonu_14_lt_30 = aroonu_14 < 30.0
     aroonu_14_15m_lt_20 = aroonu_14_15m < 20.0
     aroonu_14_15m_lt_25 = aroonu_14_15m < 25.0
@@ -24179,13 +24202,13 @@ class NostalgiaForInfinityX7(IStrategy):
           # 5m & 1h up move, 1d uptrend
           short_entry_logic.append((rsi_3 < 95.0) | (rsi_3_1h_lt_90) | (roc_9_1d_lt_100))
           # 5m up move, 15m & 1h still not high enough
-          short_entry_logic.append((rsi_3 < 95.0) | (aroond_14_15m < 25.0) | (aroond_14_1h < 25.0))
+          short_entry_logic.append((rsi_3 < 95.0) | (aroond_14_15m_lt_25) | (aroond_14_1h_lt_25))
           # 4m up move, 1h & 4h still low
           short_entry_logic.append((rsi_3 < 95.0) | (stochrsi_k_1h_gt_70) | (stochrsi_k_4h_gt_70))
           # 4m & 1h up move, 1h still low
           short_entry_logic.append((rsi_3_lt_90) | (rsi_3_1h_lt_80) | (stochrsi_k_1h_gt_50))
           # 15m & 1h up move, 4h low
-          short_entry_logic.append((rsi_3_lt_90) | (rsi_3_1h_lt_80) | (aroonu_14_4h > 20.0))
+          short_entry_logic.append((rsi_3_lt_90) | (rsi_3_1h_lt_80) | (aroonu_14_4h_gt_20))
           # 5m up move, 15m & 1h uptrend
           short_entry_logic.append((rsi_3_lt_90) | (cmf_20_15m < 0.30) | (cmf_20_1h < 0.30))
           # 5m up move, 15m stil low
@@ -24193,7 +24216,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 5m up move, 15m & 1h still not high enough
           short_entry_logic.append((rsi_3_lt_90) | (stochrsi_k_15m > 60.0) | (stochrsi_k_1h_gt_75))
           # 15m up move, 1h low
-          short_entry_logic.append((rsi_3_15m < 97.0) | (aroonu_14_1h > 30.0))
+          short_entry_logic.append((rsi_3_15m < 97.0) | (aroonu_14_1h_gt_30))
           # 15m & 1h up move, 4h still going up
           short_entry_logic.append((rsi_3_15m_lt_95) | (rsi_3_1h_lt_95) | (cci_20_change_pct_4h < -0.0))
           # 15m & 1h up move, 4h still not high enough
@@ -24205,17 +24228,17 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m & 4h up move, 1h still not high enough
           short_entry_logic.append((rsi_3_15m_lt_95) | (rsi_3_4h_lt_95) | (stochrsi_k_1h_gt_75))
           # 15m up move, 1d lost, 1h low
-          short_entry_logic.append((rsi_3_15m_lt_95) | (rsi_14_1d > 40.0) | (aroonu_14_1h > 40.0))
+          short_entry_logic.append((rsi_3_15m_lt_95) | (rsi_14_1d > 40.0) | (aroonu_14_1h_gt_40))
           # 15m up move, 15m & 4h uptrend
           short_entry_logic.append((rsi_3_15m_lt_95) | (aroonu_14_15m_lt_90) | (aroonu_14_4h_lt_90))
           # 15m up move, 15m stil not high enough, 1h low
           short_entry_logic.append((rsi_3_15m_lt_95) | (stochrsi_k_15m > 70.0) | (stochrsi_k_1h_gt_10))
           # 15m up move, 1h still not high enough, 4h low
-          short_entry_logic.append((rsi_3_15m_lt_95) | (stochrsi_k_1h_gt_70) | (aroonu_14_4h > 20.0))
+          short_entry_logic.append((rsi_3_15m_lt_95) | (stochrsi_k_1h_gt_70) | (aroonu_14_4h_gt_20))
           # 15m up move, 1h & 4h still not high enough
           short_entry_logic.append((rsi_3_15m_lt_95) | (stochrsi_k_1h_gt_70) | (stochrsi_k_4h > 80.0))
           # 15m up move, 4h still not high enough
-          short_entry_logic.append((rsi_3_15m_lt_95) | (aroonu_14_4h > 70.0))
+          short_entry_logic.append((rsi_3_15m_lt_95) | (aroonu_14_4h_gt_70))
           # 15m up move, 4h & 1d uptrend
           short_entry_logic.append((rsi_3_15m_lt_95) | (roc_9_4h_lt_30) | roc_9_1d_lt_50)
           # 15m up move, 1h up move, 1h still not high enough
@@ -24223,7 +24246,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m & 1h up move, 1h still not high enough
           short_entry_logic.append((rsi_3_15m_lt_90) | (rsi_3_1h_lt_85) | (stochrsi_k_1h_gt_70))
           # 15m & 1h up move, 1h not high enough
-          short_entry_logic.append((rsi_3_15m_lt_90) | (rsi_3_1h_lt_90) | (aroond_14_1h < 50.0))
+          short_entry_logic.append((rsi_3_15m_lt_90) | (rsi_3_1h_lt_90) | (aroond_14_1h_lt_50))
           # 15m & 1h up move, 1d stil not high enough
           short_entry_logic.append((rsi_3_15m_lt_90) | (rsi_3_1h_lt_90) | (rsi_14_1h > 80.0))
           # 15m & 1h up move, 1d uptrend
@@ -24235,17 +24258,17 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m & 4h up move, 1h still not high enough
           short_entry_logic.append((rsi_3_15m_lt_90) | (rsi_3_4h_lt_90) | (stochrsi_k_1h_gt_90))
           # 15m & 4h up move, 4h not high enough
-          short_entry_logic.append((rsi_3_15m_lt_90) | (rsi_3_4h_lt_90) | (aroond_14_4h < 50.0))
+          short_entry_logic.append((rsi_3_15m_lt_90) | (rsi_3_4h_lt_90) | (aroond_14_4h_lt_50))
           # 15m & 4h up move, 1d low
           short_entry_logic.append((rsi_3_15m_lt_90) | (rsi_3_4h_lt_85) | (stochrsi_k_1d_gt_30))
           # 15m & 4h up move, 1h low
           short_entry_logic.append((rsi_3_15m_lt_90) | (rsi_3_4h < 70.0) | (stochrsi_k_1h_gt_20))
           # 15m & 4h up move, 4h low
-          short_entry_logic.append((rsi_3_15m_lt_90) | (rsi_3_4h < 60.0) | (aroonu_14_4h > 30.0))
+          short_entry_logic.append((rsi_3_15m_lt_90) | (rsi_3_4h < 60.0) | (aroonu_14_4h_gt_30))
           # 15m up move, 1h & 4h low
-          short_entry_logic.append((rsi_3_15m_lt_90) | (aroonu_14_1h > 40.0) | (aroonu_14_4h > 10.0))
+          short_entry_logic.append((rsi_3_15m_lt_90) | (aroonu_14_1h_gt_40) | (aroonu_14_4h_gt_10))
           # 15m up move, 1h still low, 4h low
-          short_entry_logic.append((rsi_3_15m_lt_90) | (aroonu_14_1h > 60.0) | (stochrsi_k_4h_gt_30))
+          short_entry_logic.append((rsi_3_15m_lt_90) | (aroonu_14_1h_gt_60) | (stochrsi_k_4h_gt_30))
           # 15m up move, 1h low, 4h still not high enough
           short_entry_logic.append((rsi_3_15m_lt_90) | (stochrsi_k_1h_gt_30) | (stochrsi_k_4h_gt_70))
           # 15m & 4h up move, 1d low
@@ -24267,13 +24290,13 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m up move, 4h overbought
           short_entry_logic.append((rsi_3_15m_lt_85) | (roc_9_4h_lt_50))
           # 15m & 1h up move, 1h still not high enough
-          short_entry_logic.append((rsi_3_15m < 80.0) | (rsi_3_1h < 70.0) | (aroonu_14_1h > 60.0))
+          short_entry_logic.append((rsi_3_15m < 80.0) | (rsi_3_1h < 70.0) | (aroonu_14_1h_gt_60))
           # 15m & 4h up move, 15m still low
           short_entry_logic.append((rsi_3_15m < 80.0) | (rsi_3_4h_lt_80) | (aroonu_14_15m > 50.0))
           # 15m up move, 1h low
           short_entry_logic.append((rsi_3_15m < 80.0) | (stochrsi_k_1h_gt_20))
           # 15m & 1h up move, 1h low
-          short_entry_logic.append((rsi_3_15m < 70.0) | (rsi_3_1h < 70.0) | (aroonu_14_1h > 30.0))
+          short_entry_logic.append((rsi_3_15m < 70.0) | (rsi_3_1h < 70.0) | (aroonu_14_1h_gt_30))
           # 15m up move, 15m still not high enough, 1h still low
           short_entry_logic.append((rsi_3_15m < 70.0) | (stochrsi_k_15m > 90.0) | (stochrsi_k_1h_gt_50))
           # 1h & 4h up move, 1h still not high enough
@@ -24303,7 +24326,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1h & 4h up move, 1d still not high enough
           short_entry_logic.append((rsi_3_1h_lt_90) | (rsi_3_4h_lt_90) | (stochrsi_k_1d_gt_70))
           # 1h up move, 4h low, 1d overbought
-          short_entry_logic.append((rsi_3_1h_lt_90) | (aroonu_14_4h > 20.0) | roc_9_1d_lt_50)
+          short_entry_logic.append((rsi_3_1h_lt_90) | (aroonu_14_4h_gt_20) | roc_9_1d_lt_50)
           # 1h up move, 1h still low, 1d uptrend
           short_entry_logic.append((rsi_3_1h_lt_90) | (stochrsi_k_1h_gt_60) | roc_9_1d_lt_50)
           # 1h up move, 1h still not high enough, 1d low
@@ -24317,7 +24340,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1h up move, 15m & 4h still low
           short_entry_logic.append((rsi_3_1h_lt_85) | (stochrsi_k_15m_gt_50) | (stochrsi_k_4h_gt_50))
           # 1h & 4h up move, 15m still not high enough
-          short_entry_logic.append((rsi_3_1h_lt_85) | (rsi_3_4h_lt_85) | (aroond_14_15m < 50.0))
+          short_entry_logic.append((rsi_3_1h_lt_85) | (rsi_3_4h_lt_85) | (aroond_14_15m_lt_50))
           # 1h & 4h up move, 15m still not high enough
           short_entry_logic.append((rsi_3_1h_lt_85) | (rsi_3_4h_lt_85) | (stochrsi_k_15m > 90.0))
           # 1h up move, 15m still not high enough, 1h still low
@@ -24327,7 +24350,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 4h & 1d strong up move
           short_entry_logic.append((rsi_3_4h_lt_95) | (rsi_3_1d < 95.0))
           # 4h up move, 15m still low, 1h not high enough
-          short_entry_logic.append((rsi_3_4h_lt_95) | (stochrsi_k_15m_gt_50) | (aroond_14_1h < 25.0))
+          short_entry_logic.append((rsi_3_4h_lt_95) | (stochrsi_k_15m_gt_50) | (aroond_14_1h_lt_25))
           # 4h up move, 15m still not high enough, 4h overbought
           short_entry_logic.append((rsi_3_4h_lt_95) | (stochrsi_k_15m > 70.0) | (roc_9_4h_lt_60))
           # 4h up move, 15m uptrend
@@ -24337,7 +24360,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 4h up move, 1h & 4h overbought
           short_entry_logic.append((rsi_3_4h_lt_95) | (roc_9_1h_lt_30) | (roc_9_4h_lt_60))
           # 4h up move, 1h still low
-          short_entry_logic.append((rsi_3_4h_lt_90) | (aroonu_14_1h > 40.0))
+          short_entry_logic.append((rsi_3_4h_lt_90) | (aroonu_14_1h_gt_40))
           # 4h up move, 1d still low, 4h uptrend
           short_entry_logic.append((rsi_3_4h_lt_85) | (rsi_14_1d > 40.0) | (roc_9_4h_lt_20))
           # 4h up move, 4h still low
@@ -24381,11 +24404,11 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1h & 4h & 1d uptrend
           short_entry_logic.append((roc_9_1h_lt_10) | (roc_9_4h_lt_10) | (roc_9_1d_lt_20))
           # 5m green, 15m still not high enough
-          short_entry_logic.append((df["change_pct"] < 5.0) | (aroond_14_15m < 50.0))
+          short_entry_logic.append((df["change_pct"] < 5.0) | (aroond_14_15m_lt_50))
           # 5m green, 15m still not high enough
           short_entry_logic.append((df["change_pct"] < 5.0) | (stochrsi_k_15m > 90.0))
           # pump in the last half hour, 1h low
-          short_entry_logic.append((close < (df["close_min_6"] * 1.20)) | (aroonu_14_1h > 30.0))
+          short_entry_logic.append((close < (df["close_min_6"] * 1.20)) | (aroonu_14_1h_gt_30))
           # pump in the last half hour, 15m still low
           short_entry_logic.append((close < (df["close_min_6"] * 1.20)) | (stochrsi_k_15m > 40.0))
           # pump in the last half hour, 1d uptrend
@@ -24415,7 +24438,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 5m & 15m strong up move
             & ((rsi_3 < 95.0) | (rsi_3_15m_lt_95))
             # 5m & 15m up move, 4h low
-            & ((rsi_3 < 95.0) | (rsi_3_15m_lt_90) | (aroonu_14_4h > 30.0))
+            & ((rsi_3 < 95.0) | (rsi_3_15m_lt_90) | (aroonu_14_4h_gt_30))
             # 5m & 1h & 4h up move
             & ((rsi_3 < 95.0) | (rsi_3_1h_lt_90) | (rsi_3_4h_lt_90))
             # 5m & 1h up move, 15m still not high enough
@@ -24423,7 +24446,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 5m up move, 15m still low
             & ((rsi_3 < 95.0) | (stochrsi_k_15m_gt_50))
             # 5m up move, 4h low
-            & ((rsi_3_lt_90) | (aroonu_14_4h > 20.0))
+            & ((rsi_3_lt_90) | (aroonu_14_4h_gt_20))
             # 15m & 1h down move, 4h still not high enough
             & ((rsi_3_15m < 97.0) | (rsi_3_1h_lt_85) | (stochrsi_k_4h > 80.0))
             # 15m up move, 1h still low
@@ -24435,7 +24458,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m up move, 1h still low
             & ((rsi_3_15m_lt_95) | (stochrsi_k_1h_gt_40))
             # 15m up move, 4h still not high enough
-            & ((rsi_3_15m_lt_95) | (aroonu_14_4h > 70.0))
+            & ((rsi_3_15m_lt_95) | (aroonu_14_4h_gt_70))
             # 15m & 1h & 4h up move
             & ((rsi_3_15m_lt_90) | (rsi_3_1h_lt_90) | (rsi_3_4h_lt_90))
             # 15m & 1h up move, 15m still not high enough
@@ -24445,7 +24468,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h up move, 1h still not high enough
             & ((rsi_3_15m_lt_90) | (rsi_3_1h_lt_85) | (stochrsi_k_1h_gt_80))
             # 15m & 1h up move, 4h stil low
-            & ((rsi_3_15m_lt_90) | (rsi_3_1h_lt_80) | (aroonu_14_4h > 50.0))
+            & ((rsi_3_15m_lt_90) | (rsi_3_1h_lt_80) | (aroonu_14_4h_gt_50))
             # 15m & 4h up move, 1d low
             & ((rsi_3_15m_lt_90) | (rsi_3_4h_lt_85) | (rsi_14_1d > 40.0))
             # 15m & 4h up move, 1d low
@@ -24469,7 +24492,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m up move, 1h low
             & ((rsi_3_15m < 80.0) | (aroonu_14_1h > 10.0))
             # 15m up move, 1h low, 1d uptrend
-            & ((rsi_3_15m < 80.0) | (aroonu_14_1h > 40.0) | (roc_9_1d_lt_100))
+            & ((rsi_3_15m < 80.0) | (aroonu_14_1h_gt_40) | (roc_9_1d_lt_100))
             # 15m up move, 4h low
             & ((rsi_3_15m < 80.0) | (stochrsi_k_4h > 40.0))
             # 15m up move, 1h uptrend
@@ -24495,7 +24518,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h up move, 4h uptrend
             & ((rsi_3_1h_lt_90) | (roc_9_4h_lt_20))
             # 1h up move, 4h still low
-            & ((rsi_3_1h_lt_85) | (aroonu_14_4h > 50.0))
+            & ((rsi_3_1h_lt_85) | (aroonu_14_4h_gt_50))
             # 1h & 4h up move, 1d low
             & ((rsi_3_1h_lt_80) | (rsi_3_4h_lt_80) | (stochrsi_k_1d_gt_30))
             # 1h up move, 1h still not high enough
@@ -24505,7 +24528,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h up move, 4h low
             & ((rsi_3_1h_lt_80) | (stochrsi_k_4h > 20.0))
             # 1h up move, 4h low
-            & ((rsi_3_1h_lt_80) | (aroonu_14_4h > 10.0))
+            & ((rsi_3_1h_lt_80) | (aroonu_14_4h_gt_10))
             # 1h up move, 1h still low
             & ((rsi_3_1h < 75.0) | (stochrsi_k_1h_gt_50))
             # 1h up move, 4h low
@@ -24527,7 +24550,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h up move, 15m still low
             & ((rsi_3_4h_lt_90) | (stochrsi_k_15m_gt_50))
             # 4h up move, 1h still low
-            & ((rsi_3_4h_lt_90) | (aroonu_14_1h > 40.0))
+            & ((rsi_3_4h_lt_90) | (aroonu_14_1h_gt_40))
             # 4h up move, 4h still not high enough
             & ((rsi_3_4h_lt_90) | (stochrsi_k_4h > 75.0))
             # 4h up move, 4h still not high enough
@@ -24555,17 +24578,17 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m still low, 1h low
             & ((aroonu_14_15m > 50.0) | (stochrsi_k_1h_gt_30))
             # 15m still not high enough, 4h low
-            & ((stochrsi_k_15m > 70.0) | (aroonu_14_4h > 10.0))
+            & ((stochrsi_k_15m > 70.0) | (aroonu_14_4h_gt_10))
             # 1h & 4h low
-            & ((aroonu_14_1h > 20.0) | (aroonu_14_4h > 20.0))
+            & ((aroonu_14_1h_gt_20) | (aroonu_14_4h_gt_20))
             # 1h & 4h low
-            & ((aroonu_14_1h > 20.0) | (stochrsi_k_4h > 20.0))
+            & ((aroonu_14_1h_gt_20) | (stochrsi_k_4h > 20.0))
             # 1h low, 1d low
-            & ((aroonu_14_1h > 30.0) | (stochrsi_k_1d_gt_30))
+            & ((aroonu_14_1h_gt_30) | (stochrsi_k_1d_gt_30))
             # 4h still not high enough, 4h & 1d uptrend
-            & ((aroonu_14_4h > 70.0) | (roc_9_4h_lt_60) | (roc_9_1d_lt_200))
+            & ((aroonu_14_4h_gt_70) | (roc_9_4h_lt_60) | (roc_9_1d_lt_200))
             # 1h & 4h low
-            & ((stochrsi_k_1h_gt_20) | (aroonu_14_4h > 20.0))
+            & ((stochrsi_k_1h_gt_20) | (aroonu_14_4h_gt_20))
             # 1d big green, 1d still not high enough
             & ((change_pct_1d < 30.0) | (rsi_14_1d > 65.0))
             # rise in the last hour, relatively stable before the hour
@@ -24582,7 +24605,7 @@ class NostalgiaForInfinityX7(IStrategy):
             & (stochrsi_k > 80.0)
             & (close > (ema_20 * 1.060))
             & (close > (bbu_20_2_0 * 0.995))
-            & (aroond_14_15m < 25.0)
+            & (aroond_14_15m_lt_25)
           )
 
         # Condition #503 - Normal mode (Short).
@@ -24622,7 +24645,7 @@ class NostalgiaForInfinityX7(IStrategy):
           short_entry_logic.append((rsi_3_15m_lt_95) | (rsi_3_1h_lt_85) | (stochrsi_k_4h_gt_50))
           # 15m down move, 15m still not low enough, 1h & 4h still not low enough
           short_entry_logic.append(
-            (rsi_3_15m_lt_95) | (aroond_14_15m < 25.0) | (stochrsi_k_1h_gt_75) | (df["MFI_14_4h"] > 50.0)
+            (rsi_3_15m_lt_95) | (aroond_14_15m_lt_25) | (stochrsi_k_1h_gt_75) | (df["MFI_14_4h"] > 50.0)
           )
           # 5m & 1h down move, 1h still high
           short_entry_logic.append((rsi_3_15m_lt_95) | (rsi_3_1h_lt_85) | (stochrsi_k_1h_gt_50))
@@ -24641,9 +24664,9 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m & 4h down move, 1h still high
           short_entry_logic.append((rsi_3_15m_lt_90) | (rsi_3_4h_lt_95) | (stochrsi_k_1h_gt_50))
           # 15m down move, 15m still not low enough, 4h down move
-          short_entry_logic.append((rsi_3_15m_lt_90) | (aroond_14_15m < 50.0) | (rsi_3_4h_lt_85))
+          short_entry_logic.append((rsi_3_15m_lt_90) | (aroond_14_15m_lt_50) | (rsi_3_4h_lt_85))
           # 15m down move, 1h still high, 1d strong downtrend
-          short_entry_logic.append((rsi_3_15m < 80.0) | (aroond_14_1h < 25.0) | (df["MFI_14_1d"] < 90.0))
+          short_entry_logic.append((rsi_3_15m < 80.0) | (aroond_14_1h_lt_25) | (df["MFI_14_1d"] < 90.0))
           # 15m down move, 1h still high, 1d downtrend
           short_entry_logic.append((rsi_3_15m_lt_85) | (stochrsi_k_1h_gt_30) | roc_9_1d_lt_50)
           # 15m down move, 4h still high, 1d downtrend
@@ -24661,11 +24684,11 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m & 1h & 4h down move
           short_entry_logic.append((rsi_3_15m_lt_95) | (rsi_3_1h_lt_95) | (cci_20_change_pct_4h < 0.0))
           # 15m strong down move
-          short_entry_logic.append((rsi_3_15m_lt_90) | (mfi_14_15m < 85.0) | (aroond_14_15m < 25.0))
+          short_entry_logic.append((rsi_3_15m_lt_90) | (mfi_14_15m < 85.0) | (aroond_14_15m_lt_25))
           # 14m down move, 4h still high
-          short_entry_logic.append((rsi_3_15m < 80.0) | (aroond_14_15m < 50.0) | (uo_7_14_28_4h > 50.0))
+          short_entry_logic.append((rsi_3_15m < 80.0) | (aroond_14_15m_lt_50) | (uo_7_14_28_4h > 50.0))
           # 15m down move, 1h stil high, 1d overbought
-          short_entry_logic.append((rsi_3_15m_lt_85) | (aroond_14_1h < 25.0) | (roc_9_1d > -80.0))
+          short_entry_logic.append((rsi_3_15m_lt_85) | (aroond_14_1h_lt_25) | (roc_9_1d > -80.0))
           # 15m down move, 1h high, 1d overbought
           short_entry_logic.append((rsi_3_15m_lt_90) | (stochrsi_k_1h_gt_30) | roc_9_1d_gt_neg_50)
           # 1h & 4h down move, 4h still high
@@ -24673,7 +24696,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1h & 4h down move, 4h still high
           short_entry_logic.append((rsi_3_1h_lt_90) | (rsi_3_4h_lt_85) | (stochrsi_k_4h_lt_10))
           # 1h down move, 4h still not low enough, 1d overbought
-          short_entry_logic.append((rsi_3_1h_lt_90) | (aroond_14_4h < 25.0) | (roc_9_1d > -120.0))
+          short_entry_logic.append((rsi_3_1h_lt_90) | (aroond_14_4h_lt_25) | (roc_9_1d > -120.0))
           # 1h down move, 1h still not low enough, 4h still not low
           short_entry_logic.append((rsi_3_1h_lt_90) | (stochrsi_k_1h_gt_70) | (rsi_14_4h > 50.0))
           # 1h down move, 4h still high
@@ -24685,19 +24708,19 @@ class NostalgiaForInfinityX7(IStrategy):
           # 4h & 1d down move, 1h still high
           short_entry_logic.append((rsi_3_4h_lt_90) | (roc_2_1d < 20.0) | (stochrsi_k_1h_gt_50))
           # 15m still high, 1h down move, 4h high
-          short_entry_logic.append((aroond_14_15m < 50.0) | (rsi_3_change_pct_1h < 50.0) | (stochrsi_k_4h_gt_30))
+          short_entry_logic.append((aroond_14_15m_lt_50) | (rsi_3_change_pct_1h < 50.0) | (stochrsi_k_4h_gt_30))
           # 15m still high, 1h & 4h down move, 4h still high
           short_entry_logic.append(
-            (aroond_14_15m < 50.0) | (rsi_3_1h_lt_85) | (rsi_3_4h_lt_80) | (stochrsi_k_4h > 80.0)
+            (aroond_14_15m_lt_50) | (rsi_3_1h_lt_85) | (rsi_3_4h_lt_80) | (stochrsi_k_4h > 80.0)
           )
           # 15m & 1h still high, 4h overbought
-          short_entry_logic.append((aroond_14_15m < 50.0) | (aroond_14_1h < 50.0) | (roc_9_4h > -40.0))
+          short_entry_logic.append((aroond_14_15m_lt_50) | (aroond_14_1h_lt_50) | (roc_9_4h > -40.0))
           # 15m still high, 1h down move, 1d downtrend
           short_entry_logic.append((stochrsi_k_15m > 30.0) | (rsi_3_4h_lt_90) | roc_9_1d_lt_50)
           # 1h & 4h still high, 1d strong down move
           short_entry_logic.append((stochrsi_k_1h_gt_50) | (uo_7_14_28_4h > 55.0) | (rsi_3_1d < 90.0))
           # 1h still high, 4h & 1d downtrend
-          short_entry_logic.append((aroond_14_1h < 25.0) | (roc_9_4h_lt_20) | roc_9_1d_lt_50)
+          short_entry_logic.append((aroond_14_1h_lt_25) | (roc_9_4h_lt_20) | roc_9_1d_lt_50)
           # 4h moving down, 1d P&D
           short_entry_logic.append((roc_9_4h_lt_30) | (df["RSI_3_change_pct_1d"] < 50.0) | roc_9_1d_gt_neg_50)
           # 1d strong downtrend, 4h still high
@@ -24718,14 +24741,14 @@ class NostalgiaForInfinityX7(IStrategy):
           )
           # 4h red, 4h still not low enough, 1h downtrend, 1h overbought
           short_entry_logic.append(
-            (change_pct_4h < 10.0) | (aroond_14_4h < 25.0) | (roc_9_1h_lt_20) | (roc_9_1d_gt_neg_40)
+            (change_pct_4h < 10.0) | (aroond_14_4h_lt_25) | (roc_9_1h_lt_20) | (roc_9_1d_gt_neg_40)
           )
           # 4h red, 4h still high, 1d downtrend
           short_entry_logic.append((change_pct_4h < 10.0) | (stochrsi_k_4h_gt_30) | (roc_9_1d_lt_40))
           # 1d P&D, 1d overbought
           short_entry_logic.append((change_pct_1d < 10.0) | (change_pct_1d.shift(288) > -10.0) | (roc_9_1d > -100.0))
           # 1d P&D, 4h still high
-          short_entry_logic.append((change_pct_1d < 15.0) | (change_pct_1d.shift(288) > -15.0) | (aroond_14_4h < 50.0))
+          short_entry_logic.append((change_pct_1d < 15.0) | (change_pct_1d.shift(288) > -15.0) | (aroond_14_4h_lt_50))
           short_entry_logic.append((rsi_3_1h_lt_90) | (rsi_3_4h_lt_95) | (cci_20_change_pct_4h < 0.0))
 
           # Logic
@@ -24760,7 +24783,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1h & 4h down move, 4h still not low enough
           short_entry_logic.append((rsi_3_1h_lt_95) | (rsi_3_4h_lt_90) | (stochrsi_k_4h > 75.0))
           # 1h & 4h down move, 4h still not low enough
-          short_entry_logic.append((rsi_3_1h_lt_95) | (rsi_3_4h < 75.0) | (aroond_14_4h < 50.0))
+          short_entry_logic.append((rsi_3_1h_lt_95) | (rsi_3_4h < 75.0) | (aroond_14_4h_lt_50))
           # 15m down move, 1h strong downtrend
           short_entry_logic.append((rsi_3_15m_lt_95) | (rsi_3_1h_lt_95) | (mfi_14_1h > 5.0))
           # 15m downtrend, 4h down move, 4h stil high
@@ -24768,7 +24791,7 @@ class NostalgiaForInfinityX7(IStrategy):
 
           # Logic
           short_entry_logic.append(aroond_14 < 25.0)
-          short_entry_logic.append(aroond_14_15m < 25.0)
+          short_entry_logic.append(aroond_14_15m_lt_25)
           short_entry_logic.append(close > (ema_9 * 1.058))
           short_entry_logic.append(close > (ema_20 * 1.040))
 
@@ -24831,7 +24854,7 @@ class NostalgiaForInfinityX7(IStrategy):
           short_entry_logic.append((rsi_3_1h_lt_90) | (rsi_3_change_pct_4h < 70.0) | (rsi_14_4h.shift(48) > 30.0))
           # 1h & 4h down move, 4h still not low enough, 1d still high
           short_entry_logic.append(
-            (rsi_3_1h_lt_90) | (rsi_3_change_pct_4h < 50.0) | (aroond_14_4h < 25.0) | (stochrsi_k_1d_gt_60)
+            (rsi_3_1h_lt_90) | (rsi_3_change_pct_4h < 50.0) | (aroond_14_4h_lt_25) | (stochrsi_k_1d_gt_60)
           )
           # 1h down move, 1h still high, 1d going down
           short_entry_logic.append((rsi_3_1h_lt_85) | (stochrsi_k_1h_gt_50) | (roc_2_1d > -50.0))
@@ -24871,7 +24894,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1d P&D, 1d overbought
           short_entry_logic.append((change_pct_1d < 10.0) | (change_pct_1d.shift(288) > -10.0) | (roc_9_1d > -100.0))
           # 1d P&D, 4h still high
-          short_entry_logic.append((change_pct_1d < 15.0) | (change_pct_1d.shift(288) > -15.0) | (aroond_14_4h < 50.0))
+          short_entry_logic.append((change_pct_1d < 15.0) | (change_pct_1d.shift(288) > -15.0) | (aroond_14_4h_lt_50))
 
           # Logic
           short_entry_logic.append(rsi_14 > 64.0)
@@ -24908,7 +24931,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m & 4h up move, 4h still not high enough
           short_entry_logic.append((rsi_3_15m_lt_85) | (rsi_3_4h_lt_80) | (rsi_14_4h > 60.0))
           # 15m up move, 15m still not high enough, 4h still low
-          short_entry_logic.append((rsi_3_15m_lt_85) | (stochrsi_k_15m > 80.0) | (aroonu_14_4h > 50.0))
+          short_entry_logic.append((rsi_3_15m_lt_85) | (stochrsi_k_15m > 80.0) | (aroonu_14_4h_gt_50))
           # 15m up move, 4h overbought
           short_entry_logic.append((rsi_3_15m_lt_85) | (roc_9_4h_lt_50))
           # 15m & 1h up move, 15m still low
@@ -24928,7 +24951,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1h up move, 4h still low, 1h still moving higher
           short_entry_logic.append((rsi_3_1h_lt_95) | (rsi_14_4h > 60.0) | (cci_20_change_pct_1h < -0.0))
           # 1h up move, 4h low
-          short_entry_logic.append((rsi_3_1h_lt_95) | (aroonu_14_4h > 10.0))
+          short_entry_logic.append((rsi_3_1h_lt_95) | (aroonu_14_4h_gt_10))
           # 1h & 4h up move, 1h still moving higher
           short_entry_logic.append((rsi_3_1h_lt_90) | (rsi_3_4h_lt_85) | (cci_20_change_pct_1h < -0.0))
           # 1h & 4h up move, 4h still not high enough
@@ -24950,9 +24973,9 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1h up move, 15m low
           short_entry_logic.append((rsi_3_1h_lt_85) | (aroonu_14_15m > 40.0))
           # 1h up move, 4h still not high enough, 1d low
-          short_entry_logic.append((rsi_3_1h_lt_85) | (aroonu_14_4h > 80.0) | (rsi_14_1d > 40.0))
+          short_entry_logic.append((rsi_3_1h_lt_85) | (aroonu_14_4h_gt_80) | (rsi_14_1d > 40.0))
           # 1h & 4h up move, 4h still low
-          short_entry_logic.append((rsi_3_1h_lt_80) | (rsi_3_4h_lt_80) | (aroonu_14_4h > 50.0))
+          short_entry_logic.append((rsi_3_1h_lt_80) | (rsi_3_4h_lt_80) | (aroonu_14_4h_gt_50))
           # 1h & 4h up move, 1d still low
           short_entry_logic.append((rsi_3_1h_lt_80) | (rsi_3_4h_lt_80) | (aroonu_14_1d > 50.0))
           # 1h & 4h up move, 1d low
@@ -24980,7 +25003,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 4h up move, 4h uptrend
           short_entry_logic.append((rsi_3_4h_lt_80) | (aroonu_14_4h_lt_100) | (roc_9_4h_lt_20))
           # 4h up move, 15m still low, 4h still not high enough
-          short_entry_logic.append((rsi_3_4h_lt_80) | (stochrsi_k_15m > 60.0) | (aroonu_14_4h > 80.0))
+          short_entry_logic.append((rsi_3_4h_lt_80) | (stochrsi_k_15m > 60.0) | (aroonu_14_4h_gt_80))
           # 4h up move, 15m still low, 4h still not high enough
           short_entry_logic.append((rsi_3_4h < 75.0) | (stochrsi_k_15m > 60.0) | (stochrsi_k_4h > 80.0))
           # 1d up move, 4h low
@@ -25041,7 +25064,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 5m down move, 1h down, 4h high
           short_entry_logic.append((rsi_3_15m_lt_95) | (cmf_20_1h < 0.2) | (stochrsi_k_4h_gt_50))
           # 15m down move, 1h still not low enough, 4h high
-          short_entry_logic.append((rsi_3_15m_lt_95) | (aroond_14_1h < 25.0) | (stochrsi_k_4h > 10.0))
+          short_entry_logic.append((rsi_3_15m_lt_95) | (aroond_14_1h_lt_25) | (stochrsi_k_4h > 10.0))
           # 15m down move, 1h still high
           short_entry_logic.append((rsi_3_15m_lt_90) | (df["OBV_change_pct_15m"] < 50.0) | (stochrsi_k_1h_gt_30))
           # 5m & 1h strong down move, 1h still not low enough
@@ -25049,9 +25072,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 5m & 1h strong downtrend
           short_entry_logic.append((rsi_3_15m_lt_95) | (rsi_3_1h_lt_95) | (mfi_14_1h < 90.0))
           # 15m & 1h down move, 4h still high
-          short_entry_logic.append(
-            (rsi_3_15m_lt_95) | (rsi_3_1h_lt_80) | (stochrsi_k_4h_gt_70) | (aroond_14_4h < 50.0)
-          )
+          short_entry_logic.append((rsi_3_15m_lt_95) | (rsi_3_1h_lt_80) | (stochrsi_k_4h_gt_70) | (aroond_14_4h_lt_50))
           # 15m & 1h down move, 4h still high, 4h downtrend
           short_entry_logic.append((rsi_3_15m_lt_95) | (rsi_3_1h_lt_90) | (uo_7_14_28_4h > 60.0) | (roc_9_4h_lt_20))
           # 15m & 1h down move, 1d strong downtrend
@@ -25063,7 +25084,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m & 1h down move, 1h still high
           short_entry_logic.append((rsi_3_15m_lt_85) | (rsi_3_1h < 75.0) | (stochrsi_k_1h_gt_30))
           # 15m down move, 15m still not low enoug, 1h high
-          short_entry_logic.append((rsi_3_15m_lt_85) | (aroond_14_15m < 25.0) | (stochrsi_k_1h_gt_10))
+          short_entry_logic.append((rsi_3_15m_lt_85) | (aroond_14_15m_lt_25) | (stochrsi_k_1h_gt_10))
           # 15m down move, 1h downtrend, 4h overbought
           short_entry_logic.append((rsi_3_15m_lt_85) | (roc_9_1h < 5.0) | (roc_9_4h > -35.0))
           # 1h & 4h down move, 4h still not low enough
@@ -25075,7 +25096,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1h down move, 1h still not low enough, 4h still not low
           short_entry_logic.append((rsi_3_1h_lt_90) | (stochrsi_k_1h_gt_70) | (rsi_14_4h > 50.0))
           # 1h down move, 1h not low enough, 1h still high
-          short_entry_logic.append((rsi_3_1h_lt_85) | (aroond_14_1h < 50.0) | (stochrsi_k_4h_gt_50))
+          short_entry_logic.append((rsi_3_1h_lt_85) | (aroond_14_1h_lt_50) | (stochrsi_k_4h_gt_50))
           # 4h down move, 15m still not low enough, 1h still high
           short_entry_logic.append((rsi_3_4h_lt_80) | (stochrsi_k_15m > 70.0) | (stochrsi_k_1h_gt_30))
           # 4h down move, 4h still high, 1d downtrend
@@ -25140,7 +25161,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 5m down move, 1h high, 4h still not low enough
           short_entry_logic.append((rsi_3_lt_90) | (stochrsi_k_1h_gt_20) | (stochrsi_k_4h > 90.0))
           # 15m down move, 15m still not low enough, 1h still high
-          short_entry_logic.append((rsi_3_15m_lt_95) | (aroond_14_15m < 25.0) | (stochrsi_k_1h_gt_50))
+          short_entry_logic.append((rsi_3_15m_lt_95) | (aroond_14_15m_lt_25) | (stochrsi_k_1h_gt_50))
           # 15m & 1h down move, 1d still not low enough
           short_entry_logic.append((rsi_3_15m_lt_95) | (rsi_3_1h_lt_95) | (stochrsi_k_1d_gt_70))
           # 15m & 1h down move, 1h still not low enough
@@ -25190,7 +25211,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 5m down move, 15m & 4h still high
           short_entry_logic.append((rsi_3_lt_90) | (stochrsi_k_15m > 60.0) | (stochrsi_k_4h > 60.0))
           # 5m down move, 15m still high, 1h high
-          short_entry_logic.append((rsi_3 < 85.0) | (aroond_14_15m < 50.0) | (stochrsi_k_1h_gt_20))
+          short_entry_logic.append((rsi_3 < 85.0) | (aroond_14_15m_lt_50) | (stochrsi_k_1h_gt_20))
           # 15m & 1h down move, 1h still not low enough
           short_entry_logic.append((rsi_3_15m_lt_95) | (rsi_3_1h_lt_95) | (stochrsi_k_1h_gt_90))
           # 15m & 1h down move, 1d still not low enough
@@ -25299,27 +25320,27 @@ class NostalgiaForInfinityX7(IStrategy):
           short_entry_logic.append(num_empty_288 <= allowed_empty_candles_288)
 
           # 15m down move, 15m high
-          short_entry_logic.append((rsi_3_15m < 75.0) | (aroond_14_15m < 80.0))
+          short_entry_logic.append((rsi_3_15m < 75.0) | (aroond_14_15m_lt_80))
           # 15m & 1h down move, 15m still high
-          short_entry_logic.append((rsi_3_15m < 70.0) | (rsi_3_1h < 40.0) | (aroond_14_15m < 50.0))
+          short_entry_logic.append((rsi_3_15m < 70.0) | (rsi_3_1h < 40.0) | (aroond_14_15m_lt_50))
           # 15m down move, 15m & 4h still high
           short_entry_logic.append((rsi_3_15m < 70.0) | (stochrsi_k_15m_gt_50) | (stochrsi_k_4h_gt_50))
           # 15m & 1h down move, 1h high
-          short_entry_logic.append((rsi_3_15m < 60.0) | (rsi_3_1h < 60.0) | (aroond_14_1h < 70.0))
+          short_entry_logic.append((rsi_3_15m < 60.0) | (rsi_3_1h < 60.0) | (aroond_14_1h_lt_70))
           # 15m & 1h down move, 1h still high
           short_entry_logic.append((rsi_3_15m < 60.0) | (rsi_3_1h < 60.0) | (stochrsi_k_1h_gt_50))
           # 15m & 1h down move, 4h high
-          short_entry_logic.append((rsi_3_15m < 60.0) | (rsi_3_1h < 40.0) | (aroond_14_4h < 80.0))
+          short_entry_logic.append((rsi_3_15m < 60.0) | (rsi_3_1h < 40.0) | (aroond_14_4h_lt_80))
           # 15m & 4h down move, 15m high
           short_entry_logic.append((rsi_3_15m < 60.0) | (rsi_3_4h < 60.0) | (stochrsi_k_15m_gt_50))
           # 15m & 4h down move, 15m high
           short_entry_logic.append((rsi_3_15m < 60.0) | (rsi_3_4h < 40.0) | (stochrsi_k_15m > 30.0))
           # 15m down move, 15m & 1h still high
-          short_entry_logic.append((rsi_3_15m < 60.0) | (aroond_14_15m < 50.0) | (stochrsi_k_1h_gt_50))
+          short_entry_logic.append((rsi_3_15m < 60.0) | (aroond_14_15m_lt_50) | (stochrsi_k_1h_gt_50))
           # 15m down move, 15m & 1h still high
           short_entry_logic.append((rsi_3_15m < 60.0) | (stochrsi_k_15m_gt_50) | (stochrsi_k_1h_gt_50))
           # 15m down move, 4h still high, 1d overbought
-          short_entry_logic.append((rsi_3_15m < 60.0) | (aroond_14_4h < 50.0) | (roc_9_1d > -100.0))
+          short_entry_logic.append((rsi_3_15m < 60.0) | (aroond_14_4h_lt_50) | (roc_9_1d > -100.0))
           # 15m down move, 15m high, 4h still high
           short_entry_logic.append((rsi_3_15m < 55.0) | (aroond_14_15m > 30.0) | (stochrsi_k_4h_gt_50))
           # 15m down move, 15m & 1h still high
@@ -25327,7 +25348,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 15m down move, 15m still not low enough, 4h high
           short_entry_logic.append((rsi_3_15m < 50.0) | (stochrsi_k_15m > 70.0) | (stochrsi_k_4h > 10.0))
           # 1h down move, 4h still high, 1d high
-          short_entry_logic.append((rsi_3_1h < 75.0) | (aroond_14_4h < 50.0) | (stochrsi_k_1d > 10.0))
+          short_entry_logic.append((rsi_3_1h < 75.0) | (aroond_14_4h_lt_50) | (stochrsi_k_1d > 10.0))
           short_entry_logic.append((rsi_3_1h < 70.0) | (stochrsi_k_1h_gt_60) | (stochrsi_k_1d > 10.0))
           # 1h & 4h down move, 4h high
           short_entry_logic.append((rsi_3_1h < 65.0) | (rsi_3_4h < 40.0) | (stochrsi_k_4h > 20.0))
@@ -25338,89 +25359,89 @@ class NostalgiaForInfinityX7(IStrategy):
           # 1h down move, 1h high
           short_entry_logic.append((rsi_3_1h < 60.0) | (stochrsi_k_1h_gt_40))
           # 1h down move, 4h & 1d high
-          short_entry_logic.append((rsi_3_1h < 60.0) | (aroond_14_4h < 85.0) | (df["AROOND_14_1d"] < 90.0))
+          short_entry_logic.append((rsi_3_1h < 60.0) | (aroond_14_4h_lt_85) | (df["AROOND_14_1d"] < 90.0))
           # 1h down move, 1h still high, 4h high
-          short_entry_logic.append((rsi_3_1h < 55.0) | (aroond_14_1h < 50.0) | (aroond_14_4h < 90.0))
+          short_entry_logic.append((rsi_3_1h < 55.0) | (aroond_14_1h_lt_50) | (aroond_14_4h < 90.0))
           # 1h down move, 1h high
           short_entry_logic.append((rsi_3_1h < 55.0) | (stochrsi_k_1h_gt_40))
           # 1h & 4h down move, 15m high
-          short_entry_logic.append((rsi_3_1h < 50.0) | (rsi_3_4h < 40.0) | (aroond_14_15m < 70.0))
+          short_entry_logic.append((rsi_3_1h < 50.0) | (rsi_3_4h < 40.0) | (aroond_14_15m_lt_70))
           # 1h down move, 15m still high, 4h high
-          short_entry_logic.append((rsi_3_1h < 50.0) | (aroond_14_15m < 50.0) | (aroond_14_4h < 80.0))
+          short_entry_logic.append((rsi_3_1h < 50.0) | (aroond_14_15m_lt_50) | (aroond_14_4h_lt_80))
           # 1h down move, 15m high, 1h still high
-          short_entry_logic.append((rsi_3_1h < 50.0) | (aroond_14_15m < 70.0) | (stochrsi_k_1h_gt_60))
+          short_entry_logic.append((rsi_3_1h < 50.0) | (aroond_14_15m_lt_70) | (stochrsi_k_1h_gt_60))
           # 1h down move, 15m still high, 4h high
           short_entry_logic.append((rsi_3_1h < 50.0) | (stochrsi_k_15m_gt_50) | (stochrsi_k_4h > 20.0))
           # 1h down move, 15m & 1h high
           short_entry_logic.append((rsi_3_1h < 50.0) | (stochrsi_k_15m > 40.0) | (aroond_14_1h < 60.0))
           # 1h down move, 1h & 1d high
-          short_entry_logic.append((rsi_3_1h < 50.0) | (aroond_14_1h < 70.0) | (stochrsi_k_1d_gt_20))
+          short_entry_logic.append((rsi_3_1h < 50.0) | (aroond_14_1h_lt_70) | (stochrsi_k_1d_gt_20))
           # 1h down move, 4h still high, 1d high
           short_entry_logic.append((rsi_3_1h < 50.0) | (stochrsi_k_4h_gt_50) | (stochrsi_k_1d > 10.0))
           # 1h down move, 5m up move, 1h still high
           short_entry_logic.append((rsi_3_1h < 40.0) | (rsi_3 > 40.0) | (stochrsi_k_1h_gt_50))
           # 1h down move, 15m still not low enough, 1h high
-          short_entry_logic.append((rsi_3_1h < 40.0) | (stochrsi_k_15m > 70.0) | (aroond_14_1h < 70.0))
+          short_entry_logic.append((rsi_3_1h < 40.0) | (stochrsi_k_15m > 70.0) | (aroond_14_1h_lt_70))
           # 1h down move, 15m still not low enough, 1h high
           short_entry_logic.append((rsi_3_1h < 40.0) | (stochrsi_k_15m > 70.0) | (stochrsi_k_1h_gt_40))
           # 1h down move, 15m & 4h still high
           short_entry_logic.append((rsi_3_1h < 40.0) | (stochrsi_k_15m_gt_50) | (stochrsi_k_4h_gt_50))
           # 1h down move, 15m & 1h high
-          short_entry_logic.append((rsi_3_1h < 40.0) | (aroond_14_15m < 70.0) | (aroond_14_1h < 90.0))
+          short_entry_logic.append((rsi_3_1h < 40.0) | (aroond_14_15m_lt_70) | (aroond_14_1h < 90.0))
           # 1h down move, 1h still high, 4h high
-          short_entry_logic.append((rsi_3_1h < 40.0) | (aroond_14_1h < 50.0) | (stochrsi_k_4h > 10.0))
+          short_entry_logic.append((rsi_3_1h < 40.0) | (aroond_14_1h_lt_50) | (stochrsi_k_4h > 10.0))
           # 1h down move, 1h high, 4h still high
-          short_entry_logic.append((rsi_3_1h < 40.0) | (aroond_14_1h < 80.0) | (aroond_14_4h < 40.0))
+          short_entry_logic.append((rsi_3_1h < 40.0) | (aroond_14_1h < 80.0) | (aroond_14_4h_lt_40))
           # 1h down move, 1h still high, 4h high
-          short_entry_logic.append((rsi_3_1h < 40.0) | (stochrsi_k_1h_gt_60) | (aroond_14_4h < 70.0))
+          short_entry_logic.append((rsi_3_1h < 40.0) | (stochrsi_k_1h_gt_60) | (aroond_14_4h_lt_70))
           # 1h down move, 1h & 1d high
           short_entry_logic.append((rsi_3_1h < 40.0) | (stochrsi_k_1h_gt_30) | (df["AROOND_14_1d"] < 90.0))
           # 1h down move, 4h & 1d high
           short_entry_logic.append((rsi_3_1h < 40.0) | (rsi_14_4h > 30.0) | (rsi_14_1d > 20.0))
           # 4h down move, 15m high
-          short_entry_logic.append((rsi_3_4h_lt_80) | (aroond_14_15m < 80.0))
+          short_entry_logic.append((rsi_3_4h_lt_80) | (aroond_14_15m_lt_80))
           # 4h down move, 1h high
           short_entry_logic.append((rsi_3_4h < 75.0) | (stochrsi_k_1h_gt_20))
           # 4h down move, 1h & 4h still high
-          short_entry_logic.append((rsi_3_4h < 65.0) | (stochrsi_k_1h_gt_50) | (aroond_14_4h < 50.0))
+          short_entry_logic.append((rsi_3_4h < 65.0) | (stochrsi_k_1h_gt_50) | (aroond_14_4h_lt_50))
           # 4h down move, 15m & 1h high
-          short_entry_logic.append((rsi_3_4h < 60.0) | (aroond_14_15m < 80.0) | (stochrsi_k_1h_gt_30))
+          short_entry_logic.append((rsi_3_4h < 60.0) | (aroond_14_15m_lt_80) | (stochrsi_k_1h_gt_30))
           # 4h down move, 15m still high, 1h high
           short_entry_logic.append((rsi_3_4h < 60.0) | (stochrsi_k_15m > 60.0) | (stochrsi_k_1h_gt_20))
           # 4h down move, 1h still high, 4h still moving down
           short_entry_logic.append((rsi_3_4h < 60.0) | (stochrsi_k_1h_gt_50) | (cci_20_change_pct_4h < 0.0))
           # 4h down move, 1h high, 4h still high
-          short_entry_logic.append((rsi_3_4h < 55.0) | (aroond_14_1h < 70.0) | (aroond_14_4h < 50.0))
+          short_entry_logic.append((rsi_3_4h < 55.0) | (aroond_14_1h_lt_70) | (aroond_14_4h_lt_50))
           # 4h down move, 15m high, 4h still high
-          short_entry_logic.append((rsi_3_4h < 50.0) | (aroond_14_15m < 70.0) | (stochrsi_k_4h > 60.0))
+          short_entry_logic.append((rsi_3_4h < 50.0) | (aroond_14_15m_lt_70) | (stochrsi_k_4h > 60.0))
           # 4h down move, 15m still high, 1h high
           short_entry_logic.append((rsi_3_4h < 50.0) | (stochrsi_k_15m > 60.0) | (stochrsi_k_1h_gt_30))
           # 4h down move, 15m & 4h still high
-          short_entry_logic.append((rsi_3_4h < 50.0) | (stochrsi_k_15m_gt_50) | (aroond_14_4h < 50.0))
+          short_entry_logic.append((rsi_3_4h < 50.0) | (stochrsi_k_15m_gt_50) | (aroond_14_4h_lt_50))
           # 4h down move, 15m high, 4h still not low enough
           short_entry_logic.append((rsi_3_4h < 50.0) | (stochrsi_k_15m > 30.0) | (stochrsi_k_4h_gt_70))
           # 4h down move, 1h still high, 4h high
-          short_entry_logic.append((rsi_3_4h < 50.0) | (stochrsi_k_1h_gt_50) | (aroond_14_4h < 70.0))
+          short_entry_logic.append((rsi_3_4h < 50.0) | (stochrsi_k_1h_gt_50) | (aroond_14_4h_lt_70))
           # 4h down move, 15m & 4h high
-          short_entry_logic.append((rsi_3_4h < 40.0) | (aroond_14_15m < 70.0) | (aroond_14_4h < 70.0))
+          short_entry_logic.append((rsi_3_4h < 40.0) | (aroond_14_15m_lt_70) | (aroond_14_4h_lt_70))
           # 4h down move, 15m high, 4h still high
-          short_entry_logic.append((rsi_3_4h < 40.0) | (aroond_14_15m < 80.0) | (aroond_14_4h < 40.0))
+          short_entry_logic.append((rsi_3_4h < 40.0) | (aroond_14_15m_lt_80) | (aroond_14_4h_lt_40))
           # 4h down move, 15m still high, 4h high
           short_entry_logic.append((rsi_3_4h < 40.0) | (stochrsi_k_15m_gt_50) | (stochrsi_k_4h_gt_30))
           # 4h down move, 15m & 4h high
           short_entry_logic.append((rsi_3_4h < 40.0) | (stochrsi_k_15m > 30.0) | (stochrsi_k_4h > 40.0))
           # 4h down move, 1h & 4h high
-          short_entry_logic.append((rsi_3_4h < 40.0) | (stochrsi_k_1h_gt_30) | (aroond_14_4h < 70.0))
+          short_entry_logic.append((rsi_3_4h < 40.0) | (stochrsi_k_1h_gt_30) | (aroond_14_4h_lt_70))
           # 4h down move, 4h still high, 1d high
           short_entry_logic.append((rsi_3_4h < 40.0) | (stochrsi_k_4h_gt_50) | (stochrsi_k_1d_gt_20))
           # 15m high, 4h high
-          short_entry_logic.append((aroond_14_15m < 70.0) | (aroond_14_4h < 85.0))
+          short_entry_logic.append((aroond_14_15m_lt_70) | (aroond_14_4h_lt_85))
           # 15m high, 4h still high
-          short_entry_logic.append((aroond_14_15m < 80.0) | (stochrsi_k_4h_gt_50))
+          short_entry_logic.append((aroond_14_15m_lt_80) | (stochrsi_k_4h_gt_50))
           # 15m high, 1h still high
           short_entry_logic.append((stochrsi_k_15m > 30.0) | (stochrsi_k_1h_gt_60))
           # 15m & 4h high
-          short_entry_logic.append((stochrsi_k_15m > 30.0) | (aroond_14_4h < 70.0))
+          short_entry_logic.append((stochrsi_k_15m > 30.0) | (aroond_14_4h_lt_70))
           # 15m high, 1h still not low enough
           short_entry_logic.append((stochrsi_k_15m > 20.0) | (stochrsi_k_1h_gt_70))
 


### PR DESCRIPTION
## Summary
- Reuse repeated AROON threshold comparisons in `populate_entry_trend()` through named entry masks.
- Independent on latest upstream `main`.

## Safety
- Behavior-preserving Series mask reuse only.
- Touched function: `populate_entry_trend()`.
- Indicator formulas, candle selection, thresholds, condition order, profit arithmetic, order classification, return values, and signal behavior are unchanged.
- No v3 grind-entry code is touched.

## Backtest scope
- Full backtesting was not required because this patch only aliases Series comparisons that are already used by the same condition ladder.
- Indicator formulas, candle selection, thresholds, and condition order are unchanged.

## Checks
- `python3 /home/user/.codex/skills/nfi-upstream-pr/scripts/validate_nfi_pr.py --base origin/main`
- `git merge-tree \9f25e22bd594c7b51672063310f7e3a76474f673 origin/main HEAD | grep -E '\''<<<<<<<|>>>>>>>|changed in both|removed in|added in both'\'' && echo CONFLICT || echo NO_CONFLICT`
- `git diff --check`
- `ruff format --check NostalgiaForInfinityX7.py`
- `ruff check NostalgiaForInfinityX7.py`
- `PYTHONDONTWRITEBYTECODE=1 python3 -m py_compile NostalgiaForInfinityX7.py`