### PR TITLE
Configs: blacklist RB, RD, RO, RT on Bitget (tokenized stocks)

### DIFF
--- a/configs/blacklist-bitget.json
+++ b/configs/blacklist-bitget.json
@@ -23,7 +23,9 @@
       // Tokenized stocks (ON-suffix variant on Bitget)
       "(AAPL|AMD|AMZN|GOOGL|IAU|ITOT|IVV|IWM|META|MSFT|NVDA|QQQ|SLV|SPY|TSLA)ON/.*",
       // Tokenized stocks on futures using native stock ticker (Reddit, Redwire, Rocket Lab, Red Cat, Rigetti)
-      "(RCAT|RDDT|RDW|RGTI|RKLB)/.*"
+      "(RCAT|RDDT|RDW|RGTI|RKLB)/.*",
+      // Bitget tokenized stocks (rB/rD/rO/rT base coins with areaSymbol=yes)
+      "(RB|RD|RO|RT)/.*"
     ]
   }
 }


### PR DESCRIPTION
## Summary

Bitget exposes tokenized stock symbols like `RDUSDT`, `RBUSDT`, `ROUSDT`, `RTUSDT` (where baseCoin is actually `rD`/`rB`/`rO`/`rT` and `areaSymbol=yes`). These leak into the pairlist when freqtrade/ccxt tries to fetch spot OHLCV data, triggering parameter validation errors.

Per Discord discussion (2026-06-12) — confirmed with @iterativ to blacklist these.

## Files changed

1 line added to `configs/blacklist-bitget.json`:

```
"(RB|RD|RO|RT)/.*"
```

## Why this regex (and not `R[A-Z]{1,6}/.*`)

A broad `R[A-Z]{1,6}` would also block legitimate crypto pairs like RAY, RUNE, ROSE, RSR, RLC, RENDER, RVN, etc. This explicit 2-letter list catches only the 4 problematic tokenized stock symbols.

🤖 Generated with [Claude Code](https://claude.com/claude-code)