### PR TITLE
Reuse X7 entry ROC downtrend masks

### DIFF
--- a/NostalgiaForInfinityX7.py
+++ b/NostalgiaForInfinityX7.py
@@ -13526,7 +13526,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 4h down move, 1h still high
             & ((rsi_3_15m_gt_10) | (rsi_3_4h_gt_10) | (stochrsi_k_1h_lt_40))
             # 15m & 4h down move, 4h downtrend
-            & ((rsi_3_15m_gt_10) | (rsi_3_4h_gt_10) | (roc_9_4h > -20.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_4h_gt_10) | (roc_9_4h_gt_neg_20))
             # 15m & 4h down move, 1d overbought
             & ((rsi_3_15m_gt_10) | (rsi_3_4h_gt_25) | (roc_9_1d_lt_30))
             # 15m & 4h down move, 1h high
@@ -13628,7 +13628,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 1d overbought
             & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_25) | (roc_9_1d_lt_40))
             # 15m down move, 1h high, 1d downtrend
-            & ((rsi_3_1h_gt_15) | (aroonu_14_1h_lt_70) | (roc_9_1d > -20.0))
+            & ((rsi_3_1h_gt_15) | (aroonu_14_1h_lt_70) | (roc_9_1d_gt_neg_20))
             # 1h down move, 1h high, 1d overbought
             & ((rsi_3_1h_gt_15) | (aroonu_14_1h_lt_70) | roc_9_1d_lt_50)
             # 1h down move, 1h high
@@ -13696,11 +13696,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 1h high, 1d downtrend
             & ((rsi_3_4h_gt_10) | (stochrsi_k_1h_lt_60) | (roc_9_1d_gt_neg_40))
             # 4h down move, 4h still not low enough, 1d downtrend
-            & ((rsi_3_4h_gt_10) | (stochrsi_k_4h_lt_30) | (roc_9_1d > -20.0))
+            & ((rsi_3_4h_gt_10) | (stochrsi_k_4h_lt_30) | (roc_9_1d_gt_neg_20))
             # 4h down move, 1h & 4h downtrend
             & ((rsi_3_4h_gt_10) | (roc_9_1h_gt_neg_30) | (roc_9_4h_gt_neg_30))
             # 4h down move, 4h & 1d downtrend
-            & ((rsi_3_4h_gt_15) | (roc_9_4h > -20.0) | (roc_9_1d > -30.0))
+            & ((rsi_3_4h_gt_15) | (roc_9_4h_gt_neg_20) | (roc_9_1d > -30.0))
             # 4h down move, 1d high & overbought
             & (rsi_3_4h_gt_20 | (aroonu_14_1d_lt_80) | (roc_9_1d_lt_80))
             # 4h down move, 4h still high, 1d downtrend
@@ -13845,7 +13845,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 5m & 15m down move, 1h high
             & ((rsi_3_gt_5) | (rsi_3_15m_gt_30) | (stochrsi_k_1h_lt_80))
             # 5m & 4h down move, 1d downtrend
-            & ((rsi_3_gt_5) | (rsi_3_4h_gt_10) | (roc_9_1d > -20.0))
+            & ((rsi_3_gt_5) | (rsi_3_4h_gt_10) | (roc_9_1d_gt_neg_20))
             # 5m & 4h down move, 4h still not low enough
             & ((rsi_3_gt_5) | (rsi_3_4h_gt_15) | (stochrsi_k_4h < 20.0))
             # 5m down move, 4h high, 1h overbought
@@ -13905,7 +13905,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 4h down move, 1d high
             & ((rsi_3_15m_gt_3) | (rsi_3_4h_gt_10) | (aroonu_14_1d_lt_70))
             # 15m & 4h down move, 1d downtrend
-            & ((rsi_3_15m_gt_3) | (rsi_3_4h_gt_10) | (roc_9_1d > -20.0))
+            & ((rsi_3_15m_gt_3) | (rsi_3_4h_gt_10) | (roc_9_1d_gt_neg_20))
             # 15m & 4h down move, 4h still high
             & ((rsi_3_15m_gt_3) | (rsi_3_4h_gt_30) | (stochrsi_k_4h < 40.0))
             # 15m & 4h down move, 4h still high
@@ -14053,7 +14053,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 4h high, 1d downtrend
             & ((rsi_3_15m_gt_10) | (stochrsi_k_4h < 80.0) | (roc_9_1d_gt_neg_30))
             # 15m & 1h down move, 4h downtrend
-            & ((rsi_3_15m_gt_15) | (rsi_3_1h_gt_15) | (roc_9_4h > -20.0))
+            & ((rsi_3_15m_gt_15) | (rsi_3_1h_gt_15) | (roc_9_4h_gt_neg_20))
             # 15m & 1h down move, 1h downtrend
             & ((rsi_3_15m_gt_15) | rsi_3_1h_gt_20 | (cmf_20_1h_gt_neg_0_30))
             # 15m & 1h down move, 1d overbought
@@ -14071,7 +14071,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 4h down move, 1h high
             & ((rsi_3_15m_gt_15) | (rsi_3_4h_gt_15) | (aroonu_14_1h_lt_70))
             # 15m & 4h down move, 4h downtrend
-            & ((rsi_3_15m_gt_15) | (rsi_3_4h_gt_15) | (roc_9_4h > -20.0))
+            & ((rsi_3_15m_gt_15) | (rsi_3_4h_gt_15) | (roc_9_4h_gt_neg_20))
             # 15m & 4h down move, 1d high
             & ((rsi_3_15m_gt_15) | (rsi_3_4h_gt_20) | (aroonu_14_1d_lt_90))
             # 15m & 1d down move, 1h still high
@@ -14209,7 +14209,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 1h still not low enough
             & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_10) | (stochrsi_k_1h_lt_20))
             # 1h & 4h down move, 1d downtrend
-            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_10) | (roc_9_1d > -20.0))
+            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_10) | (roc_9_1d_gt_neg_20))
             # 1h & 4h & 1d down move, 4h downtrend, 1d still high
             & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_15) | (rsi_3_1d_gt_25) | (rsi_14_4h_gt_30) | (aroonu_14_1d_lt_40))
             # 1h & 4h down move, 15m high
@@ -14231,7 +14231,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 15m still high
             & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_15) | (stochrsi_k_15m_lt_50))
             # 1h & 4h down move, 4h downtrend
-            & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_15) | (roc_9_4h > -20.0))
+            & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_15) | (roc_9_4h_gt_neg_20))
             # 1h & 4h down move, 4h still high
             & ((rsi_3_1h_gt_15) | rsi_3_4h_gt_20 | (rsi_14_4h_lt_40))
             # 1h & 4h down move, 4h still not low enough
@@ -14259,7 +14259,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1d high & overbought
             & ((rsi_3_1h_gt_15) | (stochrsi_k_1d_lt_90) | (roc_9_1d_lt_40))
             # 1h down move, 4h & 1d downtrend
-            & ((rsi_3_1h_gt_15) | (roc_9_4h > -20.0) | (roc_9_1d > -20.0))
+            & ((rsi_3_1h_gt_15) | (roc_9_4h_gt_neg_20) | (roc_9_1d_gt_neg_20))
             # 1h & 4h down move, 1d overbought
             & (rsi_3_1h_gt_20 | rsi_3_4h_gt_20 | (roc_9_1d_lt_20))
             # 1h & 4h down move, 4h still high
@@ -14375,15 +14375,15 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h & 1d down move, 1d overbought
             & ((rsi_3_4h_gt_10) | (rsi_3_1d_gt_45) | (roc_9_1d_lt_10))
             # 4h down move, 1d still high, 1d downtrend
-            & ((rsi_3_4h_gt_10) | (aroonu_14_1d_lt_40) | (roc_9_1d > -20.0))
+            & ((rsi_3_4h_gt_10) | (aroonu_14_1d_lt_40) | (roc_9_1d_gt_neg_20))
             # 4h down move, 1d high & overbought
             & ((rsi_3_4h_gt_10) | (aroonu_14_1d_lt_90) | (roc_9_1d_lt_40))
             # 4h down move, 4h still high, 1d downtrend
-            & ((rsi_3_4h_gt_10) | (stochrsi_k_4h < 40.0) | (roc_9_1d > -20.0))
+            & ((rsi_3_4h_gt_10) | (stochrsi_k_4h < 40.0) | (roc_9_1d_gt_neg_20))
             # 4h & 1d down move, 1d high
             & ((rsi_3_4h_gt_15) | (rsi_3_1d_gt_20) | (aroonu_14_1d_lt_60))
             # 4h down move, 4h still high, 1d downtrend
-            & ((rsi_3_4h_gt_15) | (aroonu_14_4h_lt_50) | (roc_9_1d > -20.0))
+            & ((rsi_3_4h_gt_15) | (aroonu_14_4h_lt_50) | (roc_9_1d_gt_neg_20))
             # 4h & 1d down move, 4h still high
             & ((rsi_3_4h_gt_20) | (rsi_3_1d_gt_20) | (stochrsi_k_4h < 40.0))
             # 4h & 1d down move, 1d high
@@ -14391,7 +14391,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 1h high, 1d downtrend
             & ((rsi_3_4h_gt_15) | (aroonu_14_1h_lt_90) | (roc_9_1d_gt_neg_10))
             # 4h down move, 4h still high, 4h downtrend
-            & ((rsi_3_4h_gt_15) | (aroonu_14_4h_lt_50) | (roc_9_4h > -20.0))
+            & ((rsi_3_4h_gt_15) | (aroonu_14_4h_lt_50) | (roc_9_4h_gt_neg_20))
             # 4h down move, 1d high & overbought
             & (rsi_3_4h_gt_20 | (aroonu_14_1d_lt_70) | roc_9_1d_lt_50)
             # 4h & 1d down move, 1d overbought
@@ -14475,7 +14475,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h high, 1h overbought
             & (aroonu_14_1h_lt_80 | (aroonu_14_4h_lt_90) | (roc_9_1h_lt_30))
             # 1h & 4high, 1d downtrend
-            & (aroonu_14_1h_lt_80 | aroonu_14_4h_lt_100 | (roc_9_1d > -20.0))
+            & (aroonu_14_1h_lt_80 | aroonu_14_4h_lt_100 | (roc_9_1d_gt_neg_20))
             # 1h & 4h high, 1d overbought
             & (aroonu_14_1h_lt_80 | aroonu_14_4h_lt_100 | (roc_9_1d_lt_80))
             # 1h & 1d high, 1d overbought
@@ -14774,7 +14774,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 4h still high
             & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_10) | (aroonu_14_4h_lt_50))
             # 1h down move, 4h still high, 4h downtrend
-            & ((rsi_3_1h_gt_10) | (aroonu_14_4h_lt_40) | (roc_9_4h > -20.0))
+            & ((rsi_3_1h_gt_10) | (aroonu_14_4h_lt_40) | (roc_9_4h_gt_neg_20))
             # 1h down move, 4h high & overbought
             & ((rsi_3_1h_gt_10) | aroonu_14_4h_lt_70 | (roc_9_4h_lt_20))
             # 1h & 4h down move, 1d high
@@ -14918,7 +14918,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h & 1d down move, 1d still high
             & ((rsi_3_4h_gt_10) | (rsi_3_1d_gt_20) | (stochrsi_k_1d_lt_50))
             # 4h & 1d down move, 1d downtrend
-            & ((rsi_3_4h_gt_10) | (rsi_3_1d_gt_20) | (roc_9_1d > -20.0))
+            & ((rsi_3_4h_gt_10) | (rsi_3_1d_gt_20) | (roc_9_1d_gt_neg_20))
             # 4h & 1d down move, 4h still high
             & ((rsi_3_4h_gt_10) | (rsi_3_1d_gt_30) | (stochrsi_k_4h_lt_50))
             # 4h & 1d down move, 1d still high
@@ -15164,7 +15164,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h & 1d high, 4h overbought
             & (aroonu_14_4h_lt_80 | aroonu_14_1d_lt_100 | (roc_9_4h_lt_10))
             # 4h & 1d high, 1d downtrend
-            & (aroonu_14_4h_lt_80 | aroonu_14_1d_lt_100 | (roc_9_1d > -20.0))
+            & (aroonu_14_4h_lt_80 | aroonu_14_1d_lt_100 | (roc_9_1d_gt_neg_20))
             # 1d high, 4h & 1d downtrend
             & ((aroonu_14_1d_lt_80) | (roc_9_4h_gt_neg_20) | (roc_9_1d_gt_neg_20))
             # 1d high, 1h & 4h downtrend
@@ -15381,7 +15381,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h still high, 4h downtrend
             & ((rsi_3_1h_gt_15) | (aroonu_14_1h_lt_40) | (roc_9_4h_gt_neg_30))
             # 1h down move, 1d high, 4h downtrend
-            & ((rsi_3_1h_gt_15) | (aroonu_14_1d_lt_90) | (roc_9_4h > -20.0))
+            & ((rsi_3_1h_gt_15) | (aroonu_14_1d_lt_90) | (roc_9_4h_gt_neg_20))
             # 1h down move, 1d high & overbought
             & ((rsi_3_1h_gt_15) | (stochrsi_k_1d_lt_90) | (roc_9_1d_lt_40))
             # 1h down move, 1h still high, 4h downtrend
@@ -15612,7 +15612,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 4h still high
             & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_45) | (stochrsi_k_4h_lt_40))
             # 1h down move, 4h downtrend. 4h still not low enough
-            & ((rsi_3_1h_gt_10) | (roc_9_4h > -20.0) | (aroonu_14_4h_lt_30))
+            & ((rsi_3_1h_gt_10) | (roc_9_4h_gt_neg_20) | (aroonu_14_4h_lt_30))
             # 1h down move, 15m still high, 4h high
             & ((rsi_3_1h_gt_10) | (aroonu_14_15m_lt_40) | (stochrsi_k_4h_lt_90))
             # 1h down move, 15m high, 4h downtrend
@@ -15642,7 +15642,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 4h high, 1d high
             & ((rsi_3_1h_gt_15) | (aroonu_14_4h_lt_80) | (stochrsi_k_1d_lt_80))
             # 1h down move, 1d high, 1d downtrend
-            & ((rsi_3_1h_gt_15) | (aroonu_14_1d_lt_70) | (roc_9_1d > -20.0))
+            & ((rsi_3_1h_gt_15) | (aroonu_14_1d_lt_70) | (roc_9_1d_gt_neg_20))
             # 1h down move, 1d high, 4h overbought
             & ((rsi_3_1h_gt_15) | (aroonu_14_1d_lt_100) | (roc_9_4h_lt_60))
             # 1h down move, 1d high & overbought
@@ -15694,7 +15694,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h high, 1d downtrend
             & ((rsi_3_1h_gt_35) | (aroonu_14_1h_lt_70) | (roc_9_1d_gt_neg_25))
             # 1h down move, 1h high, 4h downtrend
-            & ((rsi_3_1h_gt_35) | (aroonu_14_1h_lt_80) | (roc_9_4h > -20.0))
+            & ((rsi_3_1h_gt_35) | (aroonu_14_1h_lt_80) | (roc_9_4h_gt_neg_20))
             # 1h down move, 1h still high, 1d overbought
             & ((rsi_3_1h_gt_35) | (stochrsi_k_1h_lt_50) | (roc_9_1d_lt_200))
             # 1h down move, 15m high, 1h high
@@ -15756,17 +15756,17 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 15m high
             & ((rsi_3_4h_gt_10) | (stochrsi_k_15m_lt_80))
             # 4h down move, 1h high, 1d downtrend
-            & ((rsi_3_4h_gt_10) | (stochrsi_k_1h_lt_70) | (roc_9_1d > -20.0))
+            & ((rsi_3_4h_gt_10) | (stochrsi_k_1h_lt_70) | (roc_9_1d_gt_neg_20))
             # 4h down move, 4h still high, 1d downtrend
-            & ((rsi_3_4h_gt_10) | (stochrsi_k_4h_lt_40) | (roc_9_1d > -20.0))
+            & ((rsi_3_4h_gt_10) | (stochrsi_k_4h_lt_40) | (roc_9_1d_gt_neg_20))
             # 4h down move, 4h downtrend, 1d overbought
-            & ((rsi_3_4h_gt_10) | (roc_9_4h > -20.0) | (roc_9_1d_lt_40))
+            & ((rsi_3_4h_gt_10) | (roc_9_4h_gt_neg_20) | (roc_9_1d_lt_40))
             # 4h & 1d down move, 4h downtrend
             & ((rsi_3_4h_gt_15) | (rsi_3_1d_gt_20) | (roc_9_4h_gt_neg_40))
             # 4h down move, 1h high, 1d downtrend
             & ((rsi_3_4h_gt_15) | (aroonu_14_1h_lt_90) | (roc_9_1d_gt_neg_10))
             # 4h down move, 4h still high, 1d downtrend
-            & ((rsi_3_4h_gt_15) | (stochrsi_k_4h_lt_50) | (roc_9_1d > -20.0))
+            & ((rsi_3_4h_gt_15) | (stochrsi_k_4h_lt_50) | (roc_9_1d_gt_neg_20))
             # 4h down move, 1h & 4h downtrend
             & ((rsi_3_4h_gt_15) | (roc_9_1h_gt_neg_30) | (roc_9_4h_gt_neg_30))
             # 4h & 1ddown move, 1d high
@@ -16307,7 +16307,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 15m still not low enough
             & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_40) | (stochrsi_k_15m_lt_30))
             # 1h down move, 1d high, 1d downtrend
-            & ((rsi_3_1h_gt_10) | (aroonu_14_1d_lt_70) | (roc_9_1d > -20.0))
+            & ((rsi_3_1h_gt_10) | (aroonu_14_1d_lt_70) | (roc_9_1d_gt_neg_20))
             # 1h down move, 4h high, 1d downtrend
             & ((rsi_3_1h_gt_10) | (stochrsi_k_4h_lt_50) | (roc_9_1d_gt_neg_40))
             # 1h & 4h down move, 15m high
@@ -16323,7 +16323,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1d high & overbought
             & ((rsi_3_1h_gt_15) | (aroonu_14_1d_lt_80) | (roc_9_1d_lt_10))
             # 1h down move, 1d high, 4h downtrend
-            & ((rsi_3_1h_gt_15) | (aroonu_14_1d_lt_90) | (roc_9_4h > -20.0))
+            & ((rsi_3_1h_gt_15) | (aroonu_14_1d_lt_90) | (roc_9_4h_gt_neg_20))
             # 1h & 4h down move, 4h high
             & (rsi_3_1h_gt_20 | (rsi_3_4h_gt_35) | (stochrsi_k_4h_lt_70))
             # 1h & 1d down move, 1d high
@@ -16471,7 +16471,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 1d still high, 4h still not low enough
             & ((rsi_3_4h_gt_15) | (rsi_14_1d_lt_40) | (stochrsi_k_4h_lt_30))
             # 4h down move, 4h still not low enough, 1d downtrend
-            & ((rsi_3_4h_gt_15) | (stochrsi_k_4h_lt_20) | (roc_9_1d > -20.0))
+            & ((rsi_3_4h_gt_15) | (stochrsi_k_4h_lt_20) | (roc_9_1d_gt_neg_20))
             # 4h down move, 1h & 4h downtrend
             & ((rsi_3_4h_gt_15) | (roc_9_1h_gt_neg_30) | (roc_9_4h_gt_neg_30))
             # 4h & 1d down move, 1d high
@@ -16902,7 +16902,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 4h high
             & ((rsi_3_15m_gt_3) | (rsi_3_1h_gt_10) | (stochrsi_k_4h_lt_60))
             # 15m & 1h down move, 1d downtrend
-            & ((rsi_3_15m_gt_3) | (rsi_3_1h_gt_15) | (roc_9_1d > -20.0))
+            & ((rsi_3_15m_gt_3) | (rsi_3_1h_gt_15) | (roc_9_1d_gt_neg_20))
             # 15m & 1h down move, 1h still high
             & ((rsi_3_15m_gt_3) | rsi_3_1h_gt_20 | (aroonu_14_1h_lt_50))
             # 15m & 1h down move, 1h high
@@ -16954,7 +16954,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 4h down move, 1h still high
             & ((rsi_3_15m_gt_5) | (rsi_3_4h_gt_5) | (stochrsi_k_1h_lt_50))
             # 15m & 4h down move, 1d downtrend
-            & ((rsi_3_15m_gt_5) | (rsi_3_4h_gt_10) | (roc_9_1d > -20.0))
+            & ((rsi_3_15m_gt_5) | (rsi_3_4h_gt_10) | (roc_9_1d_gt_neg_20))
             # 15m & 4h down move, 1h high
             & ((rsi_3_15m_gt_5) | rsi_3_4h_gt_20 | (stochrsi_k_1h_lt_80))
             # 15m & 4h down move, 1d downtrend
@@ -17140,7 +17140,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1d high, 4h downtrend
             & ((rsi_3_1h_gt_5) | (aroonu_14_1d_lt_90) | (roc_9_4h_gt_neg_30))
             # 1h down move, 1d high, 1d downtrend
-            & ((rsi_3_1h_gt_5) | (aroonu_14_1d_lt_100) | (roc_9_1d > -20.0))
+            & ((rsi_3_1h_gt_5) | (aroonu_14_1d_lt_100) | (roc_9_1d_gt_neg_20))
             # 1h down move, 1d high & overbought
             & ((rsi_3_1h_gt_5) | (aroonu_14_1d_lt_100) | (roc_9_1d_lt_20))
             # 1h down move, 4h still high, 1d downtrend
@@ -17160,7 +17160,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 4h downtrend
             & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_10) | (roc_9_4h_gt_neg_35))
             # 1h & 4h down move, 1d downtrend
-            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_10) | (roc_9_1d > -20.0))
+            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_10) | (roc_9_1d_gt_neg_20))
             # 1h & 4h down move, 15m downtrend
             & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_15) | (roc_9_15m > -20.0))
             # 1h & 4h down move, 4h still high
@@ -17384,7 +17384,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 4h still high, 1d overbought
             & ((rsi_3_4h_gt_15) | (aroonu_14_4h_lt_40) | (roc_9_1d_lt_40))
             # 4h down move, 1h still not low enough, 1d downtrend
-            & ((rsi_3_4h_gt_15) | (stochrsi_k_1h_lt_20) | (roc_9_1d > -20.0))
+            & ((rsi_3_4h_gt_15) | (stochrsi_k_1h_lt_20) | (roc_9_1d_gt_neg_20))
             # 4h & 1d down move, 1d high
             & (rsi_3_4h_gt_20 | (rsi_3_1d_gt_20) | (stochrsi_k_1d_lt_70))
             # 4h down move, 1d high & overbought
@@ -17646,9 +17646,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 1d high
             & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_10) | (stochrsi_k_1d_lt_80))
             # 1h & 4h down move, 4h downtrend
-            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_10) | (roc_9_4h > -20.0))
+            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_10) | (roc_9_4h_gt_neg_20))
             # 1h & 4h down move, 1d downtrend
-            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_10) | (roc_9_1d > -20.0))
+            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_10) | (roc_9_1d_gt_neg_20))
             # 1h & 4h down move, 1d overbought
             & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_10) | (roc_9_1d_lt_10))
             # 1h & 4h down move, 1d high
@@ -17680,7 +17680,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h downtrend, 1h high
             & ((rsi_3_1h_gt_10) | (cmf_20_1h_gt_neg_0_30) | (aroonu_14_1h_lt_70))
             # 1h down move, 1h high, 1d downtrend
-            & ((rsi_3_1h_gt_10) | (aroonu_14_1h_lt_40) | (roc_9_1d > -20.0))
+            & ((rsi_3_1h_gt_10) | (aroonu_14_1h_lt_40) | (roc_9_1d_gt_neg_20))
             # 1h down move, 1h & 4h high
             & ((rsi_3_1h_gt_10) | (aroonu_14_1h_lt_60) | aroonu_14_4h_lt_70)
             # 1h down move, 1h high, 1d overbought
@@ -17688,15 +17688,15 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 4h still high, 1d downtrend
             & ((rsi_3_1h_gt_10) | (aroonu_14_4h_lt_40) | (roc_9_1d_gt_neg_40))
             # 1h down move, 4h high, 1d downtrend
-            & ((rsi_3_1h_gt_10) | aroonu_14_4h_lt_70 | (roc_9_1d > -20.0))
+            & ((rsi_3_1h_gt_10) | aroonu_14_4h_lt_70 | (roc_9_1d_gt_neg_20))
             # 1h down move, 1d still high, 1d downtrend
-            & ((rsi_3_1h_gt_10) | (aroonu_14_1d_lt_40) | (roc_9_1d > -20.0))
+            & ((rsi_3_1h_gt_10) | (aroonu_14_1d_lt_40) | (roc_9_1d_gt_neg_20))
             # 1h down move, 1d high & overbought
             & ((rsi_3_1h_gt_10) | (aroonu_14_1d_lt_90) | (roc_9_1d_lt_30))
             # 1h down move, 15m high
             & ((rsi_3_1h_gt_10) | (stochrsi_k_15m_lt_80))
             # 1h down move, 4h & 1d downtrend
-            & ((rsi_3_1h_gt_10) | (roc_9_4h > -20.0) | (roc_9_1d_gt_neg_40))
+            & ((rsi_3_1h_gt_10) | (roc_9_4h_gt_neg_20) | (roc_9_1d_gt_neg_40))
             # 1h & 4h down move, 1d still high, 1d downtrend
             & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_15) | (rsi_14_1d_lt_40) | (roc_9_1d_gt_neg_15))
             # 1h & 4h down move, 4h still high
@@ -17726,15 +17726,15 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h still high, 1d downtrend
             & ((rsi_3_1h_gt_15) | (aroonu_14_1h_lt_50) | (roc_9_1d_gt_neg_40))
             # 1h down move, 1d still high, 4h downtrend
-            & ((rsi_3_1h_gt_15) | (aroonu_14_1d_lt_50) | (roc_9_4h > -20.0))
+            & ((rsi_3_1h_gt_15) | (aroonu_14_1d_lt_50) | (roc_9_4h_gt_neg_20))
             # 1h down move, 1d high, 1d downtrend
-            & ((rsi_3_1h_gt_15) | (aroonu_14_1d_lt_80) | (roc_9_1d > -20.0))
+            & ((rsi_3_1h_gt_15) | (aroonu_14_1d_lt_80) | (roc_9_1d_gt_neg_20))
             # 1h down move, 1d high & overbought
             & ((rsi_3_1h_gt_15) | (aroonu_14_1d_lt_80) | (roc_9_1d_lt_30))
             # 1h down move, 4h still high, 1d downtrend
             & ((rsi_3_1h_gt_15) | (stochrsi_k_4h_lt_50) | (roc_9_1d > -30.0))
             # 1h down move, 4h & 1d downtrend
-            & ((rsi_3_1h_gt_15) | (roc_9_4h > -20.0) | (roc_9_1d > -20.0))
+            & ((rsi_3_1h_gt_15) | (roc_9_4h_gt_neg_20) | (roc_9_1d_gt_neg_20))
             # 1h & 4h down move, 1h high
             & ((rsi_3_1h_gt_20) | (rsi_3_4h_gt_20) | (aroonu_14_1h_lt_70))
             # 1h & 4h down move, 1d overbought
@@ -17756,7 +17756,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h high, 1d overbought
             & ((rsi_3_1h_gt_20) | (aroonu_14_1h_lt_60) | (roc_9_1d_lt_30))
             # 1h down move, 1h high, 4h downtrend
-            & ((rsi_3_1h_gt_20) | (aroonu_14_1h_lt_70) | (roc_9_4h > -20.0))
+            & ((rsi_3_1h_gt_20) | (aroonu_14_1h_lt_70) | (roc_9_4h_gt_neg_20))
             # 1h down move, 1d high & overbought
             & ((rsi_3_1h_gt_20) | (aroonu_14_1d_lt_100) | (roc_9_1d_lt_30))
             # 1h down move, 1d high, 4h downtrend
@@ -17868,13 +17868,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h & 1d down move, 15m still not low enough
             & ((rsi_3_4h_gt_10) | (rsi_3_1d_gt_10) | (aroonu_14_15m_lt_30))
             # 4h & 1d down move, 1d downtrend
-            & ((rsi_3_4h_gt_10) | (rsi_3_1d_gt_10) | (roc_9_1d > -20.0))
+            & ((rsi_3_4h_gt_10) | (rsi_3_1d_gt_10) | (roc_9_1d_gt_neg_20))
             # 15m & 1d down move, 15m still high
             & ((rsi_3_4h_gt_10) | (rsi_3_1d_gt_15) | (stochrsi_k_15m_lt_50))
             # 4h & 1d down move, 4d & 1d downtrend
-            & ((rsi_3_4h_gt_10) | (rsi_3_1d_gt_30) | (roc_9_4h_gt_neg_10) | (roc_9_1d > -20.0))
+            & ((rsi_3_4h_gt_10) | (rsi_3_1d_gt_30) | (roc_9_4h_gt_neg_10) | (roc_9_1d_gt_neg_20))
             # 4h & 1d down move, 4h downtrend
-            & ((rsi_3_4h_gt_10) | (rsi_3_1d_gt_30) | (roc_9_4h > -20.0))
+            & ((rsi_3_4h_gt_10) | (rsi_3_1d_gt_30) | (roc_9_4h_gt_neg_20))
             # 4h & 1d down move, 1d overbought
             & ((rsi_3_4h_gt_10) | (rsi_3_1d_gt_45) | (roc_9_1d_lt_10))
             # 4h & 1d down move, 4h still not low enough
@@ -17884,11 +17884,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 15m high
             & ((rsi_3_4h_gt_10) | (stochrsi_k_15m_lt_80))
             # 4h down move, 4h still not low e nough, 1d downtrend
-            & ((rsi_3_4h_gt_10) | (stochrsi_k_4h_lt_30) | (roc_9_1d > -20.0))
+            & ((rsi_3_4h_gt_10) | (stochrsi_k_4h_lt_30) | (roc_9_1d_gt_neg_20))
             # 4h down move, 4h still high, 1d high
             & ((rsi_3_4h_gt_10) | (stochrsi_k_4h_lt_40) | (aroonu_14_1d_lt_80))
             # 4h down move, 4h & 1d downtrend
-            & ((rsi_3_4h_gt_10) | (roc_9_4h > -20.0) | (roc_9_1d_gt_neg_40))
+            & ((rsi_3_4h_gt_10) | (roc_9_4h_gt_neg_20) | (roc_9_1d_gt_neg_40))
             # 4h & 1d down move, 1d downtrend
             & ((rsi_3_4h_gt_15) | (rsi_3_1d_gt_15) | (roc_9_1d > -30.0))
             # 4h & 1d down move, 1d still high
@@ -17908,11 +17908,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 1h high, 1d downtrend
             & ((rsi_3_4h_gt_15) | (aroonu_14_1h_lt_90) | (roc_9_1d > -30.0))
             # 4h down move, 4h still high, 4h downtrend
-            & ((rsi_3_4h_gt_15) | (aroonu_14_4h_lt_40) | (roc_9_4h > -20.0))
+            & ((rsi_3_4h_gt_15) | (aroonu_14_4h_lt_40) | (roc_9_4h_gt_neg_20))
             # 4h down move, 4h still high, 1d high
             & ((rsi_3_4h_gt_15) | (aroonu_14_4h_lt_50) | (aroonu_14_1d_lt_70))
             # 4h down move, 4h still high, 1d downtrend
-            & ((rsi_3_4h_gt_15) | (aroonu_14_4h_lt_50) | (roc_9_1d > -20.0))
+            & ((rsi_3_4h_gt_15) | (aroonu_14_4h_lt_50) | (roc_9_1d_gt_neg_20))
             # 4h down move, 1h & 4h downtrend
             & ((rsi_3_4h_gt_15) | (roc_9_1h_gt_neg_40) | (roc_9_4h_gt_neg_40))
             # 4h & 1d down move, 1d high
@@ -17950,7 +17950,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 1d high & overbought
             & ((rsi_3_4h_gt_25) | (aroonu_14_1d_lt_80) | (roc_9_1d_lt_30))
             # 4h down move, 1d high, 4h downtrend
-            & ((rsi_3_4h_gt_25) | aroonu_14_1d_lt_100 | (roc_9_4h > -20.0))
+            & ((rsi_3_4h_gt_25) | aroonu_14_1d_lt_100 | (roc_9_4h_gt_neg_20))
             # 4h down move, 4h still high, 1d downtrend
             & ((rsi_3_4h_gt_25) | (stochrsi_k_4h_lt_40) | (roc_9_1d_gt_neg_30))
             # 4h down move, 4h high, 1d downtrend
@@ -17972,7 +17972,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 1h high
             & ((rsi_3_4h_gt_35) | aroonu_14_1h_lt_70)
             # 4h down move, 4h high, 1d downtrend
-            & ((rsi_3_4h_gt_35) | aroonu_14_4h_lt_80 | (roc_9_1d > -20.0))
+            & ((rsi_3_4h_gt_35) | aroonu_14_4h_lt_80 | (roc_9_1d_gt_neg_20))
             # 4h down move, 4h high, 1d overbought
             & ((rsi_3_4h_gt_35) | aroonu_14_4h_lt_80 | (roc_9_1d_lt_30))
             # 4h down move, 1d high & overbought
@@ -18201,7 +18201,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 1d high
             & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_15) | (stochrsi_k_1d_lt_90))
             # 15m & 1h down move, 4h downtrend
-            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_15) | (roc_9_4h > -20.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_15) | (roc_9_4h_gt_neg_20))
             # 15m & 1h down move, 1d downtrend
             & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_15) | (roc_9_1d_gt_neg_40))
             # 15m & 1h down move, 15m still high
@@ -18235,7 +18235,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 4h down move, 1h high
             & ((rsi_3_15m_gt_10) | (rsi_3_4h_gt_15) | (stochrsi_k_1h_lt_90))
             # 15m & 4h down move, 1d downtrend
-            & ((rsi_3_15m_gt_10) | (rsi_3_4h_gt_15) | (roc_9_1d > -20.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_4h_gt_15) | (roc_9_1d_gt_neg_20))
             # 15m & 4h down move, 4h still high
             & ((rsi_3_15m_gt_10) | (rsi_3_4h_gt_40) | (aroonu_14_4h_lt_50))
             # 15m & 4h down move, 4h high
@@ -18349,7 +18349,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h & 1d down move
             & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_10) | (rsi_3_1d_gt_15))
             # 1h & 4h down move, 1d downtrend
-            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_10) | (roc_9_1d > -20.0))
+            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_10) | (roc_9_1d_gt_neg_20))
             # 1h & 4h down move, 1h high
             & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_15) | (aroonu_14_1h_lt_60))
             # 1h & 4h down move, 1d high
@@ -18365,7 +18365,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h high, 4h overbought
             & ((rsi_3_1h_gt_10) | (aroonu_14_1h_lt_80) | (roc_9_4h_lt_10))
             # 1h down move, 1d high, 1d downtrend
-            & ((rsi_3_1h_gt_10) | (aroonu_14_1d_lt_70) | (roc_9_1d > -20.0))
+            & ((rsi_3_1h_gt_10) | (aroonu_14_1d_lt_70) | (roc_9_1d_gt_neg_20))
             # 1h down move, 4h high, 1d downtrend
             & ((rsi_3_1h_gt_10) | (stochrsi_k_4h_lt_60) | (roc_9_1d > -30.0))
             # 1h & 4h down move, 1h still not low enough
@@ -18481,7 +18481,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 1h & 4h downtrend
             & ((rsi_3_4h_gt_5) | (roc_9_1h_gt_neg_10) | (roc_9_4h_gt_neg_10))
             # 4h & 1d down move, 4h downtrend
-            & ((rsi_3_4h_gt_10) | (rsi_3_1d_gt_10) | (roc_9_4h > -20.0))
+            & ((rsi_3_4h_gt_10) | (rsi_3_1d_gt_10) | (roc_9_4h_gt_neg_20))
             # 4h & 1d down move, 1d downtrend
             & ((rsi_3_4h_gt_10) | (rsi_3_1d_gt_10) | (roc_9_1d > -30.0))
             # 4h down move, 4h still high
@@ -18489,15 +18489,15 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 1d still high, 1d downtrend
             & ((rsi_3_4h_gt_10) | (aroonu_14_1d_lt_50) | (roc_9_1d > -30.0))
             # 4h down move, 4h still not low enough, 1d downtrend
-            & ((rsi_3_4h_gt_10) | (stochrsi_k_4h_lt_30) | (roc_9_1d > -20.0))
+            & ((rsi_3_4h_gt_10) | (stochrsi_k_4h_lt_30) | (roc_9_1d_gt_neg_20))
             # 4h down move, 4h & 1d  downtrend
-            & ((rsi_3_4h_gt_10) | (roc_9_4h > -20.0) | (roc_9_1d > -30.0))
+            & ((rsi_3_4h_gt_10) | (roc_9_4h_gt_neg_20) | (roc_9_1d > -30.0))
             # 4h down move, 1h still high
             & ((rsi_3_4h_gt_15) | (aroonu_14_1h_lt_50))
             # 4h down move, 1h still high, 1d downtrend
             & ((rsi_3_4h_gt_15) | (stochrsi_k_1h_lt_50) | (roc_9_1d > -30.0))
             # 4h down move, 4h still high, 1d downtrend
-            & ((rsi_3_4h_gt_15) | (stochrsi_k_4h_lt_50) | (roc_9_1d > -20.0))
+            & ((rsi_3_4h_gt_15) | (stochrsi_k_4h_lt_50) | (roc_9_1d_gt_neg_20))
             # 4h down move, 4h still high, 1d downtrend
             & (rsi_3_4h_gt_20 | (aroonu_14_4h_lt_50) | (roc_9_1d_gt_neg_40))
             # 4h down move, 1d high & overbought
@@ -18527,7 +18527,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h still high, 4h & 1d downtrend
             & ((aroonu_14_1h_lt_40) | (roc_9_4h_gt_neg_20) | (roc_9_1d_gt_neg_40))
             # 1h & 4h high, 1d downtrend
-            & (aroonu_14_1h_lt_70 | aroonu_14_4h_lt_100 | (roc_9_1d > -20.0))
+            & (aroonu_14_1h_lt_70 | aroonu_14_4h_lt_100 | (roc_9_1d_gt_neg_20))
             # 1h & 4h high, 1d overbought
             & (aroonu_14_1h_lt_70 | aroonu_14_4h_lt_100 | (roc_9_1d_lt_20))
             # 1h & 1d high, 1d overbought
@@ -18690,7 +18690,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1d overbought
             & ((rsi_3_1h_gt_5) | (roc_9_1d_lt_100))
             # 1h & 4h down move, 1d downtrend
-            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_10) | (roc_9_1d > -20.0))
+            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_10) | (roc_9_1d_gt_neg_20))
             # 1h & 4h down move, 4h still high
             & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_15) | (rsi_14_4h_lt_40))
             # 1h & 4h down move, 1h still high
@@ -18778,7 +18778,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h & 1d high
             & ((rsi_3_1h_gt_25) | (aroonu_14_1h_lt_70) | (aroonu_14_1d_lt_80))
             # 1h down move, 4h high, 1d downtrend
-            & ((rsi_3_1h_gt_25) | (aroonu_14_4h_lt_80) | (roc_9_1d > -20.0))
+            & ((rsi_3_1h_gt_25) | (aroonu_14_4h_lt_80) | (roc_9_1d_gt_neg_20))
             # 1h down move, 1d high & overbought
             & ((rsi_3_1h_gt_25) | (aroonu_14_1d_lt_90) | (roc_9_1d_lt_100))
             # 1h down move, 1h still high, 1d overbought
@@ -18806,7 +18806,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h & 1d down move, 1d high
             & ((rsi_3_4h_gt_10) | (rsi_3_1d_gt_20) | (aroonu_14_1d_lt_80))
             # 4h down move, 1d high, 4h downtrend
-            & ((rsi_3_4h_gt_10) | (aroonu_14_1d_lt_90) | (roc_9_4h > -20.0))
+            & ((rsi_3_4h_gt_10) | (aroonu_14_1d_lt_90) | (roc_9_4h_gt_neg_20))
             # 4h down move, 1h & 4h downtrend
             & ((rsi_3_4h_gt_10) | (roc_9_1h_gt_neg_30) | (roc_9_4h_gt_neg_30))
             # 4h down move, 4h still not low enough, 1d overbought
@@ -18844,7 +18844,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h high, 1d overbought
             & (aroonu_14_1h_lt_70 | aroonu_14_4h_lt_100 | (roc_9_1d_lt_20))
             # 1h high, 4h & 1d downtrend
-            & (aroonu_14_1h_lt_70 | (roc_9_4h > -20.0) | roc_9_1d_gt_neg_50)
+            & (aroonu_14_1h_lt_70 | (roc_9_4h_gt_neg_20) | roc_9_1d_gt_neg_50)
             # 1h high, 4h downtrend
             & (aroonu_14_1h_lt_70 | (roc_9_4h_gt_neg_40))
             # 1h & 1d high, 1d overbought
@@ -19022,7 +19022,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h still high
             & ((rsi_3_1h_gt_15) | (aroonu_14_1h_lt_50))
             # 1h down move, 1d high, 4h downtrend
-            & ((rsi_3_1h_gt_15) | (aroonu_14_1d_lt_70) | (roc_9_4h > -20.0))
+            & ((rsi_3_1h_gt_15) | (aroonu_14_1d_lt_70) | (roc_9_4h_gt_neg_20))
             # 1h down move, 1h still high
             & ((rsi_3_1h_gt_15) | (stochrsi_k_1h_lt_30))
             # 1h & 4h down move, 1d overbought
@@ -19064,9 +19064,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h downmove, 4h still high
             & ((rsi_3_4h_gt_10) | (aroonu_14_4h_lt_40))
             # 4h down move, 1h still high, 1d downtrend
-            & ((rsi_3_4h_gt_10) | (stochrsi_k_1h_lt_40) | (roc_9_1d > -20.0))
+            & ((rsi_3_4h_gt_10) | (stochrsi_k_1h_lt_40) | (roc_9_1d_gt_neg_20))
             # 4h down move, 1h & 1d downtrend
-            & ((rsi_3_4h_gt_10) | (roc_9_1h_gt_neg_20) | (roc_9_1d > -20.0))
+            & ((rsi_3_4h_gt_10) | (roc_9_1h_gt_neg_20) | (roc_9_1d_gt_neg_20))
             # 4h & 1d down move, 1d still high
             & ((rsi_3_4h_gt_15) | (rsi_3_1d_gt_35) | (rsi_14_1d_lt_50))
             # 4h down move, 1h still not low enough
@@ -19199,7 +19199,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 4h down move, 1d high
             & ((rsi_3_15m_gt_10) | (rsi_3_4h_gt_15) | (stochrsi_k_1d_lt_90))
             # 15m & 4h down move, 4h downtrend
-            & ((rsi_3_15m_gt_10) | (rsi_3_4h_gt_15) | (roc_9_4h > -20.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_4h_gt_15) | (roc_9_4h_gt_neg_20))
             # 15m & 4h down move, 4h still high
             & ((rsi_3_15m_gt_10) | (rsi_3_4h_gt_20) | (aroonu_14_4h_lt_50))
             # 15m & 4h down move, 4h still not low enough
@@ -19293,7 +19293,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h still high, 1d overbought
             & ((rsi_3_1h_gt_15) | (aroonu_14_1h_lt_40) | roc_9_1d_lt_50)
             # 1h down move, 1d high, 4h downtrend
-            & ((rsi_3_1h_gt_15) | (aroonu_14_1d_lt_70) | (roc_9_4h > -20.0))
+            & ((rsi_3_1h_gt_15) | (aroonu_14_1d_lt_70) | (roc_9_4h_gt_neg_20))
             # 1h down move, 1d high & overbought
             & ((rsi_3_1h_gt_15) | (aroonu_14_1d_lt_80) | (roc_9_1d_lt_30))
             # 1h down move, 4h high
@@ -19617,7 +19617,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1d high, 4h downtrend
             & ((rsi_3_1h_gt_5) | (aroonu_14_1d_lt_90) | (roc_9_4h_gt_neg_30))
             # 1h down move, 1d high, 1d downtrend
-            & ((rsi_3_1h_gt_5) | aroonu_14_1d_lt_100 | (roc_9_1d > -20.0))
+            & ((rsi_3_1h_gt_5) | aroonu_14_1d_lt_100 | (roc_9_1d_gt_neg_20))
             # 1h & 4h down move, 1h still not low enough
             & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_10) | (stochrsi_k_1h_lt_20))
             # 1h & 4h down move, 15m downtrend
@@ -19719,7 +19719,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 1d high & overbought
             & (rsi_3_4h_gt_20 | (aroonu_14_1d_lt_80) | roc_9_1d_lt_50)
             # 4h down move, 1h still not low enough, 1d downtrend
-            & ((rsi_3_4h_gt_15) | (stochrsi_k_1h_lt_20) | (roc_9_1d > -20.0))
+            & ((rsi_3_4h_gt_15) | (stochrsi_k_1h_lt_20) | (roc_9_1d_gt_neg_20))
             # 4h down move, 4h still high, 1d downtrend
             & (rsi_3_4h_gt_20 | (stochrsi_k_4h_lt_40) | (roc_9_1d_gt_neg_20))
             # 4h down move, 4h still high, 1d downtrend
@@ -19842,7 +19842,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 4h still high
             & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_10) | (stochrsi_k_4h_lt_40))
             # 15m & 1h down move, 1d downtrend
-            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_10) | (roc_9_1d > -20.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_10) | (roc_9_1d_gt_neg_20))
             # 15m & 1h down move, 15m high
             & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_10) | (aroonu_14_15m_lt_70))
             # 15m & 1h down move, 1h still not low enough
@@ -19934,7 +19934,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 1h downtrend
             & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_10) | (roc_9_1h_gt_neg_20))
             # 1h & 4h down move, 1d downtrend
-            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_10) | (roc_9_1d > -20.0))
+            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_10) | (roc_9_1d_gt_neg_20))
             # 1h & 4h down move, 1d overbought
             & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_10) | (roc_9_1d_lt_10))
             # 1h & 4h down move, 4h still high
@@ -19968,7 +19968,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 4h high, 1d overbought
             & ((rsi_3_1h_gt_15) | aroonu_14_4h_lt_70 | (roc_9_1d_lt_100))
             # 1h down move, 1d high, 4h downtrend
-            & ((rsi_3_1h_gt_15) | (aroonu_14_1d_lt_90) | (roc_9_4h > -20.0))
+            & ((rsi_3_1h_gt_15) | (aroonu_14_1d_lt_90) | (roc_9_4h_gt_neg_20))
             # 1h & 4h down move, 4h & 1d still not low enough, 15m still not low enough
             & (rsi_3_1h_gt_20 | (rsi_3_4h_gt_20) | (rsi_14_4h_lt_30) | (rsi_14_1d < 30.0) | (stochrsi_k_15m_lt_30))
             # 1h & 4h down move, 1d high
@@ -20054,7 +20054,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h & 1d down move, 1d high
             & ((rsi_3_4h_gt_5) | (rsi_3_1d_gt_30) | (aroonu_14_1d_lt_70))
             # 4h down move, 1h high, 4h downtrend
-            & ((rsi_3_4h_gt_5) | aroonu_14_1h_lt_70 | (roc_9_4h > -20.0))
+            & ((rsi_3_4h_gt_5) | aroonu_14_1h_lt_70 | (roc_9_4h_gt_neg_20))
             # 4h down move, 4h high
             & ((rsi_3_4h_gt_5) | (aroonu_14_4h_lt_60))
             # 4h & 1d down move, 1d still not low enough
@@ -20064,13 +20064,13 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 1d still high, 1d downtrend
             & ((rsi_3_4h_gt_15) | (rsi_14_1d_lt_40) | (roc_9_1d_gt_neg_15))
             # 4h down move, 1h downtrend, 1d downtrend
-            & ((rsi_3_4h_gt_15) | (cmf_20_1h_gt_neg_0_40) | (roc_9_1d > -20.0))
+            & ((rsi_3_4h_gt_15) | (cmf_20_1h_gt_neg_0_40) | (roc_9_1d_gt_neg_20))
             # 4h down move, 15m high, 1d overbought
             & ((rsi_3_4h_gt_15) | (aroonu_14_15m_lt_70) | (roc_9_1d_lt_100))
             # 4h down move, 4h still high, 4h downtrend
-            & ((rsi_3_4h_gt_15) | (aroonu_14_4h_lt_40) | (roc_9_4h > -20.0))
+            & ((rsi_3_4h_gt_15) | (aroonu_14_4h_lt_40) | (roc_9_4h_gt_neg_20))
             # 4h down move, 15m still not low enough, 1d downtrend
-            & ((rsi_3_4h_gt_15) | (stochrsi_k_15m_lt_30) | (roc_9_1d > -20.0))
+            & ((rsi_3_4h_gt_15) | (stochrsi_k_15m_lt_30) | (roc_9_1d_gt_neg_20))
             # 4h down move, 1d high & overbought
             & ((rsi_3_4h_gt_15) | (stochrsi_k_1d_lt_90) | (roc_9_1d_lt_20))
             # 4h & 1d down move, 1d overbought
@@ -20188,7 +20188,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 4h down move, 4h still not low enough
             & ((rsi_3_15m_gt_10) | (rsi_3_4h_gt_15) | (stochrsi_k_4h_lt_30))
             # 15m & 4h down move, 1d downtrend
-            & ((rsi_3_15m_gt_10) | (rsi_3_4h_gt_15) | (roc_9_1d > -20.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_4h_gt_15) | (roc_9_1d_gt_neg_20))
             # 1h & 4h down move, 15m still high
             & ((rsi_3_15m_gt_10) | (rsi_3_4h_gt_30) | (aroonu_14_15m_lt_50))
             # 15m & 4h down move, 4h high
@@ -20316,7 +20316,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 4h still not low enough
             & ((rsi_3_1h_gt_5) | (rsi_3_4h_gt_10) | (aroonu_14_4h_lt_20))
             # 1h & 4h down move, 4h downtrend
-            & ((rsi_3_1h_gt_5) | (rsi_3_4h_gt_10) | (roc_9_4h > -20.0))
+            & ((rsi_3_1h_gt_5) | (rsi_3_4h_gt_10) | (roc_9_4h_gt_neg_20))
             # 1h & 4h down move, 4h still not low enough
             & ((rsi_3_1h_gt_5) | (rsi_3_4h_gt_15) | (aroonu_14_4h_lt_30))
             # 15m & 4h down move, 4h still not low enough, 15m still not low enough
@@ -20378,9 +20378,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h still high
             & ((rsi_3_1h_gt_15) | (aroonu_14_1h_lt_50))
             # 1h down move, 1d high, 4h downtrend
-            & ((rsi_3_1h_gt_15) | (aroonu_14_1d_lt_70) | (roc_9_4h > -20.0))
+            & ((rsi_3_1h_gt_15) | (aroonu_14_1d_lt_70) | (roc_9_4h_gt_neg_20))
             # 1h down move, 1d high, 1d downtrend
-            & ((rsi_3_1h_gt_15) | (aroonu_14_1d_lt_70) | (roc_9_1d > -20.0))
+            & ((rsi_3_1h_gt_15) | (aroonu_14_1d_lt_70) | (roc_9_1d_gt_neg_20))
             # 1h down move, 1d high & overbought
             & ((rsi_3_1h_gt_15) | (aroonu_14_1d_lt_90) | (roc_9_1d_lt_30))
             # 1h down move, 1h still high
@@ -20508,15 +20508,15 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 1d still high, 1d downtrend
             & ((rsi_3_4h_gt_10) | (aroonu_14_1d_lt_50) | (roc_9_1d > -30.0))
             # 4h down move, 1d high, 4h downtrend
-            & ((rsi_3_4h_gt_10) | (aroonu_14_1d_lt_85) | (roc_9_4h > -20.0))
+            & ((rsi_3_4h_gt_10) | (aroonu_14_1d_lt_85) | (roc_9_4h_gt_neg_20))
             # 4h down move, 15m high, 15m downtrend
             & ((rsi_3_4h_gt_10) | (stochrsi_k_15m_lt_60) | (roc_9_15m > -10.0))
             # 4h down move, 1h still high, 1d downtrend
-            & ((rsi_3_4h_gt_10) | (stochrsi_k_1h_lt_40) | (roc_9_1d > -20.0))
+            & ((rsi_3_4h_gt_10) | (stochrsi_k_1h_lt_40) | (roc_9_1d_gt_neg_20))
             # 4h down move, 1h high
             & ((rsi_3_4h_gt_10) | (stochrsi_k_1h_lt_70))
             # 4h down move, 4h still high, 1d downtrend
-            & ((rsi_3_4h_gt_10) | (stochrsi_k_4h_lt_40) | (roc_9_1d > -20.0))
+            & ((rsi_3_4h_gt_10) | (stochrsi_k_4h_lt_40) | (roc_9_1d_gt_neg_20))
             # 4h down move, 4h downtrend, 1d overbought
             & ((rsi_3_4h_gt_10) | (roc_9_4h_gt_neg_30) | (roc_9_1d_lt_40))
             # 4h & 1d down move, 1d high
@@ -20678,7 +20678,7 @@ class NostalgiaForInfinityX7(IStrategy):
           long_entry_logic.append(
             (close > (close_max_12 * 0.50))
             # 5m & 4h down move, 1d downtrend
-            & ((rsi_3_gt_5) | (rsi_3_4h_gt_10) | (roc_9_1d > -20.0))
+            & ((rsi_3_gt_5) | (rsi_3_4h_gt_10) | (roc_9_1d_gt_neg_20))
             # 5m & 4h down move, 15m still high
             & ((rsi_3_gt_5) | (rsi_3_4h_gt_25) | (stochrsi_k_15m_lt_50))
             # 5 & 15m down move, 1h high
@@ -20702,7 +20702,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 4h down move, 4h still not low enough
             & ((rsi_3_15m_gt_3) | (rsi_3_4h_gt_10) | (stochrsi_k_4h_lt_20))
             # 15m & 4h down move, 1d downtrend
-            & ((rsi_3_15m_gt_3) | (rsi_3_4h_gt_10) | (roc_9_1d > -20.0))
+            & ((rsi_3_15m_gt_3) | (rsi_3_4h_gt_10) | (roc_9_1d_gt_neg_20))
             # 15m & 4h down move, 4h still not low enough
             & ((rsi_3_15m_gt_3) | (rsi_3_4h_gt_25) | (aroonu_14_4h_lt_30))
             # 15m & 4h down move, 4h still not low enough
@@ -20886,7 +20886,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 15m still high
             & ((rsi_3_4h_gt_5) | (stochrsi_k_15m_lt_40))
             # 4h down move, 1d still high, 1d downtrend
-            & ((rsi_3_4h_gt_10) | (aroonu_14_1d_lt_40) | (roc_9_1d > -20.0))
+            & ((rsi_3_4h_gt_10) | (aroonu_14_1d_lt_40) | (roc_9_1d_gt_neg_20))
             # 4h down move, 15m 4h still high
             & ((rsi_3_4h_gt_10) | (stochrsi_k_15m_lt_40) | (aroonu_14_4h_lt_50))
             # 4h & 1d down move, 4h high
@@ -21239,7 +21239,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 4h still not low enough, 1d overbought
             & ((rsi_3_4h_gt_15) | (aroonu_14_4h_lt_30) | (roc_9_1d_lt_100))
             # 4h down move, 15m still high, 1d downtrend
-            & ((rsi_3_4h_gt_15) | (stochrsi_k_15m_lt_50) | (roc_9_1d > -20.0))
+            & ((rsi_3_4h_gt_15) | (stochrsi_k_15m_lt_50) | (roc_9_1d_gt_neg_20))
             # 4h & 1d down move, 15m still not low enough
             & (rsi_3_4h_gt_20 | (rsi_3_1d_gt_20) | (stochrsi_k_15m_lt_30))
             # 4h down move, 4h still not low enough, 1d downtrend
@@ -21406,7 +21406,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 4h still high
             & ((rsi_3_1h_gt_15) | rsi_3_4h_gt_20 | (aroonu_14_4h_lt_40))
             # 1h down move, 4h still high, 4h downtrend
-            & ((rsi_3_1h_gt_15) | (aroonu_14_4h_lt_50) | (roc_9_4h > -20.0))
+            & ((rsi_3_1h_gt_15) | (aroonu_14_4h_lt_50) | (roc_9_4h_gt_neg_20))
             # 1h down move, 15m still not low enough, 4h high
             & (rsi_3_1h_gt_20 | (aroonu_14_15m_lt_25) | aroonu_14_4h_lt_80)
             # 1h down move, 4h & 1d high
@@ -21545,7 +21545,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 5m & 4h & 1d down move
           long_entry_logic.append((rsi_3_gt_3) | rsi_3_4h_gt_20 | (rsi_3_1d_gt_20))
           # 5m & 4h down move, 1d downtrend
-          long_entry_logic.append((rsi_3_gt_5) | (rsi_3_4h_gt_10) | (roc_9_1d > -20.0))
+          long_entry_logic.append((rsi_3_gt_5) | (rsi_3_4h_gt_10) | (roc_9_1d_gt_neg_20))
           # 5m & 1h down move, 1h still high
           long_entry_logic.append((rsi_3_gt_5) | (rsi_3_1h_gt_30) | (stochrsi_k_1h_lt_50))
           # 15m & 4h & 1d down move
@@ -21711,7 +21711,7 @@ class NostalgiaForInfinityX7(IStrategy):
           # 4h down move, 1h downtrend, 1h still not low enough
           long_entry_logic.append((rsi_3_4h_gt_10) | (cmf_20_1h_gt_neg_0_25) | (aroonu_14_1h_lt_30))
           # 4h down move, 1h & 1d downtrend
-          long_entry_logic.append((rsi_3_4h_gt_10) | (roc_9_1h_gt_neg_20) | (roc_9_1d > -20.0))
+          long_entry_logic.append((rsi_3_4h_gt_10) | (roc_9_1h_gt_neg_20) | (roc_9_1d_gt_neg_20))
           # 4h & 1d down move, 4h still high
           long_entry_logic.append((rsi_3_4h_gt_15) | (rsi_3_1d_gt_45) | (stochrsi_k_4h_lt_40))
           # 4h & 1d down move, 1d high
@@ -21915,7 +21915,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 4h down move, 1d high
             & ((rsi_3_15m_gt_10) | (rsi_3_4h_gt_10) | (aroonu_14_1d_lt_80))
             # 15m & 4h down move, 1d downtrend
-            & ((rsi_3_15m_gt_10) | (rsi_3_4h_gt_10) | (roc_9_1d > -20.0))
+            & ((rsi_3_15m_gt_10) | (rsi_3_4h_gt_10) | (roc_9_1d_gt_neg_20))
             # 15m & 4h down move, 1d overbought
             & ((rsi_3_15m_gt_10) | (rsi_3_4h_gt_15) | (roc_9_1d_lt_20))
             # 15m & 4h down move, 1d high
@@ -22071,7 +22071,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 4h still high, 1d overbought
             & ((rsi_3_1h_gt_15) | (aroonu_14_4h_lt_50) | (roc_9_1d_lt_40))
             # 1h down move, 1d high, 4h downtrend
-            & ((rsi_3_1h_gt_15) | (aroonu_14_1d_lt_70) | (roc_9_4h > -20.0))
+            & ((rsi_3_1h_gt_15) | (aroonu_14_1d_lt_70) | (roc_9_4h_gt_neg_20))
             # 1h & 4h down move, 1d high
             & (rsi_3_1h_gt_20 | (rsi_3_4h_gt_25) | (aroonu_14_1d_lt_80))
             # 1h & 4h down move, 1d overbought
@@ -22133,7 +22133,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h & 1d down move, 1h high
             & ((rsi_3_4h_gt_10) | (rsi_3_1d_gt_10) | (stochrsi_k_1h_lt_60))
             # 4h & 1d down move, 4h downtrend
-            & ((rsi_3_4h_gt_10) | (rsi_3_1d_gt_10) | (roc_9_4h > -20.0))
+            & ((rsi_3_4h_gt_10) | (rsi_3_1d_gt_10) | (roc_9_4h_gt_neg_20))
             # 4h & 1d down move, 1d still high
             & ((rsi_3_4h_gt_10) | (rsi_3_1d_gt_15) | (aroonu_14_1d_lt_40))
             # 4h & 1d down move, 1d downtrend
@@ -22143,11 +22143,11 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 15m still high, 1h still high
             & ((rsi_3_4h_gt_10) | (aroonu_14_15m_lt_40) | (stochrsi_k_1h_lt_50))
             # 4h down move, 4h still high, 4h downtrend
-            & ((rsi_3_4h_gt_10) | (aroonu_14_4h_lt_40) | (roc_9_4h > -20.0))
+            & ((rsi_3_4h_gt_10) | (aroonu_14_4h_lt_40) | (roc_9_4h_gt_neg_20))
             # 4h down move, 15m high
             & ((rsi_3_4h_gt_10) | (stochrsi_k_15m_lt_80))
             # 4h down move, 1h still not low enough, 4h downtrend
-            & ((rsi_3_4h_gt_10) | (stochrsi_k_1h_lt_20) | (roc_9_4h > -20.0))
+            & ((rsi_3_4h_gt_10) | (stochrsi_k_1h_lt_20) | (roc_9_4h_gt_neg_20))
             # 4h & 1d down move, 15m still high
             & ((rsi_3_4h_gt_15) | (rsi_3_1d_gt_15) | (stochrsi_k_15m_lt_50))
             # 4h & 1d down move, 1h still high
@@ -22167,9 +22167,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 4h still high, 4h downtrend
             & ((rsi_3_4h_gt_15) | (aroonu_14_4h_lt_50) | (roc_9_4h_gt_neg_10))
             # 4h down move, 1d still high, 1d downtrend
-            & ((rsi_3_4h_gt_15) | (aroonu_14_1d_lt_50) | (roc_9_1d > -20.0))
+            & ((rsi_3_4h_gt_15) | (aroonu_14_1d_lt_50) | (roc_9_1d_gt_neg_20))
             # 4h down move, 4h still not low enough, 1d downtrend
-            & ((rsi_3_4h_gt_15) | (stochrsi_k_4h_lt_20) | (roc_9_1d > -20.0))
+            & ((rsi_3_4h_gt_15) | (stochrsi_k_4h_lt_20) | (roc_9_1d_gt_neg_20))
             # 4h down move, 1h downtrend, 1d overbought
             & ((rsi_3_4h_gt_15) | (roc_9_1h_gt_neg_10) | (roc_9_1d_lt_200))
             # 4h down move, 4h high, 4h downtrend
@@ -22288,7 +22288,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 1h down move, 1h high
             & (rsi_3_15m_gt_3 | (rsi_3_1h_gt_40) | (aroonu_14_1h_lt_75))
             # 15m & 4h down move, 1d downtrend
-            & (rsi_3_15m_gt_3 | (rsi_3_4h_gt_10) | (roc_9_1d > -20.0))
+            & (rsi_3_15m_gt_3 | (rsi_3_4h_gt_10) | (roc_9_1d_gt_neg_20))
             # 15m & 4h down move, 4h still high
             & (rsi_3_15m_gt_3 | (rsi_3_4h_gt_25) | (aroonu_14_4h_lt_40))
             # 15m down move, 1h high, 4h overbought
@@ -22386,7 +22386,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 4h down move, 15m high
             & ((rsi_3_15m_gt_15) | (rsi_3_4h_gt_15) | (aroonu_14_15m_lt_70))
             # 15m & 4h down move, 1d downtrend
-            & ((rsi_3_15m_gt_15) | (rsi_3_4h_gt_15) | (roc_9_1d > -20.0))
+            & ((rsi_3_15m_gt_15) | (rsi_3_4h_gt_15) | (roc_9_1d_gt_neg_20))
             # 15m & 4h down move, 1d overbought
             & ((rsi_3_15m_gt_15) | rsi_3_4h_gt_20 | roc_9_1d_lt_50)
             # 15m & 4h down move, 1h high
@@ -22552,9 +22552,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 1h still high, 1d downtrend
             & ((rsi_3_4h_gt_10) | (stochrsi_k_1h_lt_50) | (roc_9_1d > -30.0))
             # 4h down move, 1h high, 4h downtrend
-            & ((rsi_3_4h_gt_10) | (stochrsi_k_1h_lt_70) | (roc_9_4h > -20.0))
+            & ((rsi_3_4h_gt_10) | (stochrsi_k_1h_lt_70) | (roc_9_4h_gt_neg_20))
             # 4h down move, 4h & 1d downtrend
-            & ((rsi_3_4h_gt_10) | (roc_9_4h_gt_neg_15) | (roc_9_1d > -20.0))
+            & ((rsi_3_4h_gt_10) | (roc_9_4h_gt_neg_15) | (roc_9_1d_gt_neg_20))
             # 4h & 1d down move, 1d still high
             & ((rsi_3_4h_gt_15) | (rsi_3_1d_gt_15) | (aroonu_14_1d_lt_50))
             # 4h & 1d down move, 4h still high
@@ -22572,7 +22572,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 4h still high, 4h downtrend
             & ((rsi_3_4h_gt_15) | (aroonu_14_4h_lt_50) | (roc_9_4h_gt_neg_10))
             # 4h down move, 4h still not low enough, 1d downtrend
-            & ((rsi_3_4h_gt_15) | (stochrsi_k_4h_lt_20) | (roc_9_1d > -20.0))
+            & ((rsi_3_4h_gt_15) | (stochrsi_k_4h_lt_20) | (roc_9_1d_gt_neg_20))
             # 4h down move, 4h & 1d high
             & ((rsi_3_4h_gt_20) | (aroonu_14_4h_lt_70) | (aroonu_14_1d_lt_70))
             # 4h down move, 4h high
@@ -22737,7 +22737,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m & 4h down move, 1h still high
             & ((rsi_3_15m_gt_5) | (rsi_3_4h_gt_10) | (stochrsi_k_1h_lt_40))
             # 15m & 4h down move, 1d downtrend
-            & ((rsi_3_15m_gt_5) | (rsi_3_4h_gt_10) | (roc_9_1d > -20.0))
+            & ((rsi_3_15m_gt_5) | (rsi_3_4h_gt_10) | (roc_9_1d_gt_neg_20))
             # 15m & 1d down move, 1h still high
             & ((rsi_3_15m_gt_5) | (rsi_3_1d_gt_10) | (aroonu_14_1h_lt_50))
             # 15m & 1d down move, 1h still high
@@ -22813,7 +22813,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 1h still not low enough, 1d overbought
             & ((rsi_3_1h_gt_15) | (stochrsi_k_1h_lt_30) | roc_9_1d_lt_50)
             # 1h down move, 1h still high, 1d downtrend
-            & ((rsi_3_1h_gt_15) | (stochrsi_k_1h_lt_40) | (roc_9_1d > -20.0))
+            & ((rsi_3_1h_gt_15) | (stochrsi_k_1h_lt_40) | (roc_9_1d_gt_neg_20))
             # 1h down move, 1d high & overbought
             & ((rsi_3_1h_gt_15) | (stochrsi_k_1d_lt_90) | (roc_9_1d_lt_40))
             # 1h & 4h down move, 1h high
@@ -22861,7 +22861,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 1h high, 1d downtrend
             & ((rsi_3_4h_gt_10) | (stochrsi_k_1h_lt_50) | (roc_9_1d > -30.0))
             # 4h down move, 4h & 1d downtrend
-            & ((rsi_3_4h_gt_10) | (roc_9_4h > -20.0) | (roc_9_1d_gt_neg_40))
+            & ((rsi_3_4h_gt_10) | (roc_9_4h_gt_neg_20) | (roc_9_1d_gt_neg_40))
             # 4h & 1d down move, 1d high
             & ((rsi_3_4h_gt_15) | (rsi_3_1d_gt_20) | (aroonu_14_1d_lt_60))
             # 4h & 1d down move, 4h high
@@ -22873,7 +22873,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 4h & 1d high
             & ((rsi_3_4h_gt_15) | aroonu_14_4h_lt_70 | (aroonu_14_1d_lt_70))
             # 4h down move, 1h still not low enough, 1d downtrend
-            & ((rsi_3_4h_gt_15) | (stochrsi_k_1h_lt_20) | (roc_9_1d > -20.0))
+            & ((rsi_3_4h_gt_15) | (stochrsi_k_1h_lt_20) | (roc_9_1d_gt_neg_20))
             # 4h down move, 1h high
             & ((rsi_3_4h_gt_15) | (stochrsi_k_1h_lt_80))
             # 4h down move, 1h downtrend, 1d overbought
@@ -22984,7 +22984,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 15m down move, 4h high, 1d overbought
             & ((rsi_3_15m_gt_10) | aroonu_14_4h_lt_70 | (roc_9_1d_lt_100))
             # 15m & 4h down move, 1d downtrend
-            & ((rsi_3_15m_gt_15) | (rsi_3_4h_gt_15) | (roc_9_1d > -20.0))
+            & ((rsi_3_15m_gt_15) | (rsi_3_4h_gt_15) | (roc_9_1d_gt_neg_20))
             # 15m & 1h down move, 4h high
             & ((rsi_3_15m_gt_15) | (rsi_3_1h_gt_30) | (stochrsi_k_4h_lt_80))
             # 15m down move, 4h high & overbought
@@ -23026,7 +23026,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h & 4h down move, 15m still high
             & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_15) | (stochrsi_k_15m_lt_50))
             # 1h & 4h down move, 1d downtrend
-            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_15) | (roc_9_1d > -20.0))
+            & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_15) | (roc_9_1d_gt_neg_20))
             # 1h & 4h down move, 4h still high
             & ((rsi_3_1h_gt_10) | (rsi_3_4h_gt_25) | (stochrsi_k_4h_lt_50))
             # 1h & 1d down move, 4h high
@@ -23048,7 +23048,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 4h still high, 1d overbought
             & ((rsi_3_1h_gt_15) | (aroonu_14_4h_lt_50) | (roc_9_1d_lt_40))
             # 1h down move, 1d high, 4h downtrend
-            & ((rsi_3_1h_gt_15) | (aroonu_14_1d_lt_70) | (roc_9_4h > -20.0))
+            & ((rsi_3_1h_gt_15) | (aroonu_14_1d_lt_70) | (roc_9_4h_gt_neg_20))
             # 1h down move, 1d high & overbought
             & ((rsi_3_1h_gt_15) | (aroonu_14_1d_lt_80) | (roc_9_1d_lt_10))
             # 1h down move, 4h high & overbought
@@ -23114,7 +23114,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 4h still not low enough, 1d downtrend
             & ((rsi_3_4h_gt_10) | (aroonu_14_4h_lt_20) | (roc_9_1d_gt_neg_10))
             # 4h down move, 4h still high, 4h downtrend
-            & ((rsi_3_4h_gt_10) | (aroonu_14_4h_lt_40) | (roc_9_4h > -20.0))
+            & ((rsi_3_4h_gt_10) | (aroonu_14_4h_lt_40) | (roc_9_4h_gt_neg_20))
             # 4h down move, 1d still high, 1d downtrend
             & ((rsi_3_4h_gt_10) | (aroonu_14_1d_lt_40) | (roc_9_1d > -30.0))
             # 4h down move, 1d high, 15m high
@@ -23122,7 +23122,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 1d high, 4h downtrend
             & ((rsi_3_4h_gt_10) | (aroonu_14_1d_lt_100) | (roc_9_4h_gt_neg_10))
             # 4h down move, 4h & 1d downtrend
-            & ((rsi_3_4h_gt_10) | (roc_9_4h_gt_neg_10) | (roc_9_1d > -20.0))
+            & ((rsi_3_4h_gt_10) | (roc_9_4h_gt_neg_10) | (roc_9_1d_gt_neg_20))
             # 4h & 1d down move, 1d still high
             & ((rsi_3_4h_gt_15) | (rsi_3_1d_gt_15) | (aroonu_14_1d_lt_50))
             # 4h & 1d down move, 4h still high
@@ -23286,7 +23286,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1h down move, 4h still high, 1d overbought
             & ((rsi_3_1h_gt_10) | (aroonu_14_4h_lt_40) | (roc_9_1d_lt_40))
             # 1h down move, 1d still high, 1d downtrend
-            & ((rsi_3_1h_gt_10) | (aroonu_14_1d_lt_50) | (roc_9_1d > -20.0))
+            & ((rsi_3_1h_gt_10) | (aroonu_14_1d_lt_50) | (roc_9_1d_gt_neg_20))
             # 1h & 4h & 1d down move
             & ((rsi_3_1h_gt_15) | (rsi_3_4h_gt_15) | (rsi_3_1d_gt_20))
             # 1h & 4h down move, 15m still not low enough
@@ -23366,7 +23366,7 @@ class NostalgiaForInfinityX7(IStrategy):
             # 4h down move, 15m & 1h still not low enough
             & ((rsi_3_4h_gt_10) | (stochrsi_k_15m_lt_30) | (stochrsi_k_1h_lt_30))
             # 4h down move, 15m stil high, 4h downtrend
-            & ((rsi_3_4h_gt_10) | (stochrsi_k_15m_lt_50) | (roc_9_4h > -20.0))
+            & ((rsi_3_4h_gt_10) | (stochrsi_k_15m_lt_50) | (roc_9_4h_gt_neg_20))
             # 4h & 1d down move, 1d downtrend
             & ((rsi_3_4h_gt_15) | (rsi_3_1d_gt_25) | (roc_9_1d > -30.0))
             # 4h & 1d down move, 1h still high


### PR DESCRIPTION
## Summary
- Reuses the existing entry-local ROC -20 masks in populate_entry_trend().
- Replaces remaining raw (roc_9_1d > -20.0) and (roc_9_4h > -20.0) condition uses with roc_9_1d_gt_neg_20 and roc_9_4h_gt_neg_20.
- This branch is independent on latest upstream main.

## Safety
- Only existing comparison masks are reused; no new indicator values or formulas are introduced.
- Indicators, candle selection, thresholds, condition order, profit arithmetic, order classification, and return values are unchanged.
- Touched function: populate_entry_trend(). No active runtime adjust/exit paths are changed.
- No v3 grind-entry code is touched.

## Backtest scope
- Full backtesting was not required because this patch only replaces repeated raw entry comparisons with already-defined local masks from the same function. Indicator formulas, candle selection, thresholds, and condition order are unchanged.

## Checks
- `git diff --check`
- `ruff format --check NostalgiaForInfinityX7.py`
- `ruff check NostalgiaForInfinityX7.py`
- `PYTHONDONTWRITEBYTECODE=1 python3 -m py_compile NostalgiaForInfinityX7.py`
