### PR TITLE
Fix X7 entry EMA200 Series guards

### DIFF
--- a/NostalgiaForInfinityX7.py
+++ b/NostalgiaForInfinityX7.py
@@ -25765,11 +25765,11 @@ class NostalgiaForInfinityX7(IStrategy):
             short_entry_logic.append(sma_21 < sma_200)
           else:
             short_entry_logic.append(pd.Series([False]))
-          if isinstance(ema_200_1h.iloc[-1], np.float64):
+          if isinstance(ema_200_1h_infer.iloc[-1], np.float64):
             short_entry_logic.append(close < ema_200_1h)
           else:
             short_entry_logic.append(pd.Series([False]))
-          if isinstance(ema_200_4h.iloc[-1], np.float64):
+          if isinstance(ema_200_4h_infer.iloc[-1], np.float64):
             short_entry_logic.append(close < ema_200_4h)
           else:
             short_entry_logic.append(pd.Series([False]))
@@ -44031,36 +44031,36 @@ class NostalgiaForInfinityX7(IStrategy):
     is_not_trade_max_stake_v3 = current_stake_amount < (slice_amount * self.system_v3_max_stake)
     is_not_trade_max_stake_v3_1 = current_stake_amount < (slice_amount * self.system_v3_1_max_stake)
 
-    grind_1_cluster_max_profit_stake = trade.get_custom_data(key=f"grind_1_cluster_max_profit_stake") or 0.0
-    grind_1_cluster_max_profit_rate = trade.get_custom_data(key=f"grind_1_cluster_max_profit_rate") or 0.0
+    grind_1_cluster_max_profit_stake = trade.get_custom_data(key="grind_1_cluster_max_profit_stake") or 0.0
+    grind_1_cluster_max_profit_rate = trade.get_custom_data(key="grind_1_cluster_max_profit_rate") or 0.0
     if grind_1_current_grind_profit_stake > grind_1_cluster_max_profit_stake:
       trade.set_custom_data(key="grind_1_cluster_max_profit_stake", value=grind_1_current_grind_profit_stake)
     if grind_1_current_grind_profit_rate > grind_1_cluster_max_profit_rate:
       trade.set_custom_data(key="grind_1_cluster_max_profit_rate", value=grind_1_current_grind_profit_rate)
 
-    grind_2_cluster_max_profit_stake = trade.get_custom_data(key=f"grind_2_cluster_max_profit_stake") or 0.0
-    grind_2_cluster_max_profit_rate = trade.get_custom_data(key=f"grind_2_cluster_max_profit_rate") or 0.0
+    grind_2_cluster_max_profit_stake = trade.get_custom_data(key="grind_2_cluster_max_profit_stake") or 0.0
+    grind_2_cluster_max_profit_rate = trade.get_custom_data(key="grind_2_cluster_max_profit_rate") or 0.0
     if grind_2_current_grind_profit_stake > grind_2_cluster_max_profit_stake:
       trade.set_custom_data(key="grind_2_cluster_max_profit_stake", value=grind_2_current_grind_profit_stake)
     if grind_2_current_grind_profit_rate > grind_2_cluster_max_profit_rate:
       trade.set_custom_data(key="grind_2_cluster_max_profit_rate", value=grind_2_current_grind_profit_rate)
 
-    grind_3_cluster_max_profit_stake = trade.get_custom_data(key=f"grind_3_cluster_max_profit_stake") or 0.0
-    grind_3_cluster_max_profit_rate = trade.get_custom_data(key=f"grind_3_cluster_max_profit_rate") or 0.0
+    grind_3_cluster_max_profit_stake = trade.get_custom_data(key="grind_3_cluster_max_profit_stake") or 0.0
+    grind_3_cluster_max_profit_rate = trade.get_custom_data(key="grind_3_cluster_max_profit_rate") or 0.0
     if grind_3_current_grind_profit_stake > grind_3_cluster_max_profit_stake:
       trade.set_custom_data(key="grind_3_cluster_max_profit_stake", value=grind_3_current_grind_profit_stake)
     if grind_3_current_grind_profit_rate > grind_3_cluster_max_profit_rate:
       trade.set_custom_data(key="grind_3_cluster_max_profit_rate", value=grind_3_current_grind_profit_rate)
 
-    grind_4_cluster_max_profit_stake = trade.get_custom_data(key=f"grind_4_cluster_max_profit_stake") or 0.0
-    grind_4_cluster_max_profit_rate = trade.get_custom_data(key=f"grind_4_cluster_max_profit_rate") or 0.0
+    grind_4_cluster_max_profit_stake = trade.get_custom_data(key="grind_4_cluster_max_profit_stake") or 0.0
+    grind_4_cluster_max_profit_rate = trade.get_custom_data(key="grind_4_cluster_max_profit_rate") or 0.0
     if grind_4_current_grind_profit_stake > grind_4_cluster_max_profit_stake:
       trade.set_custom_data(key="grind_4_cluster_max_profit_stake", value=grind_4_current_grind_profit_stake)
     if grind_4_current_grind_profit_rate > grind_4_cluster_max_profit_rate:
       trade.set_custom_data(key="grind_4_cluster_max_profit_rate", value=grind_4_current_grind_profit_rate)
 
-    grind_5_cluster_max_profit_stake = trade.get_custom_data(key=f"grind_5_cluster_max_profit_stake") or 0.0
-    grind_5_cluster_max_profit_rate = trade.get_custom_data(key=f"grind_5_cluster_max_profit_rate") or 0.0
+    grind_5_cluster_max_profit_stake = trade.get_custom_data(key="grind_5_cluster_max_profit_stake") or 0.0
+    grind_5_cluster_max_profit_rate = trade.get_custom_data(key="grind_5_cluster_max_profit_rate") or 0.0
     if grind_5_current_grind_profit_stake > grind_5_cluster_max_profit_stake:
       trade.set_custom_data(key="grind_5_cluster_max_profit_stake", value=grind_5_current_grind_profit_stake)
     if grind_5_current_grind_profit_rate > grind_5_cluster_max_profit_rate:


### PR DESCRIPTION
## Summary
- Use the existing EMA200 Series locals for the `.iloc[-1]` guards in `populate_entry_trend()`.
- Keep `ema_200_1h` / `ema_200_4h` as numpy arrays for vector comparisons; only the scalar guard reads from `ema_200_1h_infer` / `ema_200_4h_infer`.
- Apply the ruff F541 cleanup for static grind cluster custom-data keys so pre-commit can pass.
- Independent on latest upstream `main`.

## Safety
- Behavior-preserving runtime safety fix.
- The EMA200 guard checks now read from the matching Series locals that were already present.
- Static f-string cleanup does not change any custom-data key values.
- Indicators, candle selection, thresholds, condition order, profit arithmetic, return values, and signal behavior are unchanged.
- Touched functions: `populate_entry_trend()` and `long_grind_adjust_trade_position_v3()` static string keys only.
- No v3 grind-entry code is touched.

## Backtest scope
- Full backtest was not required because this does not change formulas, thresholds, condition order, signal logic, stake logic, or return values.
- The main change prevents an ndarray `.iloc` issue in a currently unreachable/dead short-entry signal path if that path is enabled later.

## Checks
- `python3 ~/.codex/skills/nfi-upstream-pr/scripts/validate_nfi_pr.py --base origin/main`
- `python3` AST scan for ndarray `.iloc` / `.shift` use in `populate_entry_trend()`
- `git merge-tree` conflict simulation against `origin/main`: `NO_CONFLICT`
- targeted `git diff origin/main...HEAD -- NostalgiaForInfinityX7.py` review
- `git diff --check`
- `ruff format --check NostalgiaForInfinityX7.py`
- `ruff check --no-fix NostalgiaForInfinityX7.py`
- `PYTHONDONTWRITEBYTECODE=1 python3 -m py_compile NostalgiaForInfinityX7.py`