### PR TITLE
Guard X7 futures min-stake floor

### DIFF
--- a/NostalgiaForInfinityX7.py
+++ b/NostalgiaForInfinityX7.py
@@ -12752,15 +12752,11 @@ class NostalgiaForInfinityX7(IStrategy):
 
   # Correct Min Stake
   # ---------------------------------------------------------------------------------------------
-  def correct_min_stake(self, min_stake: float) -> float:
-    if self.config["exchange"]["name"] == "bybit":
-      if self.is_futures_mode:
-        if (min_stake is None) or (min_stake < 5.0 / self.futures_mode_leverage):
-          min_stake = 5.0 / self.futures_mode_leverage
-    elif self.config["exchange"]["name"] == "krakenfutures":
-      if self.is_futures_mode:
-        if (min_stake is None) or (min_stake < 5.0 / self.futures_mode_leverage):
-          min_stake = 5.0 / self.futures_mode_leverage
+  def correct_min_stake(self, min_stake: Optional[float], trade_leverage: Optional[float] = None) -> Optional[float]:
+    if self.is_futures_mode and self.config["exchange"]["name"] in ("binance", "bybit", "krakenfutures"):
+      min_futures_stake = 5.0 / (trade_leverage if trade_leverage is not None else self.futures_mode_leverage)
+      if (min_stake is None) or (min_stake < min_futures_stake):
+        min_stake = min_futures_stake
     return min_stake
 
   def is_backtest_mode(self) -> bool:
@@ -41172,7 +41168,7 @@ class NostalgiaForInfinityX7(IStrategy):
     long_rebuy_mode_tags = self.long_rebuy_mode_tags
     long_grind_mode_tags = self.long_grind_mode_tags
 
-    min_stake = self.correct_min_stake(min_stake)
+    min_stake = self.correct_min_stake(min_stake, trade_leverage)
     df, _ = dp.get_analyzed_dataframe(trade_pair, self.timeframe)
     if len(df) < 2:
       return None
@@ -43684,7 +43680,7 @@ class NostalgiaForInfinityX7(IStrategy):
     if trade.has_open_orders:
       return None
 
-    min_stake = self.correct_min_stake(min_stake)
+    min_stake = self.correct_min_stake(min_stake, trade_leverage)
     df, _ = dp.get_analyzed_dataframe(trade_pair, self.timeframe)
     if len(df) < 2:
       return None
@@ -45797,7 +45793,7 @@ class NostalgiaForInfinityX7(IStrategy):
     long_grind_mode_tags = self.long_grind_mode_tags
     trade_leverage = trade.leverage
 
-    min_stake = self.correct_min_stake(min_stake)
+    min_stake = self.correct_min_stake(min_stake, trade_leverage)
     df, _ = dp.get_analyzed_dataframe(trade_pair, self.timeframe)
     if len(df) < 2:
       return None
@@ -64886,7 +64882,7 @@ class NostalgiaForInfinityX7(IStrategy):
     short_rebuy_mode_tags = self.short_rebuy_mode_tags
     short_grind_mode_tags = self.short_grind_mode_tags
 
-    min_stake = self.correct_min_stake(min_stake)
+    min_stake = self.correct_min_stake(min_stake, trade_leverage)
     df, _ = dp.get_analyzed_dataframe(trade_pair, self.timeframe)
     if len(df) < 2:
       return None
@@ -67480,7 +67476,7 @@ class NostalgiaForInfinityX7(IStrategy):
     if trade.has_open_orders:
       return None
 
-    min_stake = self.correct_min_stake(min_stake)
+    min_stake = self.correct_min_stake(min_stake, trade_leverage)
     df, _ = dp.get_analyzed_dataframe(trade_pair, self.timeframe)
     if len(df) < 2:
       return None
@@ -69123,7 +69119,7 @@ class NostalgiaForInfinityX7(IStrategy):
     short_grind_mode_tags = self.short_grind_mode_tags
     trade_leverage = trade.leverage
 
-    min_stake = self.correct_min_stake(min_stake)
+    min_stake = self.correct_min_stake(min_stake, trade_leverage)
     df, _ = dp.get_analyzed_dataframe(trade_pair, self.timeframe)
     if len(df) < 2:
       return None


### PR DESCRIPTION
## Summary

- Extend the existing X7 futures min-stake correction to Binance, so implausibly tiny futures callback values like `0.0002` are floored before rebuy/grind sizing.
- Pass the current trade leverage into `correct_min_stake()` instead of always using the configured default leverage.
- Keep the correction limited to the existing exchange workaround path: Binance, Bybit, and Kraken Futures.

## Safety

- This does not blindly divide `min_stake` by leverage.
- It only raises too-small futures `min_stake` values to the existing `5.0 / leverage` floor before the existing stake-scaling logic runs.
- It preserves normal values that are already above that floor.
- It intentionally does not apply the floor to other exchanges such as Bitget.
- No indicators, candle selection, thresholds, condition order, profit arithmetic, return values, or entry/exit signal logic changed.

## RIF-style check

Using the existing grind sizing shape:

- `slice_amount = 52.8`
- base grind stake `0.05`
- `trade_leverage = 3`
- raw buy amount: `52.8 * 0.05 / 3 = 0.88`

With a tiny callback `min_stake = 0.0002`, the scaling path keeps the buy amount at `0.88`.

After this patch, Binance futures floors that tiny callback value to `5.0 / 3 = 1.6666666667`, so the existing min-stake scaling path can lift the grind stake before the later `min_stake * 1.5` guard.

## Checks

- `git diff --check`
- `ruff format --check NostalgiaForInfinityX7.py`
- `ruff check NostalgiaForInfinityX7.py`
- `PYTHONDONTWRITEBYTECODE=1 python3 -m py_compile NostalgiaForInfinityX7.py`
- `python3 ~/.codex/skills/nfi-upstream-pr/scripts/validate_nfi_pr.py --base origin/main`
- `git merge-tree` conflict check: `NO_CONFLICT`
- targeted extracted-source check for Binance/Bybit/KrakenFutures tiny `min_stake`, above-floor preservation, and Bitget unchanged behavior

Full backtest was not run because this is a defensive exchange-limit normalization before existing sizing logic; it only changes sizing when one of the guarded futures exchanges returns a callback `min_stake` below `5.0 / trade_leverage`.
