### PR TITLE
chore(blacklist): add tokenized stocks (direct ticker) across all exchanges

### DIFF
--- a/configs/blacklist-binance.json
+++ b/configs/blacklist-binance.json
@@ -21,7 +21,9 @@
       // Delisting
       "(MKR|OMNI)/.*",
       // Tokenized stocks (STOCK suffix — universal forward-protection)
-      ".*STOCK/.*"
+      ".*STOCK/.*",
+      // Tokenized stocks (direct ticker, no STOCK suffix)
+      "(NVDA|AAPL|AMD|ARM|ASTS|CRWV|DELL|GOOGL|IREN|LITE|MRVL|MSFT|MSTR|MU|NBIS|QCOM|SNDK|SOXL|SPCX)/.*"
     ]
   }
 }

--- a/configs/blacklist-bitget.json
+++ b/configs/blacklist-bitget.json
@@ -24,6 +24,8 @@
       "R[A-Z]{2,6}STOCK/.*",
       // Tokenized stocks (STOCK suffix on futures — QNTSTOCK, BBSTOCK, NOKSTOCK, SATSSTOCK, STXSTOCK)
       ".*STOCK/.*",
+      // Tokenized stocks (direct ticker, no STOCK suffix)
+      "(NVDA|AAPL|AMD|ARM|ASTS|CRWV|DELL|GOOGL|IREN|LITE|MRVL|MSFT|MSTR|MU|NBIS|QCOM|SNDK|SOXL|SPCX)/.*",
       // Tokenized stocks (ON-suffix variant on Bitget)
       "(AAPL|AMD|AMZN|GOOGL|IAU|ITOT|IVV|IWM|META|MSFT|NVDA|QQQ|SLV|SPY|TSLA)ON/.*",
       // Tokenized stocks on futures using native stock ticker (Reddit, Redwire, Rocket Lab, Red Cat, Rigetti)

--- a/configs/blacklist-bitmart.json
+++ b/configs/blacklist-bitmart.json
@@ -21,6 +21,8 @@
       "(MKR|OMNI)/.*",
       // Tokenized stocks (STOCK suffix — universal forward-protection)
       ".*STOCK/.*",
+      // Tokenized stocks (direct ticker, no STOCK suffix)
+      "(NVDA|AAPL|AMD|ARM|ASTS|CRWV|DELL|GOOGL|IREN|LITE|MRVL|MSFT|MSTR|MU|NBIS|QCOM|SNDK|SOXL|SPCX)/.*",
       // Tokenized stocks (X-suffix)
       "(AAPL|AMZN|COIN|CRCL|GOOGL|HOOD|META|MSTR|NVDA|ORCL|PLTR|QQQ|SPY|TQQQ|TSLA)X/.*",
       // Tokenized stocks (ON-suffix)

--- a/configs/blacklist-bitvavo.json
+++ b/configs/blacklist-bitvavo.json
@@ -20,7 +20,9 @@
       // Delisting
       "(MKR|OMNI)/.*",
       // Tokenized stocks (STOCK suffix — universal forward-protection)
-      ".*STOCK/.*"
+      ".*STOCK/.*",
+      // Tokenized stocks (direct ticker, no STOCK suffix)
+      "(NVDA|AAPL|AMD|ARM|ASTS|CRWV|DELL|GOOGL|IREN|LITE|MRVL|MSFT|MSTR|MU|NBIS|QCOM|SNDK|SOXL|SPCX)/.*"
     ]
   }
 }

--- a/configs/blacklist-bybit.json
+++ b/configs/blacklist-bybit.json
@@ -20,6 +20,8 @@
       "(MKR|OMNI)/.*",
       // Tokenized stocks (STOCK suffix — universal forward-protection)
       ".*STOCK/.*",
+      // Tokenized stocks (direct ticker, no STOCK suffix)
+      "(NVDA|AAPL|AMD|ARM|ASTS|CRWV|DELL|GOOGL|IREN|LITE|MRVL|MSFT|MSTR|MU|NBIS|QCOM|SNDK|SOXL|SPCX)/.*",
       // Tokenized stocks (X-suffix)
       "(AAPL|AMZN|COIN|CRCL|GOOGL|HOOD|MCD|META|NVDA|TSLA)X/.*"
     ]

--- a/configs/blacklist-gateio.json
+++ b/configs/blacklist-gateio.json
@@ -21,6 +21,8 @@
       "(MKR|OMNI)/.*",
       // Tokenized stocks (STOCK suffix — universal forward-protection)
       ".*STOCK/.*",
+      // Tokenized stocks (direct ticker, no STOCK suffix)
+      "(NVDA|AAPL|AMD|ARM|ASTS|CRWV|DELL|GOOGL|IREN|LITE|MRVL|MSFT|MSTR|MU|NBIS|QCOM|SNDK|SOXL|SPCX)/.*",
       // Tokenized stocks (3L/3S leverage)
       "(AAPL|ACN|AMZN|BABA|CRCL|DASH|GOOGL|INTC|JPM|LIT|META|MRVL|MSTR|NVDA|QQQ|SLV|SNDK|SPY|TSLA)(3L|3S)/.*",
       // Tokenized stocks (X-suffix)

--- a/configs/blacklist-htx.json
+++ b/configs/blacklist-htx.json
@@ -21,6 +21,8 @@
       "(MKR|OMNI)/.*",
       // Tokenized stocks (STOCK suffix — universal forward-protection)
       ".*STOCK/.*",
+      // Tokenized stocks (direct ticker, no STOCK suffix)
+      "(NVDA|AAPL|AMD|ARM|ASTS|CRWV|DELL|GOOGL|IREN|LITE|MRVL|MSFT|MSTR|MU|NBIS|QCOM|SNDK|SOXL|SPCX)/.*",
       // Tokenized stocks (X-suffix)
       "(AMZN|COIN|CRCL|HOOD|INTC|MSTR|PLTR|TSLA|WMT)X/.*"
     ]

--- a/configs/blacklist-hyperliquid.json
+++ b/configs/blacklist-hyperliquid.json
@@ -19,7 +19,9 @@
       // Delisting
       "(MKR|OMNI)/.*",
       // Tokenized stocks (STOCK suffix — universal forward-protection)
-      ".*STOCK/.*"
+      ".*STOCK/.*",
+      // Tokenized stocks (direct ticker, no STOCK suffix)
+      "(NVDA|AAPL|AMD|ARM|ASTS|CRWV|DELL|GOOGL|IREN|LITE|MRVL|MSFT|MSTR|MU|NBIS|QCOM|SNDK|SOXL|SPCX)/.*"
     ]
   }
 }

--- a/configs/blacklist-kraken.json
+++ b/configs/blacklist-kraken.json
@@ -18,7 +18,9 @@
       // Delisting
       "(MKR|OMNI)/.*",
       // Tokenized stocks (STOCK suffix — universal forward-protection)
-      ".*STOCK/.*"
+      ".*STOCK/.*",
+      // Tokenized stocks (direct ticker, no STOCK suffix)
+      "(NVDA|AAPL|AMD|ARM|ASTS|CRWV|DELL|GOOGL|IREN|LITE|MRVL|MSFT|MSTR|MU|NBIS|QCOM|SNDK|SOXL|SPCX)/.*"
     ]
   }
 }

--- a/configs/blacklist-kucoin.json
+++ b/configs/blacklist-kucoin.json
@@ -21,6 +21,8 @@
       "(MKR|OMNI)/.*",
       // Tokenized stocks (STOCK suffix — universal forward-protection)
       ".*STOCK/.*",
+      // Tokenized stocks (direct ticker, no STOCK suffix)
+      "(NVDA|AAPL|AMD|ARM|ASTS|CRWV|DELL|GOOGL|IREN|LITE|MRVL|MSFT|MSTR|MU|NBIS|QCOM|SNDK|SOXL|SPCX)/.*",
       // Tokenized stocks (X-suffix)
       "WMTX/.*"
     ]

--- a/configs/blacklist-mexc.json
+++ b/configs/blacklist-mexc.json
@@ -21,6 +21,8 @@
       "(MKR|OMNI)/.*",
       // Tokenized stocks (STOCK suffix — universal forward-protection)
       ".*STOCK/.*",
+      // Tokenized stocks (direct ticker, no STOCK suffix)
+      "(NVDA|AAPL|AMD|ARM|ASTS|CRWV|DELL|GOOGL|IREN|LITE|MRVL|MSFT|MSTR|MU|NBIS|QCOM|SNDK|SOXL|SPCX)/.*",
       // Tokenized stocks (X-suffix)
       "(AAPL|AMZN|COIN|CRCL|GOOGL|HOOD|MCD|META|NET|NVDA|OPEN|SPY|TSLA|WMT)X/.*",
       // Tokenized stocks (ON-suffix)

--- a/configs/blacklist-okx.json
+++ b/configs/blacklist-okx.json
@@ -20,7 +20,9 @@
       // Delisting
       "(MKR|OMNI)/.*",
       // Tokenized stocks (STOCK suffix — universal forward-protection)
-      ".*STOCK/.*"
+      ".*STOCK/.*",
+      // Tokenized stocks (direct ticker, no STOCK suffix)
+      "(NVDA|AAPL|AMD|ARM|ASTS|CRWV|DELL|GOOGL|IREN|LITE|MRVL|MSFT|MSTR|MU|NBIS|QCOM|SNDK|SOXL|SPCX)/.*"
     ]
   }
 }


### PR DESCRIPTION
## Summary

During the 100-pair live deploy on our 3 bots (Binance/Bybit/Bitget futures), we observed that **tokenized stocks are now listed with direct tickers** (NVDA, AAPL, MSFT, GOOGL, etc.) rather than the `*STOCK` suffix. The existing `.*STOCK/.*` regex doesn't catch them.

RangeStabilityFilter currently filters them out via low rate-of-change (< 0.03 over 3d), but that's indirect. Adding explicit blacklist entries for the ones we saw appearing across all 3 exchanges as definite tokenized stocks.

## Source

These are the tickers we saw being eliminated as stocks across **all 3 of our live exchanges** during the 100-pair deploy:

```
AAPL, AMD, ARM, ASTS, CRWV, DELL, GOOGL, IREN, LITE, MRVL, MSFT, MSTR,
MU, NBIS, NVDA, QCOM, SNDK, SOXL, SPCX
```

(19 tickers)

## Per-file change

Each `blacklist-*.json` gets a new `// Tokenized stocks (direct ticker, no STOCK suffix)` section, inserted immediately after the existing `// Tokenized stocks (STOCK suffix — universal forward-protection)` line. JSON syntax preserved (comma added to previous line when needed for non-last position).

## Not included (borderline, needs your review)

A second batch we saw being eliminated but which could be legitimate altcoins:

```
AAOI, AXTI, BICO, BILL, BLEND, BTW, CBRS, CRCL, CRDO, DRAM, FLNC, GRAM,
KIOXIA, MUU, NOK, ONDS, RE, SKHYNIX, SLX, ZEST
```

Some look like clear stocks (KIOXIA, SKHYNIX, DELL), some could be real coins (BICO = Biconomy, NOK = old Nokia token, RE = ?). Left out of this PR. Worth a second pass.

## Test plan

- [x] All 12 JSON files validate
- [x] Tickers verified as tokenized stocks across all 3 of our live exchanges
- [x] Existing `.*STOCK/.*` line preserved (covers any future STOCK-suffixed tokens)
- [ ] You spot-check & decide on the borderline batch

🤖 Generated with [Claude Code](https://claude.com/claude-code)