### PR TITLE
configs: bump volume pair lists — pre-filter 100→130, final 80→100

### DIFF
--- a/configs/pairlist-volume-binance-btc.json
+++ b/configs/pairlist-volume-binance-btc.json
@@ -2,7 +2,7 @@
   "pairlists": [
     {
       "method": "VolumePairList",
-      "number_assets": 100,
+      "number_assets": 130,
       "sort_key": "quoteVolume",
       "refresh_period": 1800
     },
@@ -32,7 +32,7 @@
     // },
     {
       "method": "VolumePairList",
-      "number_assets": 80,
+      "number_assets": 100,
       "sort_key": "quoteVolume"
     },
     // { "method": "ShuffleFilter" }

--- a/configs/pairlist-volume-binance-busd.json
+++ b/configs/pairlist-volume-binance-busd.json
@@ -2,7 +2,7 @@
   "pairlists": [
     {
       "method": "VolumePairList",
-      "number_assets": 100,
+      "number_assets": 130,
       "sort_key": "quoteVolume",
       "refresh_period": 1800
     },
@@ -32,7 +32,7 @@
     // },
     {
       "method": "VolumePairList",
-      "number_assets": 80,
+      "number_assets": 100,
       "sort_key": "quoteVolume"
     },
     // { "method": "ShuffleFilter" }

--- a/configs/pairlist-volume-binance-usdc.json
+++ b/configs/pairlist-volume-binance-usdc.json
@@ -2,7 +2,7 @@
   "pairlists": [
     {
       "method": "VolumePairList",
-      "number_assets": 100,
+      "number_assets": 130,
       "sort_key": "quoteVolume",
       "refresh_period": 1800
     },
@@ -32,7 +32,7 @@
     // },
     {
       "method": "VolumePairList",
-      "number_assets": 80,
+      "number_assets": 100,
       "sort_key": "quoteVolume"
     },
     // { "method": "ShuffleFilter" }

--- a/configs/pairlist-volume-binance-usdt.json
+++ b/configs/pairlist-volume-binance-usdt.json
@@ -2,7 +2,7 @@
   "pairlists": [
     {
       "method": "VolumePairList",
-      "number_assets": 100,
+      "number_assets": 130,
       "sort_key": "quoteVolume",
       "refresh_period": 1800
     },
@@ -32,7 +32,7 @@
     // },
     {
       "method": "VolumePairList",
-      "number_assets": 80,
+      "number_assets": 100,
       "sort_key": "quoteVolume"
     },
     // { "method": "ShuffleFilter" }

--- a/configs/pairlist-volume-bitget-btc.json
+++ b/configs/pairlist-volume-bitget-btc.json
@@ -2,7 +2,7 @@
   "pairlists": [
     {
       "method": "VolumePairList",
-      "number_assets": 100,
+      "number_assets": 130,
       "sort_key": "quoteVolume",
       "refresh_period": 1800
     },
@@ -32,7 +32,7 @@
     // },
     {
       "method": "VolumePairList",
-      "number_assets": 80,
+      "number_assets": 100,
       "sort_key": "quoteVolume"
     },
     // { "method": "ShuffleFilter" }

--- a/configs/pairlist-volume-bitget-usdt.json
+++ b/configs/pairlist-volume-bitget-usdt.json
@@ -2,7 +2,7 @@
   "pairlists": [
     {
       "method": "VolumePairList",
-      "number_assets": 100,
+      "number_assets": 130,
       "sort_key": "quoteVolume",
       "refresh_period": 1800
     },
@@ -32,7 +32,7 @@
     // },
     {
       "method": "VolumePairList",
-      "number_assets": 80,
+      "number_assets": 100,
       "sort_key": "quoteVolume"
     },
     // { "method": "ShuffleFilter" }

--- a/configs/pairlist-volume-bitmart-btc.json
+++ b/configs/pairlist-volume-bitmart-btc.json
@@ -2,7 +2,7 @@
   "pairlists": [
     {
       "method": "VolumePairList",
-      "number_assets": 100,
+      "number_assets": 130,
       "sort_key": "quoteVolume",
       "refresh_period": 1800
     },
@@ -32,7 +32,7 @@
     // },
     {
       "method": "VolumePairList",
-      "number_assets": 80,
+      "number_assets": 100,
       "sort_key": "quoteVolume"
     },
     // { "method": "ShuffleFilter" }

--- a/configs/pairlist-volume-bitmart-usdt.json
+++ b/configs/pairlist-volume-bitmart-usdt.json
@@ -2,7 +2,7 @@
   "pairlists": [
     {
       "method": "VolumePairList",
-      "number_assets": 100,
+      "number_assets": 130,
       "sort_key": "quoteVolume",
       "refresh_period": 1800
     },
@@ -32,7 +32,7 @@
     // },
     {
       "method": "VolumePairList",
-      "number_assets": 80,
+      "number_assets": 100,
       "sort_key": "quoteVolume"
     },
     // { "method": "ShuffleFilter" }

--- a/configs/pairlist-volume-bitvavo-eur.json
+++ b/configs/pairlist-volume-bitvavo-eur.json
@@ -2,7 +2,7 @@
   "pairlists": [
     {
       "method": "VolumePairList",
-      "number_assets": 100,
+      "number_assets": 130,
       "sort_key": "quoteVolume",
       "refresh_period": 1800
     },
@@ -32,7 +32,7 @@
     // },
     {
       "method": "VolumePairList",
-      "number_assets": 80,
+      "number_assets": 100,
       "sort_key": "quoteVolume"
     },
     // { "method": "ShuffleFilter" }

--- a/configs/pairlist-volume-bybit-btc.json
+++ b/configs/pairlist-volume-bybit-btc.json
@@ -2,7 +2,7 @@
   "pairlists": [
     {
       "method": "VolumePairList",
-      "number_assets": 100,
+      "number_assets": 130,
       "sort_key": "quoteVolume",
       "refresh_period": 1800
     },
@@ -32,7 +32,7 @@
     // },
     {
       "method": "VolumePairList",
-      "number_assets": 80,
+      "number_assets": 100,
       "sort_key": "quoteVolume"
     },
     // { "method": "ShuffleFilter" }

--- a/configs/pairlist-volume-bybit-usdt.json
+++ b/configs/pairlist-volume-bybit-usdt.json
@@ -2,7 +2,7 @@
   "pairlists": [
     {
       "method": "VolumePairList",
-      "number_assets": 100,
+      "number_assets": 130,
       "sort_key": "quoteVolume",
       "refresh_period": 1800
     },
@@ -32,7 +32,7 @@
     // },
     {
       "method": "VolumePairList",
-      "number_assets": 80,
+      "number_assets": 100,
       "sort_key": "quoteVolume"
     },
     // { "method": "ShuffleFilter" }

--- a/configs/pairlist-volume-gateio-btc.json
+++ b/configs/pairlist-volume-gateio-btc.json
@@ -2,7 +2,7 @@
   "pairlists": [
     {
       "method": "VolumePairList",
-      "number_assets": 100,
+      "number_assets": 130,
       "sort_key": "quoteVolume",
       "refresh_period": 1800
     },
@@ -32,7 +32,7 @@
     // },
     {
       "method": "VolumePairList",
-      "number_assets": 80,
+      "number_assets": 100,
       "sort_key": "quoteVolume"
     },
     // { "method": "ShuffleFilter" }

--- a/configs/pairlist-volume-gateio-usdt.json
+++ b/configs/pairlist-volume-gateio-usdt.json
@@ -2,7 +2,7 @@
   "pairlists": [
     {
       "method": "VolumePairList",
-      "number_assets": 100,
+      "number_assets": 130,
       "sort_key": "quoteVolume",
       "refresh_period": 1800
     },
@@ -32,7 +32,7 @@
     // },
     {
       "method": "VolumePairList",
-      "number_assets": 80,
+      "number_assets": 100,
       "sort_key": "quoteVolume"
     },
     // { "method": "ShuffleFilter" }

--- a/configs/pairlist-volume-htx-btc.json
+++ b/configs/pairlist-volume-htx-btc.json
@@ -2,7 +2,7 @@
   "pairlists": [
     {
       "method": "VolumePairList",
-      "number_assets": 100,
+      "number_assets": 130,
       "sort_key": "quoteVolume",
       "refresh_period": 1800
     },
@@ -32,7 +32,7 @@
     // },
     {
       "method": "VolumePairList",
-      "number_assets": 80,
+      "number_assets": 100,
       "sort_key": "quoteVolume"
     },
     // { "method": "ShuffleFilter" }

--- a/configs/pairlist-volume-htx-usdt.json
+++ b/configs/pairlist-volume-htx-usdt.json
@@ -2,7 +2,7 @@
   "pairlists": [
     {
       "method": "VolumePairList",
-      "number_assets": 100,
+      "number_assets": 130,
       "sort_key": "quoteVolume",
       "refresh_period": 1800
     },
@@ -32,7 +32,7 @@
     // },
     {
       "method": "VolumePairList",
-      "number_assets": 80,
+      "number_assets": 100,
       "sort_key": "quoteVolume"
     },
     // { "method": "ShuffleFilter" }

--- a/configs/pairlist-volume-hyperliquid-usdc.json
+++ b/configs/pairlist-volume-hyperliquid-usdc.json
@@ -2,7 +2,7 @@
   "pairlists": [
     {
       "method": "VolumePairList",
-      "number_assets": 100,
+      "number_assets": 130,
       "sort_key": "quoteVolume",
       "refresh_period": 1800
     },
@@ -28,7 +28,7 @@
     // },
     {
       "method": "VolumePairList",
-      "number_assets": 80,
+      "number_assets": 100,
       "sort_key": "quoteVolume"
     },
     // { "method": "ShuffleFilter" }

--- a/configs/pairlist-volume-kraken-futures.json
+++ b/configs/pairlist-volume-kraken-futures.json
@@ -2,7 +2,7 @@
   "pairlists": [
     {
       "method": "VolumePairList",
-      "number_assets": 80,
+      "number_assets": 100,
       "sort_key": "quoteVolume",
       "refresh_period": 86400,
       "lookback_days": 1

--- a/configs/pairlist-volume-kraken-usd.json
+++ b/configs/pairlist-volume-kraken-usd.json
@@ -2,7 +2,7 @@
   "pairlists": [
     {
       "method": "VolumePairList",
-      "number_assets": 100,
+      "number_assets": 130,
       "sort_key": "quoteVolume",
       "refresh_period": 1800
     },
@@ -32,7 +32,7 @@
     // },
     {
       "method": "VolumePairList",
-      "number_assets": 80,
+      "number_assets": 100,
       "sort_key": "quoteVolume"
     },
     // { "method": "ShuffleFilter" }

--- a/configs/pairlist-volume-kucoin-btc.json
+++ b/configs/pairlist-volume-kucoin-btc.json
@@ -2,7 +2,7 @@
   "pairlists": [
     {
       "method": "VolumePairList",
-      "number_assets": 100,
+      "number_assets": 130,
       "sort_key": "quoteVolume",
       "refresh_period": 1800
     },
@@ -32,7 +32,7 @@
     // },
     {
       "method": "VolumePairList",
-      "number_assets": 80,
+      "number_assets": 100,
       "sort_key": "quoteVolume"
     },
     // { "method": "ShuffleFilter" }

--- a/configs/pairlist-volume-kucoin-usdt.json
+++ b/configs/pairlist-volume-kucoin-usdt.json
@@ -2,7 +2,7 @@
   "pairlists": [
     {
       "method": "VolumePairList",
-      "number_assets": 100,
+      "number_assets": 130,
       "sort_key": "quoteVolume",
       "refresh_period": 1800
     },
@@ -32,7 +32,7 @@
     // },
     {
       "method": "VolumePairList",
-      "number_assets": 80,
+      "number_assets": 100,
       "sort_key": "quoteVolume"
     },
     // { "method": "ShuffleFilter" }

--- a/configs/pairlist-volume-mexc-btc.json
+++ b/configs/pairlist-volume-mexc-btc.json
@@ -2,7 +2,7 @@
   "pairlists": [
     {
       "method": "VolumePairList",
-      "number_assets": 100,
+      "number_assets": 130,
       "sort_key": "quoteVolume",
       "refresh_period": 1800
     },
@@ -32,7 +32,7 @@
     // },
     {
       "method": "VolumePairList",
-      "number_assets": 80,
+      "number_assets": 100,
       "sort_key": "quoteVolume"
     },
     // { "method": "ShuffleFilter" }

--- a/configs/pairlist-volume-mexc-usdt.json
+++ b/configs/pairlist-volume-mexc-usdt.json
@@ -2,7 +2,7 @@
   "pairlists": [
     {
       "method": "VolumePairList",
-      "number_assets": 100,
+      "number_assets": 130,
       "sort_key": "quoteVolume",
       "refresh_period": 1800
     },
@@ -32,7 +32,7 @@
     // },
     {
       "method": "VolumePairList",
-      "number_assets": 80,
+      "number_assets": 100,
       "sort_key": "quoteVolume"
     },
     // { "method": "ShuffleFilter" }

--- a/configs/pairlist-volume-okx-btc.json
+++ b/configs/pairlist-volume-okx-btc.json
@@ -2,7 +2,7 @@
   "pairlists": [
     {
       "method": "VolumePairList",
-      "number_assets": 100,
+      "number_assets": 130,
       "sort_key": "quoteVolume",
       "refresh_period": 1800
     },
@@ -32,7 +32,7 @@
     // },
     {
       "method": "VolumePairList",
-      "number_assets": 80,
+      "number_assets": 100,
       "sort_key": "quoteVolume"
     },
     // { "method": "ShuffleFilter" }

--- a/configs/pairlist-volume-okx-futures.json
+++ b/configs/pairlist-volume-okx-futures.json
@@ -2,7 +2,7 @@
   "pairlists": [
     {
       "method": "VolumePairList",
-      "number_assets": 80,
+      "number_assets": 100,
       "sort_key": "quoteVolume",
       "refresh_period": 86400,
       "lookback_days": 1

--- a/configs/pairlist-volume-okx-usdt.json
+++ b/configs/pairlist-volume-okx-usdt.json
@@ -2,7 +2,7 @@
   "pairlists": [
     {
       "method": "VolumePairList",
-      "number_assets": 100,
+      "number_assets": 130,
       "sort_key": "quoteVolume",
       "refresh_period": 1800
     },
@@ -32,7 +32,7 @@
     // },
     {
       "method": "VolumePairList",
-      "number_assets": 80,
+      "number_assets": 100,
       "sort_key": "quoteVolume"
     },
     // { "method": "ShuffleFilter" }


### PR DESCRIPTION
## Summary

Bumps the VolumePairList counts across all 25 `pairlist-volume-*.json` configs (all exchanges + quote currencies):

- **Pre-filter** `VolumePairList`: `100 → 130`
- **Final** `VolumePairList`: `80 → 100`

For the 2 configs with a single VolumePairList (`pairlist-volume-kraken-futures.json`, `pairlist-volume-okx-futures.json`), just the count: `80 → 100`.

Everything else (filter chain, refresh periods, sort keys) is unchanged.

## Live observation

Running on 3 bots (Binance/Bybit/Bitget USDT futures) with this config bump:

- **Binance** picked up 2 fresh trades from the new window within ~12h: CLO/USDT (+10.04%) and UB/USDT (+6.20%) — both closed in profit within minutes of opening.
- **Bybit + Bitget** didn't fire on the new tier yet — both have 7/10 slots free, just no entry signals triggered there during this window.
- **Timing**: zero `slow loop` / heartbeat skew / cycle warnings across 3 bots over 18h. Heartbeats steady at ~60s intervals.
- **Bybit** ccxt `rateLimit` was independently tuned `60 → 100ms` after observing initial pressure; same ratelimit pattern existed at 80 pairs too, so this is exchange-side and not pair-count related.

## Test plan

- [x] All 25 files updated consistently (verified by grep)
- [x] Live tested on Binance/Bybit/Bitget futures with the new counts
- [x] No backtest impact (pairlist changes don't affect backtesting with static pair lists)
- [x] No timing regressions observed in 18h+ of live runtime

🤖 Generated with [Claude Code](https://claude.com/claude-code)