### PR TITLE
configs: RangeStabilityFilter max_rate_of_change 2.00 → 0.95

### DIFF
--- a/configs/pairlist-volume-binance-btc.json
+++ b/configs/pairlist-volume-binance-btc.json
@@ -20,7 +20,7 @@
       "method": "RangeStabilityFilter",
       "lookback_days": 3,
       "min_rate_of_change": 0.03,
-      "max_rate_of_change": 2.00,
+      "max_rate_of_change": 0.95,
       "refresh_period": 1800
     },
     // {

--- a/configs/pairlist-volume-binance-busd.json
+++ b/configs/pairlist-volume-binance-busd.json
@@ -20,7 +20,7 @@
       "method": "RangeStabilityFilter",
       "lookback_days": 3,
       "min_rate_of_change": 0.03,
-      "max_rate_of_change": 2.00,
+      "max_rate_of_change": 0.95,
       "refresh_period": 1800
     },
     // {

--- a/configs/pairlist-volume-binance-usdc.json
+++ b/configs/pairlist-volume-binance-usdc.json
@@ -20,7 +20,7 @@
       "method": "RangeStabilityFilter",
       "lookback_days": 3,
       "min_rate_of_change": 0.03,
-      "max_rate_of_change": 2.00,
+      "max_rate_of_change": 0.95,
       "refresh_period": 1800
     },
     // {

--- a/configs/pairlist-volume-binance-usdt.json
+++ b/configs/pairlist-volume-binance-usdt.json
@@ -20,7 +20,7 @@
       "method": "RangeStabilityFilter",
       "lookback_days": 3,
       "min_rate_of_change": 0.03,
-      "max_rate_of_change": 2.00,
+      "max_rate_of_change": 0.95,
       "refresh_period": 1800
     },
     // {

--- a/configs/pairlist-volume-bitget-btc.json
+++ b/configs/pairlist-volume-bitget-btc.json
@@ -20,7 +20,7 @@
       "method": "RangeStabilityFilter",
       "lookback_days": 3,
       "min_rate_of_change": 0.03,
-      "max_rate_of_change": 2.00,
+      "max_rate_of_change": 0.95,
       "refresh_period": 1800
     },
     // {

--- a/configs/pairlist-volume-bitget-usdt.json
+++ b/configs/pairlist-volume-bitget-usdt.json
@@ -20,7 +20,7 @@
       "method": "RangeStabilityFilter",
       "lookback_days": 3,
       "min_rate_of_change": 0.03,
-      "max_rate_of_change": 2.00,
+      "max_rate_of_change": 0.95,
       "refresh_period": 1800
     },
     // {

--- a/configs/pairlist-volume-bitmart-btc.json
+++ b/configs/pairlist-volume-bitmart-btc.json
@@ -20,7 +20,7 @@
       "method": "RangeStabilityFilter",
       "lookback_days": 3,
       "min_rate_of_change": 0.03,
-      "max_rate_of_change": 2.00,
+      "max_rate_of_change": 0.95,
       "refresh_period": 1800
     },
     // {

--- a/configs/pairlist-volume-bitmart-usdt.json
+++ b/configs/pairlist-volume-bitmart-usdt.json
@@ -20,7 +20,7 @@
       "method": "RangeStabilityFilter",
       "lookback_days": 3,
       "min_rate_of_change": 0.03,
-      "max_rate_of_change": 2.00,
+      "max_rate_of_change": 0.95,
       "refresh_period": 1800
     },
     // {

--- a/configs/pairlist-volume-bitvavo-eur.json
+++ b/configs/pairlist-volume-bitvavo-eur.json
@@ -20,7 +20,7 @@
       "method": "RangeStabilityFilter",
       "lookback_days": 3,
       "min_rate_of_change": 0.03,
-      "max_rate_of_change": 2.00,
+      "max_rate_of_change": 0.95,
       "refresh_period": 1800
     },
     // {

--- a/configs/pairlist-volume-bybit-btc.json
+++ b/configs/pairlist-volume-bybit-btc.json
@@ -20,7 +20,7 @@
       "method": "RangeStabilityFilter",
       "lookback_days": 3,
       "min_rate_of_change": 0.03,
-      "max_rate_of_change": 2.00,
+      "max_rate_of_change": 0.95,
       "refresh_period": 1800
     },
     // {

--- a/configs/pairlist-volume-bybit-usdt.json
+++ b/configs/pairlist-volume-bybit-usdt.json
@@ -20,7 +20,7 @@
       "method": "RangeStabilityFilter",
       "lookback_days": 3,
       "min_rate_of_change": 0.03,
-      "max_rate_of_change": 2.00,
+      "max_rate_of_change": 0.95,
       "refresh_period": 1800
     },
     // {

--- a/configs/pairlist-volume-gateio-btc.json
+++ b/configs/pairlist-volume-gateio-btc.json
@@ -20,7 +20,7 @@
       "method": "RangeStabilityFilter",
       "lookback_days": 3,
       "min_rate_of_change": 0.03,
-      "max_rate_of_change": 2.00,
+      "max_rate_of_change": 0.95,
       "refresh_period": 1800
     },
     // {

--- a/configs/pairlist-volume-gateio-usdt.json
+++ b/configs/pairlist-volume-gateio-usdt.json
@@ -20,7 +20,7 @@
       "method": "RangeStabilityFilter",
       "lookback_days": 3,
       "min_rate_of_change": 0.03,
-      "max_rate_of_change": 2.00,
+      "max_rate_of_change": 0.95,
       "refresh_period": 1800
     },
     // {

--- a/configs/pairlist-volume-htx-btc.json
+++ b/configs/pairlist-volume-htx-btc.json
@@ -20,7 +20,7 @@
       "method": "RangeStabilityFilter",
       "lookback_days": 3,
       "min_rate_of_change": 0.03,
-      "max_rate_of_change": 2.00,
+      "max_rate_of_change": 0.95,
       "refresh_period": 1800
     },
     // {

--- a/configs/pairlist-volume-htx-usdt.json
+++ b/configs/pairlist-volume-htx-usdt.json
@@ -20,7 +20,7 @@
       "method": "RangeStabilityFilter",
       "lookback_days": 3,
       "min_rate_of_change": 0.03,
-      "max_rate_of_change": 2.00,
+      "max_rate_of_change": 0.95,
       "refresh_period": 1800
     },
     // {

--- a/configs/pairlist-volume-hyperliquid-usdc.json
+++ b/configs/pairlist-volume-hyperliquid-usdc.json
@@ -16,7 +16,7 @@
       "method": "RangeStabilityFilter",
       "lookback_days": 3,
       "min_rate_of_change": 0.03,
-      "max_rate_of_change": 2.00,
+      "max_rate_of_change": 0.95,
       "refresh_period": 1800
     },
     // {

--- a/configs/pairlist-volume-kraken-futures.json
+++ b/configs/pairlist-volume-kraken-futures.json
@@ -21,7 +21,7 @@
       "method": "RangeStabilityFilter",
       "lookback_days": 3,
       "min_rate_of_change": 0.03,
-      "max_rate_of_change": 2.00,
+      "max_rate_of_change": 0.95,
       "refresh_period": 1800
     },
     // {

--- a/configs/pairlist-volume-kraken-usd.json
+++ b/configs/pairlist-volume-kraken-usd.json
@@ -20,7 +20,7 @@
       "method": "RangeStabilityFilter",
       "lookback_days": 3,
       "min_rate_of_change": 0.03,
-      "max_rate_of_change": 2.00,
+      "max_rate_of_change": 0.95,
       "refresh_period": 1800
     },
     // {

--- a/configs/pairlist-volume-kucoin-btc.json
+++ b/configs/pairlist-volume-kucoin-btc.json
@@ -20,7 +20,7 @@
       "method": "RangeStabilityFilter",
       "lookback_days": 3,
       "min_rate_of_change": 0.03,
-      "max_rate_of_change": 2.00,
+      "max_rate_of_change": 0.95,
       "refresh_period": 1800
     },
     // {

--- a/configs/pairlist-volume-kucoin-usdt.json
+++ b/configs/pairlist-volume-kucoin-usdt.json
@@ -20,7 +20,7 @@
       "method": "RangeStabilityFilter",
       "lookback_days": 3,
       "min_rate_of_change": 0.03,
-      "max_rate_of_change": 2.00,
+      "max_rate_of_change": 0.95,
       "refresh_period": 1800
     },
     // {

--- a/configs/pairlist-volume-mexc-btc.json
+++ b/configs/pairlist-volume-mexc-btc.json
@@ -20,7 +20,7 @@
       "method": "RangeStabilityFilter",
       "lookback_days": 3,
       "min_rate_of_change": 0.03,
-      "max_rate_of_change": 2.00,
+      "max_rate_of_change": 0.95,
       "refresh_period": 1800
     },
     // {

--- a/configs/pairlist-volume-mexc-usdt.json
+++ b/configs/pairlist-volume-mexc-usdt.json
@@ -20,7 +20,7 @@
       "method": "RangeStabilityFilter",
       "lookback_days": 3,
       "min_rate_of_change": 0.03,
-      "max_rate_of_change": 2.00,
+      "max_rate_of_change": 0.95,
       "refresh_period": 1800
     },
     // {

--- a/configs/pairlist-volume-okx-btc.json
+++ b/configs/pairlist-volume-okx-btc.json
@@ -20,7 +20,7 @@
       "method": "RangeStabilityFilter",
       "lookback_days": 3,
       "min_rate_of_change": 0.03,
-      "max_rate_of_change": 2.00,
+      "max_rate_of_change": 0.95,
       "refresh_period": 1800
     },
     // {

--- a/configs/pairlist-volume-okx-futures.json
+++ b/configs/pairlist-volume-okx-futures.json
@@ -21,7 +21,7 @@
       "method": "RangeStabilityFilter",
       "lookback_days": 3,
       "min_rate_of_change": 0.03,
-      "max_rate_of_change": 2.00,
+      "max_rate_of_change": 0.95,
       "refresh_period": 1800
     },
     // {

--- a/configs/pairlist-volume-okx-usdt.json
+++ b/configs/pairlist-volume-okx-usdt.json
@@ -20,7 +20,7 @@
       "method": "RangeStabilityFilter",
       "lookback_days": 3,
       "min_rate_of_change": 0.03,
-      "max_rate_of_change": 2.00,
+      "max_rate_of_change": 0.95,
       "refresh_period": 1800
     },
     // {


### PR DESCRIPTION
## Summary

Lowers `max_rate_of_change` from `2.00` to `0.95` across all 25 `pairlist-volume-*.json` configs (all exchanges + quote currencies).

`min_rate_of_change` left unchanged at `0.03` — its only purpose is to dodge any stables not already in the blacklist.

Filter chain (FullTradesFilter, AgeFilter, PriceFilter, SpreadFilter) and refresh periods are all unchanged.

## Rationale

Above `2.00` we tend to see extreme highs and lows — heavy losses, casino-like behavior. Under `1.00` (ideally under `0.8`) the trading is much more stable. `0.95` sits between the "comfortable" floor (~1.41) and the ideal target (~0.8) — a measured step down rather than the full 2.00 → 0.8 plunge in one move.

## Live observation

3 bots (Binance/Bybit/Bitget USDT futures):

- Recent UB/USDT trade had `rate_of_change ≈ 1.05` — just above the new 0.95 cap. The trade itself closed at +6.20%, but that's the kind of swing that's risky to repeat on high-volatility pairs.
- Other recent trades (CLO +10%, VELVET, WLD, etc.) all sat well under 0.95.
- 3 bots running this filter live since today; will report 100+ trade observation back to you when it accumulates.

## Test plan

- [x] All 25 files updated (1 line per file, only the upper bound)
- [x] No other filter values touched
- [x] Live tested on Binance/Bybit/Bitget futures
- [ ] 100+ trade observation (in progress)

🤖 Generated with [Claude Code](https://claude.com/claude-code)