### PR TITLE
X7: signal 562: add bull-market V-bottom protections

### DIFF
--- a/NostalgiaForInfinityX7.py
+++ b/NostalgiaForInfinityX7.py
@@ -25640,6 +25640,18 @@ class NostalgiaForInfinityX7(IStrategy):
             & ((roc_9_4h_gt_neg_50) | (rsi_3_4h_gt_15) | (stochrsi_k_4h_gt_10))
             # 1d ultra-capitulation (STOCHRSIk = 0, RSI_3 < 10) = absolute bottom
             & ((rsi_3_1d_gt_10) | (stochrsi_k_1d > 5.0) | (rsi_3_4h_gt_40))
+            # 4h drop ended (STOCHRSIk recovered) + 1h rallied = bull pullback over
+            & ((stochrsi_k_4h_lt_50) | (stochrsi_k_1h < 60.0))
+            # 1d AROONU high = recent 1d high made = bull pullback, not bear
+            & ((aroonu_14_1d_lt_60) | (rsi_3_4h_gt_25))
+            # 15m + 1h ultra-cap + 4h CMF positive = institutional buying, V-bottom
+            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_20) | (cmf_20_4h < -0.05))
+            # 4h CMF nearly neutral + 1h rallied = money outflow stopping, bounce starting
+            & ((cmf_20_4h < -0.05) | (stochrsi_k_1h < 70.0))
+            # 1d massive crash already + 1h rallied = capitulation done, bounce starting
+            & ((roc_9_1d > -25.0) | (stochrsi_k_1h < 60.0))
+            # 15m + 1h ultra-capitulation = V-bottom forming regardless of CMF
+            & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_15))
           )
 
           # Logic — Breakdown below BB lower in downtrend


### PR DESCRIPTION
## Summary

Follow-up to #1090 — walked signal 562 (Short Trend Breakdown) through
2021 (bull) and 2022 (bear) using the same per-pair replay +
`plot-dataframe` loop. The 2021 bull surfaced 11 new losses where the
shorts catch falling knives during pullbacks; this PR adds six OR-chains
that catch those patterns without removing any of the bear-market
winners on 2022.

Signal 562 enable flag stays \`False\` — please review and turn it on as
you see fit.

### Protections added

- **4h drop ended (STOCHRSIk recovered) + 1h rallied = bull pullback over**
  (SOL 2021-11-28 -\$397K) — `(stochrsi_k_4h_lt_50) | (stochrsi_k_1h < 60.0)`
- **1d AROONU high = recent 1d high made = bull pullback, not bear**
  (NEAR 2021-10-12 -\$358K) — `(aroonu_14_1d_lt_60) | (rsi_3_4h_gt_25)`
- **15m + 1h ultra-cap + 4h CMF positive = institutional buying, V-bottom**
  (ETH 2021-09-21 -\$350K, DOGE 2021-09-29) —
  `(rsi_3_15m_gt_10) | (rsi_3_1h_gt_20) | (cmf_20_4h < -0.05)`
- **4h CMF nearly neutral + 1h rallied = outflow stopping, bounce starting**
  (DOGE 2021-09-28 -\$311K) — `(cmf_20_4h < -0.05) | (stochrsi_k_1h < 70.0)`
- **1d massive crash already + 1h rallied = capitulation done, bounce**
  (SAND 2021-06-26 -\$236K) — `(roc_9_1d > -25.0) | (stochrsi_k_1h < 60.0)`
- **15m + 1h ultra-capitulation = V-bottom forming regardless of CMF**
  (DOGE 2021-07-20 -\$208K) — `(rsi_3_15m_gt_10) | (rsi_3_1h_gt_15)`

### Backtest impact (562 enabled in test, tuning mode — derisk off, v3_2 stops on)

| Year | Phase B (after #1090) | This PR | Δ |
| --- | --- | --- | --- |
| 2021 | 814t / +\$8.2M / 97.7% / 19L | 766t / +\$11.5M / 98.4% / **12L** | **+\$3.3M / -7L** |
| 2022 | 314t / +\$45.3K / 97.8% / 7L | 283t / +\$41.6K / 97.5% / **7L** | -\$3.7K / -31t |

The 2022 cost is the \"1 trade here and there\" trim — 31 wins less,
profit virtually unchanged. The 2021 gain is the bull-market V-bottom
losses we caught: 8 large losses dropped to small residuals or zero,
and the win count we lost on those pairs is far below the dollar value
of the losses prevented.

### Notes

- 2-condition OR-chains where the pattern is obvious, 3 only when needed,
  same convention as your earlier guidance.
- Pre-computed masks used where the threshold matches; falls back to
  direct comparison when no matching mask exists in the entry scope.
- I left the 2026 baseline (the 48-coin live-loss set) intact — the
  protections we shipped in #1090 still cover that window.