### PR TITLE
X7: signal 563: add 1d ultra-capitulation protection

### DIFF
--- a/NostalgiaForInfinityX7.py
+++ b/NostalgiaForInfinityX7.py
@@ -25678,6 +25678,8 @@ class NostalgiaForInfinityX7(IStrategy):
             & ((rsi_3_4h_gt_15) | (stochrsi_k_15m < 90.0) | (aroonu_14_15m_lt_90))
             # 4h still oversold + 15m STOCHRSIk peaked = top distribution near recent levels
             & ((rsi_3_4h_gt_15) | (stochrsi_k_15m < 90.0))
+            # 1d ultra-capitulation (STOCHRSIk = 0, RSI_3 < 10) = absolute bottom
+            & ((rsi_3_1d_gt_10) | (stochrsi_k_1d > 5.0) | (rsi_3_4h_gt_40))
           )
 
           # Logic — Bounce that fails to reclaim resistance


### PR DESCRIPTION
## Summary

Small follow-up to #1090 — added the same \"1d ultra-capitulation\" OR-chain
that we already have on signal 562 to signal 563. When the daily STOCHRSIk
is at 0 and RSI_3 is below 10, the coin has hit an absolute bottom and a
bounce is much more likely than a continuation — skip the dead-cat-bounce
short there.

\`\`\`python
& ((rsi_3_1d_gt_10) | (stochrsi_k_1d > 5.0) | (rsi_3_4h_gt_40))
\`\`\`

### What this catches

CRV 2022-10-13 14:20 → previously -\$1,738 doom in the 2026 sweep when we
ran signal 563 in tuning mode. With this chain the entry is skipped and
the 2022 backtest stays at 56 trades / +\$3K / 100% WR for 563.

### Notes

- Signal 563 enable flag stays \`False\`.
- This is the missing twin of the \"1d ultra-cap\" chain on signal 562 — it
  was already in 562 from #1090, just not on 563.