### PR TITLE
X7: signal 65 + 562: round 2 V-bottom / parabolic protections

### DIFF
--- a/NostalgiaForInfinityX7.py
+++ b/NostalgiaForInfinityX7.py
@@ -20747,6 +20747,8 @@ class NostalgiaForInfinityX7(IStrategy):
             & ((stochrsi_k_4h_lt_90) | (roc_9_1d_lt_20) | (cmf_20_4h_gt_neg_0_0))
             # 15m euphoria spike without 4h confirmation = spike top fake breakout
             & ((rsi_3_15m < 90.0) | (stochrsi_k_4h > 30.0))
+            # 1d parabolic pump (huge ROC + extreme RSI_14) = exhaustion top
+            & ((rsi_14_1d < 75.0) | (roc_9_1d < 30.0))
           )
 
           # Logic — Breakout above BB upper with momentum
@@ -25662,6 +25664,14 @@ class NostalgiaForInfinityX7(IStrategy):
             & ((roc_9_1d > -25.0) | (stochrsi_k_1h < 60.0))
             # 15m + 1h ultra-capitulation = V-bottom forming regardless of CMF
             & ((rsi_3_15m_gt_10) | (rsi_3_1h_gt_15))
+            # 4h STOCHRSIk still extreme + 1h moderate = second leg waiting bounce
+            & ((stochrsi_k_4h > 10.0) | (rsi_3_1h_gt_30))
+            # 1d STOCHRSIk floor + 1d CMF positive = institutional buying after crash
+            & ((stochrsi_k_1d > 5.0) | (cmf_20_1d < 0.0) | (rsi_3_4h_gt_45))
+            # 1d big crash + 1h moderate overbought = bull pullback after sell-off
+            & ((roc_9_1d > -22.0) | (stochrsi_k_1h < 70.0))
+            # 1h overbought + 1d CMF positive = bull pullback bouncing on inflow
+            & ((stochrsi_k_1h < 70.0) | (cmf_20_1d < 0.0))
           )
 
           # Logic — Breakdown below BB lower in downtrend


### PR DESCRIPTION
## Summary

Follow-up to #1093 — kept walking signals 65 (Long Breakout) and 562
(Short Trend Breakdown) through 2021 (bull) loss residuals using the
same per-pair replay + plot-dataframe loop. The remaining losses had
narrow patterns the prior chains kept escaping by one threshold; five
new 2-condition OR-chains catch them without removing more than a
couple of winners on 2022.

Enable flags stay \`False\` — please review.

### Protections added

**Signal 65 (Long Breakout)**
- 1d parabolic pump (huge ROC + extreme RSI_14) = exhaustion top
  - \`(rsi_14_1d < 75.0) | (roc_9_1d < 30.0)\`
  - Catches **SOL 2021-09-09 -\$404K** (1d ROC +73%, 1d RSI_14 89.7)
    and **DOGE 2021-01-29 -\$1.6K** (the WSB pump — 4h ROC +572%,
    1d ROC +301%, 1d RSI_14 91.5)

**Signal 562 (Short Trend Breakdown)**
- 4h STOCHRSIk still extreme + 1h moderate = second leg waiting bounce
  - \`(stochrsi_k_4h > 10.0) | (rsi_3_1h_gt_30)\`
  - Catches **DOGE 2021-07-20 09:55** (residual after first entry
    already blocked, but the signal re-fired six hours later)
- 1d STOCHRSIk floor + 1d CMF positive = institutional buying after crash
  - \`(stochrsi_k_1d > 5.0) | (cmf_20_1d < 0.0) | (rsi_3_4h_gt_45)\`
  - Catches **ETH 2021-02-28 -\$650** (1d STOCHRSIk 0.89, CMF +0.10)
- 1d big crash + 1h moderate overbought = bull pullback after sell-off
  - \`(roc_9_1d > -22.0) | (stochrsi_k_1h < 70.0)\`
  - Catches **ETH 2021-06-26 -\$685** (1d ROC -23.6%, 1h STOCHRSIk 79.6)
- 1h overbought + 1d CMF positive = bull pullback bouncing on inflow
  - \`(stochrsi_k_1h < 70.0) | (cmf_20_1d < 0.0)\`
  - Catches **SAND 2021-09-28 -\$541K** (15m extreme cap, 1h STOCHRSIk
    86, 1d CMF +0.08)

### Per-pair tuning-mode backtest impact (signals enabled, derisk off, v3_2 stops on)

| Pair (2021) | Before | After |
| --- | --- | --- |
| SOL  | 1L (-\$404K on 65)             | 0L on 65 (the loss kept is on existing signal 45) |
| DOGE | 1L (-\$1.6K on 65, residuals)  | 0L on 65 + 562 |
| SAND | 1L (-\$541K on 562)            | 0L on 562 |
| ETH  | 2L (-\$650 + -\$685 on 562)    | 0L on 562 |

2022 trade-off — signal 562 went from 65 trades / 0L / +\$3.4K to 54
trades / 1L (\$1.2K) / +\$2.3K. One winner turned into a small loss
and ~11 trades disappeared; this matches your \"1 trade here and there
OK\" guidance.

Net across the years for the three signals together: 2021 swung from
~12 real losses to 0 on our tags, 2022 added 1, 2026 unchanged at 0.