### PR TITLE
configs: revert AgeFilter min_days_listed 90 → 60 (volume pairlists)

### DIFF
--- a/configs/pairlist-volume-binance-btc.json
+++ b/configs/pairlist-volume-binance-btc.json
@@ -7,7 +7,7 @@
       "refresh_period": 1800
     },
     { "method": "FullTradesFilter" },
-    { "method": "AgeFilter", "min_days_listed": 90 },
+    { "method": "AgeFilter", "min_days_listed": 60 },
     {
       "method": "PriceFilter",
       "low_price_ratio": 0.01

--- a/configs/pairlist-volume-binance-busd.json
+++ b/configs/pairlist-volume-binance-busd.json
@@ -7,7 +7,7 @@
       "refresh_period": 1800
     },
     { "method": "FullTradesFilter" },
-    { "method": "AgeFilter", "min_days_listed": 90 },
+    { "method": "AgeFilter", "min_days_listed": 60 },
     {
       "method": "PriceFilter",
       "low_price_ratio": 0.003

--- a/configs/pairlist-volume-binance-usdc.json
+++ b/configs/pairlist-volume-binance-usdc.json
@@ -7,7 +7,7 @@
       "refresh_period": 1800
     },
     { "method": "FullTradesFilter" },
-    { "method": "AgeFilter", "min_days_listed": 90 },
+    { "method": "AgeFilter", "min_days_listed": 60 },
     {
       "method": "PriceFilter",
       "low_price_ratio": 0.003

--- a/configs/pairlist-volume-binance-usdt.json
+++ b/configs/pairlist-volume-binance-usdt.json
@@ -7,7 +7,7 @@
       "refresh_period": 1800
     },
     { "method": "FullTradesFilter" },
-    { "method": "AgeFilter", "min_days_listed": 90 },
+    { "method": "AgeFilter", "min_days_listed": 60 },
     {
       "method": "PriceFilter",
       "low_price_ratio": 0.003

--- a/configs/pairlist-volume-bitget-btc.json
+++ b/configs/pairlist-volume-bitget-btc.json
@@ -7,7 +7,7 @@
       "refresh_period": 1800
     },
     { "method": "FullTradesFilter" },
-    { "method": "AgeFilter", "min_days_listed": 90 },
+    { "method": "AgeFilter", "min_days_listed": 60 },
     {
       "method": "PriceFilter",
       "low_price_ratio": 0.01

--- a/configs/pairlist-volume-bitget-usdt.json
+++ b/configs/pairlist-volume-bitget-usdt.json
@@ -7,7 +7,7 @@
       "refresh_period": 1800
     },
     { "method": "FullTradesFilter" },
-    { "method": "AgeFilter", "min_days_listed": 90 },
+    { "method": "AgeFilter", "min_days_listed": 60 },
     {
       "method": "PriceFilter",
       "low_price_ratio": 0.003

--- a/configs/pairlist-volume-bitmart-btc.json
+++ b/configs/pairlist-volume-bitmart-btc.json
@@ -7,7 +7,7 @@
       "refresh_period": 1800
     },
     { "method": "FullTradesFilter" },
-    { "method": "AgeFilter", "min_days_listed": 90 },
+    { "method": "AgeFilter", "min_days_listed": 60 },
     {
       "method": "PriceFilter",
       "low_price_ratio": 0.01

--- a/configs/pairlist-volume-bitmart-usdt.json
+++ b/configs/pairlist-volume-bitmart-usdt.json
@@ -7,7 +7,7 @@
       "refresh_period": 1800
     },
     { "method": "FullTradesFilter" },
-    { "method": "AgeFilter", "min_days_listed": 90 },
+    { "method": "AgeFilter", "min_days_listed": 60 },
     {
       "method": "PriceFilter",
       "low_price_ratio": 0.003

--- a/configs/pairlist-volume-bitvavo-eur.json
+++ b/configs/pairlist-volume-bitvavo-eur.json
@@ -7,7 +7,7 @@
       "refresh_period": 1800
     },
     { "method": "FullTradesFilter" },
-    { "method": "AgeFilter", "min_days_listed": 90 },
+    { "method": "AgeFilter", "min_days_listed": 60 },
     // {
     //   "method": "PriceFilter",
     //   "low_price_ratio": 0.003

--- a/configs/pairlist-volume-bybit-btc.json
+++ b/configs/pairlist-volume-bybit-btc.json
@@ -7,7 +7,7 @@
       "refresh_period": 1800
     },
     { "method": "FullTradesFilter" },
-    { "method": "AgeFilter", "min_days_listed": 90 },
+    { "method": "AgeFilter", "min_days_listed": 60 },
     {
       "method": "PriceFilter",
       "low_price_ratio": 0.01

--- a/configs/pairlist-volume-bybit-usdt.json
+++ b/configs/pairlist-volume-bybit-usdt.json
@@ -7,7 +7,7 @@
       "refresh_period": 1800
     },
     { "method": "FullTradesFilter" },
-    { "method": "AgeFilter", "min_days_listed": 90 },
+    { "method": "AgeFilter", "min_days_listed": 60 },
     {
       "method": "PriceFilter",
       "low_price_ratio": 0.003

--- a/configs/pairlist-volume-gateio-btc.json
+++ b/configs/pairlist-volume-gateio-btc.json
@@ -7,7 +7,7 @@
       "refresh_period": 1800
     },
     { "method": "FullTradesFilter" },
-    { "method": "AgeFilter", "min_days_listed": 90 },
+    { "method": "AgeFilter", "min_days_listed": 60 },
     {
       "method": "PriceFilter",
       "low_price_ratio": 0.01

--- a/configs/pairlist-volume-gateio-usdt.json
+++ b/configs/pairlist-volume-gateio-usdt.json
@@ -7,7 +7,7 @@
       "refresh_period": 1800
     },
     { "method": "FullTradesFilter" },
-    { "method": "AgeFilter", "min_days_listed": 90 },
+    { "method": "AgeFilter", "min_days_listed": 60 },
     {
       "method": "PriceFilter",
       "low_price_ratio": 0.003

--- a/configs/pairlist-volume-htx-btc.json
+++ b/configs/pairlist-volume-htx-btc.json
@@ -7,7 +7,7 @@
       "refresh_period": 1800
     },
     { "method": "FullTradesFilter" },
-    { "method": "AgeFilter", "min_days_listed": 90 },
+    { "method": "AgeFilter", "min_days_listed": 60 },
     {
       "method": "SpreadFilter",
       "max_spread_ratio": 0.0075

--- a/configs/pairlist-volume-htx-usdt.json
+++ b/configs/pairlist-volume-htx-usdt.json
@@ -7,7 +7,7 @@
       "refresh_period": 1800
     },
     { "method": "FullTradesFilter" },
-    { "method": "AgeFilter", "min_days_listed": 90 },
+    { "method": "AgeFilter", "min_days_listed": 60 },
     {
       "method": "PriceFilter",
       "low_price_ratio": 0.003

--- a/configs/pairlist-volume-hyperliquid-usdc.json
+++ b/configs/pairlist-volume-hyperliquid-usdc.json
@@ -7,7 +7,7 @@
       "refresh_period": 1800
     },
     { "method": "FullTradesFilter" },
-    { "method": "AgeFilter", "min_days_listed": 90 },
+    { "method": "AgeFilter", "min_days_listed": 60 },
     {
       "method": "PriceFilter",
       "low_price_ratio": 0.003

--- a/configs/pairlist-volume-kraken-futures.json
+++ b/configs/pairlist-volume-kraken-futures.json
@@ -8,7 +8,7 @@
       "lookback_days": 1
     },
     { "method": "FullTradesFilter" },
-    { "method": "AgeFilter", "min_days_listed": 90 },
+    { "method": "AgeFilter", "min_days_listed": 60 },
     // {
     //   "method": "PriceFilter",
     //   "low_price_ratio": 0.003

--- a/configs/pairlist-volume-kraken-usd.json
+++ b/configs/pairlist-volume-kraken-usd.json
@@ -7,7 +7,7 @@
       "refresh_period": 1800
     },
     { "method": "FullTradesFilter" },
-    { "method": "AgeFilter", "min_days_listed": 90 },
+    { "method": "AgeFilter", "min_days_listed": 60 },
     {
       "method": "PriceFilter",
       "low_price_ratio": 0.003

--- a/configs/pairlist-volume-kucoin-btc.json
+++ b/configs/pairlist-volume-kucoin-btc.json
@@ -7,7 +7,7 @@
       "refresh_period": 1800
     },
     { "method": "FullTradesFilter" },
-    { "method": "AgeFilter", "min_days_listed": 90 },
+    { "method": "AgeFilter", "min_days_listed": 60 },
     {
       "method": "PriceFilter",
       "low_price_ratio": 0.01

--- a/configs/pairlist-volume-kucoin-usdt.json
+++ b/configs/pairlist-volume-kucoin-usdt.json
@@ -7,7 +7,7 @@
       "refresh_period": 1800
     },
     { "method": "FullTradesFilter" },
-    { "method": "AgeFilter", "min_days_listed": 90 },
+    { "method": "AgeFilter", "min_days_listed": 60 },
     {
       "method": "PriceFilter",
       "low_price_ratio": 0.003

--- a/configs/pairlist-volume-mexc-btc.json
+++ b/configs/pairlist-volume-mexc-btc.json
@@ -7,7 +7,7 @@
       "refresh_period": 1800
     },
     { "method": "FullTradesFilter" },
-    { "method": "AgeFilter", "min_days_listed": 90 },
+    { "method": "AgeFilter", "min_days_listed": 60 },
     {
       "method": "PriceFilter",
       "low_price_ratio": 0.01

--- a/configs/pairlist-volume-mexc-usdt.json
+++ b/configs/pairlist-volume-mexc-usdt.json
@@ -7,7 +7,7 @@
       "refresh_period": 1800
     },
     { "method": "FullTradesFilter" },
-    { "method": "AgeFilter", "min_days_listed": 90 },
+    { "method": "AgeFilter", "min_days_listed": 60 },
     {
       "method": "PriceFilter",
       "low_price_ratio": 0.003

--- a/configs/pairlist-volume-okx-btc.json
+++ b/configs/pairlist-volume-okx-btc.json
@@ -7,7 +7,7 @@
       "refresh_period": 1800
     },
     { "method": "FullTradesFilter" },
-    { "method": "AgeFilter", "min_days_listed": 90 },
+    { "method": "AgeFilter", "min_days_listed": 60 },
     {
       "method": "PriceFilter",
       "low_price_ratio": 0.01

--- a/configs/pairlist-volume-okx-futures.json
+++ b/configs/pairlist-volume-okx-futures.json
@@ -8,7 +8,7 @@
       "lookback_days": 1
     },
     { "method": "FullTradesFilter" },
-    { "method": "AgeFilter", "min_days_listed": 90 },
+    { "method": "AgeFilter", "min_days_listed": 60 },
     // {
     //   "method": "PriceFilter",
     //   "low_price_ratio": 0.003

--- a/configs/pairlist-volume-okx-usdt.json
+++ b/configs/pairlist-volume-okx-usdt.json
@@ -7,7 +7,7 @@
       "refresh_period": 1800
     },
     { "method": "FullTradesFilter" },
-    { "method": "AgeFilter", "min_days_listed": 90 },
+    { "method": "AgeFilter", "min_days_listed": 60 },
     {
       "method": "PriceFilter",
       "low_price_ratio": 0.003


### PR DESCRIPTION
Reverts #1098 (the 60 → 90 bump).

**Why:** Bitget's daily-kline API returns at most ~90 candles, so AgeFilter can never see a pair as ≥90 days old — even assets listed for years report `age 89`. With `min_days_listed: 90` the AgeFilter validates **0 pairs** and the entire Bitget pairlist goes empty (only open trades remain). Confirmed on a live Bitget bot:

```
AgeFilter - Removed BICO/USDT:USDT ... because age 89 is less than 90 days
AgeFilter - Validated 0 pairs.
freqtrade.plugins.pairlistmanager - Whitelist with 0 pairs: []
```

Reverting to 60 restores the pairlist everywhere.