### PR TITLE
X7: use safe_filled * safe_price instead of order.cost (nullable)

### DIFF
--- a/NostalgiaForInfinityX7.py
+++ b/NostalgiaForInfinityX7.py
@@ -1951,7 +1951,7 @@ class NostalgiaForInfinityX7(IStrategy):
       total_profit += trade.funding_fees
     total_profit_ratio = total_profit / total_stake
     current_profit_ratio = total_profit / current_stake
-    init_profit_ratio = total_profit / filled_entries[0].cost
+    init_profit_ratio = total_profit / (filled_entries[0].safe_filled * filled_entries[0].safe_price)
     return total_profit, total_profit_ratio, current_profit_ratio, init_profit_ratio
 
   @staticmethod
@@ -27067,7 +27067,7 @@ class NostalgiaForInfinityX7(IStrategy):
     # Stoplosses
     if not sell:
       leverage = trade.leverage
-      entry_cost = filled_entries[0].cost
+      entry_cost = (filled_entries[0].safe_filled * filled_entries[0].safe_price)
 
       is_system_v3, is_system_v3_1, is_system_v3_2 = self.get_system_version_flags(trade)
 
@@ -27613,7 +27613,7 @@ class NostalgiaForInfinityX7(IStrategy):
             break
 
       if not sell:
-        entry_cost = filled_entries[0].cost
+        entry_cost = (filled_entries[0].safe_filled * filled_entries[0].safe_price)
         leverage = trade.leverage
         stop_threshold = None
         stop_enabled = False
@@ -28174,7 +28174,7 @@ class NostalgiaForInfinityX7(IStrategy):
 
     # Extra exit logic
     if not sell:
-      entry_cost = filled_entries[0].cost
+      entry_cost = (filled_entries[0].safe_filled * filled_entries[0].safe_price)
       leverage = trade.leverage
 
       if is_system_v3_2:
@@ -41214,7 +41214,7 @@ class NostalgiaForInfinityX7(IStrategy):
     if not self.stops_enable:
       return False, None
 
-    entry_cost = filled_entries[0].cost
+    entry_cost = (filled_entries[0].safe_filled * filled_entries[0].safe_price)
     if is_system_v3_2:
       # Stoploss doom
       if self.system_v3_2_stops_enable and (
@@ -41406,7 +41406,7 @@ class NostalgiaForInfinityX7(IStrategy):
     last_filled_entry = filled_entries[-1]
 
     current_stake_amount = trade_amount * exit_rate
-    slice_amount = first_filled_entry.cost
+    slice_amount = (first_filled_entry.safe_filled * first_filled_entry.safe_price)
     slice_profit = (exit_rate - last_filled_order.safe_price) / last_filled_order.safe_price
     slice_profit_entry = (exit_rate - last_filled_entry.safe_price) / last_filled_entry.safe_price
     slice_profit_exit = (
@@ -41890,7 +41890,7 @@ class NostalgiaForInfinityX7(IStrategy):
       (current_time - timedelta(minutes=5) > last_filled_entry.order_filled_utc)
       and ((current_time - timedelta(hours=2) > last_filled_order.order_filled_utc) or slice_profit_lt_neg_0_06)
       and (
-        (current_stake_amount < (first_filled_entry.cost * 0.50))
+        (current_stake_amount < ((first_filled_entry.safe_filled * first_filled_entry.safe_price) * 0.50))
         or (current_time - timedelta(hours=6) > last_filled_order.order_filled_utc)
         or slice_profit_lt_neg_0_06
       )
@@ -43913,7 +43913,7 @@ class NostalgiaForInfinityX7(IStrategy):
     profit_stake, profit_ratio, profit_current_stake_ratio, profit_init_ratio = profit_values
 
     current_stake_amount = trade_amount * exit_rate
-    slice_amount = filled_entries[0].cost
+    slice_amount = (filled_entries[0].safe_filled * filled_entries[0].safe_price)
     slice_profit = (exit_rate - filled_orders[-1].safe_price) / filled_orders[-1].safe_price
     slice_profit_entry = (exit_rate - filled_entries[-1].safe_price) / filled_entries[-1].safe_price
     slice_profit_exit = (
@@ -46057,7 +46057,7 @@ class NostalgiaForInfinityX7(IStrategy):
       profit_values = self.calc_total_profit(trade, filled_entries, filled_exits, exit_rate)
     profit_stake, profit_ratio, profit_current_stake_ratio, profit_init_ratio = profit_values
 
-    slice_amount = first_filled_entry.cost
+    slice_amount = (first_filled_entry.safe_filled * first_filled_entry.safe_price)
     slice_profit = (exit_rate - last_filled_order.safe_price) / last_filled_order.safe_price
     slice_profit_entry = (exit_rate - last_filled_entry.safe_price) / last_filled_entry.safe_price
     slice_profit_exit = (
@@ -46137,7 +46137,7 @@ class NostalgiaForInfinityX7(IStrategy):
         slice_amount /= regular_mode_stake_multipliers[0]
 
     is_not_trade_max_stake = current_stake_amount < (
-      (first_filled_entry.cost * self.grinding_v1_max_stake)
+      ((first_filled_entry.safe_filled * first_filled_entry.safe_price) * self.grinding_v1_max_stake)
       / (grind_mode_stake_multipliers[0] if is_grind_mode else 1.0)
     )
 
@@ -49691,7 +49691,7 @@ class NostalgiaForInfinityX7(IStrategy):
       profit_values = self.calc_total_profit(trade, filled_entries, filled_exits, exit_rate)
     profit_stake, profit_ratio, profit_current_stake_ratio, profit_init_ratio = profit_values
 
-    slice_amount = filled_entries[0].cost
+    slice_amount = (filled_entries[0].safe_filled * filled_entries[0].safe_price)
     slice_profit = (exit_rate - last_filled_order.safe_price) / last_filled_order.safe_price
     slice_profit_entry = (exit_rate - last_filled_entry.safe_price) / last_filled_entry.safe_price
     if count_of_exits > 0:
@@ -49890,7 +49890,7 @@ class NostalgiaForInfinityX7(IStrategy):
       profit_values = self.calc_total_profit(trade, filled_entries, filled_exits, exit_rate)
     profit_stake, profit_ratio, profit_current_stake_ratio, profit_init_ratio = profit_values
 
-    slice_amount = filled_entries[0].cost
+    slice_amount = (filled_entries[0].safe_filled * filled_entries[0].safe_price)
     slice_profit = (exit_rate - last_filled_order.safe_price) / last_filled_order.safe_price
     slice_profit_entry = (exit_rate - last_filled_entry.safe_price) / last_filled_entry.safe_price
     slice_profit_exit = (
@@ -50994,7 +50994,7 @@ class NostalgiaForInfinityX7(IStrategy):
 
     # Stoplosses
     if not sell:
-      entry_cost = filled_entries[0].cost
+      entry_cost = (filled_entries[0].safe_filled * filled_entries[0].safe_price)
       if is_system_v3_2:
         if profit_stake < -(
           entry_cost
@@ -51565,7 +51565,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif (0.09 >= profit_init_ratio > 0.005) and (last_rsi_3 < 1.0):
         sell, signal_name = True, f"exit_{mode_name}_rpd_10"
 
-      entry_cost = filled_entries[0].cost
+      entry_cost = (filled_entries[0].safe_filled * filled_entries[0].safe_price)
       if is_system_v3_2:
         # Stoplosses
         if self.system_v3_2_stops_enable and (
@@ -52183,7 +52183,7 @@ class NostalgiaForInfinityX7(IStrategy):
 
     # Extra exit logic
     if not sell:
-      entry_cost = filled_entries[0].cost
+      entry_cost = (filled_entries[0].safe_filled * filled_entries[0].safe_price)
       if is_system_v3_2:
         # Stoplosses
         if self.system_v3_2_stops_enable and (
@@ -64949,7 +64949,7 @@ class NostalgiaForInfinityX7(IStrategy):
     if not self.stops_enable:
       return False, None
 
-    entry_cost = filled_entries[0].cost
+    entry_cost = (filled_entries[0].safe_filled * filled_entries[0].safe_price)
     if is_system_v3_2:
       # Stoploss doom
       if self.system_v3_2_stops_enable and (
@@ -65142,7 +65142,7 @@ class NostalgiaForInfinityX7(IStrategy):
     last_filled_entry = filled_entries[-1]
 
     current_stake_amount = trade_amount * exit_rate
-    slice_amount = first_filled_entry.cost
+    slice_amount = (first_filled_entry.safe_filled * first_filled_entry.safe_price)
     slice_profit = (exit_rate - last_filled_order.safe_price) / last_filled_order.safe_price
     slice_profit_entry = (exit_rate - last_filled_entry.safe_price) / last_filled_entry.safe_price
     slice_profit_exit = (
@@ -65626,7 +65626,7 @@ class NostalgiaForInfinityX7(IStrategy):
       (current_time - timedelta(minutes=5) > last_filled_entry.order_filled_utc)
       and ((current_time - timedelta(hours=2) > last_filled_order.order_filled_utc) or slice_profit_gt_0_06)
       and (
-        (current_stake_amount < (first_filled_entry.cost * 0.50))
+        (current_stake_amount < ((first_filled_entry.safe_filled * first_filled_entry.safe_price) * 0.50))
         or (current_time - timedelta(hours=6) > last_filled_order.order_filled_utc)
         or slice_profit_gt_0_06
       )
@@ -67731,7 +67731,7 @@ class NostalgiaForInfinityX7(IStrategy):
     profit_stake, profit_ratio, profit_current_stake_ratio, profit_init_ratio = profit_values
 
     current_stake_amount = trade_amount * exit_rate
-    slice_amount = filled_entries[0].cost
+    slice_amount = (filled_entries[0].safe_filled * filled_entries[0].safe_price)
     slice_profit = (exit_rate - filled_orders[-1].safe_price) / filled_orders[-1].safe_price
     slice_profit_entry = (exit_rate - filled_entries[-1].safe_price) / filled_entries[-1].safe_price
     slice_profit_exit = (
@@ -69393,7 +69393,7 @@ class NostalgiaForInfinityX7(IStrategy):
       profit_values = self.calc_total_profit(trade, filled_entries, filled_exits, exit_rate)
     profit_stake, profit_ratio, profit_current_stake_ratio, profit_init_ratio = profit_values
 
-    slice_amount = first_filled_entry.cost
+    slice_amount = (first_filled_entry.safe_filled * first_filled_entry.safe_price)
     slice_profit = (exit_rate - last_filled_order.safe_price) / last_filled_order.safe_price
     slice_profit_entry = (exit_rate - last_filled_entry.safe_price) / last_filled_entry.safe_price
     slice_profit_exit = (
@@ -69473,7 +69473,7 @@ class NostalgiaForInfinityX7(IStrategy):
         slice_amount /= regular_mode_stake_multipliers[0]
 
     is_not_trade_max_stake = current_stake_amount < (
-      (first_filled_entry.cost * self.grinding_v1_max_stake)
+      ((first_filled_entry.safe_filled * first_filled_entry.safe_price) * self.grinding_v1_max_stake)
       / (grind_mode_stake_multipliers[0] if is_grind_mode else 1.0)
     )
 
@@ -72945,7 +72945,7 @@ class NostalgiaForInfinityX7(IStrategy):
       profit_values = self.calc_total_profit(trade, filled_entries, filled_exits, exit_rate)
     profit_stake, profit_ratio, profit_current_stake_ratio, profit_init_ratio = profit_values
 
-    slice_amount = filled_entries[0].cost
+    slice_amount = (filled_entries[0].safe_filled * filled_entries[0].safe_price)
     slice_profit = (exit_rate - last_filled_order.safe_price) / last_filled_order.safe_price
     slice_profit_entry = (exit_rate - last_filled_entry.safe_price) / last_filled_entry.safe_price
     if count_of_exits > 0:
@@ -73118,7 +73118,7 @@ class NostalgiaForInfinityX7(IStrategy):
       profit_values = self.calc_total_profit(trade, filled_entries, filled_exits, exit_rate)
     profit_stake, profit_ratio, profit_current_stake_ratio, profit_init_ratio = profit_values
 
-    slice_amount = filled_entries[0].cost
+    slice_amount = (filled_entries[0].safe_filled * filled_entries[0].safe_price)
     slice_profit = (exit_rate - last_filled_order.safe_price) / last_filled_order.safe_price
     slice_profit_entry = (exit_rate - last_filled_entry.safe_price) / last_filled_entry.safe_price
     slice_profit_exit = (


### PR DESCRIPTION
`order.cost` is a nullable DB column (`Order.cost: Mapped[float | None]`), so it can be `None` — e.g. when the exchange doesn't return cost, or for manually-migrated/synthetic orders. It's used in 23 spots in X7 (all `filled_entries[0].cost` / `first_filled_entry.cost`), feeding:
- `slice_amount = first_filled_entry.cost` (grind sizing — essential)
- `entry_cost = filled_entries[0].cost`
- `init_profit_ratio = total_profit / filled_entries[0].cost` (raises on None)

A `None` there breaks grinds / raises. `safe_cost` isn't suitable because it returns `0.0` on None (would zero the slice). This replaces all 23 with `safe_filled * safe_price`, which is always numeric.

### Backtest — NOT bit-identical (disclosed)

Isolated on the same base (v293-patched vs v293-unpatched), single docker process per year:

| Year | unpatched (raw .cost) | patched (safe_filled×price) | Δ |
|------|----------------------:|----------------------------:|--:|
| 2021 | $12,636,109.80 | $12,703,241.79 | **+$67,132 (+0.53%)** |
| 2026 | $27,437.44 | $27,436.84 | −$0.60 |

Same trade counts, same losses, same WR/DD in both years. `order.cost` is not exactly `filled × average`, so `slice_amount` shifts slightly and the difference compounds over grind cycles (visible in the grind-heavy 2021 bull year, negligible in low-grind 2026). The effect is positive here. Flagging it because it changes grind sizing — it is not a pure no-op.