### PR TITLE
X7: short_grind_entry_v3 — mirror the g3/g7/g20 stoch checks from long

### DIFF
--- a/NostalgiaForInfinityX7.py
+++ b/NostalgiaForInfinityX7.py
@@ -69210,6 +69210,7 @@ class NostalgiaForInfinityX7(IStrategy):
     last_roc_9_1d = last_candle["ROC_9_1d"]
     last_stochrsi_k = last_candle["STOCHRSIk_14_14_3_3"]
     last_stochrsik_15m = last_candle["STOCHRSIk_14_14_3_3_15m"]
+    last_stochrsi_k_1h = last_candle["STOCHRSIk_14_14_3_3_1h"]
     last_willr_14 = last_candle["WILLR_14"]
     last_willr_84_1h = last_candle["WILLR_84_1h"]
     last_bbu = last_candle["BBU_20_2.0"]
@@ -69266,6 +69267,7 @@ class NostalgiaForInfinityX7(IStrategy):
       and (last_rsi_3_4h < 85.0)
       and (last_rsi_14 > 65.0)
       and (last_aroond_14_15m < 25.0)
+      and (last_stochrsi_k_1h > 10.0)
       and (last_roc_9_1h < 15.0)
       and (last_roc_9_4h < 15.0)
       and (last_close < (last_close_min_48 * 1.15))
@@ -69329,6 +69331,7 @@ class NostalgiaForInfinityX7(IStrategy):
       and (last_willr_14 > -50.0)
       and (last_willr_84_1h > -30.0)
       and (last_stochrsi_k > 70.0)
+      and (last_stochrsi_k_1h > 10.0)
       and (last_roc_9_1h < 10.0)
       and (last_roc_9_1h > -20.0)
       and (last_roc_9_4h < 10.0)
@@ -69498,6 +69501,7 @@ class NostalgiaForInfinityX7(IStrategy):
       and (last_aroond_14 < 30.0)
       and (last_aroond_14_4h > 50.0)
       and (last_roc_9_1d < 15.0)
+      and (last_candle["STOCHRSIk_14_14_3_3_4h"] > 10.0)
       and (last_ema_50_4h < last_ema_100_4h)
       and (last_close > (last_close_min_48 * 1.05))
     ):


### PR DESCRIPTION
Mirrors the recent long-side grind entry stoch checks to short:

- **g3, g7**: long got `last_stochrsi_k_1h < 90.0` → short gets the inverted `last_stochrsi_k_1h > 10.0` (and adds the `last_stochrsi_k_1h` read, which short lacked).
- **g20**: long got `last_candle["STOCHRSIk_14_14_3_3_4h"] < 90.0` → short gets `> 10.0` (inline, matching long g20).

Inversion follows the existing short convention — short g7 already mirrors long g7's `stochrsi_k < 30` as `stochrsi_k > 70` (100 − x), so `< 90` → `> 10`. Unique 2-line anchors, `py_compile` clean. Please confirm the thresholds; happy to backtest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)