### PR TITLE
X7: g20 grind entry — add parabolic-pump branch to stoch_4h gate

### DIFF
--- a/NostalgiaForInfinityX7.py
+++ b/NostalgiaForInfinityX7.py
@@ -45999,7 +45999,7 @@ class NostalgiaForInfinityX7(IStrategy):
       and (last_aroonu_14 < 30.0)
       and (last_aroonu_14_4h > 50.0)
       and (last_roc_9_1d > -15.0)
-      and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 90.0)
+      and ((last_candle["STOCHRSIk_14_14_3_3_4h"] < 90.0) or (last_roc_9_4h < 30.0))
       and (last_ema_50_4h > last_ema_100_4h)
       and (last_close < (last_close_max_48 * 0.95))
     ):


### PR DESCRIPTION
The g20 `STOCHRSIk_4h < 90` gate correctly blocks RIF-style top-stacking, but it also cuts ~26 profitable grind trades in 2022. Making it fire only on **parabolic** overbought recovers those while keeping the top protection.

```
- and (last_candle["STOCHRSIk_14_14_3_3_4h"] < 90.0)
+ and ((last_candle["STOCHRSIk_14_14_3_3_4h"] < 90.0) or (last_roc_9_4h < 30.0))
```

**RIF still blocked** — its live top-add on the last-closed 4h was stoch 99.2 + ROC +53.6, both fail → blocked.

**Cost-free in 2022** — across 4142 moments with `stoch_4h >= 90`, **0%** had `ROC_9_4h > 30` (steady uptrends, not parabolic). The ROC branch never fires there, so it only relaxes the non-parabolic entries the gate was blocking.

| 2022 | Profit | Trades | DD |
|------|--------|--------|-----|
| `< 90` (current) | $16,319 | 122 | 11.65% |
| `< 90` OR `ROC < 30` | **$22,057** | 148 | 12.02% |

Recovers +$5,738 (all 26 trades) for +0.37pp DD. Long side only; short mirror can follow.