### PR TITLE
X7: short_exit_rebuy — mirror long's system_v3_2_stops_enable doom-stop gate

### DIFF
--- a/NostalgiaForInfinityX7.py
+++ b/NostalgiaForInfinityX7.py
@@ -51579,7 +51579,7 @@ class NostalgiaForInfinityX7(IStrategy):
     if not sell:
       entry_cost = filled_entries[0].safe_filled * filled_entries[0].safe_price
       if is_system_v3_2:
-        if profit_stake < -(
+        if self.system_v3_2_stops_enable and profit_stake < -(
           entry_cost
           * (
             self.system_v3_2_stop_threshold_futures_rebuy


### PR DESCRIPTION
`long_exit_rebuy()` gates its `is_system_v3_2` rebuy doom-stop behind `self.system_v3_2_stops_enable`:

```python
if self.system_v3_2_stops_enable and profit_stake < -(entry_cost * threshold / leverage):
    sell, signal_name = True, stoploss_doom
```

`short_exit_rebuy()` applied the same v3_2 doom-stop **unconditionally** (no flag gate). This
mirrors the long behaviour so both long and short rebuy doom-stops are controlled by the single
`system_v3_2_stops_enable` flag — so it can be enabled/disabled symmetrically.

**Backtest-neutral:** 2022 (12-coin) bit-identical to baseline (150t / $22,035 / 4L / 12.03% DD) —
short rebuy conditions 562/563 are disabled and `system_v3_2_stops_enable` defaults to False, so no
trades change. Pure symmetry fix ahead of enabling short rebuy grinding.