### PR TITLE
grind mode (120): use long_grind_entry_v3 instead of legacy long_grind_entry

### DIFF
--- a/NostalgiaForInfinityX7.py
+++ b/NostalgiaForInfinityX7.py
@@ -47541,7 +47541,9 @@ class NostalgiaForInfinityX7(IStrategy):
             else:
               return -ft_sell_amount
 
-    is_long_grind_entry = self.long_grind_entry(last_candle, previous_candle, slice_profit, True)
+    is_long_grind_entry = self.long_grind_entry_v3(
+      last_candle, previous_candle, num_open_grinds, slice_profit, slice_profit_entry, slice_profit_exit, True
+    )  # 120 grinds via the v3 entry set (g0..g23) instead of the legacy grind mode
     slice_profit_lt_neg_0_06 = slice_profit < -0.06
     num_open_grinds_eq_0 = num_open_grinds == 0
 


### PR DESCRIPTION
Per your call ("OK, we change to this") — `long_grind_adjust_trade_position()` (the grind-mode / signal-120 path, also very old trades) grinds via the legacy `long_grind_entry()`. This routes it to `long_grind_entry_v3()` — the normal v3 grind entry set (g0..g23, including the g22/g23 recovery-rebuild) — passing the extra v3 args (`num_open_grinds`, `slice_profit_entry`, `slice_profit_exit`) that are already in scope at the call site.

One-line swap (the `is_long_grind_entry = ...` call inside `long_grind_adjust_trade_position`; the `no_derisk` variant is left as-is).

The legacy grind-mode rides losers deep before stopping out; the v3 grind recovers far more of the drawdown.

**RUNE-only 2022** (`configs/rune-2022.json`, `max_open_trades: 1`, `--cache none`):

| variant | trades | net | RUNE grind trade |
|--|--|--|--|
| legacy 120 grind-mode | 13 | **-$6,645** | -$15,682 (-13.8%, stop_loss, ~176d) |
| **120 → v3 grind** | 13 | **+$3,314** | -$5,723 (-3.4%, force_exit) |

Net flips **-$6,645 → +$3,314 (+$9,959)** and the RUNE grind-death shrinks from -13.8% to -3.4%. 0 errors. It also beats disabling grind-mode entirely (`grind_mode_max_slots: 0` gave +$252).