### PR TITLE
short grind g23: sync overbought OR-chain from long (4672c16)

### DIFF
--- a/NostalgiaForInfinityX7.py
+++ b/NostalgiaForInfinityX7.py
@@ -70268,6 +70268,7 @@ class NostalgiaForInfinityX7(IStrategy):
       and ((last_rsi_3_1d < 85.0) or (last_stochrsi_k_1h > 20.0))
       and ((last_rsi_3_1d < 70.0) or (last_aroond_14_1h < 100.0))
       and ((last_rsi_3_1d < 70.0) or (last_aroond_14_4h < 100.0))
+      and ((last_rsi_3_1d < 50.0) or (last_stochrsi_k_1h > 20.0) or (last_stochrsi_k_4h > 10.0))
       and ((last_aroond_14_15m < 100.0) or (last_aroond_14_1h < 100.0))
       and ((last_aroond_14_15m < 100.0) or (last_aroond_14_4h < 100.0))
       and ((last_aroond_14_15m < 100.0) or (last_aroond_14_1d < 100.0))


### PR DESCRIPTION
`4672c16` (v408) added an OR-chain to **long g23** *after* the short g22/g23 mirror (#1131) was merged, so short g23 was left one condition behind. This mirrors that single line:

```
long : and ((last_rsi_3_1d > 50.0) or (last_stochrsi_k_1h < 80.0) or (last_stochrsi_k_4h < 90.0))
short: and ((last_rsi_3_1d < 50.0) or (last_stochrsi_k_1h > 20.0) or (last_stochrsi_k_4h > 10.0))
```

Mirror convention: RSI/StochRSI `> X` → `< 100-X` (long `>50`→short `<50`, `<80`→`>20`, `<90`→`>10`).

Verified all other grind tags (g0-g22) are already in sync long↔short; g23 was the only gap. Additive overbought-protection OR-chain, backtest-neutral (blocks over-extended short grind adds only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)