### PR TITLE
signal 563: add scenario-based entry protections (disabled)

### DIFF
--- a/NostalgiaForInfinityX7.py
+++ b/NostalgiaForInfinityX7.py
@@ -26477,6 +26477,34 @@ class NostalgiaForInfinityX7(IStrategy):
             & ((rsi_3_4h_gt_15) | (stochrsi_k_15m < 90.0))
             # 1d ultra-capitulation (STOCHRSIk = 0, RSI_3 < 10) = absolute bottom
             & ((rsi_3_1d_gt_10) | (stochrsi_k_1d > 5.0) | (rsi_3_4h_gt_40))
+            # 1d already recovering (RSI_3 elevated + STOCHRSIk not low) = real recovery, not dead-cat
+            & ((rsi_3_1d < 30.0) | (stochrsi_k_1d < 40.0))
+            # 4h RSI still elevated (both 14 and 3-period) = 4h not bearish enough = real recovery
+            & ((rsi_14_4h < 37.0) | (rsi_3_4h < 37.0))
+            # SCENARIO: 1d not-yet-recovered gate OR 4h reclaiming = failed dead-cat vs real recovery
+            & ((rsi_14_1d < 44.0) | (rsi_14_4h > 24.0))
+            # SCENARIO: 1d ultra-capitulated (RSI_3 at absolute bottom) = due for a bounce that liquidates the short
+            & (rsi_3_1d > 5.0)
+            # SCENARIO: 4h reclaiming OR 4h money-flow leaving = bounce building, not a dead-cat
+            & ((rsi_14_4h > 24.0) | (mfi_14_4h < 41.0))
+            # SCENARIO: 4h money inflow at a 1d stoch-bottom = accumulation, bounce building
+            & ((stochrsi_k_1d > 0.0) | (cci_20_change_pct_1h < -4.0))
+            # SCENARIO: 1d downside stalling + short-term ultra-oversold = sellers exhausted, reversal
+            & ((roc_9_1d < -5.0) | (rsi_3 > 28.0))
+            # SCENARIO: 1d/4h ultra-capitulated but 1h already recovering = bottom in, bounce started
+            & ((rsi_14_1h < 43.0) | (rsi_14_4h > 24.0))
+            # SCENARIO: 4h crashed hard + 1h bouncing = V-reversal after capitulation, pump liquidates short
+            & ((rsi_3_1d > 9.0) | (roc_9_4h > -23.0) | (rsi_14_1h < 40.0))
+            # SCENARIO: 1d massive crash + 1h uptrend birth = capitulation bottom reversing
+            & ((roc_9_1d > -42.0) | (aroonu_14_1h < 42.0))
+            # SCENARIO: overbought entry + 4h momentum still up = shorting into a trend bounce
+            & ((rsi_14 < 66.0) | (rsi_3_4h < 39.0))
+            # SCENARIO: 1d stoch at absolute bottom + 1d RSI mid = mixed, due-for-bounce zone
+            & ((stochrsi_k_1d > 0.0) | (rsi_14_1d < 43.0))
+            # SCENARIO: 4h absolute-oversold selloff = capitulation exhaustion, sharp bounce
+            & ((rsi_3_4h > 3.0) | (roc_9_4h > -25.0))
+            # SCENARIO: 1d ultra-cap + 1h CCI recovering = capitulation bottom bouncing
+            & ((rsi_3_1d > 9.0) | (cci_20_change_pct_1h > -38.0) | (rsi_3_4h > 17.0))
           )
 
           # Logic — Bounce that fails to reclaim resistance


### PR DESCRIPTION
Fine-tuned **signal 563** (Dead Cat Bounce Short) via the per-loss `plot-dataframe` / `--export signals` workflow over the **2025-2026 Bybit + Bitget** futures universe (grinding disabled, signal-quality isolation).

**14 scenario-based OR-chain protections** — each captures a market situation where a *dead-cat* short is actually shorting into a recovery/bounce:
- 1d recovering / 1d ultra-capitulated (absolute bottom)
- 4h reclaiming / 4h not bearish enough / 4h capitulation exhaustion
- 1h already bouncing
- overbought entry into a trend bounce

**Result across b1-b4 + bitget (2025-2026, ~317 winning 563 trades):**
- **13/14 real losses (all liquidations) eliminated**
- **0 winning trades lost** (verified per-window, 15 windows)
- The 1 remaining is a same-time market-wide pump — unfilterable at entry (grinding recovers it live)

Round thresholds, additive (only blocks over-extended short entries), so it's safe. Comments name the scenario each blocks. Some are still coin-specific; feel free to consolidate into more general protections.

**563 stays `enable = False`** — for your review + grinding-enabled validation before enabling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)