### PR TITLE
Add X7 signal 65 loss protections

### DIFF
--- a/NostalgiaForInfinityX7.py
+++ b/NostalgiaForInfinityX7.py
@@ -21398,6 +21398,37 @@ class NostalgiaForInfinityX7(IStrategy):
             & ((rsi_3_15m < 90.0) | (stochrsi_k_4h > 30.0))
             # 1d parabolic pump (huge ROC + extreme RSI_14) = exhaustion top
             & ((rsi_14_1d < 75.0) | (roc_9_1d < 30.0))
+            # P07 - daily extreme with weak 4h participation and elevated 1h RSI
+            & (
+              np.isnan(aroonu_14_1d)
+              | np.isnan(cmf_20_4h)
+              | np.isnan(rsi_14_1h)
+              | aroonu_14_1d_lt_100
+              | cmf_20_4h_gt_neg_0_10
+              | rsi_14_1h_lt_50
+            )
+            # P10 - weak 1h short-RSI participation
+            & (np.isnan(rsi_3_1h) | np.isnan(stochrsi_k_1h) | rsi_3_1h_gt_50 | stochrsi_k_1h_lt_60)
+            # P16 - weak 4h money flow during an extended 4h move
+            & (np.isnan(cmf_20_4h) | np.isnan(roc_9_4h) | cmf_20_4h_gt_neg_0_10 | roc_9_4h_lt_20)
+            # P18 - daily extension without 1h or 15m continuation
+            & (
+              np.isnan(roc_9_1d)
+              | np.isnan(rsi_3_1h)
+              | np.isnan(stochrsi_k_15m)
+              | roc_9_1d_lt_40
+              | rsi_3_1h_gt_60
+              | stochrsi_k_15m_lt_50
+            )
+            # P19 - mature 4h move without short-term continuation
+            & (
+              np.isnan(aroonu_14_4h)
+              | np.isnan(rsi_3_4h)
+              | np.isnan(stochrsi_k_1h)
+              | aroonu_14_4h_lt_70
+              | rsi_3_4h_gt_65
+              | stochrsi_k_1h_lt_50
+            )
           )
 
           # Logic — Breakout above BB upper with momentum

--- a/NostalgiaForInfinityX7.py
+++ b/NostalgiaForInfinityX7.py
@@ -68465,7 +68465,6 @@ class NostalgiaForInfinityX7(IStrategy):
     grind_open_orders,
     trade: Trade,
   ) -> tuple:
-
     # Normalize so profit is always positive when the short is profitable.
     profit = -grind_profit_rate
 


### PR DESCRIPTION
## Summary
- Add five pair/date-agnostic, fail-open protections to the existing X7 Signal 65 breakout condition.
- Keep `long_entry_condition_65_enable = False`.
- This branch is independent on the latest upstream `main` (`fa81543e5f29046dc9d4082a6b3f45fc71cbcb41`).

## Safety
- Only the Signal 65 protection expression in `populate_entry_trend()` changes.
- The guards reuse existing indicator Series and existing threshold masks.
- No pair, symbol, date, indicator formula, candle selection, stake, leverage, exit, or routing logic changes.
- Required NaN values fail open.
- No v3 grind-entry code is touched.
- The validated mixed-tag routing keeps other long tags when Signal 65 is rejected.

## Backtest scope
The fixed test scope was Binance futures, long direction, 90 pairs, and four independently reset annual windows
(2022, 2023, 2024, and 2025). Signal 65 was isolated with position adjustment and de-risk disabled while existing
system stops remained enabled.

The five accepted guards changed the Signal 65 surface from:

- 99 trades / 84 wins / 15 losses / 11 liquidations / `-15,947.83`
- to 83 trades / 80 wins / 3 losses / 2 liquidations / `+9,406.82`

This removes 12 losses and four raw winners. Duration p90 improved from 16,398 to 12,105 minutes; maximum duration
was unchanged. Integrated annual portfolio profit improved in all four windows. Drawdown improved in 2022, 2024,
and 2025; 2023 drawdown increased by 0.000055 percentage points while profit improved.

Independent accepted-set reproduction, enabled production-integration parity across all four years,
same-data default-disabled parity, and a 2022 normal-routing compatibility run passed. The extracted latest-main
Condition 65 expression is whitespace-normalized equivalent to the validated integration source, and every
referenced raw Series and threshold assignment matches.

## Limits
- This is in-sample loss-by-loss tuning on one exchange and one fixed pair cohort.
- Three Signal 65 losses remain unresolved.
- Broader out-of-sample, multi-exchange, and normal-routing validation is still required before activation.
- This PR does not request live activation or enable Signal 65 by default.

The self-contained maintainer proof shared separately has SHA-256
`daa972efd888d4a5010f28b125141777e9ba42acb6b9ca0ff140ff6a1b958f80`.

## Checks
- `$env:PYTHONUTF8='1'; python C:\Users\0\.codex\skills\nfi-upstream-pr\scripts\validate_nfi_pr.py --base origin/main --skip-static`
  - passed branch, changed-file, merge-tree, touched-function, runtime-path, and undefined-local checks
- `$base=git merge-base origin/main HEAD; git merge-tree $base origin/main HEAD`
- targeted `git diff origin/main...HEAD -- NostalgiaForInfinityX7.py` review
- `git diff --check origin/main...HEAD`
- `ruff format --check NostalgiaForInfinityX7.py`
- `ruff check NostalgiaForInfinityX7.py`
- `$env:PYTHONDONTWRITEBYTECODE='1'; python -m py_compile NostalgiaForInfinityX7.py`
