### PR TITLE
Align X7 signal 65 protection checks

### DIFF
--- a/NostalgiaForInfinityX7.py
+++ b/NostalgiaForInfinityX7.py
@@ -21399,36 +21399,15 @@ class NostalgiaForInfinityX7(IStrategy):
             # 1d parabolic pump (huge ROC + extreme RSI_14) = exhaustion top
             & ((rsi_14_1d < 75.0) | (roc_9_1d < 30.0))
             # P07 - daily extreme with weak 4h participation and elevated 1h RSI
-            & (
-              np.isnan(aroonu_14_1d)
-              | np.isnan(cmf_20_4h)
-              | np.isnan(rsi_14_1h)
-              | aroonu_14_1d_lt_100
-              | cmf_20_4h_gt_neg_0_10
-              | rsi_14_1h_lt_50
-            )
+            & ((aroonu_14_1d_lt_100) | (cmf_20_4h_gt_neg_0_10) | (rsi_14_1h_lt_50))
             # P10 - weak 1h short-RSI participation
-            & (np.isnan(rsi_3_1h) | np.isnan(stochrsi_k_1h) | rsi_3_1h_gt_50 | stochrsi_k_1h_lt_60)
+            & ((rsi_3_1h_gt_50) | (stochrsi_k_1h_lt_60))
             # P16 - weak 4h money flow during an extended 4h move
-            & (np.isnan(cmf_20_4h) | np.isnan(roc_9_4h) | cmf_20_4h_gt_neg_0_10 | roc_9_4h_lt_20)
+            & ((cmf_20_4h_gt_neg_0_10) | (roc_9_4h_lt_20))
             # P18 - daily extension without 1h or 15m continuation
-            & (
-              np.isnan(roc_9_1d)
-              | np.isnan(rsi_3_1h)
-              | np.isnan(stochrsi_k_15m)
-              | roc_9_1d_lt_40
-              | rsi_3_1h_gt_60
-              | stochrsi_k_15m_lt_50
-            )
+            & ((roc_9_1d_lt_40) | (rsi_3_1h_gt_60) | (stochrsi_k_15m_lt_50))
             # P19 - mature 4h move without short-term continuation
-            & (
-              np.isnan(aroonu_14_4h)
-              | np.isnan(rsi_3_4h)
-              | np.isnan(stochrsi_k_1h)
-              | aroonu_14_4h_lt_70
-              | rsi_3_4h_gt_65
-              | stochrsi_k_1h_lt_50
-            )
+            & ((aroonu_14_4h_lt_70) | (rsi_3_4h_gt_65) | (stochrsi_k_1h_lt_50))
           )
 
           # Logic — Breakout above BB upper with momentum


### PR DESCRIPTION
## Summary

- Remove the explicit `np.isnan(...)` fail-open clauses from the five Signal 65 protection checks.
- Parenthesize every remaining OR term consistently with the surrounding entry-condition style.
- Keep this follow-up independent on the latest upstream `main`, after the maintainer feedback on #1137.

## Safety

- All populated-row thresholds and the existing AND/OR relationships are unchanged.
- Missing required informative values now fail closed instead of bypassing a protection, as requested.
- Only the Signal 65 block in `populate_entry_trend()` is touched.
- Signal 65 remains disabled by default.
- No v3 grind-entry code is touched.

## Backtest scope

A full four-year backtest rerun was not required for this focused follow-up. The only semantic difference is the
requested handling of missing values. Across the fixed 99 raw Signal 65 trades used for #1137, all relevant
indicator values were populated. Replaying the old and new five-guard expressions produced:

- relevant NaN values: `0`
- old guards passing: `83`
- new guards passing: `83`
- result mismatches: `0`

This is a consistency cleanup and does not claim a new profitability or duration improvement.

## Checks

- `python C:\Users\0\.codex\skills\nfi-upstream-pr\scripts\validate_nfi_pr.py --base origin/main --skip-static`
- `git merge-tree` conflict simulation against `origin/main` (`0` conflict markers)
- targeted `git diff origin/main...HEAD -- NostalgiaForInfinityX7.py` review
- `git diff --check origin/main...HEAD`
- repository-pinned Ruff `0.12.5` format and lint checks
- local Ruff `0.15.0` format and lint checks
- `PYTHONDONTWRITEBYTECODE=1 python -m py_compile NostalgiaForInfinityX7.py`
- fixed-sample old/new Signal 65 guard replay described above
