### PR TITLE
X7: use grind v3 in long_grind_adjust_trade_position_v2 (rebuy de-risk path)

### DIFF
--- a/NostalgiaForInfinityX7.py
+++ b/NostalgiaForInfinityX7.py
@@ -42761,7 +42761,15 @@ class NostalgiaForInfinityX7(IStrategy):
     last_aroonu_14 = last_candle["AROONU_14"]
     last_aroonu_14_15m = last_candle["AROONU_14_15m"]
     is_long_grind_entry = (
-      self.long_grind_entry_v2(last_candle, previous_candle, slice_profit, True)
+      self.long_grind_entry_v3(
+        last_candle,
+        previous_candle,
+        num_open_grinds_and_buybacks,
+        slice_profit,
+        slice_profit_entry,
+        slice_profit_exit,
+        True,
+      )
       or (
         (is_derisk_1_found or is_derisk_2_found or is_derisk_3_found)
         and (num_open_grinds_and_buybacks == 0)


### PR DESCRIPTION
Answers your "BTW, add grind v3 to `long_grind_adjust_trade_position_v2()` also?"

**Where it's reached:** `long_grind_adjust_trade_position_v2` is *not* hit by the main grind dispatcher (that routes `is_system_v3_family` trades to `_v3`). It's reached via **`long_rebuy_adjust_trade_position`** after a **`derisk_level_3`** exit — i.e. rebuy-mode trades (tags 61-65) that have de-risked to level 3.

**Change:** it called the legacy `long_grind_entry_v2`; switch to `long_grind_entry_v3` so those rebuy-de-risk trades grind via the v3 entry set (g0..g23, incl. the g22/g23 recovery-rebuild) — same idea as the 120-path change (#1132).

**Clean swap:** `num_open_grinds_and_buybacks`, `slice_profit_entry`, `slice_profit_exit` are already computed in `_v2`'s scope, so it's just the call. Compiles clean; one-line-equivalent diff.

Behaviour-changing on the rebuy-de-risk path — worth a grinding-on pass on your side before merge (like the RUNE 120→v3 check).