### PR TITLE
X7: short_grind_entry_v3 — mirror the recent long grind fine-tunes (g14/g22/g23/g24)

### DIFF
--- a/NostalgiaForInfinityX7.py
+++ b/NostalgiaForInfinityX7.py
@@ -70561,6 +70561,7 @@ class NostalgiaForInfinityX7(IStrategy):
       and (last_close < (last_close_min_48 * 1.10))
       and ((last_rsi_3_1h < 70.0) or (last_stochrsi_k_1h > 30.0))
       and ((last_rsi_3_1d < 75.0) or (last_stochrsi_k_1h > 20.0))
+      and ((last_stochrsi_k_1h > 20.0) or (last_stochrsi_k_1d > 10.0))
     ):
       self._grind_entry_tag = "g14"
       return True
@@ -70685,6 +70686,7 @@ class NostalgiaForInfinityX7(IStrategy):
       and ((last_roc_9_1d < 20.0) or (last_aroond_14_4h < 100.0))
       and ((last_roc_9_1d < 20.0) or (last_stochrsi_k_4h > 10.0))
       and ((last_roc_9_1d < 30.0) or (last_stochrsi_k_1h > 10.0))
+      and ((last_rsi_3_1h < 70.0) or (last_stochrsi_k_1d > 20.0))
     ):
       self._grind_entry_tag = "g22"
       return True
@@ -70715,8 +70717,59 @@ class NostalgiaForInfinityX7(IStrategy):
       and ((last_stochrsik_15m > 10.0) or (last_aroond_14_1h < 100.0))
       and ((last_stochrsik_15m > 10.0) or (last_stochrsi_k_4h > 10.0))
       and ((last_stochrsi_k_1h > 10.0) or (last_stochrsi_k_4h > 10.0))
+      and ((last_rsi_3_1h < 55.0) or (last_aroond_14_4h < 80.0))
+      and ((last_rsi_3_4h < 60.0) or (last_stochrsik_15m > 10.0))
+      and ((last_aroond_14_15m < 100.0) or (last_stochrsik_15m > 10.0) or (last_stochrsi_k_1d > 20.0))
+      and ((last_aroond_14_15m < 100.0) or (last_stochrsi_k_4h > 10.0))
+      and ((last_aroond_14_1h < 100.0) or (last_aroond_14_4h < 100.0))
+      and ((last_aroond_14_4h < 100.0) or (last_stochrsi_k_1h > 10.0))
+      and ((last_aroond_14_4h < 100.0) or (last_stochrsi_k_4h > 10.0))
+      and ((last_aroond_14_1d < 100.0) or (last_stochrsik_15m > 10.0))
     ):
       self._grind_entry_tag = "g23"
+      return True
+
+    # g24 mirror — downtrend-continuation short-add: the zone BELOW the 4h 200-EMA that g22 sacrifices (mirror of long g24).
+    if (
+      # momentum healthy on the bounce: RSI holds down (a real reversal spikes RSI hard)
+      (last_rsi_3 < 80.0)
+      and (last_rsi_3_15m < 80.0)
+      and (last_rsi_14 < 60.0)
+      # trend intact + this is a BOUNCE not a reversal: 4h still falling, 1h not in melt-up
+      and (last_roc_9_1h < 10.0)
+      and (last_roc_9_4h < 0.0)
+      and (last_roc_9_4h > -25.0)  # anti-capitulation blow-off bottom
+      # bear scope-gate: confirmed 4h downtrend + price below the 200-EMA regime (complements g22's >200EMA)
+      and (last_ema_12_4h < last_ema_200_4h)
+      and (last_close < last_ema_200_4h)
+      # shallow bounce to the short EMA — short the bounce WITHIN the trend, never the bottom nor a deep pump
+      and (last_close > (last_ema_20 * 0.99))
+      and (last_close < (last_ema_20 * 1.06))
+      and ((last_rsi_3_15m < 60.0) or (last_stochrsik_15m > 30.0))
+      and ((last_rsi_3_1h < 75.0) or (last_aroond_14_1h < 80.0))
+      and ((last_rsi_3_4h < 50.0) or (last_stochrsi_k_4h > 20.0))
+      and ((last_rsi_14_1h > 30.0) or (last_stochrsi_k_4h > 10.0))
+      and ((last_aroond_14_15m < 100.0) or (last_aroond_14_1h < 100.0))
+      and ((last_aroond_14_15m < 100.0) or (last_aroond_14_4h < 100.0))
+      and ((last_aroond_14_15m < 100.0) or (last_stochrsi_k_1h > 10.0))
+      and ((last_aroond_14_15m < 100.0) or (last_stochrsi_k_4h > 10.0))
+      and ((last_aroond_14_15m < 100.0) or (last_stochrsi_k_1d > 20.0))
+      and ((last_aroond_14_1h < 100.0) or (last_stochrsi_k_4h > 10.0))
+      and ((last_aroond_14_1h < 100.0) or (last_stochrsi_k_1d > 10.0))
+      and ((last_aroond_14_4h < 100.0) or (last_aroond_14_1d < 100.0))
+      and ((last_aroond_14_4h < 100.0) or (last_stochrsi_k_1h > 10.0))
+      and ((last_aroond_14_4h < 100.0) or (last_stochrsi_k_4h > 10.0))
+      and ((last_aroond_14_1d < 100.0) or (last_stochrsik_15m > 10.0))
+      and ((last_aroond_14_1d < 100.0) or (last_stochrsi_k_1h > 10.0))
+      and ((last_aroond_14_1d < 100.0) or (last_stochrsi_k_4h > 10.0))
+      # do not short an oversold bottom on the bounce
+      and ((last_stochrsi_k > 10.0) or (last_rsi_14 > 30.0))
+      and ((last_stochrsik_15m > 10.0) or (last_stochrsi_k_1d > 10.0))
+      and ((last_stochrsi_k_1h > 10.0) or (last_roc_9_4h > -15.0))
+      and ((last_stochrsi_k_4h > 10.0) or (last_roc_9_4h > -15.0))
+      and ((last_stochrsi_k_4h > 10.0) or (last_roc_9_1d < 15.0))
+    ):
+      self._grind_entry_tag = "g24"
       return True
 
     self._grind_entry_tag = ""


### PR DESCRIPTION
The last three grind fine-tune commits (`8529441`, `0fa0a1a`, `2bc3058`) only touched `long_grind_entry_v3` — the short side fell behind. This mirrors them so the two stay symmetric, same as the earlier g22/g23 mirror.

Confirmed long-only drift: every `@@` hunk of those 3 commits lands in the long grind region; zero in the short region.

## Mirrored (long → short)
| g-tag | added to short |
|--|--|
| g14 | +1 OR-chain `(stochrsi_k_1h > 20) \| (stochrsi_k_1d > 10)` |
| g22 | +1 OR-chain `(rsi_3_1h < 70) \| (stochrsi_k_1d > 20)` |
| g23 | +8 OR-chains (rsi_3 / aroond / stochrsik_15m / stochrsi_k) |
| **g24** | **full new block** — downtrend-continuation short-add, the mirror of long g24 |

**g24 short:** long g24 buys a shallow pullback dip within a confirmed 4h uptrend, above the 200-EMA ("the zone g22 sacrifices"). The mirror shorts a shallow bounce within a confirmed 4h downtrend, below the 200-EMA: `ema_12_4h < ema_200_4h`, `close < ema_200_4h`, `roc_9_4h < 0` (still falling), `roc_9_4h > -25` (anti-capitulation), `close > ema_20*0.99 & < ema_20*1.06` (shallow bounce), + the overbought/oversold OR-chain protections mirrored.

## Mirror convention (reviewed clause-by-clause)
- RSI / STOCHRSI (0-100): `> V` ↔ `< 100−V`
- ROC: `> V` ↔ `< −V`
- `aroonu_14_X` → `aroond_14_X` (name swap, threshold kept)
- `stochrsi_k_15m` → `stochrsik_15m` (short-scope name)
- `close`/`ema`/`sma`: direction flip, multiplier `M → 2−M`, `low_min ↔ high_max`, sma-cross inverted

## Validation
- `py_compile` OK.
- **2022 gms0 backtest: 0 runtime errors, BIT-IDENTICAL to baseline** (194t / +$28,816.6 / 191W-3L / 35 shorts; losses all long-side INJ/AAVE/RUNE). Like the g22/g23 mirror, these are constraint-narrowing OR-chains that don't bind at the existing short grind points, so behavior-neutral in backtest and symmetric with long going forward.

Isolated to `short_grind_entry_v3`.