### PR TITLE
Blacklist: DEXE token collapse (all 12) + tokenized-stock sync across ALL venues

### DIFF
--- a/configs/blacklist-binance.json
+++ b/configs/blacklist-binance.json
@@ -20,6 +20,8 @@
       "(ACE|ACH|AGLD|AGT|AKE|ALAB|ALICE|BB|BEL|BLESS|BLUAI|BOBA|BTR|CGNX|COLLECT|DOLO|DOOD|DYM|EDEN|ENSO|EPIC|EVAA|EWY|F|HEI|HFT|HMSTR|INFQ|KAT|LAYER|LIGHT|LRC|MAGIC|MYX|NG|OFC|OL|ONE|OPN|PIXEL|PLAY|PORTAL|PROM|PUMPFUN|QQQ|RARE|RECALL|RESOLV|RLS|SAGA|SATS|SHIB1000|SPACE|SPORTFUN|SPY|TLM|TNSR|TON|TWLO|USO|VANRY|WCT|WET|XAI|XCU|YB|YGG|ZKP|AIN|EDGE|SAHARA|UB)/.*",
       // Delisting
       "(MKR|OMNI)/.*",
+      // Token collapse (2026-07-21): DEXE staking-contract unlimited-mint exploit, -85% to ~0, supply integrity broken
+      "(DEXE)/.*",
       // Hacked/depeg (2026-07-24, protocol-destroying, off our venues): BLC (algo-stablecoin depeg ~99.9% to ~0), AFX (~$24M key-compromise drain), VRSC (bridge exploit)
       "(BLC|AFX|VRSC)/.*",
       // Hacked / high-risk (2026-07)

--- a/configs/blacklist-bitget.json
+++ b/configs/blacklist-bitget.json
@@ -19,6 +19,8 @@
       "(ACE|ACH|AGLD|AGT|AKE|ALAB|ALICE|BB|BEL|BLESS|BLUAI|BOBA|BTR|CGNX|COLLECT|DOLO|DOOD|DYM|EDEN|ENSO|EPIC|EVAA|EWY|F|HEI|HFT|HMSTR|INFQ|KAT|LAYER|LIGHT|LRC|MAGIC|MYX|NG|OFC|OL|ONE|OPN|PIXEL|PLAY|PORTAL|PROM|PUMPFUN|QQQ|RARE|RECALL|RESOLV|RLS|SAGA|SATS|SHIB1000|SPACE|SPORTFUN|SPY|TLM|TNSR|TON|TWLO|USO|VANRY|WCT|WET|XAI|XCU|YB|YGG|ZKP|AIN|EDGE|SAHARA|UB)/.*",
       // Delisting
       "(MKR|OMNI)/.*",
+      // Token collapse (2026-07-21): DEXE staking-contract unlimited-mint exploit, -85% to ~0, supply integrity broken
+      "(DEXE)/.*",
       // Hacked/depeg (2026-07-24, protocol-destroying, off our venues): BLC (algo-stablecoin depeg ~99.9% to ~0), AFX (~$24M key-compromise drain), VRSC (bridge exploit)
       "(BLC|AFX|VRSC)/.*",
       // Hacked / high-risk (2026-07)
@@ -29,7 +31,7 @@
       // Tokenized stocks (STOCK suffix on futures — QNTSTOCK, BBSTOCK, NOKSTOCK, SATSSTOCK, STXSTOCK)
       ".*STOCK/.*",
       // Tokenized stocks (direct ticker, no STOCK suffix)
-      "(NVDA|AAPL|AMD|ARM|ASTS|CRWV|DELL|GOOGL|IREN|LITE|MRVL|MSFT|MSTR|MU|NBIS|QCOM|SNDK|SOXL|SPCX)/.*",
+      "(NVDA|AAPL|AMD|ARM|ASTS|CRWV|DELL|GOOGL|IREN|LITE|MRVL|MSFT|MSTR|MU|NBIS|QCOM|SNDK|SOXL|SPCX|AAOI|AMZN|APLD|AVGO|BABA|BE|COHR|COIN|CRCL|HOOD|INTC|IONQ|META|PLTR|SQQQ|TQQQ|TSLA|TSM)/.*",
       // Commodities (tokenized energy/metal perps — crypto gold XAUT/PAXG kept above)
       "(CL|BZ|NATGAS|XPT)/.*",
       // Tokenized stocks (ON-suffix variant on Bitget)

--- a/configs/blacklist-bitmart.json
+++ b/configs/blacklist-bitmart.json
@@ -32,7 +32,7 @@
       // Tokenized stocks (STOCK suffix — universal forward-protection)
       ".*STOCK/.*",
       // Tokenized stocks (direct ticker, no STOCK suffix)
-      "(NVDA|AAPL|AMD|ARM|ASTS|CRWV|DELL|GOOGL|IREN|LITE|MRVL|MSFT|MSTR|MU|NBIS|QCOM|SNDK|SOXL|SPCX|AAOI|APLD|BE|SQQQ)/.*",
+      "(NVDA|AAPL|AMD|ARM|ASTS|CRWV|DELL|GOOGL|IREN|LITE|MRVL|MSFT|MSTR|MU|NBIS|QCOM|SNDK|SOXL|SPCX|AAOI|APLD|BE|SQQQ|AMZN|AVGO|BABA|COHR|COIN|CRCL|HOOD|INTC|META|PLTR|TQQQ|TSLA|TSM)/.*",
       // Commodities (tokenized energy/metal perps — crypto gold XAUT/PAXG kept above)
       "(CL|BZ|NATGAS|XPT)/.*",
       // Tokenized stocks (X-suffix)

--- a/configs/blacklist-bitmart.json
+++ b/configs/blacklist-bitmart.json
@@ -19,6 +19,8 @@
       "(ACE|ACH|AGLD|AGT|AKE|ALAB|ALICE|BB|BEL|BLESS|BLUAI|BOBA|BTR|CGNX|COLLECT|DOLO|DOOD|DYM|EDEN|ENSO|EPIC|EVAA|EWY|F|HEI|HFT|HMSTR|INFQ|KAT|LAYER|LIGHT|LRC|MAGIC|MYX|NG|OFC|OL|ONE|OPN|PIXEL|PLAY|PORTAL|PROM|PUMPFUN|QQQ|RARE|RECALL|RESOLV|RLS|SAGA|SATS|SHIB1000|SPACE|SPORTFUN|SPY|TLM|TNSR|TON|TWLO|USO|VANRY|WCT|WET|XAI|XCU|YB|YGG|ZKP|AIN|EDGE|SAHARA)/.*",
       // Delisting
       "(MKR|OMNI|INDAON)/.*",
+      // Token collapse (2026-07-21): DEXE staking-contract unlimited-mint exploit, -85% to ~0, supply integrity broken
+      "(DEXE)/.*",
       // Hacked/depeg (2026-07-24, protocol-destroying, off our venues): BLC (algo-stablecoin depeg ~99.9% to ~0), AFX (~$24M key-compromise drain), VRSC (bridge exploit)
       "(BLC|AFX|VRSC)/.*",
       // Hacked / high-risk (2026-07)

--- a/configs/blacklist-bitvavo.json
+++ b/configs/blacklist-bitvavo.json
@@ -19,6 +19,8 @@
       "(ACE|ACH|AGLD|AGT|AKE|ALAB|ALICE|BB|BEL|BLESS|BLUAI|BOBA|BTR|CGNX|COLLECT|DOLO|DOOD|DYM|EDEN|ENSO|EPIC|EVAA|EWY|F|HEI|HFT|HMSTR|INFQ|KAT|LAYER|LIGHT|LRC|MAGIC|MYX|NG|OFC|OL|ONE|OPN|PIXEL|PLAY|PORTAL|PROM|PUMPFUN|QQQ|RARE|RECALL|RESOLV|RLS|SAGA|SATS|SHIB1000|SPACE|SPORTFUN|SPY|TLM|TNSR|TON|TWLO|USO|VANRY|WCT|WET|XAI|XCU|YB|YGG|ZKP|AIN|EDGE|SAHARA|UB)/.*",
       // Delisting
       "(MKR|OMNI)/.*",
+      // Token collapse (2026-07-21): DEXE staking-contract unlimited-mint exploit, -85% to ~0, supply integrity broken
+      "(DEXE)/.*",
       // Hacked/depeg (2026-07-24, protocol-destroying, off our venues): BLC (algo-stablecoin depeg ~99.9% to ~0), AFX (~$24M key-compromise drain), VRSC (bridge exploit)
       "(BLC|AFX|VRSC)/.*",
       // Hacked / high-risk (2026-07)

--- a/configs/blacklist-bybit.json
+++ b/configs/blacklist-bybit.json
@@ -27,7 +27,7 @@
       // Tokenized stocks (STOCK suffix — universal forward-protection)
       ".*STOCK/.*",
       // Tokenized stocks (direct ticker, no STOCK suffix)
-      "(NVDA|AAPL|AMD|ARM|ASTS|CRWV|DELL|GOOGL|IREN|LITE|MRVL|MSFT|MSTR|MU|NBIS|QCOM|SNDK|SOXL|SPCX|AAOI|APLD|AVGO|BABA|BE|COHR|INTC|IONQ|PLTR|SQQQ|TQQQ|TSM)/.*",
+      "(NVDA|AAPL|AMD|ARM|ASTS|CRWV|DELL|GOOGL|IREN|LITE|MRVL|MSFT|MSTR|MU|NBIS|QCOM|SNDK|SOXL|SPCX|AAOI|APLD|AVGO|BABA|BE|COHR|INTC|IONQ|PLTR|SQQQ|TQQQ|TSM|AMZN|COIN|CRCL|HOOD|META|TSLA)/.*",
       // Commodities (tokenized energy/metal perps — crypto gold XAUT/PAXG kept above)
       "(CL|BZ|NATGAS|XPT)/.*",
       // Tokenized stocks (X-suffix)

--- a/configs/blacklist-bybit.json
+++ b/configs/blacklist-bybit.json
@@ -18,6 +18,8 @@
       "(ACE|ACH|AGLD|AGT|AKE|ALAB|ALICE|BB|BEL|BLESS|BLUAI|BOBA|BTR|CGNX|COLLECT|DOLO|DOOD|DYM|EDEN|ENSO|EPIC|EVAA|EWY|F|HEI|HFT|HMSTR|INFQ|KAT|LAYER|LIGHT|LRC|MAGIC|MYX|NG|OFC|OL|ONE|OPN|PIXEL|PLAY|PORTAL|PROM|PUMPFUN|QQQ|RARE|RECALL|RESOLV|RLS|SAGA|SATS|SHIB1000|SPACE|SPORTFUN|SPY|TLM|TNSR|TON|TWLO|USO|VANRY|WCT|WET|XAI|XCU|YB|YGG|ZKP|AIN|EDGE|SAHARA|UB)/.*",
       // Delisting
       "(MKR|OMNI)/.*",
+      // Token collapse (2026-07-21): DEXE staking-contract unlimited-mint exploit, -85% to ~0, supply integrity broken
+      "(DEXE)/.*",
       // Hacked/depeg (2026-07-24, protocol-destroying, off our venues): BLC (algo-stablecoin depeg ~99.9% to ~0), AFX (~$24M key-compromise drain), VRSC (bridge exploit)
       "(BLC|AFX|VRSC)/.*",
       // Hacked / high-risk (2026-07) + ROAM KuCoin-futures delist

--- a/configs/blacklist-gateio.json
+++ b/configs/blacklist-gateio.json
@@ -19,6 +19,8 @@
       "(ACE|ACH|AGLD|AGT|AKE|ALAB|ALICE|BB|BEL|BLESS|BLUAI|BOBA|BTR|CGNX|COLLECT|DOLO|DOOD|DYM|EDEN|ENSO|EPIC|EVAA|EWY|F|HEI|HFT|HMSTR|INFQ|KAT|LAYER|LIGHT|LRC|MAGIC|MYX|NG|OFC|OL|ONE|OPN|PIXEL|PLAY|PORTAL|PROM|PUMPFUN|QQQ|RARE|RECALL|RESOLV|RLS|SAGA|SATS|SHIB1000|SPACE|SPORTFUN|SPY|TLM|TNSR|TON|TWLO|USO|VANRY|WCT|WET|XAI|XCU|YB|YGG|ZKP|AIN|EDGE|SAHARA|UB)/.*",
       // Delisting
       "(MKR|OMNI)/.*",
+      // Token collapse (2026-07-21): DEXE staking-contract unlimited-mint exploit, -85% to ~0, supply integrity broken
+      "(DEXE)/.*",
       // Hacked/depeg (2026-07-24, protocol-destroying, off our venues): BLC (algo-stablecoin depeg ~99.9% to ~0), AFX (~$24M key-compromise drain), VRSC (bridge exploit)
       "(BLC|AFX|VRSC)/.*",
       // Hacked / high-risk (2026-07)

--- a/configs/blacklist-gateio.json
+++ b/configs/blacklist-gateio.json
@@ -28,7 +28,7 @@
       // Tokenized stocks (STOCK suffix — universal forward-protection)
       ".*STOCK/.*",
       // Tokenized stocks (direct ticker, no STOCK suffix)
-      "(NVDA|AAPL|AMD|ARM|ASTS|CRWV|DELL|GOOGL|IREN|LITE|MRVL|MSFT|MSTR|MU|NBIS|QCOM|SNDK|SOXL|SPCX|AAOI|APLD|BE|COHR|IONQ|SQQQ|TSM)/.*",
+      "(NVDA|AAPL|AMD|ARM|ASTS|CRWV|DELL|GOOGL|IREN|LITE|MRVL|MSFT|MSTR|MU|NBIS|QCOM|SNDK|SOXL|SPCX|AAOI|APLD|BE|COHR|IONQ|SQQQ|TSM|AMZN|AVGO|BABA|COIN|CRCL|HOOD|INTC|META|PLTR|TQQQ|TSLA)/.*",
       // Commodities (tokenized energy/metal perps — crypto gold XAUT/PAXG kept above)
       "(CL|BZ|NATGAS|XPT)/.*",
       // Tokenized stocks (3L/3S leverage)

--- a/configs/blacklist-htx.json
+++ b/configs/blacklist-htx.json
@@ -28,7 +28,7 @@
       // Tokenized stocks (STOCK suffix — universal forward-protection)
       ".*STOCK/.*",
       // Tokenized stocks (direct ticker, no STOCK suffix)
-      "(NVDA|AAPL|AMD|ARM|ASTS|CRWV|DELL|GOOGL|IREN|LITE|MRVL|MSFT|MSTR|MU|NBIS|QCOM|SNDK|SOXL|SPCX|AAOI|APLD|AVGO|BABA|BE|COHR|IONQ|META|SQQQ|TQQQ|TSM)/.*",
+      "(NVDA|AAPL|AMD|ARM|ASTS|CRWV|DELL|GOOGL|IREN|LITE|MRVL|MSFT|MSTR|MU|NBIS|QCOM|SNDK|SOXL|SPCX|AAOI|APLD|AVGO|BABA|BE|COHR|IONQ|META|SQQQ|TQQQ|TSM|AMZN|COIN|CRCL|HOOD|INTC|PLTR|TSLA)/.*",
       // Commodities (tokenized energy/metal perps — crypto gold XAUT/PAXG kept above)
       "(CL|BZ|NATGAS|XPT)/.*",
       // Tokenized stocks (X-suffix)

--- a/configs/blacklist-htx.json
+++ b/configs/blacklist-htx.json
@@ -19,6 +19,8 @@
       "(ACE|ACH|AGLD|AGT|AKE|ALAB|ALICE|BB|BEL|BLESS|BLUAI|BOBA|BTR|CGNX|COLLECT|DOLO|DOOD|DYM|EDEN|ENSO|EPIC|EVAA|EWY|F|HEI|HFT|HMSTR|INFQ|KAT|LAYER|LIGHT|LRC|MAGIC|MYX|NG|OFC|OL|ONE|OPN|PIXEL|PLAY|PORTAL|PROM|PUMPFUN|QQQ|RARE|RECALL|RESOLV|RLS|SAGA|SATS|SHIB1000|SPACE|SPORTFUN|SPY|TLM|TNSR|TON|TWLO|USO|VANRY|WCT|WET|XAI|XCU|YB|YGG|ZKP|AIN|EDGE|SAHARA|UB)/.*",
       // Delisting
       "(MKR|OMNI)/.*",
+      // Token collapse (2026-07-21): DEXE staking-contract unlimited-mint exploit, -85% to ~0, supply integrity broken
+      "(DEXE)/.*",
       // Hacked/depeg (2026-07-24, protocol-destroying, off our venues): BLC (algo-stablecoin depeg ~99.9% to ~0), AFX (~$24M key-compromise drain), VRSC (bridge exploit)
       "(BLC|AFX|VRSC)/.*",
       // Hacked / high-risk (2026-07)

--- a/configs/blacklist-hyperliquid.json
+++ b/configs/blacklist-hyperliquid.json
@@ -18,6 +18,8 @@
       "(ACE|ACH|AGLD|AGT|AKE|ALAB|ALICE|BB|BEL|BLESS|BLUAI|BOBA|BTR|CGNX|COLLECT|DOLO|DOOD|DYM|EDEN|ENSO|EPIC|EVAA|EWY|F|HEI|HFT|HMSTR|INFQ|KAT|LAYER|LIGHT|LRC|MAGIC|MYX|NG|OFC|OL|ONE|OPN|PIXEL|PLAY|PORTAL|PROM|PUMPFUN|QQQ|RARE|RECALL|RESOLV|RLS|SAGA|SATS|SHIB1000|SPACE|SPORTFUN|SPY|TLM|TNSR|TON|TWLO|USO|VANRY|WCT|WET|XAI|XCU|YB|YGG|ZKP|AIN|EDGE|SAHARA)/.*",
       // Delisting
       "(MKR|OMNI)/.*",
+      // Token collapse (2026-07-21): DEXE staking-contract unlimited-mint exploit, -85% to ~0, supply integrity broken
+      "(DEXE)/.*",
       // Hacked/depeg (2026-07-24, protocol-destroying, off our venues): BLC (algo-stablecoin depeg ~99.9% to ~0), AFX (~$24M key-compromise drain), VRSC (bridge exploit)
       "(BLC|AFX|VRSC)/.*",
       // Hacked / high-risk (2026-07)

--- a/configs/blacklist-kraken.json
+++ b/configs/blacklist-kraken.json
@@ -17,6 +17,8 @@
       "(ACE|ACH|AGLD|AGT|AKE|ALAB|ALICE|BB|BEL|BLESS|BLUAI|BOBA|BTR|CGNX|COLLECT|DOLO|DOOD|DYM|EDEN|ENSO|EPIC|EVAA|EWY|F|HEI|HFT|HMSTR|INFQ|KAT|LAYER|LIGHT|LRC|MAGIC|MYX|NG|OFC|OL|ONE|OPN|PIXEL|PLAY|PORTAL|PROM|PUMPFUN|QQQ|RARE|RECALL|RESOLV|RLS|SAGA|SATS|SHIB1000|SPACE|SPORTFUN|SPY|TLM|TNSR|TON|TWLO|USO|VANRY|WCT|WET|XAI|XCU|YB|YGG|ZKP|AIN|EDGE|SAHARA|UB)/.*",
       // Delisting
       "(MKR|OMNI)/.*",
+      // Token collapse (2026-07-21): DEXE staking-contract unlimited-mint exploit, -85% to ~0, supply integrity broken
+      "(DEXE)/.*",
       // Hacked/depeg (2026-07-24, protocol-destroying, off our venues): BLC (algo-stablecoin depeg ~99.9% to ~0), AFX (~$24M key-compromise drain), VRSC (bridge exploit)
       "(BLC|AFX|VRSC)/.*",
       // Hacked / high-risk (2026-07)

--- a/configs/blacklist-kucoin.json
+++ b/configs/blacklist-kucoin.json
@@ -19,6 +19,8 @@
       "(ACE|ACH|AGLD|AGT|AKE|ALAB|ALICE|BB|BEL|BLESS|BLUAI|BOBA|BTR|CGNX|COLLECT|DOLO|DOOD|DYM|EDEN|ENSO|EPIC|EVAA|EWY|F|HEI|HFT|HMSTR|INFQ|KAT|KORU|LAYER|LIGHT|LRC|MAGIC|MYX|NG|OFC|OL|ONE|OPN|PIXEL|PLAY|PORTAL|PROM|PUMPFUN|QQQ|RARE|RECALL|RESOLV|RLS|SAGA|SATS|SHIB1000|SOXS|SPACE|SPORTFUN|SPY|TLM|TNSR|TON|TWLO|USO|VANRY|WCT|WET|XAI|XCU|YB|YGG|ZKP|AIN|EDGE|SAHARA|UB)/.*",
       // Delisting
       "(MKR|OMNI)/.*",
+      // Token collapse (2026-07-21): DEXE staking-contract unlimited-mint exploit, -85% to ~0, supply integrity broken
+      "(DEXE)/.*",
       // Hacked/depeg (2026-07-24, protocol-destroying, off our venues): BLC (algo-stablecoin depeg ~99.9% to ~0), AFX (~$24M key-compromise drain), VRSC (bridge exploit)
       "(BLC|AFX|VRSC)/.*",
       // Hacked/high-risk (2026-07) + ROAM KuCoin-futures delist

--- a/configs/blacklist-mexc.json
+++ b/configs/blacklist-mexc.json
@@ -19,6 +19,8 @@
       "(ACE|ACH|AGLD|AGT|AKE|ALAB|ALICE|BB|BEL|BLESS|BLUAI|BOBA|BTR|CGNX|COLLECT|DOLO|DOOD|DYM|EDEN|ENSO|EPIC|EVAA|EWY|F|HEI|HFT|HMSTR|INFQ|KAT|LAYER|LIGHT|LRC|MAGIC|MYX|NG|OFC|OL|ONE|OPN|PIXEL|PLAY|PORTAL|PROM|PUMPFUN|QQQ|RARE|RECALL|RESOLV|RLS|SAGA|SATS|SHIB1000|SPACE|SPORTFUN|SPY|TLM|TNSR|TON|TWLO|USO|VANRY|WCT|WET|XAI|XCU|YB|YGG|ZKP|AIN|EDGE|SAHARA)/.*",
       // Delisting
       "(MKR|OMNI)/.*",
+      // Token collapse (2026-07-21): DEXE staking-contract unlimited-mint exploit, -85% to ~0, supply integrity broken
+      "(DEXE)/.*",
       // Hacked/depeg (2026-07-24, protocol-destroying, off our venues): BLC (algo-stablecoin depeg ~99.9% to ~0), AFX (~$24M key-compromise drain), VRSC (bridge exploit)
       "(BLC|AFX|VRSC)/.*",
       // Hacked / high-risk (2026-07)

--- a/configs/blacklist-mexc.json
+++ b/configs/blacklist-mexc.json
@@ -30,7 +30,7 @@
       // Tokenized stocks (STOCK suffix — universal forward-protection)
       ".*STOCK/.*",
       // Tokenized stocks (direct ticker, no STOCK suffix)
-      "(NVDA|AAPL|AMD|ARM|ASTS|CRWV|DELL|GOOGL|IREN|LITE|MRVL|MSFT|MSTR|MU|NBIS|QCOM|SNDK|SOXL|SPCX|AAOI|APLD|BE|SQQQ)/.*",
+      "(NVDA|AAPL|AMD|ARM|ASTS|CRWV|DELL|GOOGL|IREN|LITE|MRVL|MSFT|MSTR|MU|NBIS|QCOM|SNDK|SOXL|SPCX|AAOI|APLD|BE|SQQQ|AMZN|AVGO|BABA|COHR|COIN|CRCL|HOOD|INTC|IONQ|META|PLTR|TQQQ|TSLA|TSM)/.*",
       // Commodities (tokenized energy/metal perps — crypto gold XAUT/PAXG kept above)
       "(CL|BZ|NATGAS|XPT)/.*",
       // Tokenized stocks (X-suffix)

--- a/configs/blacklist-okx.json
+++ b/configs/blacklist-okx.json
@@ -19,6 +19,8 @@
       "(ACE|ACH|AGLD|AGT|AKE|ALAB|ALICE|BB|BEL|BLESS|BLUAI|BOBA|BTR|CGNX|COLLECT|DOLO|DOOD|DYM|EDEN|ENSO|EPIC|EVAA|EWY|F|HEI|HFT|HMSTR|INFQ|KAT|LAYER|LIGHT|LRC|MAGIC|MYX|NG|OFC|OL|ONE|OPN|PIXEL|PLAY|PORTAL|PROM|PUMPFUN|QQQ|RARE|RECALL|RESOLV|RLS|SAGA|SATS|SHIB1000|SPACE|SPORTFUN|SPY|TLM|TNSR|TON|TWLO|USO|VANRY|WCT|WET|XAI|XCU|YB|YGG|ZKP|AIN|EDGE|SAHARA|UB)/.*",
       // Delisting
       "(MKR|OMNI)/.*",
+      // Token collapse (2026-07-21): DEXE staking-contract unlimited-mint exploit, -85% to ~0, supply integrity broken
+      "(DEXE)/.*",
       // Hacked/depeg (2026-07-24, protocol-destroying, off our venues): BLC (algo-stablecoin depeg ~99.9% to ~0), AFX (~$24M key-compromise drain), VRSC (bridge exploit)
       "(BLC|AFX|VRSC)/.*",
       // Hacked / high-risk (2026-07)


### PR DESCRIPTION
Daily review, two items — both bring every venue into line.

## 1. DEXE → all 12 venues (token-integrity collapse)
DeXe governance token crashed ~85-90% (ATH ~\$48.89 on 07-13 → ~\$4-5) after a **staking-contract exploit enabling unlimited token minting** (07-21), draining DEX liquidity, >\$2B mcap wiped. Uncapped mint = supply integrity broken → universally toxic (same class as NIGHT/BLC). Was 0/12.

## 2. Tokenized-stock list synced on ALL venues to binance's set
Auditing revealed the tokenized-stock direct-ticker list was **behind on 6 venues**, not just bitget. Synced them all up to binance's 37-ticker reference:
- **bitget** +18 (was live-trading short-562 on TQQQ & AAOI at review time)
- **bybit** +6 (AMZN COIN CRCL HOOD META TSLA)
- **htx** +7 · **gateio** +11 · **bitmart** +13 · **mexc** +14
- bitvavo / hyperliquid / kraken / kucoin / okx were already complete.

These are universal tokenized US stocks (TSLA/META/COIN/AMZN/TQQQ/...) — should be blacklisted on every venue that can list them; they were just overlooked on these. Now TSLA/META/COIN/AMZN/TQQQ all match 12/12.

## Not included (no action)
- **AERGO** (Binance Futures perp delist 07-24) — already 12/12.
- **LIEN** (\$542K USDC pool exploit 07-24) — token survived (~\$0.21, -12%), not blacklist-worthy.

Verified: DEXE 12/12; tokenized stocks 12/12; all 12 JSONs validate; real crypto coins unaffected (CHZ binance-side is a pre-existing FAN-token entry).