### PR TITLE
Blacklist: remove DEXE (revert), keep tokenized-stock sync

### DIFF
--- a/configs/blacklist-binance.json
+++ b/configs/blacklist-binance.json
@@ -20,8 +20,6 @@
       "(ACE|ACH|AGLD|AGT|AKE|ALAB|ALICE|BB|BEL|BLESS|BLUAI|BOBA|BTR|CGNX|COLLECT|DOLO|DOOD|DYM|EDEN|ENSO|EPIC|EVAA|EWY|F|HEI|HFT|HMSTR|INFQ|KAT|LAYER|LIGHT|LRC|MAGIC|MYX|NG|OFC|OL|ONE|OPN|PIXEL|PLAY|PORTAL|PROM|PUMPFUN|QQQ|RARE|RECALL|RESOLV|RLS|SAGA|SATS|SHIB1000|SPACE|SPORTFUN|SPY|TLM|TNSR|TON|TWLO|USO|VANRY|WCT|WET|XAI|XCU|YB|YGG|ZKP|AIN|EDGE|SAHARA|UB)/.*",
       // Delisting
       "(MKR|OMNI)/.*",
-      // Token collapse (2026-07-21): DEXE staking-contract unlimited-mint exploit, -85% to ~0, supply integrity broken
-      "(DEXE)/.*",
       // Hacked/depeg (2026-07-24, protocol-destroying, off our venues): BLC (algo-stablecoin depeg ~99.9% to ~0), AFX (~$24M key-compromise drain), VRSC (bridge exploit)
       "(BLC|AFX|VRSC)/.*",
       // Hacked / high-risk (2026-07)

--- a/configs/blacklist-bitget.json
+++ b/configs/blacklist-bitget.json
@@ -19,8 +19,6 @@
       "(ACE|ACH|AGLD|AGT|AKE|ALAB|ALICE|BB|BEL|BLESS|BLUAI|BOBA|BTR|CGNX|COLLECT|DOLO|DOOD|DYM|EDEN|ENSO|EPIC|EVAA|EWY|F|HEI|HFT|HMSTR|INFQ|KAT|LAYER|LIGHT|LRC|MAGIC|MYX|NG|OFC|OL|ONE|OPN|PIXEL|PLAY|PORTAL|PROM|PUMPFUN|QQQ|RARE|RECALL|RESOLV|RLS|SAGA|SATS|SHIB1000|SPACE|SPORTFUN|SPY|TLM|TNSR|TON|TWLO|USO|VANRY|WCT|WET|XAI|XCU|YB|YGG|ZKP|AIN|EDGE|SAHARA|UB)/.*",
       // Delisting
       "(MKR|OMNI)/.*",
-      // Token collapse (2026-07-21): DEXE staking-contract unlimited-mint exploit, -85% to ~0, supply integrity broken
-      "(DEXE)/.*",
       // Hacked/depeg (2026-07-24, protocol-destroying, off our venues): BLC (algo-stablecoin depeg ~99.9% to ~0), AFX (~$24M key-compromise drain), VRSC (bridge exploit)
       "(BLC|AFX|VRSC)/.*",
       // Hacked / high-risk (2026-07)

--- a/configs/blacklist-bitmart.json
+++ b/configs/blacklist-bitmart.json
@@ -19,8 +19,6 @@
       "(ACE|ACH|AGLD|AGT|AKE|ALAB|ALICE|BB|BEL|BLESS|BLUAI|BOBA|BTR|CGNX|COLLECT|DOLO|DOOD|DYM|EDEN|ENSO|EPIC|EVAA|EWY|F|HEI|HFT|HMSTR|INFQ|KAT|LAYER|LIGHT|LRC|MAGIC|MYX|NG|OFC|OL|ONE|OPN|PIXEL|PLAY|PORTAL|PROM|PUMPFUN|QQQ|RARE|RECALL|RESOLV|RLS|SAGA|SATS|SHIB1000|SPACE|SPORTFUN|SPY|TLM|TNSR|TON|TWLO|USO|VANRY|WCT|WET|XAI|XCU|YB|YGG|ZKP|AIN|EDGE|SAHARA)/.*",
       // Delisting
       "(MKR|OMNI|INDAON)/.*",
-      // Token collapse (2026-07-21): DEXE staking-contract unlimited-mint exploit, -85% to ~0, supply integrity broken
-      "(DEXE)/.*",
       // Hacked/depeg (2026-07-24, protocol-destroying, off our venues): BLC (algo-stablecoin depeg ~99.9% to ~0), AFX (~$24M key-compromise drain), VRSC (bridge exploit)
       "(BLC|AFX|VRSC)/.*",
       // Hacked / high-risk (2026-07)

--- a/configs/blacklist-bitvavo.json
+++ b/configs/blacklist-bitvavo.json
@@ -19,8 +19,6 @@
       "(ACE|ACH|AGLD|AGT|AKE|ALAB|ALICE|BB|BEL|BLESS|BLUAI|BOBA|BTR|CGNX|COLLECT|DOLO|DOOD|DYM|EDEN|ENSO|EPIC|EVAA|EWY|F|HEI|HFT|HMSTR|INFQ|KAT|LAYER|LIGHT|LRC|MAGIC|MYX|NG|OFC|OL|ONE|OPN|PIXEL|PLAY|PORTAL|PROM|PUMPFUN|QQQ|RARE|RECALL|RESOLV|RLS|SAGA|SATS|SHIB1000|SPACE|SPORTFUN|SPY|TLM|TNSR|TON|TWLO|USO|VANRY|WCT|WET|XAI|XCU|YB|YGG|ZKP|AIN|EDGE|SAHARA|UB)/.*",
       // Delisting
       "(MKR|OMNI)/.*",
-      // Token collapse (2026-07-21): DEXE staking-contract unlimited-mint exploit, -85% to ~0, supply integrity broken
-      "(DEXE)/.*",
       // Hacked/depeg (2026-07-24, protocol-destroying, off our venues): BLC (algo-stablecoin depeg ~99.9% to ~0), AFX (~$24M key-compromise drain), VRSC (bridge exploit)
       "(BLC|AFX|VRSC)/.*",
       // Hacked / high-risk (2026-07)

--- a/configs/blacklist-bybit.json
+++ b/configs/blacklist-bybit.json
@@ -18,8 +18,6 @@
       "(ACE|ACH|AGLD|AGT|AKE|ALAB|ALICE|BB|BEL|BLESS|BLUAI|BOBA|BTR|CGNX|COLLECT|DOLO|DOOD|DYM|EDEN|ENSO|EPIC|EVAA|EWY|F|HEI|HFT|HMSTR|INFQ|KAT|LAYER|LIGHT|LRC|MAGIC|MYX|NG|OFC|OL|ONE|OPN|PIXEL|PLAY|PORTAL|PROM|PUMPFUN|QQQ|RARE|RECALL|RESOLV|RLS|SAGA|SATS|SHIB1000|SPACE|SPORTFUN|SPY|TLM|TNSR|TON|TWLO|USO|VANRY|WCT|WET|XAI|XCU|YB|YGG|ZKP|AIN|EDGE|SAHARA|UB)/.*",
       // Delisting
       "(MKR|OMNI)/.*",
-      // Token collapse (2026-07-21): DEXE staking-contract unlimited-mint exploit, -85% to ~0, supply integrity broken
-      "(DEXE)/.*",
       // Hacked/depeg (2026-07-24, protocol-destroying, off our venues): BLC (algo-stablecoin depeg ~99.9% to ~0), AFX (~$24M key-compromise drain), VRSC (bridge exploit)
       "(BLC|AFX|VRSC)/.*",
       // Hacked / high-risk (2026-07) + ROAM KuCoin-futures delist

--- a/configs/blacklist-gateio.json
+++ b/configs/blacklist-gateio.json
@@ -19,8 +19,6 @@
       "(ACE|ACH|AGLD|AGT|AKE|ALAB|ALICE|BB|BEL|BLESS|BLUAI|BOBA|BTR|CGNX|COLLECT|DOLO|DOOD|DYM|EDEN|ENSO|EPIC|EVAA|EWY|F|HEI|HFT|HMSTR|INFQ|KAT|LAYER|LIGHT|LRC|MAGIC|MYX|NG|OFC|OL|ONE|OPN|PIXEL|PLAY|PORTAL|PROM|PUMPFUN|QQQ|RARE|RECALL|RESOLV|RLS|SAGA|SATS|SHIB1000|SPACE|SPORTFUN|SPY|TLM|TNSR|TON|TWLO|USO|VANRY|WCT|WET|XAI|XCU|YB|YGG|ZKP|AIN|EDGE|SAHARA|UB)/.*",
       // Delisting
       "(MKR|OMNI)/.*",
-      // Token collapse (2026-07-21): DEXE staking-contract unlimited-mint exploit, -85% to ~0, supply integrity broken
-      "(DEXE)/.*",
       // Hacked/depeg (2026-07-24, protocol-destroying, off our venues): BLC (algo-stablecoin depeg ~99.9% to ~0), AFX (~$24M key-compromise drain), VRSC (bridge exploit)
       "(BLC|AFX|VRSC)/.*",
       // Hacked / high-risk (2026-07)

--- a/configs/blacklist-htx.json
+++ b/configs/blacklist-htx.json
@@ -19,8 +19,6 @@
       "(ACE|ACH|AGLD|AGT|AKE|ALAB|ALICE|BB|BEL|BLESS|BLUAI|BOBA|BTR|CGNX|COLLECT|DOLO|DOOD|DYM|EDEN|ENSO|EPIC|EVAA|EWY|F|HEI|HFT|HMSTR|INFQ|KAT|LAYER|LIGHT|LRC|MAGIC|MYX|NG|OFC|OL|ONE|OPN|PIXEL|PLAY|PORTAL|PROM|PUMPFUN|QQQ|RARE|RECALL|RESOLV|RLS|SAGA|SATS|SHIB1000|SPACE|SPORTFUN|SPY|TLM|TNSR|TON|TWLO|USO|VANRY|WCT|WET|XAI|XCU|YB|YGG|ZKP|AIN|EDGE|SAHARA|UB)/.*",
       // Delisting
       "(MKR|OMNI)/.*",
-      // Token collapse (2026-07-21): DEXE staking-contract unlimited-mint exploit, -85% to ~0, supply integrity broken
-      "(DEXE)/.*",
       // Hacked/depeg (2026-07-24, protocol-destroying, off our venues): BLC (algo-stablecoin depeg ~99.9% to ~0), AFX (~$24M key-compromise drain), VRSC (bridge exploit)
       "(BLC|AFX|VRSC)/.*",
       // Hacked / high-risk (2026-07)

--- a/configs/blacklist-hyperliquid.json
+++ b/configs/blacklist-hyperliquid.json
@@ -18,8 +18,6 @@
       "(ACE|ACH|AGLD|AGT|AKE|ALAB|ALICE|BB|BEL|BLESS|BLUAI|BOBA|BTR|CGNX|COLLECT|DOLO|DOOD|DYM|EDEN|ENSO|EPIC|EVAA|EWY|F|HEI|HFT|HMSTR|INFQ|KAT|LAYER|LIGHT|LRC|MAGIC|MYX|NG|OFC|OL|ONE|OPN|PIXEL|PLAY|PORTAL|PROM|PUMPFUN|QQQ|RARE|RECALL|RESOLV|RLS|SAGA|SATS|SHIB1000|SPACE|SPORTFUN|SPY|TLM|TNSR|TON|TWLO|USO|VANRY|WCT|WET|XAI|XCU|YB|YGG|ZKP|AIN|EDGE|SAHARA)/.*",
       // Delisting
       "(MKR|OMNI)/.*",
-      // Token collapse (2026-07-21): DEXE staking-contract unlimited-mint exploit, -85% to ~0, supply integrity broken
-      "(DEXE)/.*",
       // Hacked/depeg (2026-07-24, protocol-destroying, off our venues): BLC (algo-stablecoin depeg ~99.9% to ~0), AFX (~$24M key-compromise drain), VRSC (bridge exploit)
       "(BLC|AFX|VRSC)/.*",
       // Hacked / high-risk (2026-07)

--- a/configs/blacklist-kraken.json
+++ b/configs/blacklist-kraken.json
@@ -17,8 +17,6 @@
       "(ACE|ACH|AGLD|AGT|AKE|ALAB|ALICE|BB|BEL|BLESS|BLUAI|BOBA|BTR|CGNX|COLLECT|DOLO|DOOD|DYM|EDEN|ENSO|EPIC|EVAA|EWY|F|HEI|HFT|HMSTR|INFQ|KAT|LAYER|LIGHT|LRC|MAGIC|MYX|NG|OFC|OL|ONE|OPN|PIXEL|PLAY|PORTAL|PROM|PUMPFUN|QQQ|RARE|RECALL|RESOLV|RLS|SAGA|SATS|SHIB1000|SPACE|SPORTFUN|SPY|TLM|TNSR|TON|TWLO|USO|VANRY|WCT|WET|XAI|XCU|YB|YGG|ZKP|AIN|EDGE|SAHARA|UB)/.*",
       // Delisting
       "(MKR|OMNI)/.*",
-      // Token collapse (2026-07-21): DEXE staking-contract unlimited-mint exploit, -85% to ~0, supply integrity broken
-      "(DEXE)/.*",
       // Hacked/depeg (2026-07-24, protocol-destroying, off our venues): BLC (algo-stablecoin depeg ~99.9% to ~0), AFX (~$24M key-compromise drain), VRSC (bridge exploit)
       "(BLC|AFX|VRSC)/.*",
       // Hacked / high-risk (2026-07)

--- a/configs/blacklist-kucoin.json
+++ b/configs/blacklist-kucoin.json
@@ -19,8 +19,6 @@
       "(ACE|ACH|AGLD|AGT|AKE|ALAB|ALICE|BB|BEL|BLESS|BLUAI|BOBA|BTR|CGNX|COLLECT|DOLO|DOOD|DYM|EDEN|ENSO|EPIC|EVAA|EWY|F|HEI|HFT|HMSTR|INFQ|KAT|KORU|LAYER|LIGHT|LRC|MAGIC|MYX|NG|OFC|OL|ONE|OPN|PIXEL|PLAY|PORTAL|PROM|PUMPFUN|QQQ|RARE|RECALL|RESOLV|RLS|SAGA|SATS|SHIB1000|SOXS|SPACE|SPORTFUN|SPY|TLM|TNSR|TON|TWLO|USO|VANRY|WCT|WET|XAI|XCU|YB|YGG|ZKP|AIN|EDGE|SAHARA|UB)/.*",
       // Delisting
       "(MKR|OMNI)/.*",
-      // Token collapse (2026-07-21): DEXE staking-contract unlimited-mint exploit, -85% to ~0, supply integrity broken
-      "(DEXE)/.*",
       // Hacked/depeg (2026-07-24, protocol-destroying, off our venues): BLC (algo-stablecoin depeg ~99.9% to ~0), AFX (~$24M key-compromise drain), VRSC (bridge exploit)
       "(BLC|AFX|VRSC)/.*",
       // Hacked/high-risk (2026-07) + ROAM KuCoin-futures delist

--- a/configs/blacklist-mexc.json
+++ b/configs/blacklist-mexc.json
@@ -19,8 +19,6 @@
       "(ACE|ACH|AGLD|AGT|AKE|ALAB|ALICE|BB|BEL|BLESS|BLUAI|BOBA|BTR|CGNX|COLLECT|DOLO|DOOD|DYM|EDEN|ENSO|EPIC|EVAA|EWY|F|HEI|HFT|HMSTR|INFQ|KAT|LAYER|LIGHT|LRC|MAGIC|MYX|NG|OFC|OL|ONE|OPN|PIXEL|PLAY|PORTAL|PROM|PUMPFUN|QQQ|RARE|RECALL|RESOLV|RLS|SAGA|SATS|SHIB1000|SPACE|SPORTFUN|SPY|TLM|TNSR|TON|TWLO|USO|VANRY|WCT|WET|XAI|XCU|YB|YGG|ZKP|AIN|EDGE|SAHARA)/.*",
       // Delisting
       "(MKR|OMNI)/.*",
-      // Token collapse (2026-07-21): DEXE staking-contract unlimited-mint exploit, -85% to ~0, supply integrity broken
-      "(DEXE)/.*",
       // Hacked/depeg (2026-07-24, protocol-destroying, off our venues): BLC (algo-stablecoin depeg ~99.9% to ~0), AFX (~$24M key-compromise drain), VRSC (bridge exploit)
       "(BLC|AFX|VRSC)/.*",
       // Hacked / high-risk (2026-07)

--- a/configs/blacklist-okx.json
+++ b/configs/blacklist-okx.json
@@ -19,8 +19,6 @@
       "(ACE|ACH|AGLD|AGT|AKE|ALAB|ALICE|BB|BEL|BLESS|BLUAI|BOBA|BTR|CGNX|COLLECT|DOLO|DOOD|DYM|EDEN|ENSO|EPIC|EVAA|EWY|F|HEI|HFT|HMSTR|INFQ|KAT|LAYER|LIGHT|LRC|MAGIC|MYX|NG|OFC|OL|ONE|OPN|PIXEL|PLAY|PORTAL|PROM|PUMPFUN|QQQ|RARE|RECALL|RESOLV|RLS|SAGA|SATS|SHIB1000|SPACE|SPORTFUN|SPY|TLM|TNSR|TON|TWLO|USO|VANRY|WCT|WET|XAI|XCU|YB|YGG|ZKP|AIN|EDGE|SAHARA|UB)/.*",
       // Delisting
       "(MKR|OMNI)/.*",
-      // Token collapse (2026-07-21): DEXE staking-contract unlimited-mint exploit, -85% to ~0, supply integrity broken
-      "(DEXE)/.*",
       // Hacked/depeg (2026-07-24, protocol-destroying, off our venues): BLC (algo-stablecoin depeg ~99.9% to ~0), AFX (~$24M key-compromise drain), VRSC (bridge exploit)
       "(BLC|AFX|VRSC)/.*",
       // Hacked / high-risk (2026-07)


### PR DESCRIPTION
Reverting the DEXE addition from the prior review (#1151). Per iterativ — the DEXE collapse already happened and those entries would come from NFI's own logic anyway, so blacklisting after the fact isn't the right call. Removing `DEXE` from all 12 venues.

**Unchanged:** the tokenized-stock sync from the same batch stays — TSLA/META/COIN/AMZN/TQQQ and the full bitget list `(AAOI|AMZN|APLD|AVGO|BABA|BE|COHR|COIN|CRCL|HOOD|INTC|IONQ|META|PLTR|SQQQ|TQQQ|TSLA|TSM)` remain blacklisted 12/12.

Verified: DEXE 0/12; TSLA 12/12; all 12 JSONs validate.