### PR TITLE
numpy conversion for protections & faster CMF

### DIFF
--- a/NostalgiaForInfinityX7.py
+++ b/NostalgiaForInfinityX7.py
@@ -3170,57 +3170,22 @@ class NostalgiaForInfinityX7(IStrategy):
     return list(informative_pairs)
 
   @staticmethod
-  def rolling_sum(arr: np.ndarray, timeperiod: int) -> np.ndarray:
-    """
-    Compute a rolling sum over a fixed window size.
-
-    Returns an array where each element contains the sum of the
-    previous `timeperiod` values. Values before the first complete
-    window are set to NaN.
-
-    NaN values inside the input are treated as 0 to prevent a single
-    invalid candle from contaminating the entire rolling window.
-    """
-    arr = np.asarray(arr, dtype=np.float64)
-    out = np.full(arr.shape, np.nan, dtype=np.float64)
-    if arr.size < timeperiod:
-      return out
-
-    # Treat NaNs as 0 to avoid contaminating entire windows
-    arr_clean = np.nan_to_num(arr, nan=0.0)
-
-    csum = np.cumsum(arr_clean, dtype=np.float64)
-    csum[timeperiod:] = csum[timeperiod:] - csum[:-timeperiod]
-    out[timeperiod - 1 :] = csum[timeperiod - 1 :]
-
-    return out
-
-  @staticmethod
-  def chaikin_money_flow(
-    high: np.ndarray, low: np.ndarray, close: np.ndarray, volume: np.ndarray, timeperiod: int = 20
-  ) -> np.ndarray:
-    """
-    Candles where high == low are treated as neutral money flow (0)
-    to avoid NaN propagation.
-    """
+  def chaikin_money_flow(high, low, close, volume, timeperiod=20):
     hl_range = high - low
     mfm = np.zeros_like(close, dtype=np.float64)
-
     valid = hl_range != 0
     mfm[valid] = ((close[valid] - low[valid]) - (high[valid] - close[valid])) / hl_range[valid]
-
     mfv = mfm * volume
-    mfv_sum = __class__.rolling_sum(mfv, timeperiod)
 
-    # Use the same NaN-tolerant rolling_sum for volume as for mfv.
-    # ta.SUM propagates NaN for `timeperiod` candles after a single
-    # gap, while rolling_sum treats it as 0 — mixing the two meant
-    # the numerator and denominator could go out of sync after any
-    # data gap, silently producing NaN CMF for `timeperiod` candles
-    # even though the numerator alone was fine.
-    vol_sum = __class__.rolling_sum(volume, timeperiod)
+    stacked = np.vstack([mfv, volume])
+    stacked_clean = np.nan_to_num(stacked, nan=0.0)
+    csum = np.cumsum(stacked_clean, axis=1)
+    csum[:, timeperiod:] -= csum[:, :-timeperiod]
+
+    out = np.full(stacked.shape, np.nan, dtype=np.float64)
+    out[:, timeperiod - 1:] = csum[:, timeperiod - 1:]
+    mfv_sum, vol_sum = out[0], out[1]
     vol_sum = np.where(vol_sum == 0, np.nan, vol_sum)
-
     return mfv_sum / vol_sum
 
   @staticmethod
@@ -12961,8 +12926,10 @@ class NostalgiaForInfinityX7(IStrategy):
     mfi_14_15m = np_view("MFI_14_15m")
     mfi_14_1h = np_view("MFI_14_1h")
     num_empty_288 = np_view("num_empty_288")
-    protections_long_global = df["protections_long_global"]
-    protections_short_global = df["protections_short_global"]
+    protections_long_global = np_view("protections_long_global")
+    protections_short_global = np_view("protections_short_global")
+    global_protections_short_pump = np_view("global_protections_short_pump")
+    global_protections_short_dump = np_view("global_protections_short_dump")
     roc_2 = np_view("ROC_2")
     roc_9 = np_view("ROC_9")
     rsi_14 = np_view("RSI_14")
@@ -13019,7 +12986,6 @@ class NostalgiaForInfinityX7(IStrategy):
     bot_wick_pct_1d = np_view("bot_wick_pct_1d")
     low_min_12_1h = np_view("low_min_12_1h")
     low_min_30_1d = np_view("low_min_30_1d")
-    obv_change_pct_15m = np_view("OBV_change_pct_15m")
     rsi_14_change_pct_4h = np_view("RSI_14_change_pct_4h")
     rsi_3_change_pct_15m = np_view("RSI_3_change_pct_15m")
     close_max_6 = np_view("close_max_6")
@@ -25631,8 +25597,8 @@ class NostalgiaForInfinityX7(IStrategy):
           # Protections
           short_entry_logic.append(num_empty_288 <= allowed_empty_candles_288)
           short_entry_logic.append(protections_short_global == True)
-          short_entry_logic.append(df["global_protections_short_pump"] == True)
-          short_entry_logic.append(df["global_protections_short_dump"] == True)
+          short_entry_logic.append(global_protections_short_pump == True)
+          short_entry_logic.append(global_protections_short_dump == True)
 
           short_entry_logic.append(rsi_3_1h >= 5.0)
           short_entry_logic.append(rsi_3_4h >= 20.0)


### PR DESCRIPTION
fix duplicate: obv_change_pct_15m = np_view("OBV_change_pct_15m")
100 pairs took 12s, now 10s on my slow vm.