### PR TITLE
blacklist: FIGHT (all 12) + IDOL/MEET48 (all 12)

### DIFF
--- a/configs/blacklist-binance.json
+++ b/configs/blacklist-binance.json
@@ -1,6 +1,8 @@
 {
   "exchange": {
     "pair_blacklist": [
+      // FIGHT all-12 + IDOL (MEET48) — iterativ 2026-08-02
+      "(FIGHT|IDOL)/.*",
       // Exchange
       "(RIF|BNB)/.*",
       "(1000.*).*/.*",

--- a/configs/blacklist-bitget.json
+++ b/configs/blacklist-bitget.json
@@ -1,6 +1,8 @@
 {
   "exchange": {
     "pair_blacklist": [
+      // FIGHT all-12 + IDOL (MEET48) — iterativ 2026-08-02
+      "(FIGHT|IDOL)/.*",
       // Exchange Tokens
       "BGB/.*",
       // Leverage tokens

--- a/configs/blacklist-bitmart.json
+++ b/configs/blacklist-bitmart.json
@@ -1,6 +1,8 @@
 {
   "exchange": {
     "pair_blacklist": [
+      // FIGHT all-12 + IDOL (MEET48) — iterativ 2026-08-02
+      "IDOL/.*",
       // Exchange Tokens
       "(RIF|BMX)/.*",
       // Leverage tokens

--- a/configs/blacklist-bitvavo.json
+++ b/configs/blacklist-bitvavo.json
@@ -1,6 +1,8 @@
 {
   "exchange": {
     "pair_blacklist": [
+      // FIGHT all-12 + IDOL (MEET48) — iterativ 2026-08-02
+      "(FIGHT|IDOL)/.*",
       // Exchange Tokens
       //"(RIF|GT|POINT)/.*",
       // Leverage tokens

--- a/configs/blacklist-bybit.json
+++ b/configs/blacklist-bybit.json
@@ -1,6 +1,8 @@
 {
   "exchange": {
     "pair_blacklist": [
+      // FIGHT all-12 + IDOL (MEET48) — iterativ 2026-08-02
+      "(FIGHT|IDOL)/.*",
       // Exchange Tokens
       // Leverage tokens
       ".*(5L|5S|3L|3S|2L|2S)/.*",

--- a/configs/blacklist-gateio.json
+++ b/configs/blacklist-gateio.json
@@ -1,6 +1,8 @@
 {
   "exchange": {
     "pair_blacklist": [
+      // FIGHT all-12 + IDOL (MEET48) — iterativ 2026-08-02
+      "IDOL/.*",
       // Exchange Tokens
       "(RIF|GT|POINT)/.*",
       // Leverage tokens

--- a/configs/blacklist-htx.json
+++ b/configs/blacklist-htx.json
@@ -1,6 +1,8 @@
 {
   "exchange": {
     "pair_blacklist": [
+      // FIGHT all-12 + IDOL (MEET48) — iterativ 2026-08-02
+      "IDOL/.*",
       // Exchange Tokens
       "HT/.*",
       // Leverage tokens

--- a/configs/blacklist-hyperliquid.json
+++ b/configs/blacklist-hyperliquid.json
@@ -1,6 +1,8 @@
 {
   "exchange": {
     "pair_blacklist": [
+      // FIGHT all-12 + IDOL (MEET48) — iterativ 2026-08-02
+      "IDOL/.*",
       // Exchange Tokens
       // Leverage tokens
       ".*(3L|3S|5L|5S)/.*",

--- a/configs/blacklist-kraken.json
+++ b/configs/blacklist-kraken.json
@@ -1,6 +1,8 @@
 {
   "exchange": {
     "pair_blacklist": [
+      // FIGHT all-12 + IDOL (MEET48) — iterativ 2026-08-02
+      "(FIGHT|IDOL)/.*",
       // Leverage tokens
       ".*(3L|3S|5L|5S|UP|DOWN)/.*",
       // Fiat

--- a/configs/blacklist-kucoin.json
+++ b/configs/blacklist-kucoin.json
@@ -1,6 +1,8 @@
 {
   "exchange": {
     "pair_blacklist": [
+      // FIGHT all-12 + IDOL (MEET48) — iterativ 2026-08-02
+      "(FIGHT|IDOL)/.*",
       // Exchange Tokens
       "KCS/.*",
       // Leverage tokens

--- a/configs/blacklist-mexc.json
+++ b/configs/blacklist-mexc.json
@@ -1,6 +1,8 @@
 {
   "exchange": {
     "pair_blacklist": [
+      // FIGHT all-12 + IDOL (MEET48) — iterativ 2026-08-02
+      "IDOL/.*",
       // Exchange Tokens
       "(RIF|MX)/.*",
       // Leverage tokens

--- a/configs/blacklist-okx.json
+++ b/configs/blacklist-okx.json
@@ -1,6 +1,8 @@
 {
   "exchange": {
     "pair_blacklist": [
+      // FIGHT all-12 + IDOL (MEET48) — iterativ 2026-08-02
+      "(FIGHT|IDOL)/.*",
       // Exchange Tokens
       "OKB/.*",
       // Leverage tokens


### PR DESCRIPTION
- **FIGHT** was only on 5 of the 12 lists (bitmart, gateio, htx, hyperliquid, mexc). Added to the remaining 7 (binance, bybit, bitget, bitvavo, kraken, kucoin, okx) so it's consistent across all venues.
- **IDOL** (MEET48 token — speculative idol/AI fan-economy token) added to all 12.