### PR TITLE
blacklist: ACX + VIC (all 12) — Binance delist 2026-08-17

### DIFF
--- a/configs/blacklist-binance.json
+++ b/configs/blacklist-binance.json
@@ -1,6 +1,8 @@
 {
   "exchange": {
     "pair_blacklist": [
+      // Binance delist 2026-08-17 (full-coin) — iterativ 2026-08-03
+      "(ACX|VIC)/.*",
       // FIGHT all-12 + IDOL (MEET48) — iterativ 2026-08-02
       "(FIGHT|IDOL)/.*",
       // Exchange

--- a/configs/blacklist-bitget.json
+++ b/configs/blacklist-bitget.json
@@ -1,6 +1,8 @@
 {
   "exchange": {
     "pair_blacklist": [
+      // Binance delist 2026-08-17 (full-coin) — iterativ 2026-08-03
+      "(ACX|VIC)/.*",
       // FIGHT all-12 + IDOL (MEET48) — iterativ 2026-08-02
       "(FIGHT|IDOL)/.*",
       // Exchange Tokens

--- a/configs/blacklist-bitmart.json
+++ b/configs/blacklist-bitmart.json
@@ -1,6 +1,8 @@
 {
   "exchange": {
     "pair_blacklist": [
+      // Binance delist 2026-08-17 (full-coin) — iterativ 2026-08-03
+      "(ACX|VIC)/.*",
       // FIGHT all-12 + IDOL (MEET48) — iterativ 2026-08-02
       "IDOL/.*",
       // Exchange Tokens

--- a/configs/blacklist-bitvavo.json
+++ b/configs/blacklist-bitvavo.json
@@ -1,6 +1,8 @@
 {
   "exchange": {
     "pair_blacklist": [
+      // Binance delist 2026-08-17 (full-coin) — iterativ 2026-08-03
+      "(ACX|VIC)/.*",
       // FIGHT all-12 + IDOL (MEET48) — iterativ 2026-08-02
       "(FIGHT|IDOL)/.*",
       // Exchange Tokens

--- a/configs/blacklist-bybit.json
+++ b/configs/blacklist-bybit.json
@@ -1,6 +1,8 @@
 {
   "exchange": {
     "pair_blacklist": [
+      // Binance delist 2026-08-17 (full-coin) — iterativ 2026-08-03
+      "(ACX|VIC)/.*",
       // FIGHT all-12 + IDOL (MEET48) — iterativ 2026-08-02
       "(FIGHT|IDOL)/.*",
       // Exchange Tokens

--- a/configs/blacklist-gateio.json
+++ b/configs/blacklist-gateio.json
@@ -1,6 +1,8 @@
 {
   "exchange": {
     "pair_blacklist": [
+      // Binance delist 2026-08-17 (full-coin) — iterativ 2026-08-03
+      "(ACX|VIC)/.*",
       // FIGHT all-12 + IDOL (MEET48) — iterativ 2026-08-02
       "IDOL/.*",
       // Exchange Tokens

--- a/configs/blacklist-htx.json
+++ b/configs/blacklist-htx.json
@@ -1,6 +1,8 @@
 {
   "exchange": {
     "pair_blacklist": [
+      // Binance delist 2026-08-17 (full-coin) — iterativ 2026-08-03
+      "(ACX|VIC)/.*",
       // FIGHT all-12 + IDOL (MEET48) — iterativ 2026-08-02
       "IDOL/.*",
       // Exchange Tokens

--- a/configs/blacklist-hyperliquid.json
+++ b/configs/blacklist-hyperliquid.json
@@ -1,6 +1,8 @@
 {
   "exchange": {
     "pair_blacklist": [
+      // Binance delist 2026-08-17 (full-coin) — iterativ 2026-08-03
+      "(ACX|VIC)/.*",
       // FIGHT all-12 + IDOL (MEET48) — iterativ 2026-08-02
       "IDOL/.*",
       // Exchange Tokens

--- a/configs/blacklist-kraken.json
+++ b/configs/blacklist-kraken.json
@@ -1,6 +1,8 @@
 {
   "exchange": {
     "pair_blacklist": [
+      // Binance delist 2026-08-17 (full-coin) — iterativ 2026-08-03
+      "(ACX|VIC)/.*",
       // FIGHT all-12 + IDOL (MEET48) — iterativ 2026-08-02
       "(FIGHT|IDOL)/.*",
       // Leverage tokens

--- a/configs/blacklist-kucoin.json
+++ b/configs/blacklist-kucoin.json
@@ -1,6 +1,8 @@
 {
   "exchange": {
     "pair_blacklist": [
+      // Binance delist 2026-08-17 (full-coin) — iterativ 2026-08-03
+      "(ACX|VIC)/.*",
       // FIGHT all-12 + IDOL (MEET48) — iterativ 2026-08-02
       "(FIGHT|IDOL)/.*",
       // Exchange Tokens

--- a/configs/blacklist-mexc.json
+++ b/configs/blacklist-mexc.json
@@ -1,6 +1,8 @@
 {
   "exchange": {
     "pair_blacklist": [
+      // Binance delist 2026-08-17 (full-coin) — iterativ 2026-08-03
+      "(ACX|VIC)/.*",
       // FIGHT all-12 + IDOL (MEET48) — iterativ 2026-08-02
       "IDOL/.*",
       // Exchange Tokens

--- a/configs/blacklist-okx.json
+++ b/configs/blacklist-okx.json
@@ -1,6 +1,8 @@
 {
   "exchange": {
     "pair_blacklist": [
+      // Binance delist 2026-08-17 (full-coin) — iterativ 2026-08-03
+      "(ACX|VIC)/.*",
       // FIGHT all-12 + IDOL (MEET48) — iterativ 2026-08-02
       "(FIGHT|IDOL)/.*",
       // Exchange Tokens


### PR DESCRIPTION
Binance is delisting **ACX** and **VIC** (all quote pairs — TRY/USDC/USDT) on **2026-08-17**. Both are still active USDT perps (ACX on binance/bybit/bitget, VIC on binance).

Added to all 12 lists (forward-protection + consistency — the rest of that delist batch, HFT/PYR/VANRY, are already all-12). PIVX from the same announcement is skipped — no active futures perp on the covered venues.

Source: Binance delisting announcement, 2026-08-17.