### PR TITLE
Fix None min_stake crash in non-v3 rebuy adjust paths

### DIFF
--- a/NostalgiaForInfinityX7.py
+++ b/NostalgiaForInfinityX7.py
@@ -51342,7 +51342,7 @@ class NostalgiaForInfinityX7(IStrategy):
     trade_amount = trade.amount
     trade_leverage = trade.leverage
 
-    min_stake /= trade_leverage
+    min_stake = self.correct_min_stake(min_stake, trade_leverage)
     # we already waiting for an order to get filled
     if trade.has_open_orders:
       return None
@@ -74823,7 +74823,7 @@ class NostalgiaForInfinityX7(IStrategy):
     trade_amount = trade.amount
     trade_leverage = trade.leverage
 
-    min_stake /= trade_leverage
+    min_stake = self.correct_min_stake(min_stake, trade_leverage)
     # we already waiting for an order to get filled
     if trade.has_open_orders:
       return None


### PR DESCRIPTION
## Summary

Use the already-merged `correct_min_stake(min_stake, trade_leverage)` pattern in the two non-v3 rebuy adjust functions, matching what the v3 rebuy paths already do.

The non-v3 paths still had:

```python
min_stake /= trade_leverage
```

which crashes with `TypeError: unsupported operand type(s) for /=: 'NoneType' and 'float'` when the exchange reports no min stake (`None`), and also double-divides the leverage-adjusted `min_stake` that freqtrade already provides.

Changed:

- `long_rebuy_adjust_trade_position` -> `min_stake = self.correct_min_stake(min_stake, trade_leverage)`
- `short_rebuy_adjust_trade_position` -> `min_stake = self.correct_min_stake(min_stake, trade_leverage)`

## Safety

- Same pattern already merged for the v3 rebuy paths (`long/short_rebuy_adjust_trade_position_v3`).
- These non-v3 rebuy paths are not the active live path (v3 is), so the trading surface is unchanged.
- No indicators, candle selection, thresholds, condition order, profit arithmetic, return values, or entry/exit signal logic changed.

## Checks

- `git diff --check`
- `ruff format --check NostalgiaForInfinityX7.py`
- `ruff check NostalgiaForInfinityX7.py`
- `PYTHONDONTWRITEBYTECODE=1 python3 -m py_compile NostalgiaForInfinityX7.py`

No backtest run: the change only aligns the unused non-v3 rebuy paths with the already-merged `correct_min_stake` pattern used on the active v3 rebuy paths. No formula, threshold, condition order, or return value changes on active paths.
