### PR TITLE
blacklist(mexc): add GIGA — MEXC futures delist 2026-07-27

### DIFF
--- a/configs/blacklist-mexc.json
+++ b/configs/blacklist-mexc.json
@@ -31,6 +31,8 @@
       "(NIGHT)/.*",
       // Delist notice (2026-07-24)
       "(SOLANGELES|MCN|STBU)/.*",
+      // MEXC futures delist 2026-07-27: GIGA (BOB from same notice already covered above)
+      "(GIGA)/.*",
       // Tokenized stocks (STOCK suffix — universal forward-protection)
       ".*STOCK/.*",
       // Tokenized stocks (direct ticker, no STOCK suffix)


### PR DESCRIPTION
MEXC delisted the GIGA USDT-M perpetual on 2026-07-27 (same notice as BOB, which is already covered in this file). GIGA was 0/12 across the blacklists; single-venue delist → added to the MEXC file only per the per-venue policy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)