### PR TITLE
Refactor NostalgiaForInfinityX7 informative indicators (#450)

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -1,0 +1,202 @@
+name: NFI X7 Informative Indicators Tests
+
+on:
+  pull_request:
+    paths:
+      - NostalgiaForInfinityX7.py
+      - tests/unit/test_NFIX7_informative_indicators.py
+      - tests/differential/test_NFIX7_informative_equivalence.py
+      - tests/differential/verify_nfix7_evidence.py
+      - .github/workflows/unit-tests.yml
+      - docker/Dockerfile.custom
+      - tests/requirements.txt
+      - docker-compose.tests.yml
+
+permissions:
+  contents: read
+
+jobs:
+  unit-tests:
+    runs-on: ubuntu-latest
+    env:
+      BASE_SHA: ${{ github.event.pull_request.base.sha }}
+      HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+
+    steps:
+      - name: Checkout exact pull-request head
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Run immutable #450 evidence gates
+        shell: bash
+        run: |
+          set -euo pipefail
+          rm -f \
+            artifacts/focused.xml artifacts/full-unit.xml artifacts/differential.xml \
+            artifacts/nfix7-informative-raw.json \
+            artifacts/nfix7-informative-equivalence.json
+
+          test "$(git rev-parse HEAD)" = "$HEAD_SHA"
+          test "$BASE_SHA" != "$HEAD_SHA"
+          git fetch --no-tags origin "$BASE_SHA"
+          test "$(git rev-parse "$BASE_SHA^{commit}")" = "$BASE_SHA"
+          test "$(git rev-parse "$HEAD_SHA^{commit}")" = "$HEAD_SHA"
+
+          ALLOWED_PATHS=(
+            NostalgiaForInfinityX7.py
+            tests/unit/test_NFIX7_informative_indicators.py
+            tests/differential/test_NFIX7_informative_equivalence.py
+            tests/differential/verify_nfix7_evidence.py
+            .github/workflows/unit-tests.yml
+          )
+          IFS=$'\t' read -r CHANGED_PATHS_JSON CHANGED_PATHS_SHA256 < <(
+          python3 - "$BASE_SHA" "$HEAD_SHA" "${ALLOWED_PATHS[@]}" <<'PY'
+          import hashlib, json, subprocess, sys
+          base, head = sys.argv[1:3]
+          expected = sorted(sys.argv[3:])
+          raw = subprocess.check_output([
+              "git", "-c", "diff.renames=false", "diff",
+              "--name-only", "-z", base, head,
+          ])
+          actual = sorted(path.decode("utf-8") for path in raw.split(b"\0") if path)
+          if actual != expected:
+              raise SystemExit(f"scope mismatch: expected={expected!r} actual={actual!r}")
+          payload = "\0".join(actual).encode("utf-8")
+          print(json.dumps(actual, separators=(",", ":")), hashlib.sha256(payload).hexdigest(), sep="\t")
+          PY
+          )
+
+          mkdir -p artifacts artifacts/nfix7-baseline
+          chmod 0777 artifacts
+          git show "$BASE_SHA:NostalgiaForInfinityX7.py" \
+            > artifacts/nfix7-baseline/NostalgiaForInfinityX7.py
+          BASE_SOURCE_SHA256=$(sha256sum artifacts/nfix7-baseline/NostalgiaForInfinityX7.py | cut -d' ' -f1)
+
+          PRECOMMIT_VENV=/tmp/nfix7-precommit-4.6.1
+          python3 -m venv --clear "$PRECOMMIT_VENV"
+          "$PRECOMMIT_VENV/bin/python" -m pip install \
+            --disable-pip-version-check 'pre-commit==4.6.1'
+          PRE_COMMIT_VERSION=$("$PRECOMMIT_VENV/bin/pre-commit" --version)
+          test "$PRE_COMMIT_VERSION" = 'pre-commit 4.6.1'
+
+          python3 -m py_compile NostalgiaForInfinityX7.py
+          "$PRECOMMIT_VENV/bin/pre-commit" run --files \
+            NostalgiaForInfinityX7.py \
+            tests/unit/test_NFIX7_informative_indicators.py \
+            tests/differential/test_NFIX7_informative_equivalence.py \
+            tests/differential/verify_nfix7_evidence.py \
+            .github/workflows/unit-tests.yml
+          git diff --check
+          test "$(git rev-parse HEAD)" = "$HEAD_SHA"
+          test -z "$(git status --porcelain=v1 --untracked-files=all)"
+          git diff --exit-code "$HEAD_SHA" --
+          git diff --cached --exit-code "$HEAD_SHA" --
+
+          FEATURE_SOURCE_SHA256=$(sha256sum NostalgiaForInfinityX7.py | cut -d' ' -f1)
+          test "$BASE_SOURCE_SHA256" != "$FEATURE_SOURCE_SHA256"
+          FEATURE_BUNDLE_SHA256=$(python3 - "${ALLOWED_PATHS[@]}" <<'PY'
+          import hashlib, pathlib, sys
+          digest = hashlib.sha256()
+          for raw_path in sorted(sys.argv[1:]):
+              path = pathlib.Path(raw_path)
+              data = path.read_bytes()
+              name = path.as_posix().encode("utf-8")
+              digest.update(len(name).to_bytes(8, "big")); digest.update(name)
+              digest.update(len(data).to_bytes(8, "big")); digest.update(data)
+          print(digest.hexdigest())
+          PY
+          )
+
+          TEST_IMAGE_TAG="nfi-x7-issue450-tests:${HEAD_SHA}"
+          docker build -f docker/Dockerfile.custom -t "$TEST_IMAGE_TAG" .
+          TEST_IMAGE_ID=$(docker image inspect "$TEST_IMAGE_TAG" --format '{{.Id}}')
+          test -n "$TEST_IMAGE_ID"
+
+          docker run --rm -v "$PWD:/testing" -w /testing --entrypoint "" \
+            "$TEST_IMAGE_ID" python -m pytest -o addopts="" -o xfail_strict=true \
+            tests/unit/test_NFIX7_informative_indicators.py -q \
+            --junitxml=/testing/artifacts/focused.xml
+
+          docker run --rm -v "$PWD:/testing" -w /testing --entrypoint "" \
+            "$TEST_IMAGE_ID" python -m pytest -o addopts="" tests/unit -q \
+            --junitxml=/testing/artifacts/full-unit.xml
+
+          docker run --rm -v "$PWD:/testing" -w /testing --entrypoint "" \
+            -e NFI_BASE_STRATEGY=/testing/artifacts/nfix7-baseline/NostalgiaForInfinityX7.py \
+            -e NFI_EVIDENCE_MODE=pull-request \
+            -e NFI_BASE_SHA="$BASE_SHA" -e NFI_HEAD_SHA="$HEAD_SHA" \
+            -e NFI_BASE_SOURCE_SHA256="$BASE_SOURCE_SHA256" \
+            -e NFI_FEATURE_SOURCE_SHA256="$FEATURE_SOURCE_SHA256" \
+            -e NFI_FEATURE_BUNDLE_SHA256="$FEATURE_BUNDLE_SHA256" \
+            -e NFI_CHANGED_PATHS_JSON="$CHANGED_PATHS_JSON" \
+            -e NFI_CHANGED_PATHS_SHA256="$CHANGED_PATHS_SHA256" \
+            -e NFI_TEST_IMAGE_ID="$TEST_IMAGE_ID" \
+            -e NFI_PRE_COMMIT_VERSION="$PRE_COMMIT_VERSION" \
+            "$TEST_IMAGE_ID" python -m pytest -o addopts="" -o xfail_strict=true \
+            tests/differential/test_NFIX7_informative_equivalence.py -q \
+            --junitxml=/testing/artifacts/differential.xml
+
+          test "$(git rev-parse HEAD)" = "$HEAD_SHA"
+          test -z "$(git status --porcelain=v1 --untracked-files=all)"
+          git diff --exit-code "$HEAD_SHA" --
+          git diff --cached --exit-code "$HEAD_SHA" --
+          python3 - \
+            "$BASE_SHA" "$HEAD_SHA" \
+            "$FEATURE_SOURCE_SHA256" "$FEATURE_BUNDLE_SHA256" \
+            "$CHANGED_PATHS_JSON" "$CHANGED_PATHS_SHA256" \
+            "${ALLOWED_PATHS[@]}" <<'PY'
+          import hashlib, json, pathlib, subprocess, sys
+          base, head, expected_source, expected_bundle, expected_json, expected_path_hash = sys.argv[1:7]
+          allowed = sorted(sys.argv[7:])
+          source = hashlib.sha256(pathlib.Path("NostalgiaForInfinityX7.py").read_bytes()).hexdigest()
+          assert source == expected_source
+          raw = subprocess.check_output([
+              "git", "-c", "diff.renames=false", "diff",
+              "--name-only", "-z", base, head,
+          ])
+          paths = sorted(path.decode("utf-8") for path in raw.split(b"\0") if path)
+          assert paths == allowed
+          actual_json = json.dumps(paths, separators=(",", ":"))
+          assert actual_json == expected_json
+          assert hashlib.sha256("\0".join(paths).encode("utf-8")).hexdigest() == expected_path_hash
+          digest = hashlib.sha256()
+          for raw_path in paths:
+              path = pathlib.Path(raw_path)
+              data = path.read_bytes()
+              name = path.as_posix().encode("utf-8")
+              digest.update(len(name).to_bytes(8, "big")); digest.update(name)
+              digest.update(len(data).to_bytes(8, "big")); digest.update(data)
+          assert digest.hexdigest() == expected_bundle
+          PY
+          test "$(git rev-parse HEAD)" = "$HEAD_SHA"
+
+          docker run --rm -v "$PWD:/testing" -w /testing --entrypoint "" \
+            "$TEST_IMAGE_ID" python tests/differential/verify_nfix7_evidence.py \
+            --focused artifacts/focused.xml \
+            --full-unit artifacts/full-unit.xml \
+            --differential artifacts/differential.xml \
+            --raw artifacts/nfix7-informative-raw.json \
+            --output artifacts/nfix7-informative-equivalence.json \
+            --mode pull-request --base-sha "$BASE_SHA" --head-sha "$HEAD_SHA" \
+            --base-source-sha256 "$BASE_SOURCE_SHA256" \
+            --feature-source-sha256 "$FEATURE_SOURCE_SHA256" \
+            --feature-bundle-sha256 "$FEATURE_BUNDLE_SHA256" \
+            --changed-paths-json "$CHANGED_PATHS_JSON" \
+            --changed-paths-sha256 "$CHANGED_PATHS_SHA256" \
+            --image-id "$TEST_IMAGE_ID" \
+            --pre-commit-version "$PRE_COMMIT_VERSION"
+
+      - name: Upload #450 test evidence
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: nfix7-informative-indicators-${{ github.event.pull_request.head.sha }}
+          if-no-files-found: warn
+          path: |
+            artifacts/focused.xml
+            artifacts/full-unit.xml
+            artifacts/differential.xml
+            artifacts/nfix7-informative-raw.json
+            artifacts/nfix7-informative-equivalence.json

--- a/NostalgiaForInfinityX7.py
+++ b/NostalgiaForInfinityX7.py
@@ -13,6 +13,7 @@ from freqtrade.persistence import Trade, Order
 from datetime import datetime, timedelta
 import time
 from typing import Optional
+from dataclasses import dataclass
 import warnings
 
 log = logging.getLogger(__name__)
@@ -65,6 +66,17 @@ warnings.simplefilter(action="ignore", category=pd.errors.PerformanceWarning)
 ##         (Welcome Bonus worth 241 USDT upon completion of a deposit and trade)                           ##
 ##  Bitvavo: https://bitvavo.com/invite?a=D22103A4BC (no fees for the first € 10000)                       ##
 #############################################################################################################
+
+
+@dataclass(frozen=True)
+class _NFIInformativeContext:
+  source: DataFrame
+  index: object
+  open: np.ndarray
+  high: np.ndarray
+  low: np.ndarray
+  close: np.ndarray
+  volume: np.ndarray
 
 
 class NostalgiaForInfinityX7(IStrategy):
@@ -3341,740 +3353,485 @@ class NostalgiaForInfinityX7(IStrategy):
 
   # Informative 1d Timeframe Indicators
   # ---------------------------------------------------------------------------------------------
-  def informative_1d_indicators(self, metadata: dict, info_timeframe) -> DataFrame:
-    debug_time = False
-    if debug_time:
-      tik = time.perf_counter()
-    dp = self.dp
-    fast_pct_change = self.fast_pct_change
-    stochrsi_k_func = self.stochrsi_k
-    chaikin_money_flow = self.chaikin_money_flow
-    ta_rsi = ta.RSI
-    ta_aroon = ta.AROON
-    ta_roc = ta.ROC
-    ta_min = ta.MIN
-    ta_max = ta.MAX
-    ta_sma = ta.SMA
+  @staticmethod
+  def _nfix7_common_raw_values(context):
+    rsi_3 = ta.RSI(context.close, timeperiod=3)
+    rsi_14 = ta.RSI(context.close, timeperiod=14)
+    aroon_down, aroon_up = ta.AROON(context.high, context.low, timeperiod=14)
+    _, stoch_k = ta.STOCHF(
+      context.high,
+      context.low,
+      context.close,
+      fastk_period=14,
+      fastd_period=3,
+      fastd_matype=0,
+    )
+    mfi_14 = ta.MFI(context.high, context.low, context.close, context.volume, timeperiod=14)
+    willr_14 = ta.WILLR(context.high, context.low, context.close, timeperiod=14)
+    roc_9 = ta.ROC(context.close, timeperiod=9)
+    open_safe = np.where(context.open == 0, np.nan, context.open)
+    change_pct = ((context.close - context.open) / open_safe) * 100.0
+    return {
+      "RSI_3": rsi_3,
+      "RSI_14": rsi_14,
+      "AROONU_14": aroon_up,
+      "AROOND_14": aroon_down,
+      "STOCHk_14_3_3": stoch_k,
+      "MFI_14": mfi_14,
+      "WILLR_14": willr_14,
+      "ROC_9": roc_9,
+      "change_pct": change_pct,
+    }
 
-    assert dp, "DataProvider is required for multiple timeframes."
+  @staticmethod
+  def _nfix7_assemble_common_values(raw, *, rsi3_change, stochrsi_k, cmf):
+    return {
+      "RSI_3": raw["RSI_3"],
+      "RSI_14": raw["RSI_14"],
+      "RSI_3_change_pct": rsi3_change,
+      "AROONU_14": raw["AROONU_14"],
+      "AROOND_14": raw["AROOND_14"],
+      "STOCHk_14_3_3": raw["STOCHk_14_3_3"],
+      "STOCHRSIk_14_14_3_3": stochrsi_k,
+      "MFI_14": raw["MFI_14"],
+      "CMF_20": cmf,
+      "WILLR_14": raw["WILLR_14"],
+      "ROC_9": raw["ROC_9"],
+      "change_pct": raw["change_pct"],
+    }
 
-    # Get dataframe
-    metadata_pair = metadata["pair"]
-    informative_1d = dp.get_pair_dataframe(pair=metadata_pair, timeframe=info_timeframe)
-
-    # Empty dataframe protection
-    if informative_1d.empty:
-      return informative_1d
-
-    # =========================================================================
-    # BASE DATA
-    # =========================================================================
-    close_np = informative_1d["close"].to_numpy(copy=False)
-    high_np = informative_1d["high"].to_numpy(copy=False)
-    low_np = informative_1d["low"].to_numpy(copy=False)
-    open_np = informative_1d["open"].to_numpy(copy=False)
-    volume_np = informative_1d["volume"].to_numpy(copy=False)
-
-    # =========================================================================
-    # CORE INDICATORS
-    # =========================================================================
-    rsi_3 = ta_rsi(close_np, timeperiod=3)
-    rsi_14 = ta_rsi(close_np, timeperiod=14)
-    aroon_down, aroon_up = ta_aroon(high_np, low_np, timeperiod=14)
-
-    # =========================================================================
-    # STOCH
-    # =========================================================================
-    _, stoch_k = ta.STOCHF(high_np, low_np, close_np, fastk_period=14, fastd_period=3, fastd_matype=0)
-    stochrsi_k = stochrsi_k_func(rsi_14, ta_min, ta_max, ta_sma)
-
-    # =========================================================================
-    # MONEY FLOW
-    # =========================================================================
-    mfi_14 = ta.MFI(high_np, low_np, close_np, volume_np, timeperiod=14)
-    cmf_20 = chaikin_money_flow(high_np, low_np, close_np, volume_np, timeperiod=20)
-
-    # =========================================================================
-    # MOMENTUM
-    # =========================================================================
-    willr_14 = ta.WILLR(high_np, low_np, close_np, timeperiod=14)
-    roc_2 = ta_roc(close_np, timeperiod=2)
-    roc_9 = ta_roc(close_np, timeperiod=9)
-
-    # =========================================================================
-    # RSI CHANGE %
-    # =========================================================================
-    rsi3_change = fast_pct_change(rsi_3)
-
-    # =========================================================================
-    # CANDLE %
-    # =========================================================================
-    open_safe = np.where(open_np == 0, np.nan, open_np)
-    change_pct = ((close_np - open_np) / open_safe) * 100.0
-
-    # =========================================================================
-    # WICK %
-    # =========================================================================
-    max_oc = np.maximum(open_np, close_np)
-    min_oc = np.minimum(open_np, close_np)
+  def _nfix7_build_1d_columns(self, context):
+    raw = NostalgiaForInfinityX7._nfix7_common_raw_values(context)
+    roc_2 = ta.ROC(context.close, timeperiod=2)
+    max_oc = np.maximum(context.open, context.close)
+    min_oc = np.minimum(context.open, context.close)
     max_oc_calc = np.where(max_oc == 0, np.nan, max_oc)
     min_oc_calc = np.where(min_oc == 0, np.nan, min_oc)
-    top_wick_pct = ((high_np - max_oc) / max_oc_calc) * 100.0
-    bot_wick_pct = np.abs(((low_np - min_oc) / min_oc_calc) * 100.0)
-
-    # =========================================================================
-    # HIGH / LOW ROLLING
-    # =========================================================================
-    high_max_6 = ta_max(high_np, timeperiod=6)
-    high_max_12 = ta_max(high_np, timeperiod=12)
-    high_max_20 = ta_max(high_np, timeperiod=20)
-    high_max_30 = ta_max(high_np, timeperiod=30)
-    low_min_6 = ta_min(low_np, timeperiod=6)
-    low_min_12 = ta_min(low_np, timeperiod=12)
-    low_min_20 = ta_min(low_np, timeperiod=20)
-    low_min_30 = ta_min(low_np, timeperiod=30)
+    top_wick_pct = ((context.high - max_oc) / max_oc_calc) * 100.0
+    bot_wick_pct = np.abs(((context.low - min_oc) / min_oc_calc) * 100.0)
+    high_max_6 = ta.MAX(context.high, timeperiod=6)
+    high_max_12 = ta.MAX(context.high, timeperiod=12)
+    high_max_20 = ta.MAX(context.high, timeperiod=20)
+    high_max_30 = ta.MAX(context.high, timeperiod=30)
+    low_min_6 = ta.MIN(context.low, timeperiod=6)
+    low_min_12 = ta.MIN(context.low, timeperiod=12)
+    low_min_20 = ta.MIN(context.low, timeperiod=20)
+    low_min_30 = ta.MIN(context.low, timeperiod=30)
 
     bad_trade_controller_indicators = {}
     if self.bad_trade_controller_enable:
-      nonzero_low_np = np.where(low_np == 0.0, np.nan, low_np)
-      daily_range_pct_np = (high_np - low_np) / nonzero_low_np * 100.0
+      nonzero_low = np.where(context.low == 0.0, np.nan, context.low)
+      daily_range_pct = (context.high - context.low) / nonzero_low * 100.0
       bad_trade_controller_indicators = {
-        "EMA_50": ta.EMA(close_np, timeperiod=50),
-        "EMA_200": ta.EMA(close_np, timeperiod=200),
-        "RANGE_PCT_14": ta_sma(daily_range_pct_np, timeperiod=14),
+        "EMA_50": ta.EMA(context.close, timeperiod=50),
+        "EMA_200": ta.EMA(context.close, timeperiod=200),
+        "RANGE_PCT_14": ta.SMA(daily_range_pct, timeperiod=14),
       }
 
-    # =========================================================================
-    # ASSIGN DATAFRAME
-    # =========================================================================
-    new_cols = pd.DataFrame(
-      {
-        "RSI_3": rsi_3,
-        "RSI_14": rsi_14,
-        "STOCHk_14_3_3": stoch_k,
-        "STOCHRSIk_14_14_3_3": stochrsi_k,
-        "MFI_14": mfi_14,
-        "CMF_20": cmf_20,
-        "WILLR_14": willr_14,
-        "AROONU_14": aroon_up,
-        "AROOND_14": aroon_down,
-        "ROC_2": roc_2,
-        "ROC_9": roc_9,
-        "RSI_3_change_pct": rsi3_change,
-        "change_pct": change_pct,
-        "top_wick_pct": top_wick_pct,
-        "bot_wick_pct": bot_wick_pct,
-        "high_max_6": high_max_6,
-        "high_max_12": high_max_12,
-        "high_max_20": high_max_20,
-        "high_max_30": high_max_30,
-        "low_min_6": low_min_6,
-        "low_min_12": low_min_12,
-        "low_min_20": low_min_20,
-        "low_min_30": low_min_30,
-        **bad_trade_controller_indicators,
-      },
-      index=informative_1d.index,
+    stochrsi_k = self.stochrsi_k(raw["RSI_14"], ta.MIN, ta.MAX, ta.SMA)
+    cmf_20 = self.chaikin_money_flow(
+      context.high,
+      context.low,
+      context.close,
+      context.volume,
+      timeperiod=20,
     )
-    informative_1d = pd.concat([informative_1d, new_cols], axis=1, copy=False)
+    rsi3_change = self.fast_pct_change(raw["RSI_3"])
+    common = NostalgiaForInfinityX7._nfix7_assemble_common_values(
+      raw,
+      rsi3_change=rsi3_change,
+      stochrsi_k=stochrsi_k,
+      cmf=cmf_20,
+    )
+    columns_map = {
+      "RSI_3": common["RSI_3"],
+      "RSI_14": common["RSI_14"],
+      "STOCHk_14_3_3": common["STOCHk_14_3_3"],
+      "STOCHRSIk_14_14_3_3": common["STOCHRSIk_14_14_3_3"],
+      "MFI_14": common["MFI_14"],
+      "CMF_20": common["CMF_20"],
+      "WILLR_14": common["WILLR_14"],
+      "AROONU_14": common["AROONU_14"],
+      "AROOND_14": common["AROOND_14"],
+      "ROC_2": roc_2,
+      "ROC_9": common["ROC_9"],
+      "RSI_3_change_pct": common["RSI_3_change_pct"],
+      "change_pct": common["change_pct"],
+      "top_wick_pct": top_wick_pct,
+      "bot_wick_pct": bot_wick_pct,
+      "high_max_6": high_max_6,
+      "high_max_12": high_max_12,
+      "high_max_20": high_max_20,
+      "high_max_30": high_max_30,
+      "low_min_6": low_min_6,
+      "low_min_12": low_min_12,
+      "low_min_20": low_min_20,
+      "low_min_30": low_min_30,
+      **bad_trade_controller_indicators,
+    }
+    debug_cols = list(columns_map)
+    return columns_map, debug_cols, "[%s] informative_1d_indicators took: %.4f seconds."
 
-    # Enable ONLY during debugging
+  def _nfix7_build_4h_columns(self, context):
+    raw = NostalgiaForInfinityX7._nfix7_common_raw_values(context)
+    bb_upper_20, _, bb_lower_20 = ta.BBANDS(
+      context.close,
+      timeperiod=20,
+      nbdevup=2.0,
+      nbdevdn=2.0,
+      matype=0,
+    )
+    bb_range = bb_upper_20 - bb_lower_20
+    bbp_20 = (context.close - bb_lower_20) / np.where(bb_range == 0, np.nan, bb_range)
+    ema_12 = ta.EMA(context.close, timeperiod=12)
+    ema_50 = ta.EMA(context.close, timeperiod=50)
+    ema_100 = ta.EMA(context.close, timeperiod=100)
+    ema_200 = ta.EMA(context.close, timeperiod=200)
+    uo = ta.ULTOSC(context.high, context.low, context.close)
+    roc_2 = ta.ROC(context.close, timeperiod=2)
+    cci_20 = ta.CCI(context.high, context.low, context.close, timeperiod=20)
+    max_oc = np.maximum(context.open, context.close)
+    max_oc_calc = np.where(max_oc == 0, np.nan, max_oc)
+    top_wick_pct = ((context.high - max_oc) / max_oc_calc) * 100.0
+    high_max_6 = ta.MAX(context.high, timeperiod=6)
+    high_max_12 = ta.MAX(context.high, timeperiod=12)
+    high_max_24 = ta.MAX(context.high, timeperiod=24)
+    low_min_12 = ta.MIN(context.low, timeperiod=12)
+    low_min_24 = ta.MIN(context.low, timeperiod=24)
+    adx_14 = ta.ADX(context.high, context.low, context.close, timeperiod=14)
+    plus_di_14 = ta.PLUS_DI(context.high, context.low, context.close, timeperiod=14)
+    minus_di_14 = ta.MINUS_DI(context.high, context.low, context.close, timeperiod=14)
+
+    stochrsi_k = self.stochrsi_k(raw["RSI_14"], ta.MIN, ta.MAX, ta.SMA)
+    kst_main, kst_signal = self.calc_kst(context.close, ta.ROC, ta.SMA)
+    cmf_20 = self.chaikin_money_flow(
+      context.high,
+      context.low,
+      context.close,
+      context.volume,
+      timeperiod=20,
+    )
+    rsi_3_change = self.fast_pct_change(raw["RSI_3"])
+    rsi_14_change = self.fast_pct_change(raw["RSI_14"])
+    stochrsi_change = self.fast_pct_change(stochrsi_k)
+    cci_change = self.fast_pct_change(cci_20)
+    common = NostalgiaForInfinityX7._nfix7_assemble_common_values(
+      raw,
+      rsi3_change=rsi_3_change,
+      stochrsi_k=stochrsi_k,
+      cmf=cmf_20,
+    )
+    columns_map = {
+      "RSI_3": common["RSI_3"],
+      "RSI_14": common["RSI_14"],
+      "ADX_14": adx_14,
+      "PLUS_DI_14": plus_di_14,
+      "MINUS_DI_14": minus_di_14,
+      "AROONU_14": common["AROONU_14"],
+      "AROOND_14": common["AROOND_14"],
+      "BBP_20_2.0": bbp_20,
+      "STOCHk_14_3_3": common["STOCHk_14_3_3"],
+      "STOCHRSIk_14_14_3_3": common["STOCHRSIk_14_14_3_3"],
+      "KST_10_15_20_30_10_10_10_15": kst_main,
+      "KSTs_9": kst_signal,
+      "MFI_14": common["MFI_14"],
+      "CMF_20": common["CMF_20"],
+      "EMA_12": ema_12,
+      "EMA_50": ema_50,
+      "EMA_100": ema_100,
+      "EMA_200": ema_200,
+      "WILLR_14": common["WILLR_14"],
+      "UO_7_14_28": uo,
+      "ROC_2": roc_2,
+      "ROC_9": common["ROC_9"],
+      "CCI_20": cci_20,
+      "STOCHRSIk_14_14_3_3_change_pct": stochrsi_change,
+      "CCI_20_change_pct": cci_change,
+      "RSI_3_change_pct": common["RSI_3_change_pct"],
+      "RSI_14_change_pct": rsi_14_change,
+      "change_pct": common["change_pct"],
+      "top_wick_pct": top_wick_pct,
+      "high_max_6": high_max_6,
+      "high_max_12": high_max_12,
+      "high_max_24": high_max_24,
+      "low_min_12": low_min_12,
+      "low_min_24": low_min_24,
+    }
+    debug_cols = [
+      "RSI_3",
+      "RSI_14",
+      "AROONU_14",
+      "AROOND_14",
+      "STOCHk_14_3_3",
+      "STOCHRSIk_14_14_3_3",
+      "KST_10_15_20_30_10_10_10_15",
+      "KSTs_9",
+      "MFI_14",
+      "CMF_20",
+      "EMA_12",
+      "EMA_50",
+      "EMA_100",
+      "EMA_200",
+      "WILLR_14",
+      "UO_7_14_28",
+      "ROC_2",
+      "ROC_9",
+      "CCI_20",
+      "STOCHRSIk_14_14_3_3_change_pct",
+      "CCI_20_change_pct",
+      "RSI_3_change_pct",
+      "RSI_14_change_pct",
+      "OBV_change_pct",
+      "change_pct",
+      "high_max_6",
+      "high_max_12",
+      "high_max_24",
+      "low_min_12",
+      "low_min_24",
+    ]
+    return columns_map, debug_cols, "[%s] informative_4h_indicators took: %.4f seconds."
+
+  def _nfix7_build_1h_columns(self, context):
+    raw = NostalgiaForInfinityX7._nfix7_common_raw_values(context)
+    bb_upper, bb_middle, bb_lower = ta.BBANDS(
+      context.close,
+      timeperiod=20,
+      nbdevup=2.0,
+      nbdevdn=2.0,
+      matype=0,
+    )
+    bb_middle_safe = np.where(bb_middle == 0, np.nan, bb_middle)
+    bbb_20 = ((bb_upper - bb_lower) / bb_middle_safe) * 100.0
+    ema_12 = ta.EMA(context.close, timeperiod=12)
+    ema_200 = ta.EMA(context.close, timeperiod=200)
+    sma_16 = ta.SMA(context.close, timeperiod=16)
+    willr_84 = ta.WILLR(context.high, context.low, context.close, timeperiod=84)
+    uo = ta.ULTOSC(context.high, context.low, context.close)
+    roc_2 = ta.ROC(context.close, timeperiod=2)
+    cci_20 = ta.CCI(context.high, context.low, context.close, timeperiod=20)
+    high_max_6 = ta.MAX(context.high, timeperiod=6)
+    high_max_12 = ta.MAX(context.high, timeperiod=12)
+    high_max_24 = ta.MAX(context.high, timeperiod=24)
+    low_min_6 = ta.MIN(context.low, timeperiod=6)
+    low_min_12 = ta.MIN(context.low, timeperiod=12)
+    low_min_24 = ta.MIN(context.low, timeperiod=24)
+
+    stochrsi_k = self.stochrsi_k(raw["RSI_14"], ta.MIN, ta.MAX, ta.SMA)
+    kst_main, kst_signal = self.calc_kst(context.close, ta.ROC, ta.SMA)
+    cmf_20 = self.chaikin_money_flow(
+      context.high,
+      context.low,
+      context.close,
+      context.volume,
+      timeperiod=20,
+    )
+    rsi_3_change = self.fast_pct_change(raw["RSI_3"])
+    rsi_14_change = self.fast_pct_change(raw["RSI_14"])
+    cci_change = self.fast_pct_change(cci_20)
+    common = NostalgiaForInfinityX7._nfix7_assemble_common_values(
+      raw,
+      rsi3_change=rsi_3_change,
+      stochrsi_k=stochrsi_k,
+      cmf=cmf_20,
+    )
+    columns_map = {
+      "RSI_3": common["RSI_3"],
+      "RSI_14": common["RSI_14"],
+      "RSI_3_change_pct": common["RSI_3_change_pct"],
+      "RSI_14_change_pct": rsi_14_change,
+      "EMA_12": ema_12,
+      "EMA_200": ema_200,
+      "SMA_16": sma_16,
+      "BBL_20_2.0": bb_lower,
+      "BBU_20_2.0": bb_upper,
+      "BBB_20_2.0": bbb_20,
+      "MFI_14": common["MFI_14"],
+      "CMF_20": common["CMF_20"],
+      "WILLR_14": common["WILLR_14"],
+      "WILLR_84": willr_84,
+      "AROONU_14": common["AROONU_14"],
+      "AROOND_14": common["AROOND_14"],
+      "STOCHk_14_3_3": common["STOCHk_14_3_3"],
+      "STOCHRSIk_14_14_3_3": common["STOCHRSIk_14_14_3_3"],
+      "KST_10_15_20_30_10_10_10_15": kst_main,
+      "KSTs_9": kst_signal,
+      "UO_7_14_28": uo,
+      "ROC_2": roc_2,
+      "ROC_9": common["ROC_9"],
+      "CCI_20": cci_20,
+      "CCI_20_change_pct": cci_change,
+      "change_pct": common["change_pct"],
+      "high_max_6": high_max_6,
+      "high_max_12": high_max_12,
+      "high_max_24": high_max_24,
+      "low_min_6": low_min_6,
+      "low_min_12": low_min_12,
+      "low_min_24": low_min_24,
+    }
+    debug_cols = list(columns_map)
+    return columns_map, debug_cols, "[%s] informative_1h_indicators took: %.4f seconds."
+
+  def _nfix7_build_15m_columns(self, context):
+    raw = NostalgiaForInfinityX7._nfix7_common_raw_values(context)
+    ema_12 = ta.EMA(context.close, timeperiod=12)
+    ema_20 = ta.EMA(context.close, timeperiod=20)
+    ema_26 = ta.EMA(context.close, timeperiod=26)
+    ema_50 = ta.EMA(context.close, timeperiod=50)
+    ema_200 = ta.EMA(context.close, timeperiod=200)
+    uo = ta.ULTOSC(context.high, context.low, context.close)
+    obv = ta.OBV(context.close, context.volume)
+    cci_20 = ta.CCI(context.high, context.low, context.close, timeperiod=20)
+
+    stochrsi_k = self.stochrsi_k(raw["RSI_14"], ta.MIN, ta.MAX, ta.SMA)
+    cmf_20 = self.chaikin_money_flow(
+      context.high,
+      context.low,
+      context.close,
+      context.volume,
+      timeperiod=20,
+    )
+    rsi_3_change = self.fast_pct_change(raw["RSI_3"])
+    rsi_14_change = self.fast_pct_change(raw["RSI_14"])
+    uo_change = self.fast_pct_change(uo)
+    obv_change = self.fast_pct_change(obv)
+    cci_change = self.fast_pct_change(cci_20)
+    common = NostalgiaForInfinityX7._nfix7_assemble_common_values(
+      raw,
+      rsi3_change=rsi_3_change,
+      stochrsi_k=stochrsi_k,
+      cmf=cmf_20,
+    )
+    columns_map = {
+      "RSI_3": common["RSI_3"],
+      "RSI_14": common["RSI_14"],
+      "RSI_3_change_pct": common["RSI_3_change_pct"],
+      "RSI_14_change_pct": rsi_14_change,
+      "EMA_12": ema_12,
+      "EMA_20": ema_20,
+      "EMA_26": ema_26,
+      "EMA_50": ema_50,
+      "EMA_200": ema_200,
+      "MFI_14": common["MFI_14"],
+      "CMF_20": common["CMF_20"],
+      "WILLR_14": common["WILLR_14"],
+      "AROONU_14": common["AROONU_14"],
+      "AROOND_14": common["AROOND_14"],
+      "STOCHk_14_3_3": common["STOCHk_14_3_3"],
+      "STOCHRSIk_14_14_3_3": common["STOCHRSIk_14_14_3_3"],
+      "UO_7_14_28": uo,
+      "UO_7_14_28_change_pct": uo_change,
+      "OBV_change_pct": obv_change,
+      "ROC_9": common["ROC_9"],
+      "CCI_20": cci_20,
+      "CCI_20_change_pct": cci_change,
+      "change_pct": common["change_pct"],
+    }
+    debug_cols = list(columns_map)
+    return columns_map, debug_cols, "[%s] informative_15m_indicators took: %.4f seconds."
+
+  def _nfix7_informative_indicators_impl(
+    self,
+    metadata: dict,
+    *,
+    loaded_timeframe: str,
+    profile: str,
+  ) -> DataFrame:
+    if profile not in ("1d", "4h", "1h", "15m"):
+      raise RuntimeError(f"{profile} not supported as informative profile.")
+
     debug = False
+    debug_time = False
+    if debug_time:
+      tik = time.perf_counter()
+
+    dp = self.dp
+    assert dp, "DataProvider is required for multiple timeframes."
+    metadata_pair = metadata["pair"]
+    source = dp.get_pair_dataframe(pair=metadata_pair, timeframe=loaded_timeframe)
+    if source.empty:
+      return source
+
+    context = _NFIInformativeContext(
+      source=source,
+      index=source.index,
+      open=source["open"].to_numpy(copy=False),
+      high=source["high"].to_numpy(copy=False),
+      low=source["low"].to_numpy(copy=False),
+      close=source["close"].to_numpy(copy=False),
+      volume=source["volume"].to_numpy(copy=False),
+    )
+    builders = {
+      "1d": NostalgiaForInfinityX7._nfix7_build_1d_columns,
+      "4h": NostalgiaForInfinityX7._nfix7_build_4h_columns,
+      "1h": NostalgiaForInfinityX7._nfix7_build_1h_columns,
+      "15m": NostalgiaForInfinityX7._nfix7_build_15m_columns,
+    }
+    builder = builders[profile]
+    columns_map, debug_cols, timing_label = builder(self, context)
+    generated = pd.DataFrame(columns_map, index=source.index)
+    result = pd.concat([source, generated], axis=1, copy=False)
+
     if debug:
-      debug_cols = [
-        "RSI_3",
-        "RSI_14",
-        "STOCHk_14_3_3",
-        "STOCHRSIk_14_14_3_3",
-        "MFI_14",
-        "CMF_20",
-        "WILLR_14",
-        "AROONU_14",
-        "AROOND_14",
-        "ROC_2",
-        "ROC_9",
-        "RSI_3_change_pct",
-        "change_pct",
-        "top_wick_pct",
-        "bot_wick_pct",
-        "high_max_6",
-        "high_max_12",
-        "high_max_20",
-        "high_max_30",
-        "low_min_6",
-        "low_min_12",
-        "low_min_20",
-        "low_min_30",
-      ]
-      if self.bad_trade_controller_enable:
-        debug_cols.extend(["EMA_50", "EMA_200", "RANGE_PCT_14"])
-
-      self.validate_indicators(df=informative_1d, columns=debug_cols, pair=metadata_pair, timeframe=info_timeframe)
-
-    # =========================================================================
-    # LOGGING
-    # =========================================================================
+      self.validate_indicators(
+        df=result,
+        columns=debug_cols,
+        pair=metadata_pair,
+        timeframe=loaded_timeframe,
+      )
     if debug_time:
       tok = time.perf_counter()
-      log.debug("[%s] informative_1d_indicators took: %.4f seconds.", metadata_pair, tok - tik)
+      log.debug(timing_label, metadata_pair, tok - tik)
+    return result
 
-    return informative_1d
+  def informative_indicators(self, metadata: dict, info_timeframe: str) -> DataFrame:
+    if info_timeframe not in ("1d", "4h", "1h", "15m"):
+      raise RuntimeError(f"{info_timeframe} not supported as informative profile.")
+    return NostalgiaForInfinityX7._nfix7_informative_indicators_impl(
+      self,
+      metadata,
+      loaded_timeframe=info_timeframe,
+      profile=info_timeframe,
+    )
+
+  # Informative 1d Timeframe Indicators
+  # ---------------------------------------------------------------------------------------------
+  def informative_1d_indicators(self, metadata: dict, info_timeframe) -> DataFrame:
+    return NostalgiaForInfinityX7._nfix7_informative_indicators_impl(
+      self,
+      metadata,
+      loaded_timeframe=info_timeframe,
+      profile="1d",
+    )
 
   # Informative 4h Timeframe Indicators
   # ---------------------------------------------------------------------------------------------
   def informative_4h_indicators(self, metadata: dict, info_timeframe) -> DataFrame:
-    debug_time = False
-    if debug_time:
-      tik = time.perf_counter()
-    dp = self.dp
-    fast_pct_change = self.fast_pct_change
-    stochrsi_k_func = self.stochrsi_k
-    chaikin_money_flow = self.chaikin_money_flow
-    calc_kst = self.calc_kst
-    ta_rsi = ta.RSI
-    ta_aroon = ta.AROON
-    ta_sma = ta.SMA
-    ta_roc = ta.ROC
-    ta_ema = ta.EMA
-    ta_max = ta.MAX
-    ta_min = ta.MIN
-    ta_bbands = ta.BBANDS
-
-    assert dp, "DataProvider is required for multiple timeframes."
-
-    # Get dataframe
-    metadata_pair = metadata["pair"]
-    informative_4h = dp.get_pair_dataframe(pair=metadata_pair, timeframe=info_timeframe)
-
-    # Empty dataframe protection
-    if informative_4h.empty:
-      return informative_4h
-
-    # =========================================================================
-    # BASE DATA
-    # =========================================================================
-    close_np = informative_4h["close"].to_numpy(copy=False)
-    high_np = informative_4h["high"].to_numpy(copy=False)
-    low_np = informative_4h["low"].to_numpy(copy=False)
-    open_np = informative_4h["open"].to_numpy(copy=False)
-    volume_np = informative_4h["volume"].to_numpy(copy=False)
-
-    # =========================================================================
-    # CORE INDICATORS
-    # =========================================================================
-    rsi_3 = ta_rsi(close_np, timeperiod=3)
-    rsi_14 = ta_rsi(close_np, timeperiod=14)
-    aroon_down, aroon_up = ta_aroon(high_np, low_np, timeperiod=14)
-    bb_upper_20, _, bb_lower_20 = ta_bbands(close_np, timeperiod=20, nbdevup=2.0, nbdevdn=2.0, matype=0)
-    bbp_20 = (close_np - bb_lower_20) / np.where(bb_upper_20 - bb_lower_20 == 0, np.nan, bb_upper_20 - bb_lower_20)
-
-    # =========================================================================
-    # STOCH
-    # =========================================================================
-    _, stoch_k = ta.STOCHF(high_np, low_np, close_np, fastk_period=14, fastd_period=3, fastd_matype=0)
-    stochrsi_k = stochrsi_k_func(rsi_14, ta_min, ta_max, ta_sma)
-
-    # =========================================================================
-    # KST
-    # =========================================================================
-    kst_main, kst_signal = calc_kst(close_np, ta_roc, ta_sma)
-
-    # =========================================================================
-    # MONEY FLOW
-    # =========================================================================
-    mfi_14 = ta.MFI(high_np, low_np, close_np, volume_np, timeperiod=14)
-    cmf_20 = chaikin_money_flow(high_np, low_np, close_np, volume_np, timeperiod=20)
-
-    # =========================================================================
-    # MOMENTUM
-    # =========================================================================
-    ema_12 = ta_ema(close_np, timeperiod=12)
-    ema_50 = ta_ema(close_np, timeperiod=50)
-    ema_100 = ta_ema(close_np, timeperiod=100)
-    ema_200 = ta_ema(close_np, timeperiod=200)
-    willr_14 = ta.WILLR(high_np, low_np, close_np, timeperiod=14)
-    uo = ta.ULTOSC(high_np, low_np, close_np)
-    roc_2 = ta_roc(close_np, timeperiod=2)
-    roc_9 = ta_roc(close_np, timeperiod=9)
-    cci_20 = ta.CCI(high_np, low_np, close_np, timeperiod=20)
-
-    # =========================================================================
-    # CHANGE %
-    # =========================================================================
-    rsi_3_change = fast_pct_change(rsi_3)
-    rsi_14_change = fast_pct_change(rsi_14)
-    stochrsi_change = fast_pct_change(stochrsi_k)
-    cci_change = fast_pct_change(cci_20)
-
-    # =========================================================================
-    # CANDLE %
-    # =========================================================================
-    open_safe = np.where(open_np == 0, np.nan, open_np)
-    change_pct = ((close_np - open_np) / open_safe) * 100.0
-
-    # =========================================================================
-    # WICK %
-    # =========================================================================
-    max_oc = np.maximum(open_np, close_np)
-    max_oc_calc = np.where(max_oc == 0, np.nan, max_oc)
-    top_wick_pct = ((high_np - max_oc) / max_oc_calc) * 100.0
-
-    # =========================================================================
-    # ROLLING
-    # =========================================================================
-    high_max_6 = ta_max(high_np, timeperiod=6)
-    high_max_12 = ta_max(high_np, timeperiod=12)
-    high_max_24 = ta_max(high_np, timeperiod=24)
-    low_min_12 = ta_min(low_np, timeperiod=12)
-    low_min_24 = ta_min(low_np, timeperiod=24)
-
-    # ADX/DMI — trend strength + direction (signals 7/505 experimental; NFI's first ADX use)
-    adx_14 = ta.ADX(high_np, low_np, close_np, timeperiod=14)
-    plus_di_14 = ta.PLUS_DI(high_np, low_np, close_np, timeperiod=14)
-    minus_di_14 = ta.MINUS_DI(high_np, low_np, close_np, timeperiod=14)
-
-    # =========================================================================
-    # ASSIGN DATAFRAME
-    # =========================================================================
-    new_cols = pd.DataFrame(
-      {
-        "RSI_3": rsi_3,
-        "RSI_14": rsi_14,
-        "ADX_14": adx_14,
-        "PLUS_DI_14": plus_di_14,
-        "MINUS_DI_14": minus_di_14,
-        "AROONU_14": aroon_up,
-        "AROOND_14": aroon_down,
-        "BBP_20_2.0": bbp_20,
-        "STOCHk_14_3_3": stoch_k,
-        "STOCHRSIk_14_14_3_3": stochrsi_k,
-        "KST_10_15_20_30_10_10_10_15": kst_main,
-        "KSTs_9": kst_signal,
-        "MFI_14": mfi_14,
-        "CMF_20": cmf_20,
-        "EMA_12": ema_12,
-        "EMA_50": ema_50,
-        "EMA_100": ema_100,
-        "EMA_200": ema_200,
-        "WILLR_14": willr_14,
-        "UO_7_14_28": uo,
-        "ROC_2": roc_2,
-        "ROC_9": roc_9,
-        "CCI_20": cci_20,
-        "STOCHRSIk_14_14_3_3_change_pct": stochrsi_change,
-        "CCI_20_change_pct": cci_change,
-        "RSI_3_change_pct": rsi_3_change,
-        "RSI_14_change_pct": rsi_14_change,
-        "change_pct": change_pct,
-        "top_wick_pct": top_wick_pct,
-        "high_max_6": high_max_6,
-        "high_max_12": high_max_12,
-        "high_max_24": high_max_24,
-        "low_min_12": low_min_12,
-        "low_min_24": low_min_24,
-      },
-      index=informative_4h.index,
+    return NostalgiaForInfinityX7._nfix7_informative_indicators_impl(
+      self,
+      metadata,
+      loaded_timeframe=info_timeframe,
+      profile="4h",
     )
-
-    informative_4h = pd.concat([informative_4h, new_cols], axis=1, copy=False)
-
-    # Enable ONLY during debugging
-    debug = False
-    if debug:
-      debug_cols = [
-        "RSI_3",
-        "RSI_14",
-        "AROONU_14",
-        "AROOND_14",
-        "STOCHk_14_3_3",
-        "STOCHRSIk_14_14_3_3",
-        "KST_10_15_20_30_10_10_10_15",
-        "KSTs_9",
-        "MFI_14",
-        "CMF_20",
-        "EMA_12",
-        "EMA_50",
-        "EMA_100",
-        "EMA_200",
-        "WILLR_14",
-        "UO_7_14_28",
-        "ROC_2",
-        "ROC_9",
-        "CCI_20",
-        "STOCHRSIk_14_14_3_3_change_pct",
-        "CCI_20_change_pct",
-        "RSI_3_change_pct",
-        "RSI_14_change_pct",
-        "OBV_change_pct",
-        "change_pct",
-        "high_max_6",
-        "high_max_12",
-        "high_max_24",
-        "low_min_12",
-        "low_min_24",
-      ]
-
-      self.validate_indicators(df=informative_4h, columns=debug_cols, pair=metadata_pair, timeframe=info_timeframe)
-    # =========================================================================
-    # LOGGING
-    # =========================================================================
-    if debug_time:
-      tok = time.perf_counter()
-      log.debug("[%s] informative_4h_indicators took: %.4f seconds.", metadata_pair, tok - tik)
-
-    return informative_4h
 
   # Informative 1h Timeframe Indicators
   # ---------------------------------------------------------------------------------------------
   def informative_1h_indicators(self, metadata: dict, info_timeframe) -> DataFrame:
-    debug_time = False
-    if debug_time:
-      tik = time.perf_counter()
-    dp = self.dp
-    fast_pct_change = self.fast_pct_change
-    stochrsi_k_func = self.stochrsi_k
-    chaikin_money_flow = self.chaikin_money_flow
-    calc_kst = self.calc_kst
-    ta_rsi = ta.RSI
-    ta_bbands = ta.BBANDS
-    ta_aroon = ta.AROON
-    ta_sma = ta.SMA
-    ta_roc = ta.ROC
-    ta_ema = ta.EMA
-    ta_willr = ta.WILLR
-    ta_max = ta.MAX
-    ta_min = ta.MIN
-
-    assert dp, "DataProvider is required for multiple timeframes."
-
-    # =========================================================================
-    # GET DATAFRAME
-    # =========================================================================
-
-    metadata_pair = metadata["pair"]
-    informative_1h = dp.get_pair_dataframe(pair=metadata_pair, timeframe=info_timeframe)
-
-    # Empty dataframe protection
-    if informative_1h.empty:
-      return informative_1h
-
-    # =========================================================================
-    # BASE DATA
-    # =========================================================================
-    close_np = informative_1h["close"].to_numpy(copy=False)
-    high_np = informative_1h["high"].to_numpy(copy=False)
-    low_np = informative_1h["low"].to_numpy(copy=False)
-    open_np = informative_1h["open"].to_numpy(copy=False)
-    volume_np = informative_1h["volume"].to_numpy(copy=False)
-
-    # =========================================================================
-    # CORE INDICATORS
-    # =========================================================================
-    rsi_3 = ta_rsi(close_np, timeperiod=3)
-    rsi_14 = ta_rsi(close_np, timeperiod=14)
-    bb_upper, bb_middle, bb_lower = ta_bbands(close_np, timeperiod=20, nbdevup=2.0, nbdevdn=2.0, matype=0)
-    bb_middle_safe = np.where(bb_middle == 0, np.nan, bb_middle)
-    aroon_down, aroon_up = ta_aroon(high_np, low_np, timeperiod=14)
-
-    # =========================================================================
-    # STOCH
-    # =========================================================================
-    _, stoch_k = ta.STOCHF(high_np, low_np, close_np, fastk_period=14, fastd_period=3, fastd_matype=0)
-    stochrsi_k = stochrsi_k_func(rsi_14, ta_min, ta_max, ta_sma)
-
-    # =========================================================================
-    # KST
-    # =========================================================================
-    kst_main, kst_signal = calc_kst(close_np, ta_roc, ta_sma)
-
-    # =========================================================================
-    # MONEY FLOW
-    # =========================================================================
-    mfi_14 = ta.MFI(high_np, low_np, close_np, volume_np, timeperiod=14)
-    cmf_20 = chaikin_money_flow(high_np, low_np, close_np, volume_np, timeperiod=20)
-
-    # =========================================================================
-    # MOMENTUM
-    # =========================================================================
-    ema_12 = ta_ema(close_np, timeperiod=12)
-    ema_200 = ta_ema(close_np, timeperiod=200)
-    sma_16 = ta_sma(close_np, timeperiod=16)
-    willr_14 = ta_willr(high_np, low_np, close_np, timeperiod=14)
-    willr_84 = ta_willr(high_np, low_np, close_np, timeperiod=84)
-    uo = ta.ULTOSC(high_np, low_np, close_np)
-    roc_2 = ta_roc(close_np, timeperiod=2)
-    roc_9 = ta_roc(close_np, timeperiod=9)
-    cci_20 = ta.CCI(high_np, low_np, close_np, timeperiod=20)
-
-    # =========================================================================
-    # CHANGE %
-    # =========================================================================
-    rsi_3_change = fast_pct_change(rsi_3)
-    rsi_14_change = fast_pct_change(rsi_14)
-    cci_change = fast_pct_change(cci_20)
-
-    # =========================================================================
-    # CANDLE %
-    # =========================================================================
-    open_safe = np.where(open_np == 0, np.nan, open_np)
-    change_pct = ((close_np - open_np) / open_safe) * 100.0
-
-    # =========================================================================
-    # ROLLING
-    # =========================================================================
-    high_max_6 = ta_max(high_np, timeperiod=6)
-    high_max_12 = ta_max(high_np, timeperiod=12)
-    high_max_24 = ta_max(high_np, timeperiod=24)
-    low_min_6 = ta_min(low_np, timeperiod=6)
-    low_min_12 = ta_min(low_np, timeperiod=12)
-    low_min_24 = ta_min(low_np, timeperiod=24)
-
-    new_cols = pd.DataFrame(
-      {
-        "RSI_3": rsi_3,
-        "RSI_14": rsi_14,
-        "RSI_3_change_pct": rsi_3_change,
-        "RSI_14_change_pct": rsi_14_change,
-        "EMA_12": ema_12,
-        "EMA_200": ema_200,
-        "SMA_16": sma_16,
-        "BBL_20_2.0": bb_lower,
-        "BBU_20_2.0": bb_upper,
-        "BBB_20_2.0": ((bb_upper - bb_lower) / bb_middle_safe) * 100.0,
-        "MFI_14": mfi_14,
-        "CMF_20": cmf_20,
-        "WILLR_14": willr_14,
-        "WILLR_84": willr_84,
-        "AROONU_14": aroon_up,
-        "AROOND_14": aroon_down,
-        "STOCHk_14_3_3": stoch_k,
-        "STOCHRSIk_14_14_3_3": stochrsi_k,
-        "KST_10_15_20_30_10_10_10_15": kst_main,
-        "KSTs_9": kst_signal,
-        "UO_7_14_28": uo,
-        "ROC_2": roc_2,
-        "ROC_9": roc_9,
-        "CCI_20": cci_20,
-        "CCI_20_change_pct": cci_change,
-        "change_pct": change_pct,
-        "high_max_6": high_max_6,
-        "high_max_12": high_max_12,
-        "high_max_24": high_max_24,
-        "low_min_6": low_min_6,
-        "low_min_12": low_min_12,
-        "low_min_24": low_min_24,
-      },
-      index=informative_1h.index,
+    return NostalgiaForInfinityX7._nfix7_informative_indicators_impl(
+      self,
+      metadata,
+      loaded_timeframe=info_timeframe,
+      profile="1h",
     )
-
-    informative_1h = pd.concat([informative_1h, new_cols], axis=1, copy=False)
-
-    # Enable ONLY during debugging
-    debug = False
-    if debug:
-      debug_cols = [
-        "RSI_3",
-        "RSI_14",
-        "RSI_3_change_pct",
-        "RSI_14_change_pct",
-        "EMA_12",
-        "EMA_200",
-        "SMA_16",
-        "BBL_20_2.0",
-        "BBU_20_2.0",
-        "BBB_20_2.0",
-        "MFI_14",
-        "CMF_20",
-        "WILLR_14",
-        "WILLR_84",
-        "AROONU_14",
-        "AROOND_14",
-        "STOCHk_14_3_3",
-        "STOCHRSIk_14_14_3_3",
-        "KST_10_15_20_30_10_10_10_15",
-        "KSTs_9",
-        "UO_7_14_28",
-        "ROC_2",
-        "ROC_9",
-        "CCI_20",
-        "CCI_20_change_pct",
-        "change_pct",
-        "high_max_6",
-        "high_max_12",
-        "high_max_24",
-        "low_min_6",
-        "low_min_12",
-        "low_min_24",
-      ]
-
-      self.validate_indicators(df=informative_1h, columns=debug_cols, pair=metadata_pair, timeframe=info_timeframe)
-
-    # =========================================================================
-    # LOGGING
-    # =========================================================================
-    if debug_time:
-      tok = time.perf_counter()
-      log.debug("[%s] informative_1h_indicators took: %.4f seconds.", metadata_pair, tok - tik)
-
-    return informative_1h
 
   # Informative 15m Timeframe Indicators
   # ---------------------------------------------------------------------------------------------
   def informative_15m_indicators(self, metadata: dict, info_timeframe) -> DataFrame:
-    debug_time = False
-    if debug_time:
-      tik = time.perf_counter()
-    dp = self.dp
-    fast_pct_change = self.fast_pct_change
-    stochrsi_k_func = self.stochrsi_k
-    chaikin_money_flow = self.chaikin_money_flow
-    ta_rsi = ta.RSI
-    ta_aroon = ta.AROON
-    ta_ema = ta.EMA
-    ta_min = ta.MIN
-    ta_max = ta.MAX
-    ta_sma = ta.SMA
-
-    assert dp, "DataProvider is required for multiple timeframes."
-
-    # =========================================================================
-    # GET DATAFRAME
-    # =========================================================================
-
-    metadata_pair = metadata["pair"]
-    informative_15m = dp.get_pair_dataframe(pair=metadata_pair, timeframe=info_timeframe)
-
-    # Empty dataframe protection
-    if informative_15m.empty:
-      return informative_15m
-
-    # =========================================================================
-    # BASE DATA
-    # =========================================================================
-    close_np = informative_15m["close"].to_numpy(copy=False)
-    high_np = informative_15m["high"].to_numpy(copy=False)
-    low_np = informative_15m["low"].to_numpy(copy=False)
-    open_np = informative_15m["open"].to_numpy(copy=False)
-    volume_np = informative_15m["volume"].to_numpy(copy=False)
-
-    # =========================================================================
-    # CORE INDICATORS
-    # =========================================================================
-    rsi_3 = ta_rsi(close_np, timeperiod=3)
-    rsi_14 = ta_rsi(close_np, timeperiod=14)
-    aroon_down, aroon_up = ta_aroon(high_np, low_np, timeperiod=14)
-
-    # =========================================================================
-    # STOCH
-    # =========================================================================
-    _, stoch_k = ta.STOCHF(high_np, low_np, close_np, fastk_period=14, fastd_period=3, fastd_matype=0)
-    stochrsi_k = stochrsi_k_func(rsi_14, ta_min, ta_max, ta_sma)
-
-    # =========================================================================
-    # MONEY FLOW
-    # =========================================================================
-    mfi_14 = ta.MFI(high_np, low_np, close_np, volume_np, timeperiod=14)
-    cmf_20 = chaikin_money_flow(high_np, low_np, close_np, volume_np, timeperiod=20)
-
-    # =========================================================================
-    # MOMENTUM
-    # =========================================================================
-    ema_12 = ta_ema(close_np, timeperiod=12)
-    ema_20 = ta_ema(close_np, timeperiod=20)
-    ema_26 = ta_ema(close_np, timeperiod=26)
-    ema_50 = ta_ema(close_np, timeperiod=50)
-    ema_200 = ta_ema(close_np, timeperiod=200)
-    willr_14 = ta.WILLR(high_np, low_np, close_np, timeperiod=14)
-    uo = ta.ULTOSC(high_np, low_np, close_np)
-    obv = ta.OBV(close_np, volume_np)
-    roc_9 = ta.ROC(close_np, timeperiod=9)
-    cci_20 = ta.CCI(high_np, low_np, close_np, timeperiod=20)
-
-    # =========================================================================
-    # CHANGE %
-    # =========================================================================
-    rsi_3_change = fast_pct_change(rsi_3)
-    rsi_14_change = fast_pct_change(rsi_14)
-    uo_change = fast_pct_change(uo)
-    obv_change = fast_pct_change(obv)
-    cci_change = fast_pct_change(cci_20)
-
-    # =========================================================================
-    # CANDLE %
-    # =========================================================================
-    open_safe = np.where(open_np == 0, np.nan, open_np)
-    change_pct = ((close_np - open_np) / open_safe) * 100.0
-
-    new_cols = pd.DataFrame(
-      {
-        "RSI_3": rsi_3,
-        "RSI_14": rsi_14,
-        "RSI_3_change_pct": rsi_3_change,
-        "RSI_14_change_pct": rsi_14_change,
-        "EMA_12": ema_12,
-        "EMA_20": ema_20,
-        "EMA_26": ema_26,
-        "EMA_50": ema_50,
-        "EMA_200": ema_200,
-        "MFI_14": mfi_14,
-        "CMF_20": cmf_20,
-        "WILLR_14": willr_14,
-        "AROONU_14": aroon_up,
-        "AROOND_14": aroon_down,
-        "STOCHk_14_3_3": stoch_k,
-        "STOCHRSIk_14_14_3_3": stochrsi_k,
-        "UO_7_14_28": uo,
-        "UO_7_14_28_change_pct": uo_change,
-        "OBV_change_pct": obv_change,
-        "ROC_9": roc_9,
-        "CCI_20": cci_20,
-        "CCI_20_change_pct": cci_change,
-        "change_pct": change_pct,
-      },
-      index=informative_15m.index,
+    return NostalgiaForInfinityX7._nfix7_informative_indicators_impl(
+      self,
+      metadata,
+      loaded_timeframe=info_timeframe,
+      profile="15m",
     )
-
-    informative_15m = pd.concat([informative_15m, new_cols], axis=1, copy=False)
-
-    # Enable ONLY during debugging
-    debug = False
-    if debug:
-      debug_cols = [
-        "RSI_3",
-        "RSI_14",
-        "RSI_3_change_pct",
-        "RSI_14_change_pct",
-        "EMA_12",
-        "EMA_20",
-        "EMA_26",
-        "EMA_50",
-        "EMA_200",
-        "MFI_14",
-        "CMF_20",
-        "WILLR_14",
-        "AROONU_14",
-        "AROOND_14",
-        "STOCHk_14_3_3",
-        "STOCHRSIk_14_14_3_3",
-        "UO_7_14_28",
-        "UO_7_14_28_change_pct",
-        "OBV_change_pct",
-        "ROC_9",
-        "CCI_20",
-        "CCI_20_change_pct",
-        "change_pct",
-      ]
-
-      self.validate_indicators(df=informative_15m, columns=debug_cols, pair=metadata_pair, timeframe=info_timeframe)
-
-    # =========================================================================
-    # LOGGING
-    # =========================================================================
-    if debug_time:
-      tok = time.perf_counter()
-      log.debug("[%s] informative_15m_indicators took: %.4f seconds.", metadata_pair, tok - tik)
-
-    return informative_15m
 
   # Coin Pair Base Timeframe Indicators
   # ---------------------------------------------------------------------------------------------

--- a/tests/differential/test_NFIX7_informative_equivalence.py
+++ b/tests/differential/test_NFIX7_informative_equivalence.py
@@ -1,0 +1,669 @@
+"""Strict differential/evidence gate for OpenSpec #450.
+
+This module deliberately cannot pass against the unrefactored source: Phase 4 must
+first provide the architecture asserted below.  Baseline and feature are always
+loaded from different source paths in the same Python process/image.
+"""
+
+from __future__ import annotations
+
+import ast
+import hashlib
+import importlib.metadata
+import importlib.util
+import json
+import os
+import platform
+import sys
+from collections import Counter
+from pathlib import Path
+from typing import Any
+from unittest.mock import Mock
+
+import numpy as np
+import pandas as pd
+import pytest
+from pandas.testing import assert_frame_equal
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+FEATURE_SOURCE = REPO_ROOT / "NostalgiaForInfinityX7.py"
+RAW_OUTPUT = REPO_ROOT / "artifacts/nfix7-informative-raw.json"
+PROFILES = ("1d", "4h", "1h", "15m")
+WRAPPERS = {p: f"informative_{p}_indicators" for p in PROFILES}
+ALLOWED_PATHS = sorted(
+  [
+    ".github/workflows/unit-tests.yml",
+    "NostalgiaForInfinityX7.py",
+    "tests/differential/test_NFIX7_informative_equivalence.py",
+    "tests/differential/verify_nfix7_evidence.py",
+    "tests/unit/test_NFIX7_informative_indicators.py",
+  ]
+)
+REQUIRED_ENV = (
+  "NFI_EVIDENCE_MODE",
+  "NFI_BASE_SHA",
+  "NFI_HEAD_SHA",
+  "NFI_BASE_SOURCE_SHA256",
+  "NFI_FEATURE_SOURCE_SHA256",
+  "NFI_FEATURE_BUNDLE_SHA256",
+  "NFI_CHANGED_PATHS_JSON",
+  "NFI_CHANGED_PATHS_SHA256",
+  "NFI_TEST_IMAGE_ID",
+  "NFI_PRE_COMMIT_VERSION",
+  "NFI_BASE_STRATEGY",
+)
+COMMON_RAW_KEYS = [
+  "RSI_3",
+  "RSI_14",
+  "AROONU_14",
+  "AROOND_14",
+  "STOCHk_14_3_3",
+  "MFI_14",
+  "WILLR_14",
+  "ROC_9",
+  "change_pct",
+]
+COMMON_FINAL_KEYS = [
+  "RSI_3",
+  "RSI_14",
+  "RSI_3_change_pct",
+  "AROONU_14",
+  "AROOND_14",
+  "STOCHk_14_3_3",
+  "STOCHRSIk_14_14_3_3",
+  "MFI_14",
+  "CMF_20",
+  "WILLR_14",
+  "ROC_9",
+  "change_pct",
+]
+HELPERS = ("fast_pct_change", "stochrsi_k", "chaikin_money_flow", "calc_kst")
+
+
+def _load_unit_support():
+  path = REPO_ROOT / "tests/unit/test_NFIX7_informative_indicators.py"
+  spec = importlib.util.spec_from_file_location("nfix7_unit_support", path)
+  assert spec and spec.loader
+  module = importlib.util.module_from_spec(spec)
+  spec.loader.exec_module(module)
+  return module
+
+
+support = _load_unit_support()
+REPORT: dict[str, Any] = {
+  "schema": 1,
+  "matrix": {},
+  "call_fingerprints": {},
+  "debug_instrumentation": {},
+  "runtime_instrumentation": {},
+  "caller_source_gate": {},
+  "structural_ast": {},
+}
+
+
+def sha256_path(path: Path) -> str:
+  return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def class_node(path: Path) -> ast.ClassDef:
+  tree = ast.parse(path.read_text())
+  return next(n for n in tree.body if isinstance(n, ast.ClassDef) and n.name == "NostalgiaForInfinityX7")
+
+
+def method_node(path: Path, name: str) -> ast.FunctionDef:
+  return next(n for n in class_node(path).body if isinstance(n, ast.FunctionDef) and n.name == name)
+
+
+def call_name(node: ast.Call) -> str:
+  if isinstance(node.func, ast.Name):
+    return node.func.id
+  if isinstance(node.func, ast.Attribute):
+    parts = []
+    value: ast.expr = node.func
+    while isinstance(value, ast.Attribute):
+      parts.append(value.attr)
+      value = value.value
+    if isinstance(value, ast.Name):
+      parts.append(value.id)
+    return ".".join(reversed(parts))
+  return "<dynamic>"
+
+
+def returned_dict_keys(method: ast.FunctionDef) -> list[str]:
+  candidates = []
+  for node in ast.walk(method):
+    if isinstance(node, ast.Dict):
+      keys = [k.value for k in node.keys if isinstance(k, ast.Constant) and isinstance(k.value, str)]
+      if len(keys) > len(candidates):
+        candidates = keys
+  return candidates
+
+
+def signature_shape(method: ast.FunctionDef) -> dict[str, Any]:
+  args = method.args
+  return {
+    "positional": [a.arg for a in args.posonlyargs + args.args],
+    "kwonly": [a.arg for a in args.kwonlyargs],
+    "defaults": len(args.defaults),
+    "kw_defaults": [x is not None for x in args.kw_defaults],
+    "vararg": args.vararg.arg if args.vararg else None,
+    "kwarg": args.kwarg.arg if args.kwarg else None,
+    "annotations": [
+      ast.unparse(a.annotation) if a.annotation else None for a in args.posonlyargs + args.args + args.kwonlyargs
+    ],
+    "returns": ast.unparse(method.returns) if method.returns else None,
+  }
+
+
+@pytest.fixture(scope="module")
+def env():
+  missing = [key for key in REQUIRED_ENV if not os.environ.get(key)]
+  assert not missing, f"missing mandatory evidence environment: {missing}"
+  values = {key: os.environ[key] for key in REQUIRED_ENV}
+  assert values["NFI_EVIDENCE_MODE"] in ("local-precommit", "pull-request")
+  if values["NFI_EVIDENCE_MODE"] == "pull-request":
+    assert values["NFI_BASE_SHA"] != values["NFI_HEAD_SHA"]
+  paths = json.loads(values["NFI_CHANGED_PATHS_JSON"])
+  assert paths == ALLOWED_PATHS
+  assert hashlib.sha256("\0".join(paths).encode()).hexdigest() == values["NFI_CHANGED_PATHS_SHA256"]
+  baseline = Path(values["NFI_BASE_STRATEGY"]).resolve()
+  assert baseline.is_file() and baseline != FEATURE_SOURCE.resolve()
+  assert sha256_path(baseline) == values["NFI_BASE_SOURCE_SHA256"]
+  assert sha256_path(FEATURE_SOURCE) == values["NFI_FEATURE_SOURCE_SHA256"]
+  assert values["NFI_BASE_SOURCE_SHA256"] != values["NFI_FEATURE_SOURCE_SHA256"]
+  return values
+
+
+@pytest.fixture(scope="module")
+def modules(env):
+  baseline = support.load_strategy_module(Path(env["NFI_BASE_STRATEGY"]), "nfix7_diff_baseline")
+  feature = support.load_strategy_module(FEATURE_SOURCE, "nfix7_diff_feature")
+  assert baseline.__name__ != feature.__name__
+  assert Path(baseline.__file__).resolve() != Path(feature.__file__).resolve()
+  return baseline, feature
+
+
+def run_wrapper(module, profile: str, frame: pd.DataFrame):
+  strategy = support.make_strategy(module.NostalgiaForInfinityX7)
+  strategy.dp = support.FakeDP(frame)
+  result = getattr(strategy, WRAPPERS[profile])({"pair": "TEST/USDT"}, profile)
+  return result, strategy.dp.calls
+
+
+def assert_special_masks_equal(left: pd.DataFrame, right: pd.DataFrame):
+  for predicate in (np.isnan, np.isposinf, np.isneginf):
+    np.testing.assert_array_equal(predicate(left.to_numpy()), predicate(right.to_numpy()))
+
+
+@pytest.mark.parametrize("profile", PROFILES)
+@pytest.mark.parametrize("fixture_name", list(support.fixture_matrix()))
+def test_exact_differential_matrix(modules, fixture_name, profile):
+  baseline, feature = modules
+  left_source = support.fixture_matrix()[fixture_name]
+  right_source = left_source.copy(deep=True)
+  left_before = left_source.copy(deep=True)
+  right_before = right_source.copy(deep=True)
+  left, left_calls = run_wrapper(baseline, profile, left_source)
+  right, right_calls = run_wrapper(feature, profile, right_source)
+  assert_frame_equal(
+    left,
+    right,
+    check_like=False,
+    check_exact=True,
+    check_dtype=True,
+    check_index_type=True,
+    check_column_type=True,
+    check_names=True,
+  )
+  assert_special_masks_equal(left, right)
+  assert_frame_equal(left_source, left_before, check_exact=True)
+  assert_frame_equal(right_source, right_before, check_exact=True)
+  assert left_calls == right_calls == [{"pair": "TEST/USDT", "timeframe": profile}]
+  REPORT["matrix"][f"{fixture_name}:{profile}"] = "passed"
+
+
+def _instrument_calls(module, profile: str):
+  ta_trace: list[dict[str, Any]] = []
+  originals = {}
+  ta_names = sorted(set().union(*[set(v) for v in support.EXPECTED_TA_COUNTS.values()]))
+  for name in ta_names:
+    original = getattr(module.ta, name)
+    originals[name] = original
+
+    def wrapper(*args, __name=name, __original=original, **kwargs):
+      ta_trace.append(support.canonical_call(__name, args, kwargs))
+      return __original(*args, **kwargs)
+
+    wrapper.__name__ = name
+    setattr(module.ta, name, wrapper)
+  cls = module.NostalgiaForInfinityX7
+  helper_trace: list[dict[str, Any]] = []
+
+  class Stateful(cls):
+    counter = 0
+
+    def _record(self, name, args, kwargs, inherited):
+      self.counter += 1
+      helper_trace.append(support.canonical_call(name, args, kwargs) | {"counter": self.counter})
+      result = inherited(*args, **kwargs)
+      delta = self.counter * 2**-40
+      return tuple(np.asarray(x) + delta for x in result) if isinstance(result, tuple) else np.asarray(result) + delta
+
+    def fast_pct_change(self, *a, **k):
+      return self._record("fast_pct_change", a, k, cls.fast_pct_change)
+
+    def stochrsi_k(self, *a, **k):
+      return self._record("stochrsi_k", a, k, cls.stochrsi_k)
+
+    def chaikin_money_flow(self, *a, **k):
+      return self._record("chaikin_money_flow", a, k, cls.chaikin_money_flow)
+
+    def calc_kst(self, *a, **k):
+      return self._record("calc_kst", a, k, cls.calc_kst)
+
+  try:
+    strategy = support.make_strategy(Stateful)
+    strategy.dp = support.FakeDP(support.normal_frame())
+    frame = getattr(strategy, WRAPPERS[profile])({"pair": "TEST/USDT"}, profile)
+  finally:
+    for name, original in originals.items():
+      setattr(module.ta, name, original)
+  canonical_ta = sorted(ta_trace, key=lambda value: json.dumps(value, sort_keys=True))
+  return canonical_ta, helper_trace, frame
+
+
+@pytest.mark.parametrize("profile", PROFILES)
+def test_call_fingerprints_and_stateful_helper_outputs(modules, profile):
+  baseline, feature = modules
+  base_ta, base_helpers, base_frame = _instrument_calls(baseline, profile)
+  feature_ta, feature_helpers, feature_frame = _instrument_calls(feature, profile)
+  assert base_ta == feature_ta
+  assert base_helpers == feature_helpers
+  assert [x["name"] for x in base_helpers] == support.EXPECTED_HELPER_ORDER[profile]
+  assert Counter(x["name"] for x in base_ta) == Counter(support.EXPECTED_TA_COUNTS[profile])
+  assert_frame_equal(base_frame, feature_frame, check_exact=True)
+  REPORT["call_fingerprints"][profile] = {"ta": base_ta, "helpers": base_helpers, "passed": True}
+
+
+def test_source_identity_and_environment_manifest(env):
+  REPORT["identity"] = {
+    "mode": env["NFI_EVIDENCE_MODE"],
+    "base_sha": env["NFI_BASE_SHA"],
+    "head_sha": env["NFI_HEAD_SHA"],
+    "base_source_sha256": env["NFI_BASE_SOURCE_SHA256"],
+    "feature_source_sha256": env["NFI_FEATURE_SOURCE_SHA256"],
+    "feature_bundle_sha256": env["NFI_FEATURE_BUNDLE_SHA256"],
+    "changed_paths": json.loads(env["NFI_CHANGED_PATHS_JSON"]),
+    "changed_paths_sha256": env["NFI_CHANGED_PATHS_SHA256"],
+    "image_id": env["NFI_TEST_IMAGE_ID"],
+    "pre_commit_version": env["NFI_PRE_COMMIT_VERSION"],
+  }
+
+
+def test_context_and_exact_method_signatures():
+  tree = ast.parse(FEATURE_SOURCE.read_text())
+  context = next(n for n in tree.body if isinstance(n, ast.ClassDef) and n.name == "_NFIInformativeContext")
+  assert any(
+    isinstance(d, ast.Call)
+    and call_name(d) == "dataclass"
+    and any(k.arg == "frozen" and isinstance(k.value, ast.Constant) and k.value.value is True for k in d.keywords)
+    for d in context.decorator_list
+  )
+  fields = [n.target.id for n in context.body if isinstance(n, ast.AnnAssign) and isinstance(n.target, ast.Name)]
+  assert fields == ["source", "index", "open", "high", "low", "close", "volume"]
+  expected = {
+    "informative_indicators": {
+      "positional": ["self", "metadata", "info_timeframe"],
+      "kwonly": [],
+      "returns": "DataFrame",
+    },
+    "_nfix7_informative_indicators_impl": {
+      "positional": ["self", "metadata"],
+      "kwonly": ["loaded_timeframe", "profile"],
+      "returns": "DataFrame",
+    },
+  }
+  for name, wanted in expected.items():
+    shape = signature_shape(method_node(FEATURE_SOURCE, name))
+    assert shape["positional"] == wanted["positional"] and shape["kwonly"] == wanted["kwonly"]
+    assert (
+      shape["vararg"] is None and shape["kwarg"] is None and shape["defaults"] == 0 and not any(shape["kw_defaults"])
+    )
+    assert shape["returns"] == wanted["returns"]
+  core = signature_shape(method_node(FEATURE_SOURCE, "_nfix7_informative_indicators_impl"))
+  assert core["annotations"] == [None, "dict", "str", "str"]
+  raw = signature_shape(method_node(FEATURE_SOURCE, "_nfix7_common_raw_values"))
+  assert raw == {
+    "positional": ["context"],
+    "kwonly": [],
+    "defaults": 0,
+    "kw_defaults": [],
+    "vararg": None,
+    "kwarg": None,
+    "annotations": [None],
+    "returns": None,
+  }
+  assembly = signature_shape(method_node(FEATURE_SOURCE, "_nfix7_assemble_common_values"))
+  assert assembly == {
+    "positional": ["raw"],
+    "kwonly": ["rsi3_change", "stochrsi_k", "cmf"],
+    "defaults": 0,
+    "kw_defaults": [False, False, False],
+    "vararg": None,
+    "kwarg": None,
+    "annotations": [None, None, None, None],
+    "returns": None,
+  }
+  REPORT["structural_ast"]["signatures"] = "passed"
+
+
+def _calls(method):
+  return [n for n in ast.walk(method) if isinstance(n, ast.Call)]
+
+
+def test_structural_ast_ownership_and_architecture():
+  cls = class_node(FEATURE_SOURCE)
+  methods = {n.name: n for n in cls.body if isinstance(n, ast.FunctionDef)}
+  region_names = [
+    "informative_indicators",
+    *WRAPPERS.values(),
+    "_nfix7_informative_indicators_impl",
+    "_nfix7_common_raw_values",
+    "_nfix7_assemble_common_values",
+    "_nfix7_build_1d_columns",
+    "_nfix7_build_4h_columns",
+    "_nfix7_build_1h_columns",
+    "_nfix7_build_15m_columns",
+  ]
+  assert all(name in methods for name in region_names)
+  core = methods["_nfix7_informative_indicators_impl"]
+  raw = methods["_nfix7_common_raw_values"]
+  assembly = methods["_nfix7_assemble_common_values"]
+  assert any(isinstance(d, ast.Name) and d.id == "staticmethod" for d in raw.decorator_list)
+  assert any(isinstance(d, ast.Name) and d.id == "staticmethod" for d in assembly.decorator_list)
+  assert returned_dict_keys(raw) == COMMON_RAW_KEYS
+  assert returned_dict_keys(assembly) == COMMON_FINAL_KEYS
+  raw_calls = Counter(call_name(c).split(".")[-1] for c in _calls(raw))
+  assert raw_calls == Counter({"RSI": 2, "AROON": 1, "STOCHF": 1, "MFI": 1, "WILLR": 1, "ROC": 1, "where": 1})
+  assert not any(call_name(c).split(".")[-1] in HELPERS for c in _calls(assembly))
+
+  prohibited_dynamic = {"getattr", "setattr", "__import__"}
+  for name in region_names:
+    calls = [call_name(c) for c in _calls(methods[name])]
+    assert not any(c.split(".")[-1] in prohibited_dynamic or c.startswith("importlib") for c in calls)
+
+  ownership_tokens = (
+    "get_pair_dataframe",
+    "_NFIInformativeContext",
+    "pd.DataFrame",
+    "pd.concat",
+    "validate_indicators",
+    "log.debug",
+  )
+  for name in region_names:
+    if name == core.name:
+      continue
+    calls = [call_name(c) for c in _calls(methods[name])]
+    assert not any(token in calls for token in ownership_tokens), (name, calls)
+    assert not any(
+      isinstance(n, ast.Attribute) and isinstance(n.value, ast.Name) and n.value.id == "self" and n.attr == "dp"
+      for n in ast.walk(methods[name])
+    )
+    assert not any(
+      isinstance(n, ast.Subscript)
+      and isinstance(n.value, ast.Name)
+      and n.value.id == "metadata"
+      and isinstance(n.slice, ast.Constant)
+      and n.slice.value == "pair"
+      for n in ast.walk(methods[name])
+    )
+
+  core_calls = Counter(call_name(c) for c in _calls(core))
+  for exact in ("get_pair_dataframe", "_NFIInformativeContext", "pd.DataFrame", "pd.concat"):
+    assert sum(count for name, count in core_calls.items() if name.endswith(exact)) == 1, (exact, core_calls)
+  assert sum(isinstance(n, ast.Assert) for n in ast.walk(core)) == 1
+  returns = [n for n in ast.walk(core) if isinstance(n, ast.Return)]
+  assert any(isinstance(n.value, ast.Name) for n in returns)
+  assignments = Counter(
+    t.id
+    for n in ast.walk(core)
+    if isinstance(n, ast.Assign)
+    for t in n.targets
+    if isinstance(t, ast.Name) and t.id in ("debug", "debug_time")
+  )
+  assert assignments == {"debug": 1, "debug_time": 1}
+
+  for profile, wrapper_name in WRAPPERS.items():
+    wrapper = methods[wrapper_name]
+    executable = [n for n in wrapper.body if not isinstance(n, ast.Expr) or not isinstance(n.value, ast.Constant)]
+    assert len(executable) == 1 and isinstance(executable[0], ast.Return) and isinstance(executable[0].value, ast.Call)
+    call = executable[0].value
+    assert call_name(call) == "NostalgiaForInfinityX7._nfix7_informative_indicators_impl"
+    assert [k.arg for k in call.keywords] == ["loaded_timeframe", "profile"]
+    assert isinstance(call.keywords[0].value, ast.Name) and call.keywords[0].value.id == "info_timeframe"
+    assert isinstance(call.keywords[1].value, ast.Constant) and call.keywords[1].value.value == profile
+
+  public = methods["informative_indicators"]
+  assert any(
+    isinstance(n, ast.Tuple) and [e.value for e in n.elts if isinstance(e, ast.Constant)] == list(PROFILES)
+    for n in ast.walk(public)
+  )
+  assert any(call_name(c) == "NostalgiaForInfinityX7._nfix7_informative_indicators_impl" for c in _calls(public))
+
+  builders = [methods[f"_nfix7_build_{p}_columns"] for p in PROFILES]
+  for builder in builders:
+    calls = Counter(call_name(c) for c in _calls(builder))
+    assert calls["NostalgiaForInfinityX7._nfix7_common_raw_values"] == 1
+    assert calls["NostalgiaForInfinityX7._nfix7_assemble_common_values"] == 1
+    assert not any(other.name in " ".join(calls) for other in builders if other is not builder)
+  REPORT["structural_ast"]["ownership"] = "passed"
+
+
+class _ProbeTransformer(ast.NodeTransformer):
+  def __init__(self):
+    self.in_core = False
+    self.found = Counter()
+
+  def visit_FunctionDef(self, node):
+    previous = self.in_core
+    if node.name != "_nfix7_informative_indicators_impl":
+      return node
+    self.in_core = True
+    node = self.generic_visit(node)
+    self.in_core = previous
+    return node
+
+  def visit_Call(self, node):
+    node = self.generic_visit(node)
+    if not self.in_core:
+      return node
+    name = call_name(node)
+    label = None
+    if name.endswith("_NFIInformativeContext"):
+      label = "context"
+    elif name == "pd.DataFrame":
+      label = "dataframe"
+    elif name == "pd.concat":
+      label = "concat"
+    elif isinstance(node.func, ast.Name) and node.func.id in ("builder", "selected_builder"):
+      label = "builder"
+    if label:
+      self.found[label] += 1
+      return ast.copy_location(
+        ast.Call(
+          func=ast.Name(id="_nfi_probe", ctx=ast.Load()),
+          args=[ast.Constant(label), node.func, *node.args],
+          keywords=node.keywords,
+        ),
+        node,
+      )
+    return node
+
+
+def _instrumented_feature_module():
+  tree = ast.parse(FEATURE_SOURCE.read_text(), filename=str(FEATURE_SOURCE))
+  transformer = _ProbeTransformer()
+  tree = transformer.visit(tree)
+  ast.fix_missing_locations(tree)
+  assert transformer.found == {"context": 1, "builder": 1, "dataframe": 1, "concat": 1}
+  spec = importlib.util.spec_from_loader("nfix7_runtime_instrumented", loader=None)
+  assert spec is not None
+  module = importlib.util.module_from_spec(spec)
+  module.__file__ = str(FEATURE_SOURCE)
+  sys.modules[module.__name__] = module
+  exec(compile(tree, str(FEATURE_SOURCE), "exec"), module.__dict__)
+  return module
+
+
+@pytest.mark.parametrize("profile", PROFILES)
+@pytest.mark.parametrize("empty", [False, True])
+def test_runtime_structural_instrumentation(profile, empty):
+  module = _instrumented_feature_module()
+  counters = Counter()
+
+  def probe(label, function, *args, **kwargs):
+    counters[label] += 1
+    return function(*args, **kwargs)
+
+  module._nfi_probe = probe
+  source = support.fixture_matrix()["empty" if empty else "normal_512"]
+  strategy = support.make_strategy(module.NostalgiaForInfinityX7)
+  strategy.dp = support.FakeDP(source)
+  result = getattr(strategy, WRAPPERS[profile])({"pair": "TEST/USDT"}, profile)
+  counters["dp"] = len(strategy.dp.calls)
+  expected = {
+    "dp": 1,
+    "context": 0 if empty else 1,
+    "builder": 0 if empty else 1,
+    "dataframe": 0 if empty else 1,
+    "concat": 0 if empty else 1,
+  }
+  assert {key: counters[key] for key in expected} == expected
+  if empty:
+    assert result is source
+  REPORT["runtime_instrumentation"][f"{profile}:{'empty' if empty else 'nonempty'}"] = expected
+
+
+class _DebugTransformer(ast.NodeTransformer):
+  def __init__(self, target):
+    self.target = target
+    self.inside = False
+    self.counts = Counter()
+
+  def visit_FunctionDef(self, node):
+    old = self.inside
+    if node.name != self.target:
+      return node
+    self.inside = True
+    node = self.generic_visit(node)
+    self.inside = old
+    return node
+
+  def visit_Assign(self, node):
+    node = self.generic_visit(node)
+    if (
+      self.inside
+      and len(node.targets) == 1
+      and isinstance(node.targets[0], ast.Name)
+      and node.targets[0].id in ("debug", "debug_time")
+      and isinstance(node.value, ast.Constant)
+      and node.value.value is False
+    ):
+      self.counts[node.targets[0].id] += 1
+      node.value = ast.Constant(True)
+    return node
+
+
+def _debug_module(path: Path, name: str, target: str):
+  tree = ast.parse(path.read_text(), filename=str(path))
+  transform = _DebugTransformer(target)
+  tree = transform.visit(tree)
+  ast.fix_missing_locations(tree)
+  assert transform.counts == {"debug": 1, "debug_time": 1}
+  spec = importlib.util.spec_from_loader(name, loader=None)
+  assert spec is not None
+  module = importlib.util.module_from_spec(spec)
+  module.__file__ = str(path)
+  sys.modules[name] = module
+  exec(compile(tree, str(path), "exec"), module.__dict__)
+  return module
+
+
+def _debug_observation(module, profile):
+  strategy = support.make_strategy(module.NostalgiaForInfinityX7)
+  strategy.dp = support.FakeDP(support.normal_frame())
+  validator = Mock()
+  strategy.validate_indicators = validator
+  logger = Mock()
+  module.log = logger
+  outcome = None
+  try:
+    getattr(strategy, WRAPPERS[profile])({"pair": "TEST/USDT"}, "custom-sentinel")
+  except Exception as error:
+    outcome = (type(error).__name__, str(error))
+  assert validator.call_count == 1 and logger.debug.call_count == 1
+  kwargs = validator.call_args.kwargs
+  log_args = logger.debug.call_args.args
+  return {
+    "outcome": outcome,
+    "columns": kwargs["columns"],
+    "pair": kwargs["pair"],
+    "timeframe": kwargs["timeframe"],
+    "df_columns": list(kwargs["df"].columns),
+    "log_format": log_args[0],
+    "log_pair": log_args[1],
+  }
+
+
+@pytest.mark.parametrize("profile", PROFILES)
+def test_debug_instrumentation(env, profile):
+  baseline = _debug_module(Path(env["NFI_BASE_STRATEGY"]), f"nfix7_debug_base_{profile}", WRAPPERS[profile])
+  feature = _debug_module(FEATURE_SOURCE, f"nfix7_debug_feature_{profile}", "_nfix7_informative_indicators_impl")
+  left = _debug_observation(baseline, profile)
+  right = _debug_observation(feature, profile)
+  assert left == right
+  REPORT["debug_instrumentation"][profile] = left | {"passed": True}
+
+
+def ast_hash(path: Path, method: str) -> str:
+  payload = ast.dump(method_node(path, method), include_attributes=False).encode()
+  return hashlib.sha256(payload).hexdigest()
+
+
+@pytest.mark.parametrize("method", ["info_switcher", "populate_indicators"])
+def test_unchanged_caller_source_hash(env, method):
+  baseline_hash = ast_hash(Path(env["NFI_BASE_STRATEGY"]), method)
+  feature_hash = ast_hash(FEATURE_SOURCE, method)
+  assert baseline_hash == feature_hash
+  REPORT["caller_source_gate"][method] = {"baseline": baseline_hash, "feature": feature_hash, "passed": True}
+
+
+def _package_version(distribution: str) -> str:
+  try:
+    return importlib.metadata.version(distribution)
+  except importlib.metadata.PackageNotFoundError:
+    return "not-installed"
+
+
+def test_zz_emit_raw_evidence(env):
+  assert len(REPORT["matrix"]) == len(support.fixture_matrix()) * len(PROFILES)
+  assert set(REPORT["call_fingerprints"]) == set(PROFILES)
+  assert set(REPORT["debug_instrumentation"]) == set(PROFILES)
+  assert len(REPORT["runtime_instrumentation"]) == len(PROFILES) * 2
+  assert set(REPORT["caller_source_gate"]) == {"info_switcher", "populate_indicators"}
+  REPORT["manifest"] = REPORT["identity"] | {
+    "python": platform.python_version(),
+    "freqtrade": _package_version("freqtrade"),
+    "pandas": pd.__version__,
+    "numpy": np.__version__,
+    "ta_lib": _package_version("TA-Lib"),
+    "test_counts": {
+      "fixtures": len(support.fixture_matrix()),
+      "profiles": len(PROFILES),
+      "matrix_cases": len(REPORT["matrix"]),
+    },
+  }
+  REPORT["result"] = "passed"
+  RAW_OUTPUT.parent.mkdir(parents=True, exist_ok=True)
+  RAW_OUTPUT.write_text(json.dumps(REPORT, indent=2, sort_keys=True) + "\n")
+  assert RAW_OUTPUT.is_file() and RAW_OUTPUT.stat().st_size > 0

--- a/tests/differential/verify_nfix7_evidence.py
+++ b/tests/differential/verify_nfix7_evidence.py
@@ -1,0 +1,240 @@
+#!/usr/bin/env python3
+"""Validate all #450 evidence inputs and atomically publish the final manifest."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import sys
+import tempfile
+import xml.etree.ElementTree as ET
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+ALLOWED_PATHS = sorted(
+  [
+    ".github/workflows/unit-tests.yml",
+    "NostalgiaForInfinityX7.py",
+    "tests/differential/test_NFIX7_informative_equivalence.py",
+    "tests/differential/verify_nfix7_evidence.py",
+    "tests/unit/test_NFIX7_informative_indicators.py",
+  ]
+)
+NEW_TEST_SOURCES = [
+  REPO_ROOT / "tests/unit/test_NFIX7_informative_indicators.py",
+  REPO_ROOT / "tests/differential/test_NFIX7_informative_equivalence.py",
+]
+
+
+def fail(message: str) -> None:
+  raise SystemExit(f"nfix7 evidence verification failed: {message}")
+
+
+def sha256_bytes(data: bytes) -> str:
+  return hashlib.sha256(data).hexdigest()
+
+
+def source_sha(path: Path) -> str:
+  if not path.is_file():
+    fail(f"missing file: {path}")
+  return sha256_bytes(path.read_bytes())
+
+
+def bundle_sha(paths: list[str]) -> str:
+  digest = hashlib.sha256()
+  for raw_path in sorted(paths):
+    path = REPO_ROOT / raw_path
+    if not path.is_file():
+      fail(f"bundle file missing: {raw_path}")
+    data = path.read_bytes()
+    name = raw_path.encode("utf-8")
+    digest.update(len(name).to_bytes(8, "big"))
+    digest.update(name)
+    digest.update(len(data).to_bytes(8, "big"))
+    digest.update(data)
+  return digest.hexdigest()
+
+
+def junit_stats(path: Path, *, allow_skips: bool) -> dict[str, int]:
+  if not path.is_file():
+    fail(f"JUnit file missing: {path}")
+  try:
+    root = ET.parse(path).getroot()
+  except ET.ParseError as error:
+    fail(f"invalid JUnit XML {path}: {error}")
+  suites = [root] if root.tag == "testsuite" else list(root.findall("testsuite"))
+  if not suites:
+    fail(f"no testsuite in {path}")
+  stats = {key: sum(int(s.get(key, "0")) for s in suites) for key in ("tests", "failures", "errors", "skipped")}
+  if stats["tests"] <= 0:
+    fail(f"no tests recorded in {path}")
+  if stats["failures"] or stats["errors"]:
+    fail(f"failed JUnit gate {path}: {stats}")
+  if not allow_skips and stats["skipped"]:
+    fail(f"focused/differential skips or xfails forbidden in {path}: {stats}")
+  return stats
+
+
+def assert_no_expected_failure_markers() -> None:
+  forbidden = ("pytest.mark.xfail", "pytest.xfail(", "@pytest.mark.skip", "pytest.skip(")
+  for path in NEW_TEST_SOURCES:
+    text = path.read_text()
+    hits = [token for token in forbidden if token in text]
+    if hits:
+      fail(f"forbidden skip/xfail markers in {path}: {hits}")
+
+
+def require_equal(actual: Any, expected: Any, label: str) -> None:
+  if actual != expected:
+    fail(f"{label} mismatch: expected={expected!r}, actual={actual!r}")
+
+
+def validate_raw(raw: dict[str, Any], args, changed_paths: list[str]) -> None:
+  require_equal(raw.get("result"), "passed", "raw result")
+  manifest = raw.get("manifest")
+  if not isinstance(manifest, dict):
+    fail("raw manifest is absent")
+  expected = {
+    "mode": args.mode,
+    "base_sha": args.base_sha,
+    "head_sha": args.head_sha,
+    "base_source_sha256": args.base_source_sha256,
+    "feature_source_sha256": args.feature_source_sha256,
+    "feature_bundle_sha256": args.feature_bundle_sha256,
+    "changed_paths": changed_paths,
+    "changed_paths_sha256": args.changed_paths_sha256,
+    "image_id": args.image_id,
+    "pre_commit_version": args.pre_commit_version,
+  }
+  for key, value in expected.items():
+    require_equal(manifest.get(key), value, f"raw manifest {key}")
+  for package in ("python", "freqtrade", "pandas", "numpy", "ta_lib"):
+    if not isinstance(manifest.get(package), str) or not manifest[package]:
+      fail(f"missing package version: {package}")
+
+  matrix = raw.get("matrix", {})
+  require_equal(len(matrix), 40, "fixture/profile matrix size")
+  if any(value != "passed" for value in matrix.values()):
+    fail("matrix contains a failed entry")
+  expected_profiles = {"1d", "4h", "1h", "15m"}
+  calls = raw.get("call_fingerprints", {})
+  debug = raw.get("debug_instrumentation", {})
+  require_equal(set(calls), expected_profiles, "call fingerprint profiles")
+  require_equal(set(debug), expected_profiles, "debug profiles")
+  if any(not value.get("passed") for value in calls.values()):
+    fail("call fingerprint result is not passed")
+  if any(not value.get("passed") for value in debug.values()):
+    fail("debug instrumentation result is not passed")
+  runtime = raw.get("runtime_instrumentation", {})
+  require_equal(len(runtime), 8, "runtime instrumentation matrix")
+  callers = raw.get("caller_source_gate", {})
+  require_equal(set(callers), {"info_switcher", "populate_indicators"}, "caller source gate")
+  for name, value in callers.items():
+    if not value.get("passed") or value.get("baseline") != value.get("feature"):
+      fail(f"caller AST gate failed: {name}")
+  structural = raw.get("structural_ast", {})
+  require_equal(structural.get("signatures"), "passed", "structural signatures")
+  require_equal(structural.get("ownership"), "passed", "structural ownership")
+
+
+def parse_args(argv=None):
+  parser = argparse.ArgumentParser()
+  parser.add_argument("--focused", required=True, type=Path)
+  parser.add_argument("--full-unit", required=True, type=Path)
+  parser.add_argument("--differential", required=True, type=Path)
+  parser.add_argument("--raw", required=True, type=Path)
+  parser.add_argument("--output", required=True, type=Path)
+  parser.add_argument("--mode", required=True, choices=("local-precommit", "pull-request"))
+  parser.add_argument("--base-sha", required=True)
+  parser.add_argument("--head-sha", required=True)
+  parser.add_argument("--base-source-sha256", required=True)
+  parser.add_argument("--feature-source-sha256", required=True)
+  parser.add_argument("--feature-bundle-sha256", required=True)
+  parser.add_argument("--changed-paths-json", required=True)
+  parser.add_argument("--changed-paths-sha256", required=True)
+  parser.add_argument("--image-id", required=True)
+  parser.add_argument("--pre-commit-version", required=True)
+  return parser.parse_args(argv)
+
+
+def main(argv=None) -> int:
+  args = parse_args(argv)
+  output = args.output.resolve()
+  # A failed verifier may never leave a stale final artifact behind.
+  output.unlink(missing_ok=True)
+
+  if args.mode == "pull-request" and args.base_sha == args.head_sha:
+    fail("pull-request BASE_SHA equals HEAD_SHA")
+  if args.base_source_sha256 == args.feature_source_sha256:
+    fail("baseline and feature source identities are equal")
+  try:
+    changed_paths = json.loads(args.changed_paths_json)
+  except json.JSONDecodeError as error:
+    fail(f"invalid changed-path JSON: {error}")
+  require_equal(changed_paths, ALLOWED_PATHS, "changed path allowlist")
+  require_equal(sha256_bytes("\0".join(changed_paths).encode()), args.changed_paths_sha256, "changed path hash")
+  require_equal(
+    source_sha(REPO_ROOT / "NostalgiaForInfinityX7.py"), args.feature_source_sha256, "current feature source hash"
+  )
+  require_equal(bundle_sha(changed_paths), args.feature_bundle_sha256, "current feature bundle hash")
+
+  focused = junit_stats(args.focused, allow_skips=False)
+  full_unit = junit_stats(args.full_unit, allow_skips=True)
+  differential = junit_stats(args.differential, allow_skips=False)
+  assert_no_expected_failure_markers()
+  if not args.raw.is_file():
+    fail(f"raw evidence missing: {args.raw}")
+  try:
+    raw = json.loads(args.raw.read_text())
+  except json.JSONDecodeError as error:
+    fail(f"invalid raw JSON: {error}")
+  validate_raw(raw, args, changed_paths)
+
+  final = {
+    "schema": 1,
+    "result": "passed",
+    "mode": args.mode,
+    "identity": {
+      "base_sha": args.base_sha,
+      "head_sha": args.head_sha,
+      "base_source_sha256": args.base_source_sha256,
+      "feature_source_sha256": args.feature_source_sha256,
+      "feature_bundle_sha256": args.feature_bundle_sha256,
+      "changed_paths": changed_paths,
+      "changed_paths_sha256": args.changed_paths_sha256,
+      "image_id": args.image_id,
+      "pre_commit_version": args.pre_commit_version,
+    },
+    "junit": {"focused": focused, "full_unit": full_unit, "differential": differential},
+    "packages": {key: raw["manifest"][key] for key in ("python", "freqtrade", "pandas", "numpy", "ta_lib")},
+    "differential": {
+      "matrix": raw["matrix"],
+      "call_fingerprints": raw["call_fingerprints"],
+      "debug_instrumentation": raw["debug_instrumentation"],
+      "runtime_instrumentation": raw["runtime_instrumentation"],
+      "caller_source_gate": raw["caller_source_gate"],
+      "structural_ast": raw["structural_ast"],
+    },
+  }
+  output.parent.mkdir(parents=True, exist_ok=True)
+  fd, temporary_name = tempfile.mkstemp(prefix=f".{output.name}.", suffix=".tmp", dir=output.parent)
+  temporary = Path(temporary_name)
+  try:
+    with os.fdopen(fd, "w") as handle:
+      json.dump(final, handle, indent=2, sort_keys=True)
+      handle.write("\n")
+      handle.flush()
+      os.fsync(handle.fileno())
+    os.replace(temporary, output)
+  finally:
+    temporary.unlink(missing_ok=True)
+  if not output.is_file() or output.stat().st_size == 0:
+    fail("atomic output creation failed")
+  return 0
+
+
+if __name__ == "__main__":
+  sys.exit(main())

--- a/tests/unit/test_NFIX7_informative_indicators.py
+++ b/tests/unit/test_NFIX7_informative_indicators.py
@@ -1,0 +1,567 @@
+"""Executable characterization for the NFI X7 informative-indicator refactor (#450).
+
+The two ``new_public`` tests are intentionally RED until Phase 4 adds the API.
+Everything else is required to pass against the immutable unrefactored baseline.
+"""
+
+from __future__ import annotations
+
+import ast
+import hashlib
+import importlib.util
+import json
+import sys
+from collections import Counter
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import pandas as pd
+import pytest
+from pandas.testing import assert_frame_equal
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+FEATURE_SOURCE = REPO_ROOT / "NostalgiaForInfinityX7.py"
+BASELINE_SOURCE = REPO_ROOT / "artifacts/nfix7-baseline/NostalgiaForInfinityX7.py"
+PROFILES = ("1d", "4h", "1h", "15m")
+WRAPPERS = {profile: f"informative_{profile}_indicators" for profile in PROFILES}
+DP_ASSERTION = "DataProvider is required for multiple timeframes."
+
+SOURCE_COLUMNS = ["open", "high", "low", "close", "volume"]
+EXPECTED_GENERATED_COLUMNS = {
+  "1d": [
+    "RSI_3",
+    "RSI_14",
+    "STOCHk_14_3_3",
+    "STOCHRSIk_14_14_3_3",
+    "MFI_14",
+    "CMF_20",
+    "WILLR_14",
+    "AROONU_14",
+    "AROOND_14",
+    "ROC_2",
+    "ROC_9",
+    "RSI_3_change_pct",
+    "change_pct",
+    "top_wick_pct",
+    "bot_wick_pct",
+    "high_max_6",
+    "high_max_12",
+    "high_max_20",
+    "high_max_30",
+    "low_min_6",
+    "low_min_12",
+    "low_min_20",
+    "low_min_30",
+  ],
+  "4h": [
+    "RSI_3",
+    "RSI_14",
+    "ADX_14",
+    "PLUS_DI_14",
+    "MINUS_DI_14",
+    "AROONU_14",
+    "AROOND_14",
+    "BBP_20_2.0",
+    "STOCHk_14_3_3",
+    "STOCHRSIk_14_14_3_3",
+    "KST_10_15_20_30_10_10_10_15",
+    "KSTs_9",
+    "MFI_14",
+    "CMF_20",
+    "EMA_12",
+    "EMA_50",
+    "EMA_100",
+    "EMA_200",
+    "WILLR_14",
+    "UO_7_14_28",
+    "ROC_2",
+    "ROC_9",
+    "CCI_20",
+    "STOCHRSIk_14_14_3_3_change_pct",
+    "CCI_20_change_pct",
+    "RSI_3_change_pct",
+    "RSI_14_change_pct",
+    "change_pct",
+    "top_wick_pct",
+    "high_max_6",
+    "high_max_12",
+    "high_max_24",
+    "low_min_12",
+    "low_min_24",
+  ],
+  "1h": [
+    "RSI_3",
+    "RSI_14",
+    "RSI_3_change_pct",
+    "RSI_14_change_pct",
+    "EMA_12",
+    "EMA_200",
+    "SMA_16",
+    "BBL_20_2.0",
+    "BBU_20_2.0",
+    "BBB_20_2.0",
+    "MFI_14",
+    "CMF_20",
+    "WILLR_14",
+    "WILLR_84",
+    "AROONU_14",
+    "AROOND_14",
+    "STOCHk_14_3_3",
+    "STOCHRSIk_14_14_3_3",
+    "KST_10_15_20_30_10_10_10_15",
+    "KSTs_9",
+    "UO_7_14_28",
+    "ROC_2",
+    "ROC_9",
+    "CCI_20",
+    "CCI_20_change_pct",
+    "change_pct",
+    "high_max_6",
+    "high_max_12",
+    "high_max_24",
+    "low_min_6",
+    "low_min_12",
+    "low_min_24",
+  ],
+  "15m": [
+    "RSI_3",
+    "RSI_14",
+    "RSI_3_change_pct",
+    "RSI_14_change_pct",
+    "EMA_12",
+    "EMA_20",
+    "EMA_26",
+    "EMA_50",
+    "EMA_200",
+    "MFI_14",
+    "CMF_20",
+    "WILLR_14",
+    "AROONU_14",
+    "AROOND_14",
+    "STOCHk_14_3_3",
+    "STOCHRSIk_14_14_3_3",
+    "UO_7_14_28",
+    "UO_7_14_28_change_pct",
+    "OBV_change_pct",
+    "ROC_9",
+    "CCI_20",
+    "CCI_20_change_pct",
+    "change_pct",
+  ],
+}
+EXPECTED_HELPER_ORDER = {
+  "1d": ["stochrsi_k", "chaikin_money_flow", "fast_pct_change"],
+  "4h": ["stochrsi_k", "calc_kst", "chaikin_money_flow"] + ["fast_pct_change"] * 4,
+  "1h": ["stochrsi_k", "calc_kst", "chaikin_money_flow"] + ["fast_pct_change"] * 3,
+  "15m": ["stochrsi_k", "chaikin_money_flow"] + ["fast_pct_change"] * 5,
+}
+EXPECTED_TA_COUNTS = {
+  "1d": {"RSI": 2, "AROON": 1, "STOCHF": 1, "MIN": 5, "MAX": 5, "SMA": 1, "MFI": 1, "WILLR": 1, "ROC": 2},
+  "4h": {
+    "RSI": 2,
+    "AROON": 1,
+    "ADX": 1,
+    "PLUS_DI": 1,
+    "MINUS_DI": 1,
+    "BBANDS": 1,
+    "STOCHF": 1,
+    "MIN": 3,
+    "MAX": 4,
+    "SMA": 6,
+    "ROC": 6,
+    "MFI": 1,
+    "EMA": 4,
+    "WILLR": 1,
+    "ULTOSC": 1,
+    "CCI": 1,
+  },
+  "1h": {
+    "RSI": 2,
+    "BBANDS": 1,
+    "AROON": 1,
+    "STOCHF": 1,
+    "MIN": 4,
+    "MAX": 4,
+    "SMA": 7,
+    "ROC": 6,
+    "MFI": 1,
+    "EMA": 2,
+    "WILLR": 2,
+    "ULTOSC": 1,
+    "CCI": 1,
+  },
+  "15m": {
+    "RSI": 2,
+    "AROON": 1,
+    "STOCHF": 1,
+    "MIN": 1,
+    "MAX": 1,
+    "SMA": 1,
+    "MFI": 1,
+    "EMA": 5,
+    "WILLR": 1,
+    "ULTOSC": 1,
+    "OBV": 1,
+    "ROC": 1,
+    "CCI": 1,
+  },
+}
+CALLABLE_ROLES = {
+  ("stochrsi_k", 1): ("ta_min", "MIN"),
+  ("stochrsi_k", 2): ("ta_max", "MAX"),
+  ("stochrsi_k", 3): ("ta_sma", "SMA"),
+  ("calc_kst", 1): ("ta_roc", "ROC"),
+  ("calc_kst", 2): ("ta_sma", "SMA"),
+}
+
+
+def load_strategy_module(path: Path, name: str):
+  spec = importlib.util.spec_from_file_location(name, path)
+  assert spec and spec.loader
+  module = importlib.util.module_from_spec(spec)
+  sys.modules[name] = module
+  spec.loader.exec_module(module)
+  return module
+
+
+def make_strategy(cls):
+  strategy = object.__new__(cls)
+  strategy.dp = None
+  return strategy
+
+
+class FakeDP:
+  def __init__(self, frame: pd.DataFrame):
+    self.frame = frame
+    self.calls: list[dict[str, Any]] = []
+
+  def get_pair_dataframe(self, **kwargs):
+    self.calls.append(kwargs)
+    return self.frame
+
+
+def normal_frame(length: int = 512) -> pd.DataFrame:
+  i = np.arange(512, dtype=np.float64)
+  open_ = 100 + 0.05 * i + 2 * np.sin(i / 11)
+  close = open_ + 0.7 * np.sin(i / 7)
+  frame = pd.DataFrame(
+    {
+      "open": open_,
+      "high": np.maximum(open_, close) + 1 + 0.1 * (i % 5),
+      "low": np.minimum(open_, close) - 1 - 0.1 * (i % 3),
+      "close": close,
+      "volume": 1000 + 10 * (i % 17) + 0.5 * i,
+    },
+    index=pd.date_range("2024-01-01T00:00:00Z", periods=512, freq="5min"),
+  )
+  return frame.iloc[:length].copy()
+
+
+def fixture_matrix() -> dict[str, pd.DataFrame]:
+  normal = normal_frame()
+  empty = normal.iloc[:0].copy()
+  zero_open = normal.copy()
+  zero_open.iloc[[0, 256, 511], zero_open.columns.get_loc("open")] = 0.0
+  nan_ohlcv = normal.copy()
+  for column, row in {"open": 3, "high": 17, "low": 63, "close": 255, "volume": 400}.items():
+    nan_ohlcv.iloc[row, nan_ohlcv.columns.get_loc(column)] = np.nan
+  passthrough = normal.copy()
+  passthrough["custom_passthrough"] = np.arange(512, dtype=np.float64)
+  duplicate = normal.copy()
+  duplicate["RSI_3"] = np.arange(512, dtype=np.float64)
+  non_default = normal.copy()
+  non_default.index = pd.Index(1000 + 3 * np.arange(512), name="non_default")
+  return {
+    "normal_512": normal,
+    "empty": empty,
+    "short_1": normal_frame(1),
+    "short_13": normal_frame(13),
+    "short_199": normal_frame(199),
+    "zero_open": zero_open,
+    "nan_ohlcv": nan_ohlcv,
+    "passthrough": passthrough,
+    "duplicate_indicator": duplicate,
+    "non_default_index": non_default,
+  }
+
+
+def array_fingerprint(value: Any):
+  array = np.asarray(value)
+  contiguous = np.ascontiguousarray(array)
+  return (array.shape, array.dtype.str, hashlib.sha256(contiguous.view(np.uint8).tobytes()).hexdigest())
+
+
+def value_fingerprint(call: str, position: int | None, value: Any):
+  role = CALLABLE_ROLES.get((call, position))
+  if role:
+    semantic, expected_name = role
+    # ``talib.abstract.Function`` is callable but exposes its stable semantic
+    # name through ``info`` rather than ``__name__`` in the pinned image.
+    callable_name = getattr(value, "__name__", None) or getattr(value, "info", {}).get("name")
+    assert callable(value) and callable_name == expected_name
+    return ("callable-role", semantic, type(value).__name__)
+  if isinstance(value, (np.ndarray, pd.Series)):
+    return ("array",) + array_fingerprint(value)
+  return (f"{type(value).__module__}.{type(value).__qualname__}", repr(value))
+
+
+def canonical_call(call: str, args: tuple[Any, ...], kwargs: dict[str, Any]):
+  return {
+    "name": call,
+    "args": [value_fingerprint(call, i, value) for i, value in enumerate(args)],
+    "kwargs": [(key, value_fingerprint(call, None, kwargs[key])) for key in sorted(kwargs)],
+  }
+
+
+def ast_method(source: Path, name: str) -> ast.FunctionDef:
+  tree = ast.parse(source.read_text())
+  cls = next(node for node in tree.body if isinstance(node, ast.ClassDef) and node.name == "NostalgiaForInfinityX7")
+  return next(node for node in cls.body if isinstance(node, ast.FunctionDef) and node.name == name)
+
+
+def signature_dump(node: ast.FunctionDef) -> str:
+  return ast.dump(
+    ast.Module(
+      body=[
+        ast.FunctionDef(
+          name="method", args=node.args, body=[ast.Pass()], decorator_list=[], returns=node.returns, type_comment=None
+        )
+      ],
+      type_ignores=[],
+    ),
+    include_attributes=False,
+  )
+
+
+@pytest.fixture(scope="module")
+def feature_module():
+  return load_strategy_module(FEATURE_SOURCE, "nfix7_unit_feature")
+
+
+@pytest.mark.parametrize("profile", PROFILES)
+def test_exact_profile_columns_and_source_immutability(feature_module, profile):
+  source = normal_frame()
+  before = source.copy(deep=True)
+  strategy = make_strategy(feature_module.NostalgiaForInfinityX7)
+  strategy.dp = FakeDP(source)
+  result = getattr(strategy, WRAPPERS[profile])({"pair": "TEST/USDT"}, profile)
+  assert list(result.columns) == SOURCE_COLUMNS + EXPECTED_GENERATED_COLUMNS[profile]
+  assert_frame_equal(source, before, check_exact=True)
+  assert result.index is source.index
+
+
+@pytest.mark.parametrize("loaded_timeframe", ["4h", "custom-sentinel"])
+def test_direct_1d_wrapper_passes_loaded_timeframe_unchanged(feature_module, loaded_timeframe):
+  strategy = make_strategy(feature_module.NostalgiaForInfinityX7)
+  strategy.dp = FakeDP(normal_frame(13))
+  strategy.informative_1d_indicators({"pair": "TEST/USDT"}, loaded_timeframe)
+  assert strategy.dp.calls == [{"pair": "TEST/USDT", "timeframe": loaded_timeframe}]
+
+
+def test_dp_assertion_precedes_metadata_for_wrapper(feature_module):
+  strategy = make_strategy(feature_module.NostalgiaForInfinityX7)
+  with pytest.raises(AssertionError, match=f"^{DP_ASSERTION}$"):
+    strategy.informative_1d_indicators({}, "custom-sentinel")
+
+
+def test_missing_pair_precedes_dp_call_for_wrapper(feature_module):
+  strategy = make_strategy(feature_module.NostalgiaForInfinityX7)
+  strategy.dp = FakeDP(normal_frame(1))
+  with pytest.raises(KeyError) as error:
+    strategy.informative_1d_indicators({}, "custom-sentinel")
+  assert error.value.args == ("pair",)
+  assert strategy.dp.calls == []
+
+
+def test_info_switcher_unsupported_exact_error(feature_module):
+  strategy = make_strategy(feature_module.NostalgiaForInfinityX7)
+  with pytest.raises(RuntimeError) as error:
+    strategy.info_switcher({"pair": "TEST/USDT"}, "2h")
+  assert str(error.value) == "2h not supported as informative timeframe for BTC pair."
+
+
+def test_info_switcher_is_virtual_and_ignores_public_name_collision(feature_module):
+  class Collision(feature_module.NostalgiaForInfinityX7):
+    def informative_1d_indicators(self, metadata, info_timeframe):
+      return ("wrapper", metadata, info_timeframe)
+
+    def informative_indicators(self, *args, **kwargs):
+      raise AssertionError("colliding additive API must not be called")
+
+  strategy = make_strategy(Collision)
+  assert strategy.info_switcher({"pair": "P"}, "1d") == ("wrapper", {"pair": "P"}, "1d")
+
+
+@pytest.mark.parametrize("profile", PROFILES)
+def test_empty_returns_identical_object_without_ta_or_helpers(feature_module, monkeypatch, profile):
+  source = fixture_matrix()["empty"]
+  strategy = make_strategy(feature_module.NostalgiaForInfinityX7)
+  strategy.dp = FakeDP(source)
+
+  def forbidden(*args, **kwargs):
+    raise AssertionError("empty guard must precede TA/helper/context/builder work")
+
+  for name in dir(feature_module.ta):
+    if name.isupper() and callable(getattr(feature_module.ta, name)):
+      monkeypatch.setattr(feature_module.ta, name, forbidden)
+  for name in ("fast_pct_change", "stochrsi_k", "chaikin_money_flow", "calc_kst"):
+    monkeypatch.setattr(strategy, name, forbidden)
+  if hasattr(feature_module, "_NFIInformativeContext"):
+    monkeypatch.setattr(feature_module, "_NFIInformativeContext", forbidden)
+  result = getattr(strategy, WRAPPERS[profile])({"pair": "TEST/USDT"}, "custom-sentinel")
+  assert result is source
+  assert strategy.dp.calls == [{"pair": "TEST/USDT", "timeframe": "custom-sentinel"}]
+
+
+@pytest.mark.parametrize("profile", PROFILES)
+def test_passthrough_duplicate_labels_and_non_default_index(feature_module, profile):
+  for fixture_name in ("passthrough", "duplicate_indicator", "non_default_index"):
+    source = fixture_matrix()[fixture_name]
+    strategy = make_strategy(feature_module.NostalgiaForInfinityX7)
+    strategy.dp = FakeDP(source)
+    result = getattr(strategy, WRAPPERS[profile])({"pair": "TEST/USDT"}, profile)
+    assert list(result.columns[: len(source.columns)]) == list(source.columns)
+    assert result.index.equals(source.index)
+    assert result.index.name == source.index.name
+    if fixture_name == "duplicate_indicator":
+      assert list(result.columns).count("RSI_3") == 2
+
+
+@pytest.mark.parametrize("profile", PROFILES)
+def test_stateful_helper_order_and_outputs_are_deterministic(feature_module, profile):
+  base_cls = feature_module.NostalgiaForInfinityX7
+
+  class Stateful(base_cls):
+    trace: list[dict[str, Any]]
+    counter: int
+
+    def _record(self, name, args, kwargs, inherited):
+      self.counter += 1
+      self.trace.append(canonical_call(name, args, kwargs) | {"counter": self.counter})
+      result = inherited(*args, **kwargs)
+      delta = self.counter * 2**-40
+      if isinstance(result, tuple):
+        return tuple(np.asarray(item) + delta for item in result)
+      return np.asarray(result) + delta
+
+    def fast_pct_change(self, *args, **kwargs):
+      return self._record("fast_pct_change", args, kwargs, base_cls.fast_pct_change)
+
+    def stochrsi_k(self, *args, **kwargs):
+      return self._record("stochrsi_k", args, kwargs, base_cls.stochrsi_k)
+
+    def chaikin_money_flow(self, *args, **kwargs):
+      return self._record("chaikin_money_flow", args, kwargs, base_cls.chaikin_money_flow)
+
+    def calc_kst(self, *args, **kwargs):
+      return self._record("calc_kst", args, kwargs, base_cls.calc_kst)
+
+  def execute():
+    strategy = make_strategy(Stateful)
+    strategy.trace = []
+    strategy.counter = 0
+    strategy.dp = FakeDP(normal_frame())
+    frame = getattr(strategy, WRAPPERS[profile])({"pair": "TEST/USDT"}, profile)
+    return strategy.trace, frame
+
+  trace_a, frame_a = execute()
+  trace_b, frame_b = execute()
+  assert [entry["name"] for entry in trace_a] == EXPECTED_HELPER_ORDER[profile]
+  assert json.dumps(trace_a, sort_keys=True) == json.dumps(trace_b, sort_keys=True)
+  assert_frame_equal(frame_a, frame_b, check_exact=True)
+
+
+@pytest.mark.parametrize("profile", PROFILES)
+def test_pure_ta_call_multiset_fingerprint(feature_module, monkeypatch, profile):
+  calls = []
+  for name in sorted(set().union(*[set(counts) for counts in EXPECTED_TA_COUNTS.values()])):
+    original = getattr(feature_module.ta, name)
+
+    def wrapper(*args, __name=name, __original=original, **kwargs):
+      calls.append(canonical_call(__name, args, kwargs))
+      return __original(*args, **kwargs)
+
+    monkeypatch.setattr(feature_module.ta, name, wrapper)
+  strategy = make_strategy(feature_module.NostalgiaForInfinityX7)
+  strategy.dp = FakeDP(normal_frame())
+  getattr(strategy, WRAPPERS[profile])({"pair": "TEST/USDT"}, profile)
+  assert Counter(call["name"] for call in calls) == Counter(EXPECTED_TA_COUNTS[profile])
+  assert all(call["args"] or call["kwargs"] for call in calls)
+
+
+def test_callable_fingerprints_are_canonical_across_isolated_imports():
+  first = load_strategy_module(BASELINE_SOURCE, "nfix7_callable_a")
+  second = load_strategy_module(BASELINE_SOURCE, "nfix7_callable_b")
+  pairs = [
+    ("stochrsi_k", 1, (first.ta.MIN, first.ta.MAX, first.ta.SMA), (second.ta.MIN, second.ta.MAX, second.ta.SMA)),
+    ("calc_kst", 1, (first.ta.ROC, first.ta.SMA), (second.ta.ROC, second.ta.SMA)),
+  ]
+  for call, start, values, other in pairs:
+    assert [value_fingerprint(call, i + start, value) for i, value in enumerate(values)] == [
+      value_fingerprint(call, i + start, value) for i, value in enumerate(other)
+    ]
+
+
+@pytest.mark.parametrize("wrapper", WRAPPERS.values())
+def test_wrapper_ast_signatures_match_baseline(wrapper):
+  assert signature_dump(ast_method(FEATURE_SOURCE, wrapper)) == signature_dump(ast_method(BASELINE_SOURCE, wrapper))
+
+
+def test_fixture_matrix_is_exact():
+  fixtures = fixture_matrix()
+  assert list(fixtures) == [
+    "normal_512",
+    "empty",
+    "short_1",
+    "short_13",
+    "short_199",
+    "zero_open",
+    "nan_ohlcv",
+    "passthrough",
+    "duplicate_indicator",
+    "non_default_index",
+  ]
+  assert all(
+    all(dtype == np.dtype("float64") for dtype in frame[SOURCE_COLUMNS].dtypes) for frame in fixtures.values()
+  )
+  assert fixtures["zero_open"].index[fixtures["zero_open"]["open"] == 0].tolist() == [
+    fixtures["zero_open"].index[i] for i in (0, 256, 511)
+  ]
+  assert {column: np.flatnonzero(fixtures["nan_ohlcv"][column].isna()).tolist() for column in SOURCE_COLUMNS} == {
+    "open": [3],
+    "high": [17],
+    "low": [63],
+    "close": [255],
+    "volume": [400],
+  }
+
+
+# Exactly these two tests are the Phase-2 strict RED tracer bullets.
+def test_new_public_supported_profile(feature_module):
+  strategy = make_strategy(feature_module.NostalgiaForInfinityX7)
+  strategy.dp = FakeDP(normal_frame(13))
+  result = strategy.informative_indicators({"pair": "TEST/USDT"}, "1d")
+  assert list(result.columns) == SOURCE_COLUMNS + EXPECTED_GENERATED_COLUMNS["1d"]
+  assert strategy.dp.calls == [{"pair": "TEST/USDT", "timeframe": "1d"}]
+
+  strategy.dp = None
+  with pytest.raises(AssertionError, match=f"^{DP_ASSERTION}$"):
+    strategy.informative_indicators({}, "1d")
+
+  strategy.dp = FakeDP(normal_frame(1))
+  with pytest.raises(KeyError) as error:
+    strategy.informative_indicators({}, "1d")
+  assert error.value.args == ("pair",)
+  assert strategy.dp.calls == []
+
+  with pytest.raises(RuntimeError, match="^invalid-private not supported as informative profile\\.$"):
+    feature_module.NostalgiaForInfinityX7._nfix7_informative_indicators_impl(
+      strategy, {}, loaded_timeframe="custom-sentinel", profile="invalid-private"
+    )
+
+
+def test_new_public_invalid_profile_precedes_dp_and_metadata(feature_module):
+  strategy = make_strategy(feature_module.NostalgiaForInfinityX7)
+  with pytest.raises(RuntimeError, match="^invalid-profile not supported as informative profile\\.$"):
+    strategy.informative_indicators({}, "invalid-profile")


### PR DESCRIPTION
Closes #450.

## Summary
Centralizes the duplicated retrieval / guard / context / common-calculation / finalization logic shared by `informative_1d_indicators`, `informative_4h_indicators`, `informative_1h_indicators` and `informative_15m_indicators` into a single private, class-qualified implementation — a behavior-preserving refactor with no trading-logic changes.

## What changed
- Add frozen `_NFIInformativeContext` and a two-stage common pipeline:
  - `_nfix7_common_raw_values` — raw TA + numpy values;
  - `_nfix7_assemble_common_values` — zero-call assembly of the 12 shared outputs.
- Add class-qualified private core `_nfix7_informative_indicators_impl` that exclusively owns DataProvider access, `metadata["pair"]`, the empty-frame guard, context construction, `DataFrame`/`concat` and debug/validator/logging.
- Four explicit per-profile builders compute only their profile-specific indicators.
- The **four existing wrapper methods are kept as a compatibility layer** — unchanged names/signatures, each a one-line class-qualified delegation — so `info_switcher` routing and any subclass overrides remain intact.
- Add an additive convenience method `informative_indicators(metadata, info_timeframe)`.

## Behavior preservation
Exactly preserved: every formula and TA parameter, output column order/schema, dtypes, NaN/+inf/-inf, index, duplicate labels, `concat` semantics, arbitrary loaded-timeframe passthrough, the exact ordered virtual dispatch of `stochrsi_k`/`calc_kst`/`chaikin_money_flow`/`fast_pct_change` (verified under stateful subclass overrides), and unchanged `info_switcher`/`populate_indicators` (AST-hash equality). No union of indicators, no foreign-profile calculations, no extra heavy calls.

## Tests & CI
- Committed characterization tests plus a differential equivalence harness comparing feature output against the merge-base baseline across a fixture × profile matrix (exact frames, NaN/inf masks, call fingerprints, structural AST ownership, runtime instrumentation, debug instrumentation, unchanged-caller AST hashes).
- A fail-closed pull-request workflow builds one immutable image and runs focused/full/differential gates with strict xfail and identity-bound evidence.
- Local run: focused 34, full unit 74, differential 62 — all green.