### PR TITLE
Blacklist: add PIVX (Binance full-coin delist 2026-08-17)

### DIFF
--- a/configs/blacklist-binance.json
+++ b/configs/blacklist-binance.json
@@ -2,7 +2,7 @@
   "exchange": {
     "pair_blacklist": [
       // Binance delist 2026-08-17 (full-coin) — iterativ 2026-08-03
-      "(ACX|VIC)/.*",
+      "(ACX|PIVX|VIC)/.*",
       // FIGHT all-12 + IDOL (MEET48) — iterativ 2026-08-02
       "(FIGHT|IDOL)/.*",
       // Exchange

--- a/configs/blacklist-bitget.json
+++ b/configs/blacklist-bitget.json
@@ -4,7 +4,7 @@
       // Declining alt (2026-08-07; binance already covers via FAN group)
       "(CHZ)/.*",
       // Binance delist 2026-08-17 (full-coin) — iterativ 2026-08-03
-      "(ACX|VIC)/.*",
+      "(ACX|PIVX|VIC)/.*",
       // FIGHT all-12 + IDOL (MEET48) — iterativ 2026-08-02
       "(FIGHT|IDOL)/.*",
       // Exchange Tokens

--- a/configs/blacklist-bitmart.json
+++ b/configs/blacklist-bitmart.json
@@ -4,7 +4,7 @@
       // Declining alt (2026-08-07; binance already covers via FAN group)
       "(CHZ)/.*",
       // Binance delist 2026-08-17 (full-coin) — iterativ 2026-08-03
-      "(ACX|VIC)/.*",
+      "(ACX|PIVX|VIC)/.*",
       // FIGHT all-12 + IDOL (MEET48) — iterativ 2026-08-02
       "IDOL/.*",
       // Exchange Tokens

--- a/configs/blacklist-bitvavo.json
+++ b/configs/blacklist-bitvavo.json
@@ -4,7 +4,7 @@
       // Declining alt (2026-08-07; binance already covers via FAN group)
       "(CHZ)/.*",
       // Binance delist 2026-08-17 (full-coin) — iterativ 2026-08-03
-      "(ACX|VIC)/.*",
+      "(ACX|PIVX|VIC)/.*",
       // FIGHT all-12 + IDOL (MEET48) — iterativ 2026-08-02
       "(FIGHT|IDOL)/.*",
       // Exchange Tokens

--- a/configs/blacklist-bybit.json
+++ b/configs/blacklist-bybit.json
@@ -4,7 +4,7 @@
       // Declining alt (2026-08-07; binance already covers via FAN group)
       "(CHZ)/.*",
       // Binance delist 2026-08-17 (full-coin) — iterativ 2026-08-03
-      "(ACX|VIC)/.*",
+      "(ACX|PIVX|VIC)/.*",
       // FIGHT all-12 + IDOL (MEET48) — iterativ 2026-08-02
       "(FIGHT|IDOL)/.*",
       // Exchange Tokens

--- a/configs/blacklist-gateio.json
+++ b/configs/blacklist-gateio.json
@@ -4,7 +4,7 @@
       // Declining alt (2026-08-07; binance already covers via FAN group)
       "(CHZ)/.*",
       // Binance delist 2026-08-17 (full-coin) — iterativ 2026-08-03
-      "(ACX|VIC)/.*",
+      "(ACX|PIVX|VIC)/.*",
       // FIGHT all-12 + IDOL (MEET48) — iterativ 2026-08-02
       "IDOL/.*",
       // Exchange Tokens

--- a/configs/blacklist-htx.json
+++ b/configs/blacklist-htx.json
@@ -4,7 +4,7 @@
       // Declining alt (2026-08-07; binance already covers via FAN group)
       "(CHZ)/.*",
       // Binance delist 2026-08-17 (full-coin) — iterativ 2026-08-03
-      "(ACX|VIC)/.*",
+      "(ACX|PIVX|VIC)/.*",
       // FIGHT all-12 + IDOL (MEET48) — iterativ 2026-08-02
       "IDOL/.*",
       // Exchange Tokens

--- a/configs/blacklist-hyperliquid.json
+++ b/configs/blacklist-hyperliquid.json
@@ -4,7 +4,7 @@
       // Declining alt (2026-08-07; binance already covers via FAN group)
       "(CHZ)/.*",
       // Binance delist 2026-08-17 (full-coin) — iterativ 2026-08-03
-      "(ACX|VIC)/.*",
+      "(ACX|PIVX|VIC)/.*",
       // FIGHT all-12 + IDOL (MEET48) — iterativ 2026-08-02
       "IDOL/.*",
       // Exchange Tokens

--- a/configs/blacklist-kraken.json
+++ b/configs/blacklist-kraken.json
@@ -4,7 +4,7 @@
       // Declining alt (2026-08-07; binance already covers via FAN group)
       "(CHZ)/.*",
       // Binance delist 2026-08-17 (full-coin) — iterativ 2026-08-03
-      "(ACX|VIC)/.*",
+      "(ACX|PIVX|VIC)/.*",
       // FIGHT all-12 + IDOL (MEET48) — iterativ 2026-08-02
       "(FIGHT|IDOL)/.*",
       // Leverage tokens

--- a/configs/blacklist-kucoin.json
+++ b/configs/blacklist-kucoin.json
@@ -4,7 +4,7 @@
       // Declining alt (2026-08-07; binance already covers via FAN group)
       "(CHZ)/.*",
       // Binance delist 2026-08-17 (full-coin) — iterativ 2026-08-03
-      "(ACX|VIC)/.*",
+      "(ACX|PIVX|VIC)/.*",
       // FIGHT all-12 + IDOL (MEET48) — iterativ 2026-08-02
       "(FIGHT|IDOL)/.*",
       // Exchange Tokens

--- a/configs/blacklist-mexc.json
+++ b/configs/blacklist-mexc.json
@@ -4,7 +4,7 @@
       // Declining alt (2026-08-07; binance already covers via FAN group)
       "(CHZ)/.*",
       // Binance delist 2026-08-17 (full-coin) — iterativ 2026-08-03
-      "(ACX|VIC)/.*",
+      "(ACX|PIVX|VIC)/.*",
       // FIGHT all-12 + IDOL (MEET48) — iterativ 2026-08-02
       "IDOL/.*",
       // Exchange Tokens

--- a/configs/blacklist-okx.json
+++ b/configs/blacklist-okx.json
@@ -4,7 +4,7 @@
       // Declining alt (2026-08-07; binance already covers via FAN group)
       "(CHZ)/.*",
       // Binance delist 2026-08-17 (full-coin) — iterativ 2026-08-03
-      "(ACX|VIC)/.*",
+      "(ACX|PIVX|VIC)/.*",
       // FIGHT all-12 + IDOL (MEET48) — iterativ 2026-08-02
       "(FIGHT|IDOL)/.*",
       // Exchange Tokens


### PR DESCRIPTION
Binance is delisting six tokens on 2026-08-17 03:00 UTC: ACX, HFT, PIVX, PYR, VANRY, VIC. Five of the six are already covered in all 12 blacklists (ACX/VIC from the 2026-08-03 delist group, HFT/VANRY in low-cap, PYR from the earlier KuCoin delist) — PIVX was the only gap (0/12).

Added PIVX to the existing `(ACX|VIC)` Binance-delist group in all 12 configs. PIVX has no USDT-M perp on Binance/Bybit/Bitget (checked via ccxt), so this is pure forward-protection: a Binance-delisted legacy coin that could surface on any venue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)