### PR TITLE
Blacklist: allow 5 more tokenized stocks (MSTR, NVDA, CRCL, COIN, MSFT)

### DIFF
--- a/configs/blacklist-binance.json
+++ b/configs/blacklist-binance.json
@@ -33,7 +33,7 @@
       // Tokenized stocks (STOCK suffix — universal forward-protection)
       ".*STOCK/.*",
       // Tokenized stocks (direct ticker, no STOCK suffix)
-      "(NVDA|AAPL|AMD|ARM|ASTS|CRWV|DELL|GOOGL|IREN|LITE|MRVL|MSFT|MSTR|MU|NBIS|QCOM|SNDK|SPCX|AAOI|AMZN|APLD|AVGO|BABA|BE|COHR|COIN|CRCL|HOOD|INTC|IONQ|META|PLTR|SQQQ|TQQQ|TSLA|TSM)/.*",
+      "(AAPL|AMD|ARM|ASTS|CRWV|DELL|GOOGL|IREN|LITE|MRVL|MU|NBIS|QCOM|SNDK|SPCX|AAOI|AMZN|APLD|AVGO|BABA|BE|COHR|HOOD|INTC|IONQ|META|PLTR|SQQQ|TQQQ|TSLA|TSM)/.*",
       // Commodities (tokenized energy/metal perps — crypto gold XAUT/PAXG kept above)
       "(CL|BZ|NATGAS|XPT)/.*"
     ]

--- a/configs/blacklist-bitget.json
+++ b/configs/blacklist-bitget.json
@@ -37,7 +37,7 @@
       // Tokenized stocks (STOCK suffix on futures — QNTSTOCK, BBSTOCK, NOKSTOCK, SATSSTOCK, STXSTOCK)
       ".*STOCK/.*",
       // Tokenized stocks (direct ticker, no STOCK suffix)
-      "(NVDA|AAPL|AMD|ARM|ASTS|CRWV|DELL|GOOGL|IREN|LITE|MRVL|MSFT|MSTR|MU|NBIS|QCOM|SNDK|SPCX|AAOI|AMZN|APLD|AVGO|BABA|BE|COHR|COIN|CRCL|HOOD|INTC|IONQ|META|PLTR|SQQQ|TQQQ|TSLA|TSM)/.*",
+      "(AAPL|AMD|ARM|ASTS|CRWV|DELL|GOOGL|IREN|LITE|MRVL|MU|NBIS|QCOM|SNDK|SPCX|AAOI|AMZN|APLD|AVGO|BABA|BE|COHR|HOOD|INTC|IONQ|META|PLTR|SQQQ|TQQQ|TSLA|TSM)/.*",
       // Commodities (tokenized energy/metal perps — crypto gold XAUT/PAXG kept above)
       "(CL|BZ|NATGAS|XPT)/.*",
       // Tokenized stocks (ON-suffix variant on Bitget)

--- a/configs/blacklist-bitmart.json
+++ b/configs/blacklist-bitmart.json
@@ -38,7 +38,7 @@
       // Tokenized stocks (STOCK suffix — universal forward-protection)
       ".*STOCK/.*",
       // Tokenized stocks (direct ticker, no STOCK suffix)
-      "(NVDA|AAPL|AMD|ARM|ASTS|CRWV|DELL|GOOGL|IREN|LITE|MRVL|MSFT|MSTR|MU|NBIS|QCOM|SNDK|SPCX|AAOI|APLD|BE|SQQQ|AMZN|AVGO|BABA|COHR|COIN|CRCL|HOOD|INTC|META|PLTR|TQQQ|TSLA|TSM)/.*",
+      "(AAPL|AMD|ARM|ASTS|CRWV|DELL|GOOGL|IREN|LITE|MRVL|MU|NBIS|QCOM|SNDK|SPCX|AAOI|APLD|BE|SQQQ|AMZN|AVGO|BABA|COHR|HOOD|INTC|META|PLTR|TQQQ|TSLA|TSM)/.*",
       // Commodities (tokenized energy/metal perps — crypto gold XAUT/PAXG kept above)
       "(CL|BZ|NATGAS|XPT)/.*",
       // Tokenized stocks (X-suffix)

--- a/configs/blacklist-bitvavo.json
+++ b/configs/blacklist-bitvavo.json
@@ -34,7 +34,7 @@
       // Tokenized stocks (STOCK suffix — universal forward-protection)
       ".*STOCK/.*",
       // Tokenized stocks (direct ticker, no STOCK suffix)
-      "(NVDA|AAPL|AMD|ARM|ASTS|CRWV|DELL|GOOGL|IREN|LITE|MRVL|MSFT|MSTR|MU|NBIS|QCOM|SNDK|SPCX|AAOI|AMZN|APLD|AVGO|BABA|BE|COHR|COIN|CRCL|HOOD|INTC|IONQ|META|PLTR|SQQQ|TQQQ|TSLA|TSM)/.*",
+      "(AAPL|AMD|ARM|ASTS|CRWV|DELL|GOOGL|IREN|LITE|MRVL|MU|NBIS|QCOM|SNDK|SPCX|AAOI|AMZN|APLD|AVGO|BABA|BE|COHR|HOOD|INTC|IONQ|META|PLTR|SQQQ|TQQQ|TSLA|TSM)/.*",
       // Commodities (tokenized energy/metal perps — crypto gold XAUT/PAXG kept above)
       "(CL|BZ|NATGAS|XPT)/.*"
     ]

--- a/configs/blacklist-bybit.json
+++ b/configs/blacklist-bybit.json
@@ -33,7 +33,7 @@
       // Tokenized stocks (STOCK suffix — universal forward-protection)
       ".*STOCK/.*",
       // Tokenized stocks (direct ticker, no STOCK suffix)
-      "(NVDA|AAPL|AMD|ARM|ASTS|CRWV|DELL|GOOGL|IREN|LITE|MRVL|MSFT|MSTR|MU|NBIS|QCOM|SNDK|SPCX|AAOI|APLD|AVGO|BABA|BE|COHR|INTC|IONQ|PLTR|SQQQ|TQQQ|TSM|AMZN|COIN|CRCL|HOOD|META|TSLA)/.*",
+      "(AAPL|AMD|ARM|ASTS|CRWV|DELL|GOOGL|IREN|LITE|MRVL|MU|NBIS|QCOM|SNDK|SPCX|AAOI|APLD|AVGO|BABA|BE|COHR|INTC|IONQ|PLTR|SQQQ|TQQQ|TSM|AMZN|HOOD|META|TSLA)/.*",
       // Commodities (tokenized energy/metal perps — crypto gold XAUT/PAXG kept above)
       "(CL|BZ|NATGAS|XPT)/.*",
       // Tokenized stocks (X-suffix)

--- a/configs/blacklist-gateio.json
+++ b/configs/blacklist-gateio.json
@@ -34,7 +34,7 @@
       // Tokenized stocks (STOCK suffix — universal forward-protection)
       ".*STOCK/.*",
       // Tokenized stocks (direct ticker, no STOCK suffix)
-      "(NVDA|AAPL|AMD|ARM|ASTS|CRWV|DELL|GOOGL|IREN|LITE|MRVL|MSFT|MSTR|MU|NBIS|QCOM|SNDK|SPCX|AAOI|APLD|BE|COHR|IONQ|SQQQ|TSM|AMZN|AVGO|BABA|COIN|CRCL|HOOD|INTC|META|PLTR|TQQQ|TSLA)/.*",
+      "(AAPL|AMD|ARM|ASTS|CRWV|DELL|GOOGL|IREN|LITE|MRVL|MU|NBIS|QCOM|SNDK|SPCX|AAOI|APLD|BE|COHR|IONQ|SQQQ|TSM|AMZN|AVGO|BABA|HOOD|INTC|META|PLTR|TQQQ|TSLA)/.*",
       // Commodities (tokenized energy/metal perps — crypto gold XAUT/PAXG kept above)
       "(CL|BZ|NATGAS|XPT)/.*",
       // Tokenized stocks (3L/3S leverage)

--- a/configs/blacklist-htx.json
+++ b/configs/blacklist-htx.json
@@ -34,7 +34,7 @@
       // Tokenized stocks (STOCK suffix — universal forward-protection)
       ".*STOCK/.*",
       // Tokenized stocks (direct ticker, no STOCK suffix)
-      "(NVDA|AAPL|AMD|ARM|ASTS|CRWV|DELL|GOOGL|IREN|LITE|MRVL|MSFT|MSTR|MU|NBIS|QCOM|SNDK|SPCX|AAOI|APLD|AVGO|BABA|BE|COHR|IONQ|META|SQQQ|TQQQ|TSM|AMZN|COIN|CRCL|HOOD|INTC|PLTR|TSLA)/.*",
+      "(AAPL|AMD|ARM|ASTS|CRWV|DELL|GOOGL|IREN|LITE|MRVL|MU|NBIS|QCOM|SNDK|SPCX|AAOI|APLD|AVGO|BABA|BE|COHR|IONQ|META|SQQQ|TQQQ|TSM|AMZN|HOOD|INTC|PLTR|TSLA)/.*",
       // Commodities (tokenized energy/metal perps — crypto gold XAUT/PAXG kept above)
       "(CL|BZ|NATGAS|XPT)/.*",
       // Tokenized stocks (X-suffix)

--- a/configs/blacklist-hyperliquid.json
+++ b/configs/blacklist-hyperliquid.json
@@ -33,7 +33,7 @@
       // Tokenized stocks (STOCK suffix — universal forward-protection)
       ".*STOCK/.*",
       // Tokenized stocks (direct ticker, no STOCK suffix)
-      "(NVDA|AAPL|AMD|ARM|ASTS|CRWV|DELL|GOOGL|IREN|LITE|MRVL|MSFT|MSTR|MU|NBIS|QCOM|SNDK|SPCX|AAOI|AMZN|APLD|AVGO|BABA|BE|COHR|COIN|CRCL|HOOD|INTC|IONQ|META|PLTR|SQQQ|TQQQ|TSLA|TSM)/.*",
+      "(AAPL|AMD|ARM|ASTS|CRWV|DELL|GOOGL|IREN|LITE|MRVL|MU|NBIS|QCOM|SNDK|SPCX|AAOI|AMZN|APLD|AVGO|BABA|BE|COHR|HOOD|INTC|IONQ|META|PLTR|SQQQ|TQQQ|TSLA|TSM)/.*",
       // Commodities (tokenized energy/metal perps — crypto gold XAUT/PAXG kept above)
       "(CL|BZ|NATGAS|XPT)/.*"
     ]

--- a/configs/blacklist-kraken.json
+++ b/configs/blacklist-kraken.json
@@ -32,7 +32,7 @@
       // Tokenized stocks (STOCK suffix — universal forward-protection)
       ".*STOCK/.*",
       // Tokenized stocks (direct ticker, no STOCK suffix)
-      "(NVDA|AAPL|AMD|ARM|ASTS|CRWV|DELL|GOOGL|IREN|LITE|MRVL|MSFT|MSTR|MU|NBIS|QCOM|SNDK|SPCX|AAOI|AMZN|APLD|AVGO|BABA|BE|COHR|COIN|CRCL|HOOD|INTC|IONQ|META|PLTR|SQQQ|TQQQ|TSLA|TSM)/.*",
+      "(AAPL|AMD|ARM|ASTS|CRWV|DELL|GOOGL|IREN|LITE|MRVL|MU|NBIS|QCOM|SNDK|SPCX|AAOI|AMZN|APLD|AVGO|BABA|BE|COHR|HOOD|INTC|IONQ|META|PLTR|SQQQ|TQQQ|TSLA|TSM)/.*",
       // Commodities (tokenized energy/metal perps — crypto gold XAUT/PAXG kept above)
       "(CL|BZ|NATGAS|XPT)/.*"
     ]

--- a/configs/blacklist-kucoin.json
+++ b/configs/blacklist-kucoin.json
@@ -34,7 +34,7 @@
       // Tokenized stocks (STOCK suffix — universal forward-protection)
       ".*STOCK/.*",
       // Tokenized stocks (direct ticker, no STOCK suffix)
-      "(NVDA|AAPL|AMD|ARM|ASTS|CRWV|DELL|GOOGL|IREN|LITE|MRVL|MSFT|MSTR|MU|NBIS|QCOM|SNDK|SPCX|AAOI|AMZN|APLD|AVGO|BABA|BE|COHR|COIN|CRCL|HOOD|INTC|IONQ|META|PLTR|SQQQ|TQQQ|TSLA|TSM)/.*",
+      "(AAPL|AMD|ARM|ASTS|CRWV|DELL|GOOGL|IREN|LITE|MRVL|MU|NBIS|QCOM|SNDK|SPCX|AAOI|AMZN|APLD|AVGO|BABA|BE|COHR|HOOD|INTC|IONQ|META|PLTR|SQQQ|TQQQ|TSLA|TSM)/.*",
       // Commodities (tokenized energy/metal perps — crypto gold XAUT/PAXG kept above)
       "(CL|BZ|NATGAS|XPT)/.*",
       // Tokenized stocks (X-suffix)

--- a/configs/blacklist-mexc.json
+++ b/configs/blacklist-mexc.json
@@ -38,7 +38,7 @@
       // Tokenized stocks (STOCK suffix — universal forward-protection)
       ".*STOCK/.*",
       // Tokenized stocks (direct ticker, no STOCK suffix)
-      "(NVDA|AAPL|AMD|ARM|ASTS|CRWV|DELL|GOOGL|IREN|LITE|MRVL|MSFT|MSTR|MU|NBIS|QCOM|SNDK|SPCX|AAOI|APLD|BE|SQQQ|AMZN|AVGO|BABA|COHR|COIN|CRCL|HOOD|INTC|IONQ|META|PLTR|TQQQ|TSLA|TSM)/.*",
+      "(AAPL|AMD|ARM|ASTS|CRWV|DELL|GOOGL|IREN|LITE|MRVL|MU|NBIS|QCOM|SNDK|SPCX|AAOI|APLD|BE|SQQQ|AMZN|AVGO|BABA|COHR|HOOD|INTC|IONQ|META|PLTR|TQQQ|TSLA|TSM)/.*",
       // Commodities (tokenized energy/metal perps — crypto gold XAUT/PAXG kept above)
       "(CL|BZ|NATGAS|XPT)/.*",
       // Tokenized stocks (X-suffix)

--- a/configs/blacklist-okx.json
+++ b/configs/blacklist-okx.json
@@ -34,7 +34,7 @@
       // Tokenized stocks (STOCK suffix — universal forward-protection)
       ".*STOCK/.*",
       // Tokenized stocks (direct ticker, no STOCK suffix)
-      "(NVDA|AAPL|AMD|ARM|ASTS|CRWV|DELL|GOOGL|IREN|LITE|MRVL|MSFT|MSTR|MU|NBIS|QCOM|SNDK|SPCX|AAOI|AMZN|APLD|AVGO|BABA|BE|COHR|COIN|CRCL|HOOD|INTC|IONQ|META|PLTR|SQQQ|TQQQ|TSLA|TSM)/.*",
+      "(AAPL|AMD|ARM|ASTS|CRWV|DELL|GOOGL|IREN|LITE|MRVL|MU|NBIS|QCOM|SNDK|SPCX|AAOI|AMZN|APLD|AVGO|BABA|BE|COHR|HOOD|INTC|IONQ|META|PLTR|SQQQ|TQQQ|TSLA|TSM)/.*",
       // Commodities (tokenized energy/metal perps — crypto gold XAUT/PAXG kept above)
       "(CL|BZ|NATGAS|XPT)/.*"
     ]


### PR DESCRIPTION
Follow-up to #1175 (SOXL). We scored the remaining 35 blacklisted tokenized-stock tokens against Binance TRADIFI perp data (24h quote volume + 30d daily OHLCV: avg daily range, 30d return, distance off 30d high) for fit with the strategy's profile (3x dip-buyer with grinding: needs depth for limit entries/grind adds, no structural decay, mean-reversion rather than falling-knife trend). These 5 pass cleanly:

| ticker | 24h vol | avg daily range | 30d | off 30d high | why |
|---|---|---|---|---|---|
| MSTR | $81.4M | 5.1% | +7.0% | −3.8% | BTC-proxy equity, crypto-correlated — closest cousin to what the strategy already trades |
| NVDA | $54.5M | 3.2% | +6.3% | −0.4% | Mega-cap at its highs, deep liquidity, calm range |
| CRCL | $103.1M | 6.6% | +0.8% | −8.9% | Circle — crypto-adjacent, top-3 volume of the whole group |
| COIN | $19.6M | 4.9% | −3.6% | −15.1% | Coinbase, crypto-correlated; mild pullback, not a knife |
| MSFT | $14.3M | 3.0% | +29.5% | −1.2% | Strong steady uptrend at highs |

Kept blacklisted (for now):
- Structural: SQQQ (3x inverse — decays by design), TQQQ (3x leveraged, ~9x effective at 3x strategy leverage; SOXL was the demand-driven exception).
- Current falling knives: SNDK (−37%/30d), TSLA (−19%), HOOD, AMD, NBIS, ARM, META, QCOM, MU, INTC, MRVL, BE — re-scorable once they base out.
- Too thin (<~$20M/24h): DELL, AAPL, TSM, CRWV, IREN, BABA, AVGO, ASTS.
- Watch list for a later batch: SPCX (huge volume but young listing, mid-drawdown), GOOGL, AAOI, LITE, COHR, AMZN.

Scope notes (same as #1175):
- Only the plain `(NVDA|AAPL|...)` tokenized group is touched, all 12 configs, 1 line each.
- Wrapped/derivative products stay blacklisted: Bitget `R(...)` prefixed group and `(...)ON`, Bitmart/Bybit/Gate/MEXC `(...)X` xStocks, Gate `(...)3L/3S` and `(...)ON` — different products, untouched.
- No frozen candles seen in 30d on any of the 34 checked (they price 24/7), but weekend liquidity thins and Monday cash-open gaps are real — we'll watch the first live positions like we're doing with SOXL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)