### PR TITLE
X7: port Squeeze Momentum release scalps (166 long / 664 short), disabled

### DIFF
--- a/NostalgiaForInfinityX7.py
+++ b/NostalgiaForInfinityX7.py
@@ -141,7 +141,7 @@ class NostalgiaForInfinityX7(IStrategy):
   # Long top coins mode tags
   long_top_coins_mode_tags = ["141", "142", "143", "144", "145"]
   # Long scalp mode tags
-  long_scalp_mode_tags = ["161", "162", "163", "164", "165"]
+  long_scalp_mode_tags = ["161", "162", "163", "164", "165", "166"]
 
   long_rebuy_grind_mode_tags = long_rebuy_mode_tags + long_grind_mode_tags
   long_scalp_rebuy_grind_mode_tags = long_scalp_mode_tags + long_rebuy_mode_tags + long_grind_mode_tags
@@ -201,7 +201,7 @@ class NostalgiaForInfinityX7(IStrategy):
   # Short top coins mode tags
   short_top_coins_mode_tags = ["641", "642"]
   # Short scalp mode tags
-  short_scalp_mode_tags = ["661", "662", "663"]
+  short_scalp_mode_tags = ["661", "662", "663", "664"]
 
   short_rebuy_grind_mode_tags = short_rebuy_mode_tags + short_grind_mode_tags
   short_scalp_rebuy_grind_mode_tags = short_scalp_mode_tags + short_rebuy_mode_tags + short_grind_mode_tags
@@ -905,6 +905,7 @@ class NostalgiaForInfinityX7(IStrategy):
     "long_entry_condition_193_enable": False,
     "long_entry_condition_164_enable": False,
     "long_entry_condition_165_enable": False,
+    "long_entry_condition_166_enable": False,
   }
 
   short_entry_signal_params = {
@@ -927,6 +928,7 @@ class NostalgiaForInfinityX7(IStrategy):
     "short_entry_condition_593_enable": False,
     "short_entry_condition_662_enable": False,
     "short_entry_condition_663_enable": False,
+    "short_entry_condition_664_enable": False,
     # "short_entry_condition_603_enable": True,
     # "short_entry_condition_641_enable": True,
     # "short_entry_condition_642_enable": True,
@@ -4163,6 +4165,14 @@ class NostalgiaForInfinityX7(IStrategy):
     _or_valid = df["date"].dt.hour >= 4
     orange_h_col = df["high"].where(_or_first4h).groupby(_or_day).transform("max").where(_or_valid).to_numpy()
     orange_l_col = df["low"].where(_or_first4h).groupby(_or_day).transform("min").where(_or_valid).to_numpy()
+
+    # Squeeze Momentum (LazyBear) — signals 166/664 (experimental): BB inside Keltner = coil
+    _sq_ma = pd.Series(close_np).rolling(20).mean()
+    _sq_rng = pd.Series(high_np - low_np).rolling(20).mean()
+    _sq_kc_u = (_sq_ma + 1.5 * _sq_rng).to_numpy()
+    _sq_kc_l = (_sq_ma - 1.5 * _sq_rng).to_numpy()
+    sqz_on_col = ((bb_lower_20 > _sq_kc_l) & (bb_upper_20 < _sq_kc_u)).astype(float)
+    sqz_cnt24_col = pd.Series(sqz_on_col).rolling(24).sum().to_numpy()
     new_cols = pd.DataFrame(
       {
         "RSI_3": rsi_3,
@@ -4215,6 +4225,9 @@ class NostalgiaForInfinityX7(IStrategy):
         "CVD_SELL_VOL": cvd_sell_vol,
         "ORANGE_H": orange_h_col,
         "ORANGE_L": orange_l_col,
+
+        "SQZ_ON": sqz_on_col,
+        "SQZ_CNT_24": sqz_cnt24_col,
         "STOCH_9_3": quad_s93,
         "STOCH_14_3": quad_s143,
         "STOCH_4_4": quad_s44,
@@ -12932,6 +12945,9 @@ class NostalgiaForInfinityX7(IStrategy):
     orange_l = np_view("ORANGE_L")
     willr_14_4h = np_view("WILLR_14_4h")
     stoch_k_4h = np_view("STOCHk_14_3_3_4h")
+
+    sqz_on = np_view("SQZ_ON")
+    sqz_cnt_24 = np_view("SQZ_CNT_24")
     stoch_9_3 = np_view("STOCH_9_3")
     stoch_14_3 = np_view("STOCH_14_3")
     stoch_4_4 = np_view("STOCH_4_4")
@@ -25896,6 +25912,17 @@ class NostalgiaForInfinityX7(IStrategy):
           long_entry_logic.append(_fib_retr_165 >= 0.5)
           long_entry_logic.append(_fib_retr_165 <= 0.618)
 
+        # Condition #166 - Squeeze Momentum release (Long, experimental, RAW — LazyBear port).
+        if long_entry_condition_index == 166:
+          long_entry_logic.append(num_empty_288 <= allowed_empty_candles_288)
+          long_entry_logic.append(protections_long_global == True)
+          # squeeze RELEASE this candle after a coil (>=12 of the prior 24 candles squeezed)
+          long_entry_logic.append(np_shift(sqz_on, 1) > 0.5)
+          long_entry_logic.append(sqz_on < 0.5)
+          long_entry_logic.append(np_shift(sqz_cnt_24, 1) >= 12.0)
+          # expansion direction: close breaks through the upper band
+          long_entry_logic.append(close > bbu_20_2_0)
+
         long_entry_logic.append(df["volume"] > 0)
         item_long_entry = _and_entry_conditions(long_entry_logic)
         _append_entry_tag(entry_tags, item_long_entry, f"{long_entry_condition_index} ")
@@ -27932,6 +27959,16 @@ class NostalgiaForInfinityX7(IStrategy):
           short_entry_logic.append(np_shift(_fib_retr_663, 1) < 0.5)
           short_entry_logic.append(_fib_retr_663 >= 0.5)
           short_entry_logic.append(_fib_retr_663 <= 0.618)
+
+        # Condition #664 - Squeeze Momentum release (Short, experimental, RAW — mirror).
+        if short_entry_condition_index == 664:
+          short_entry_logic.append(num_empty_288 <= allowed_empty_candles_288)
+          short_entry_logic.append(protections_short_global == True)
+          short_entry_logic.append(np_shift(sqz_on, 1) > 0.5)
+          short_entry_logic.append(sqz_on < 0.5)
+          short_entry_logic.append(np_shift(sqz_cnt_24, 1) >= 12.0)
+          # expansion direction: close breaks through the lower band
+          short_entry_logic.append(close < bbl_20_2_0)
 
         short_entry_logic.append(df["volume"] > 0)
         item_short_entry = _and_entry_conditions(short_entry_logic)


### PR DESCRIPTION
Next external port. Source: the LazyBear **Squeeze Momentum** classic (BB inside Keltner = volatility coil; trade the release in its direction). Ported mechanically on base 5m: `SQZ_ON` (BB(20,2) fully inside KC(20,1.5)) + `SQZ_CNT_24` coil-persistence; trigger = release candle after ≥12/24 squeezed + close through the band on the release side. **166** long / **664** short, scalp-band numbers, scalp-mode placement. Branch is a single commit on current main (de6caae).

**Shipped RAW on purpose.** Honest numbers (2026 gms0, single-entry rig): 1,177 trades, 1,055W-122L (**89.6% WR**), net −$8.4K — high hit-rate, the usual doom-tail economics. We tried the light-touch route and it didn't clear breakeven (best 2-3 gate combos keeping ≥45% of trades: −$143 long / −$1,074 short), so rather than shrink it we're handing you the raw entry + everything we learned for your protection pass:

**Loss scenario classes found (from a per-loss export analysis):**
- shorts against a RISING daily (`ROC_9_1d > ~2.5`) — squeeze fuel;
- shorts into a WASHED-OUT daily (`RSI_3_1d < 15`, daily stochrsi floored) — bounce bait;
- longs on releases without 4h participation (`STOCHRSIk_4h < ~40` while winners sat > 60);
- everything in violent pump/collapse phases (regime transitions) — calm orderly drift is the winning habitat (several pairs ran 24W/0L untouched).

**A curiosity worth knowing:** rescaling the coil to 60-period (15m-scale) with ≥36/72 persistence + the four scenario guards above produced a tiny but perfect variant — 18 trades, 18W-0L, +$1.8K (threshold sweep confirmed tighter>looser). We chose not to ship that miniature; the raw form gives your protection iterations the full population to work with.

All disabled; nothing changes until you enable. Full round archive + per-loss tables: `S197_597_SQUEEZE_MOMENTUM_FOR_ITERATIVV.md` in our repo (test numbering).

🤖 Generated with [Claude Code](https://claude.com/claude-code)