### PR TITLE
Add experimental Williams %R snapback signals 105, 605 (disabled — high-WR raw material + loss anatomy)

### DIFF
--- a/NostalgiaForInfinityX7.py
+++ b/NostalgiaForInfinityX7.py
@@ -894,6 +894,7 @@ class NostalgiaForInfinityX7(IStrategy):
     "long_entry_condition_102_enable": True,
     "long_entry_condition_103_enable": True,
     "long_entry_condition_104_enable": True,
+    "long_entry_condition_105_enable": False,
     "long_entry_condition_120_enable": True,
     "long_entry_condition_121_enable": False,
     "long_entry_condition_141_enable": True,
@@ -931,6 +932,7 @@ class NostalgiaForInfinityX7(IStrategy):
     "short_entry_condition_563_enable": False,
     "short_entry_condition_592_enable": False,
     "short_entry_condition_593_enable": False,
+    "short_entry_condition_605_enable": False,
     "short_entry_condition_662_enable": False,
     "short_entry_condition_663_enable": False,
     "short_entry_condition_664_enable": False,
@@ -23320,6 +23322,19 @@ class NostalgiaForInfinityX7(IStrategy):
             & (((ema_50 - ema_200) / close * 100.0) < -5.5)
           )
 
+        # Condition #105 - Williams %R snapback (Long, experimental — Goodwin mean-reversion port).
+        if long_entry_condition_index == 105:
+          long_entry_logic.append(num_empty_288 <= allowed_empty_candles_288)
+          long_entry_logic.append(protections_long_global == True)
+          # money still flowing in on the hour and a healthy 4h — no dip-buying a bleed
+          long_entry_logic.append(cmf_20_1h > -0.02)
+          long_entry_logic.append(rsi_14_4h > 45.0)
+          # 1h close crosses INTO the oversold extreme (source strategy runs on 30m/1h scale)
+          long_entry_logic.append(willr_14_1h < -90.0)
+          long_entry_logic.append(np_shift(willr_14_1h, 12) >= -90.0)
+          # mean-revert WITH the daily trend: only long when the day is up
+          long_entry_logic.append(change_pct_1d > 0.0)
+
         # Condition #120 - Grind mode (Long).
         if long_entry_condition_index == 120:
           # Protections
@@ -27930,6 +27945,18 @@ class NostalgiaForInfinityX7(IStrategy):
           short_entry_logic.append(rsi_4 > 54.0)
           short_entry_logic.append(rsi_20 > rsi_20_shift_1)
           short_entry_logic.append(close > sma_16 * 1.042)
+
+        # Condition #605 - Williams %R snapback (Short, experimental — mirror).
+        if short_entry_condition_index == 605:
+          short_entry_logic.append(num_empty_288 <= allowed_empty_candles_288)
+          short_entry_logic.append(protections_short_global == True)
+          # never fade the bounce of a fully-capitulated daily (violent squeeze habitat)
+          short_entry_logic.append(rsi_3_1d > 12.0)
+          # 1h close crosses INTO the overbought extreme
+          short_entry_logic.append(willr_14_1h > -10.0)
+          short_entry_logic.append(np_shift(willr_14_1h, 12) <= -10.0)
+          # mean-revert WITH the daily trend: only short when the day is down
+          short_entry_logic.append(change_pct_1d < 0.0)
 
         # Condition #661 - Scalp mode (Short).
         if short_entry_condition_index == 661:


### PR DESCRIPTION
## What

Williams %R mean-reversion snapbacks, rapid-band (105 long / 605 short), shipped **disabled**. Source: Jared Goodwin's 13-year-backtested FX strategy (https://youtu.be/GyikfniCLqU): close crosses INTO the %R extreme (1h scale) → revert, filtered by the day's direction. Zero new columns — `WILLR_14_1h` and `change_pct_1d` already exist; rapid lists already contain 105/605. Diff is 2 flags + 2 dispatch blocks.

## Honest measurements — 2026, grinds disabled (single-entry isolate, v3_2 stops on)

| Config | 105 long | 605 short |
|---|---|---|
| 5m cross raw | 604t, 89.2%, −$4,061 | 695t, 91.4%, −$3,926 |
| 1h cross | 779t, 91.1%, −$3,915 | 924t, 92.5%, −$1,303 |
| + scenario gates (this PR) | **363t, 91.7%, +$1,252** | 990t, 91.0%, −$11,284 |
| 105-only isolate | 586t, 92.7%, −$4,815 | — |

WR sits at 91-93% throughout with ~6-8 fires/day, but the two sides' economics are entangled through slot competition (compare rows 3-4: the same gated 105 is +$1.2K next to 605 and −$4.8K alone). We're handing this over as raw material — the loss anatomy is complete and it needs your per-loss pass, not our light touch.

## Loss anatomy (export + price-path eyeball)

- **605 has ONE death scenario**: fading the violent relief rally of a coin that crashed 15-43% in the prior 24h — price rips +4..+24% within 1-4h after entry (RIVER ×11, −$2,485). At entry the daily is fully washed: `RSI_3_1d ≤ 12` separates it cleanly → the shipped one-line gate `rsi_3_1d > 12.0`.
- **105's death scenario is the "slow bleed"**: after entry price never bounces (+1h ≈ −0.5%, then −5..−11% grind for 12-24h). Shipped gates `cmf_20_1h > -0.02` + `rsi_14_4h > 45.0` took the long side from −$3,915 to +$1,252 in the paired run.
- **Regime note**: the source edge lives in FX majors' mean-reverting regime; crypto's fat tails make the extremes carry trend information as often as reversion information.
- **Method note**: at this fire volume, offline single-signal estimates do not survive real runs — slot coupling reshuffles which entries execute. Judge only full runs.

Full report: `S105_605_WILLIAMS_R_FOR_ITERATIVV.md` in our repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)