### PR TITLE
Add experimental marubozu conviction signals 172, 670 (disabled — BOTH sides positive)

### DIFF
--- a/NostalgiaForInfinityX7.py
+++ b/NostalgiaForInfinityX7.py
@@ -141,7 +141,7 @@ class NostalgiaForInfinityX7(IStrategy):
   # Long top coins mode tags
   long_top_coins_mode_tags = ["141", "142", "143", "144", "145"]
   # Long scalp mode tags
-  long_scalp_mode_tags = ["161", "162", "163", "164", "165", "166", "167", "168", "169", "170", "171"]
+  long_scalp_mode_tags = ["161", "162", "163", "164", "165", "166", "167", "168", "169", "170", "171", "172"]
 
   long_rebuy_grind_mode_tags = long_rebuy_mode_tags + long_grind_mode_tags
   long_scalp_rebuy_grind_mode_tags = long_scalp_mode_tags + long_rebuy_mode_tags + long_grind_mode_tags
@@ -201,7 +201,7 @@ class NostalgiaForInfinityX7(IStrategy):
   # Short top coins mode tags
   short_top_coins_mode_tags = ["641", "642"]
   # Short scalp mode tags
-  short_scalp_mode_tags = ["661", "662", "663", "664", "665", "666", "667"]
+  short_scalp_mode_tags = ["661", "662", "663", "664", "665", "666", "667", "670"]
 
   short_rebuy_grind_mode_tags = short_rebuy_mode_tags + short_grind_mode_tags
   short_scalp_rebuy_grind_mode_tags = short_scalp_mode_tags + short_rebuy_mode_tags + short_grind_mode_tags
@@ -915,6 +915,7 @@ class NostalgiaForInfinityX7(IStrategy):
     "long_entry_condition_169_enable": False,
     "long_entry_condition_170_enable": False,
     "long_entry_condition_171_enable": False,
+    "long_entry_condition_172_enable": False,
   }
 
   short_entry_signal_params = {
@@ -942,6 +943,7 @@ class NostalgiaForInfinityX7(IStrategy):
     "short_entry_condition_665_enable": False,
     "short_entry_condition_666_enable": False,
     "short_entry_condition_667_enable": False,
+    "short_entry_condition_670_enable": False,
     # "short_entry_condition_603_enable": True,
     # "short_entry_condition_641_enable": True,
     # "short_entry_condition_642_enable": True,
@@ -4224,6 +4226,12 @@ class NostalgiaForInfinityX7(IStrategy):
     _ph_h12 = pd.Series(high_np).rolling(12).max().shift(1).to_numpy()
     _ph_l12 = pd.Series(low_np).rolling(12).min().shift(1).to_numpy()
     ph_pre_tight_col = np.divide(_ph_h12 - _ph_l12, close_np, out=np.full_like(close_np, np.nan), where=close_np > 0) * 100.0
+    # Marubozu — signals 172/670 (experimental): full-body candle = pure momentum ignition
+    _mrb_rng = high_np - low_np
+    _mrb_body_ratio = np.divide(np.abs(close_np - open_np), _mrb_rng, out=np.zeros_like(_mrb_rng), where=_mrb_rng > 0)
+    _mrb_body_pct = np.divide(np.abs(close_np - open_np), close_np, out=np.zeros_like(close_np), where=close_np > 0)
+    mrb_bull_col = ((close_np > open_np) & (_mrb_body_ratio > 0.9) & (_mrb_body_pct > 0.005)).astype(float)
+    mrb_bear_col = ((close_np < open_np) & (_mrb_body_ratio > 0.9) & (_mrb_body_pct > 0.005)).astype(float)
     new_cols = pd.DataFrame(
       {
         "RSI_3": rsi_3,
@@ -4236,6 +4244,8 @@ class NostalgiaForInfinityX7(IStrategy):
         "PH_CROSS_CNT_12": ph_cross_cnt12_col,
         "PH_BASE_POS": ph_base_pos_col,
         "PH_PRE_TIGHT": ph_pre_tight_col,
+        "MRB_BULL": mrb_bull_col,
+        "MRB_BEAR": mrb_bear_col,
         "ENGULF_BULL": engulf_bull_col,
         "ENGULF_BEAR": engulf_bear_col,
 
@@ -13114,6 +13124,8 @@ class NostalgiaForInfinityX7(IStrategy):
     ph_base_pos = np_view("PH_BASE_POS")
     ph_pre_tight = np_view("PH_PRE_TIGHT")
     low_px = np_view("low")
+    mrb_bull = np_view("MRB_BULL")
+    mrb_bear = np_view("MRB_BEAR")
     global_protections_short_pump = np_view("global_protections_short_pump")
     global_protections_short_dump = np_view("global_protections_short_dump")
     roc_2 = np_view("ROC_2")
@@ -26151,6 +26163,17 @@ class NostalgiaForInfinityX7(IStrategy):
           # PH_CROSS_CNT_12 first-fire counter) are defined above and ready for your protection
           # pass — shipped RAW per our measurements (character gates halved damage but the raw
           # form carries the highest WR; full matrix in the PR)
+        # Condition #172 - Marubozu momentum (Long, experimental — full-body ignition).
+        if long_entry_condition_index == 172:
+          # trend side + momentum side (the frame proven on the engulfing pair)
+          long_entry_logic.append(rsi_14 > 50.0)
+          # hourly money-flow must support the ignition (no conviction candle in a bleed)
+          long_entry_logic.append(cmf_20_1h > 0.02)
+          # 4h trend must agree — conviction candles inside brief above-EMA windows of a
+          # chronic downtrend are traps (the SOON cluster, verified on the chart)
+          long_entry_logic.append(ema_12_4h > ema_200_4h)
+          # full-body green candle: body >90% of range and a meaningful size
+          long_entry_logic.append(mrb_bull > 0.5)
 
         # Condition #192 - Quad-rotation stochastic pullback (Long, experimental).
         if long_entry_condition_index == 192:
@@ -28237,6 +28260,10 @@ class NostalgiaForInfinityX7(IStrategy):
           short_entry_logic.append(ib_ready > 0.5)
           short_entry_logic.append(np_shift(close, 1) >= ib_mother_l)
           short_entry_logic.append(close < ib_mother_l)
+        # Condition #670 - Marubozu momentum (Short, experimental, RAW — mirror).
+        if short_entry_condition_index == 670:
+          short_entry_logic.append(rsi_14 < 50.0)
+          short_entry_logic.append(mrb_bear > 0.5)
 
         # Condition #592 - Quad-rotation stochastic pullback (Short, experimental).
         if short_entry_condition_index == 592:


### PR DESCRIPTION
## What

Candle-family port #3 (after 167/665 engulfing and 169/667 inside-bar): the **marubozu** — a full-body candle with no wicks is a completed CONVICTION fact (one side controlled the entire candle without a single pullback). Source: the classic pattern (https://youtu.be/K8lhUVwP60c) whose core rule — "only works when the prior story points the same way" — is the EMA200+RSI50 frame proven on our engulfing pair. Shipped **disabled**, scalp tags 172/670 (668/669 left reserved for future short mirrors of 170/171, preserving the band's +498 pairing).

These are candle-scale versions of the two hunters: 670 rides crash legs (best win +66%), 172 rides pump legs (+47%) without the pump-hunter's chase problem — the trigger is a one-candle fact, not a level break.

## Results — 2026, grinds disabled (single-entry isolate, v3_2 stops on)

| Stage | 172 long | 670 short | Portfolio |
|---|---|---|---|
| Raw | 645t, 87.8%, −$8,717 | 620t, 91.5%, **+$1,239** | −$5,034 |
| **Shipped: long dual-gate, short raw** | **251t, 90.8%, +$2,351** | **1,233t, 91.3%, +$602** | **+$12,297** |

**First pair in our candle series with BOTH sides positive.** Fastest typical trades of the family: win medians 2.0h / 2.9h (a quarter of 172's wins close under 36 minutes).

## The gates (each eyeball-verified on charts AND export-calculated)

- **172 `cmf_20_1h > 0.02`** — no conviction candle in an hourly bleed (loss centroid 0.01 vs win 0.04).
- **172 `ema_12_4h > ema_200_4h`** — the heavy lifter (−$8.7K → +$2.4K): green conviction candles inside brief above-EMA200 windows of a chronic downtrend never follow through (the SOON cluster: +1h already negative, −5..−10% within a day).
- **670 deliberately ships RAW** — we tried protections and the measurements rejected them: `roc_9_1d < 2` hurt the real run; `rsi_3_1d` floors show zero separation in 670's own data (d=0.08). A 2-clause combo search finds offline candidates (best: `roc_9_1d<5 & change_pct_1d>-6`, matching the bounce-trap anatomy we saw on charts) but we don't ship single-year mined pairs — listed in the report as raw material for your multi-regime pass.

Method note: real-run populations reshuffle under any gate change (the same short ranged 613→1,233 fires across configs) — we decided everything on full real runs.

Full report: `S172_670_MARUBOZU_FOR_ITERATIVV.md` in our repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)