### PR TITLE
Categorize unlisted experimental tags into normal-mode lists (67/70/71, 192/193, 592/593)

### DIFF
--- a/NostalgiaForInfinityX7.py
+++ b/NostalgiaForInfinityX7.py
@@ -123,7 +123,7 @@ class NostalgiaForInfinityX7(IStrategy):
   num_cores_indicators_calc = 0
 
   # Long Normal mode tags
-  long_normal_mode_tags = ["1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13"]
+  long_normal_mode_tags = ["1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "67", "70", "71", "192", "193"]
   # Long Pump mode tags
   long_pump_mode_tags = ["21", "22", "23", "24", "25", "26"]
   # Long Quick mode tags
@@ -185,7 +185,7 @@ class NostalgiaForInfinityX7(IStrategy):
   # Shorting
 
   # Short normal mode tags
-  short_normal_mode_tags = ["501", "502"]
+  short_normal_mode_tags = ["501", "502", "592", "593"]
   # Short Pump mode tags
   short_pump_mode_tags = ["521", "522", "523", "524", "525", "526"]
   # Short Quick mode tags


### PR DESCRIPTION
Housekeeping: the experimental tags we shipped unlisted (confluence 67/70/71 and the quad-rotation 192/193/592/593) currently reach normal-mode behavior via the unknown-tag fallback. This adds them explicitly to `long_normal_mode_tags` / `short_normal_mode_tags` — same exits, but the membership is now visible and intentional instead of implicit. All tags remain disabled; zero live impact. (Our newer normal-band pairs 7/505 and 8/506 on #1190/#1191 are already listed.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)