### PR TITLE
Blacklist TUT on all 12 venues (parabolic squeeze — 4 accounts hit on one 542 signal candle)

### DIFF
--- a/configs/blacklist-binance.json
+++ b/configs/blacklist-binance.json
@@ -1,6 +1,8 @@
 {
   "exchange": {
     "pair_blacklist": [
+      // Parabolic squeeze — 542 shorts liquidated on 4 accounts, 2026-08-07 (+801%/7d)
+      "(TUT)/.*",
       // Binance delist 2026-08-17 (full-coin) — iterativ 2026-08-03
       "(ACX|PIVX|VIC)/.*",
       // FIGHT all-12 + IDOL (MEET48) — iterativ 2026-08-02

--- a/configs/blacklist-bitget.json
+++ b/configs/blacklist-bitget.json
@@ -1,6 +1,8 @@
 {
   "exchange": {
     "pair_blacklist": [
+      // Parabolic squeeze — 542 shorts liquidated on 4 accounts, 2026-08-07 (+801%/7d)
+      "(TUT)/.*",
       // Declining alt (2026-08-07; binance already covers via FAN group)
       "(CHZ)/.*",
       // Binance delist 2026-08-17 (full-coin) — iterativ 2026-08-03

--- a/configs/blacklist-bitmart.json
+++ b/configs/blacklist-bitmart.json
@@ -1,6 +1,8 @@
 {
   "exchange": {
     "pair_blacklist": [
+      // Parabolic squeeze — 542 shorts liquidated on 4 accounts, 2026-08-07 (+801%/7d)
+      "(TUT)/.*",
       // Declining alt (2026-08-07; binance already covers via FAN group)
       "(CHZ)/.*",
       // Binance delist 2026-08-17 (full-coin) — iterativ 2026-08-03

--- a/configs/blacklist-bitvavo.json
+++ b/configs/blacklist-bitvavo.json
@@ -1,6 +1,8 @@
 {
   "exchange": {
     "pair_blacklist": [
+      // Parabolic squeeze — 542 shorts liquidated on 4 accounts, 2026-08-07 (+801%/7d)
+      "(TUT)/.*",
       // Declining alt (2026-08-07; binance already covers via FAN group)
       "(CHZ)/.*",
       // Binance delist 2026-08-17 (full-coin) — iterativ 2026-08-03

--- a/configs/blacklist-bybit.json
+++ b/configs/blacklist-bybit.json
@@ -1,6 +1,8 @@
 {
   "exchange": {
     "pair_blacklist": [
+      // Parabolic squeeze — 542 shorts liquidated on 4 accounts, 2026-08-07 (+801%/7d)
+      "(TUT)/.*",
       // Declining alt (2026-08-07; binance already covers via FAN group)
       "(CHZ)/.*",
       // Binance delist 2026-08-17 (full-coin) — iterativ 2026-08-03

--- a/configs/blacklist-gateio.json
+++ b/configs/blacklist-gateio.json
@@ -1,6 +1,8 @@
 {
   "exchange": {
     "pair_blacklist": [
+      // Parabolic squeeze — 542 shorts liquidated on 4 accounts, 2026-08-07 (+801%/7d)
+      "(TUT)/.*",
       // Declining alt (2026-08-07; binance already covers via FAN group)
       "(CHZ)/.*",
       // Binance delist 2026-08-17 (full-coin) — iterativ 2026-08-03

--- a/configs/blacklist-htx.json
+++ b/configs/blacklist-htx.json
@@ -1,6 +1,8 @@
 {
   "exchange": {
     "pair_blacklist": [
+      // Parabolic squeeze — 542 shorts liquidated on 4 accounts, 2026-08-07 (+801%/7d)
+      "(TUT)/.*",
       // Declining alt (2026-08-07; binance already covers via FAN group)
       "(CHZ)/.*",
       // Binance delist 2026-08-17 (full-coin) — iterativ 2026-08-03

--- a/configs/blacklist-hyperliquid.json
+++ b/configs/blacklist-hyperliquid.json
@@ -1,6 +1,8 @@
 {
   "exchange": {
     "pair_blacklist": [
+      // Parabolic squeeze — 542 shorts liquidated on 4 accounts, 2026-08-07 (+801%/7d)
+      "(TUT)/.*",
       // Declining alt (2026-08-07; binance already covers via FAN group)
       "(CHZ)/.*",
       // Binance delist 2026-08-17 (full-coin) — iterativ 2026-08-03

--- a/configs/blacklist-kraken.json
+++ b/configs/blacklist-kraken.json
@@ -1,6 +1,8 @@
 {
   "exchange": {
     "pair_blacklist": [
+      // Parabolic squeeze — 542 shorts liquidated on 4 accounts, 2026-08-07 (+801%/7d)
+      "(TUT)/.*",
       // Declining alt (2026-08-07; binance already covers via FAN group)
       "(CHZ)/.*",
       // Binance delist 2026-08-17 (full-coin) — iterativ 2026-08-03

--- a/configs/blacklist-kucoin.json
+++ b/configs/blacklist-kucoin.json
@@ -1,6 +1,8 @@
 {
   "exchange": {
     "pair_blacklist": [
+      // Parabolic squeeze — 542 shorts liquidated on 4 accounts, 2026-08-07 (+801%/7d)
+      "(TUT)/.*",
       // Declining alt (2026-08-07; binance already covers via FAN group)
       "(CHZ)/.*",
       // Binance delist 2026-08-17 (full-coin) — iterativ 2026-08-03

--- a/configs/blacklist-mexc.json
+++ b/configs/blacklist-mexc.json
@@ -1,6 +1,8 @@
 {
   "exchange": {
     "pair_blacklist": [
+      // Parabolic squeeze — 542 shorts liquidated on 4 accounts, 2026-08-07 (+801%/7d)
+      "(TUT)/.*",
       // Declining alt (2026-08-07; binance already covers via FAN group)
       "(CHZ)/.*",
       // Binance delist 2026-08-17 (full-coin) — iterativ 2026-08-03

--- a/configs/blacklist-okx.json
+++ b/configs/blacklist-okx.json
@@ -1,6 +1,8 @@
 {
   "exchange": {
     "pair_blacklist": [
+      // Parabolic squeeze — 542 shorts liquidated on 4 accounts, 2026-08-07 (+801%/7d)
+      "(TUT)/.*",
       // Declining alt (2026-08-07; binance already covers via FAN group)
       "(CHZ)/.*",
       // Binance delist 2026-08-17 (full-coin) — iterativ 2026-08-03


### PR DESCRIPTION
Per your call after today's review.

**What happened.** Tag 542 (top fade, short) fired on TUT/USDT at 2026-08-07 07:15-07:18 UTC on all three of our live bots and on a community Bitget X7 bot that reported it on Discord — same coin, same tag, same candle, four independent accounts:

| Account | Venue | Exit | Result |
|---|---|---|---|
| ours | Binance | force_exit (manual) | −$139.58 (−55.1%) |
| ours | Bybit | **liquidation** | −$63.67 (−55.6%) |
| ours | Bitget | force_exit (manual) | −$31.97 (−55.3%) |
| community | Bitget | **liquidation** (Aug 9) | −113.50 USDT |

TUT then ran from ~0.031 to 0.2054 within 48h (**~+500% against the short**), with daily ranges of 68% → 230% → 264%. It is **+801% over 7 days**, still 45% off its top, and carries **$2.2B** of 24h Binance volume — so it stays in every volume whitelist and can fire again. Present on Binance, Bybit and Bitget (and elsewhere), hence all 12 files rather than one venue.

**Why the existing protections did not see it** (measured on the signal candle, close 0.03044): 24h return +9.7%, 4h +9.7%, 1h +6.8%, 26.5% above the 24h low, 2.9% below the 24h high, relative volume 2.72×. Every 24-hour-scale feature read ordinary. The extreme was **multi-day**: +89% on the week with four consecutive 20-40% daily ranges. If you ever want a guard for this class rather than the coin, that is the axis the data points at — multi-day momentum plus a daily-range regime check — since nothing at the 24h scale was loud.

Temporary by intent: same removal path as ORDI / ID / TURBO / SAPIEN once it calms down.

🤖 Generated with [Claude Code](https://claude.com/claude-code)