### PR TITLE
Blacklist LSK and STX (Binance monitoring tag — delisting-risk watchlist)

### DIFF
--- a/configs/blacklist-binance.json
+++ b/configs/blacklist-binance.json
@@ -1,6 +1,8 @@
 {
   "exchange": {
     "pair_blacklist": [
+      // Binance monitoring tag 2026-08 (delisting-risk watchlist)
+      "(LSK|STX)/.*",
       // Parabolic squeeze — 542 shorts liquidated on 4 accounts, 2026-08-07 (+801%/7d)
       "(TUT)/.*",
       // Binance delist 2026-08-17 (full-coin) — iterativ 2026-08-03

--- a/configs/blacklist-bitget.json
+++ b/configs/blacklist-bitget.json
@@ -1,6 +1,8 @@
 {
   "exchange": {
     "pair_blacklist": [
+      // Binance monitoring tag 2026-08 (delisting-risk watchlist)
+      "(LSK)/.*",
       // Parabolic squeeze — 542 shorts liquidated on 4 accounts, 2026-08-07 (+801%/7d)
       "(TUT)/.*",
       // Declining alt (2026-08-07; binance already covers via FAN group)

--- a/configs/blacklist-bitmart.json
+++ b/configs/blacklist-bitmart.json
@@ -1,6 +1,8 @@
 {
   "exchange": {
     "pair_blacklist": [
+      // Binance monitoring tag 2026-08 (delisting-risk watchlist)
+      "(LSK)/.*",
       // Parabolic squeeze — 542 shorts liquidated on 4 accounts, 2026-08-07 (+801%/7d)
       "(TUT)/.*",
       // Declining alt (2026-08-07; binance already covers via FAN group)

--- a/configs/blacklist-bitvavo.json
+++ b/configs/blacklist-bitvavo.json
@@ -1,6 +1,8 @@
 {
   "exchange": {
     "pair_blacklist": [
+      // Binance monitoring tag 2026-08 (delisting-risk watchlist)
+      "(LSK|STX)/.*",
       // Parabolic squeeze — 542 shorts liquidated on 4 accounts, 2026-08-07 (+801%/7d)
       "(TUT)/.*",
       // Declining alt (2026-08-07; binance already covers via FAN group)

--- a/configs/blacklist-bybit.json
+++ b/configs/blacklist-bybit.json
@@ -1,6 +1,8 @@
 {
   "exchange": {
     "pair_blacklist": [
+      // Binance monitoring tag 2026-08 (delisting-risk watchlist)
+      "(LSK|STX)/.*",
       // Parabolic squeeze — 542 shorts liquidated on 4 accounts, 2026-08-07 (+801%/7d)
       "(TUT)/.*",
       // Declining alt (2026-08-07; binance already covers via FAN group)

--- a/configs/blacklist-gateio.json
+++ b/configs/blacklist-gateio.json
@@ -1,6 +1,8 @@
 {
   "exchange": {
     "pair_blacklist": [
+      // Binance monitoring tag 2026-08 (delisting-risk watchlist)
+      "(LSK|STX)/.*",
       // Parabolic squeeze — 542 shorts liquidated on 4 accounts, 2026-08-07 (+801%/7d)
       "(TUT)/.*",
       // Declining alt (2026-08-07; binance already covers via FAN group)

--- a/configs/blacklist-htx.json
+++ b/configs/blacklist-htx.json
@@ -1,6 +1,8 @@
 {
   "exchange": {
     "pair_blacklist": [
+      // Binance monitoring tag 2026-08 (delisting-risk watchlist)
+      "(LSK|STX)/.*",
       // Parabolic squeeze — 542 shorts liquidated on 4 accounts, 2026-08-07 (+801%/7d)
       "(TUT)/.*",
       // Declining alt (2026-08-07; binance already covers via FAN group)

--- a/configs/blacklist-hyperliquid.json
+++ b/configs/blacklist-hyperliquid.json
@@ -1,6 +1,8 @@
 {
   "exchange": {
     "pair_blacklist": [
+      // Binance monitoring tag 2026-08 (delisting-risk watchlist)
+      "(LSK|STX)/.*",
       // Parabolic squeeze — 542 shorts liquidated on 4 accounts, 2026-08-07 (+801%/7d)
       "(TUT)/.*",
       // Declining alt (2026-08-07; binance already covers via FAN group)

--- a/configs/blacklist-kraken.json
+++ b/configs/blacklist-kraken.json
@@ -1,6 +1,8 @@
 {
   "exchange": {
     "pair_blacklist": [
+      // Binance monitoring tag 2026-08 (delisting-risk watchlist)
+      "(LSK|STX)/.*",
       // Parabolic squeeze — 542 shorts liquidated on 4 accounts, 2026-08-07 (+801%/7d)
       "(TUT)/.*",
       // Declining alt (2026-08-07; binance already covers via FAN group)

--- a/configs/blacklist-kucoin.json
+++ b/configs/blacklist-kucoin.json
@@ -1,6 +1,8 @@
 {
   "exchange": {
     "pair_blacklist": [
+      // Binance monitoring tag 2026-08 (delisting-risk watchlist)
+      "(LSK|STX)/.*",
       // Parabolic squeeze — 542 shorts liquidated on 4 accounts, 2026-08-07 (+801%/7d)
       "(TUT)/.*",
       // Declining alt (2026-08-07; binance already covers via FAN group)

--- a/configs/blacklist-mexc.json
+++ b/configs/blacklist-mexc.json
@@ -1,6 +1,8 @@
 {
   "exchange": {
     "pair_blacklist": [
+      // Binance monitoring tag 2026-08 (delisting-risk watchlist)
+      "(LSK)/.*",
       // Parabolic squeeze — 542 shorts liquidated on 4 accounts, 2026-08-07 (+801%/7d)
       "(TUT)/.*",
       // Declining alt (2026-08-07; binance already covers via FAN group)

--- a/configs/blacklist-okx.json
+++ b/configs/blacklist-okx.json
@@ -1,6 +1,8 @@
 {
   "exchange": {
     "pair_blacklist": [
+      // Binance monitoring tag 2026-08 (delisting-risk watchlist)
+      "(LSK|STX)/.*",
       // Parabolic squeeze — 542 shorts liquidated on 4 accounts, 2026-08-07 (+801%/7d)
       "(TUT)/.*",
       // Declining alt (2026-08-07; binance already covers via FAN group)


### PR DESCRIPTION
Binance added **ACX, LSK and STX** to its Monitoring Tag — the same early-warning list that preceded the Aug-17 delist batch: ACX, PIVX, PYR and VANRY all carried the tag weeks before their delisting was announced. ACX is already covered by the delist group; this adds the other two.

Current state before this PR:

| Coin | our files | Binance perp 24h vol | Bybit | Bitget |
|---|---|---|---|---|
| ACX | 12/12 (delist group) | delisting Aug 17 | — | — |
| **LSK** | **0/12** | $38.6M | $6.5M | $2.3M |
| **STX** | **3/12** (bitget, bitmart, mexc) | $3.7M | $1.1M | $0.7M |

So STX was already blacklisted on three venues — the current state looks accidental rather than deliberate, and this completes it.

Cost check before proposing: neither coin has ever produced a trade on any of our three live bots (Binance, Bybit, Bitget), so pre-empting the tag costs no measurable volume. The upside is closing the gap we hit with PIVX, where we only caught the coin at delist-announcement time.

If you would rather act only on confirmed delistings, the minimum consistent alternative is to complete STX to 12/12 and drop LSK from this PR — happy to trim it either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)