### PR TITLE
Blacklist GLMR, ICX, MOVR, SOPH (Binance monitoring tag, 2026-08-11 batch)

### DIFF
--- a/configs/blacklist-binance.json
+++ b/configs/blacklist-binance.json
@@ -1,6 +1,8 @@
 {
   "exchange": {
     "pair_blacklist": [
+      // Binance monitoring tag 2026-08-11 (delisting-risk watchlist, batch 2)
+      "(GLMR|ICX|MOVR|SOPH)/.*",
       // Binance monitoring tag 2026-08 (delisting-risk watchlist)
       "(LSK|STX)/.*",
       // Parabolic squeeze — 542 shorts liquidated on 4 accounts, 2026-08-07 (+801%/7d)

--- a/configs/blacklist-bitget.json
+++ b/configs/blacklist-bitget.json
@@ -1,6 +1,8 @@
 {
   "exchange": {
     "pair_blacklist": [
+      // Binance monitoring tag 2026-08-11 (delisting-risk watchlist, batch 2)
+      "(GLMR|ICX|MOVR|SOPH)/.*",
       // Binance monitoring tag 2026-08 (delisting-risk watchlist)
       "(LSK)/.*",
       // Parabolic squeeze — 542 shorts liquidated on 4 accounts, 2026-08-07 (+801%/7d)

--- a/configs/blacklist-bitmart.json
+++ b/configs/blacklist-bitmart.json
@@ -1,6 +1,8 @@
 {
   "exchange": {
     "pair_blacklist": [
+      // Binance monitoring tag 2026-08-11 (delisting-risk watchlist, batch 2)
+      "(GLMR|ICX|MOVR|SOPH)/.*",
       // Binance monitoring tag 2026-08 (delisting-risk watchlist)
       "(LSK)/.*",
       // Parabolic squeeze — 542 shorts liquidated on 4 accounts, 2026-08-07 (+801%/7d)

--- a/configs/blacklist-bitvavo.json
+++ b/configs/blacklist-bitvavo.json
@@ -1,6 +1,8 @@
 {
   "exchange": {
     "pair_blacklist": [
+      // Binance monitoring tag 2026-08-11 (delisting-risk watchlist, batch 2)
+      "(GLMR|ICX|MOVR|SOPH)/.*",
       // Binance monitoring tag 2026-08 (delisting-risk watchlist)
       "(LSK|STX)/.*",
       // Parabolic squeeze — 542 shorts liquidated on 4 accounts, 2026-08-07 (+801%/7d)

--- a/configs/blacklist-bybit.json
+++ b/configs/blacklist-bybit.json
@@ -1,6 +1,8 @@
 {
   "exchange": {
     "pair_blacklist": [
+      // Binance monitoring tag 2026-08-11 (delisting-risk watchlist, batch 2)
+      "(GLMR|ICX|MOVR|SOPH)/.*",
       // Binance monitoring tag 2026-08 (delisting-risk watchlist)
       "(LSK|STX)/.*",
       // Parabolic squeeze — 542 shorts liquidated on 4 accounts, 2026-08-07 (+801%/7d)

--- a/configs/blacklist-gateio.json
+++ b/configs/blacklist-gateio.json
@@ -1,6 +1,8 @@
 {
   "exchange": {
     "pair_blacklist": [
+      // Binance monitoring tag 2026-08-11 (delisting-risk watchlist, batch 2)
+      "(GLMR|ICX|MOVR|SOPH)/.*",
       // Binance monitoring tag 2026-08 (delisting-risk watchlist)
       "(LSK|STX)/.*",
       // Parabolic squeeze — 542 shorts liquidated on 4 accounts, 2026-08-07 (+801%/7d)

--- a/configs/blacklist-htx.json
+++ b/configs/blacklist-htx.json
@@ -1,6 +1,8 @@
 {
   "exchange": {
     "pair_blacklist": [
+      // Binance monitoring tag 2026-08-11 (delisting-risk watchlist, batch 2)
+      "(GLMR|ICX|MOVR|SOPH)/.*",
       // Binance monitoring tag 2026-08 (delisting-risk watchlist)
       "(LSK|STX)/.*",
       // Parabolic squeeze — 542 shorts liquidated on 4 accounts, 2026-08-07 (+801%/7d)

--- a/configs/blacklist-hyperliquid.json
+++ b/configs/blacklist-hyperliquid.json
@@ -1,6 +1,8 @@
 {
   "exchange": {
     "pair_blacklist": [
+      // Binance monitoring tag 2026-08-11 (delisting-risk watchlist, batch 2)
+      "(GLMR|ICX|MOVR|SOPH)/.*",
       // Binance monitoring tag 2026-08 (delisting-risk watchlist)
       "(LSK|STX)/.*",
       // Parabolic squeeze — 542 shorts liquidated on 4 accounts, 2026-08-07 (+801%/7d)

--- a/configs/blacklist-kraken.json
+++ b/configs/blacklist-kraken.json
@@ -1,6 +1,8 @@
 {
   "exchange": {
     "pair_blacklist": [
+      // Binance monitoring tag 2026-08-11 (delisting-risk watchlist, batch 2)
+      "(GLMR|ICX|MOVR|SOPH)/.*",
       // Binance monitoring tag 2026-08 (delisting-risk watchlist)
       "(LSK|STX)/.*",
       // Parabolic squeeze — 542 shorts liquidated on 4 accounts, 2026-08-07 (+801%/7d)

--- a/configs/blacklist-kucoin.json
+++ b/configs/blacklist-kucoin.json
@@ -1,6 +1,8 @@
 {
   "exchange": {
     "pair_blacklist": [
+      // Binance monitoring tag 2026-08-11 (delisting-risk watchlist, batch 2)
+      "(GLMR|ICX|MOVR|SOPH)/.*",
       // Binance monitoring tag 2026-08 (delisting-risk watchlist)
       "(LSK|STX)/.*",
       // Parabolic squeeze — 542 shorts liquidated on 4 accounts, 2026-08-07 (+801%/7d)

--- a/configs/blacklist-mexc.json
+++ b/configs/blacklist-mexc.json
@@ -1,6 +1,8 @@
 {
   "exchange": {
     "pair_blacklist": [
+      // Binance monitoring tag 2026-08-11 (delisting-risk watchlist, batch 2)
+      "(GLMR|ICX|MOVR|SOPH)/.*",
       // Binance monitoring tag 2026-08 (delisting-risk watchlist)
       "(LSK)/.*",
       // Parabolic squeeze — 542 shorts liquidated on 4 accounts, 2026-08-07 (+801%/7d)

--- a/configs/blacklist-okx.json
+++ b/configs/blacklist-okx.json
@@ -1,6 +1,8 @@
 {
   "exchange": {
     "pair_blacklist": [
+      // Binance monitoring tag 2026-08-11 (delisting-risk watchlist, batch 2)
+      "(GLMR|ICX|MOVR|SOPH)/.*",
       // Binance monitoring tag 2026-08 (delisting-risk watchlist)
       "(LSK|STX)/.*",
       // Parabolic squeeze — 542 shorts liquidated on 4 accounts, 2026-08-07 (+801%/7d)


### PR DESCRIPTION
Follow-up to #1198. On 2026-08-11 Binance added five more coins to its Monitoring Tag: **Moonbeam (GLMR), ICON (ICX), Moonriver (MOVR), SuperRare (RARE) and Sophon (SOPH)**. RARE is already 12/12 in our files; this covers the other four.

The tag has just proven itself as a leading indicator: **all six coins delisting on Aug 17 carried it first** — ACX (team winding the project down), HFT (inflationary tokenomics), PIVX (privacy-coin regulation), PYR (ecosystem collapse), VANRY (no on-chain activity), VIC (doubled supply). The gap we hit with PIVX was exactly this: we only caught it at announcement time.

| Coin | our files before | Binance perp 24h | Bybit | Bitget |
|---|---|---|---|---|
| **GLMR** | 0/12 | ~$0M (illiquid) | — | — |
| **ICX** | 0/12 | $2.7M | $0.5M | $0.3M |
| **MOVR** | 0/12 | $12.4M | $2.3M | $1.3M |
| RARE | 12/12 ✓ | $37.7M | $5.3M | $2.4M |
| **SOPH** | 0/12 | $5.6M | $1.5M | $0.2M |

Cost check, same as last time: **none of the four has ever produced a trade on any of our three live bots** (Binance, Bybit, Bitget), so this blocks nothing we were actually earning from. MOVR independently shows up in today's drop scan at −31.8% on the week and 35.9% off its top, which is what a flagged coin under pressure looks like.

Happy to trim to a subset if you would rather act only on confirmed delistings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)