### PR TITLE
Blacklist SYN, COOKIE, DODO/DODOX, STORJ (Binance monitoring tag 2026-08)

### DIFF
--- a/configs/blacklist-binance.json
+++ b/configs/blacklist-binance.json
@@ -2,7 +2,7 @@
   "exchange": {
     "pair_blacklist": [
       // Binance monitoring tag 2026-08-11 (delisting-risk watchlist, batch 2)
-      "(GLMR|ICX|MOVR|SOPH)/.*",
+      "(GLMR|ICX|MOVR|SOPH|SYN|COOKIE|DODO|DODOX|STORJ)/.*",
       // Binance monitoring tag 2026-08 (delisting-risk watchlist)
       "(LSK|STX)/.*",
       // Parabolic squeeze — 542 shorts liquidated on 4 accounts, 2026-08-07 (+801%/7d)

--- a/configs/blacklist-bitget.json
+++ b/configs/blacklist-bitget.json
@@ -2,7 +2,7 @@
   "exchange": {
     "pair_blacklist": [
       // Binance monitoring tag 2026-08-11 (delisting-risk watchlist, batch 2)
-      "(GLMR|ICX|MOVR|SOPH)/.*",
+      "(GLMR|ICX|MOVR|SOPH|SYN|COOKIE|DODO|DODOX|STORJ)/.*",
       // Binance monitoring tag 2026-08 (delisting-risk watchlist)
       "(LSK)/.*",
       // Parabolic squeeze — 542 shorts liquidated on 4 accounts, 2026-08-07 (+801%/7d)

--- a/configs/blacklist-bitmart.json
+++ b/configs/blacklist-bitmart.json
@@ -2,7 +2,7 @@
   "exchange": {
     "pair_blacklist": [
       // Binance monitoring tag 2026-08-11 (delisting-risk watchlist, batch 2)
-      "(GLMR|ICX|MOVR|SOPH)/.*",
+      "(GLMR|ICX|MOVR|SOPH|SYN|COOKIE|DODO|DODOX|STORJ)/.*",
       // Binance monitoring tag 2026-08 (delisting-risk watchlist)
       "(LSK)/.*",
       // Parabolic squeeze — 542 shorts liquidated on 4 accounts, 2026-08-07 (+801%/7d)

--- a/configs/blacklist-bitvavo.json
+++ b/configs/blacklist-bitvavo.json
@@ -2,7 +2,7 @@
   "exchange": {
     "pair_blacklist": [
       // Binance monitoring tag 2026-08-11 (delisting-risk watchlist, batch 2)
-      "(GLMR|ICX|MOVR|SOPH)/.*",
+      "(GLMR|ICX|MOVR|SOPH|SYN|COOKIE|DODO|DODOX|STORJ)/.*",
       // Binance monitoring tag 2026-08 (delisting-risk watchlist)
       "(LSK|STX)/.*",
       // Parabolic squeeze — 542 shorts liquidated on 4 accounts, 2026-08-07 (+801%/7d)

--- a/configs/blacklist-bybit.json
+++ b/configs/blacklist-bybit.json
@@ -2,7 +2,7 @@
   "exchange": {
     "pair_blacklist": [
       // Binance monitoring tag 2026-08-11 (delisting-risk watchlist, batch 2)
-      "(GLMR|ICX|MOVR|SOPH)/.*",
+      "(GLMR|ICX|MOVR|SOPH|SYN|COOKIE|DODO|DODOX|STORJ)/.*",
       // Binance monitoring tag 2026-08 (delisting-risk watchlist)
       "(LSK|STX)/.*",
       // Parabolic squeeze — 542 shorts liquidated on 4 accounts, 2026-08-07 (+801%/7d)

--- a/configs/blacklist-gateio.json
+++ b/configs/blacklist-gateio.json
@@ -2,7 +2,7 @@
   "exchange": {
     "pair_blacklist": [
       // Binance monitoring tag 2026-08-11 (delisting-risk watchlist, batch 2)
-      "(GLMR|ICX|MOVR|SOPH)/.*",
+      "(GLMR|ICX|MOVR|SOPH|SYN|COOKIE|DODO|DODOX|STORJ)/.*",
       // Binance monitoring tag 2026-08 (delisting-risk watchlist)
       "(LSK|STX)/.*",
       // Parabolic squeeze — 542 shorts liquidated on 4 accounts, 2026-08-07 (+801%/7d)

--- a/configs/blacklist-htx.json
+++ b/configs/blacklist-htx.json
@@ -2,7 +2,7 @@
   "exchange": {
     "pair_blacklist": [
       // Binance monitoring tag 2026-08-11 (delisting-risk watchlist, batch 2)
-      "(GLMR|ICX|MOVR|SOPH)/.*",
+      "(GLMR|ICX|MOVR|SOPH|SYN|COOKIE|DODO|DODOX|STORJ)/.*",
       // Binance monitoring tag 2026-08 (delisting-risk watchlist)
       "(LSK|STX)/.*",
       // Parabolic squeeze — 542 shorts liquidated on 4 accounts, 2026-08-07 (+801%/7d)

--- a/configs/blacklist-hyperliquid.json
+++ b/configs/blacklist-hyperliquid.json
@@ -2,7 +2,7 @@
   "exchange": {
     "pair_blacklist": [
       // Binance monitoring tag 2026-08-11 (delisting-risk watchlist, batch 2)
-      "(GLMR|ICX|MOVR|SOPH)/.*",
+      "(GLMR|ICX|MOVR|SOPH|SYN|COOKIE|DODO|DODOX|STORJ)/.*",
       // Binance monitoring tag 2026-08 (delisting-risk watchlist)
       "(LSK|STX)/.*",
       // Parabolic squeeze — 542 shorts liquidated on 4 accounts, 2026-08-07 (+801%/7d)

--- a/configs/blacklist-kraken.json
+++ b/configs/blacklist-kraken.json
@@ -2,7 +2,7 @@
   "exchange": {
     "pair_blacklist": [
       // Binance monitoring tag 2026-08-11 (delisting-risk watchlist, batch 2)
-      "(GLMR|ICX|MOVR|SOPH)/.*",
+      "(GLMR|ICX|MOVR|SOPH|SYN|COOKIE|DODO|DODOX|STORJ)/.*",
       // Binance monitoring tag 2026-08 (delisting-risk watchlist)
       "(LSK|STX)/.*",
       // Parabolic squeeze — 542 shorts liquidated on 4 accounts, 2026-08-07 (+801%/7d)

--- a/configs/blacklist-kucoin.json
+++ b/configs/blacklist-kucoin.json
@@ -2,7 +2,7 @@
   "exchange": {
     "pair_blacklist": [
       // Binance monitoring tag 2026-08-11 (delisting-risk watchlist, batch 2)
-      "(GLMR|ICX|MOVR|SOPH)/.*",
+      "(GLMR|ICX|MOVR|SOPH|SYN|COOKIE|DODO|DODOX|STORJ)/.*",
       // Binance monitoring tag 2026-08 (delisting-risk watchlist)
       "(LSK|STX)/.*",
       // Parabolic squeeze — 542 shorts liquidated on 4 accounts, 2026-08-07 (+801%/7d)

--- a/configs/blacklist-mexc.json
+++ b/configs/blacklist-mexc.json
@@ -2,7 +2,7 @@
   "exchange": {
     "pair_blacklist": [
       // Binance monitoring tag 2026-08-11 (delisting-risk watchlist, batch 2)
-      "(GLMR|ICX|MOVR|SOPH)/.*",
+      "(GLMR|ICX|MOVR|SOPH|SYN|COOKIE|DODO|DODOX|STORJ)/.*",
       // Binance monitoring tag 2026-08 (delisting-risk watchlist)
       "(LSK)/.*",
       // Parabolic squeeze — 542 shorts liquidated on 4 accounts, 2026-08-07 (+801%/7d)

--- a/configs/blacklist-okx.json
+++ b/configs/blacklist-okx.json
@@ -2,7 +2,7 @@
   "exchange": {
     "pair_blacklist": [
       // Binance monitoring tag 2026-08-11 (delisting-risk watchlist, batch 2)
-      "(GLMR|ICX|MOVR|SOPH)/.*",
+      "(GLMR|ICX|MOVR|SOPH|SYN|COOKIE|DODO|DODOX|STORJ)/.*",
       // Binance monitoring tag 2026-08 (delisting-risk watchlist)
       "(LSK|STX)/.*",
       // Parabolic squeeze — 542 shorts liquidated on 4 accounts, 2026-08-07 (+801%/7d)


### PR DESCRIPTION
Binance extended the monitoring tag to **ALCX, COOKIE, DODO, EPIC, HEI, HFT, STORJ, SYN, TLM**. Five were already covered 12/12; these four were not:

| coin | venues (active swaps) | note |
|---|---|---|
| SYN | binance, bitget | |
| COOKIE | binance, bybit, bitget | |
| DODO | binance only — **as `DODOX`** | both names added; a `DODO` pattern does not fullmatch `DODOX/USDT:USDT`, the same gap TSTBSC had in #1200 |
| STORJ | binance, bybit, bitget | |

The tag has been the reliable early warning — every token delisted on August 17 carried it first, ACX by only 24 days.

Worth noting for anyone holding these: a blacklist entry blocks new entries only, it does not touch open trades. All four have traded profitably in our fleet recently (SYN +$51, COOKIE +$27, DODO +$26 across binance/bybit/bitget), so this is pre-emption with a real premium rather than removing dead weight — same call as LSK/STX in #1198, but those had never traded.

One line changed per file, nothing else touched.