### PR TITLE
X7: signal 171: add protections (pump hunter gate round)

### DIFF
--- a/NostalgiaForInfinityX7.py
+++ b/NostalgiaForInfinityX7.py
@@ -13243,6 +13243,8 @@ class NostalgiaForInfinityX7(IStrategy):
     low_min_12_1h = np_view("low_min_12_1h")
     low_min_30_1d = np_view("low_min_30_1d")
     rsi_14_change_pct_4h = np_view("RSI_14_change_pct_4h")
+    stochk_14_3_3_1h = np_view("STOCHk_14_3_3_1h")
+    uo_7_14_28_15m = np_view("UO_7_14_28_15m")
     stochk_14_3_3_4h = np_view("STOCHk_14_3_3_4h")
     uo_7_14_28_change_pct_15m = np_view("UO_7_14_28_change_pct_15m")
     stochrsi_k_change_pct_4h = np_view("STOCHRSIk_14_14_3_3_change_pct_4h")
@@ -26322,12 +26324,59 @@ class NostalgiaForInfinityX7(IStrategy):
           long_entry_logic.append(protections_long_global == True)
           # calm base: not already pumped over the rolling 24h (ride ignition, don't chase)
           long_entry_logic.append(roc_288 < 10.0)
-          # ignition: green candle CROSSING above the prior 48-candle high...
-          long_entry_logic.append(close > open_rate)
+          # ignition: green candle with a real body, closing in its upper half, CROSSING above
+          # the prior 48-candle high (a doji-sized "ignition" or one that closes back in the lower
+          # half of its own range has no follow-through: measured -4,693 and -4,587 respectively)
+          long_entry_logic.append(close > (open_rate * 1.002))
+          long_entry_logic.append(close > ((high_px + low_px) / 2.0))
           long_entry_logic.append(np_shift(close, 1) <= np_shift(close_max_48, 1))
           long_entry_logic.append(close > np_shift(close_max_48, 1))
-          # ...on explosive volume (pump signature)
-          long_entry_logic.append(vol_rel > 3.0)
+          # ...on explosive volume (pump signature). Unlike the dump hunter, where 3.0 is the
+          # sweet spot, the pump side loses in the 3-4x band (-5,767 over 343 trades) — the
+          # ignition needs real participation, not a routine tick up in volume
+          long_entry_logic.append(vol_rel > 4.0)
+          # do not buy an ignition while the higher timeframes are caving: the 4h RSI must not be
+          # collapsing, hourly money flow must not be drained, and the pair must not already be
+          # deep in the red over the rolling 24h (the mirror of what the dump hunter needs)
+          long_entry_logic.append(rsi_14_change_pct_4h > -15.0)
+          long_entry_logic.append(mfi_14_1h > 25.0)
+          long_entry_logic.append(roc_288 > -6.0)
+          # nor after the hourly momentum has already tripled (late chase), nor with the daily
+          # pinned at its floor, nor out of an hourly base too tight to have a move in it
+          long_entry_logic.append(rsi_3_change_pct_1h < 200.0)
+          long_entry_logic.append(rsi_3_1d > 8.0)
+          long_entry_logic.append(bbb_20_2_0_1h > 2.0)
+          # and not at the very top of the multi-day hourly range: buying an ignition there is the
+          # late chase that produced the fattest losses (WILLR_84_1h at the ceiling)
+          long_entry_logic.append(willr_84_1h < -1.9)
+          long_entry_logic.append(stochrsi_k_4h > 2.0)
+          long_entry_logic.append(ph_base_pos > 2.0)
+          # no 4h rejection wick over the ignition, 15m momentum not caving, and not pinned at the
+          # 40h extreme high (the long-side reading of the room-to-move check)
+          long_entry_logic.append(top_wick_pct_4h < 3.0)
+          long_entry_logic.append(rsi_3_change_pct_15m > -40.0)
+          # the 15m must not be in a dead zone and the 5m must not already have gone vertical
+          long_entry_logic.append(uo_7_14_28_15m > 43.0)
+          long_entry_logic.append(rsi_14_change_pct < 55.0)
+          # the hourly stochastic must not be parked at the ceiling and the 4h oscillator must not
+          # already have exploded (the long-side reading of the dump hunter's rollover check)
+          long_entry_logic.append(stochk_14_3_3_1h < 95.0)
+          long_entry_logic.append(stochrsi_k_change_pct_4h < 250.0)
+          # the ignition must actually be up on the candle, and the 5m oscillator must not be
+          # already maxed out when we buy it
+          long_entry_logic.append(change_pct > 0.22)
+          long_entry_logic.append(stochrsi_k < 100.0)
+          # nor with the rotation stochastic already maxed, the 4h momentum caved, or 15m volume
+          # flow collapsing under the ignition
+          long_entry_logic.append(quad_s93_max_12 < 100.0)
+          long_entry_logic.append(rsi_3_change_pct_4h > -50.0)
+          long_entry_logic.append(obv_change_pct_15m > -32.0)
+          # and the hourly must not be washed out underneath the ignition — together with the
+          # ceiling checks above this brackets the 1h into a band instead of an extreme
+          long_entry_logic.append(stoch_4_4 > 59.0)
+          long_entry_logic.append(willr_14_1h > -82.0)
+          long_entry_logic.append(stochrsi_k_1h > 6.0)
+          long_entry_logic.append(willr_480 < -1.4)
           # NOTE: the measured PUMP CHARACTER columns (PH_BASE_POS d=0.95, PH_PRE_TIGHT d=0.65,
           # PH_CROSS_CNT_12 first-fire counter) are defined above and ready for your protection
           # pass — shipped RAW per our measurements (character gates halved damage but the raw


### PR DESCRIPTION
Same treatment as 669 in #1201, on the raw pump hunter from #1187. **Stays disabled.**

Rig: `position_adjustment_enable=False`, `derisk_enable=False`, `system_v3_2_stops_enable=True`, 171 the only experimental tag on (669 off so its gates do not compete for slots).

## 2026 gms0

| stage | trades | net | losses | WR | portfolio |
|---|---|---|---|---|---|
| raw | 977 | −$8,608 | 105 | 89.3% | −$6,716 |
| +logic tightening | 1,063 | +$92 | 99 | 90.7% | +$7,822 |
| **final (25 gates)** | **865** | **+$37,285** | **69** | **92.0%** | **+$65,629** |

## What they say

The mirror of the dump hunter's sentence — *do not buy an ignition while the higher timeframes are caving, and do not buy one that has already gone vertical*:

- **not caving**: `rsi_14_change_pct_4h > −15`, `rsi_3_change_pct_4h > −50`, `mfi_14_1h > 25`, `roc_288 > −6`, `obv_change_pct_15m > −32`
- **not late / vertical**: `rsi_3_change_pct_1h < 200`, `rsi_14_change_pct < 55`, `stochrsi_k_change_pct_4h < 250`, `willr_84_1h < −1.9`, `willr_480 < −1.4`, `stochk_14_3_3_1h < 95`, `stochrsi_k < 100`, `quad_s93_max_12 < 100`
- **not washed out underneath**: `rsi_3_1d > 8`, `stochrsi_k_4h > 2`, `stochrsi_k_1h > 6`, `stoch_4_4 > 59`, `willr_14_1h > −82`, `uo_7_14_28_15m > 43`, `ph_base_pos > 2`
- **base and candle**: `bbb_20_2_0_1h > 2`, `top_wick_pct_4h < 3`, `change_pct > 0.22`

The single biggest step was tightening the ignition definition itself (+$2,968 tag / +$4,707 portfolio):

```python
close > (open_rate * 1.002)          # a real body: the 0-0.2% band is -$4,693
close > ((high_px + low_px) / 2.0)   # closes in its upper half: lower-half closes -$4,587
vol_rel > 4.0                        # was 3.0: the 3-4x band is -$5,767 over 343 trades
```

That volume result is the **opposite** of 669, where 3.0 is load-bearing and dropping it to 2.0 destroys 92% of the profit. Same parameter, opposite behaviour — nothing here was mirrored from the short side blind, each gate was measured on 171's own data.

## Out of sample — not established yet, stated plainly

669 was validated on 2022 and held, but that is a short signal in a bear year, i.e. its own turf. Running 171 through 2022 gives 1,263t / −$11,633 / WR 86.9% — a year that is structurally hostile to a long ignition-rider, and we do not have the matching raw-2022 baseline to say whether the gates helped or hurt *within* it. The meaningful test is a rising or mixed year (2021 / 2024 / 2025), and it has not been run yet; the fitting year 2026 was itself a −32.6% market.

So: strong on the year it was fitted on, unvalidated elsewhere. Shipping disabled; the rising-market run will be posted here when it lands.

Diff is the 171 block plus 2 `np_view` lines; all referenced columns already exist.