### PR TITLE
Blacklist APR, VELVET (all 12) + complete STX on bitget/bitmart/mexc

### DIFF
--- a/configs/blacklist-binance.json
+++ b/configs/blacklist-binance.json
@@ -7,6 +7,8 @@
       "(LSK|STX)/.*",
       // Parabolic squeeze — 542 shorts liquidated on 4 accounts, 2026-08-07 (+801%/7d)
       "(TUT)/.*",
+      // Pump-and-dump knives — APR +192% then -68% (2026-08-12/15), VELVET -46% in an hour (2026-07-24)
+      "(APR|VELVET)/.*",
       // Binance delist 2026-08-17 (full-coin) — iterativ 2026-08-03
       "(ACX|PIVX|VIC)/.*",
       // FIGHT all-12 + IDOL (MEET48) — iterativ 2026-08-02

--- a/configs/blacklist-bitget.json
+++ b/configs/blacklist-bitget.json
@@ -4,9 +4,11 @@
       // Binance monitoring tag 2026-08-11 (delisting-risk watchlist, batch 2)
       "(GLMR|ICX|MOVR|SOPH|SYN|COOKIE|DODO|DODOX|STORJ)/.*",
       // Binance monitoring tag 2026-08 (delisting-risk watchlist)
-      "(LSK)/.*",
+      "(LSK|STX)/.*",
       // Parabolic squeeze — 542 shorts liquidated on 4 accounts, 2026-08-07 (+801%/7d)
       "(TUT)/.*",
+      // Pump-and-dump knives — APR +192% then -68% (2026-08-12/15), VELVET -46% in an hour (2026-07-24)
+      "(APR|VELVET)/.*",
       // Declining alt (2026-08-07; binance already covers via FAN group)
       "(CHZ)/.*",
       // Binance delist 2026-08-17 (full-coin) — iterativ 2026-08-03

--- a/configs/blacklist-bitmart.json
+++ b/configs/blacklist-bitmart.json
@@ -4,9 +4,11 @@
       // Binance monitoring tag 2026-08-11 (delisting-risk watchlist, batch 2)
       "(GLMR|ICX|MOVR|SOPH|SYN|COOKIE|DODO|DODOX|STORJ)/.*",
       // Binance monitoring tag 2026-08 (delisting-risk watchlist)
-      "(LSK)/.*",
+      "(LSK|STX)/.*",
       // Parabolic squeeze — 542 shorts liquidated on 4 accounts, 2026-08-07 (+801%/7d)
       "(TUT)/.*",
+      // Pump-and-dump knives — APR +192% then -68% (2026-08-12/15), VELVET -46% in an hour (2026-07-24)
+      "(APR|VELVET)/.*",
       // Declining alt (2026-08-07; binance already covers via FAN group)
       "(CHZ)/.*",
       // Binance delist 2026-08-17 (full-coin) — iterativ 2026-08-03

--- a/configs/blacklist-bitvavo.json
+++ b/configs/blacklist-bitvavo.json
@@ -7,6 +7,8 @@
       "(LSK|STX)/.*",
       // Parabolic squeeze — 542 shorts liquidated on 4 accounts, 2026-08-07 (+801%/7d)
       "(TUT)/.*",
+      // Pump-and-dump knives — APR +192% then -68% (2026-08-12/15), VELVET -46% in an hour (2026-07-24)
+      "(APR|VELVET)/.*",
       // Declining alt (2026-08-07; binance already covers via FAN group)
       "(CHZ)/.*",
       // Binance delist 2026-08-17 (full-coin) — iterativ 2026-08-03

--- a/configs/blacklist-bybit.json
+++ b/configs/blacklist-bybit.json
@@ -7,6 +7,8 @@
       "(LSK|STX)/.*",
       // Parabolic squeeze — 542 shorts liquidated on 4 accounts, 2026-08-07 (+801%/7d)
       "(TUT)/.*",
+      // Pump-and-dump knives — APR +192% then -68% (2026-08-12/15), VELVET -46% in an hour (2026-07-24)
+      "(APR|VELVET)/.*",
       // Declining alt (2026-08-07; binance already covers via FAN group)
       "(CHZ)/.*",
       // Binance delist 2026-08-17 (full-coin) — iterativ 2026-08-03

--- a/configs/blacklist-gateio.json
+++ b/configs/blacklist-gateio.json
@@ -7,6 +7,8 @@
       "(LSK|STX)/.*",
       // Parabolic squeeze — 542 shorts liquidated on 4 accounts, 2026-08-07 (+801%/7d)
       "(TUT)/.*",
+      // Pump-and-dump knives — APR +192% then -68% (2026-08-12/15), VELVET -46% in an hour (2026-07-24)
+      "(APR|VELVET)/.*",
       // Declining alt (2026-08-07; binance already covers via FAN group)
       "(CHZ)/.*",
       // Binance delist 2026-08-17 (full-coin) — iterativ 2026-08-03

--- a/configs/blacklist-htx.json
+++ b/configs/blacklist-htx.json
@@ -7,6 +7,8 @@
       "(LSK|STX)/.*",
       // Parabolic squeeze — 542 shorts liquidated on 4 accounts, 2026-08-07 (+801%/7d)
       "(TUT)/.*",
+      // Pump-and-dump knives — APR +192% then -68% (2026-08-12/15), VELVET -46% in an hour (2026-07-24)
+      "(APR|VELVET)/.*",
       // Declining alt (2026-08-07; binance already covers via FAN group)
       "(CHZ)/.*",
       // Binance delist 2026-08-17 (full-coin) — iterativ 2026-08-03

--- a/configs/blacklist-hyperliquid.json
+++ b/configs/blacklist-hyperliquid.json
@@ -7,6 +7,8 @@
       "(LSK|STX)/.*",
       // Parabolic squeeze — 542 shorts liquidated on 4 accounts, 2026-08-07 (+801%/7d)
       "(TUT)/.*",
+      // Pump-and-dump knives — APR +192% then -68% (2026-08-12/15), VELVET -46% in an hour (2026-07-24)
+      "(APR|VELVET)/.*",
       // Declining alt (2026-08-07; binance already covers via FAN group)
       "(CHZ)/.*",
       // Binance delist 2026-08-17 (full-coin) — iterativ 2026-08-03

--- a/configs/blacklist-kraken.json
+++ b/configs/blacklist-kraken.json
@@ -7,6 +7,8 @@
       "(LSK|STX)/.*",
       // Parabolic squeeze — 542 shorts liquidated on 4 accounts, 2026-08-07 (+801%/7d)
       "(TUT)/.*",
+      // Pump-and-dump knives — APR +192% then -68% (2026-08-12/15), VELVET -46% in an hour (2026-07-24)
+      "(APR|VELVET)/.*",
       // Declining alt (2026-08-07; binance already covers via FAN group)
       "(CHZ)/.*",
       // Binance delist 2026-08-17 (full-coin) — iterativ 2026-08-03

--- a/configs/blacklist-kucoin.json
+++ b/configs/blacklist-kucoin.json
@@ -7,6 +7,8 @@
       "(LSK|STX)/.*",
       // Parabolic squeeze — 542 shorts liquidated on 4 accounts, 2026-08-07 (+801%/7d)
       "(TUT)/.*",
+      // Pump-and-dump knives — APR +192% then -68% (2026-08-12/15), VELVET -46% in an hour (2026-07-24)
+      "(APR|VELVET)/.*",
       // Declining alt (2026-08-07; binance already covers via FAN group)
       "(CHZ)/.*",
       // Binance delist 2026-08-17 (full-coin) — iterativ 2026-08-03

--- a/configs/blacklist-mexc.json
+++ b/configs/blacklist-mexc.json
@@ -4,9 +4,11 @@
       // Binance monitoring tag 2026-08-11 (delisting-risk watchlist, batch 2)
       "(GLMR|ICX|MOVR|SOPH|SYN|COOKIE|DODO|DODOX|STORJ)/.*",
       // Binance monitoring tag 2026-08 (delisting-risk watchlist)
-      "(LSK)/.*",
+      "(LSK|STX)/.*",
       // Parabolic squeeze — 542 shorts liquidated on 4 accounts, 2026-08-07 (+801%/7d)
       "(TUT)/.*",
+      // Pump-and-dump knives — APR +192% then -68% (2026-08-12/15), VELVET -46% in an hour (2026-07-24)
+      "(APR|VELVET)/.*",
       // Declining alt (2026-08-07; binance already covers via FAN group)
       "(CHZ)/.*",
       // Binance delist 2026-08-17 (full-coin) — iterativ 2026-08-03

--- a/configs/blacklist-okx.json
+++ b/configs/blacklist-okx.json
@@ -7,6 +7,8 @@
       "(LSK|STX)/.*",
       // Parabolic squeeze — 542 shorts liquidated on 4 accounts, 2026-08-07 (+801%/7d)
       "(TUT)/.*",
+      // Pump-and-dump knives — APR +192% then -68% (2026-08-12/15), VELVET -46% in an hour (2026-07-24)
+      "(APR|VELVET)/.*",
       // Declining alt (2026-08-07; binance already covers via FAN group)
       "(CHZ)/.*",
       // Binance delist 2026-08-17 (full-coin) — iterativ 2026-08-03


### PR DESCRIPTION
Per your call today: APR and VELVET, plus STX where it was not already blacklisted.

## APR (Apriori) — buyback pump and collapse

| Date | Move | Day range | Volume |
|---|---|---|---|
| 2026-08-12 | **+192%** (0.2078 → 0.6074) | 205.9% | **$1.37B** |
| 2026-08-13 | −18% | 54.4% | $737M |
| 2026-08-15 | **−68%** (0.511 → 0.162) | **265.2%** | $214M |

Now −72.5% from its 45-day high, still trading $209M/24h.

## VELVET — chronic knife

| Date | Event | Day range | Volume |
|---|---|---|---|
| 2026-07-24 | 0.4771 → 0.2589 in about an hour (**−46%**) | 84.3% | $85M |
| 2026-08-11 | | **107.1%** | $284M |
| 2026-08-14 | | **135.2%** | $224M |

Six daily ranges above 50% in the last 45 days.

## Why the blacklist rather than leaving it to the pairlist

`RangeStabilityFilter` (3-day lookback, `max_rate_of_change: 0.95`) does block both today — but only today. Measured on the three completed days:

| Coin | 3d RoC | Filter |
|---|---|---|
| APR | 3.12 | blocked |
| VELVET | 1.60 | blocked |

The window is rolling, so each name drops out of the whitelist during an event and returns after 72 quiet hours, still just as thin. VELVET already reached a live bot that way once.

Both are junk-class names that can list on any venue, so all 12 configs.

## STX — consistency fix

The crypto pattern `(LSK|STX)/.*` is present in nine configs but reads `(LSK)/.*` in **bitget, bitmart and mexc**. Those three files do contain the string `STX`, but only inside the tokenized-stock list, where it is **Seagate**, not Stacks — which is why the gap was easy to miss on a plain grep. STX carries the Binance monitoring tag, so this completes 12/12.

## Verification

- All 12 files parse as valid JSON with comments stripped.
- No ticker added twice; `APR`/`VELVET` were absent from every pattern in every config beforehand.
- Post-change coverage: APR 12/12, VELVET 12/12, STX 12/12 (crypto patterns only, tokenized-stock list excluded from the match).