### PR TITLE
X7: signal 505: protections for the ADX trend-birth short

### DIFF
--- a/NostalgiaForInfinityX7.py
+++ b/NostalgiaForInfinityX7.py
@@ -27148,12 +27148,70 @@ class NostalgiaForInfinityX7(IStrategy):
 
         # Condition #505 - ADX trend-birth (Short, experimental, RAW — mirror).
         if short_entry_condition_index == 505:
+          # Protections
           short_entry_logic.append(num_empty_288 <= allowed_empty_candles_288)
           short_entry_logic.append(protections_short_global == True)
-          short_entry_logic.append(adx_14_4h > 20.0)
-          short_entry_logic.append(np_shift(adx_14_4h, 48) <= 20.0)
-          short_entry_logic.append(minus_di_14_4h > plus_di_14_4h)
-          short_entry_logic.append(close < ema_200)
+
+          short_entry_logic.append(
+            # 5m thrust up while price is already well off its 40h low
+            ((rsi_3 < 85.0) | (willr_480 < -75.0))
+            # 15m printing a fresh low with the 5m bid
+            & ((cmf_20 < 0.15) | aroond_14_15m_lt_80)
+            # 15m at its low with a fresh 5m high
+            & ((aroonu_14 < 95.0) | (willr_14_15m > -60.0))
+            # 15m stoch on the floor while the 5m has lifted
+            & ((stochrsi_k < 50.0) | (stochk_14_3_3_15m > 10.0))
+            # 15m falling fast while the 5m is off its low
+            & ((willr_14 < -30.0) | (roc_9_15m > -2.0))
+            # 1h stoch on the floor while the 5m dumps
+            & ((cmf_20 > -0.3) | (stochk_14_3_3_1h > 10.0))
+            # 1h snapback off an oversold low
+            & (stochrsi_k_1h_lt_60 | (rsi_14_1h > 40.0))
+            # 1h squeezed flat with money coming in
+            & ((bbb_20_2_0_1h > 5.0) | (mfi_14_1h < 55.0))
+            # 15m recovered with the 4h pinned at its floor
+            & ((rsi_3_15m < 30.0) | (willr_14_4h > -95.0))
+            # 1h selling into a 4h that is not weak
+            & ((cmf_20_1h > -0.25) | (uo_7_14_28_4h < 45.0))
+            # 15m bid into a 4h that has already dropped
+            & ((mfi_14_15m < 55.0) | (roc_2_4h > -3.0))
+            # 4h high recent, 4h still no selling
+            & (aroonu_14_4h_lt_50 | (mfi_14_4h < 35.0))
+            # 1h stretched while the 4h RSI_3 collapses
+            & ((uo_7_14_28_1h < 55.0) | (rsi_3_change_pct_4h > -30.0))
+            # 15m and 4h both flat — nothing is going down
+            & ((roc_9_15m < -0.5) | (roc_9_4h < -1.0))
+            # 1h up inside a 4h that has already dropped
+            & ((change_pct_1h < 0.0) | (change_pct_4h > -5.0))
+            # 1d strong with buyers defending a long lower wick
+            & ((rsi_14_1d < 55.0) | (bot_wick_pct_1d < 1.5))
+            # 15m selling into a flat day
+            & ((cmf_20_15m > -0.25) | (change_pct_1d < -1.0))
+            # 15m bid while the day collapses
+            & ((cmf_20_15m < 0.15) | (rsi_3_change_pct_1d > -50.0))
+            # 1h bid while the two-day drift is flat
+            & ((mfi_14_1h < 45.0) | (roc_2_1d < -3.0))
+            # 15m bouncing hard, 1d pinned at its low
+            & (aroonu_14_15m_lt_80 | (willr_14_1d > -90.0))
+            # 1d down move spent, 1h off the floor
+            & (stochrsi_k_1h_lt_20 | rsi_3_1d_gt_20)
+            # 1d printing a fresh 14-day low while its stoch is not washed out
+            & ((stochk_14_3_3_1d < 40.0) | (aroond_14_1d < 90.0))
+            # 1d strong underneath a topped-out fast stoch
+            & ((stoch_4_4 < 80.0) | (rsi_14_1d < 55.0))
+            # 4h already down hard under a day that is still firm
+            & ((change_pct_4h > -5.0) | rsi_14_1d_lt_50)
+          )
+
+          # Logic
+          short_entry_logic.append(
+            # 4h trend birth: ADX up through 20 after 8 quiet days
+            (adx_14_4h > 20.0)
+            & (np_shift(adx_14_4h, 48) <= 20.0)
+            # pointing down, under the 200 EMA
+            & (minus_di_14_4h > plus_di_14_4h)
+            & (close < ema_200)
+          )
 
         # Condition #506 - Donchian 7-day breakdown (Short, experimental, RAW — mirror).
         if short_entry_condition_index == 506:


### PR DESCRIPTION
505 (ADX trend-birth, short) shipped raw in #1190. This adds **24 protection chains**, built on **2022** — a short's scene is richest in a bear year — with every step decided by its own full backtest.

Signal stays **disabled**. Rig: `position_adjustment_enable=False`, `derisk_enable=False`, `system_v3_2_stops_enable=True`, 505 the only experimental tag enabled, gms0.

| | trades | losses | percent points | per trade |
|---|---:|---:|---:|---:|
| raw | 468 | 44 (9.4%) | +637.3 | +1.362% |
| 3 backbone chains | 362 | 17 | +1184.7 | +3.273% |
| **+ per-loss chains** | **326** | **1 (0.3%)** | **+1624.6** | **+4.983%** |

70% of the volume kept, loss rate down from 9.4% to 0.3%, return per trade 3.7x.

## What the signal was doing wrong

The month table has one story in it. 505 is excellent in a falling market and loses money in a rising one:

| month | BTC | 505 per trade | loss rate |
|---|---|---|---|
| Jan | falling | **+5.96%** | 0% |
| Mar | +5.4% | -2.16% | 16.7% |
| **Jul** | **+16.9%** | **-7.10%** | **32%** |
| Sep | -3.1% (rally inside it) | -4.44% | 21.4% |

Losses cluster by **day**, not by pair — six on 2022-07-26, five of six trades on 09-07. BTC regime columns are out, so the rally had to be said through each coin's own timeframes. Measured, the entry-moment form of "the market is rallying" is **the drop is already spent**: the day has been falling hard for three sessions and the hour is no longer on the floor.

The three backbone chains say that in three places:

```python
# 1h snapback off an oversold low
(stochrsi_k_1h_lt_60 | (rsi_14_1h > 40.0))
# 4h high recent, 4h still no selling
& (aroonu_14_4h_lt_50 | (mfi_14_4h < 35.0))
# 1d down move spent, 1h off the floor
& (stochrsi_k_1h_lt_20 | rsi_3_1d_gt_20)
```

## Two things worth reporting

**Blocking a candle postpones the trade, it does not remove it.** A setup lasts hours; the signal re-evaluates every 5m. Rules built on fast axes moved entries forward by minutes and the losses came back: FIL 09-07 walked 00:00 -> 00:45 -> 01:30 -> 03:05 across four rounds, and went away entirely on the first **daily**-level rule. Every rule here that actually removed a loss is 1h/4h/1d state.

**Correlated columns are not necessarily redundant clauses.** The first chain pairs `stochrsi_k_1h` and `rsi_14_1h` at r = 0.78. Replacing it with an independent clause at r = 0.12 looked more correct and **cost three losses** (326t/1L -> 333t/4L). Thresholded in opposite directions, a correlated pair carves the band where the two disagree — here, the hour whose stochastic has lifted while RSI is still low. Same direction plus correlation is the case that repeats itself.

## Style

Grouped by timeframe (5m -> 15m -> 1h -> 4h -> 1d, each chain in the group of its highest), family-ordered inside each group, clauses ordered low timeframe to high. Every 0-100 oscillator threshold is a multiple of 5; the CMF values (-0.30, -0.25, 0.15) are ones already in use elsewhere in the file. Cached booleans used where they exist. Two clauses each, three where a third was needed. The reordering was verified behaviour-neutral.

## The remaining loss is deliberate

AVAX 2022-03-07 stays in. Entry-candle rules only postpone it (04:00 -> 04:05 -> 04:15 -> 05:00 across five rounds; a three-clause chain that blocked it for zero winners changed the result by -0.2 points). Persistent rules can reach it, but it is not distinct from the winners there — it sits at the 4th percentile of an axis the winners occupy too, and the cheapest route costs **27 winners for one loss**, dropping total points from 1624 to ~1541. Zero losses is not the target.

## Out of sample

Fitted on 2022 only. 2021 (the hostile bull regime) has not been run yet, and 2023/2020 are held out untouched. One year is a fit, not a validation — saying so rather than presenting it otherwise.
