### PR TITLE
X7: signal 506: fine-tune the entry

### DIFF
--- a/NostalgiaForInfinityX7.py
+++ b/NostalgiaForInfinityX7.py
@@ -27376,11 +27376,26 @@ class NostalgiaForInfinityX7(IStrategy):
 
         # Condition #506 - Donchian 7-day breakdown (Short, experimental, RAW — mirror).
         if short_entry_condition_index == 506:
+          # Protections
           short_entry_logic.append(num_empty_288 <= allowed_empty_candles_288)
           short_entry_logic.append(protections_short_global == True)
-          short_entry_logic.append(close < open_rate)
-          short_entry_logic.append(np_shift(close, 1) >= dc_low_7d)
-          short_entry_logic.append(close < dc_low_7d)
+
+          short_entry_logic.append(
+            # the day is still up while the last 24h flushed hard
+            ((roc_9_1d < 0.0) | (roc_288 > -15.0))
+            # a vertical ten-minute drop while the 4h high is over a day old
+            & ((roc_2 > -5.0) | (aroonu_14_4h > 40.0))
+            # 1h money exhausted after a two-day drop
+            & ((mfi_14_1h > 25.0) | (roc_2_1d > -7.0))
+          )
+
+          # Logic
+          short_entry_logic.append(
+            # first close below the prior 7-day low
+            (close < open_rate)
+            & (np_shift(close, 1) >= dc_low_7d)
+            & (close < dc_low_7d)
+          )
 
         # Condition #541 - Quick mode (Short).
         if short_entry_condition_index == 541:


### PR DESCRIPTION
Signal 506 (short, Donchian 7-day-low breakdown) stays **disabled**. It had no protections at all; this adds three, measured on 2021 and 2022 with gms0 configs, position adjustment and de-risk off, v3_2 stops on, and 506 the only experimental tag enabled.

| year | raw | +1 chain | +2 chains | +3 chains |
|---|---|---|---|---|
| 2021 | 1059t / 188L / −1126 | 989t / 154L / −148 | 957t / 136L / +424 | **873t / 113L / +864** |
| 2022 | 1543t / 163L / +1546 | 1541t / 162L / +1574 | 1518t / 153L / +1740 | **1450t / 143L / +1924** |
| total | **+420** | +1426 | +2164 | **+2788** |

Average winner +5.15% against an average loss of −35.85%, so break-even is 0.144 losses per winner forgone; all three chains run well above it.

### What the losses are, before writing anything

Each loss was classified by what price did after entry, read from the candles: **131 of 134 in 2022 and 146 of 159 in 2021 are entry problems** (the break fails, or bleeds and reverses), only 3 and 13 are trades whose entry was right and whose exit was not. Worth checking before spending a round on entry chains.

Winners and losses separate sharply on the same measure:

| | winner | loss |
|---|---|---|
| 24h low | −6.21% | −1.29% |
| time to low | 8.5h | **0.5h** |
| first two hours | −0.04% | **+2.69%** |
| fell during the first two hours | 50% | **8%** |

A losing break turns up within two hours 92% of the time and prints its low half an hour in — the entry *is* the bottom.

### The chains

**`((roc_9_1d < 0.0) | (roc_288 > -15.0))`** — the daily is still up while the last 24h fell 15% or more. A scenario census over entry state put this box at a 25-28% loss rate against a base of 11%. Chart, RUNE 2021-05-19: 15.7 → 8.5 within an hour, the signal shorts 8.96, an hour later 13.92 — +55% against a 3x short, which is where that day's −99.4% trades come from.

**`& ((roc_2 > -5.0) | (aroonu_14_4h > 40.0))`** — a vertical ten-minute drop while the 4h high is over a day old. A 45-minute window was tried first and cut too many winners: on 2021-05-19 it blocked 3 losses and cut 5 winners where the ten-minute version blocks the same 3 and cuts 3. The two it releases are BNB 11:35 (+33.4%) and 04:30 (+9.8%), where the 45-minute drop read −7.8% and −7.2% but the ten-minute drop only −4.7% and −4.9%. The mistake is not selling a decline, it is selling **the last vertical candle** of one.

**`& ((mfi_14_1h > 25.0) | (roc_2_1d > -7.0))`** — hourly money flow washed out at 25 or below after a two-day fall of 7% or more: the sellers are finished and the break is sold anyway. Chart, ETH on the FTX night 2022-11-09 23:15 — entry 1096.87 after falling from 1191 through the evening, `MFI_14_1h` 22.8, `ROC_2_1d` −14.9, and the next fourteen hours give a low of −2.35% against a high of +12.41%. The threshold sits on a plateau: −5 +1011, −6 +1043, −7 +1066, −8 +855, −10 +745.

### Two limits worth stating

All three chains say the same thing from different hours — *do not sell a break once the move is over* — so this is one failure family found three times rather than three findings.

And they cannot separate pairs like SAND 2021-12-04, which wins +25.3% at 05:05 and loses −41.9% at 05:30 with identical 1h and 1d readings. Both are blocked; part of the winner cost is exactly that.

2024, 2025 and 2026 have not been run yet. `roc_288` is an axis we use and you do not — happy to swap it if you would rather keep the palette narrow.