### PR TITLE
X7: signal 192: add quad-pullback entry protection + scoped doom stop

### DIFF
--- a/NostalgiaForInfinityX7.py
+++ b/NostalgiaForInfinityX7.py
@@ -2066,6 +2066,13 @@ class NostalgiaForInfinityX7(IStrategy):
       trade, current_time, current_rate, filled_orders, filled_entries, filled_exits, profit_values
     )
 
+    # Signal 192 (Quad pullback long) tight doom stop: every 192 loss bottoms at a
+    # 11.8-14% price drop (the shared 0.35 doom threshold) while winners' max adverse
+    # excursion sits below 9.63% price. Scoping 192's doom to -0.30 margin (~10% price
+    # at 3x) flips the tag net-positive without touching any other signal's exit.
+    if "192" in enter_tags and current_profit <= -0.30:
+      return f"exit_long_normal_stoploss_doom ( {enter_tag})"
+
     max_profit = 0.0
     max_loss = 0.0
 
@@ -26474,6 +26481,25 @@ class NostalgiaForInfinityX7(IStrategy):
           long_entry_logic.append((rsi_14_1h < 55.0) | (rsi_14_1h > 65.0) | (roc_9_1d > 0.0))
           # Round 3 (RUNE loss): 1d capitulation + money outflow = knife; need 1d alive OR inflow
           long_entry_logic.append((rsi_3_1d > 15.0) | (cmf_20 > -0.10))
+          # Round 4 (5-regime group: SAND 21, AXS 24, AVAX 24, GALA 25): quad-oversold pullback into a
+          # weak 1d with no hourly money flow = falling-knife day; need 1d alive OR hourly inflow
+          long_entry_logic.append((rsi_14_1d >= 40.0) | (cmf_20_1h >= 0.0))
+          # Round 5 (4h-exhausted group: CRV 21-09, CRV 25-03, AXS 25-08): quad-oversold fade at a 4h
+          # top already stretched (1h hot + 4h ROC rising) = chasing the top; need 1h cool OR 4h flat
+          long_entry_logic.append((rsi_14_1h < 74.0) | (roc_9_4h < 13.0))
+          # Round 6 (XRP 21-04): 4h actively collapsing (rate-of-change -16) = knife, not a dip
+          long_entry_logic.append(roc_9_4h > -15.0)
+          # Round 7 (ETH 22-04): 15m money-flow collapse (OBV -64 pct) at a 4h still-stretched top
+          long_entry_logic.append(obv_change_pct_15m > -64.2)
+          # Round 8 (LINK 24-03): pullback entered while the 15m momentum was snapping higher
+          # (UO change 19) right before the top; block entries with that hot 15m momentum
+          long_entry_logic.append(uo_7_14_28_change_pct_15m < 19.0)
+          # Round 9 (LINK 24-06): 1h RSI collapsing >-30 pct at entry = falling knife, not a dip
+          long_entry_logic.append(rsi_3_change_pct_1h > -30.0)
+          # Round 10 (5-regime group: DOT 21, ETH 24, LINK 24, DOGE 25, GALA 26): pullback entered
+          # with 1h momentum already weakening (CCI change negative) OR a 4h still in downtrend
+          # (Aroon-D < 80) OR no 1d money inflow (MFI <= 45) = dead-cat fade, not a reversal.
+          long_entry_logic.append((cci_20_change_pct_1h_lt_0) | (aroond_14_4h_lt_80) | (mfi_14_1d > 45.0))
           # --- Logic: embedded up-regime + quad-oversold pullback + 5-candle shift kink ---
           long_entry_logic.append(stoch_60_10 > 80.0)
           long_entry_logic.append(stoch_9_3 < 20.0)


### PR DESCRIPTION
## Signal 192 (Quad pullback, long) — entry protection + scoped doom stop

Closes the SIGNAL_MAP "Quad 192 validation" lane. 192 stays **default-disabled**; this ships the
protection work and the scoped stop, not the enable flip.

### Change (26 insertions, 1 file)

1. **R4–R10 entry protections** on top of the existing R1–R3 block — tightens the *dead-cat fade*
   anatomy (oversold-pullback that looks alive on 1h/4h but has no 1d money behind it, then bleeds
   to the doom stop):
   - R4: `(rsi_14_1d >= 40.0) | (cmf_20_1h >= 0.0)` — 1d alive OR hourly inflow
   - R5: `(rsi_14_1h < 74.0) | (roc_9_4h < 13.0)` — 1h cool OR 4h flat (not chasing a 4h top)
   - R6: `roc_9_4h > -15.0` — 4h not actively collapsing
   - R7: `obv_change_pct_15m > -64.2` — 15m money flow not collapsing
   - R8: `uo_7_14_28_change_pct_15m < 19.0` — 15m momentum not snapping higher into the top
   - R9: `rsi_3_change_pct_1h > -30.0` — 1h RSI not in free-fall
   - R10 (3-clause roll-up): `(cci_20_change_pct_1h < 0) | (aroond_14_4h < 80) | (mfi_14_1d > 45)`
2. **192-scoped doom stop** in `custom_exit`: `if "192" in enter_tags and current_profit <= -0.30`
   → `exit_long_normal_stoploss_doom`. Rationale: every 192 loss bottoms at 11.8–14% price on the
   shared 0.35 doom, while winners' max adverse excursion stays under 9.63% price. Scoping 192 to
   ~10% price (0.30 margin at 3x) flips the tag without touching any other signal's exit.

All R4–R10 clauses reuse existing cached booleans/views — **no new indicators**.

### Measurement (gms0-replica: pos-adjust off, derisk off, v3_2 stops on, 192 only experimental)

19-pair Binance USDT-M list, freqtrade 2026.6 docker, `--cache none`.

| regime | trades | W/L | pct |
|---|---|---|---|
| 2021 (bull, w100) | 10 | 10W/0L | +48.09 |
| 2022 (bear) | 14 | 13W/1L | +32.22 |
| 2024 | 25 | 24W/1L | +44.35 |
| 2025 | 23 | 22W/1L | +38.61 |
| 2026 (→08-17) | 5 | 5W/0L | +14.46 |
| **mined** | **77** | **74W/3L** | **+177.74** |
| 2023 (held-out) | 25 | 23W/2L | +29.72 |
| 2020 (held-out) | 4 | 4W/0L | +23.17 |
| **held-out** | **29** | **27W/2L** | **+52.89** |

**Combined 7 regimes: 106 trades, 101W/5L (95.3%), +230.63pt / +76,850 USDT, break-even 0.139.**

### Anti-overfit checks (all passed)

- **Nudge**: every clause ±one grid step → +146 to +211pt (flat basin, not a razor edge).
- **Regime leave-one-out**: dropping any single mined regime leaves +98 to +160pt — no year
  carries the edge.
- **Rounding (doc §1)**: `mfi_14_1d > 45` and `aroond_14_4h < 80` are 5-multiples (45 optimal —
  50 costs 2 winners, 55 costs 3); `cci_20_change_pct_1h < 0` is an own-scale ROC crossing.
- **Held-out flat**: mined +17.92 → +177.74pt, held +53.99 → +52.89pt (no held-out tax).

### Known limits (disclosed, not hidden)

- **3 mined losses left un-blocked** (BNB 22, DOT 24, RUNE 25): each is an isolated coordinate
  with same-valued winners beside it — no indicator places all three outside the pooled-winner
  min/max. Blocking them requires razor-tight single-trade memorisation (forbidden by doc §3).
- **Correlation**: `mfi_14_1d > 45` (R10) overlaps R4's `rsi_14_1d >= 40` at ρ = 0.77.
- **Rig is a 19-pair replica**, not production gms0 — absolute PnL/WR are not comparable; regime
  *sign* is the measurement. Production activation is a separate lane, out of scope here.

Report: `s192_validation/S192_VALIDATION_5_REGIME.md` in the research workspace.
