### PR TITLE
X7: fix TypeError when exchange provides no min_stake in custom_stake_amount

### DIFF
--- a/NostalgiaForInfinityX7.py
+++ b/NostalgiaForInfinityX7.py
@@ -2570,7 +2570,7 @@ class NostalgiaForInfinityX7(IStrategy):
 
     def scaled_stake(stake_multiplier: float) -> float:
       stake = proposed_stake * stake_multiplier
-      return stake if stake > min_stake else min_stake
+      return stake if (min_stake is None) or (stake > min_stake) else min_stake
 
     if side == "long":
       # Rebuy mode
@@ -2591,7 +2591,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif all(c in long_grind_mode_tags for c in enter_tags):
         for item in grind_mode_stake_multipliers:
           stake = proposed_stake * item
-          if stake > min_stake:
+          if (min_stake is None) or (stake > min_stake):
             return stake
       # Btc mode
       elif all(c in long_btc_mode_tags for c in enter_tags):
@@ -2614,7 +2614,7 @@ class NostalgiaForInfinityX7(IStrategy):
       elif all(c in short_grind_mode_tags for c in enter_tags):
         for item in grind_mode_stake_multipliers:
           stake = proposed_stake * item
-          if stake > min_stake:
+          if (min_stake is None) or (stake > min_stake):
             return stake
       # Rapid mode
       if system_name_is_v3 and (


### PR DESCRIPTION
## What

`custom_stake_amount()` crashed with:

```
TypeError: '>' not supported between instances of 'float' and 'NoneType'
  at return stake if stake > min_stake else min_stake  (scaled_stake())
```

`min_stake` is `None` when the exchange market defines neither `limits.cost.min` nor `limits.amount.min` (`_get_stake_amount_limit` returns `None` for min in that case). It is **not** a zero-balance issue — with zero balance freqtrade skips the entry entirely.

The same latent bug exists in the long/short grind-mode loops, where a `None` min_stake silently falls through the loop and returns the raw `proposed_stake` (no multiplier, no floor).

## Fix

Treat a missing `min_stake` as "no floor to enforce" in all three spots:

- `scaled_stake()`: `return stake if (min_stake is None) or (stake > min_stake) else min_stake`
- long grind loop and short grind loop: `if (min_stake is None) or (stake > min_stake): return stake`

`validate_stake_amount` still applies the final checks afterwards.

Matches the `None`-guard already used in `correct_min_stake` (rebuy adjust paths, fixed 2026-08-03 in 5ec54e977 / 06413faf8 — those commits did not cover this path).

## Notes

The `stake > min_stake` comparison predates the 5/30 refactor (`f4d42963e8`) — it goes back to X7 v1 (`b6a44afc9d`). The refactor preserved it verbatim; this PR closes the gap.