### PR TITLE
Signal 506: fifteen entry protections for the 7-day-low short

### DIFF
--- a/NostalgiaForInfinityX7.py
+++ b/NostalgiaForInfinityX7.py
@@ -27407,12 +27407,42 @@ class NostalgiaForInfinityX7(IStrategy):
           short_entry_logic.append(protections_short_global == True)
 
           short_entry_logic.append(
-            # the day is still up while the last 24h flushed hard
-            ((roc_9_1d < 0.0) | (roc_288 > -15.0))
+            # 1h money draining and the 5m washed out, but the 15m is not making fresh lows
+            ((mfi_14 > 30) | (willr_14_15m < -95) | (cmf_20_1h > -0.3))
+            # a 7-day low broken on drained 5m money while the two days above it rose and the daily sits mid-range
+            & ((mfi_14 > 20) | (roc_2_1d < 2) | (willr_14_1d < -60))
             # a vertical ten-minute drop while the 4h high is over a day old
             & ((roc_2 > -5.0) | (aroonu_14_4h > 40.0))
+            # the nine-day trend is still up while the last 24h flushed hard
+            & ((roc_288 > -15.0) | (roc_9_1d < 0.0))
+            # the 15m has stopped making new lows and money is still flowing into it, and the 5m breaks a 7-day low anyway
+            & ((aroond_14_15m > 50) | (mfi_14_15m < 40))
+            # nothing is making new lows — not the hour, not the day — and the 15m just printed a fresh high, yet the 5m breaks a 7-day low
+            & (aroonu_14_15m_lt_50 | (aroond_14_1h > 25) | (aroond_14_1d > 15))
+            # the daily is being bought and has not made a low in two weeks, and the 15m just printed a fresh high
+            & ((aroonu_14_15m < 45) | (aroond_14_1d > 25) | (mfi_14_1d < 65))
+            # 15m money out and the 4h downtrend set, but the 15m has already lifted off the floor
+            & ((cmf_20_15m > -0.3) | (mfi_14_15m < 15) | (minus_di_14_4h < 30))
+            # money is leaving on the 15m while the 4h is mid-range and has made no new low — a liquidity flush, not a breakdown
+            & ((cmf_20_15m > -0.3) | (aroond_14_4h > 35) | (willr_14_4h < -60))
+            # 15m money still flowing while the 4h is drained and its downtrend set
+            & ((mfi_14_15m < 25) | (cmf_20_4h > -0.2) | (minus_di_14_4h < 30))
             # 1h money exhausted after a two-day drop
             & ((mfi_14_1h > 25.0) | (roc_2_1d > -7.0))
+            # the hour has turned up hard — momentum, its rate of change and the oscillator all lifted — and the 5m sells the 7-day low into it
+            & ((rsi_3_1h < 25) | (rsi_3_change_pct_1h < 65) | (stochrsi_k_1h < 45))
+            # momentum has exploded upward on the hour and the day at once, and the 5m sells the 7-day low into the bounce
+            & ((rsi_3_change_pct_1h < 200) | (rsi_3_change_pct_1d < 300))
+            # the 7-day low breaks while neither the hourly nor the 4h is anywhere near oversold
+            & (stochrsi_k_1h_lt_40 | (stochrsi_k_4h < 35))
+            # the 4h has already rallied hard — oscillator topped, no new 4h low for days — and the 5m breaks a 7-day low against it
+            & ((adx_14_4h < 40) | (aroond_14_4h > 30) | (stochrsi_k_4h < 75))
+            # the 4h is drained but has printed no new low for days — the decline has stalled, and the 5m sells the 7-day low into the stall
+            & ((aroond_14_4h > 20) | (mfi_14_4h > 25))
+            # the 4h has already snapped up while the day is still washed out
+            & ((rsi_3_change_pct_4h < 65) | rsi_3_1d_gt_30)
+            # the 4h stochastic is pinned at the floor and the day is washed out, but the daily stochastic has not followed
+            & ((stochk_14_3_3_4h > 15) | rsi_3_1d_gt_30 | (stochk_14_3_3_1d < 35))
           )
 
           # Logic


### PR DESCRIPTION
506 sells the first close below the prior seven-day low. Raw, that is 2602 trades with 351
losses for +420 points across 2021+2022 -- almost exactly break-even, because the average
winner is +5.2% against an average loss of -35.9%, so the break-even win rate is ~87%.

With the three chains already merged plus the fifteen here:

| | trades | losses | points | WR |
|---|---|---|---|---|
| raw | 2602 | 351 | +420 | 86.5% |
| 3 chains (shipped) | 2099 | 192 | +4352.6 | 90.9% |
| **18 chains** | **2003** | **152** | **+5666.7** | **92.4%** |

Volume falls 4.3% from the shipped block while losses fall 21% and points rise 30%. Of the
90 trades removed, 37 are losses and 53 winners -- a ratio of 0.70 against a 0.16 break-even.
The 2021 run also loses its only liquidation (DOGE 2021-12-13, -91.90%).

Every chain was decided by a full backtest of both years, never by an offline projection:
the projections were the right sign but the wrong size all the way through (+336 against
+357.6 real, +20.5 against +97.3, +68.1 against +140.0, +98 against +145.7).

Each chain is anchored to a named loss that was read on the chart first. A few examples:

* DOGE 2021-12-13 19:30 -- eight hours of orderly drift into the low, then +43.45% high
  against -1.29% low over the next twenty hours. The only liquidation in the round.
* GALA 2022-06-13 11:30 -- +24.47% against -1.05% over eight hours. The +13.3% winner on
  the same pair four hours earlier is untouched.
* SOL 2021-10-12 12:30 and its twin at 12:45 -- neither trades below -0.45%/+0.13% on the
  way in; both run +10.49%/+12.09% against the short over 48h.
* AXS 2021-12-06 11:05 -- never below +1.40% on the way in, +26.61% against -1.39% after.

Notes for review:

* **Two chains were rewritten after their first version failed the run.** Both used the
  target's most extreme reading, which was a 15m column; both were blocked and the same
  trade returned 10-15 minutes later. Putting the twins side by side showed every 1h/4h/1d
  column bit-identical between them and only the 15m ones moving. Rebuilt from slower
  clauses they went from +3.1 to +78.1 and from -14.3 to +38.0.
* **Six candidates were measured and rejected**, all for the same reason: they scored well
  at one exact threshold and collapsed or flipped sign one grid step out.
* **`rsi_3_change_pct` thresholds diverge from house vocabulary.** Yours are [50] at 1d and
  [-75, -50, -20] at 1h; this PR uses 300 and 200. The column runs past 900 on the trade
  they were written for, which sits 633 and 286 clear of them. Stated rather than hidden.
* **`cmf_20_15m < -0.3` likewise** -- your cmf_20 values are -0.1..0.0 on a 0.1 step. The
  ladder is positive from -0.20 to -0.35; -0.20 would be closer to convention at a cost of
  about 45 points.
* **Two lines that are not new chains.** The `roc_288`/`roc_9_1d` chain has its clauses
  reordered low timeframe to high, and its comment corrected -- `roc_9_1d` is the nine-day
  trend, not "the day". Both are behaviour-neutral.

Signal 506 stays disabled. 2023 was deliberately left untouched as a checkpoint and 2020
sealed; 2024/2025 have not been run, so the block is fitted to two regimes and should be
read that way.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>