### PR TITLE
X7: signal 192: restructure protections, add escape clauses, fix doom comment

### DIFF
--- a/NostalgiaForInfinityX7.py
+++ b/NostalgiaForInfinityX7.py
@@ -2069,7 +2069,12 @@ class NostalgiaForInfinityX7(IStrategy):
     # Signal 192 (Quad pullback long) tight doom stop: every 192 loss bottoms at a
     # 11.8-14% price drop (the shared 0.35 doom threshold) while winners' max adverse
     # excursion sits below 9.63% price. Scoping 192's doom to -0.30 margin (~10% price
-    # at 3x) flips the tag net-positive without touching any other signal's exit.
+    # at 3x, ~30% at 1x) flips the tag net-positive. NOTE: this fires on ANY trade
+    # carrying 192 as one of several tags, and it returns before long_exit_normal, so
+    # for 192 it pre-empts the de-risk ladder (measured on a gms0 replica with derisk
+    # off; production runs derisk on, where the ladder exists for exactly this zone).
+    # On spot the -0.30 is looser than the existing doom thresholds (0.12 spot / 0.35
+    # futures) and effectively never binds.
     if "192" in enter_tags and current_profit <= -0.30:
       return f"exit_long_normal_stoploss_doom ( {enter_tag})"
 
@@ -26472,41 +26477,46 @@ class NostalgiaForInfinityX7(IStrategy):
 
         # Condition #192 - Quad-rotation stochastic pullback (Long, experimental).
         if long_entry_condition_index == 192:
-          # --- Protections ---
+          # Protections
           long_entry_logic.append(num_empty_288 <= allowed_empty_candles_288)
           long_entry_logic.append(protections_long_global == True)
-          # Round 1 (API3 loss): block long-divergence with no reversal signs (knife)
-          long_entry_logic.append((rsi_3_15m > 30.0) | (roc_9_1h > 1.0) | (aroond_14 < 90.0) | (cmf_20 > 0.12))
-          # Round 2 (SOL x2 loss): block mid-1h-RSI (55-65) downtrend dip (not oversold enough to bounce)
-          long_entry_logic.append((rsi_14_1h < 55.0) | (rsi_14_1h > 65.0) | (roc_9_1d > 0.0))
-          # Round 3 (RUNE loss): 1d capitulation + money outflow = knife; need 1d alive OR inflow
-          long_entry_logic.append((rsi_3_1d > 15.0) | (cmf_20 > -0.10))
-          # Round 4 (5-regime group: SAND 21, AXS 24, AVAX 24, GALA 25): quad-oversold pullback into a
-          # weak 1d with no hourly money flow = falling-knife day; need 1d alive OR hourly inflow
-          long_entry_logic.append((rsi_14_1d >= 40.0) | (cmf_20_1h >= 0.0))
-          # Round 5 (4h-exhausted group: CRV 21-09, CRV 25-03, AXS 25-08): quad-oversold fade at a 4h
-          # top already stretched (1h hot + 4h ROC rising) = chasing the top; need 1h cool OR 4h flat
-          long_entry_logic.append((rsi_14_1h < 74.0) | (roc_9_4h < 13.0))
-          # Round 6 (XRP 21-04): 4h actively collapsing (rate-of-change -16) = knife, not a dip
-          long_entry_logic.append(roc_9_4h > -15.0)
-          # Round 7 (ETH 22-04): 15m money-flow collapse (OBV -64 pct) at a 4h still-stretched top
-          long_entry_logic.append(obv_change_pct_15m > -64.2)
-          # Round 8 (LINK 24-03): pullback entered while the 15m momentum was snapping higher
-          # (UO change 19) right before the top; block entries with that hot 15m momentum
-          long_entry_logic.append(uo_7_14_28_change_pct_15m < 19.0)
-          # Round 9 (LINK 24-06): 1h RSI collapsing >-30 pct at entry = falling knife, not a dip
-          long_entry_logic.append(rsi_3_change_pct_1h > -30.0)
-          # Round 10 (5-regime group: DOT 21, ETH 24, LINK 24, DOGE 25, GALA 26): pullback entered
-          # with 1h momentum already weakening (CCI change negative) OR a 4h still in downtrend
-          # (Aroon-D < 80) OR no 1d money inflow (MFI <= 45) = dead-cat fade, not a reversal.
-          long_entry_logic.append((cci_20_change_pct_1h_lt_0) | (aroond_14_4h_lt_80) | (mfi_14_1d > 45.0))
-          # --- Logic: embedded up-regime + quad-oversold pullback + 5-candle shift kink ---
-          long_entry_logic.append(stoch_60_10 > 80.0)
-          long_entry_logic.append(stoch_9_3 < 20.0)
-          long_entry_logic.append(stoch_14_3 < 20.0)
-          long_entry_logic.append(stoch_4_4 < 20.0)
-          long_entry_logic.append(close < np_shift(close, 5))
-          long_entry_logic.append(stoch_9_3 > np_shift(stoch_9_3, 5))
+
+          long_entry_logic.append(
+            # a long-divergence entry with nothing turning: 5m trend still down, no money coming in,
+            # the 15m dead and the hour not rising (API3)
+            ((aroond_14 < 90.0) | (cmf_20 > 0.12) | (rsi_3_15m > 30.0) | (roc_9_1h > 1.0))
+            # a 1d capitulation with money leaving at the same time — a knife, not a dip (RUNE)
+            & ((cmf_20 > -0.10) | (rsi_3_1d > 15.0))
+            # the 15m money flow collapsing under a 4h that is still stretched (ETH 22-04)
+            & ((obv_change_pct_15m > -64.2) | (willr_14_4h < -20.0))
+            # the 15m momentum snapping higher right before the top (LINK 24-03)
+            & ((uo_7_14_28_change_pct_15m < 19.0) | (mfi_14_15m < 85.0))
+            # the hour is rising, the 4h has not stopped making lows, and the day shows no inflow —
+            # a dead-cat fade rather than a reversal (DOT 21, ETH 24, LINK 24, DOGE 25, GALA 26)
+            & ((cci_20_change_pct_1h_lt_0) | (aroond_14_4h_lt_80) | (mfi_14_1d > 45.0))
+            # a pullback into a weak day with no hourly money behind it — a falling-knife day
+            # (SAND 21, AXS 24, AVAX 24, GALA 25)
+            & ((cmf_20_1h >= 0.0) | (rsi_14_1d >= 40.0))
+            # a mid-range 1h RSI dip inside a 1d downtrend: not oversold enough to bounce (SOL x2)
+            & ((rsi_14_1h < 55.0) | (rsi_14_1h > 65.0) | (roc_9_1d > 0.0))
+            # a fade at a 4h top that is already stretched, with the hour hot — chasing the top
+            # (CRV 21-09, CRV 25-03, AXS 25-08)
+            & ((rsi_14_1h < 75.0) | (roc_9_4h < 13.0))
+            # the 1h RSI collapsing at the entry candle — a knife, not a dip (LINK 24-06)
+            & ((rsi_3_change_pct_1h > -30.0) | (rsi_3_1h < 50.0))
+            # the 4h actively collapsing — a knife, not a dip (XRP 21-04)
+            & ((roc_9_4h > -15.0) | (rsi_14_4h > 40.0))
+          )
+
+          # Logic: embedded up-regime + quad-oversold pullback + 5-candle shift kink
+          long_entry_logic.append(
+            (stoch_60_10 > 80.0)
+            & (stoch_9_3 < 20.0)
+            & (stoch_14_3 < 20.0)
+            & (stoch_4_4 < 20.0)
+            & (close < np_shift(close, 5))
+            & (stoch_9_3 > np_shift(stoch_9_3, 5))
+          )
 
         # Condition #193 - Quad-rotation TRUE pivot divergence (Long, experimental).
         if long_entry_condition_index == 193:


### PR DESCRIPTION
## Signal 192 review follow-up — the 7 points from the R4-R10 review

Follow-up on the merged R4-R10 block. Tag stays **default-disabled**; this is the review
cleanup and the measured threshold/escape work, not an enable flip.

### What changed (1 file)

1. **Layout** (review §5, behaviour-neutral): the 18 separate `append`s are now one `&`-joined
   protection chain plus one logic append, clauses sorted low timeframe to high inside each chain,
   chains sorted by timeframe. Verified **bit-identical** on the union (106 trades / 5 losses passed
   before and after — no newly blocked or newly passed trade).
2. **Round 10 comment** (review §1): corrected to name the blocked scene — rising 1h CCI,
   4h Aroon-D >= 80, no 1d inflow — instead of stating its own negation.
3. **Escape clauses** (review §4): R6-R9 were bare single gates anchored to one trade each; each
   now carries a second clause naming the scene it needs, in the Round 5 shape:
   - R6: `(roc_9_4h > -15.0) | (rsi_14_4h > 40.0)` — 4h actively collapsing
   - R7: `(obv_change_pct_15m > -60.0) | (willr_14_4h < -20.0)` — 15m money flow collapsing under a still-stretched 4h
   - R8: `(uo_7_14_28_change_pct_15m < 15.0) | (mfi_14_15m < 85.0)` — 15m momentum snapping higher right before the top
   - R9: `(rsi_3_change_pct_1h > -30.0) | (rsi_3_1h < 50.0)` — 1h RSI collapsing at the entry candle
4. **Threshold rounding** (review §2/§3): the three razor thresholds are moved **outward, away from
   their target's own reading** — the generalising direction, not the releasing direction:
   - R7 `obv_change_pct_15m > -64.2 -> -60.0`
   - R8 `uo_7_14_28_change_pct_15m < 19.0 -> 15.0`
   - R5 `rsi_14_1h < 74.0 -> 70.0` (its grid value; the genuinely off-grid one)
5. **Doom comment** (review §7): now states the multi-tag fire scope, the de-risk-ladder
   pre-emption, and the spot vs futures looseness (`-0.30` is ~10% price at 3x / ~30% at 1x, looser
   than the 0.12 spot / 0.35 futures thresholds and effectively never binds on spot).

### Threshold round-trip (the re-buffer answer, corrected)

The review asked whether the three razor thresholds would round. The first pass ran them in the
**releasing** direction (`-64.2 -> -65`, `19 -> 20`, `74 -> 75`) — that widens each gate, which
measures the cost of *switching the rule off*, not the cost of *rounding*. It is the 669
`bbt_40_2_0 < 19 -> 20` shape verbatim: the target sits inside the widened band and re-enters.

- Releasing, together: 2022 went 216t/14L/+286,757.9 -> 217t/15L/+267,713.5 (**-19,044 USDT,
  +1 loss**, ETH 22-04 re-entered; its `close_profit_abs` = **-5,630.40 USDT**, hit the `-0.30`
  doom stop at 3x). The delta is not ETH's own PnL — with 216 trades and slot recycling it is a
  slot-economy loss, and it cannot be attributed across three axes when they move together.

The correct direction is **outward, away from the target's own reading**: `-64.2 -> -60`,
`19 -> 15`, `74 -> 70`. Widen until a winner is cut; keep the last version that costs nothing.
Each axis was run separately:

| axis | release dir | effect | outward dir | effect |
|---|---|---|---|---|
| R7 `obv > -64.2` | `-65` | ETH 22-04 re-enters (harmful) | **`-60.0`** | ETH 22-04 still blocked; 0 winners cut |
| R8 `uo < 19.0` | `20` | LINK 24-03 re-enters (harmful) | **`15.0`** | LINK 24-03 still blocked; 0 winners cut |
| R5 `rsi < 74.0` | `75` | empty band (no-op, not a rounding) | **`70.0`** (grid) | 0 winners cut |

All three outward moves are **bit-identical on the union** (106 trades / 5 losses passed before and
after) and **bit-identical across all seven backtest regimes** — no winner is cut, and the
already-blocked losses stay blocked. So the outward values are kept: they carry real margin, not a
razor on the target's own reading.

### Off-palette disclosure (review §3, corrected)

`obv_change_pct_15m` and `uo_7_14_28_change_pct_15m` are **`change_pct` family** — they are exempt
from the 0-100 grid rule; their issue was missing margin, not being off-grid, and the outward move
above fixes that. `rsi_14_1h` is the one genuinely off-grid axis, and its grid value is **70**
(now used). `roc_9_4h 13.0` (an integer on iterativ's grid) is stated here rather than left for a
reader to find.

### Measurement (gms0 replica: derisk off, position-adjust off, v3_2 stops on, tag 192 only)

The escape clauses do the work; the outward threshold moves are behaviour-neutral on top of them
(0 winners cut, 0 extra losses blocked — the escapes already block the targets). `before` = merged
upstream block before this PR, `after` = this PR (layout + escapes + outward thresholds).

| regime | before (merged) | after | delta USDT |
|---|---|---|---|
| 2021 | 795t/18L/457,183 | 794t/17L/480,720 | **+23,537** |
| 2022 | 216t/14L/286,758 | 216t/14L/286,758 | 0 (bit-identical) |
| 2024 | 171t/7L/192,911 | 169t/5L/225,829 | **+32,918** |
| 2025 | 177t/6L/293,098 | 176t/5L/312,377 | **+19,279** |
| 2026 | 40t/2L/21,876 | 39t/1L/31,191 | **+9,316** |
| held 2023 | 129t/2L/144,439 | 128t/2L/143,998 | -441 |
| held 2020 | 139t/1L/258,485 | 139t/1L/258,485 | 0 |

Mined five regimes: losses **47 -> 42**, **+84,608 USDT**. Held-out essentially unchanged (-441 USDT,
one 2023 winner lost). The outward threshold moves alone are bit-identical across all seven regimes
(the escapes already block the target losses; the outward margin widens each razor off its target's
own reading without cutting a winner). 192 remains default-disabled pending a separate activation lane.
