### PR TITLE
X7: signal 192: round R7/R8/R5 thresholds outward (obv -60, uo 15, rsi 70)

### DIFF
--- a/NostalgiaForInfinityX7.py
+++ b/NostalgiaForInfinityX7.py
@@ -26488,9 +26488,9 @@ class NostalgiaForInfinityX7(IStrategy):
             # a 1d capitulation with money leaving at the same time — a knife, not a dip (RUNE)
             & ((cmf_20 > -0.10) | (rsi_3_1d > 15.0))
             # the 15m money flow collapsing under a 4h that is still stretched (ETH 22-04)
-            & ((obv_change_pct_15m > -64.2) | (willr_14_4h < -20.0))
+            & ((obv_change_pct_15m > -60.0) | (willr_14_4h < -20.0))
             # the 15m momentum snapping higher right before the top (LINK 24-03)
-            & ((uo_7_14_28_change_pct_15m < 19.0) | (mfi_14_15m < 85.0))
+            & ((uo_7_14_28_change_pct_15m < 15.0) | (mfi_14_15m < 85.0))
             # the hour is rising, the 4h has not stopped making lows, and the day shows no inflow —
             # a dead-cat fade rather than a reversal (DOT 21, ETH 24, LINK 24, DOGE 25, GALA 26)
             & ((cci_20_change_pct_1h_lt_0) | (aroond_14_4h_lt_80) | (mfi_14_1d > 45.0))
@@ -26501,7 +26501,7 @@ class NostalgiaForInfinityX7(IStrategy):
             & ((rsi_14_1h < 55.0) | (rsi_14_1h > 65.0) | (roc_9_1d > 0.0))
             # a fade at a 4h top that is already stretched, with the hour hot — chasing the top
             # (CRV 21-09, CRV 25-03, AXS 25-08)
-            & ((rsi_14_1h < 75.0) | (roc_9_4h < 13.0))
+            & ((rsi_14_1h < 70.0) | (roc_9_4h < 13.0))
             # the 1h RSI collapsing at the entry candle — a knife, not a dip (LINK 24-06)
             & ((rsi_3_change_pct_1h > -30.0) | (rsi_3_1h < 50.0))
             # the 4h actively collapsing — a knife, not a dip (XRP 21-04)


### PR DESCRIPTION
## Signal 192: round R7/R8/R5 thresholds outward (obv -60, uo 15, rsi 70)

Follow-up to PR #1217 (which restructured the protections and added the escape clauses). That PR
landed with the three razor thresholds still sitting **on their target's own reading**:

- R7 `obv_change_pct_15m > -64.2` — ETH 22-04 reads -64.24
- R8 `uo_7_14_28_change_pct_15m < 19.0` — LINK 24-03 reads 19.07
- R5 `rsi_14_1h < 75.0` — off-grid (its grid value is 70)

The first round-trip ran them in the **releasing** direction (`-64.2 -> -65`, `19 -> 20`,
`74/75 -> wider`), which widens each gate and measures the cost of *switching the rule off*, not
the cost of *rounding*. That let ETH 22-04 and LINK 24-03 re-enter (-19,044 USDT in 2022 alone).

The correct direction is **outward, away from the target's own reading**. Widen until a winner is
cut; keep the last version that costs nothing. Each axis run one at a time:

| axis | releasing (wrong) | outward (correct) | result |
|---|---|---|---|
| R7 `obv > -64.2` | -65 → ETH 22-04 re-enters | **-60.0** | ETH 22-04 stays blocked, 0 winners cut |
| R8 `uo < 19.0` | 20 → LINK 24-03 re-enters | **15.0** | LINK 24-03 stays blocked, 0 winners cut |
| R5 `rsi < 74.0` | 75 → empty band (no-op) | **70.0** (grid) | 0 winners cut |

All three outward values are **bit-identical across all seven regimes** (2021/2022/2024/2025/2026
mined + 2023/2020 held-out): 0 winners cut, the already-blocked losses stay blocked. The escape
clauses from #1217 already block the targets; this widens each razor off its target's own reading
without cutting a winner.

`close_profit_abs` for ETH 22-04 = **-5,630.40 USDT** (hit the `-0.30` doom stop at 3x). The
-19,044 is a slot-economy delta, not ETH's own PnL, and it cannot be attributed across three axes
moved together — which is why the re-run was one axis at a time.

Grid note: `obv_change_pct` and `uo_..._change_pct` are `change_pct` family → exempt from the
0-100 grid; their issue was missing margin, which the outward move fixes. `rsi_14_1h` is the
genuinely off-grid axis and its grid value is **70**.

192 remains default-disabled; this is a threshold-margin correction, not an enable flip.
