### PR TITLE
Blacklist: drop the blanket 1000* rule on binance

### DIFF
--- a/configs/blacklist-binance.json
+++ b/configs/blacklist-binance.json
@@ -15,7 +15,6 @@
       "(FIGHT|IDOL)/.*",
       // Exchange
       "(RIF|BNB)/.*",
-      "(1000.*).*/.*",
       // Leverage
       ".*(_PREMIUM|BEAR|BULL|HALF|HEDGE|UP|DOWN|[1235][SL])/.*",
       // Fiat


### PR DESCRIPTION
`"(1000.*).*/.*"` blocks every 1000-denominated perpetual on Binance and has no
equivalent in the other eleven configs, so the same tokens are tradable everywhere
else. The prefix is a unit convention for low-priced tokens, not a risk marker, and
the rule catches two different populations at once.

Twelve active USDT-M perpetuals are currently blocked by it. The high-volatility end
is the part worth having:

| coin | worst day (30d) | best day | 24h vol |
|---|---|---|---|
| 1000RATS | 140.2% | +125.0% | $98.4M |
| 1000CAT | 59.3% | +34.7% | $0.9M |
| 1000SATS | 38.4% | +18.9% | $2.9M |
| 1000SHIB | 24.5% | +17.1% | $17.7M |
| 1000XEC | 22.1% | +11.9% | $1.1M |
| 1000BONK | 19.3% | +14.4% | $8.1M |

The remaining six (1000CHEEMS, 1000000BOB, 1000PEPE, 1000000MOG, 1000FLOKI,
1000LUNC) read 9-16% worst day — ordinary, and 1000PEPE at $83.6M is one of the more
liquid names on the venue. The four thin ones sit at $0.2-0.9M and would not clear a
volume pairlist anyway, so dropping the rule does not flood a whitelist.

Measured rather than assumed: on the two venues where the rule does not exist, our
three bots have closed **13 trades on 1000* names, all thirteen green, zero losses**
— Bybit 7 (+0.29% … +9.80%), Bitget 6 (+0.64% … +12.38%), Binance 0 because of this
rule. Best was 1000BONK +12.38% on tag 103. 1000RATS fired on all three bots this
morning on tag 41; Bybit closed +3.15%, Bitget +3.40%, Binance could not enter.

Note the fullmatch semantics: `SATS` and `SHIB1000` already sit in the main coin list
but do not cover `1000SATS` / `1000SHIB`, so this line is the only thing blocking them.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>