### PR TITLE
Signal 506: a per-loss round across four regimes

### DIFF
--- a/NostalgiaForInfinityX7.py
+++ b/NostalgiaForInfinityX7.py
@@ -27421,26 +27421,102 @@ class NostalgiaForInfinityX7(IStrategy):
           short_entry_logic.append(protections_short_global == True)
 
           short_entry_logic.append(
-            # 5m momentum rising, high in its range and 4h money drained
-            ((rsi_14_change_pct < -2.0) | (willr_14 < -75) | (mfi_14_4h > 20))
             # 5m momentum alive, a volume spike and 4h a trend established
-            & ((rsi_3 < 10) | (vol_rel < 16) | (adx_14_4h < 20))
+            ((rsi_3 < 10) | (vol_rel < 16) | (adx_14_4h < 20))
+            # 4h a long upper wick, 5m momentum alive and daily a long lower wick
+            & ((rsi_3 < 20) | (top_wick_pct_4h < 2) | (bot_wick_pct_1d < 2))
+            # 4h a long upper wick, 5m momentum alive and a trend established
+            & ((rsi_3 < 20) | (adx_14_4h < 25) | (top_wick_pct_4h < 2.5))
+            # 15m high in its range, 5m momentum alive and 1h a new high
+            & ((rsi_3 < 25) | (willr_14_15m < -70) | (aroonu_14_1h < 30))
+            # 15m stochastic high, 5m momentum alive and daily no recent low
+            & ((stochrsi_k_15m < 45) | (rsi_3 < 25) | (aroond_14_1d > 85))
+            # 5m not oversold, a volume spike and 4h a trend established
+            & ((rsi_4 < 20) | (vol_rel < 16) | (adx_14_4h < 15))
+            # 5m money flowing in, the coil's roof low and not oversold
+            & ((mfi_14 < 40) | (quad_s93_max_12 > 60) | (rsi_4 < 25))
+            # 15m a new high, 5m the coil's floor lifted and not oversold
+            & ((quad_s93_min_12 < 10) | (rsi_4 < 15) | (aroonu_14_15m < 45))
+            # 5m not oversold, tightly squeezed and 1h stochastic at the floor
+            & ((rsi_4 < 20) | (sqz_cnt_24 < 15) | (stochrsi_k_1h > 5))
+            # 4h at an extreme low, 5m not oversold and 1h not down
+            & ((rsi_4 < 25) | (change_pct_1h < -1) | (cci_20_4h > -230))
             # 1h momentum collapsing, 5m not oversold and 4h no upward push
             & ((rsi_3_change_pct_1h > -60.0) | (rsi_14 < 35) | (plus_di_14_4h > 10))
             # daily a long upper wick, 5m not oversold and not falling
             & ((top_wick_pct_1d < 4.5) | (rsi_14 < 35) | (roc_2_1d < -1.5))
+            # daily falling, 5m not oversold and 4h stochastic high
+            & ((rsi_14 < 35) | (stochrsi_k_4h < 30) | (roc_2_1d > -8))
+            # 4h money leaving, 5m not oversold and daily not down
+            & ((rsi_14 < 35) | (cmf_20_4h > -0.2) | (change_pct_1d < -2.5))
+            # 4h downtrend set, 5m not oversold and 15m oscillator lifting
+            & ((rsi_14 < 35) | (uo_7_14_28_change_pct_15m < 0) | (minus_di_14_4h < 35))
+            # 15m high in its range, 4h stochastic high and 5m not oversold
+            & ((rsi_14 < 30) | (willr_14_15m < -75) | (stochrsi_k_4h < 65))
+            # 5m momentum rising, high in its range and 4h money drained
+            & ((rsi_14_change_pct < -2.0) | (willr_14 < -75) | (mfi_14_4h > 20))
+            # 5m the last 24h fell hard, momentum falling and 4h stochastic high
+            & ((roc_288 > -11) | (rsi_14_change_pct > -30) | (stochrsi_k_4h < 25))
+            # 4h no recent low, daily falling and 5m momentum falling
+            & ((rsi_14_change_pct > -20) | (aroond_14_4h > 50) | (roc_2_1d > -8))
+            # 4h stochastic high, 5m momentum falling and daily falling
+            & ((rsi_14_change_pct > -30) | (stochrsi_k_4h < 70) | (roc_2_1d > -4.5))
+            # 15m oscillator falling, 5m momentum rising and daily money drained
+            & ((rsi_14_change_pct < -5) | (uo_7_14_28_change_pct_15m > -20) | (mfi_14_1d > 35))
+            # 15m money flowing in, 5m momentum falling and 4h not falling
+            & ((rsi_14_change_pct > -30) | (mfi_14_15m < 40) | (roc_9_4h < -1.5))
             # 1h not falling, 5m oversold and the coil's roof low
             & ((roc_2_1h < 0.0) | (rsi_20 > 20) | (quad_s93_max_12 > 65))
             # 1h momentum collapsing, 5m not oversold and cycle falling
             & ((rsi_3_change_pct_1h > -65.0) | (rsi_20 < 35) | (cci_20_change_pct_1h > 10.0))
             # 1h stochastic high, 5m oversold and 4h at an extreme low
             & ((stochrsi_k_1h < 75) | (rsi_20 > 20) | (cci_20_4h > -160.0))
-            # 15m oscillator low, 5m not oversold and 4h at an extreme low
-            & ((uo_7_14_28_15m > 25) | (rsi_20 < 30) | (cci_20_4h > -225.0))
-            # 5m not oversold, a volume spike and 4h a trend established
-            & ((rsi_4 < 20) | (vol_rel < 16) | (adx_14_4h < 15))
-            # 5m money flowing in, the coil's roof low and not oversold
-            & ((mfi_14 < 40) | (quad_s93_max_12 > 60) | (rsi_4 < 25))
+            # 1h momentum dead, 5m tightly squeezed and not oversold
+            & ((rsi_20 < 35) | (sqz_cnt_24 < 12) | (rsi_3_1h > 5))
+            # 1h momentum snapping up, 5m stochastic high and a new high
+            & ((aroonu_14 < 45) | (stochrsi_k < 60) | (rsi_3_change_pct_1h < 90))
+            # 15m oscillator lifting, 4h stochastic turning up and 5m stochastic at the floor
+            & ((uo_7_14_28_change_pct_15m < 10.0) | (stochrsi_k_change_pct_4h < 65.0) | (stochrsi_k > 15))
+            # 4h momentum rising, 5m tightly squeezed and stochastic high
+            & ((sqz_cnt_24 < 10) | (stochrsi_k < 25) | (rsi_14_change_pct_4h < 5))
+            # 5m fast stochastic high, stochastic high and 15m stochastic high
+            & ((stoch_4_4 < 25) | (stochrsi_k < 55) | (stochrsi_k_15m < 60))
+            # 5m stochastic high, 15m money leaving and 1h not extended
+            & ((stochrsi_k < 35) | (cmf_20_15m > -0.2) | (cci_20_1h < -65))
+            # 1h oscillator high, daily oversold and 5m stochastic high
+            & ((stochrsi_k < 20) | (uo_7_14_28_1h < 50) | (rsi_14_1d > 35))
+            # daily falling, 5m stochastic high and 1h no new high
+            & ((stochrsi_k < 65) | (aroonu_14_1h > 5) | (roc_9_1d > -30))
+            # 1h money flowing in, 5m stochastic high and 15m money leaving
+            & ((stochrsi_k < 40) | (cmf_20_15m > -0.25) | (mfi_14_1h < 50))
+            # 1h stochastic high, 5m stochastic high and daily stochastic at the floor
+            & ((stochrsi_k < 50) | (stochk_14_3_3_1h < 35) | (stochrsi_k_1d > 5))
+            # 15m momentum alive, 5m stochastic at the floor and 4h money drained
+            & ((rsi_3_15m < 20) | (stochrsi_k > 0) | (mfi_14_4h > 20))
+            # 5m a volume spike, stochastic high and daily a recent low
+            & ((vol_rel < 15) | (stochrsi_k < 50) | (aroond_14_1d < 90))
+            # 5m falling and daily at the floor of its range
+            & ((roc_9 > -4) | (stochrsi_k_lt_20) | (willr_14_1d > -90))
+            # daily stochastic high, not falling and 5m stochastic high
+            & ((stoch_14_3 < 15) | (roc_2_1d < 2) | (stochk_14_3_3_1d < 50))
+            # 15m not down, 5m fast stochastic high and daily a recent low
+            & ((change_pct_15m < 0.0) | (stoch_4_4 < 40) | (aroond_14_1d < 45))
+            # 5m fast stochastic at the floor, the coil's floor lifted and daily no upper wick
+            & ((stoch_4_4 > 10) | (quad_s93_min_12 < 15) | (top_wick_pct_1d > 1.0))
+            # 5m fast stochastic at the floor, the coil's floor lifted and 4h a recent low
+            & ((stoch_4_4 > 5) | (quad_s93_min_12 < 15) | (aroond_14_4h < 90))
+            # daily stochastic high, 5m fast stochastic high and money drained
+            & ((stoch_4_4 < 35) | (mfi_14_1d > 40) | (stochrsi_k_1d < 80))
+            # 1h stochastic at the floor, 5m long cycle high and no recent low
+            & ((stochrsi_k_1h > 0) | (stoch_60_10 < 20) | (aroond_14_1h > 75))
+            # 4h momentum snapping up, 5m stochastic high and no trend established
+            & ((stoch_9_3 < 25) | (adx_14_4h > 20) | (rsi_3_change_pct_4h < 45))
+            # 4h a long upper wick, 5m stochastic high and 1h at an extreme low
+            & ((stoch_9_3 < 20) | (cci_20_1h > -185) | (top_wick_pct_4h < 2.5))
+            # 15m money drained, daily at the floor of its range and 5m stochastic high
+            & ((stoch_9_3 < 20) | (mfi_14_15m > 10) | (willr_14_1d > -95))
+            # 4h momentum dead, 5m stochastic at the floor and 1h the two-day window off its floor
+            & ((stoch_9_3 > 5) | (willr_84_1h < -85) | (rsi_3_4h > 5))
             # a 7-day low broken on drained 5m money while the two days above it rose and the daily sits mid-range
             & ((mfi_14 > 20) | (roc_2_1d < 2) | (willr_14_1d < -60))
             # 1h money flowing in, 5m money flowing in and cycle turning up
@@ -27449,28 +27525,44 @@ class NostalgiaForInfinityX7(IStrategy):
             & ((mfi_14_1h < 50) | (mfi_14 < 40) | (cci_20_change_pct_1h < -0.3))
             # 1h money draining and the 5m washed out, but the 15m is not making fresh lows
             & ((mfi_14 > 30) | (willr_14_15m < -95) | (cmf_20_1h > -0.3))
+            # 4h at an extreme low, 5m money flowing in and downtrend weak
+            & ((mfi_14 < 45) | (cci_20_4h > -230) | (minus_di_14_4h > 30))
+            # 5m money flowing in, the two-day window off its floor and daily a recent low
+            & ((mfi_14 < 45) | (willr_480 < -90) | (aroond_14_1d < 65))
+            # 5m the last 24h fell hard, money drained and 1h high in its range
+            & ((mfi_14 > 15) | (roc_288 > -23) | (willr_14_1h < -90))
+            # 15m stochastic at the floor, 5m money flowing in and 4h no trend established
+            & ((mfi_14 < 40) | (stochrsi_k_15m > 5) | (adx_14_4h > 25))
+            # 1h momentum alive, 5m money flowing in and daily no recent low
+            & ((mfi_14 < 40) | (rsi_3_1h < 40) | (aroond_14_1d > 5))
+            # 5m money flowing in, 15m money flowing in and stochastic high
+            & ((cmf_20 < 0) | (mfi_14_15m < 45) | (stochrsi_k_15m < 60))
+            # 5m money flowing in, the coil's roof low and 1h falling
+            & ((cmf_20 < 0.05) | (quad_s93_max_12 > 45) | (roc_2_1h > -2))
+            # 4h stochastic high, daily not falling and 5m money leaving
+            & ((cmf_20 > -0.3) | (stochrsi_k_4h < 70) | (roc_9_1d < 0))
+            # 4h a new high, 5m money flowing in and daily stochastic high
+            & ((cmf_20 < 0) | (aroonu_14_4h < 50) | (stochrsi_k_1d < 10))
+            # 15m stochastic high, 5m money leaving and 4h stochastic at the floor
+            & ((cmf_20 > -0.45) | (stochrsi_k_15m < 25) | (stochrsi_k_4h > 5))
             # 15m momentum collapsing, 5m money flowing in and 1h no recent low
             & ((rsi_3_change_pct_15m > -75.0) | (cmf_20 < 0.05) | (aroond_14_1h > 80))
             # daily oversold, 5m volume flow rising and 4h momentum falling
             & ((rsi_14_1d > 35) | (obv_change_pct < 3.5) | (rsi_14_change_pct_4h > -15.0))
             # 4h stochastic high, 5m volume flow falling and a trend established
             & ((stochrsi_k_4h < 65) | (obv_change_pct > -1.0) | (adx_14_4h < 30))
-            # 15m oscillator lifting, 4h stochastic turning up and 5m stochastic at the floor
-            & ((uo_7_14_28_change_pct_15m < 10.0) | (stochrsi_k_change_pct_4h < 65.0) | (stochrsi_k > 15))
-            # 15m not down, 5m fast stochastic high and daily a recent low
-            & ((change_pct_15m < 0.0) | (stoch_4_4 < 40) | (aroond_14_1d < 45))
-            # 5m fast stochastic at the floor, the coil's floor lifted and daily no upper wick
-            & ((stoch_4_4 > 10) | (quad_s93_min_12 < 15) | (top_wick_pct_1d > 1.0))
-            # 5m fast stochastic at the floor, the coil's floor lifted and 4h a recent low
-            & ((stoch_4_4 > 5) | (quad_s93_min_12 < 15) | (aroond_14_4h < 90))
-            # 1h stochastic at the floor, 5m long cycle high and no recent low
-            & ((stochrsi_k_1h > 0) | (stoch_60_10 < 20) | (aroond_14_1h > 75))
+            # 5m no recent low, 4h money drained and oscillator high
+            & ((aroond_14 > 75) | (mfi_14_4h > 30) | (uo_7_14_28_4h < 50))
             # daily a long upper wick, 5m no recent low and 1h money leaving
             & ((top_wick_pct_1d < 4.0) | (aroond_14 > 45) | (cmf_20_1h > -0.2))
             # 15m oscillator lifting, 5m no recent low and 1h down
             & ((uo_7_14_28_change_pct_15m < 10.0) | (aroond_14 > 60) | (change_pct_1h > -2.0))
-            # 4h high in its range, 5m at the floor of its range and daily no recent low
-            & ((willr_14_4h < -70) | (willr_14 > -100) | (aroond_14_1d > 0))
+            # 5m a new high, the coil's roof low and 4h no new high
+            & ((aroonu_14 < 15) | (quad_s93_max_12 > 35) | (aroonu_14_4h > 5))
+            # 15m money flowing in, daily falling and 5m a new high
+            & ((aroonu_14 < 40) | (cmf_20_15m < 0.05) | (roc_2_1d > -8))
+            # 1h money flowing in, 5m high in its range and 4h no new high
+            & ((willr_14 < -70) | (cmf_20_1h < 0.1) | (aroonu_14_4h > 5))
             # 5m the two-day window off its floor and 1h money flowing in
             & ((willr_480 < -90) | (cmf_20_1h < 0.15))
             # a vertical ten-minute drop while the 4h high is over a day old
@@ -27481,14 +27573,28 @@ class NostalgiaForInfinityX7(IStrategy):
             & ((change_pct_15m > -2.0) | (roc_288 < -2.0) | (adx_14_4h < 30))
             # the nine-day trend is still up while the last 24h flushed hard
             & ((roc_288 > -15.0) | (roc_9_1d < 0.0))
+            # 4h at an extreme low, daily money drained and 5m the last 24h fell hard
+            & ((roc_288 > -10) | (cci_20_4h > -205) | (mfi_14_1d > 20))
             # 1h momentum alive, 5m the last 24h fell hard and 4h no trend established
             & ((rsi_3_1h < 45) | (roc_288 > -14.0) | (adx_14_4h > 25.0))
             # 4h stochastic falling, 5m the last 24h is flat and no trend established
             & ((stochrsi_k_change_pct_4h > -100.0) | (roc_288 < -3.0) | (adx_14_4h > 20))
+            # 1h down, 5m not falling and a new high
+            & ((roc_9 < -1.5) | (aroonu_14_1h < 45) | (change_pct_1h > -4.5))
+            # 15m no new high, 4h momentum rising and 5m not falling
+            & ((roc_9 < -0.95) | (aroonu_14_15m > 5) | (rsi_14_change_pct_4h < 5))
+            # 15m at an extreme low, 5m not falling and 1h at an extreme low
+            & ((roc_9 < -1.5) | (cci_20_15m > -340) | (cci_20_1h > -145))
+            # 15m money drained, 5m falling and 1h momentum rising
+            & ((roc_9 > -5.5) | (mfi_14_15m > 5) | (rsi_14_change_pct_1h < -15))
+            # 5m not falling, 15m momentum dead and 1h momentum snapping up
+            & ((roc_9 < -2.5) | (rsi_3_15m > 10) | (rsi_3_change_pct_1h < 80))
             # 1h down, 5m not falling and tightly squeezed
             & ((change_pct_1h > -3.0) | (roc_9 < -1.5) | (sqz_cnt_24 < 9))
             # 1h stochastic at the floor, oscillator high and 5m not falling
             & ((stochrsi_k_1h > 0) | (uo_7_14_28_1h < 45) | (roc_9 < -0.65))
+            # 4h stochastic turning up, 5m not falling and daily a recent low
+            & ((stochrsi_k_change_pct_4h < 40.0) | (roc_9 < -0.5) | (aroond_14_1d < 80))
             # daily a long lower wick, 5m a volume spike and 4h no recent low
             & ((bot_wick_pct_1d < 4.5) | (vol_rel < 15) | (aroond_14_4h > 40))
             # daily down, 5m a volume spike and money leaving
@@ -27499,18 +27605,20 @@ class NostalgiaForInfinityX7(IStrategy):
             & ((vol_rel < 10) | (adx_14_4h < 50))
             # 5m quiet volume, a bear regime and 4h cycle turning up
             & ((vol_rel > 1.0) | (mrb_bear < 0.9) | (cci_20_change_pct_4h < 175.0))
-            # 15m money flowing in, 4h a trend established and 5m the coil's roof low
-            & ((cmf_20_15m < 0.05) | (adx_14_4h < 45) | (quad_s93_max_12 > 65))
-            # 4h money drained, 5m the coil's roof low and 15m not extended
-            & ((mfi_14_4h > 20) | (quad_s93_max_12 > 25) | (cci_20_15m < -170.0))
-            # 1h the two-day window off its floor, 5m the coil's roof lifted and 4h no trend established
-            & ((willr_84_1h < -75) | (quad_s93_max_12 < 100) | (adx_14_4h > 15))
-            # daily a long lower wick, 5m the coil's floor lifted and 4h momentum falling
-            & ((bot_wick_pct_1d < 4.0) | (quad_s93_min_12 < 10) | (rsi_14_change_pct_4h > -15.0))
-            # 4h money leaving, 5m the coil's floor lifted and 1h a new high
-            & ((cmf_20_4h > -0.2) | (quad_s93_min_12 < 15) | (aroonu_14_1h < 15))
-            # 1h stochastic high, 5m the coil's floor lifted and 4h a trend established
-            & ((stochk_14_3_3_1h < 45) | (quad_s93_min_12 < 15) | (adx_14_4h < 20))
+            # 4h momentum dead, 5m a volume spike and money flowing in
+            & ((vol_rel < 12) | (mfi_14_4h < 30) | (rsi_3_4h > 5))
+            # 5m tightly squeezed, the coil's floor lifted and 1h at the floor of its range
+            & ((quad_s93_min_12 < 10) | (sqz_cnt_24 < 15) | (willr_14_1h > -90))
+            # 4h falling, 5m tightly squeezed and 1h money leaving
+            & ((sqz_cnt_24 < 15) | (cmf_20_1h > -0.2) | (roc_2_4h > -7))
+            # daily a long lower wick, 5m tightly squeezed and at the floor of its range
+            & ((sqz_cnt_24 < 16) | (bot_wick_pct_1d < 3) | (willr_14_1d > -85))
+            # daily momentum snapping up, 5m tightly squeezed and stochastic at the floor
+            & ((sqz_cnt_24 < 15) | (rsi_3_change_pct_1d < 35) | (stochrsi_k_1d > 5))
+            # 4h stochastic high, daily not oversold and 5m tightly squeezed
+            & ((sqz_cnt_24 < 10) | (stochrsi_k_4h < 50) | (rsi_14_1d < 55))
+            # 15m no new high, 4h money drained and 5m tightly squeezed
+            & ((sqz_cnt_24 < 10) | (aroonu_14_15m > 20) | (mfi_14_4h > 15))
             # 1h cycle falling, 5m tightly squeezed and money drained
             & ((cci_20_change_pct_1h > -25.0) | (sqz_cnt_24 < 16) | (mfi_14_1h > 30))
             # 1h momentum collapsing, 5m tightly squeezed and 4h cycle turning up
@@ -27519,10 +27627,46 @@ class NostalgiaForInfinityX7(IStrategy):
             & ((stochrsi_k_change_pct_4h < 65.0) | (sqz_cnt_24 < 13) | (stochrsi_k_4h < 25))
             # 15m oscillator low, 5m tightly squeezed and daily no lower wick
             & ((uo_7_14_28_15m > 30) | (sqz_cnt_24 < 16) | (bot_wick_pct_1d > 0.4))
+            # 1h not down, daily not down and 5m tightly squeezed
+            & ((change_pct_1h < 0.0) | (change_pct_1d < 2.0) | (sqz_cnt_24 < 15))
+            # 1h stochastic at the floor, 5m the coil's roof low and daily money flowing in
+            & ((quad_s93_max_12 > 35) | (stochk_14_3_3_1h > 10) | (mfi_14_1d < 60))
+            # 15m money drained, 5m the coil's roof lifted and daily at the floor of its range
+            & ((quad_s93_max_12 < 85) | (mfi_14_15m > 10) | (willr_14_1d > -90))
+            # 15m momentum alive, 5m the coil's roof low and daily no recent low
+            & ((quad_s93_max_12 > 55) | (rsi_3_15m < 35) | (aroond_14_1d > 45))
+            # 15m no recent low, 5m the coil's roof low and 1h falling
+            & ((quad_s93_max_12 > 55) | (aroond_14_15m > 55) | (roc_9_1h > -6.5))
+            # 4h a long upper wick, 5m the coil's roof low and a new high
+            & ((quad_s93_max_12 > 25) | (aroonu_14_4h < 45) | (top_wick_pct_4h < 1.5))
+            # 5m the coil's roof low, 1h oversold and 15m momentum falling
+            & ((quad_s93_max_12 > 60) | (rsi_14_change_pct_15m > -20) | (rsi_14_1h > 20))
+            # 4h a long upper wick, 5m the coil's roof low and daily money flowing in
+            & ((quad_s93_max_12 > 25) | (top_wick_pct_4h < 1.5) | (cmf_20_1d < 0.05))
+            # 4h oversold, 5m the coil's roof low and daily no upper wick
+            & ((quad_s93_max_12 > 35) | (rsi_14_4h > 25) | (top_wick_pct_1d > 0.6))
+            # 15m money flowing in, 4h a trend established and 5m the coil's roof low
+            & ((cmf_20_15m < 0.05) | (adx_14_4h < 45) | (quad_s93_max_12 > 65))
+            # 4h money drained, 5m the coil's roof low and 15m not extended
+            & ((mfi_14_4h > 20) | (quad_s93_max_12 > 25) | (cci_20_15m < -170.0))
+            # 1h the two-day window off its floor, 5m the coil's roof lifted and 4h no trend established
+            & ((willr_84_1h < -75) | (quad_s93_max_12 < 100) | (adx_14_4h > 15))
+            # 5m the coil's floor lifted, 15m stochastic at the floor and daily money drained
+            & ((quad_s93_min_12 < 10) | (stochrsi_k_15m > 10) | (mfi_14_1d > 25))
+            # 4h falling, 5m the coil's floor lifted and 15m money drained
+            & ((quad_s93_min_12 < 10) | (mfi_14_15m > 20) | (roc_9_4h > -8))
+            # 1h no new high, 5m the coil's floor lifted and stochastic high
+            & ((quad_s93_min_12 < 5) | (aroonu_14_1h > 10) | (stochk_14_3_3_1h < 35))
+            # 4h not down, 5m the coil's floor lifted and daily at the floor of its range
+            & ((quad_s93_min_12 < 10) | (change_pct_4h < 0) | (willr_14_1d > -85))
+            # daily a long lower wick, 5m the coil's floor lifted and 4h momentum falling
+            & ((bot_wick_pct_1d < 4.0) | (quad_s93_min_12 < 10) | (rsi_14_change_pct_4h > -15.0))
+            # 4h money leaving, 5m the coil's floor lifted and 1h a new high
+            & ((cmf_20_4h > -0.2) | (quad_s93_min_12 < 15) | (aroonu_14_1h < 15))
+            # 1h stochastic high, 5m the coil's floor lifted and 4h a trend established
+            & ((stochk_14_3_3_1h < 45) | (quad_s93_min_12 < 15) | (adx_14_4h < 20))
             # 4h falling, 5m no pre-break coil and cycle turning up
             & ((roc_9_4h > -12.0) | (ph_pre_tight > 2.0) | (cci_20_change_pct_4h < 20.0))
-            # 15m momentum snapping up, 4h no upward push and not falling
-            & ((rsi_3_change_pct_15m < -40.0) | (plus_di_14_4h > 5) | (roc_2_4h < -1.5))
             # 4h money leaving, momentum falling and 15m momentum alive
             & ((cmf_20_4h > -0.25) | (rsi_14_change_pct_4h > -20.0) | (rsi_3_15m < 25))
             # 4h not falling, stochastic falling and 15m momentum alive
@@ -27533,36 +27677,28 @@ class NostalgiaForInfinityX7(IStrategy):
             & ((rsi_3_15m < 35) | (cci_20_1h > -240.0) | (aroonu_14_4h < 15))
             # 15m momentum dead, no recent low and 1h cycle turning up
             & ((rsi_3_15m > 5) | (aroond_14_15m > 80) | (cci_20_change_pct_1h < 120.0))
+            # 15m at an extreme low, momentum alive and 4h stochastic at the floor
+            & ((cci_20_15m > -195) | (rsi_3_15m < 25) | (stochrsi_k_4h > 15))
+            # 4h momentum falling, daily a long upper wick and 15m momentum alive
+            & ((rsi_3_15m < 5) | (rsi_14_change_pct_4h > -25) | (top_wick_pct_1d < 3))
+            # 15m momentum alive, 1h money flowing in and 4h money flowing in
+            & ((rsi_3_15m < 35) | (cmf_20_1h < 0.05) | (cmf_20_4h < 0.05))
+            # 15m momentum snapping up, 4h no upward push and not falling
+            & ((rsi_3_change_pct_15m < -40.0) | (plus_di_14_4h > 5) | (roc_2_4h < -1.5))
+            # 15m momentum snapping up, a new high and 4h falling
+            & ((aroonu_14_15m < 45) | (rsi_3_change_pct_15m < 50) | (roc_2_4h > -2))
             # 15m not oversold, 4h cycle turning up and downtrend weak
             & ((rsi_14_15m < 35) | (cci_20_change_pct_4h < 180.0) | (minus_di_14_4h > 25))
             # 15m not oversold, 4h downtrend set and daily momentum snapping up
             & ((rsi_14_15m < 35) | (minus_di_14_4h < 40) | (rsi_3_change_pct_1d < -25.0))
             # 15m oversold, 1h oscillator high and a new high
             & ((rsi_14_15m > 25) | (uo_7_14_28_1h < 55) | (aroonu_14_1h < 65))
-            # daily money leaving, high in its range and 15m money flowing in
-            & ((cmf_20_1d > -0.1) | (willr_14_1d < -45) | (mfi_14_15m < 40))
-            # 15m money still flowing while the 4h is drained and its downtrend set
-            & ((mfi_14_15m < 25) | (cmf_20_4h > -0.2) | (minus_di_14_4h < 30))
-            # 15m money flowing in, 4h cycle turning up and money flowing in
-            & ((mfi_14_15m < 45) | (cci_20_change_pct_4h < 95.0) | (cmf_20_4h < 0.05))
-            # 15m money drained, 4h downtrend set and high in its range
-            & ((mfi_14_15m > 10) | (minus_di_14_4h < 40) | (willr_14_4h < -80))
-            # 15m money drained, 1h high in its range and daily no recent low
-            & ((mfi_14_15m > 10) | (willr_14_1h < -60) | (aroond_14_1d > 0))
-            # 15m money drained, 4h money flowing in and no trend established
-            & ((mfi_14_15m > 5) | (cmf_20_4h < 0.1) | (adx_14_4h > 20))
-            # 15m money drained, 4h oscillator low and stochastic high
-            & ((mfi_14_15m > 5) | (uo_7_14_28_4h > 35) | (stochrsi_k_4h < 15))
-            # 15m money flowing in, daily a long lower wick and stochastic high
-            & ((cmf_20_15m < 0.05) | (bot_wick_pct_1d < 3.5) | (stochk_14_3_3_15m < 45))
-            # 15m money flowing in and daily a long lower wick
-            & ((cmf_20_15m < 0.1) | (bot_wick_pct_1d < 3.5))
-            # money is leaving on the 15m while the 4h is mid-range and has made no new low — a liquidity flush, not a breakdown
-            & ((cmf_20_15m > -0.3) | (aroond_14_4h > 35) | (willr_14_4h < -60))
-            # 15m money out and the 4h downtrend set, but the 15m has already lifted off the floor
-            & ((cmf_20_15m > -0.3) | (mfi_14_15m < 15) | (minus_di_14_4h < 30))
-            # 4h stochastic falling, momentum falling and 15m money leaving
-            & ((stochrsi_k_change_pct_4h > -100.0) | (rsi_14_change_pct_4h > -15.0) | (cmf_20_15m > -0.2))
+            # 15m momentum falling, money flowing in and 4h stochastic high
+            & ((cmf_20_15m < -0.05) | (rsi_14_change_pct_15m > -35) | (stochrsi_k_4h < 50))
+            # 15m momentum falling, money flowing in and 1h a new high
+            & ((cmf_20_15m < 0.05) | (rsi_14_change_pct_15m > -25) | (aroonu_14_1h < 30))
+            # 1h stochastic high, 4h momentum falling and 15m momentum falling
+            & ((rsi_14_change_pct_15m > -25) | (stochk_14_3_3_1h < 35) | (rsi_14_change_pct_4h > -22))
             # 15m stochastic high, 4h not oversold and daily a recent low
             & ((stochrsi_k_15m < 50) | (rsi_14_4h < 45) | (aroond_14_1d < 40))
             # 15m stochastic high, 4h not falling and money drained
@@ -27573,6 +27709,14 @@ class NostalgiaForInfinityX7(IStrategy):
             & ((stochrsi_k_15m < 70) | (rsi_3_change_pct_1h > -40.0) | (cci_20_15m > -135.0))
             # 4h stochastic turning up, a long upper wick and 15m stochastic high
             & ((stochrsi_k_change_pct_4h < 40.0) | (top_wick_pct_4h < 2.0) | (stochrsi_k_15m < 10))
+            # 15m no recent low, stochastic at the floor and daily stochastic high
+            & ((aroond_14_15m > 45) | (stochrsi_k_15m > 15) | (stochrsi_k_1d < 20))
+            # 15m stochastic high, daily a long upper wick and 4h no trend established
+            & ((stochrsi_k_15m < 65) | (adx_14_4h > 30) | (top_wick_pct_1d < 6))
+            # 15m stochastic high, 1h oversold and 4h stochastic high
+            & ((stochrsi_k_15m < 65) | (rsi_14_1h > 20) | (stochrsi_k_4h < 20))
+            # 15m money flowing in, daily a long lower wick and stochastic high
+            & ((cmf_20_15m < 0.05) | (bot_wick_pct_1d < 3.5) | (stochk_14_3_3_15m < 45))
             # 15m stochastic high, daily down and no upper wick
             & ((stochk_14_3_3_15m < 40) | (change_pct_1d > -9.0) | (top_wick_pct_1d > 0.15))
             # 15m stochastic high, 4h momentum alive and a recent low
@@ -27583,74 +27727,164 @@ class NostalgiaForInfinityX7(IStrategy):
             & ((stochk_14_3_3_15m > 10) | (uo_7_14_28_15m < 50) | (adx_14_4h > 15))
             # 15m stochastic at the floor and daily a long lower wick
             & ((stochk_14_3_3_15m > 5) | (bot_wick_pct_1d < 6.0))
+            # daily money leaving, high in its range and 15m money flowing in
+            & ((cmf_20_1d > -0.1) | (willr_14_1d < -45) | (mfi_14_15m < 40))
+            # 15m money still flowing while the 4h is drained and its downtrend set
+            & ((mfi_14_15m < 25) | (cmf_20_4h > -0.2) | (minus_di_14_4h < 30))
+            # 15m money flowing in, 4h cycle turning up and money flowing in
+            & ((mfi_14_15m < 45) | (cci_20_change_pct_4h < 95.0) | (cmf_20_4h < 0.05))
+            # 15m money drained, 4h downtrend set and high in its range
+            & ((mfi_14_15m > 10) | (minus_di_14_4h < 40) | (willr_14_4h < -80))
+            # 15m money drained, 4h money flowing in and no trend established
+            & ((mfi_14_15m > 5) | (cmf_20_4h < 0.1) | (adx_14_4h > 20))
+            # 15m money drained, 4h oscillator low and stochastic high
+            & ((mfi_14_15m > 5) | (uo_7_14_28_4h > 35) | (stochrsi_k_4h < 15))
+            # 15m money out and the 4h downtrend set, but the 15m has already lifted off the floor
+            & ((cmf_20_15m > -0.3) | (mfi_14_15m < 15) | (minus_di_14_4h < 30))
+            # the 15m has stopped making new lows and money is still flowing into it, and the 5m breaks a 7-day low anyway
+            & ((aroond_14_15m > 50) | (mfi_14_15m < 40))
+            # 15m money flowing in, 4h stochastic high and daily no recent low
+            & ((mfi_14_15m < 35) | (stochk_14_3_3_4h < 40) | (aroond_14_1d > 5))
+            # 15m money flowing in and daily a long lower wick
+            & ((cmf_20_15m < 0.1) | (bot_wick_pct_1d < 3.5))
+            # money is leaving on the 15m while the 4h is mid-range and has made no new low — a liquidity flush, not a breakdown
+            & ((cmf_20_15m > -0.3) | (aroond_14_4h > 35) | (willr_14_4h < -60))
+            # 4h stochastic falling, momentum falling and 15m money leaving
+            & ((stochrsi_k_change_pct_4h > -100.0) | (rsi_14_change_pct_4h > -15.0) | (cmf_20_15m > -0.2))
+            # 15m money flowing in, daily falling and 1h money flowing in
+            & ((cmf_20_15m < -0.05) | (cmf_20_1h < 0) | (roc_2_1d > -13))
+            # 1h a new high, 15m money flowing in and daily a long upper wick
+            & ((cmf_20_15m < 0.1) | (aroonu_14_1h < 10) | (top_wick_pct_1d < 2))
+            # 15m oscillator high, daily money leaving and 4h not extended
+            & ((uo_7_14_28_15m < 50) | (cmf_20_1d > -0.2) | (cci_20_4h < -160.0))
+            # 15m oscillator low, daily a long upper wick and 4h stochastic at the floor
+            & ((uo_7_14_28_15m > 30) | (stochk_14_3_3_4h > 20) | (top_wick_pct_1d < 4))
+            # daily no new high, 4h momentum snapping up and 15m oscillator high
+            & ((uo_7_14_28_15m < 50) | (rsi_3_change_pct_4h < -20) | (aroonu_14_1d > 20))
+            # 15m oscillator high, 4h not falling and a recent low
+            & ((uo_7_14_28_15m < 50) | (aroond_14_4h < 90) | (roc_9_4h < -2))
+            # 15m oscillator high, 1h stochastic high and daily no new high
+            & ((uo_7_14_28_15m < 50) | (stochk_14_3_3_1h < 40) | (aroonu_14_1d > 5))
             # 15m oscillator lifting, 1h no recent low and daily a recent low
             & ((uo_7_14_28_change_pct_15m < 10.0) | (aroond_14_1h > 15) | (aroond_14_1d < 25))
             # 15m oscillator lifting, daily falling and 4h stochastic falling
             & ((uo_7_14_28_change_pct_15m < 10.0) | (roc_9_1d > -20.0) | (stochrsi_k_change_pct_4h > -45.0))
-            # 15m oscillator high, daily money leaving and 4h not extended
-            & ((uo_7_14_28_15m < 50) | (cmf_20_1d > -0.2) | (cci_20_4h < -160.0))
+            # 15m oscillator lifting, 1h not down and 4h a recent low
+            & ((uo_7_14_28_change_pct_15m < 10) | (change_pct_1h < 0) | (aroond_14_4h < 95))
+            # 15m oscillator lifting, 4h money leaving and 1h falling
+            & ((uo_7_14_28_change_pct_15m < 5) | (roc_2_1h > -5) | (cmf_20_4h > -0.25))
             # 15m at an extreme low, 4h oversold and 1h no recent low
             & ((cci_20_15m > -310.0) | (rsi_14_4h > 25) | (aroond_14_1h > 75))
-            # the 15m has stopped making new lows and money is still flowing into it, and the 5m breaks a 7-day low anyway
-            & ((aroond_14_15m > 50) | (mfi_14_15m < 40))
+            # 15m at an extreme low, 4h falling and 1h not falling
+            & ((cci_20_15m > -290) | (roc_2_1h < -2.5) | (roc_2_4h > -7))
             # 4h oscillator low, daily not falling and 15m no recent low
             & ((uo_7_14_28_4h > 35) | (roc_2_1d < 1.0) | (aroond_14_15m > 60))
+            # 15m a new high, no recent low and daily money flowing in
+            & ((aroond_14_15m > 75) | (aroonu_14_15m < 45) | (cmf_20_1d < 0.15))
             # the daily is being bought and has not made a low in two weeks, and the 15m just printed a fresh high
             & ((aroonu_14_15m < 45) | (aroond_14_1d > 25) | (mfi_14_1d < 65))
             # 1h at an extreme low, 4h momentum dead and 15m a new high
             & ((cci_20_1h > -225.0) | (rsi_3_4h > 5) | (aroonu_14_15m < 40))
+            # 15m a new high, daily money drained and stochastic high
+            & ((aroonu_14_15m < 45) | (mfi_14_1d > 45) | (stochrsi_k_1d < 80))
+            # 15m a new high, daily momentum snapping up and 4h not falling
+            & ((aroonu_14_15m < 65) | (roc_2_4h < -1) | (rsi_3_change_pct_1d < 40))
+            # 15m a new high, daily momentum snapping up and 1h not falling
+            & ((aroonu_14_15m < 65) | (roc_9_1h < -1.5) | (rsi_3_change_pct_1d < 15))
+            # 15m a new high, falling and 1h money flowing in
+            & ((aroonu_14_15m < 45) | (roc_9_15m > -7) | (cmf_20_1h < -0.15))
             # 15m high in its range, 4h stochastic at the floor and no trend established
             & ((willr_14_15m < -75) | (stochk_14_3_3_4h > 5) | (adx_14_4h > 15))
+            # 15m high in its range, 4h stochastic high and 1h money leaving
+            & ((willr_14_15m < -70) | (cmf_20_1h > -0.15) | (stochrsi_k_4h < 65))
             # 1h no recent low, oscillator low and 15m not falling
             & ((aroond_14_1h > 35) | (uo_7_14_28_1h > 35) | (roc_9_15m < -2.0))
+            # 15m not falling, 1h high in its range and daily a long upper wick
+            & ((roc_9_15m < -1) | (willr_14_1h < -70) | (top_wick_pct_1d < 3.5))
+            # 1h a new high, 4h money leaving and 15m falling
+            & ((roc_9_15m > -6) | (aroonu_14_1h < 60) | (cmf_20_4h > -0.1))
+            # 1h a new high, daily money leaving and 15m falling
+            & ((roc_9_15m > -3) | (aroonu_14_1h < 50) | (cmf_20_1d > -0.2))
             # 15m not down, 1h oversold and daily no new high
             & ((change_pct_15m < 0.0) | (rsi_14_1h > 20) | (aroonu_14_1d > 10))
-            # momentum has exploded upward on the hour and the day at once, and the 5m sells the 7-day low into the bounce
-            & ((rsi_3_change_pct_1h < 200) | (rsi_3_change_pct_1d < 300))
-            # 1h momentum collapsing, 4h at an extreme low and stochastic high
-            & ((rsi_3_change_pct_1h > -65.0) | (cci_20_4h > -250.0) | (stochrsi_k_1h < 25))
             # the hour has turned up hard — momentum, its rate of change and the oscillator all lifted — and the 5m sells the 7-day low into it
             & ((rsi_3_1h < 25) | (rsi_3_change_pct_1h < 65) | (stochrsi_k_1h < 45))
             # 1h momentum alive, momentum collapsing and 4h no trend established
             & ((rsi_3_1h < 30) | (rsi_3_change_pct_1h > -55.0) | (adx_14_4h > 25))
-            # 1h momentum alive, daily oversold and cycle turning up
-            & ((rsi_3_1h < 45) | (rsi_14_1d > 30) | (cci_20_change_pct_1h < -15.0))
+            # momentum has exploded upward on the hour and the day at once, and the 5m sells the 7-day low into the bounce
+            & ((rsi_3_change_pct_1h < 200) | (rsi_3_change_pct_1d < 300))
+            # 1h momentum collapsing, 4h at an extreme low and stochastic high
+            & ((rsi_3_change_pct_1h > -65.0) | (cci_20_4h > -250.0) | (stochrsi_k_1h < 25))
             # 1h not oversold, 4h momentum dead and a trend established
             & ((rsi_14_1h < 40) | (rsi_3_4h > 10) | (adx_14_4h < 40))
+            # 1h not oversold, money leaving and a new high
+            & ((aroonu_14_1h < 15) | (cmf_20_1h > -0.2) | (rsi_14_1h < 35))
+            # 1h oversold, daily high in its range and at an extreme low
+            & ((cci_20_1h > -300) | (rsi_14_1h > 20) | (willr_14_1d < -30))
+            # 1h no new high, 4h falling and momentum rising
+            & ((aroonu_14_1h > 10) | (rsi_14_change_pct_1h < 5) | (roc_2_4h > -8))
+            # 1h stochastic high, 4h downtrend weak and stochastic at the floor
+            & ((stochrsi_k_1h < 60) | (minus_di_14_4h > 20) | (stochk_14_3_3_1h > 40))
+            # 1h stochastic at the floor, 4h falling and no upper wick
+            & ((stochrsi_k_1h > 0) | (roc_9_4h > -10.0) | (top_wick_pct_4h > 0.05))
+            # 1h stochastic high, 4h no recent low and oversold
+            & ((stochrsi_k_1h < 35) | (aroond_14_4h > 45) | (rsi_14_4h > 30))
+            # daily money drained, a new high and 1h stochastic at the floor
+            & ((stochrsi_k_1h > 15) | (aroonu_14_1d < 55) | (mfi_14_1d > 30))
+            # 1h stochastic high, 4h stochastic high and a trend established
+            & ((stochk_14_3_3_1h < 50) | (stochrsi_k_4h < 65) | (adx_14_4h < 20))
+            # 4h a trend established, money leaving and 1h stochastic high
+            & ((stochk_14_3_3_1h < 20) | (adx_14_4h < 45) | (cmf_20_4h > -0.2))
+            # 1h stochastic high, 4h a trend established and daily oversold
+            & ((stochk_14_3_3_1h < 50) | (adx_14_4h < 35) | (rsi_14_1d > 35))
             # 1h money flowing in, 4h stochastic at the floor and a trend established
             & ((mfi_14_1h < 50) | (stochrsi_k_4h > 5) | (adx_14_4h < 40))
             # 1h money drained, 4h a trend established and stochastic falling
             & ((mfi_14_1h > 10) | (adx_14_4h < 40) | (stochrsi_k_change_pct_4h > -45.0))
             # 1h money exhausted after a two-day drop
             & ((mfi_14_1h > 25.0) | (roc_2_1d > -7.0))
+            # 1h money drained, daily momentum dead and at an extreme low
+            & ((cci_20_1h > -250) | (mfi_14_1h > 15) | (rsi_3_1d > 20))
+            # 1h money flowing in, 4h momentum falling and daily a recent low
+            & ((mfi_14_1h < 50) | (rsi_14_change_pct_4h > -25) | (aroond_14_1d < 30))
             # 1h money leaving, daily oversold and 4h a new high
             & ((cmf_20_1h > -0.3) | (rsi_14_1d > 30) | (aroonu_14_4h < 25))
             # daily stochastic high, falling and 1h money leaving
             & ((stochrsi_k_1d < 50) | (roc_9_1d > -17.0) | (cmf_20_1h > -0.2))
             # 4h stochastic at the floor, momentum falling and 1h money leaving
             & ((stochrsi_k_4h > 0) | (rsi_14_change_pct_4h > -20.0) | (cmf_20_1h > -0.35))
-            # 1h stochastic high, 4h downtrend weak and stochastic at the floor
-            & ((stochrsi_k_1h < 60) | (minus_di_14_4h > 20) | (stochk_14_3_3_1h > 40))
-            # 1h stochastic at the floor, 4h falling and no upper wick
-            & ((stochrsi_k_1h > 0) | (roc_9_4h > -10.0) | (top_wick_pct_4h > 0.05))
-            # 1h stochastic high, 4h stochastic high and a trend established
-            & ((stochk_14_3_3_1h < 50) | (stochrsi_k_4h < 65) | (adx_14_4h < 20))
-            # 1h cycle turning up, daily at the floor of its range and 4h no trend established
-            & ((cci_20_change_pct_1h < 255.0) | (willr_14_1d > -95) | (adx_14_4h > 15))
+            # 1h no recent low, 4h no trend established and money leaving
+            & ((aroond_14_1h > 15) | (adx_14_4h > 15) | (cmf_20_1h > -0.05))
+            # 1h money flowing in, 4h a trend established and daily a new high
+            & ((cmf_20_1h < 0.15) | (adx_14_4h < 40) | (aroonu_14_1d < 40))
+            # 1h money leaving, daily a long lower wick and 4h stochastic high
+            & ((cmf_20_1h > -0.25) | (stochrsi_k_4h < 55) | (bot_wick_pct_1d < 4))
+            # 1h oscillator high, daily no recent low and 4h money flowing in
+            & ((uo_7_14_28_1h < 55) | (cmf_20_4h < -0.05) | (aroond_14_1d > 5))
+            # 1h oscillator high, daily not falling and 4h stochastic falling
+            & ((uo_7_14_28_1h < 50) | (stochrsi_k_change_pct_4h > -60) | (roc_9_1d < 4))
             # 1h at an extreme low, 4h stochastic turning up and daily no recent low
             & ((cci_20_1h > -300.0) | (stochrsi_k_change_pct_4h < 45.0) | (aroond_14_1d > 10))
+            # 1h cycle turning up, daily at the floor of its range and 4h no trend established
+            & ((cci_20_change_pct_1h < 255.0) | (willr_14_1d > -95) | (adx_14_4h > 15))
             # nothing is making new lows — not the hour, not the day — and the 15m just printed a fresh high, yet the 5m breaks a 7-day low
             & (aroonu_14_15m_lt_50 | (aroond_14_1h > 25) | (aroond_14_1d > 15))
+            # 4h momentum falling, daily momentum snapping up and 1h a recent low
+            & ((aroond_14_1h < 90) | (rsi_14_change_pct_4h > -25) | (rsi_3_change_pct_1d < 110))
+            # 1h no recent low, 4h stochastic high and daily not falling
+            & ((aroond_14_1h > 15) | (stochrsi_k_4h < 65) | (roc_9_1d < -10))
+            # 4h stochastic high, 1h high in its range and daily down
+            & ((willr_14_1h < -95) | (stochrsi_k_4h < 40) | (change_pct_1d > -10))
             # 1h the two-day window off its floor, daily oversold and 4h a trend established
             & ((willr_84_1h < -80) | (rsi_14_1d > 30) | (adx_14_4h < 45))
             # 1h the two-day window off its floor, 4h at the floor of its range and a trend established
             & ((willr_84_1h < -80) | (willr_14_4h > -95) | (adx_14_4h < 30))
+            # 1h the two-day window off its floor, 4h a trend established and oversold
+            & ((willr_84_1h < -85) | (adx_14_4h < 45) | (rsi_14_4h > 25))
             # 1h falling, 4h no upward push and daily not falling
             & ((roc_9_1h > -6.0) | (plus_di_14_4h > 5.0) | (roc_9_1d < -20.0))
             # 1h down, 4h at an extreme low and daily no recent low
             & ((change_pct_1h > -4.0) | (cci_20_4h > -250.0) | (aroond_14_1d > 20.0))
-            # the 4h has already snapped up while the day is still washed out
-            & ((rsi_3_change_pct_4h < 65) | rsi_3_1d_gt_30)
             # 4h momentum alive, a recent low and daily no new high
             & ((rsi_3_4h < 40) | (aroond_14_4h < 95) | (aroonu_14_1d > 30))
             # 4h momentum alive, daily stochastic at the floor and not falling
@@ -27659,40 +27893,82 @@ class NostalgiaForInfinityX7(IStrategy):
             & ((rsi_3_4h > 10) | (stochrsi_k_change_pct_4h < 40.0) | (adx_14_4h > 25))
             # 4h momentum dead, cycle turning up and daily no new high
             & ((rsi_3_4h > 5) | (cci_20_change_pct_4h < 180.0) | (aroonu_14_1d > 10))
-            # 4h momentum dead, downtrend weak and daily no new high
-            & ((rsi_3_4h > 5) | (minus_di_14_4h > 25) | (aroonu_14_1d > 0))
-            # 4h money drained, daily a long upper wick and momentum alive
-            & ((mfi_14_4h > 20) | (top_wick_pct_1d < 4.0) | (rsi_3_1d < 30))
-            # 4h money flowing in, daily down and no recent low
-            & ((cmf_20_4h < 0.1) | (change_pct_1d > -9.0) | (aroond_14_1d > 20.0))
+            # daily momentum alive, 4h momentum alive and stochastic at the floor
+            & ((rsi_3_4h < 30) | (rsi_3_1d < 45) | (stochrsi_k_1d > 50))
+            # 4h momentum alive, at the floor of its range and daily no new high
+            & ((rsi_3_4h < 25) | (willr_14_4h > -95) | (aroonu_14_1d > 10))
+            # the 4h has already snapped up while the day is still washed out
+            & ((rsi_3_change_pct_4h < 65) | rsi_3_1d_gt_30)
             # 4h stochastic falling, momentum collapsing and no trend established
             & ((stochrsi_k_change_pct_4h > -70.0) | (rsi_3_change_pct_4h > -75.0) | (adx_14_4h > 30))
+            # 4h momentum collapsing, daily a recent low and money leaving
+            & ((cmf_20_4h > -0.15) | (rsi_3_change_pct_4h > -75) | (aroond_14_1d < 95))
+            # 4h a new high, momentum rising and daily a recent low
+            & ((aroonu_14_4h < 80) | (rsi_14_change_pct_4h < 5) | (aroond_14_1d < 30))
             # 4h stochastic high, at an extreme low and a trend established
             & ((stochrsi_k_4h < 65) | (cci_20_4h > -195.0) | (adx_14_4h < 15))
             # the 7-day low breaks while neither the hourly nor the 4h is anywhere near oversold
             & (stochrsi_k_1h_lt_40 | (stochrsi_k_4h < 35))
+            # the 4h has already rallied hard — oscillator topped, no new 4h low for days — and the 5m breaks a 7-day low against it
+            & ((adx_14_4h < 40) | (aroond_14_4h > 30) | (stochrsi_k_4h < 75))
+            # 4h down, stochastic high and daily a new high
+            & ((change_pct_4h > -6) | (stochrsi_k_4h < 60) | (aroonu_14_1d < 45))
+            # 4h stochastic at the floor, daily money drained and high in its range
+            & ((stochrsi_k_4h > 10) | (mfi_14_1d > 30) | (willr_14_1d < -65))
             # daily money flowing in, a long lower wick and 4h stochastic at the floor
             & ((mfi_14_1d < 70) | (bot_wick_pct_1d < 5.0) | (stochk_14_3_3_4h > 20))
             # the 4h stochastic is pinned at the floor and the day is washed out, but the daily stochastic has not followed
             & ((stochk_14_3_3_4h > 15) | rsi_3_1d_gt_30 | (stochk_14_3_3_1d < 35))
-            # 4h stochastic at the floor, oscillator high and a trend established
-            & ((stochk_14_3_3_4h > 5) | (uo_7_14_28_4h < 40) | (adx_14_4h < 15))
+            # 4h money drained, daily a long upper wick and momentum alive
+            & ((mfi_14_4h > 20) | (top_wick_pct_1d < 4.0) | (rsi_3_1d < 30))
+            # the 4h is drained but has printed no new low for days — the decline has stalled, and the 5m sells the 7-day low into the stall
+            & ((aroond_14_4h > 20) | (mfi_14_4h > 25))
+            # 4h a trend established, money drained and daily a new high
+            & ((adx_14_4h < 45) | (mfi_14_4h > 15) | (aroonu_14_1d < 25))
+            # 4h money flowing in, at an extreme low and daily falling
+            & ((cci_20_4h > -230) | (mfi_14_4h < 45) | (roc_2_1d > -1.5))
+            # 4h money flowing in, daily down and no recent low
+            & ((cmf_20_4h < 0.1) | (change_pct_1d > -9.0) | (aroond_14_1d > 20.0))
+            # daily no recent low, falling and 4h money flowing in
+            & ((cmf_20_4h < 0) | (aroond_14_1d > 5) | (roc_9_1d > -19))
             # 4h oscillator high, daily a long upper wick and no recent low
             & ((uo_7_14_28_4h < 55) | (top_wick_pct_1d < 3.0) | (aroond_14_1d > 25))
-            # 4h cycle turning up, daily stochastic at the floor and a trend established
-            & ((cci_20_change_pct_4h < 150.0) | (stochrsi_k_1d > 0) | (adx_14_4h < 30))
-            # 4h not extended, down and stochastic at the floor
-            & ((cci_20_4h < -50.0) | (change_pct_4h > -4.0) | (stochk_14_3_3_4h > 45))
+            # 4h oscillator high, falling and a trend established
+            & ((adx_14_4h < 40) | (roc_2_4h > -6) | (uo_7_14_28_4h < 50))
             # daily momentum alive, stochastic at the floor and 4h not extended
             & ((rsi_3_1d < 35) | (stochrsi_k_1d > 5) | (cci_20_4h < -90.0))
             # daily stochastic high, a long lower wick and 4h not extended
             & ((stochrsi_k_1d < 85) | (bot_wick_pct_1d < 5.0) | (cci_20_4h < -250.0))
-            # the 4h is drained but has printed no new low for days — the decline has stalled, and the 5m sells the 7-day low into the stall
-            & ((aroond_14_4h > 20) | (mfi_14_4h > 25))
-            # the 4h has already rallied hard — oscillator topped, no new 4h low for days — and the 5m breaks a 7-day low against it
-            & ((adx_14_4h < 40) | (aroond_14_4h > 30) | (stochrsi_k_4h < 75))
+            # daily money flowing in, momentum snapping up and 4h at an extreme low
+            & ((cci_20_4h > -100) | (mfi_14_1d < 55) | (rsi_3_change_pct_1d < 145))
+            # 4h at an extreme low, daily money drained and stochastic at the floor
+            & ((cci_20_4h > -195) | (mfi_14_1d > 25) | (stochrsi_k_1d > 5))
+            # 4h cycle turning up, daily stochastic at the floor and a trend established
+            & ((cci_20_change_pct_4h < 150.0) | (stochrsi_k_1d > 0) | (adx_14_4h < 30))
             # 4h not falling, cycle falling and daily a new high
             & ((roc_2_4h < -1.0) | (cci_20_change_pct_4h > -265.0) | (aroonu_14_1d < 5))
+            # 4h a new high, a long upper wick and a recent low
+            & ((aroond_14_4h < 60) | (aroonu_14_4h < 80) | (top_wick_pct_4h < 2.5))
+            # 4h no trend established, daily oversold and a new high
+            & ((adx_14_4h > 15) | (aroonu_14_4h < 30) | (rsi_14_1d > 40))
+            # daily momentum alive, money drained and 4h at the floor of its range
+            & ((willr_14_4h > -90) | (mfi_14_1d > 30) | (rsi_3_1d < 35))
+            # daily stochastic high, money leaving and 4h no trend established
+            & ((adx_14_4h > 15) | (cmf_20_1d > -0.2) | (stochk_14_3_3_1d < 35))
+            # 4h no trend established, daily oversold and falling
+            & ((adx_14_4h > 25) | (roc_2_4h > -4) | (rsi_14_1d > 35))
+            # daily stochastic at the floor, stochastic high and 4h down
+            & ((change_pct_4h > -1) | (stochk_14_3_3_1d > 20) | (stochrsi_k_1d < 60))
+            # 4h a long upper wick, daily a long upper wick and momentum alive
+            & ((top_wick_pct_4h < 2) | (rsi_3_1d < 45) | (top_wick_pct_1d < 4.5))
+            # daily stochastic high, money drained and momentum alive
+            & ((mfi_14_1d > 35) | (rsi_3_1d < 40) | (stochrsi_k_1d < 80))
+            # daily stochastic high, money drained and momentum alive
+            & ((mfi_14_1d > 40) | (rsi_3_1d < 40) | (stochrsi_k_1d < 80))
+            # daily money flowing in, at the floor of its range and a new high
+            & ((aroonu_14_1d < 75) | (mfi_14_1d < 55) | (willr_14_1d > -90))
+            # daily no new high, no recent low and a long lower wick
+            & ((aroond_14_1d > 5) | (aroonu_14_1d > 5) | (bot_wick_pct_1d < 3))
           )
 
           # Logic


### PR DESCRIPTION

The block goes from 136 chains to 274, measured on 2021, 2022, 2024 and 2025.
Signal stays disabled.

Rig: 506 the only experimental tag enabled, position_adjustment off, derisk
off, system_v3_2 stops on, gms0 configs — so these are the entry's own numbers,
before grinding rescues anything.

              trades   losses    points   per trade   max DD   worst day
  2021          623      23     +2995.2    +4.81%     -176.5   2021-07-21  -73.9
  2022         1154      40     +4449.7    +3.86%     -231.4   2022-05-30 -143.7
  2024          717      25     +2888.1    +4.03%     -203.1   2024-05-17  -75.0
  2025          852      37     +2439.0    +2.86%     -190.9   2025-10-02 -174.9
  total        3346     125    +12,772.1               win rate 96.26%

On the two regimes the round opened with:

  raw 506                  2021+2022   2602t / 351L /   +420 points
  the 18 chains merged in #1216        2003t / 152L /  +5667
  this block                           1777t /  63L /  +7445

506 breaks even near an 87% win rate: the average winner is +5.2% against an
average loss of -35.9%, so one loss costs about seven winners. Raw ran 86.5%
on 2021+2022, which is why it was flat while winning nine trades in ten.

Every chain is two or three clauses, never four, and each went through the same
gate before it was applied: threshold inside the column's observed range, clause
true for at least a fifth of trades, on the house grid, standing a real distance
from the target's own reading, clause correlation measured across all four
regimes with direction (opposite directions kept — correlated columns thresholded
against each other are a divergence filter, and replacing one on 505 cost three
losses), a nudge test that moves each threshold one grid step and fails the chain
if it turns negative, and at least one clause on 1h/4h/1d.

That last rule came out of a measurement I did not expect: blocking a candle does
not remove the trade, it postpones it. On 506, 81-92% of what a chain blocks
comes back on the same pair, median 25 minutes later, because the signal fires on
a transition and `dc_low_7d` keeps dropping in a falling market. A clause read off
the entry candle is stepped over; a 1h/4h/1d one still reads the same when the
setup re-arms. Two chains were rewritten onto a slow axis for this and went from
+3.1 to +78.1 and from -14.3 to +38.0.

Vocabulary divergences, stated rather than buried: this round uses CCI at 15m,
1h and 4h thresholds that do not appear in your blocks, and
`uo_7_14_28_change_pct_15m`, `roc_288`, `stochrsi_k_change_pct_4h` and
`cmf_20_15m` are our axes, not yours.

Seven chains from #1216 are dropped here. On our exports they block nothing at
all — three rest on a column's floor (`aroond_14_1d > 0`, `willr_14 > -100`),
three are true for 7-14% of trades, one touches a single trade in 7708. Worth
saying plainly: a chain reading 0L/0W on an export produced by a block that
contains it is not necessarily inert, and we were caught by exactly that once
today, so treat this as a suggestion rather than a finding.

What was not done: 2023 and 2020 were never run. Four fitted regimes are not
validation and I would rather say so than call anything out-of-sample. Group
chains — one chain answering several losses at once — were measured and mostly
dropped: on 2024 five of them cost 21 winners for 3 losses where twelve
per-loss chains cost 9 for 2, so they pay across the whole set and put the bill
on whichever regime you are trying to finish.

The block is ordered 5m, 15m, 1h, 4h, 1d and by indicator family inside each
group; the reorder was verified behaviour-neutral against the run that preceded
it (2021: 623t / 23L / +2995.2, identical to the digit).