### PR TITLE
Blacklist: add SCRT (Binance spot delist 2026-09-03)

### DIFF
--- a/configs/blacklist-binance.json
+++ b/configs/blacklist-binance.json
@@ -1,6 +1,8 @@
 {
   "exchange": {
     "pair_blacklist": [
+      // Binance spot delist 2026-09-03 (periodic review) — ICX and STORJ already covered above
+      "(SCRT)/.*",
       // Binance monitoring tag 2026-08-11 (delisting-risk watchlist, batch 2)
       "(GLMR|ICX|MOVR|SOPH|SYN|COOKIE|DODO|DODOX|STORJ)/.*",
       // Binance monitoring tag 2026-08 (delisting-risk watchlist)

--- a/configs/blacklist-bitget.json
+++ b/configs/blacklist-bitget.json
@@ -1,6 +1,8 @@
 {
   "exchange": {
     "pair_blacklist": [
+      // Binance spot delist 2026-09-03 (periodic review) — ICX and STORJ already covered above
+      "(SCRT)/.*",
       // Binance monitoring tag 2026-08-11 (delisting-risk watchlist, batch 2)
       "(GLMR|ICX|MOVR|SOPH|SYN|COOKIE|DODO|DODOX|STORJ)/.*",
       // Binance monitoring tag 2026-08 (delisting-risk watchlist)

--- a/configs/blacklist-bitmart.json
+++ b/configs/blacklist-bitmart.json
@@ -1,6 +1,8 @@
 {
   "exchange": {
     "pair_blacklist": [
+      // Binance spot delist 2026-09-03 (periodic review) — ICX and STORJ already covered above
+      "(SCRT)/.*",
       // Binance monitoring tag 2026-08-11 (delisting-risk watchlist, batch 2)
       "(GLMR|ICX|MOVR|SOPH|SYN|COOKIE|DODO|DODOX|STORJ)/.*",
       // Binance monitoring tag 2026-08 (delisting-risk watchlist)

--- a/configs/blacklist-bitvavo.json
+++ b/configs/blacklist-bitvavo.json
@@ -1,6 +1,8 @@
 {
   "exchange": {
     "pair_blacklist": [
+      // Binance spot delist 2026-09-03 (periodic review) — ICX and STORJ already covered above
+      "(SCRT)/.*",
       // Binance monitoring tag 2026-08-11 (delisting-risk watchlist, batch 2)
       "(GLMR|ICX|MOVR|SOPH|SYN|COOKIE|DODO|DODOX|STORJ)/.*",
       // Binance monitoring tag 2026-08 (delisting-risk watchlist)

--- a/configs/blacklist-bybit.json
+++ b/configs/blacklist-bybit.json
@@ -1,6 +1,8 @@
 {
   "exchange": {
     "pair_blacklist": [
+      // Binance spot delist 2026-09-03 (periodic review) — ICX and STORJ already covered above
+      "(SCRT)/.*",
       // Binance monitoring tag 2026-08-11 (delisting-risk watchlist, batch 2)
       "(GLMR|ICX|MOVR|SOPH|SYN|COOKIE|DODO|DODOX|STORJ)/.*",
       // Binance monitoring tag 2026-08 (delisting-risk watchlist)

--- a/configs/blacklist-gateio.json
+++ b/configs/blacklist-gateio.json
@@ -1,6 +1,8 @@
 {
   "exchange": {
     "pair_blacklist": [
+      // Binance spot delist 2026-09-03 (periodic review) — ICX and STORJ already covered above
+      "(SCRT)/.*",
       // Binance monitoring tag 2026-08-11 (delisting-risk watchlist, batch 2)
       "(GLMR|ICX|MOVR|SOPH|SYN|COOKIE|DODO|DODOX|STORJ)/.*",
       // Binance monitoring tag 2026-08 (delisting-risk watchlist)

--- a/configs/blacklist-htx.json
+++ b/configs/blacklist-htx.json
@@ -1,6 +1,8 @@
 {
   "exchange": {
     "pair_blacklist": [
+      // Binance spot delist 2026-09-03 (periodic review) — ICX and STORJ already covered above
+      "(SCRT)/.*",
       // Binance monitoring tag 2026-08-11 (delisting-risk watchlist, batch 2)
       "(GLMR|ICX|MOVR|SOPH|SYN|COOKIE|DODO|DODOX|STORJ)/.*",
       // Binance monitoring tag 2026-08 (delisting-risk watchlist)

--- a/configs/blacklist-hyperliquid.json
+++ b/configs/blacklist-hyperliquid.json
@@ -1,6 +1,8 @@
 {
   "exchange": {
     "pair_blacklist": [
+      // Binance spot delist 2026-09-03 (periodic review) — ICX and STORJ already covered above
+      "(SCRT)/.*",
       // Binance monitoring tag 2026-08-11 (delisting-risk watchlist, batch 2)
       "(GLMR|ICX|MOVR|SOPH|SYN|COOKIE|DODO|DODOX|STORJ)/.*",
       // Binance monitoring tag 2026-08 (delisting-risk watchlist)

--- a/configs/blacklist-kraken.json
+++ b/configs/blacklist-kraken.json
@@ -1,6 +1,8 @@
 {
   "exchange": {
     "pair_blacklist": [
+      // Binance spot delist 2026-09-03 (periodic review) — ICX and STORJ already covered above
+      "(SCRT)/.*",
       // Binance monitoring tag 2026-08-11 (delisting-risk watchlist, batch 2)
       "(GLMR|ICX|MOVR|SOPH|SYN|COOKIE|DODO|DODOX|STORJ)/.*",
       // Binance monitoring tag 2026-08 (delisting-risk watchlist)

--- a/configs/blacklist-kucoin.json
+++ b/configs/blacklist-kucoin.json
@@ -1,6 +1,8 @@
 {
   "exchange": {
     "pair_blacklist": [
+      // Binance spot delist 2026-09-03 (periodic review) — ICX and STORJ already covered above
+      "(SCRT)/.*",
       // Binance monitoring tag 2026-08-11 (delisting-risk watchlist, batch 2)
       "(GLMR|ICX|MOVR|SOPH|SYN|COOKIE|DODO|DODOX|STORJ)/.*",
       // Binance monitoring tag 2026-08 (delisting-risk watchlist)

--- a/configs/blacklist-mexc.json
+++ b/configs/blacklist-mexc.json
@@ -1,6 +1,8 @@
 {
   "exchange": {
     "pair_blacklist": [
+      // Binance spot delist 2026-09-03 (periodic review) — ICX and STORJ already covered above
+      "(SCRT)/.*",
       // Binance monitoring tag 2026-08-11 (delisting-risk watchlist, batch 2)
       "(GLMR|ICX|MOVR|SOPH|SYN|COOKIE|DODO|DODOX|STORJ)/.*",
       // Binance monitoring tag 2026-08 (delisting-risk watchlist)

--- a/configs/blacklist-okx.json
+++ b/configs/blacklist-okx.json
@@ -1,6 +1,8 @@
 {
   "exchange": {
     "pair_blacklist": [
+      // Binance spot delist 2026-09-03 (periodic review) — ICX and STORJ already covered above
+      "(SCRT)/.*",
       // Binance monitoring tag 2026-08-11 (delisting-risk watchlist, batch 2)
       "(GLMR|ICX|MOVR|SOPH|SYN|COOKIE|DODO|DODOX|STORJ)/.*",
       // Binance monitoring tag 2026-08 (delisting-risk watchlist)


### PR DESCRIPTION

Binance announced on 2026-08-20 that spot support ends for ICON, Secret and
Storj on 2026-09-03 03:00 UTC, from its periodic review. ICX and STORJ are
already blocked in all twelve configs; SCRT is in none of them, and it is the
most liquid of the three on the perp side at $17.8M in 24h.

It is not theoretical — SCRT is live on binance, bybit and bitget, and one of
our bots traded it on 2026-08-12 (tag 3, opened 12:36, closed 13:15, +3.18%).
The whitelist reaches it today. Its worst daily range in the last month is
49.8%, which is what a name in this state does.

All twelve rather than binance only, by the usual convention for a coin losing
support: it can surface on any venue, and it is already listed on three of ours.

The seven spot pairs delisted on 2026-08-21 (F/USDC, HIVE/USDC, ILV/USDC,
LTC/BNB, NMR/USDC, STEEM/USDC, SUI/BNB) are quote-pair removals, not coin
delistings — every one of those tokens keeps other Binance spot markets — so
nothing is proposed for them.