### PR TITLE
X7: protect signal 193 pivot divergence

### DIFF
--- a/NostalgiaForInfinityX7.py
+++ b/NostalgiaForInfinityX7.py
@@ -26541,14 +26541,34 @@ class NostalgiaForInfinityX7(IStrategy):
           # --- Protections ---
           long_entry_logic.append(num_empty_288 <= allowed_empty_candles_288)
           long_entry_logic.append(protections_long_global == True)
+          long_entry_logic.append(
+            # Negative 15m flow is ongoing sell pressure, not a pivot recovery (COMP/BAND/MTL);
+            # require short-term money flow to turn positive.
+            (cmf_20_15m > 0.0)
+            # A divergence in trendless 4h chop has no recovery structure; require a real trend.
+            & (adx_14_4h > 20.0)
+            # A 4h candle already down 8% is a falling knife (RUNE 2024-06), not a pivot.
+            & (change_pct_4h > -8.0)
+            # A hot 15m pulse inside an unrecovered day is a false counter-trend bounce (1INCH
+            # 2022-12); need 15m relief OR cooler momentum OR daily recovery.
+            & ((willr_14_15m > -40.0) | (uo_7_14_28_15m < 50.0) | (stochrsi_k_1d > 25.0))
+            # Positive hourly flow without a price response while the day is pinned is trapped
+            # inflow (EGLD 2022-11, MTL/ZEN 2024); need low flow OR hourly lift OR a daily reset.
+            & ((cmf_20_1h < 0.05) | (stochk_14_3_3_1h > 80.0) | stochrsi_k_1d_gt_10)
+            # Daily capitulation with no sustained 1h/4h flow is a dead-cat bounce (THETA/EGLD
+            # 2024, BAND/ZEN 2026); need hourly inflow OR positive 4h flow OR daily RSI recovery.
+            & ((cmf_20_1h > 0.15) | (cmf_20_4h > 0.0) | rsi_3_1d_gt_20)
+          )
           # --- Logic: embedded up-regime + quad-oversold + two-pivot bullish divergence ---
-          long_entry_logic.append(stoch_60_10 > 80.0)
-          long_entry_logic.append(stoch_9_3 < 20.0)
-          long_entry_logic.append(stoch_14_3 < 20.0)
-          long_entry_logic.append(stoch_4_4 < 20.0)
-          # price LOWER-LOW across swing windows while stoch makes a HIGHER-LOW (real divergence)
-          long_entry_logic.append(quad_low_min_12 < np_shift(quad_low_min_12, 12))
-          long_entry_logic.append(quad_s93_min_12 > np_shift(quad_s93_min_12, 12))
+          long_entry_logic.append(
+            (stoch_60_10 > 80.0)
+            & (stoch_9_3 < 20.0)
+            & (stoch_14_3 < 20.0)
+            & (stoch_4_4 < 20.0)
+            # Price makes a lower low while stochastic makes a higher low (real divergence).
+            & (quad_low_min_12 < np_shift(quad_low_min_12, 12))
+            & (quad_s93_min_12 > np_shift(quad_s93_min_12, 12))
+          )
 
         long_entry_logic.append(df["volume"] > 0)
         item_long_entry = _and_entry_conditions(long_entry_logic)
@@ -29971,7 +29991,7 @@ class NostalgiaForInfinityX7(IStrategy):
     if short_entry_conditions:
       df.loc[:, "enter_short"] = _or_entry_conditions(short_entry_conditions).astype(int)
 
-    df.loc[:, "enter_tag"] = entry_tags
+    df.loc[:, "enter_tag"] = pd.array(entry_tags, dtype="string")
     if debug:
       tok = time.perf_counter()
       log.debug("populate_entry_trend took a total of: %.4f seconds.", tok - tik)


### PR DESCRIPTION
## Summary

- add six entry protections to default-disabled Signal 193 (Quad TRUE pivot divergence)
- preserve the original divergence logic while grouping protections and logic into one append each
- make `enter_tag` assignment safe for pandas length-one frames with an explicit string array

Signal 193 remains default-disabled. This PR is a protection port, not an activation request.

## Protection scenes

1. require positive 15m money flow instead of ongoing sell pressure
2. require an established 4h trend and reject a 4h candle already down 8%
3. reject a hot 15m pulse while the daily oscillator has not recovered
4. reject positive hourly flow that produces no price response while daily StochRSI is pinned
5. reject daily capitulation when neither 1h nor 4h money flow has recovered

Every OR chain uses rounded thresholds, target margin, population coverage, raw-union reach, pairwise correlation, and one-step nudge checks. The 0.15 hourly CMF threshold is intentionally disclosed as off iterativ's extracted vocabulary; it is the center of the measured 0.10/0.15/0.20 plateau.

## Latest upstream-main referee

Pinned 150-pair gms0 rig, Signal 193 only, `position_adjustment_enable=False`, `derisk_enable=False`, v3.2 stops enabled, `--export signals`, `--cache none`:

| Year | Signal 193 |
|---|---:|
| 2022 | 18t / 17W / 1L / +57.757783pt |
| 2023 opened control | 33t / 32W / 1L / +71.453620pt |
| 2024 | 37t / 37W / 0L / +146.056040pt |
| 2025 | 26t / 26W / 0L / +76.731112pt |
| 2026 | 3t / 3W / 0L / +1.839602pt |

Mined 2022/2024/2025/2026 total: **84t / 83W / 1L / +282.384536pt**. The only mined loss is LINK at the timerange end (`force_exit`), so mined doom losses are zero. Including the already-opened 2023 control: **117t / 115W / 2L / +353.838156pt**.

Backtests do not prove future profitability. No untouched wide-universe 2020/2021 data is available, so the signal stays disabled pending a separate forward/OOS activation lane.

## Verification

- `python -m py_compile NostalgiaForInfinityX7.py`
- `pre-commit run --files NostalgiaForInfinityX7.py`
- `git diff --check`
- five real Freqtrade runs above on current `upstream/main`
- 2023 reproduces the prior pandas length-one failure before the `pd.array(..., dtype="string")` fix and completes after it