### PR TITLE
Signal 665: a backbone round on 2021 and 2022

### DIFF
--- a/NostalgiaForInfinityX7.py
+++ b/NostalgiaForInfinityX7.py
@@ -29447,16 +29447,54 @@ class NostalgiaForInfinityX7(IStrategy):
 
         # Condition #665 - Engulfing continuation (Short, experimental, RAW — mirror).
         if short_entry_condition_index == 665:
+          # Protections
           short_entry_logic.append(num_empty_288 <= allowed_empty_candles_288)
           short_entry_logic.append(protections_short_global == True)
-          # breakdown must be real: price already in the lower half of the range,
-          # 15m momentum actually down (losses were top-of-range fake breakdowns)
-          short_entry_logic.append(willr_14 < -50.0)
-          short_entry_logic.append(rsi_3_15m < 45.0)
-          # downtrend regime + momentum side + bearish engulfing close
-          short_entry_logic.append(close < ema_200)
-          short_entry_logic.append(rsi_14 < 50.0)
-          short_entry_logic.append(engulf_bear > 0.5)
+
+          short_entry_logic.append(
+            # daily money flowing in and 4h not oversold
+            ((cmf_20_1d > 0.05) | (rsi_14_4h_lt_40))
+            # 5m money flowing in and 1h money flowing in
+            & ((mfi_14 < 30) | (mfi_14_1h < 40))
+            # 5m no recent low, daily oversold and 15m stochastic at the floor
+            & ((aroond_14 > 40) | (rsi_14_1d > 35) | (stochrsi_k_15m_gt_40))
+            # the last 24h fell hard and the 4h cycle is turning up
+            & ((roc_288 > -11.0) | (cci_20_change_pct_4h < -10.0))
+            # 4h a trend established, money flowing in and 5m falling
+            & ((adx_14_4h < 40) | (cmf_20_4h_lt_0_15) | (roc_9 > -2))
+            # below-average volume and 1h momentum alive
+            & ((vol_rel > 1.25) | (rsi_3_1h < 20))
+            # the two-day window off its floor and tightly squeezed
+            & ((willr_84_1h < -75) | (sqz_cnt_24 < 10))
+            # 15m money flowing in, 4h downtrend weak and oscillator lifting
+            & ((cmf_20_15m_lt_0_10) | (minus_di_14_4h > 25) | (uo_7_14_28_change_pct_15m < 5))
+            # 1h a recent low, falling and stochastic high
+            & ((aroond_14_1h < 80) | (roc_9_1h > -7) | (stochrsi_k_1h_lt_30))
+            # 1h at an extreme low and daily a long lower wick
+            & ((cci_20_1h > -175.0) | (bot_wick_pct_1d < 3))
+            # 4h money leaving and 1h at the floor of its range
+            & ((cmf_20_4h > -0.05) | (willr_14_1h < -75))
+            # 4h momentum alive and stochastic turning up
+            & ((rsi_3_4h < 65) | (stochrsi_k_change_pct_4h < 5))
+            # 4h momentum falling and daily no upper wick
+            & ((rsi_14_change_pct_4h > -15.0) | (top_wick_pct_1d > 1.5))
+            # 4h no trend established and stochastic falling hard
+            & ((adx_14_4h > 20) | (stochrsi_k_change_pct_4h > -70.0))
+            # 4h money flowing in and high in its range
+            & ((mfi_14_4h < 55) | (willr_14_4h > -40))
+            # 4h no recent low and money flowing in
+            & ((aroond_14_4h > 5) | (cmf_20_4h < 0.05))
+          )
+
+          # Logic
+          short_entry_logic.append(
+            # a bearish engulfing inside a downtrend, in the lower half of the range
+            (close < ema_200)
+            & (rsi_14 < 50.0)
+            & (willr_14 < -50.0)
+            & (rsi_3_15m < 45.0)
+            & (engulf_bear > 0.5)
+          )
 
         # Condition #666 - Swing-failure pattern (Short, experimental, RAW — mirror).
         if short_entry_condition_index == 666:


### PR DESCRIPTION

665 goes from bare logic to twelve backbone chains and four group chains,
still disabled. Rig: 665 the only experimental tag enabled, position_adjustment
off, derisk off, system_v3_2 stops on, gms0 configs — the entry's own numbers,
before grinding rescues anything.

              trades   winners  losses    WR      per trade
  2021 raw       584       477     107   81.7%     -3.429%
  2021 now      1601      1488     113   92.9%     +1.255%
  2022 raw      3135      2852     283   91.0%     +0.419%
  2022 now      1759      1671      88   95.0%     +2.055%

665 breaks even near 89.9%: the average winner is +3.97% against an average
loss of -35.35%, so one loss costs about nine winners. Raw ran 91.0% in 2022,
barely above, and 81.7% in 2021, far below — which is why the raw signal was
+0.42% per trade in the bear year and -3.43% in the bull one.

The 2021 raw figure is worth reading carefully rather than at face value: on
the w100 wallet the raw signal fell from $100 to $1.43 by 11 February and
stopped trading for the remaining ten months, so those 584 trades are January
and February, not the year. Per-trade and win rate are the honest comparison
there; the totals are not. (The 10k wallet is not the fix — 2021 compounds
until the stake exceeds what a pair will take, "Stake amount 12,688,045 too
high for SAND/USDT:USDT", and the run dies.)

The twelve backbone chains are one thesis measured twelve ways — do not sell
continuation when the fall is not actually continuing — with the escape that
keeps the cases where it is:

    4h low stale + money flowing in      aroond_14_4h > 5   | cmf_20_4h < 0.05
    4h money flow + position in range    mfi_14_4h < 55     | willr_14_4h > -40
    4h momentum                          rsi_3_4h < 65      | stochrsi_k_change_pct_4h < 5
    the last 24h already fell            roc_288 > -11      | cci_20_change_pct_4h < -10
    conviction by volume                 vol_rel > 1.25     | rsi_3_1h < 20
    short-term selling pressure          mfi_14 < 30        | mfi_14_1h < 40
    daily money flow                     cmf_20_1d > 0.05   | rsi_14_4h_lt_40
    two-day window + squeeze             willr_84_1h < -75  | sqz_cnt_24 < 10
    1h extreme + daily lower wick        cci_20_1h > -175   | bot_wick_pct_1d < 3
    4h money leaving + 1h at its floor   cmf_20_4h > -0.05  | willr_14_1h < -75
    4h momentum + daily upper wick       rsi_14_change_pct_4h > -15 | top_wick_pct_1d > 1.5
    4h trend + stochastic collapse       adx_14_4h > 20     | stochrsi_k_change_pct_4h > -70

Method notes, because two of them changed what the round did:

*   Scanning by theme rather than by score. A plain scan returns the same
    subject five ways: three top candidates summed to +4761 points and gave
    +2268 together, because two shared a clause. Grouped by what the column
    measures — money flow, momentum, trend, position, volatility, volume, price
    action — one per theme gave +845 where the separate figures summed to +861.
*   The OR form beats the hard gate on this signal, which is not true of every
    one. `mfi_14_4h < 65` as a gate scored +470 across both years; with
    `adx_14_4h > 30` as an escape it scored +690 while giving back 289 trades.
    Measured, not assumed — on 669 the gates won.

Measured and rejected: loosening the daily-money-flow chain with a third clause.
Offline said it would give back 342 trades and gain 422 points; the real run gave
back 363 trades of which 35 were losses, and per-trade fell in both years. It
came out again.

The two thresholds off the house grid are deliberate and both directions were
measured. `roc_288 > -11`: the neighbours read +1561 at -13, +1682 at -12, +1709
at -11 and +1481 at -10, so -10 costs 228 points. `vol_rel > 1.25`: the 1.0
version failed the gate for having no clause on a slow timeframe, and the 1.25
version with `rsi_3_1h < 20` passed and scored +666 better.

Also stated rather than buried: `roc_288`, `sqz_cnt_24`, `cmf_20_15m` and the
CCI thresholds at 15m/1h/4h are our axes, not ones that appear in your blocks.

What was not done: 2024, 2025, 2023 and 2020 were never run. Two fitted regimes
are not validation. The per-loss stage was not started either — 113 losses
remain in 2021 and 88 in 2022, and the group lane closed at four chains with
its last two candidates failing the nudge test.

The block is ordered 5m, 15m, 1h, 4h, 1d and by indicator family inside each
group; the reorder was verified behaviour-neutral against the run preceding it,
identical to the digit in both years.