### PR TITLE
X7: signal 167: drop an orphaned comment

### DIFF
--- a/NostalgiaForInfinityX7.py
+++ b/NostalgiaForInfinityX7.py
@@ -26384,7 +26384,6 @@ class NostalgiaForInfinityX7(IStrategy):
           long_entry_logic.append(protections_long_global == True)
 
           long_entry_logic.append(
-            # daily in its lower half, no recent 1h low, 5m cutting a fresh one
             # 1h & 4h have both already run, 1h bands still wide from it
             ((bbb_20_2_0 < 9) | (roc_9_1h < 14) | (change_pct_4h < 5))
             # a strong 5m candle with the 4h oscillator not even positive


### PR DESCRIPTION
The first chain in 167's block carries two comments:

```python
long_entry_logic.append(
  # daily in its lower half, no recent 1h low, 5m cutting a fresh one
  # 1h & 4h have both already run, 1h bands still wide from it
  ((bbb_20_2_0 < 9) | (roc_9_1h < 14) | (change_pct_4h < 5))
```

The upper one belongs to a chain that was measured, applied, and then reverted — its real run removed no losses at all in 2022 where the offline estimate promised three, and cost 26.1 points. The chain came out; the comment did not, and it now labels a line that says something else.

Mine, from the round that went in yesterday. Comment-only, no behaviour change.