### PR TITLE
Add X7 Signal 165 wide-universe protection gates

### DIFF
--- a/NostalgiaForInfinityX7.py
+++ b/NostalgiaForInfinityX7.py
@@ -26371,8 +26371,32 @@ class NostalgiaForInfinityX7(IStrategy):
 
         # Condition #165 - Fib golden-pocket continuation (Long, experimental, RAW — The Moving Average port).
         if long_entry_condition_index == 165:
+          # Protections
           long_entry_logic.append(num_empty_288 <= allowed_empty_candles_288)
           long_entry_logic.append(protections_long_global == True)
+
+          long_entry_logic.append(
+            # 4h downside pressure while the long window stays near highs = distribution rollover.
+            ((willr_480 < -15) | (minus_di_14_4h < 20))
+            # 15m momentum floor during deep daily decline with an RSI snap = failed dead-cat bounce.
+            & ((stochrsi_k_15m_gt_20) | (roc_9_1d > -8) | (rsi_3_change_pct_1d < 10))
+            # 4h momentum snap with sustained hourly outflow = unsupported rebound.
+            & ((cmf_20_1h > -0.1) | (rsi_3_change_pct_4h < 70))
+            # Muted 4h momentum without hourly flow or a fresh 4h impulse = unsupported continuation.
+            & ((cmf_20_1h > 0.05) | (change_pct_4h > 2.5) | (roc_9_4h > 9.5))
+            # Hourly RSI acceleration without 4h trend strength = unsupported momentum burst.
+            & ((rsi_3_change_pct_1h < 15) | (adx_14_4h > 40))
+            # Persistent 4h RSI acceleration without 4h trend strength = repeated unsupported momentum burst.
+            & ((adx_14_4h > 35) | (rsi_3_change_pct_4h < 20))
+            # 4h downside pressure with sustained 4h outflow = continuation lower.
+            & ((cmf_20_4h > -0.05) | (minus_di_14_4h < 20))
+            # Daily price surge without daily money flow = distribution spike.
+            & ((change_pct_1d < 20) | (cmf_20_1d > 0.1))
+            # Daily momentum floor during deep daily decline despite an RSI snap = failed rebound.
+            & ((roc_9_1d > -8) | (rsi_3_change_pct_1d < 10) | (stochrsi_k_1d_gt_10))
+          )
+
+          # Logic
           # trend filter (video: "only clear trends") + impulse quality (never draw fibs in chop)
           long_entry_logic.append(ema_12_4h > ema_200_4h)
           # R1 (eyeball): only a CLEAN ACTIVE uptrend — whipsaw chop (RIVER) has rsi_4h ~50 and stale 4h highs


### PR DESCRIPTION
## Summary
- Adds one grouped protection block to the default-disabled X7 long Signal 165 fib golden-pocket entry.
- Uses existing cached 15m, 1h, 4h, and 1d values; no indicator or timeframe is added.
- Independent on current upstream `main` (`bcee500e1`).
- Signal 165 remains disabled, Signal 663 is unchanged, and this PR does not request activation.

## Safety
- The diff is limited to the Signal 165 branch in `populate_entry_trend()`.
- The original fib entry logic, candle selection, exit paths, profit arithmetic, stake sizing, and return values are unchanged.
- The protection expression is an AST-identical port of the frozen research candidate (`bf45437802d923d3a9544038b3c83216cc7120997cab0ed3c6aa14ad02f33c92`).
- No v3 grind-entry code is touched.

## Backtest scope
This changes trading conditions, so it was run with position adjustment and de-risk enabled, system v3.2 stops enabled, one experimental tag, and exact trade percentage points as the score unit.

The latest-main upstream port was then rerun on the 19-pair `20260101-20260807` lane with the pinned Freqtrade image. It produced 69 trades / 65 wins / 4 losses / +175.462858 exact points, and all 69 exported trade records were bit-identical to the frozen candidate run.

Fitted 19-pair matrix:

| Timerange | Trades | Losses | Exact points |
| --- | ---: | ---: | ---: |
| 2021 | 598 | 36 | +1626.389474 |
| 2022 | 122 | 7 | +241.258705 |
| 2024 | 233 | 13 | +470.869899 |
| 2025 | 139 | 11 | +69.797682 |
| 2026 | 69 | 4 | +175.462858 |
| **Total** | **1161** | **71** | **+2583.778617** |

Wide 87-pair development matrix:

| Timerange | Trades | Losses | Exact points |
| --- | ---: | ---: | ---: |
| 2022 | 424 | 44 | +82.054119 |
| 2024 | 786 | 83 | +132.326769 |
| 2025 | 563 | 53 | +363.959575 |
| 2026 | 634 | 59 | +721.404747 |
| **Total** | **2407** | **239** | **+1299.745211** |

The preregistered, pair-disjoint 44-pair sealed holdout was run once and **did not pass activation admission**:

| Timerange | Trades | Losses | Exact points |
| --- | ---: | ---: | ---: |
| 2022 | 181 | 21 | +75.421293 |
| 2024 | 509 | 47 | +469.421770 |
| 2025 | 335 | 35 | +2.980770 |
| 2026 | 287 | 41 | **-193.557352** |
| **Total** | **1312** | **144** | **+354.266480** |

The predeclared rule required every timerange to be non-empty and strictly positive. The 2026 result failed that rule. The holdout will not be mined, tuned against, or rerun; Signal 165 should remain disabled. This PR only makes the reviewed protection candidate available for maintainer review.

Backtests do not prove future profitability.

## Checks
- `python3 ~/.codex/skills/nfi-upstream-pr/scripts/validate_nfi_pr.py --base upstream/main`
- merge-tree conflict simulation against current `upstream/main`
- targeted `git diff upstream/main...HEAD -- NostalgiaForInfinityX7.py` review
- protection-expression AST equality against the frozen candidate
- 2026 latest-main port backtest and exported-trade parity against the frozen candidate
- `git diff --check`
- `ruff format --check NostalgiaForInfinityX7.py`
- `ruff check NostalgiaForInfinityX7.py`
- `PYTHONDONTWRITEBYTECODE=1 python3 -m py_compile NostalgiaForInfinityX7.py`
