### PR TITLE
blacklist: Kraken scheduled delisting cycle 2026-08-27

### DIFF
--- a/configs/blacklist-kraken.json
+++ b/configs/blacklist-kraken.json
@@ -1,6 +1,9 @@
 {
   "exchange": {
     "pair_blacklist": [
+      // Kraken scheduled delisting cycle 2026-08-27 (iterativ). The other six of the batch —
+      // IR, VANRY, MIR, RIZE, EPT and ACA — are already covered above.
+      "(XTER|GAIA|SCA|BNC|SBR|RBC|JUNO|HDX|MULTI|MAT|CQT|CXT|BKS|VULT|M)/.*",
       // Binance spot delist 2026-09-03 (periodic review) — ICX and STORJ already covered above
       "(SCRT)/.*",
       // Binance monitoring tag 2026-08-11 (delisting-risk watchlist, batch 2)


### PR DESCRIPTION
Fifteen of the twenty-one assets in the cycle were not covered in the Kraken list:

`XTER, GAIA, SCA, BNC, SBR, RBC, JUNO, HDX, MULTI, MAT, CQT, CXT, BKS, VULT, M`

The other six — IR, VANRY, MIR, RIZE, EPT and ACA — are already blacklisted above.

All twenty-one are still live pairs on Kraken (checked through ccxt), so the entries take effect rather than sitting dead.

**Kraken-scoped on purpose.** This is one venue's scheduled review, not evidence that the assets are toxic everywhere, so the other eleven lists are untouched.

**Two things found while checking, unrelated to this cycle:**

- **M is in none of the twelve lists.** It trades on Binance, Bybit and Bitget and has been profitable there — three closed trades per venue, all green — so it is added here only. Happy to extend it if you read the Kraken delist as a wider signal.
- **ACA is 11/12** (the Bybit list is the one missing it) and **MULTI is 2/12**. Both predate this cycle; say the word and I will send a separate PR.

**Verified:** the new group matches all fifteen targets as `MAT/USD`-style pairs, and matches none of MATIC, MULTIVAC, SCART, SCRT, ACALA, BNCX, BNB, MATH or MKRX — the short tickers do not over-reach.