### PR TITLE
blacklist: TAC — collapse after a 215% day

### DIFF
--- a/configs/blacklist-binance.json
+++ b/configs/blacklist-binance.json
@@ -1,6 +1,9 @@
 {
   "exchange": {
     "pair_blacklist": [
+      // Collapse after a 215% day — -46.1% and -31.5% on consecutive days, -64.3% off
+      // its 10-day high (2026-08-26/28)
+      "(TAC)/.*",
       // Binance spot delist 2026-09-03 (periodic review) — ICX and STORJ already covered above
       "(SCRT)/.*",
       // Binance monitoring tag 2026-08-11 (delisting-risk watchlist, batch 2)

--- a/configs/blacklist-bitget.json
+++ b/configs/blacklist-bitget.json
@@ -1,6 +1,9 @@
 {
   "exchange": {
     "pair_blacklist": [
+      // Collapse after a 215% day — -46.1% and -31.5% on consecutive days, -64.3% off
+      // its 10-day high (2026-08-26/28)
+      "(TAC)/.*",
       // Binance spot delist 2026-09-03 (periodic review) — ICX and STORJ already covered above
       "(SCRT)/.*",
       // Binance monitoring tag 2026-08-11 (delisting-risk watchlist, batch 2)

--- a/configs/blacklist-bitmart.json
+++ b/configs/blacklist-bitmart.json
@@ -1,6 +1,9 @@
 {
   "exchange": {
     "pair_blacklist": [
+      // Collapse after a 215% day — -46.1% and -31.5% on consecutive days, -64.3% off
+      // its 10-day high (2026-08-26/28)
+      "(TAC)/.*",
       // Binance spot delist 2026-09-03 (periodic review) — ICX and STORJ already covered above
       "(SCRT)/.*",
       // Binance monitoring tag 2026-08-11 (delisting-risk watchlist, batch 2)

--- a/configs/blacklist-bitvavo.json
+++ b/configs/blacklist-bitvavo.json
@@ -1,6 +1,9 @@
 {
   "exchange": {
     "pair_blacklist": [
+      // Collapse after a 215% day — -46.1% and -31.5% on consecutive days, -64.3% off
+      // its 10-day high (2026-08-26/28)
+      "(TAC)/.*",
       // Binance spot delist 2026-09-03 (periodic review) — ICX and STORJ already covered above
       "(SCRT)/.*",
       // Binance monitoring tag 2026-08-11 (delisting-risk watchlist, batch 2)

--- a/configs/blacklist-bybit.json
+++ b/configs/blacklist-bybit.json
@@ -1,6 +1,9 @@
 {
   "exchange": {
     "pair_blacklist": [
+      // Collapse after a 215% day — -46.1% and -31.5% on consecutive days, -64.3% off
+      // its 10-day high (2026-08-26/28)
+      "(TAC)/.*",
       // Binance spot delist 2026-09-03 (periodic review) — ICX and STORJ already covered above
       "(SCRT)/.*",
       // Binance monitoring tag 2026-08-11 (delisting-risk watchlist, batch 2)

--- a/configs/blacklist-gateio.json
+++ b/configs/blacklist-gateio.json
@@ -1,6 +1,9 @@
 {
   "exchange": {
     "pair_blacklist": [
+      // Collapse after a 215% day — -46.1% and -31.5% on consecutive days, -64.3% off
+      // its 10-day high (2026-08-26/28)
+      "(TAC)/.*",
       // Binance spot delist 2026-09-03 (periodic review) — ICX and STORJ already covered above
       "(SCRT)/.*",
       // Binance monitoring tag 2026-08-11 (delisting-risk watchlist, batch 2)

--- a/configs/blacklist-htx.json
+++ b/configs/blacklist-htx.json
@@ -1,6 +1,9 @@
 {
   "exchange": {
     "pair_blacklist": [
+      // Collapse after a 215% day — -46.1% and -31.5% on consecutive days, -64.3% off
+      // its 10-day high (2026-08-26/28)
+      "(TAC)/.*",
       // Binance spot delist 2026-09-03 (periodic review) — ICX and STORJ already covered above
       "(SCRT)/.*",
       // Binance monitoring tag 2026-08-11 (delisting-risk watchlist, batch 2)

--- a/configs/blacklist-hyperliquid.json
+++ b/configs/blacklist-hyperliquid.json
@@ -1,6 +1,9 @@
 {
   "exchange": {
     "pair_blacklist": [
+      // Collapse after a 215% day — -46.1% and -31.5% on consecutive days, -64.3% off
+      // its 10-day high (2026-08-26/28)
+      "(TAC)/.*",
       // Binance spot delist 2026-09-03 (periodic review) — ICX and STORJ already covered above
       "(SCRT)/.*",
       // Binance monitoring tag 2026-08-11 (delisting-risk watchlist, batch 2)

--- a/configs/blacklist-kraken.json
+++ b/configs/blacklist-kraken.json
@@ -1,6 +1,9 @@
 {
   "exchange": {
     "pair_blacklist": [
+      // Collapse after a 215% day — -46.1% and -31.5% on consecutive days, -64.3% off
+      // its 10-day high (2026-08-26/28)
+      "(TAC)/.*",
       // Kraken scheduled delisting cycle 2026-08-27 (iterativ). The other six of the batch —
       // IR, VANRY, MIR, RIZE, EPT and ACA — are already covered above.
       "(XTER|GAIA|SCA|BNC|SBR|RBC|JUNO|HDX|MULTI|MAT|CQT|CXT|BKS|VULT|M)/.*",

--- a/configs/blacklist-kucoin.json
+++ b/configs/blacklist-kucoin.json
@@ -1,6 +1,9 @@
 {
   "exchange": {
     "pair_blacklist": [
+      // Collapse after a 215% day — -46.1% and -31.5% on consecutive days, -64.3% off
+      // its 10-day high (2026-08-26/28)
+      "(TAC)/.*",
       // Binance spot delist 2026-09-03 (periodic review) — ICX and STORJ already covered above
       "(SCRT)/.*",
       // Binance monitoring tag 2026-08-11 (delisting-risk watchlist, batch 2)

--- a/configs/blacklist-mexc.json
+++ b/configs/blacklist-mexc.json
@@ -1,6 +1,9 @@
 {
   "exchange": {
     "pair_blacklist": [
+      // Collapse after a 215% day — -46.1% and -31.5% on consecutive days, -64.3% off
+      // its 10-day high (2026-08-26/28)
+      "(TAC)/.*",
       // Binance spot delist 2026-09-03 (periodic review) — ICX and STORJ already covered above
       "(SCRT)/.*",
       // Binance monitoring tag 2026-08-11 (delisting-risk watchlist, batch 2)

--- a/configs/blacklist-okx.json
+++ b/configs/blacklist-okx.json
@@ -1,6 +1,9 @@
 {
   "exchange": {
     "pair_blacklist": [
+      // Collapse after a 215% day — -46.1% and -31.5% on consecutive days, -64.3% off
+      // its 10-day high (2026-08-26/28)
+      "(TAC)/.*",
       // Binance spot delist 2026-09-03 (periodic review) — ICX and STORJ already covered above
       "(SCRT)/.*",
       // Binance monitoring tag 2026-08-11 (delisting-risk watchlist, batch 2)


### PR DESCRIPTION
Two consecutive collapse days on rising volume:

| | |
|---|---|
| 2026-08-26 | −31.5% |
| 2026-08-28 | **−46.1%** on $311M |
| from its 10-day high | **−64.3%** |
| daily ranges, last four days | 38% · 112% · **215%** · 22% |

The 215% range is the signature this list already acts on — TUT printed 263% and went in after it liquidated accounts on four venues, VELVET printed 561%. TAC is in that class, and it is not one bad candle: two consecutive days of −31.5% and −46.1%.

**All twelve lists rather than one.** A coin that prints a 215% day and gives back 64% is not a venue-specific problem.

**No exposure.** The only TAC position the fleet held closed on 2026-08-23 at **+$14.92**, five days before the collapse started and two before the first −31.5% day. This is forward protection, not a post-mortem.

**Verified:** `TAC/USDT:USDT` matches in all twelve lists, and TACO, ATAC, TACT and CONTACT match in none of them.