### PR TITLE
Add opt-in X7 first-entry loss exits and long-grind sizing

### DIFF
--- a/NostalgiaForInfinityX7.py
+++ b/NostalgiaForInfinityX7.py
@@ -284,6 +284,18 @@ class NostalgiaForInfinityX7(IStrategy):
   doom_stops_enable = True
   u_e_stops_enable = False
 
+  # Bad-trade controller. Opt-in: the measured benefit is regime- and whitelist-dependent.
+  bad_trade_controller_enable = False
+  bad_trade_controller_structure_break_exit_enable = True
+  bad_trade_controller_long_grind_stake_boost_enable = True
+  bad_trade_controller_long_grind_stake_multiplier = 1.5
+  bad_trade_controller_structure_break_ema_gap_pct = 35.0
+  bad_trade_controller_structure_break_min_adverse_move_pct = 25.0
+  bad_trade_controller_stale_exit_enable = True
+  bad_trade_controller_stale_min_age_days = 14.0
+  bad_trade_controller_stale_max_daily_range_pct = 7.0
+  bad_trade_controller_stale_min_adverse_move_pct = 10.0
+
   # Grinding
   grinding_v1_max_stake = 1.0  # ratio of first entry
   derisk_use_grind_stops = True
@@ -1017,6 +1029,16 @@ class NostalgiaForInfinityX7(IStrategy):
       "grind_mode_max_slots",
       "grind_mode_coins",
       "max_slippage",
+      "bad_trade_controller_enable",
+      "bad_trade_controller_structure_break_exit_enable",
+      "bad_trade_controller_long_grind_stake_boost_enable",
+      "bad_trade_controller_long_grind_stake_multiplier",
+      "bad_trade_controller_structure_break_ema_gap_pct",
+      "bad_trade_controller_structure_break_min_adverse_move_pct",
+      "bad_trade_controller_stale_exit_enable",
+      "bad_trade_controller_stale_min_age_days",
+      "bad_trade_controller_stale_max_daily_range_pct",
+      "bad_trade_controller_stale_min_adverse_move_pct",
     ]
 
     exchange_config = config["exchange"]
@@ -1858,6 +1880,107 @@ class NostalgiaForInfinityX7(IStrategy):
         append_exit(order)
     return filled_orders, filled_entries, filled_exits
 
+  @staticmethod
+  def _bad_trade_controller_ema_gap_and_adverse_move(
+    trade: "Trade", current_rate: float, last_candle, filled_entries: "Orders"
+  ) -> tuple:
+    """Return position-signed daily EMA gap and adverse move from the first filled entry."""
+    ema_50_1d = last_candle.get("EMA_50_1d")
+    ema_200_1d = last_candle.get("EMA_200_1d")
+    if (
+      ema_50_1d is None
+      or ema_200_1d is None
+      or not np.isfinite(ema_50_1d)
+      or not np.isfinite(ema_200_1d)
+      or ema_200_1d <= 0.0
+    ):
+      daily_ema_gap_pct = None
+    else:
+      daily_ema_gap_pct = (ema_50_1d / ema_200_1d - 1.0) * 100.0
+      if trade.is_short:
+        daily_ema_gap_pct = -daily_ema_gap_pct
+
+    if not filled_entries:
+      return daily_ema_gap_pct, None
+    first_entry_rate = filled_entries[0].safe_price
+    if first_entry_rate is None or not np.isfinite(first_entry_rate) or first_entry_rate <= 0.0:
+      return daily_ema_gap_pct, None
+    first_entry_adverse_move_pct = (
+      ((current_rate - first_entry_rate) if trade.is_short else (first_entry_rate - current_rate))
+      / first_entry_rate
+      * 100.0
+    )
+    return daily_ema_gap_pct, first_entry_adverse_move_pct
+
+  def _bad_trade_controller_exit_reason(
+    self,
+    trade: "Trade",
+    current_time: "datetime",
+    current_rate: float,
+    last_candle,
+    filled_entries: "Orders",
+  ) -> Optional[str]:
+    """Return an opt-in structure-break or stale-position exit reason."""
+    daily_ema_gap_pct, first_entry_adverse_move_pct = self._bad_trade_controller_ema_gap_and_adverse_move(
+      trade, current_rate, last_candle, filled_entries
+    )
+    if first_entry_adverse_move_pct is None or not np.isfinite(first_entry_adverse_move_pct):
+      return None
+    if (
+      self.bad_trade_controller_structure_break_exit_enable
+      and daily_ema_gap_pct is not None
+      and daily_ema_gap_pct <= -self.bad_trade_controller_structure_break_ema_gap_pct
+      and first_entry_adverse_move_pct >= self.bad_trade_controller_structure_break_min_adverse_move_pct
+    ):
+      return f"exit_bad_trade_broken_{first_entry_adverse_move_pct:.0f}pct"
+
+    daily_range_pct_14_1d = last_candle.get("RANGE_PCT_14_1d")
+    trade_age_days = (current_time - trade.open_date_utc).total_seconds() / 86400.0
+    if (
+      self.bad_trade_controller_stale_exit_enable
+      and daily_range_pct_14_1d is not None
+      and np.isfinite(daily_range_pct_14_1d)
+      and daily_range_pct_14_1d < self.bad_trade_controller_stale_max_daily_range_pct
+      and first_entry_adverse_move_pct >= self.bad_trade_controller_stale_min_adverse_move_pct
+      and trade_age_days >= self.bad_trade_controller_stale_min_age_days
+    ):
+      return f"exit_bad_trade_abandon_{trade_age_days:.0f}d"
+    return None
+
+  def _boost_bad_trade_long_grind_stake(self, trade: "Trade", current_rate: float, max_stake: float, grind_adjustment):
+    """Boost positive long-grind entries only, preserving the adjustment tag and limits."""
+    if (
+      not self.bad_trade_controller_enable
+      or not self.bad_trade_controller_long_grind_stake_boost_enable
+      or trade.is_short
+      or grind_adjustment is None
+    ):
+      return grind_adjustment
+    grind_stake = grind_adjustment[0] if isinstance(grind_adjustment, tuple) else grind_adjustment
+    if grind_stake <= 0.0:
+      return grind_adjustment
+    analyzed_dataframe, _ = self.dp.get_analyzed_dataframe(trade.pair, self.timeframe)
+    if len(analyzed_dataframe) < 1:
+      return grind_adjustment
+    filled_entries = trade.select_filled_orders(trade.entry_side)
+    daily_ema_gap_pct, _ = self._bad_trade_controller_ema_gap_and_adverse_move(
+      trade, current_rate, analyzed_dataframe.iloc[-1], filled_entries
+    )
+    if daily_ema_gap_pct is None or daily_ema_gap_pct <= 0.0:
+      return grind_adjustment
+    boosted_grind_stake = min(grind_stake * self.bad_trade_controller_long_grind_stake_multiplier, max_stake)
+    if boosted_grind_stake <= grind_stake:
+      return grind_adjustment
+    log.info(
+      "Bad-trade long-grind stake boost [%s] | tag %s | %.2f -> %.2f | daily EMA gap %.1f%%",
+      trade.pair,
+      trade.enter_tag,
+      grind_stake,
+      boosted_grind_stake,
+      daily_ema_gap_pct,
+    )
+    return (boosted_grind_stake, *grind_adjustment[1:]) if isinstance(grind_adjustment, tuple) else boosted_grind_stake
+
   def trade_order_state(self, trade: "Trade") -> tuple:
     orders = trade.orders
 
@@ -2065,6 +2188,13 @@ class NostalgiaForInfinityX7(IStrategy):
     cache_backtest_profit_snapshot(
       trade, current_time, current_rate, filled_orders, filled_entries, filled_exits, profit_values
     )
+
+    if self.bad_trade_controller_enable and current_profit < 0.0:
+      bad_trade_exit_reason = self._bad_trade_controller_exit_reason(
+        trade, current_time, current_rate, last_candle, filled_entries
+      )
+      if bad_trade_exit_reason is not None:
+        return f"{bad_trade_exit_reason} ( {enter_tag})"
 
     # Signal 192 (Quad pullback long) tight doom stop: every 192 loss bottoms at a
     # 11.8-14% price drop (the shared 0.35 doom threshold) while winners' max adverse
@@ -2833,25 +2963,29 @@ class NostalgiaForInfinityX7(IStrategy):
           is_long_known_mode = any(c in self.long_known_mode_tags for c in enter_tags)
 
           if is_long_adjust_mode or not is_long_known_mode:
-            return self.long_grind_adjust_trade_position_v3(*args)
+            grind_adjustment = self.long_grind_adjust_trade_position_v3(*args)
+            return self._boost_bad_trade_long_grind_stake(trade, current_rate, max_stake, grind_adjustment)
 
         # ---------------------------------------------------------------------
         # LEGACY GRIND
         # ---------------------------------------------------------------------
         elif is_long_grind_mode or is_long_btc_mode or not is_v2_date:
-          return self.long_grind_adjust_trade_position(*args)
+          grind_adjustment = self.long_grind_adjust_trade_position(*args)
+          return self._boost_bad_trade_long_grind_stake(trade, current_rate, max_stake, grind_adjustment)
 
       # -----------------------------------------------------------------------
       # V2 / LEGACY ROUTING
       # -----------------------------------------------------------------------
       if is_long_grind_mode or is_long_btc_mode or not is_v2_date:
-        return self.long_grind_adjust_trade_position(*args)
+        grind_adjustment = self.long_grind_adjust_trade_position(*args)
+        return self._boost_bad_trade_long_grind_stake(trade, current_rate, max_stake, grind_adjustment)
 
       is_long_adjust_mode = any(c in self.long_adjust_mode_tags for c in enter_tags)
       is_long_known_mode = any(c in self.long_known_mode_tags for c in enter_tags)
 
       if is_long_adjust_mode or not is_long_known_mode:
-        return self.long_grind_adjust_trade_position_v2(*args)
+        grind_adjustment = self.long_grind_adjust_trade_position_v2(*args)
+        return self._boost_bad_trade_long_grind_stake(trade, current_rate, max_stake, grind_adjustment)
 
     # =========================================================================
     # SHORT
@@ -3300,6 +3434,16 @@ class NostalgiaForInfinityX7(IStrategy):
     low_min_20 = ta_min(low_np, timeperiod=20)
     low_min_30 = ta_min(low_np, timeperiod=30)
 
+    bad_trade_controller_indicators = {}
+    if self.bad_trade_controller_enable:
+      nonzero_low_np = np.where(low_np == 0.0, np.nan, low_np)
+      daily_range_pct_np = (high_np - low_np) / nonzero_low_np * 100.0
+      bad_trade_controller_indicators = {
+        "EMA_50": ta.EMA(close_np, timeperiod=50),
+        "EMA_200": ta.EMA(close_np, timeperiod=200),
+        "RANGE_PCT_14": ta_sma(daily_range_pct_np, timeperiod=14),
+      }
+
     # =========================================================================
     # ASSIGN DATAFRAME
     # =========================================================================
@@ -3328,6 +3472,7 @@ class NostalgiaForInfinityX7(IStrategy):
         "low_min_12": low_min_12,
         "low_min_20": low_min_20,
         "low_min_30": low_min_30,
+        **bad_trade_controller_indicators,
       },
       index=informative_1d.index,
     )
@@ -3361,6 +3506,8 @@ class NostalgiaForInfinityX7(IStrategy):
         "low_min_20",
         "low_min_30",
       ]
+      if self.bad_trade_controller_enable:
+        debug_cols.extend(["EMA_50", "EMA_200", "RANGE_PCT_14"])
 
       self.validate_indicators(df=informative_1d, columns=debug_cols, pair=metadata_pair, timeframe=info_timeframe)
 

--- a/tests/unit/test_NFIX7_bad_trade_controller.py
+++ b/tests/unit/test_NFIX7_bad_trade_controller.py
@@ -1,0 +1,248 @@
+from datetime import datetime
+from datetime import timedelta
+from datetime import timezone
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from NostalgiaForInfinityX7 import NostalgiaForInfinityX7
+
+
+class MockTrade:
+  def __init__(self, *, is_short=False, enter_tag="120", first_entry_rate=100.0, age_days=15):
+    self.is_short = is_short
+    self.enter_tag = enter_tag
+    self.pair = "TEST/USDT"
+    self.entry_side = "sell" if is_short else "buy"
+    self.open_date_utc = datetime(2026, 1, 20, tzinfo=timezone.utc) - timedelta(days=age_days)
+    self._filled_entries = [SimpleNamespace(safe_price=first_entry_rate)]
+
+  def select_filled_orders(self, side):
+    assert side == self.entry_side
+    return self._filled_entries
+
+
+def bad_trade_controller_strategy():
+  strategy = NostalgiaForInfinityX7.__new__(NostalgiaForInfinityX7)
+  strategy.bad_trade_controller_enable = True
+  strategy.bad_trade_controller_structure_break_exit_enable = True
+  strategy.bad_trade_controller_long_grind_stake_boost_enable = True
+  strategy.bad_trade_controller_long_grind_stake_multiplier = 1.5
+  strategy.bad_trade_controller_structure_break_ema_gap_pct = 35.0
+  strategy.bad_trade_controller_structure_break_min_adverse_move_pct = 25.0
+  strategy.bad_trade_controller_stale_exit_enable = True
+  strategy.bad_trade_controller_stale_min_age_days = 14.0
+  strategy.bad_trade_controller_stale_max_daily_range_pct = 7.0
+  strategy.bad_trade_controller_stale_min_adverse_move_pct = 10.0
+  strategy.timeframe = "5m"
+  return strategy
+
+
+@pytest.mark.parametrize(
+  "trade,current_rate,last_candle,expected_readings",
+  [
+    (MockTrade(), 70.0, {"EMA_50_1d": 60.0, "EMA_200_1d": 100.0}, (-40.0, 30.0)),
+    (MockTrade(is_short=True), 130.0, {"EMA_50_1d": 140.0, "EMA_200_1d": 100.0}, (-40.0, 30.0)),
+  ],
+)
+def test_controller_ema_gap_and_adverse_move_are_signed_toward_position(
+  trade, current_rate, last_candle, expected_readings
+):
+  readings = bad_trade_controller_strategy()._bad_trade_controller_ema_gap_and_adverse_move(
+    trade, current_rate, last_candle, trade._filled_entries
+  )
+  assert readings == pytest.approx(expected_readings)
+
+
+def test_controller_exits_use_first_entry_and_reject_nonfinite_range():
+  strategy = bad_trade_controller_strategy()
+  current_time = datetime(2026, 1, 20, tzinfo=timezone.utc)
+  trade = MockTrade()
+
+  structure_break_candle = {
+    "EMA_50_1d": 60.0,
+    "EMA_200_1d": 100.0,
+    "RANGE_PCT_14_1d": 10.0,
+  }
+  assert (
+    strategy._bad_trade_controller_exit_reason(
+      trade, current_time, 70.0, structure_break_candle, trade._filled_entries
+    )
+    == "exit_bad_trade_broken_30pct"
+  )
+  strategy.bad_trade_controller_structure_break_exit_enable = False
+  assert (
+    strategy._bad_trade_controller_exit_reason(
+      trade, current_time, 70.0, structure_break_candle, trade._filled_entries
+    )
+    is None
+  )
+  strategy.bad_trade_controller_structure_break_exit_enable = True
+
+  stale_trade_candle = {
+    "EMA_50_1d": 105.0,
+    "EMA_200_1d": 100.0,
+    "RANGE_PCT_14_1d": 6.0,
+  }
+  assert (
+    strategy._bad_trade_controller_exit_reason(trade, current_time, 85.0, stale_trade_candle, trade._filled_entries)
+    == "exit_bad_trade_abandon_15d"
+  )
+
+  stale_trade_candle["RANGE_PCT_14_1d"] = np.inf
+  assert (
+    strategy._bad_trade_controller_exit_reason(trade, current_time, 85.0, stale_trade_candle, trade._filled_entries)
+    is None
+  )
+  assert strategy._bad_trade_controller_exit_reason(trade, current_time, 70.0, structure_break_candle, []) is None
+
+
+def test_long_grind_stake_boost_preserves_tag_and_clamps_to_max_stake():
+  strategy = bad_trade_controller_strategy()
+  trade = MockTrade()
+  analyzed_dataframe = pd.DataFrame([{"EMA_50_1d": 110.0, "EMA_200_1d": 100.0}])
+  strategy.dp = SimpleNamespace(get_analyzed_dataframe=lambda pair, timeframe: (analyzed_dataframe, None))
+
+  assert strategy._boost_bad_trade_long_grind_stake(trade, 90.0, 100.0, (80.0, "grind_1_entry")) == (
+    100.0,
+    "grind_1_entry",
+  )
+  strategy.bad_trade_controller_long_grind_stake_boost_enable = False
+  assert strategy._boost_bad_trade_long_grind_stake(trade, 90.0, 100.0, (80.0, "grind_1_entry")) == (
+    80.0,
+    "grind_1_entry",
+  )
+  strategy.bad_trade_controller_long_grind_stake_boost_enable = True
+  assert strategy._boost_bad_trade_long_grind_stake(trade, 90.0, 100.0, (-20.0, "derisk")) == (
+    -20.0,
+    "derisk",
+  )
+  trade.is_short = True
+  assert strategy._boost_bad_trade_long_grind_stake(trade, 110.0, 100.0, (80.0, "grind")) == (
+    80.0,
+    "grind",
+  )
+
+
+def test_adjustment_router_boosts_grind_but_not_rebuy():
+  strategy = bad_trade_controller_strategy()
+  strategy.position_adjustment_enable = True
+  strategy.long_rebuy_mode_tags = {"61"}
+  strategy.long_rebuy_grind_mode_tags = {"61", "120"}
+  strategy.long_grind_mode_tags = {"120"}
+  strategy.long_btc_mode_tags = set()
+  strategy.long_adjust_mode_tags = set()
+  strategy.long_known_mode_tags = {"61", "120"}
+  strategy.is_backtest_mode = lambda: True
+  strategy.get_system_version_flags = lambda trade: (False, False, False)
+  strategy.long_rebuy_adjust_trade_position = MagicMock(return_value=(20.0, "rebuy"))
+  strategy.long_grind_adjust_trade_position = MagicMock(return_value=(20.0, "grind"))
+  strategy._boost_bad_trade_long_grind_stake = MagicMock(return_value=(30.0, "grind"))
+  adjustment_kwargs = {
+    "current_time": datetime(2026, 1, 20, tzinfo=timezone.utc),
+    "current_rate": 90.0,
+    "current_profit": -0.1,
+    "min_stake": 1.0,
+    "max_stake": 100.0,
+    "current_entry_rate": 90.0,
+    "current_exit_rate": 90.0,
+    "current_entry_profit": -0.1,
+    "current_exit_profit": -0.1,
+  }
+
+  assert strategy.adjust_trade_position(MockTrade(enter_tag="120"), **adjustment_kwargs) == (
+    30.0,
+    "grind",
+  )
+  strategy._boost_bad_trade_long_grind_stake.assert_called_once()
+  strategy._boost_bad_trade_long_grind_stake.reset_mock()
+
+  assert strategy.adjust_trade_position(MockTrade(enter_tag="61"), **adjustment_kwargs) == (
+    20.0,
+    "rebuy",
+  )
+  strategy._boost_bad_trade_long_grind_stake.assert_not_called()
+
+
+def test_custom_exit_controller_preempts_existing_router():
+  strategy = bad_trade_controller_strategy()
+  for name in (
+    "long_normal_mode_tags",
+    "long_pump_mode_tags",
+    "long_quick_mode_tags",
+    "long_rebuy_mode_tags",
+    "long_rebuy_grind_mode_tags",
+    "long_high_profit_mode_tags",
+    "long_rapid_mode_tags",
+    "long_rapid_rebuy_grind_scalp_mode_tags",
+    "long_grind_mode_tags",
+    "long_btc_mode_tags",
+    "long_top_coins_mode_tags",
+    "long_scalp_mode_tags",
+    "long_scalp_rebuy_grind_mode_tags",
+    "long_known_mode_tags",
+    "short_normal_mode_tags",
+    "short_pump_mode_tags",
+    "short_quick_mode_tags",
+    "short_rebuy_mode_tags",
+    "short_high_profit_mode_tags",
+    "short_rapid_mode_tags",
+    "short_scalp_mode_tags",
+    "short_scalp_rebuy_grind_mode_tags",
+    "short_exit_known_mode_tags",
+  ):
+    setattr(strategy, name, set())
+  strategy.long_exit_normal = MagicMock(return_value=(False, None))
+  strategy.long_exit_pump = MagicMock(return_value=(False, None))
+  strategy.long_exit_quick = MagicMock(return_value=(False, None))
+  strategy.short_exit_normal = MagicMock(return_value=(False, None))
+  analyzed_dataframe = pd.DataFrame(
+    [
+      {"EMA_50_1d": 60.0, "EMA_200_1d": 100.0, "RANGE_PCT_14_1d": 10.0},
+      {"EMA_50_1d": 60.0, "EMA_200_1d": 100.0, "RANGE_PCT_14_1d": 10.0},
+    ]
+  )
+  strategy.dp = SimpleNamespace(get_analyzed_dataframe=lambda pair, timeframe: (analyzed_dataframe, None))
+  trade = MockTrade()
+  strategy.filled_order_snapshot = MagicMock(return_value=(trade._filled_entries, trade._filled_entries, []))
+  strategy.calc_total_profit = MagicMock(return_value=(-10.0, -0.1, -0.1, -0.1))
+  strategy.cache_backtest_profit_snapshot = MagicMock()
+
+  reason = strategy.custom_exit(
+    trade.pair,
+    trade,
+    datetime(2026, 1, 20, tzinfo=timezone.utc),
+    70.0,
+    -0.1,
+  )
+
+  assert reason == "exit_bad_trade_broken_30pct ( 120)"
+  strategy.long_exit_normal.assert_not_called()
+
+
+def test_controller_indicators_are_absent_when_disabled_and_present_when_enabled():
+  rows = 240
+  close = np.linspace(100.0, 140.0, rows)
+  informative_1d = pd.DataFrame(
+    {
+      "open": close - 1.0,
+      "high": close + 2.0,
+      "low": close - 2.0,
+      "close": close,
+      "volume": np.full(rows, 1000.0),
+    }
+  )
+  strategy = bad_trade_controller_strategy()
+  strategy.dp = SimpleNamespace(get_pair_dataframe=lambda pair, timeframe: informative_1d.copy())
+
+  strategy.bad_trade_controller_enable = False
+  disabled = strategy.informative_1d_indicators({"pair": "TEST/USDT"}, "1d")
+  assert not {"EMA_50", "EMA_200", "RANGE_PCT_14"} & set(disabled.columns)
+
+  strategy.bad_trade_controller_enable = True
+  enabled = strategy.informative_1d_indicators({"pair": "TEST/USDT"}, "1d")
+  assert {"EMA_50", "EMA_200", "RANGE_PCT_14"} <= set(enabled.columns)
+  assert np.isfinite(enabled["RANGE_PCT_14"].iloc[-1])


### PR DESCRIPTION
## Summary
- Add a default-disabled X7 controller that reads the position-signed daily EMA_50/EMA_200 gap and adverse move from the first filled entry.
- It can close structurally broken or stale losing trades and scale qualifying long-grind additions.
- Use concrete names for the exact EMA gap, first-entry adverse move, stale-range threshold, grind adjustment, and boosted stake being handled.
- Base this change independently on current upstream `main`.

## Safety
- `bad_trade_controller_enable = False`; normal strategy behavior and indicator surface remain unchanged by default.
- The three daily indicator columns are computed only when the controller is enabled.
- The exit path reuses `custom_exit()`'s existing filled-order snapshot, runs only while the averaged position is losing, and fails closed on missing or non-finite inputs.
- The sizing helper is limited to positive long-grind adjustments. Rebuy routes, short routes, de-risk/partial-exit values, and `None` pass through unchanged.
- Tuple adjustment tags are preserved and the boosted stake is clamped to `max_stake`.
- Touched active runtime paths: `custom_exit()` and `adjust_trade_position()`; `informative_1d_indicators()` is also extended conditionally.
- No v3 grind-entry condition or candle-lookup code is touched.

## Exact 2022 referee

Pinned commit: `7d9a02f64929e274743a6fd31131d6e5e30927eb`; embedded strategy SHA-256: `40796e8be7ad11ba14dc51607ee1d002d1c7cce743f1476f67ddfac5283a5aeb`.

All four arms used the same frozen 19-pair Binance futures data, `20220101-20230101`, wallet 100,000, `max_open_trades=6`, unlimited stake, cache disabled, and Freqtrade 2026.6 image `freqtradeorg/freqtrade@sha256:87aa5c6d65359b34e9d99a0bb260a38c0efe0315253811e6f48c2afe8f278a6a`. Runs were sequential. `position_adjustment_enable=True`, `grinding_enable=True`, `derisk_enable=True`, and `stops_enable=True` in every arm.

Primary A/B: controller OFF versus ON with `grind_mode_max_slots=1`; that flag was the only config difference.

| metric | controller OFF | controller ON | ON − OFF |
|---|---:|---:|---:|
| trades / wins / losses | 164 / 160 / 4 | 181 / 176 / 5 | +17 / +16 / +1 |
| exact percentage points | 1,061.507 | 1,193.910 | **+132.403** |
| `profit_total_abs` | 204,976.61 | 353,558.02 | **+148,581.41** |
| sum of negative `profit_abs` | −91,651.74 | −68,995.06 | **+22,656.68 (24.7% less loss magnitude)** |
| account drawdown | 23.108% | 11.069% | **−12.039 points** |
| position-adjustment entry orders | 291 | 222 | −69 |
| grind-tagged add orders | 288 | 219 | −69 |
| controller exits / boost events / doom exits | 0 / 0 / 0 | 7 / 4 / 0 | +7 / +4 / 0 |

This exercised the grinding path, not only exits: both arms produced hundreds of real position-adjustment and grind-tagged add orders. The ON arm logged four tag-120 CRV stake boosts, each exactly 1.5x, for 8,036.25 additional stake in total. It also exercised seven controller exits. Neither arm produced a doom exit or liquidation. The trade count changed through slot recycling/backfill, so the extra loss (4 → 5) is reported alongside the lower aggregate loss PnL and drawdown rather than treating trades as pairwise identical.

Secondary isolation: `grind_mode_max_slots=0` blocks new tag-120 grind-mode entries; it does **not** globally disable position adjustment or all grind routines. Both arms still exercised 217 → 170 position-adjustment entry orders and 214 → 167 grind-tagged adds. Controller OFF → ON moved exact points 1,235.122 → 1,245.823, `profit_total_abs` 325,499.01 → 368,834.05, negative `profit_abs` −91,606.21 → −68,155.85, and drawdown 17.715% → 10.963%. Tag 120 and boost events were zero in both arms; controller exits were 0 → 3; doom exits were zero.

Execution verdict: **VALID**; all eleven admissions passed, including exact embedded source/config, exact timerange, real position adjustment/grind activity, controller event activity, and no controller events in OFF arms. These historical backtests are bounded to this exact surface and do not prove future profitability. The PR remains draft for code review.

## Checks
- `python3.12 ~/.codex/skills/nfi-upstream-pr/scripts/validate_nfi_pr.py --base origin/main --allow-extra-file tests/unit/test_NFIX7_bad_trade_controller.py`
- focused AST undefined-local scan: zero findings
- merge-tree conflict simulation against current upstream `main`
- targeted diff review of `custom_exit()`, `adjust_trade_position()`, and `informative_1d_indicators()`
- Docker/Freqtrade targeted unit tests: 7 passed
- Freqtrade 2026.6 `list-strategies`: `NostalgiaForInfinityX7` status `OK`
- `ruff format --check NostalgiaForInfinityX7.py tests/unit/test_NFIX7_bad_trade_controller.py`
- `ruff check NostalgiaForInfinityX7.py tests/unit/test_NFIX7_bad_trade_controller.py`
- `PYTHONDONTWRITEBYTECODE=1 python3.12 -m py_compile NostalgiaForInfinityX7.py tests/unit/test_NFIX7_bad_trade_controller.py`
- four sequential full-year backtests plus `python3.12 analyze_referee.py`: all admissions true