### PR TITLE
Blacklist OPG — market maker impaired, book down to $11.8M combined

### DIFF
--- a/configs/blacklist-binance.json
+++ b/configs/blacklist-binance.json
@@ -1,6 +1,10 @@
 {
   "exchange": {
     "pair_blacklist": [
+      // OpenGradient market maker impaired — the team said on 2026-08-10 its market-making
+      // funds are stuck on BitMart, which began winding down on 07-26. Book is thin
+      // ($11.8M across the three venues) and the token is -84% from its April high.
+      "(OPG)/.*",
       // Collapse after a 215% day — -46.1% and -31.5% on consecutive days, -64.3% off
       // its 10-day high (2026-08-26/28)
       "(TAC)/.*",

--- a/configs/blacklist-bitget.json
+++ b/configs/blacklist-bitget.json
@@ -1,6 +1,10 @@
 {
   "exchange": {
     "pair_blacklist": [
+      // OpenGradient market maker impaired — the team said on 2026-08-10 its market-making
+      // funds are stuck on BitMart, which began winding down on 07-26. Book is thin
+      // ($11.8M across the three venues) and the token is -84% from its April high.
+      "(OPG)/.*",
       // Collapse after a 215% day — -46.1% and -31.5% on consecutive days, -64.3% off
       // its 10-day high (2026-08-26/28)
       "(TAC)/.*",

--- a/configs/blacklist-bitmart.json
+++ b/configs/blacklist-bitmart.json
@@ -1,6 +1,10 @@
 {
   "exchange": {
     "pair_blacklist": [
+      // OpenGradient market maker impaired — the team said on 2026-08-10 its market-making
+      // funds are stuck on BitMart, which began winding down on 07-26. Book is thin
+      // ($11.8M across the three venues) and the token is -84% from its April high.
+      "(OPG)/.*",
       // Collapse after a 215% day — -46.1% and -31.5% on consecutive days, -64.3% off
       // its 10-day high (2026-08-26/28)
       "(TAC)/.*",

--- a/configs/blacklist-bitvavo.json
+++ b/configs/blacklist-bitvavo.json
@@ -1,6 +1,10 @@
 {
   "exchange": {
     "pair_blacklist": [
+      // OpenGradient market maker impaired — the team said on 2026-08-10 its market-making
+      // funds are stuck on BitMart, which began winding down on 07-26. Book is thin
+      // ($11.8M across the three venues) and the token is -84% from its April high.
+      "(OPG)/.*",
       // Collapse after a 215% day — -46.1% and -31.5% on consecutive days, -64.3% off
       // its 10-day high (2026-08-26/28)
       "(TAC)/.*",

--- a/configs/blacklist-bybit.json
+++ b/configs/blacklist-bybit.json
@@ -1,6 +1,10 @@
 {
   "exchange": {
     "pair_blacklist": [
+      // OpenGradient market maker impaired — the team said on 2026-08-10 its market-making
+      // funds are stuck on BitMart, which began winding down on 07-26. Book is thin
+      // ($11.8M across the three venues) and the token is -84% from its April high.
+      "(OPG)/.*",
       // Collapse after a 215% day — -46.1% and -31.5% on consecutive days, -64.3% off
       // its 10-day high (2026-08-26/28)
       "(TAC)/.*",

--- a/configs/blacklist-gateio.json
+++ b/configs/blacklist-gateio.json
@@ -1,6 +1,10 @@
 {
   "exchange": {
     "pair_blacklist": [
+      // OpenGradient market maker impaired — the team said on 2026-08-10 its market-making
+      // funds are stuck on BitMart, which began winding down on 07-26. Book is thin
+      // ($11.8M across the three venues) and the token is -84% from its April high.
+      "(OPG)/.*",
       // Collapse after a 215% day — -46.1% and -31.5% on consecutive days, -64.3% off
       // its 10-day high (2026-08-26/28)
       "(TAC)/.*",

--- a/configs/blacklist-htx.json
+++ b/configs/blacklist-htx.json
@@ -1,6 +1,10 @@
 {
   "exchange": {
     "pair_blacklist": [
+      // OpenGradient market maker impaired — the team said on 2026-08-10 its market-making
+      // funds are stuck on BitMart, which began winding down on 07-26. Book is thin
+      // ($11.8M across the three venues) and the token is -84% from its April high.
+      "(OPG)/.*",
       // Collapse after a 215% day — -46.1% and -31.5% on consecutive days, -64.3% off
       // its 10-day high (2026-08-26/28)
       "(TAC)/.*",

--- a/configs/blacklist-hyperliquid.json
+++ b/configs/blacklist-hyperliquid.json
@@ -1,6 +1,10 @@
 {
   "exchange": {
     "pair_blacklist": [
+      // OpenGradient market maker impaired — the team said on 2026-08-10 its market-making
+      // funds are stuck on BitMart, which began winding down on 07-26. Book is thin
+      // ($11.8M across the three venues) and the token is -84% from its April high.
+      "(OPG)/.*",
       // Collapse after a 215% day — -46.1% and -31.5% on consecutive days, -64.3% off
       // its 10-day high (2026-08-26/28)
       "(TAC)/.*",

--- a/configs/blacklist-kraken.json
+++ b/configs/blacklist-kraken.json
@@ -1,6 +1,10 @@
 {
   "exchange": {
     "pair_blacklist": [
+      // OpenGradient market maker impaired — the team said on 2026-08-10 its market-making
+      // funds are stuck on BitMart, which began winding down on 07-26. Book is thin
+      // ($11.8M across the three venues) and the token is -84% from its April high.
+      "(OPG)/.*",
       // Collapse after a 215% day — -46.1% and -31.5% on consecutive days, -64.3% off
       // its 10-day high (2026-08-26/28)
       "(TAC)/.*",

--- a/configs/blacklist-kucoin.json
+++ b/configs/blacklist-kucoin.json
@@ -1,6 +1,10 @@
 {
   "exchange": {
     "pair_blacklist": [
+      // OpenGradient market maker impaired — the team said on 2026-08-10 its market-making
+      // funds are stuck on BitMart, which began winding down on 07-26. Book is thin
+      // ($11.8M across the three venues) and the token is -84% from its April high.
+      "(OPG)/.*",
       // Collapse after a 215% day — -46.1% and -31.5% on consecutive days, -64.3% off
       // its 10-day high (2026-08-26/28)
       "(TAC)/.*",

--- a/configs/blacklist-mexc.json
+++ b/configs/blacklist-mexc.json
@@ -1,6 +1,10 @@
 {
   "exchange": {
     "pair_blacklist": [
+      // OpenGradient market maker impaired — the team said on 2026-08-10 its market-making
+      // funds are stuck on BitMart, which began winding down on 07-26. Book is thin
+      // ($11.8M across the three venues) and the token is -84% from its April high.
+      "(OPG)/.*",
       // Collapse after a 215% day — -46.1% and -31.5% on consecutive days, -64.3% off
       // its 10-day high (2026-08-26/28)
       "(TAC)/.*",

--- a/configs/blacklist-okx.json
+++ b/configs/blacklist-okx.json
@@ -1,6 +1,10 @@
 {
   "exchange": {
     "pair_blacklist": [
+      // OpenGradient market maker impaired — the team said on 2026-08-10 its market-making
+      // funds are stuck on BitMart, which began winding down on 07-26. Book is thin
+      // ($11.8M across the three venues) and the token is -84% from its April high.
+      "(OPG)/.*",
       // Collapse after a 215% day — -46.1% and -31.5% on consecutive days, -64.3% off
       // its 10-day high (2026-08-26/28)
       "(TAC)/.*",


### PR DESCRIPTION
OPG is not blacklisted anywhere today (0/12). Suggesting it on all twelve.

**Why.** OpenGradient's team said on 2026-08-10 that its market-making funds are stuck on BitMart, which began winding down on 2026-07-26 and has not published a proof-of-reserves. The order book reads like that: **$9.7M on binance, $1.3M on bybit, $0.8M on bitget — $11.8M combined.** Bybit keeps the symbol in its innovation tier.

**Price.** Listed 2026-04-22, so 129 days old. From 0.5239 to 0.0850 — **-84% from its high, -75% from the 120-day high** — with a 9.65% median daily range. Down 11.5% on the day this was written.

**Not a delisting.** All three venues still report the symbol active with no notice, so this is a liquidity judgement rather than a venue event. Token-level rather than venue-level, which is why it goes to all twelve files rather than one.

Verified with `re.fullmatch(pattern, "OPG/USDT:USDT")` against every file — 12/12 — since a loose match would have read as covered without being so.

We hold one open position on bitget, opened 52 days ago; blacklisting blocks new entries and leaves it to grind.