### PR TITLE
Refine X7 Signal 663 fib entry and protections

### DIFF
--- a/NostalgiaForInfinityX7.py
+++ b/NostalgiaForInfinityX7.py
@@ -29850,23 +29850,46 @@ class NostalgiaForInfinityX7(IStrategy):
           short_entry_logic.append(close < orange_h)
           short_entry_logic.append(close > orange_l)
 
-        # Condition #663 - Fib golden-pocket continuation (Short, experimental, RAW — mirror).
+        # Condition #663 - Fib golden-pocket continuation (Short, experimental, protected).
         if short_entry_condition_index == 663:
+          # Protections
           short_entry_logic.append(num_empty_288 <= allowed_empty_candles_288)
           short_entry_logic.append(protections_short_global == True)
+
+          short_entry_logic.append(
+            # Mar/May fast break in 4h trend: +DI4h >= 15, ROC2_4h >= -4, RSI change <= -12; need relief
+            ((rsi_14_change_pct > -12) | (plus_di_14_4h < 15) | (roc_2_4h < -4))
+            # Aug/Dec no-flow bounce: Aroon-up1h >= 30, CMF15m <= -0.05, WILLR15m <= -35; need one escape
+            & ((cmf_20_15m > -0.05) | (willr_14_15m > -35) | aroonu_14_1h_lt_30)
+            # Sep/Dec outflow bounce: 1h Aroon-up >= 20, CMF <= -0.15, RSI surge >= 20; need one escape
+            & (aroonu_14_1h_lt_20 | (cmf_20_1h > -0.15) | (rsi_14_change_pct_1h < 20))
+            # Dec-20 crash rebound: 4h ROC <= -14, 1h RSI acceleration >= 50; need either side softer
+            & ((rsi_14_change_pct_1h < 50) | (roc_2_4h > -14))
+          )
+
+          # Logic
           short_entry_logic.append(ema_12_4h < ema_200_4h)
           # R1 (eyeball): only a clean active downtrend
           short_entry_logic.append(rsi_14_4h < 45.0)
           short_entry_logic.append(aroond_14_4h > 70.0)
           # R1: anti-capitulation mirror
           short_entry_logic.append(roc_9_1d > -30.0)
-          short_entry_logic.append((close_max_48 - close_min_48) > (close_min_48 * 0.04))
-          # FIRST entry into the 0.5-0.618 retrace band of the down-impulse (from below)
-          _fib_rng_663 = close_max_48 - close_min_48
-          _fib_retr_663 = (close - close_min_48) / _fib_rng_663
-          short_entry_logic.append(np_shift(_fib_retr_663, 1) < 0.5)
+          _fib_high_wick_663 = ta.MAX(high_px, timeperiod=48)
+          _fib_low_wick_663 = ta.MIN(low_px, timeperiod=48)
+          _fib_high_index_663 = ta.MAXINDEX(high_px, timeperiod=48)
+          _fib_low_index_663 = ta.MININDEX(low_px, timeperiod=48)
+          _fib_ordered_663 = np.where(_fib_high_index_663 < _fib_low_index_663, 1.0, 0.0)
+          _fib_rng_663 = _fib_high_wick_663 - _fib_low_wick_663
+          _fib_retr_663 = (close - _fib_low_wick_663) / _fib_rng_663
+          _fib_retr_prev_663 = np_shift(_fib_retr_663, 1)
+          short_entry_logic.append(_fib_rng_663 > (_fib_low_wick_663 * 0.04))
+          # The engulfing candle closes back through the wick-anchored pocket's 0.618 edge.
+          short_entry_logic.append(_fib_ordered_663 > 0.5)
+          short_entry_logic.append(_fib_retr_prev_663 >= 0.618)
+          short_entry_logic.append(_fib_retr_prev_663 <= 0.786)
           short_entry_logic.append(_fib_retr_663 >= 0.5)
-          short_entry_logic.append(_fib_retr_663 <= 0.618)
+          short_entry_logic.append(_fib_retr_663 < 0.618)
+          short_entry_logic.append(engulf_bear > 0.5)
 
         # Condition #664 - Squeeze Momentum release (Short, experimental, RAW — mirror).
         if short_entry_condition_index == 664:


### PR DESCRIPTION
## Summary
- Refine the existing default-disabled X7 Signal 663 short entry on latest upstream `main`.
- Replace the close-only first-band entry with an ordered, wick-anchored 0.618-edge rejection that requires a bearish engulfing candle.
- Add four grouped protection scenes using existing entry-scope values and cached Aroon booleans.
- This branch is independent on upstream `main` at `5accc7a30a73071b08f6ae3d7ad4d68fcc3c4bb9`.

## Safety
- Only the Signal 663 block in `populate_entry_trend()` changes.
- `short_entry_condition_663_enable` remains `False`; default strategy behavior is unchanged.
- The patch changes entry behavior only for users who explicitly enable Signal 663.
- No new dataframe indicator columns, timeframe merges, exit logic, sizing, leverage, order classification, or profit arithmetic are added.
- No v3 grind-entry code is touched.

## Protection scenes
- XRP 2024-03-20 / GALA 2024-05-21: fast RSI breakdown inside an intact 4h trend.
- LINK/GALA 2024-08-05, ADA 2024-08-16, ETH 2024-12-20: rebound without 15m inflow.
- ETH 2024-09-06 plus the Dec-20 cluster: 1h bounce into weak money flow.
- GALA/AXS/FIL/AVAX 2024-12-20: synchronized crash rebound with extreme hourly RSI acceleration.

All four chains returned final `READY` from the v3.2 chain gate. Warnings and threshold choices were reviewed in the frozen research lane; no gate `FAIL` was bypassed. This is a frozen-candidate port and does not claim fresh per-axis rounding validation.

## Backtest scope
This changes trading conditions, so I ran a real latest-main control/candidate A/B with one annual worker.

- Fitted periods, in order: 2022, 2021, 2024, 2025, 2026 through 2026-08-06
- Frozen 19-pair Binance futures universe
- `position_adjustment_enable=False`
- `derisk_enable=False`
- `system_v3_2_stops_enable=True`
- 2021 wallet: 100; other periods: 100000
- Image: `freqtradeorg/freqtrade@sha256:87aa5c6d65359b34e9d99a0bb260a38c0efe0315253811e6f48c2afe8f278a6a`
- Score order: losses, exact percentage points, trades

| Period | Latest-main control | Protected C5 | Delta |
|---|---:|---:|---:|
| 2022 | 818t / 86L / -250.143699pp | 188t / 12L / +320.775153pp | -74L / +570.918852pp |
| 2021 | 749t / 88L / -442.864669pp | 111t / 7L / +101.512558pp | -81L / +544.377227pp |
| 2024 | 390t / 66L / -1134.623007pp | 83t / 7L / +18.415916pp | -59L / +1153.038923pp |
| 2025 | 579t / 69L / -456.378007pp | 110t / 6L / +158.943710pp | -63L / +615.321717pp |
| 2026 | 187t / 13L / +246.145427pp | 48t / 2L / +95.456891pp | -11L / -150.688536pp |

Aggregate control: 2,723 trades / 322 losses / -2,037.863956pp.  
Aggregate protected C5: 540 trades / 34 losses / +695.104227pp.  
Delta: -288 losses / +2,732.968183pp / -2,183 trades.

The latest-main port exactly reproduced the frozen protected-C5 annual metrics. These are fitted-period results, not a profitability or activation claim. The 2024 margin is thin at +18.415916pp. 2023 and 2020 remain sealed and were not run. Signal 663 remains default-disabled pending a separate untouched/forward gate.

## Checks
- `python3 ~/.codex/skills/nfi-upstream-pr/scripts/validate_nfi_pr.py --base upstream/main`
- merge-tree conflict simulation against current `upstream/main`
- targeted `populate_entry_trend()` and full Signal 663 callsite review
- `git diff --check`
- `ruff format --check NostalgiaForInfinityX7.py`
- `ruff check NostalgiaForInfinityX7.py`
- `PYTHONDONTWRITEBYTECODE=1 python3 -m py_compile NostalgiaForInfinityX7.py`
- Docker strategy load plus five-period latest-main control/candidate referee
