### PR TITLE
blacklist: stop the leverage pattern from removing JUP (4 venues)

### DIFF
--- a/configs/blacklist-binance.json
+++ b/configs/blacklist-binance.json
@@ -25,7 +25,8 @@
       // Exchange
       "(RIF|BNB)/.*",
       // Leverage
-      ".*(_PREMIUM|BEAR|BULL|HALF|HEDGE|UP|DOWN|[1235][SL])/.*",
+      ".*(_PREMIUM|BEAR|BULL|HALF|HEDGE|[1235][SL])/.*",
+      ".{3,}(UP|DOWN)/.*",
       // Fiat
       "(ARS|AUD|BIDR|BRZ|BRL|CAD|CHF|EUR|GBP|HKD|IDRT|JPY|NGN|PLN|RON|RUB|SGD|TRY|UAH|USD|ZAR)/.*",
       // Stable

--- a/configs/blacklist-bitget.json
+++ b/configs/blacklist-bitget.json
@@ -27,7 +27,8 @@
       // Exchange Tokens
       "BGB/.*",
       // Leverage tokens
-      ".*(3L|3S|5L|5S|UP|DOWN)/.*",
+      ".*(3L|3S|5L|5S)/.*",
+      ".{3,}(UP|DOWN)/.*",
       // Fiat
       "(RCCL|RTRV|RTXSTOCK|RIF|AUD|BRZ|CAD|CHF|EUR|GBP|HKD|IDRT|JPY|NGN|RUB|SGD|TRY|UAH|USD|ZAR)/.*",
       // Stable tokens

--- a/configs/blacklist-kraken.json
+++ b/configs/blacklist-kraken.json
@@ -28,7 +28,8 @@
       // FIGHT all-12 + IDOL (MEET48) — iterativ 2026-08-02
       "(FIGHT|IDOL)/.*",
       // Leverage tokens
-      ".*(3L|3S|5L|5S|UP|DOWN)/.*",
+      ".*(3L|3S|5L|5S)/.*",
+      ".{3,}(UP|DOWN)/.*",
       // Fiat
       "(RIF|AUD|BRZ|CAD|CHF|EUR|GBP|HKD|IDRT|JPY|NGN|RUB|SGD|TRY|UAH|USD|ZAR)/.*",
       // Stable tokens

--- a/configs/blacklist-kucoin.json
+++ b/configs/blacklist-kucoin.json
@@ -27,7 +27,8 @@
       // Exchange Tokens
       "KCS/.*",
       // Leverage tokens
-      ".*(3L|3S|5L|5S|UP|DOWN)/.*",
+      ".*(3L|3S|5L|5S)/.*",
+      ".{3,}(UP|DOWN)/.*",
       // Fiat
       "(RIF|AUD|BRZ|CAD|CHF|EUR|GBP|HKD|IDRT|JPY|NGN|RUB|SGD|TRY|UAH|USD|ZAR)/.*",
       // Stable tokens


### PR DESCRIPTION
The leveraged-token filters match **JUP** (Jupiter), because the symbol ends in `UP` and the leading `.*` absorbs the `J`:

| file | pattern |
|---|---|
| `blacklist-kraken.json`, `blacklist-bitget.json`, `blacklist-kucoin.json` | `.*(3L\|3S\|5L\|5S\|UP\|DOWN)/.*` |
| `blacklist-binance.json` | `.*(_PREMIUM\|BEAR\|BULL\|HALF\|HEDGE\|UP\|DOWN\|[1235][SL])/.*` |

Freqtrade expands blacklist entries with `re.fullmatch(..., re.IGNORECASE)` (`freqtrade/plugins/pairlist/pairlist_helpers.py`), so `JUP/USD` is a full match.

JUP is in the static pairlist for **all twelve** venues, so on these four it is whitelisted and then removed again at every start:

```
freqtrade.plugins.pairlistmanager - WARNING - Pair JUP/USD in your blacklist. Removing it from whitelist...
```

### What the pattern actually catches

Every symbol in all 61 `configs/pairlist-*.json` files, matched against the leverage pattern:

| | symbols caught |
|---|---|
| before | BTC3L, BTC3S, ETH3L, ETH3S, **JUP** |
| after | BTC3L, BTC3S, ETH3L, ETH3S |

Within NFI's own pair universe the `UP|DOWN` alternation currently catches nothing except the false positive.

### The change

Require at least three characters before `UP`/`DOWN`. Every real leveraged token has a full symbol as its stem (BTCUP, ETHDOWN, ADAUP, 1INCHUP, LINKUP, XTZUP, FILDOWN …); JUP has one letter.

```diff
       // Leverage tokens
-      ".*(3L|3S|5L|5S|UP|DOWN)/.*",
+      ".*(3L|3S|5L|5S)/.*",
+      ".{3,}(UP|DOWN)/.*",
```

Verified against 23 real leveraged-token names (BTCUP, BTCDOWN, ETHUP, ETHDOWN, ADAUP, XRPUP, LINKUP, DOTDOWN, 1INCHUP, SXPUP, XTZUP, FILDOWN, BTC3L, ETH3S, BNB5L, EOS3S, BTCBULL, ETHBEAR, BTCHEDGE, BTCHALF, BTC_PREMIUM, BTC2L, ETH5S): the replacement misses none that the current pattern catches, on either venue style. All four files still parse.

Found while auditing why our own Kraken whitelist ran 56 pairs instead of 59.