### PR TITLE
short_grind_entry_v3: bring the grind blocks back in step with long

### DIFF
--- a/NostalgiaForInfinityX7.py
+++ b/NostalgiaForInfinityX7.py
@@ -74123,13 +74123,16 @@ class NostalgiaForInfinityX7(IStrategy):
       and (last_rsi_14_1h < 55.0)
       and (last_roc_9_1h < 0.0)
       and (last_roc_9_4h < 10.0)
-      # anti-capitulation: even at a formed top, a capitulative 4h overshoot reverses (dead-bounce).
+      # anti-capitulative: even at a formed top, a capitulative 4h overshoot reverses (dead-bounce).
+      # cross-coin (SFP/CELR/DYDX/APE): cuts 17 severe at ~1% good cost within breakdown-starts.
       and (last_roc_9_4h > -25.0)
       # breakdown-started gate: only rebuild once the 4h top is IN (not still making new highs).
-      # AROONU high = a fresh 4h high was just made = still pumping; require it high = top formed.
+      # g22's job is the breakdown rebuild — NOT entering mid-pump (that's g1..g21). AROOND low =
+      # a fresh 4h high was just made = still pumping; require it high = top formed = breakdown start.
       and (last_aroonu_14_4h > 50.0)
-      # aggressive risk-free: g22 fires ONLY well above the 4h 200-EMA (fresh breakdown zone). The
-      # near/below-EMA overextended-drop zone is where dead-bounces live — g23 (extended-continuation)
+      # aggressive risk-free: g22 fires ONLY deep above the 4h 200-EMA (fresh breakdown zone). The
+      # near/below-EMA overextended-pullback zone is where dead-cats live AND where g22's late-breakdown
+      # adds sit — we sacrifice those wins on purpose, because g23 (extended-continuation, ~0.2% severe)
       # backstops the real breakdowns below. So g22 stays clean, g23 captures the continuation.
       and (last_close > last_ema_200_4h)
       and (last_close < (last_high_max_12_4h * 0.90))
@@ -74172,7 +74175,7 @@ class NostalgiaForInfinityX7(IStrategy):
       and (last_rsi_14_1h < 50.0)
       and (last_roc_9_1h < 0.0)
       and (last_roc_9_4h < 0.0)
-      # anti-capitulation blow-off + anti-exhaustion bottom
+      # anti-capitulative blow-off + anti-exhaustion bottom
       and (last_roc_9_4h > -25.0)
       and ((last_stochrsi_k > 3.0) or (last_rsi_14 > 20.0))
       and (last_close < (last_high_max_12_4h * 0.90))
@@ -74189,6 +74192,7 @@ class NostalgiaForInfinityX7(IStrategy):
       and ((last_rsi_3_1d < 70.0) or (last_aroonu_14_4h > 0.0))
       and ((last_rsi_3_1d < 50.0) or (last_stochrsi_k_1h > 20.0) or (last_stochrsi_k_4h > 10.0))
       and ((last_rsi_3_1d < 45.0) or (last_aroonu_14_15m > 0.0) or (last_stochrsi_k_15m > 10.0))
+      and ((last_aroonu_14_15m > 20.0) or (last_aroonu_14_1h > 0.0) or (last_roc_9_1d > -10.0))
       and ((last_aroonu_14_15m > 10.0) or (last_stochrsi_k_4h > 10.0))
       and ((last_aroonu_14_15m > 0.0) or (last_aroonu_14_1h > 0.0))
       and ((last_aroonu_14_15m > 0.0) or (last_aroonu_14_4h > 0.0))
@@ -74209,6 +74213,7 @@ class NostalgiaForInfinityX7(IStrategy):
       and ((last_stochrsi_k_15m > 10.0) or (last_stochrsi_k_4h > 10.0))
       and ((last_stochrsi_k_1h > 10.0) or (last_stochrsi_k_4h > 10.0))
       and ((last_stochrsi_k_1h > 10.0) or (last_stochrsi_k_4h > 10.0))
+      and ((last_stochrsi_k_1h > 10.0) or (last_stochrsi_k_1d > 10.0))
     ):
       self._grind_entry_tag = "g23"
       return True
@@ -74216,7 +74221,7 @@ class NostalgiaForInfinityX7(IStrategy):
     # g24 — downtrend-bounce continuation add: the zone BELOW the 4h 200-EMA that g22 explicitly sacrifices.
     # (mirror long g24)
     if (
-      # momentum healthy on the bounce: RSI holds down (a real reversal spikes RSI hard)
+      # momentum healthy on the bounce: RSI holds up (a real reversal cracks RSI hard)
       (last_rsi_3 < 80.0)
       and (last_rsi_3_15m < 80.0)
       and (last_rsi_14 < 60.0)
@@ -74224,10 +74229,10 @@ class NostalgiaForInfinityX7(IStrategy):
       and (last_roc_9_1h < 10.0)
       and (last_roc_9_4h < 0.0)
       and (last_roc_9_4h > -25.0)  # anti-parabolic blow-off top
-      # bear scope-gate: confirmed 4h downtrend + price below the 200-EMA regime (complements g22's >200EMA)
+      # bear scope-gate: confirmed 4h downtrend + price below the 200-EMA regime (complements g22's <200EMA)
       and (last_ema_12_4h < last_ema_200_4h)
       and (last_close < last_ema_200_4h)
-      # shallow bounce to the short EMA — short the bounce WITHIN the trend, never the bottom nor a deep dump
+      # shallow bounce to the short EMA — sell the dip WITHIN the trend, never the bottom nor a deep pump
       and (last_close > (last_ema_20 * 0.99))
       and (last_close < (last_ema_20 * 1.06))
       and ((last_rsi_3_15m < 60.0) or (last_stochrsi_k_15m > 30.0))
@@ -74254,6 +74259,7 @@ class NostalgiaForInfinityX7(IStrategy):
       and ((last_rsi_3_1h < 55.0) or (last_aroonu_14_4h > 20.0) or (last_roc_9_1d > -10.0))
       and ((last_rsi_3_1h < 50.0) or (last_aroonu_14_1h > 20.0) or (last_stochrsi_k_4h > 30.0))
       and ((last_rsi_3_1h < 50.0) or (last_rsi_3_4h < 45.0) or (last_stochrsi_k_4h > 30.0))
+      and ((last_rsi_3_1h < 50.0) or (last_aroonu_14_1h > 30.0) or (last_aroonu_14_1d > 30.0))
       and ((last_rsi_3_1h < 50.0) or (last_aroonu_14_4h > 20.0) or (last_aroonu_14_1d > 0.0))
       and ((last_rsi_3_1h < 50.0) or (last_aroonu_14_4h > 10.0) or (last_stochrsi_k_4h > 10.0))
       and ((last_rsi_3_1h < 45.0) or (last_rsi_3_4h < 45.0) or (last_stochrsi_k_15m > 30.0))
@@ -74266,7 +74272,6 @@ class NostalgiaForInfinityX7(IStrategy):
       and ((last_rsi_3_1h < 35.0) or (last_aroonu_14_1h > 0.0) or (last_stochrsi_k_4h > 30.0))
       and ((last_rsi_3_4h < 75.0) or (last_roc_9_1d > -30.0))
       and ((last_rsi_3_4h < 60.0) or (last_rsi_3_1d < 40.0) or (last_aroonu_14_1d > 0.0))
-      # do not short an oversold bottom on the bounce
       and ((last_rsi_3_4h < 60.0) or (last_aroonu_14_15m > 30.0) or (last_aroonu_14_1d > 10.0))
       and ((last_rsi_3_4h < 60.0) or (last_aroonu_14_1d > 10.0) or (last_roc_9_1d > -10.0))
       and ((last_rsi_3_4h < 60.0) or (last_stochrsi_k_15m > 40.0) or (last_aroonu_14_1d > 10.0))
@@ -74283,6 +74288,7 @@ class NostalgiaForInfinityX7(IStrategy):
       and ((last_rsi_3_1d < 65.0) or (last_stochrsi_k_1h > 10.0))
       and ((last_rsi_3_1d < 65.0) or (last_stochrsi_k_4h > 20.0))
       and ((last_rsi_3_1d < 55.0) or (last_stochrsi_k_1h > 30.0) or (last_stochrsi_k_4h > 20.0))
+      and ((last_rsi_3_1d < 50.0) or (last_stochrsi_k_15m > 10.0) or (last_roc_9_1d > -10.0))
       and ((last_rsi_3_1d < 40.0) or (last_aroonu_14_1h > 20.0) or (last_aroonu_14_1d > 0.0))
       and ((last_rsi_14_1h > 30.0) or (last_stochrsi_k_4h > 10.0))
       and ((last_aroonu_14_15m > 20.0) or (last_aroonu_14_1h > 20.0) or (last_aroonu_14_4h > 20.0))
@@ -74313,9 +74319,11 @@ class NostalgiaForInfinityX7(IStrategy):
       and ((last_aroonu_14_1d > 0.0) or (last_stochrsi_k_1h > 10.0))
       and ((last_aroonu_14_1d > 0.0) or (last_stochrsi_k_4h > 10.0))
       and ((last_aroonu_14_1d > 0.0) or (last_roc_9_4h > -15.0) or (last_roc_9_1d > -50.0))
+      # do not sell an oversold bottom on the pullback
       and ((last_stochrsi_k > 10.0) or (last_rsi_14 > 30.0))
       and ((last_stochrsi_k_15m > 20.0) or (last_stochrsi_k_1h > 20.0) or (last_roc_9_1d > -10.0))
       and ((last_stochrsi_k_15m > 20.0) or (last_aroonu_14_1d > 0.0))
+      and ((last_stochrsi_k_15m > 20.0) or (last_stochrsi_k_1d > 10.0) or (last_roc_9_1d > -20.0))
       and ((last_stochrsi_k_15m > 10.0) or (last_stochrsi_k_1h > 10.0))
       and ((last_stochrsi_k_15m > 10.0) or (last_stochrsi_k_1d > 10.0))
       and ((last_stochrsi_k_1h > 20.0) or (last_stochrsi_k_1d > 10.0))
@@ -74339,14 +74347,16 @@ class NostalgiaForInfinityX7(IStrategy):
       and (last_roc_9_1h > -2.0)
       and (last_close < (last_ema_20 * 1.02))
       and (last_close > (last_ema_20 * 0.98))
-      # squeeze integrity: regime still broken, 4h reclaim HELD, not dripping to new lows
+      # squeeze integrity: regime still broken, 4h rejection HELD, not dripping to new highs
       and (last_close > last_ema_200_4h)
       and (last_close < (last_high_max_12_4h * 0.90))
       and (last_close < (last_close_max_12 * 0.995))
       # general protections first
       and ((last_rsi_3_15m < 80.0) or (last_stochrsi_k_4h > 10.0))
       and ((last_rsi_3_1h < 85.0) or (last_aroonu_14_4h > 30.0))
+      and ((last_rsi_3_1h < 80.0) or (last_rsi_3_4h < 80.0) or (last_aroonu_14_1d > 10.0))
       and ((last_rsi_3_1h < 80.0) or (last_stochrsi_k_1h > 20.0))
+      and ((last_rsi_3_1h < 70.0) or (last_rsi_3_1d < 70.0) or (last_stochrsi_k_1h > 30.0))
       and ((last_rsi_3_1h < 65.0) or (last_aroonu_14_1h > 30.0))
       and ((last_rsi_3_1h < 65.0) or (last_aroonu_14_4h > 30.0))
       and ((last_rsi_3_1h < 60.0) or (last_aroonu_14_4h > 20.0))
@@ -74363,6 +74373,7 @@ class NostalgiaForInfinityX7(IStrategy):
       and ((last_rsi_3_1h < 40.0) or (last_rsi_3_1d < 40.0) or (last_aroonu_14_1h > 20.0))
       and ((last_rsi_3_1h < 40.0) or (last_stochrsi_k_4h > 30.0) or (last_stochrsi_k_1d > 20.0))
       and ((last_rsi_3_1h < 40.0) or (last_stochrsi_k_4h > 20.0) or (last_roc_9_4h > -10.0))
+      and ((last_rsi_3_4h < 90.0) or (last_rsi_3_1d < 60.0) or (last_stochrsi_k_15m > 20.0))
       and ((last_rsi_3_4h < 75.0) or (last_stochrsi_k_4h > 50.0) or (last_roc_9_4h > -10.0))
       and ((last_rsi_3_4h < 65.0) or (last_stochrsi_k_4h > 30.0))
       and ((last_rsi_3_4h < 60.0) or (last_rsi_3_1d < 60.0) or (last_aroonu_14_15m > 30.0))
@@ -74378,11 +74389,11 @@ class NostalgiaForInfinityX7(IStrategy):
       and ((last_rsi_3_4h < 35.0) or (last_aroonu_14_1h > 30.0) or (last_stochrsi_k_4h > 10.0))
       and ((last_rsi_3_4h < 35.0) or (last_aroonu_14_4h > 20.0) or (last_stochrsi_k_4h > 30.0))
       and ((last_rsi_3_4h < 35.0) or (last_stochrsi_k_4h > 10.0) or (last_roc_9_4h > -10.0))
-      and ((last_rsi_3_1d < 90.0) or (last_aroonu_14_1h > 10.0))
-      and ((last_rsi_3_1d < 90.0) or (last_stochrsi_k_1h > 20.0))
       and ((last_rsi_3_1d < 90.0) or (last_stochrsi_k_4h > 30.0))
       and ((last_rsi_3_1d < 80.0) or (last_aroonu_14_1d > 10.0))
       and ((last_rsi_3_1d < 75.0) or (last_stochrsi_k_15m > 30.0))
+      and ((last_rsi_3_1d < 75.0) or (last_aroonu_14_1h > 30.0))
+      and ((last_rsi_3_1d < 75.0) or (last_stochrsi_k_1h > 10.0))
       and ((last_rsi_3_1d < 70.0) or (last_aroonu_14_15m > 0.0))
       and ((last_rsi_3_1d < 70.0) or (last_stochrsi_k_4h > 10.0))
       and ((last_aroonu_14_15m > 30.0) or (last_aroonu_14_1h > 0.0) or (last_stochrsi_k_1d > 20.0))
@@ -74391,6 +74402,8 @@ class NostalgiaForInfinityX7(IStrategy):
       and ((last_aroonu_14_15m > 20.0) or (last_aroonu_14_1h > 0.0))
       and ((last_aroonu_14_15m > 0.0) or (last_aroonu_14_4h > 10.0))
       and ((last_aroonu_14_15m > 0.0) or (last_stochrsi_k_4h > 10.0))
+      and ((last_aroonu_14_1h > 20.0) or (last_aroonu_14_4h > 0.0) or (last_stochrsi_k_1h > 20.0))
+      and ((last_aroonu_14_1h > 20.0) or (last_stochrsi_k_4h > 0.0) or (last_stochrsi_k_4h > 20.0))
       and ((last_aroonu_14_1h > 20.0) or (last_stochrsi_k_4h > 10.0) or (last_roc_9_4h > -10.0))
       and ((last_aroonu_14_1h > 0.0) or (last_aroonu_14_1d > 0.0))
       and ((last_aroonu_14_1h > 0.0) or (last_stochrsi_k_15m > 20.0))


### PR DESCRIPTION
The long grind blocks were tuned again after the last mirror, so the short side had fallen behind twice over: missing the new chains, and still carrying two that long has since tightened.

Each short block was rebuilt from its long counterpart rather than patched — overwriting cannot skip a line.

| block | change |
|---|---|
| g23 | +2 conditions |
| g24 | +3 conditions |
| g27 | +5 new, −2 stale (the `rsi_3_1d < 90.0` pair long tightened to `< 75.0`) |
| g22 | comments only; its conditions were already in step |

## Checks

- every long condition's mirror is present in short, **in the same order, across all 26 blocks**
- threshold families mirror exactly and the counts match: aroonu 216/216 (long 25..100 against short 0..75), rsi 266/266 (5..80 against 20..95), stochrsi 193/193 (20..100 against 0..80), roc 88/88 (−40..60 against −60..40), willr 2/2, cmf 1/1
- `bbl_20 * 1.010` → `bbu * 0.990`; `bbands_20_1h` → `bbb_1h` unchanged, because band width has no direction
- no undefined variables, `py_compile` clean, and every hunk lands inside `short_grind_entry_v3`

## Backtest

2022 with signal 669 enabled, which is what actually puts short grinding on the path:

| | trades | profit | DD |
|---|---|---|---|
| before | 1018 | $8,877,980.94 | 0.00% |
| after | 1018 | $8,878,316.29 | 0.00% |

Short grind tags fire identically in both runs — g24 ×91, g0 ×51, g23 ×6, g14 ×1 — so the added guards do not remove a grind add; they shift a few of them by a candle. No loss, no drawdown change.

Worth noting for anyone testing this area: under `grind_mode_max_slots: 0` the v3 grind blocks never fire at all, so a gms0 run comes back bit-identical and proves nothing about this change. That is why the measurement above uses the normal rig with a short signal enabled.