### PR TITLE
Fix X8 short top coins exit routing

### DIFF
--- a/NostalgiaForInfinityX8.py
+++ b/NostalgiaForInfinityX8.py
@@ -234,6 +234,7 @@ class NostalgiaForInfinityX8(IStrategy):
     + short_high_profit_mode_tags
     + short_rapid_mode_tags
     + short_grind_mode_tags
+    + short_top_coins_mode_tags
     + short_scalp_mode_tags
   )
 
@@ -1869,6 +1870,7 @@ class NostalgiaForInfinityX8(IStrategy):
     short_rebuy_mode_tags = self.short_rebuy_mode_tags
     short_high_profit_mode_tags = self.short_high_profit_mode_tags
     short_rapid_mode_tags = self.short_rapid_mode_tags
+    short_top_coins_mode_tags = self.short_top_coins_mode_tags
     short_scalp_mode_tags = self.short_scalp_mode_tags
     short_scalp_rebuy_grind_mode_tags = self.short_scalp_rebuy_grind_mode_tags
     short_exit_known_mode_tags = self.short_exit_known_mode_tags
@@ -2292,6 +2294,29 @@ class NostalgiaForInfinityX8(IStrategy):
         profit_init_ratio,
         max_profit,
         max_loss,
+        filled_entries,
+        filled_exits,
+        last_candle,
+        previous_candle_1,
+        trade,
+        current_time,
+        enter_tags,
+      )
+      if sell and (signal_name is not None):
+        return f"{signal_name} ( {enter_tag})"
+
+    # Short Top Coins mode
+    if any(c in short_top_coins_mode_tags for c in enter_tags):
+      sell, signal_name = self.short_exit_top_coins(
+        pair,
+        current_rate,
+        profit_stake,
+        profit_ratio,
+        profit_current_stake_ratio,
+        profit_init_ratio,
+        max_profit,
+        max_loss,
+        filled_orders,
         filled_entries,
         filled_exits,
         last_candle,
@@ -25397,7 +25422,6 @@ class NostalgiaForInfinityX8(IStrategy):
     current_time: "datetime",
     buy_tag,
   ) -> tuple:
-
     #  Here ends exit signal conditions for long_exit_williams_r
 
     return False, None
@@ -25416,7 +25440,6 @@ class NostalgiaForInfinityX8(IStrategy):
     current_time: "datetime",
     buy_tag,
   ) -> tuple:
-
     #  Here ends exit signal conditions for long_exit_dec
 
     return False, None
@@ -39583,7 +39606,6 @@ class NostalgiaForInfinityX8(IStrategy):
     current_time: "datetime",
     buy_tag,
   ) -> tuple:
-
     #  Here ends exit signal conditions for short_exit_williams_r
 
     return False, None
@@ -39602,7 +39624,6 @@ class NostalgiaForInfinityX8(IStrategy):
     current_time: "datetime",
     buy_tag,
   ) -> tuple:
-
     #  Here ends exit signal conditions for short_exit_dec
 
     return False, None

--- a/tests/unit/test_NFIX8_custom_exit.py
+++ b/tests/unit/test_NFIX8_custom_exit.py
@@ -1,0 +1,100 @@
+from datetime import datetime
+from datetime import timezone
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pandas as pd
+import pytest
+
+from NostalgiaForInfinityX8 import NostalgiaForInfinityX8
+
+
+@pytest.fixture
+def exit_strategy():
+  strategy = NostalgiaForInfinityX8.__new__(NostalgiaForInfinityX8)
+  candle = {
+    "RSI_14": 10.0,
+    "close": 95.0,
+    "EMA_200": 100.0,
+    "EMA_50": 100.0,
+    "RSI_14_1h": 15.0,
+    "BBL_20_2.0": 96.0,
+    "BBL_20_2.0_1h": 96.0,
+    "BB_BELOW_COUNT": 5,
+  }
+  dataframe = pd.DataFrame([candle, candle])
+  strategy.dp = SimpleNamespace(get_analyzed_dataframe=lambda pair, timeframe: (dataframe, None))
+  strategy.filled_order_snapshot = MagicMock(return_value=(["entry", "exit"], ["entry"], ["exit"]))
+  strategy.calc_total_profit = MagicMock(return_value=(2.0, 0.02, 0.025, 0.03))
+  strategy.cache_backtest_profit_snapshot = MagicMock()
+  strategy.target_profit_cache = SimpleNamespace(data={}, save=MagicMock())
+  strategy.short_exit_normal = MagicMock(return_value=(False, None))
+  strategy.short_exit_scalp = MagicMock(return_value=(False, None))
+  strategy.long_exit_top_coins = MagicMock(return_value=(False, None))
+  strategy.short_exit_top_coins = MagicMock(wraps=strategy.short_exit_top_coins)
+  return strategy
+
+
+def run_custom_exit(strategy, enter_tag, is_short=True):
+  trade = SimpleNamespace(
+    pair="BTC/USDT:USDT",
+    is_short=is_short,
+    enter_tag=enter_tag,
+    get_custom_data=lambda key: "system_v4",
+  )
+  current_time = datetime(2026, 9, 7, tzinfo=timezone.utc)
+  return strategy.custom_exit(trade.pair, trade, current_time, 95.0, 0.02)
+
+
+@pytest.mark.parametrize("enter_tag", ["641", "642", "641 642", "501 641", "641 661"])
+def test_short_top_coins_reaches_existing_exit_signal(exit_strategy, enter_tag):
+  reason = run_custom_exit(exit_strategy, enter_tag)
+
+  assert reason == f"exit_short_tc_1_1_1 ( {enter_tag})"
+  exit_strategy.short_exit_top_coins.assert_called_once()
+  args = exit_strategy.short_exit_top_coins.call_args.args
+  assert args[:11] == (
+    "BTC/USDT:USDT",
+    95.0,
+    2.0,
+    0.02,
+    0.025,
+    0.03,
+    0.0,
+    0.0,
+    ["entry", "exit"],
+    ["entry"],
+    ["exit"],
+  )
+  assert args[-1] == enter_tag.split()
+  assert exit_strategy.target_profit_cache.data["BTC/USDT:USDT"]["sell_reason"] == "exit_short_tc_1_1_1"
+  if "501" not in enter_tag.split():
+    exit_strategy.short_exit_normal.assert_not_called()
+  exit_strategy.short_exit_scalp.assert_not_called()
+  exit_strategy.long_exit_top_coins.assert_not_called()
+
+
+@pytest.mark.parametrize("enter_tag", ["641", "642", "641 642"])
+def test_short_top_coins_without_exit_keeps_its_profit_target(exit_strategy, enter_tag):
+  exit_strategy.short_exit_signals = MagicMock(return_value=(False, None))
+  exit_strategy.short_exit_main = MagicMock(return_value=(False, None))
+  exit_strategy.short_exit_stoploss = MagicMock(return_value=(False, None))
+  exit_strategy.short_exit_normal.return_value = (True, "exit_short_normal_test")
+
+  assert run_custom_exit(exit_strategy, enter_tag) is None
+  exit_strategy.short_exit_top_coins.assert_called_once()
+  exit_strategy.short_exit_normal.assert_not_called()
+  assert exit_strategy.target_profit_cache.data["BTC/USDT:USDT"]["sell_reason"] == "exit_profit_short_tc_max"
+
+
+@pytest.mark.parametrize(
+  "enter_tag,is_short,handler",
+  [("141", False, "long_exit_top_coins"), ("501", True, "short_exit_normal"), ("unknown", True, "short_exit_normal")],
+)
+def test_other_exit_routes_are_preserved(exit_strategy, enter_tag, is_short, handler):
+  exit_handler = getattr(exit_strategy, handler)
+  exit_handler.return_value = (True, "existing_exit")
+
+  assert run_custom_exit(exit_strategy, enter_tag, is_short) == f"existing_exit ( {enter_tag})"
+  exit_handler.assert_called_once()
+  exit_strategy.short_exit_top_coins.assert_not_called()


### PR DESCRIPTION
## Summary

- Route X8 short top coins tags (`641`, `642`) through the existing `short_exit_top_coins()` handler in `custom_exit()`, matching the long top coins branch.
- Include those tags in `short_exit_known_mode_tags` so a trade waiting for a top coins exit does not fall through to the unknown-trade normal exit handler.
- Based independently on upstream `main` at `f0c033ee`.

## Safety

The active runtime change is in `custom_exit()` and its known-mode tag list. Top coins trades now use `short_tc` exits and profit targets. Mixed tags follow the existing handler order.

The exit helper, indicators, candle selection, profit arithmetic, and thresholds are unchanged. No v3 grind-entry code is touched. The repository formatter also removes four existing blank lines.

## Backtest scope

Ran targeted callback regression tests with Freqtrade `2026.8`, including the real `short_exit_top_coins()` and `short_exit_signals()` methods. The tests cover both tags, mixed tags, profit targets when no exit fires, argument forwarding, and existing long/normal/unknown routes. Before the fix: 8 failed, 3 passed. After: all 11 passed.

This changes exit routing intentionally; no full market-data backtest was run.

## Checks

- `python -m pytest -o addopts= -o log_cli=false -p no:cacheprovider tests/unit/test_NFIX8_custom_exit.py -q`
- NFI PR validator with `--base origin/main --strategy NostalgiaForInfinityX8.py --allow-extra-file tests/unit/test_NFIX8_custom_exit.py`
- Separate X8 AST review: the new branch matches the long branch, added locals are bound, and all other strategy logic is unchanged.
- Latest-base check, merge-tree simulation, targeted diff review, `git diff --check`, Ruff, and Python compilation passed.
- `pre-commit run --files NostalgiaForInfinityX8.py tests/unit/test_NFIX8_custom_exit.py` passed.
