### PR TITLE
X8: long_exit_dec — fill the stub with an SMA_200 rollover block

### DIFF
--- a/NostalgiaForInfinityX8.py
+++ b/NostalgiaForInfinityX8.py
@@ -3389,6 +3389,9 @@ class NostalgiaForInfinityX8(IStrategy):
     # MOMENTUM
     # =========================================================================
     ema_12 = ta_ema(close_np, timeperiod=12)
+    sma_200 = ta_sma(close_np, timeperiod=200)
+    # SMA_200 below where it was 6 candles back = the slow trend is rolling over.
+    sma_200_dec_6 = sma_200 < self.np_shift(sma_200, 6)
     ema_50 = ta_ema(close_np, timeperiod=50)
     ema_100 = ta_ema(close_np, timeperiod=100)
     ema_200 = ta_ema(close_np, timeperiod=200)
@@ -3456,6 +3459,7 @@ class NostalgiaForInfinityX8(IStrategy):
         "EMA_50": ema_50,
         "EMA_100": ema_100,
         "EMA_200": ema_200,
+        "SMA_200_dec_6": sma_200_dec_6,
         "WILLR_14": willr_14,
         "UO_7_14_28": uo,
         "ROC_2": roc_2,
@@ -3599,6 +3603,9 @@ class NostalgiaForInfinityX8(IStrategy):
     ema_12 = ta_ema(close_np, timeperiod=12)
     ema_200 = ta_ema(close_np, timeperiod=200)
     sma_16 = ta_sma(close_np, timeperiod=16)
+    sma_200 = ta_sma(close_np, timeperiod=200)
+    # SMA_200 below where it was 12 candles back = the slow trend is rolling over.
+    sma_200_dec_12 = sma_200 < self.np_shift(sma_200, 12)
     willr_14 = ta_willr(high_np, low_np, close_np, timeperiod=14)
     willr_84 = ta_willr(high_np, low_np, close_np, timeperiod=84)
     uo = ta.ULTOSC(high_np, low_np, close_np)
@@ -3637,6 +3644,7 @@ class NostalgiaForInfinityX8(IStrategy):
         "RSI_14_change_pct": rsi_14_change,
         "EMA_12": ema_12,
         "EMA_200": ema_200,
+        "SMA_200_dec_12": sma_200_dec_12,
         "SMA_16": sma_16,
         "BBL_20_2.0": bb_lower,
         "BBU_20_2.0": bb_upper,
@@ -3963,6 +3971,8 @@ class NostalgiaForInfinityX8(IStrategy):
     sma_21 = ta_sma(close_np, timeperiod=21)
     sma_30 = ta_sma(close_np, timeperiod=30)
     sma_200 = ta_sma(close_np, timeperiod=200)
+    # SMA_200 below where it was 24 candles back = the slow trend is rolling over.
+    sma_200_dec_24 = sma_200 < np_shift(sma_200, 24)
     willr_14 = ta_willr(high_np, low_np, close_np, timeperiod=14)
     willr_480 = ta_willr(high_np, low_np, close_np, timeperiod=480)
     roc_2 = ta_roc(close_np, timeperiod=2)
@@ -4239,6 +4249,7 @@ class NostalgiaForInfinityX8(IStrategy):
         "SMA_21": sma_21,
         "SMA_30": sma_30,
         "SMA_200": sma_200,
+        "SMA_200_dec_24": sma_200_dec_24,
         "BBL_20_2.0": bb_lower_20,
         "BBU_20_2.0": bb_upper_20,
         "BBB_20_2.0": ((bb_upper_20 - bb_lower_20) / bb_middle_20_safe) * 100.0,
@@ -25442,9 +25453,90 @@ class NostalgiaForInfinityX8(IStrategy):
     current_time: "datetime",
     buy_tag,
   ) -> tuple:
+    last_sma_200_dec = last_candle["SMA_200_dec_24"]
+    last_stochrsi_k = last_candle["STOCHRSIk_14_14_3_3"]
+    last_aroonu_14 = last_candle["AROONU_14"]
+    last_willr_480 = last_candle["WILLR_480"]
+    last_aroonu_14_4h = last_candle["AROONU_14_4h"]
+    last_sma_200_dec_1h = last_candle["SMA_200_dec_12_1h"]
+    last_sma_200_dec_4h = last_candle["SMA_200_dec_6_4h"]
+
+    if 0.01 > current_profit >= 0.001:
+      if (
+        last_sma_200_dec
+        and last_sma_200_dec_1h
+        and last_sma_200_dec_4h
+        and (last_stochrsi_k > 95.0)
+        and (last_aroonu_14 > 95.0)
+      ):
+        return True, f"exit_{mode_name}_d_0_1"
+    elif 0.02 > current_profit >= 0.01:
+      if (
+        last_sma_200_dec
+        and last_sma_200_dec_1h
+        and last_sma_200_dec_4h
+        and (last_stochrsi_k > 95.0)
+        and (last_aroonu_14 > 95.0)
+      ):
+        return True, f"exit_{mode_name}_d_1_1"
+    elif 0.03 > current_profit >= 0.02:
+      if (
+        last_sma_200_dec
+        and last_sma_200_dec_1h
+        and last_sma_200_dec_4h
+        and (last_stochrsi_k > 95.0)
+        and (last_aroonu_14 > 95.0)
+      ):
+        return True, f"exit_{mode_name}_d_2_1"
+    elif 0.04 > current_profit >= 0.03:
+      if last_sma_200_dec and (last_stochrsi_k > 95.0) and (last_aroonu_14 > 90.0):
+        return True, f"exit_{mode_name}_d_3_1"
+    elif 0.05 > current_profit >= 0.04:
+      if last_sma_200_dec and (last_stochrsi_k > 92.0) and (last_aroonu_14 > 90.0):
+        return True, f"exit_{mode_name}_d_4_1"
+    elif 0.06 > current_profit >= 0.05:
+      if last_sma_200_dec and (last_stochrsi_k > 90.0) and (last_aroonu_14 > 90.0):
+        return True, f"exit_{mode_name}_d_5_1"
+    elif 0.07 > current_profit >= 0.06:
+      if last_sma_200_dec:
+        return True, f"exit_{mode_name}_d_6_1"
+      elif (last_stochrsi_k > 65.0) and (last_willr_480 > -50.0) and (last_aroonu_14_4h > 25.0):
+        return True, f"exit_{mode_name}_d_6_2"
+    elif 0.08 > current_profit >= 0.07:
+      if last_sma_200_dec:
+        return True, f"exit_{mode_name}_d_7_1"
+      elif (last_stochrsi_k > 65.0) and (last_willr_480 > -50.0) and (last_aroonu_14_4h > 25.0):
+        return True, f"exit_{mode_name}_d_7_2"
+    elif 0.09 > current_profit >= 0.08:
+      if last_sma_200_dec:
+        return True, f"exit_{mode_name}_d_8_1"
+      elif (last_stochrsi_k > 65.0) and (last_willr_480 > -50.0) and (last_aroonu_14_4h > 25.0):
+        return True, f"exit_{mode_name}_d_8_2"
+    elif 0.1 > current_profit >= 0.09:
+      if last_sma_200_dec:
+        return True, f"exit_{mode_name}_d_9_1"
+      elif (last_stochrsi_k > 65.0) and (last_willr_480 > -50.0) and (last_aroonu_14_4h > 25.0):
+        return True, f"exit_{mode_name}_d_9_2"
+    elif 0.12 > current_profit >= 0.1:
+      if last_sma_200_dec:
+        return True, f"exit_{mode_name}_d_10_1"
+      elif (last_stochrsi_k > 65.0) and (last_willr_480 > -50.0) and (last_aroonu_14_4h > 25.0):
+        return True, f"exit_{mode_name}_d_10_2"
+    elif 0.2 > current_profit >= 0.12:
+      if last_sma_200_dec:
+        return True, f"exit_{mode_name}_d_11_1"
+      elif (last_stochrsi_k > 65.0) and (last_willr_480 > -50.0) and (last_aroonu_14_4h > 25.0):
+        return True, f"exit_{mode_name}_d_11_2"
+    elif current_profit >= 0.2:
+      if last_sma_200_dec:
+        return True, f"exit_{mode_name}_d_12_1"
+      elif (last_stochrsi_k > 65.0) and (last_willr_480 > -50.0) and (last_aroonu_14_4h > 25.0):
+        return True, f"exit_{mode_name}_d_12_2"
+
     #  Here ends exit signal conditions for long_exit_dec
 
     return False, None
+
 
   # Long Exit Stop Loss
   # ---------------------------------------------------------------------------------------------


### PR DESCRIPTION
`long_exit_dec()` is an empty stub in X8, so nothing exits on the slow trend rolling over the way it does in X7. This fills it with a small block built around your idea — `SMA_200` below where it was N candles back — measured one change per backtest, 2026 gms0, 48 pairs.

## Result

| | trades | profit | real losses | max DD | avg hold | median giveback |
|---|---|---|---|---|---|---|
| X8 v18.0.2 as is (no dec) | 139 | $37,704 | **1** | 2.75% | 11h19m | 9.67p |
| X7 v17.5.41 (mature dec, 1,729 rules) | 141 | $28,991 | 0 | 0.92% | 4h12m | 3.91p |
| **this PR** | 140 | **$46,495** | **0** | **0.39%** | 7h29m | **4.30p** |

Giveback is peak-to-close in profit points — the thing dec exists to fix, and it does not show up in the profit column. The one reported loss is the ZEC data-cutoff `force_exit` (−2.34%, 50 minutes, its 5m data ends 2026-06-06), the same artefact that appears in every run on this set.

## Shape

The block asks a different question in each profit region. That is not decoration — four separate measurements found the same boundary at ~6%.

```
0.1-3%    base + 1h + 4h dec, STOCH > 95, AROONU > 95      (five clauses)
3-6%      dec and STOCH ladder (95..90) and AROONU > 90
above 6%  dec alone
          or a second case: STOCH > 65 and WILLR_480 > -50 and AROONU_14_4h > 25
```

Below 6% several exit paths already compete for the same trade, so a loose rule there mostly wins races it should lose — a lone dec check in those bands cost $23,313. Above 6% nothing better is waiting behind dec, so the same lone check is the second-best thing measured. The second case covers what `SMA_200` cannot see: a fast vertical move topping out while the higher timeframe is still strong, which is exactly why the slow average has not turned. Its thresholds were read off the trades it was meant to catch, then nudged a full grid step in both directions — profit moves $114 across all three settings, so it describes a state rather than a fitted point.

## Periods

Each timeframe gets a period meaning roughly the same horizon, since `np_shift` counts candles of that frame:

```
base 5m   24 candles = 2 hours
1h        12 candles = 12 hours
4h         6 candles = 1 day
```

Using 24 everywhere made the 4h check ask about a four-day rollover in bands where trades last hours; the proportional periods are worth $367 and improve giveback.

1d was deliberately left out — 200 daily candles is over half a year of history, so the column would be NaN on any recent listing.

## Notes

- **Additive**: 92 insertions, 0 deletions.
- `self.np_shift` in the informative builders — the bare name is only aliased in the base-timeframe function and raises `NameError` at runtime, not at import.
- `AROONU_14`, `AROONU_14_4h`, `STOCHRSIk_14_14_3_3` and `WILLR_480` already exist.
- **2026 only.** Every threshold was chosen on this one regime; 2021 and 2022 have not been run on this shape.
- **Short side not included.** `short_exit_dec` is still a stub. Mirroring it has one question I did not want to guess into a PR: the house convention flips `AROONU > T` to `100 − T`, while the semantic mirror of "at a fresh 14-period high" is `AROOND_14 > T`. These are not the same statement — tell me which you want and I will send the mirror.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Dq23uSiXuSScTSa84tbtpa
