### PR TITLE
X8: move the pump-top exit out of long_exit_dec into long_exit_williams_r

### DIFF
--- a/NostalgiaForInfinityX8.py
+++ b/NostalgiaForInfinityX8.py
@@ -25439,6 +25439,50 @@ class NostalgiaForInfinityX8(IStrategy):
     current_time: "datetime",
     buy_tag,
   ) -> tuple:
+    last_stochrsi_k = last_candle["STOCHRSIk_14_14_3_3"]
+    last_willr_480 = last_candle["WILLR_480"]
+    last_aroonu_14_4h = last_candle["AROONU_14_4h"]
+
+    if 0.01 > current_profit >= 0.001:
+      if (last_stochrsi_k > 95.0) and (last_willr_480 > -1.0) and (last_aroonu_14_4h > 95.0):
+        return True, f"exit_{mode_name}_w_0_1"
+    elif 0.02 > current_profit >= 0.01:
+      if (last_stochrsi_k > 95.0) and (last_willr_480 > -1.0) and (last_aroonu_14_4h > 95.0):
+        return True, f"exit_{mode_name}_w_1_1"
+    elif 0.03 > current_profit >= 0.02:
+      if (last_stochrsi_k > 95.0) and (last_willr_480 > -1.0) and (last_aroonu_14_4h > 95.0):
+        return True, f"exit_{mode_name}_w_2_1"
+    elif 0.04 > current_profit >= 0.03:
+      if (last_stochrsi_k > 95.0) and (last_willr_480 > -1.0) and (last_aroonu_14_4h > 95.0):
+        return True, f"exit_{mode_name}_w_3_1"
+    elif 0.05 > current_profit >= 0.04:
+      if (last_stochrsi_k > 90.0) and (last_willr_480 > -10.0) and (last_aroonu_14_4h > 90.0):
+        return True, f"exit_{mode_name}_w_4_1"
+    elif 0.06 > current_profit >= 0.05:
+      if (last_stochrsi_k > 90.0) and (last_willr_480 > -10.0) and (last_aroonu_14_4h > 90.0):
+        return True, f"exit_{mode_name}_w_5_1"
+    elif 0.07 > current_profit >= 0.06:
+      if (last_stochrsi_k > 90.0) and (last_willr_480 > -10.0) and (last_aroonu_14_4h > 90.0):
+        return True, f"exit_{mode_name}_w_6_1"
+    elif 0.08 > current_profit >= 0.07:
+      if (last_stochrsi_k > 90.0) and (last_willr_480 > -10.0) and (last_aroonu_14_4h > 90.0):
+        return True, f"exit_{mode_name}_w_7_1"
+    elif 0.09 > current_profit >= 0.08:
+      if (last_stochrsi_k > 90.0) and (last_willr_480 > -10.0) and (last_aroonu_14_4h > 90.0):
+        return True, f"exit_{mode_name}_w_8_1"
+    elif 0.1 > current_profit >= 0.09:
+      if (last_stochrsi_k > 90.0) and (last_willr_480 > -10.0) and (last_aroonu_14_4h > 90.0):
+        return True, f"exit_{mode_name}_w_9_1"
+    elif 0.12 > current_profit >= 0.1:
+      if (last_stochrsi_k > 90.0) and (last_willr_480 > -10.0) and (last_aroonu_14_4h > 90.0):
+        return True, f"exit_{mode_name}_w_10_1"
+    elif 0.2 > current_profit >= 0.12:
+      if (last_stochrsi_k > 90.0) and (last_willr_480 > -10.0) and (last_aroonu_14_4h > 90.0):
+        return True, f"exit_{mode_name}_w_11_1"
+    elif current_profit >= 0.2:
+      if (last_stochrsi_k > 90.0) and (last_willr_480 > -10.0) and (last_aroonu_14_4h > 90.0):
+        return True, f"exit_{mode_name}_w_12_1"
+
     #  Here ends exit signal conditions for long_exit_williams_r
 
     return False, None
@@ -25460,8 +25504,6 @@ class NostalgiaForInfinityX8(IStrategy):
     last_sma_200_dec = last_candle["SMA_200_dec_24"]
     last_stochrsi_k = last_candle["STOCHRSIk_14_14_3_3"]
     last_aroonu_14 = last_candle["AROONU_14"]
-    last_willr_480 = last_candle["WILLR_480"]
-    last_aroonu_14_4h = last_candle["AROONU_14_4h"]
     last_sma_200_dec_1h = last_candle["SMA_200_dec_12_1h"]
     last_sma_200_dec_4h = last_candle["SMA_200_dec_6_4h"]
 
@@ -25504,38 +25546,24 @@ class NostalgiaForInfinityX8(IStrategy):
     elif 0.07 > current_profit >= 0.06:
       if last_sma_200_dec:
         return True, f"exit_{mode_name}_d_6_1"
-      elif (last_stochrsi_k > 65.0) and (last_willr_480 > -50.0) and (last_aroonu_14_4h > 25.0):
-        return True, f"exit_{mode_name}_d_6_2"
     elif 0.08 > current_profit >= 0.07:
       if last_sma_200_dec:
         return True, f"exit_{mode_name}_d_7_1"
-      elif (last_stochrsi_k > 65.0) and (last_willr_480 > -50.0) and (last_aroonu_14_4h > 25.0):
-        return True, f"exit_{mode_name}_d_7_2"
     elif 0.09 > current_profit >= 0.08:
       if last_sma_200_dec:
         return True, f"exit_{mode_name}_d_8_1"
-      elif (last_stochrsi_k > 65.0) and (last_willr_480 > -50.0) and (last_aroonu_14_4h > 25.0):
-        return True, f"exit_{mode_name}_d_8_2"
     elif 0.1 > current_profit >= 0.09:
       if last_sma_200_dec:
         return True, f"exit_{mode_name}_d_9_1"
-      elif (last_stochrsi_k > 65.0) and (last_willr_480 > -50.0) and (last_aroonu_14_4h > 25.0):
-        return True, f"exit_{mode_name}_d_9_2"
     elif 0.12 > current_profit >= 0.1:
       if last_sma_200_dec:
         return True, f"exit_{mode_name}_d_10_1"
-      elif (last_stochrsi_k > 65.0) and (last_willr_480 > -50.0) and (last_aroonu_14_4h > 25.0):
-        return True, f"exit_{mode_name}_d_10_2"
     elif 0.2 > current_profit >= 0.12:
       if last_sma_200_dec:
         return True, f"exit_{mode_name}_d_11_1"
-      elif (last_stochrsi_k > 65.0) and (last_willr_480 > -50.0) and (last_aroonu_14_4h > 25.0):
-        return True, f"exit_{mode_name}_d_11_2"
     elif current_profit >= 0.2:
       if last_sma_200_dec:
         return True, f"exit_{mode_name}_d_12_1"
-      elif (last_stochrsi_k > 65.0) and (last_willr_480 > -50.0) and (last_aroonu_14_4h > 25.0):
-        return True, f"exit_{mode_name}_d_12_2"
 
     #  Here ends exit signal conditions for long_exit_dec
 


### PR DESCRIPTION
Follow-up to #1251, doing what you asked for in review.

## The case was in the wrong function

The `_2` case never touches `sma_200_dec` — it fires on a fast vertical top while the higher timeframe is still strong. `long_exit_williams_r()` is the right home, it is an empty stub, and it is dispatched *before* `long_exit_dec` anyway.

Moving it is behaviour-neutral: the run comes back **$46,495.478**, identical to the cent. I expected a difference since williams_r gets first refusal; there are no candles where both would fire.

Tags follow X7's convention, `w_0_1` … `w_12_1`, and the case now exists for all thirteen profit bands rather than only above 6%.

## The old thresholds really were nearly no-ops

You called this and the base rates over **2,238,716 candles** agree:

| clause | true on |
|---|---|
| `STOCHRSIk > 65` | 37.8% |
| `WILLR_480 > -50` | 42.7% |
| **`AROONU_14_4h > 25`** | **58.9%** |
| all three | 11.3% |

`AROONU_14_4h > 25` removed 4.8 points beyond the other two. At a high profit that reads as "exit right away", which is exactly what you said.

New values, in the tail instead:

```
bands 0-3    STOCH > 95, WILLR_480 > -1.0,  AROONU_14_4h > 95
bands 4-12   STOCH > 90, WILLR_480 > -10.0, AROONU_14_4h > 90
```

| clause | true on |
|---|---|
| `STOCHRSIk > 90` | 14.20% |
| `WILLR_480 > -10` | 5.27% |
| `AROONU_14_4h > 90` | 16.17% |
| all three | **0.95%** |

## Result, and what it does not show

**2026 gms0: 140 trades, 139 wins, $44,062, max drawdown 0.39%, median giveback 4.68p.** The one reported loss is the ZEC data-cutoff `force_exit`.

**The case fires once in the whole year** (SUI, `w_5_1`, +17.2%), so this dataset cannot evaluate it in either direction — the $161 difference from having no case at all is slot flow, not the rule. Tightening `w_0`/`w_1` to −1.0, then `w_2`/`w_3`, then moving `WILLR_480` from −10 to −20 on the upper bands all returned the same number: those low bands never fire at any threshold. What binds is not the threshold but the intersection — one candle in 105 carries the state, and it meeting an eligible open trade happens once.

The loose version earned **$2,433 more**, and your read of why is right: it earned it by cutting trades that were still running. On the one case I could follow all the way, SUI, it exits at 19.5% where leaving it alone returns 42.1%.

## Also measured, and not included

- **A `_2` with a real down component** (`ROC_9_1h < 0`, all bands): $44,471, fires 13 times, and it *still* cuts SUI at 19.5%. It does not fix the problem.
- **Requiring a completed turn** (`WILLR_14 < -20 and RSI_3 < 50`): $45,294, fires twice a year.
- **`d_3_1` raised to the same strictness as `d_0..d_2`**: 12 fires → 1, costs $1,007, and the eleven released trades split five up / five down (PLAY 11.0→16.2% but PLAY 10.3→0.9%, NAORIS 9.7→21.3% but NAORIS 9.1→0.3%). Same action, opposite outcomes, so I left it out rather than decide it on one year.

I also checked whether anything separates the trade that should be held from the tops that should be cut — indicators at the exit candle, entry count, how deep the trade dipped first, duration, the logs. Nothing does. SUI looks like the ARIA that was right to cut.

**Still 2026 only.** 2021 and 2022 next, before anything else here gets tuned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Dq23uSiXuSScTSa84tbtpa
