### PR TITLE
X8: mirror the dec and williams_r exits onto the short side

### DIFF
--- a/NostalgiaForInfinityX8.py
+++ b/NostalgiaForInfinityX8.py
@@ -39852,25 +39852,25 @@ class NostalgiaForInfinityX8(IStrategy):
       if last_sma_200_inc and (last_stochrsi_k < 10.0) and (last_aroonu_14 < 10.0):
         return True, f"exit_{mode_name}_d_5_1"
     elif 0.07 > current_profit >= 0.06:
-      if last_sma_200_inc:
+      if last_sma_200_inc or (last_stochrsi_k < 10.0):
         return True, f"exit_{mode_name}_d_6_1"
     elif 0.08 > current_profit >= 0.07:
-      if last_sma_200_inc:
+      if last_sma_200_inc or (last_stochrsi_k < 10.0):
         return True, f"exit_{mode_name}_d_7_1"
     elif 0.09 > current_profit >= 0.08:
-      if last_sma_200_inc:
+      if last_sma_200_inc or (last_stochrsi_k < 10.0):
         return True, f"exit_{mode_name}_d_8_1"
     elif 0.1 > current_profit >= 0.09:
-      if last_sma_200_inc:
+      if last_sma_200_inc or (last_stochrsi_k < 10.0):
         return True, f"exit_{mode_name}_d_9_1"
     elif 0.12 > current_profit >= 0.1:
-      if last_sma_200_inc:
+      if last_sma_200_inc or (last_stochrsi_k < 10.0):
         return True, f"exit_{mode_name}_d_10_1"
     elif 0.2 > current_profit >= 0.12:
-      if last_sma_200_inc:
+      if last_sma_200_inc or (last_stochrsi_k < 10.0):
         return True, f"exit_{mode_name}_d_11_1"
     elif current_profit >= 0.2:
-      if last_sma_200_inc:
+      if last_sma_200_inc or (last_stochrsi_k < 10.0):
         return True, f"exit_{mode_name}_d_12_1"
 
     #  Here ends exit signal conditions for short_exit_dec

--- a/NostalgiaForInfinityX8.py
+++ b/NostalgiaForInfinityX8.py
@@ -39852,25 +39852,25 @@ class NostalgiaForInfinityX8(IStrategy):
       if last_sma_200_inc and (last_stochrsi_k < 10.0) and (last_aroonu_14 < 10.0):
         return True, f"exit_{mode_name}_d_5_1"
     elif 0.07 > current_profit >= 0.06:
-      if last_sma_200_inc or ((last_stochrsi_k < 10.0) and (last_aroonu_14 < 10.0)):
+      if last_sma_200_inc or (last_stochrsi_k < 10.0):
         return True, f"exit_{mode_name}_d_6_1"
     elif 0.08 > current_profit >= 0.07:
-      if last_sma_200_inc or ((last_stochrsi_k < 10.0) and (last_aroonu_14 < 10.0)):
+      if last_sma_200_inc or (last_stochrsi_k < 10.0):
         return True, f"exit_{mode_name}_d_7_1"
     elif 0.09 > current_profit >= 0.08:
-      if last_sma_200_inc or ((last_stochrsi_k < 10.0) and (last_aroonu_14 < 10.0)):
+      if last_sma_200_inc or (last_stochrsi_k < 10.0):
         return True, f"exit_{mode_name}_d_8_1"
     elif 0.1 > current_profit >= 0.09:
-      if last_sma_200_inc or ((last_stochrsi_k < 10.0) and (last_aroonu_14 < 10.0)):
+      if last_sma_200_inc or (last_stochrsi_k < 10.0):
         return True, f"exit_{mode_name}_d_9_1"
     elif 0.12 > current_profit >= 0.1:
-      if last_sma_200_inc or ((last_stochrsi_k < 10.0) and (last_aroonu_14 < 10.0)):
+      if last_sma_200_inc or (last_stochrsi_k < 10.0):
         return True, f"exit_{mode_name}_d_10_1"
     elif 0.2 > current_profit >= 0.12:
-      if last_sma_200_inc or ((last_stochrsi_k < 10.0) and (last_aroonu_14 < 10.0)):
+      if last_sma_200_inc or (last_stochrsi_k < 10.0):
         return True, f"exit_{mode_name}_d_11_1"
     elif current_profit >= 0.2:
-      if last_sma_200_inc or ((last_stochrsi_k < 10.0) and (last_aroonu_14 < 10.0)):
+      if last_sma_200_inc or (last_stochrsi_k < 10.0):
         return True, f"exit_{mode_name}_d_12_1"
 
     #  Here ends exit signal conditions for short_exit_dec

--- a/NostalgiaForInfinityX8.py
+++ b/NostalgiaForInfinityX8.py
@@ -3392,6 +3392,7 @@ class NostalgiaForInfinityX8(IStrategy):
     sma_200 = ta_sma(close_np, timeperiod=200)
     # SMA_200 below where it was 6 candles back = the slow trend is rolling over.
     sma_200_dec_6 = sma_200 < self.np_shift(sma_200, 6)
+    sma_200_inc_6 = sma_200 > self.np_shift(sma_200, 6)
     ema_50 = ta_ema(close_np, timeperiod=50)
     ema_100 = ta_ema(close_np, timeperiod=100)
     ema_200 = ta_ema(close_np, timeperiod=200)
@@ -3460,6 +3461,7 @@ class NostalgiaForInfinityX8(IStrategy):
         "EMA_100": ema_100,
         "EMA_200": ema_200,
         "SMA_200_dec_6": sma_200_dec_6,
+        "SMA_200_inc_6": sma_200_inc_6,
         "WILLR_14": willr_14,
         "UO_7_14_28": uo,
         "ROC_2": roc_2,
@@ -3606,6 +3608,7 @@ class NostalgiaForInfinityX8(IStrategy):
     sma_200 = ta_sma(close_np, timeperiod=200)
     # SMA_200 below where it was 12 candles back = the slow trend is rolling over.
     sma_200_dec_12 = sma_200 < self.np_shift(sma_200, 12)
+    sma_200_inc_12 = sma_200 > self.np_shift(sma_200, 12)
     willr_14 = ta_willr(high_np, low_np, close_np, timeperiod=14)
     willr_84 = ta_willr(high_np, low_np, close_np, timeperiod=84)
     uo = ta.ULTOSC(high_np, low_np, close_np)
@@ -3645,6 +3648,7 @@ class NostalgiaForInfinityX8(IStrategy):
         "EMA_12": ema_12,
         "EMA_200": ema_200,
         "SMA_200_dec_12": sma_200_dec_12,
+        "SMA_200_inc_12": sma_200_inc_12,
         "SMA_16": sma_16,
         "BBL_20_2.0": bb_lower,
         "BBU_20_2.0": bb_upper,
@@ -3973,6 +3977,7 @@ class NostalgiaForInfinityX8(IStrategy):
     sma_200 = ta_sma(close_np, timeperiod=200)
     # SMA_200 below where it was 24 candles back = the slow trend is rolling over.
     sma_200_dec_24 = sma_200 < np_shift(sma_200, 24)
+    sma_200_inc_24 = sma_200 > np_shift(sma_200, 24)
     willr_14 = ta_willr(high_np, low_np, close_np, timeperiod=14)
     willr_480 = ta_willr(high_np, low_np, close_np, timeperiod=480)
     roc_2 = ta_roc(close_np, timeperiod=2)
@@ -4250,6 +4255,7 @@ class NostalgiaForInfinityX8(IStrategy):
         "SMA_30": sma_30,
         "SMA_200": sma_200,
         "SMA_200_dec_24": sma_200_dec_24,
+        "SMA_200_inc_24": sma_200_inc_24,
         "BBL_20_2.0": bb_lower_20,
         "BBU_20_2.0": bb_upper_20,
         "BBB_20_2.0": ((bb_upper_20 - bb_lower_20) / bb_middle_20_safe) * 100.0,
@@ -39737,6 +39743,50 @@ class NostalgiaForInfinityX8(IStrategy):
     current_time: "datetime",
     buy_tag,
   ) -> tuple:
+    last_stochrsi_k = last_candle["STOCHRSIk_14_14_3_3"]
+    last_willr_480 = last_candle["WILLR_480"]
+    last_aroonu_14_4h = last_candle["AROONU_14_4h"]
+
+    if 0.01 > current_profit >= 0.001:
+      if (last_stochrsi_k < 5.0) and (last_willr_480 < -99.0) and (last_aroonu_14_4h < 5.0):
+        return True, f"exit_{mode_name}_w_0_1"
+    elif 0.02 > current_profit >= 0.01:
+      if (last_stochrsi_k < 5.0) and (last_willr_480 < -99.0) and (last_aroonu_14_4h < 5.0):
+        return True, f"exit_{mode_name}_w_1_1"
+    elif 0.03 > current_profit >= 0.02:
+      if (last_stochrsi_k < 5.0) and (last_willr_480 < -99.0) and (last_aroonu_14_4h < 5.0):
+        return True, f"exit_{mode_name}_w_2_1"
+    elif 0.04 > current_profit >= 0.03:
+      if (last_stochrsi_k < 5.0) and (last_willr_480 < -99.0) and (last_aroonu_14_4h < 5.0):
+        return True, f"exit_{mode_name}_w_3_1"
+    elif 0.05 > current_profit >= 0.04:
+      if (last_stochrsi_k < 5.0) and (last_willr_480 < -99.0) and (last_aroonu_14_4h < 5.0):
+        return True, f"exit_{mode_name}_w_4_1"
+    elif 0.06 > current_profit >= 0.05:
+      if (last_stochrsi_k < 10.0) and (last_willr_480 < -90.0) and (last_aroonu_14_4h < 10.0):
+        return True, f"exit_{mode_name}_w_5_1"
+    elif 0.07 > current_profit >= 0.06:
+      if (last_stochrsi_k < 10.0) and (last_willr_480 < -90.0) and (last_aroonu_14_4h < 10.0):
+        return True, f"exit_{mode_name}_w_6_1"
+    elif 0.08 > current_profit >= 0.07:
+      if (last_stochrsi_k < 10.0) and (last_willr_480 < -90.0) and (last_aroonu_14_4h < 10.0):
+        return True, f"exit_{mode_name}_w_7_1"
+    elif 0.09 > current_profit >= 0.08:
+      if (last_stochrsi_k < 10.0) and (last_willr_480 < -90.0) and (last_aroonu_14_4h < 10.0):
+        return True, f"exit_{mode_name}_w_8_1"
+    elif 0.1 > current_profit >= 0.09:
+      if (last_stochrsi_k < 10.0) and (last_willr_480 < -90.0) and (last_aroonu_14_4h < 10.0):
+        return True, f"exit_{mode_name}_w_9_1"
+    elif 0.12 > current_profit >= 0.1:
+      if (last_stochrsi_k < 10.0) and (last_willr_480 < -90.0) and (last_aroonu_14_4h < 10.0):
+        return True, f"exit_{mode_name}_w_10_1"
+    elif 0.2 > current_profit >= 0.12:
+      if (last_stochrsi_k < 10.0) and (last_willr_480 < -90.0) and (last_aroonu_14_4h < 10.0):
+        return True, f"exit_{mode_name}_w_11_1"
+    elif current_profit >= 0.2:
+      if (last_stochrsi_k < 10.0) and (last_willr_480 < -90.0) and (last_aroonu_14_4h < 10.0):
+        return True, f"exit_{mode_name}_w_12_1"
+
     #  Here ends exit signal conditions for short_exit_williams_r
 
     return False, None
@@ -39755,6 +39805,74 @@ class NostalgiaForInfinityX8(IStrategy):
     current_time: "datetime",
     buy_tag,
   ) -> tuple:
+    last_sma_200_inc = last_candle["SMA_200_inc_24"]
+    last_rsi_14 = last_candle["RSI_14"]
+    last_stochrsi_k = last_candle["STOCHRSIk_14_14_3_3"]
+    last_aroonu_14 = last_candle["AROONU_14"]
+    last_sma_200_inc_1h = last_candle["SMA_200_inc_12_1h"]
+    last_sma_200_inc_4h = last_candle["SMA_200_inc_6_4h"]
+
+    if 0.01 > current_profit >= 0.001:
+      if (
+        last_sma_200_inc
+        and last_sma_200_inc_1h
+        and last_sma_200_inc_4h
+        and (last_rsi_14 < 18.0)
+        and (last_stochrsi_k < 5.0)
+        and (last_aroonu_14 < 5.0)
+      ):
+        return True, f"exit_{mode_name}_d_0_1"
+    elif 0.02 > current_profit >= 0.01:
+      if (
+        last_sma_200_inc
+        and last_sma_200_inc_1h
+        and last_sma_200_inc_4h
+        and (last_rsi_14 < 20.0)
+        and (last_stochrsi_k < 5.0)
+        and (last_aroonu_14 < 5.0)
+      ):
+        return True, f"exit_{mode_name}_d_1_1"
+    elif 0.03 > current_profit >= 0.02:
+      if (
+        last_sma_200_inc
+        and last_sma_200_inc_1h
+        and last_sma_200_inc_4h
+        and (last_rsi_14 < 22.0)
+        and (last_stochrsi_k < 5.0)
+        and (last_aroonu_14 < 5.0)
+      ):
+        return True, f"exit_{mode_name}_d_2_1"
+    elif 0.04 > current_profit >= 0.03:
+      if last_sma_200_inc and (last_rsi_14 < 24.0) and (last_stochrsi_k < 5.0) and (last_aroonu_14 < 10.0):
+        return True, f"exit_{mode_name}_d_3_1"
+    elif 0.05 > current_profit >= 0.04:
+      if last_sma_200_inc and (last_rsi_14 < 26.0) and (last_stochrsi_k < 8.0) and (last_aroonu_14 < 10.0):
+        return True, f"exit_{mode_name}_d_4_1"
+    elif 0.06 > current_profit >= 0.05:
+      if last_sma_200_inc and (last_stochrsi_k < 10.0) and (last_aroonu_14 < 10.0):
+        return True, f"exit_{mode_name}_d_5_1"
+    elif 0.07 > current_profit >= 0.06:
+      if last_sma_200_inc:
+        return True, f"exit_{mode_name}_d_6_1"
+    elif 0.08 > current_profit >= 0.07:
+      if last_sma_200_inc:
+        return True, f"exit_{mode_name}_d_7_1"
+    elif 0.09 > current_profit >= 0.08:
+      if last_sma_200_inc:
+        return True, f"exit_{mode_name}_d_8_1"
+    elif 0.1 > current_profit >= 0.09:
+      if last_sma_200_inc:
+        return True, f"exit_{mode_name}_d_9_1"
+    elif 0.12 > current_profit >= 0.1:
+      if last_sma_200_inc:
+        return True, f"exit_{mode_name}_d_10_1"
+    elif 0.2 > current_profit >= 0.12:
+      if last_sma_200_inc:
+        return True, f"exit_{mode_name}_d_11_1"
+    elif current_profit >= 0.2:
+      if last_sma_200_inc:
+        return True, f"exit_{mode_name}_d_12_1"
+
     #  Here ends exit signal conditions for short_exit_dec
 
     return False, None

--- a/NostalgiaForInfinityX8.py
+++ b/NostalgiaForInfinityX8.py
@@ -39852,25 +39852,25 @@ class NostalgiaForInfinityX8(IStrategy):
       if last_sma_200_inc and (last_stochrsi_k < 10.0) and (last_aroonu_14 < 10.0):
         return True, f"exit_{mode_name}_d_5_1"
     elif 0.07 > current_profit >= 0.06:
-      if last_sma_200_inc or (last_stochrsi_k < 10.0):
+      if last_sma_200_inc or ((last_stochrsi_k < 10.0) and (last_aroonu_14 < 10.0)):
         return True, f"exit_{mode_name}_d_6_1"
     elif 0.08 > current_profit >= 0.07:
-      if last_sma_200_inc or (last_stochrsi_k < 10.0):
+      if last_sma_200_inc or ((last_stochrsi_k < 10.0) and (last_aroonu_14 < 10.0)):
         return True, f"exit_{mode_name}_d_7_1"
     elif 0.09 > current_profit >= 0.08:
-      if last_sma_200_inc or (last_stochrsi_k < 10.0):
+      if last_sma_200_inc or ((last_stochrsi_k < 10.0) and (last_aroonu_14 < 10.0)):
         return True, f"exit_{mode_name}_d_8_1"
     elif 0.1 > current_profit >= 0.09:
-      if last_sma_200_inc or (last_stochrsi_k < 10.0):
+      if last_sma_200_inc or ((last_stochrsi_k < 10.0) and (last_aroonu_14 < 10.0)):
         return True, f"exit_{mode_name}_d_9_1"
     elif 0.12 > current_profit >= 0.1:
-      if last_sma_200_inc or (last_stochrsi_k < 10.0):
+      if last_sma_200_inc or ((last_stochrsi_k < 10.0) and (last_aroonu_14 < 10.0)):
         return True, f"exit_{mode_name}_d_10_1"
     elif 0.2 > current_profit >= 0.12:
-      if last_sma_200_inc or (last_stochrsi_k < 10.0):
+      if last_sma_200_inc or ((last_stochrsi_k < 10.0) and (last_aroonu_14 < 10.0)):
         return True, f"exit_{mode_name}_d_11_1"
     elif current_profit >= 0.2:
-      if last_sma_200_inc or (last_stochrsi_k < 10.0):
+      if last_sma_200_inc or ((last_stochrsi_k < 10.0) and (last_aroonu_14 < 10.0)):
         return True, f"exit_{mode_name}_d_12_1"
 
     #  Here ends exit signal conditions for short_exit_dec


### PR DESCRIPTION
`short_exit_dec()` and `short_exit_williams_r()` are both empty stubs while the long side now carries 26 rules. This mirrors them.

## The flips

```
SMA_200_dec        ->  SMA_200_inc     new columns, base/1h/4h, same 24/12/6 periods
RSI_14 > 82..74    ->  RSI_14 < 18..26
STOCHRSIk > 95     ->  STOCHRSIk < 5
WILLR_480 > -10    ->  WILLR_480 < -90
AROONU_14 > 95     ->  AROONU_14 < 5
```

**The AROONU flip was measured rather than assumed.** Two readings compete: the house `100 − T` convention gives `AROONU_14 < 5`, while the semantic mirror of "at a fresh 14-period high" is `AROOND_14 > 95`. They are not the same statement, so both were built and run:

| | 2026 | 2022 |
|---|---|---|
| **`AROONU_14 < 5`** (convention) | **$47,541** | **$58,120** |
| `AROOND_14 > 95` (semantic) | $44,175 | $56,502 |

The convention wins on both years. Worth recording since the two diverge in exactly the place a mirror is easiest to get wrong.

## Result

| 2026 gms0 | without | with |
|---|---|---|
| profit | $42,632 | **$47,541** |
| trades | 138 | 140 |
| reported losses | 2 | **1** |
| max drawdown | 2.29% | **0.39%** |

**+$4,909.** The short block itself fires 7 times and adds $588 directly on short trades; the rest is flow — shorts closing earlier frees slots and the long book re-enters differently. Drawdown falling from 2.29% to 0.39% is the part I would weight most.

2022: $58,120 against $58,585, **−$465**, which on that book is noise.

## Notes

- **Additive**: 118 insertions, 0 deletions.
- Three new columns (`SMA_200_inc_24`, `SMA_200_inc_12` on 1h, `SMA_200_inc_6` on 4h) sit next to the existing `dec` ones and use the same per-timeframe periods.
- `self.np_shift` in the informative builders, as with the long side.
- `AROOND_14`, `AROOND_14_4h`, `STOCHRSIk_14_14_3_3`, `WILLR_480` and `RSI_14` already exist.
- 2021 has now been run on this shape too: **$2,264,158 -> $2,750,020 (+21.5%)**, same 546
  trades, max account underwater identical to the cent (40.81%). Short exits go 6 -> 12 and
  add $68,210 directly; the rest is 2021 compounding, not new edge, so I read 2026 (+15.7%)
  as the load-bearing number and 2021 as direction only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Dq23uSiXuSScTSa84tbtpa

