### PR TITLE
X8: williams_r exits — take every band to the extreme WILLR threshold

### DIFF
--- a/NostalgiaForInfinityX8.py
+++ b/NostalgiaForInfinityX8.py
@@ -25467,28 +25467,28 @@ class NostalgiaForInfinityX8(IStrategy):
       if (last_stochrsi_k > 90.0) and (last_willr_480 > -1.0) and (last_aroonu_14_4h > 90.0):
         return True, f"exit_{mode_name}_w_4_1"
     elif 0.06 > current_profit >= 0.05:
-      if (last_stochrsi_k > 90.0) and (last_willr_480 > -10.0) and (last_aroonu_14_4h > 90.0):
+      if (last_stochrsi_k > 90.0) and (last_willr_480 > -1.0) and (last_aroonu_14_4h > 90.0):
         return True, f"exit_{mode_name}_w_5_1"
     elif 0.07 > current_profit >= 0.06:
-      if (last_stochrsi_k > 90.0) and (last_willr_480 > -10.0) and (last_aroonu_14_4h > 90.0):
+      if (last_stochrsi_k > 90.0) and (last_willr_480 > -1.0) and (last_aroonu_14_4h > 90.0):
         return True, f"exit_{mode_name}_w_6_1"
     elif 0.08 > current_profit >= 0.07:
-      if (last_stochrsi_k > 90.0) and (last_willr_480 > -10.0) and (last_aroonu_14_4h > 90.0):
+      if (last_stochrsi_k > 90.0) and (last_willr_480 > -1.0) and (last_aroonu_14_4h > 90.0):
         return True, f"exit_{mode_name}_w_7_1"
     elif 0.09 > current_profit >= 0.08:
-      if (last_stochrsi_k > 90.0) and (last_willr_480 > -10.0) and (last_aroonu_14_4h > 90.0):
+      if (last_stochrsi_k > 90.0) and (last_willr_480 > -1.0) and (last_aroonu_14_4h > 90.0):
         return True, f"exit_{mode_name}_w_8_1"
     elif 0.1 > current_profit >= 0.09:
-      if (last_stochrsi_k > 90.0) and (last_willr_480 > -10.0) and (last_aroonu_14_4h > 90.0):
+      if (last_stochrsi_k > 90.0) and (last_willr_480 > -1.0) and (last_aroonu_14_4h > 90.0):
         return True, f"exit_{mode_name}_w_9_1"
     elif 0.12 > current_profit >= 0.1:
-      if (last_stochrsi_k > 90.0) and (last_willr_480 > -10.0) and (last_aroonu_14_4h > 90.0):
+      if (last_stochrsi_k > 90.0) and (last_willr_480 > -1.0) and (last_aroonu_14_4h > 90.0):
         return True, f"exit_{mode_name}_w_10_1"
     elif 0.2 > current_profit >= 0.12:
-      if (last_stochrsi_k > 90.0) and (last_willr_480 > -10.0) and (last_aroonu_14_4h > 90.0):
+      if (last_stochrsi_k > 90.0) and (last_willr_480 > -1.0) and (last_aroonu_14_4h > 90.0):
         return True, f"exit_{mode_name}_w_11_1"
     elif current_profit >= 0.2:
-      if (last_stochrsi_k > 90.0) and (last_willr_480 > -10.0) and (last_aroonu_14_4h > 90.0):
+      if (last_stochrsi_k > 90.0) and (last_willr_480 > -1.0) and (last_aroonu_14_4h > 90.0):
         return True, f"exit_{mode_name}_w_12_1"
 
     #  Here ends exit signal conditions for long_exit_williams_r
@@ -39765,28 +39765,28 @@ class NostalgiaForInfinityX8(IStrategy):
       if (last_stochrsi_k < 5.0) and (last_willr_480 < -99.0) and (last_aroonu_14_4h < 5.0):
         return True, f"exit_{mode_name}_w_4_1"
     elif 0.06 > current_profit >= 0.05:
-      if (last_stochrsi_k < 10.0) and (last_willr_480 < -90.0) and (last_aroonu_14_4h < 10.0):
+      if (last_stochrsi_k < 10.0) and (last_willr_480 < -99.0) and (last_aroonu_14_4h < 10.0):
         return True, f"exit_{mode_name}_w_5_1"
     elif 0.07 > current_profit >= 0.06:
-      if (last_stochrsi_k < 10.0) and (last_willr_480 < -90.0) and (last_aroonu_14_4h < 10.0):
+      if (last_stochrsi_k < 10.0) and (last_willr_480 < -99.0) and (last_aroonu_14_4h < 10.0):
         return True, f"exit_{mode_name}_w_6_1"
     elif 0.08 > current_profit >= 0.07:
-      if (last_stochrsi_k < 10.0) and (last_willr_480 < -90.0) and (last_aroonu_14_4h < 10.0):
+      if (last_stochrsi_k < 10.0) and (last_willr_480 < -99.0) and (last_aroonu_14_4h < 10.0):
         return True, f"exit_{mode_name}_w_7_1"
     elif 0.09 > current_profit >= 0.08:
-      if (last_stochrsi_k < 10.0) and (last_willr_480 < -90.0) and (last_aroonu_14_4h < 10.0):
+      if (last_stochrsi_k < 10.0) and (last_willr_480 < -99.0) and (last_aroonu_14_4h < 10.0):
         return True, f"exit_{mode_name}_w_8_1"
     elif 0.1 > current_profit >= 0.09:
-      if (last_stochrsi_k < 10.0) and (last_willr_480 < -90.0) and (last_aroonu_14_4h < 10.0):
+      if (last_stochrsi_k < 10.0) and (last_willr_480 < -99.0) and (last_aroonu_14_4h < 10.0):
         return True, f"exit_{mode_name}_w_9_1"
     elif 0.12 > current_profit >= 0.1:
-      if (last_stochrsi_k < 10.0) and (last_willr_480 < -90.0) and (last_aroonu_14_4h < 10.0):
+      if (last_stochrsi_k < 10.0) and (last_willr_480 < -99.0) and (last_aroonu_14_4h < 10.0):
         return True, f"exit_{mode_name}_w_10_1"
     elif 0.2 > current_profit >= 0.12:
-      if (last_stochrsi_k < 10.0) and (last_willr_480 < -90.0) and (last_aroonu_14_4h < 10.0):
+      if (last_stochrsi_k < 10.0) and (last_willr_480 < -99.0) and (last_aroonu_14_4h < 10.0):
         return True, f"exit_{mode_name}_w_11_1"
     elif current_profit >= 0.2:
-      if (last_stochrsi_k < 10.0) and (last_willr_480 < -90.0) and (last_aroonu_14_4h < 10.0):
+      if (last_stochrsi_k < 10.0) and (last_willr_480 < -99.0) and (last_aroonu_14_4h < 10.0):
         return True, f"exit_{mode_name}_w_12_1"
 
     #  Here ends exit signal conditions for short_exit_williams_r


### PR DESCRIPTION
`long_exit_williams_r` carried two different `WILLR_480` thresholds: `-1.0` on `w_0`–`w_4`, `-10.0` on `w_5`–`w_12`. This takes the whole ladder to `-1.0`.

```python
# w_5_1 .. w_12_1, was: (last_willr_480 > -10.0)
if (last_stochrsi_k > 90.0) and (last_willr_480 > -1.0) and (last_aroonu_14_4h > 90.0):
  return True, f"exit_{mode_name}_w_5_1"
```

The short side is mirrored the same way — `w_5`–`w_12` go `-90.0` → `-99.0`, which is what `w_0`–`w_4` already used.

### Measured — 2026, gms0 rig, against v18.0.6

| | absolute profit | delta |
|---|---|---|
| base | $49,343.20 | — |
| `w_5_1` alone to `-1.0` | $49,399.55 | +$56 |
| **all bands to `-1.0`** | **$49,399.55** | **+$56 (identical)** |

**The exit is not removed, it moves one band later.** The only long fire in the year is a rebuy trade on signal `64`:

| | tag | profit | trade |
|---|---|---|---|
| base | `exit_long_rebuy_w_5_1` | +17.18% | $235.99 |
| tightened | `exit_long_rebuy_w_6_1` | **+19.5%** | **$267.85** |

It no longer qualifies in the 5–6% band, keeps running, and leaves in the 6–7% band 2.3 points higher.

### What this measurement cannot say

"All bands" and "`w_5` alone" are indistinguishable on 2026 to the cent, because `w_6`–`w_12` never fire there — and by the time that trade reached the 6–7% band, `WILLR_480` was already above `-1.0` on its own, so the tighter threshold bound only at the 5–6% moment. **2022 and 2021 were not run on this shape**, so 2026 shows the change is safe and slightly positive but cannot separate the two forms. Happy to add those two years if you want them before merging.

The short mirror is included for ladder consistency and can be dropped on its own if you would rather leave the short side where it is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Dq23uSiXuSScTSa84tbtpa