### PR TITLE
blacklist: MEXC perpetual delistings of 2026-09-09 (ROAM, UTILITY, EGG, GAIB, CUPSEY)

### DIFF
--- a/configs/blacklist-mexc.json
+++ b/configs/blacklist-mexc.json
@@ -57,6 +57,10 @@
       "(SOLANGELES|MCN|STBU)/.*",
       // MEXC futures delist 2026-07-27: GIGA (BOB from same notice already covered above)
       "(GIGA)/.*",
+      // MEXC futures delist 2026-09-09 07:00 UTC (announced 09-05): MEXC-only listings, all under
+      // $80k daily volume and -66% to -95% off their highs; UTILITY printed a 538% day inside the
+      // last month, EGG 163%. HFT from the same notice is already covered above.
+      "(ROAM|UTILITY|EGG|GAIB|CUPSEY)/.*",
       // Tokenized stocks (STOCK suffix — universal forward-protection)
       ".*STOCK/.*",
       // Tokenized stocks (direct ticker, no STOCK suffix)


### PR DESCRIPTION
MEXC announced on **2026-09-05** that six USDT-M perpetual pairs settle and delist on **2026-09-09 07:00 UTC**. `HFT` from that notice is already covered in all 12 files; the other five are not blacklisted anywhere for MEXC.

| token | from high | worst 30d day range | age | current coverage |
|---|---|---|---|---|
| `ROAM` | −91.8% | 33% | 400d | 2/12 *(bybit, kucoin)* |
| `UTILITY` | −92.6% | **538%** | 26d | **0/12** |
| `EGG` | −87.5% | **163%** | 16d | **0/12** |
| `GAIB` | −94.7% | 26% | 294d | **0/12** |
| `CUPSEY` | −66.5% | 82% | 35d | **0/12** |

Every one trades **under $80k a day** on MEXC. That figure looks like a placeholder because the five are so close together, so as a control: the same call returns **$3.37B** for `BTC/USDT:USDT`. The field is live — these are simply dead markets.

`ROAM` already sitting in the bybit and kucoin files is corroboration: other venues reached this verdict earlier, MEXC is the last to move.

### Scope — `blacklist-mexc.json` only

All five are **MEXC-only listings**. None has an active USDT-M perp on Binance, Bybit or Bitget (`GAIB` exists on Binance but is **inactive**). These are single-venue listings dying on their one venue, not universally toxic tokens, so this follows the `GIGA` entry of 2026-07-27 rather than the all-12 convention.

### Verification

`re.fullmatch` against **live ccxt MEXC symbols**:

- **13/13 target symbols matched** — spot, perp and the `USD1` pairs (`UTILITY/USD1`, `EGG/USD1`, `CUPSEY/USD1`).
- **Zero substring false positives** — no other MEXC symbol contains any of the five tickers.
- `BTC`, `ETH`, `SOL`, `JASMY` stay unmatched.
- JSON parses with comments stripped.

### Also swept, deliberately not included

- **Upbit ending support for `JASMY` / `TT` (2026-09-14)** — Upbit is not one of the 12 configs, and `JASMY` is active on Binance, Bybit, Bitget and MEXC with $6.9M of Binance perp volume. A single Korean venue does not kill it.
- **14 MEXC "ST Warning" tokens (`MEER`, `BUTTCOIN`, `3ULL`, `PIGGY`, `ECHELON`, `AAST`, `CLS`, `RXD`, `XR`, `SQGROW`, `SPARKLET`, `YURU`, `RTF`, `IR`)** — warnings, not delistings, so your call. `IR` is already 12/12; `BUTTCOIN`, `MEER` and `CLS` are on none of the four venues checked.
- **The Liquid Network exploit (2026-09-06, ~4,000 BTC)** — the drained asset is **L-BTC**, a sidechain wrap with no perp anywhere; USDT and DePix on Liquid were unaffected and 85% has been returned. Note that `LBTC` on exchanges is **Lombard Staked BTC**, a different asset — nothing to add here.
- **`ICX` / `SCRT` / `STORJ`** (Binance spot delist 09-03, KuCoin perps 09-07) — already 12/12.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Dq23uSiXuSScTSa84tbtpa