### PR TITLE
Revise X8 signal 68 momentum guards

### DIFF
--- a/NostalgiaForInfinityX8.py
+++ b/NostalgiaForInfinityX8.py
@@ -15474,6 +15474,10 @@ class NostalgiaForInfinityX8(IStrategy):
             & ((rsi_3_1h > 10.0) | (roc_9_4h > -15.0) | (cmf_20_4h > -0.20))
           )
           long_entry_logic.append((rsi_14_1h > 25.0) | (rsi_14_4h > 25.0) | (rsi_3_1d > 15.0))
+          # Daily selling pressure with a strong recent 4h rebound.
+          long_entry_logic.append(aroonu_14_4h_lt_80 | (roc_9_1d > -10.0) | cmf_20_1d_gt_neg_0_0)
+          # Hourly momentum weakened while daily fast momentum remains elevated.
+          long_entry_logic.append((rsi_14_1h > 45.0) | (rsi_3_1d < 75.0))
           long_entry_logic.append(rsi_3 < 5.0)
           long_entry_logic.append(rsi_14 < 28.0)
           long_entry_logic.append(stochrsi_k < 3.0)
@@ -15482,7 +15486,6 @@ class NostalgiaForInfinityX8(IStrategy):
           long_entry_logic.append(mfi_14 > 25.0)
           long_entry_logic.append(close < bbl_20_2_0)
           long_entry_logic.append(rsi_14_1h > 35.0)
-          long_entry_logic.append(aroonu_14_4h > 25.0)
 
         # Condition #101 - Rapid mode (Long).
         if long_entry_condition_index == 101:


### PR DESCRIPTION
## Summary

**Before: unmodified Native 68 ON. After: the modified 68 ON candidate (B).** Both sides keep 171 OFF and use matching data/settings within each row. Signal 68 and 171 remain OFF in the shipped defaults.

**Signal 68 trades — before versus after.** Net PnL in USDT, including fees and funding. These are the 68-tagged trades within the full strategy.

| Period / tested version | Native 68 net PnL | Modified 68 net PnL | Change, USDT | Native wins / losses | Modified wins / losses |
|---|---:|---:|---:|---:|---:|
| 2021 / v18.0.10 | +48.87 | +48.87 | +0.00 | 3 / 0 | 3 / 0 |
| 2022 / v18.0.10 | +1,007.98 | +3,997.88 | +2,989.89 | 2 / 1 | 4 / 0 |
| 2023 / v18.0.19 → v18.0.20 parity | +940.73 | +1,675.55 | +734.83 | 5 / 1 | 6 / 1 |
| 2024 / v18.0.10 | +1,102.98 | +2,898.94 | +1,795.96 | 4 / 0 | 9 / 0 |
| 2025 / v18.0.10 | -4,125.91 | +2,944.10 | +7,070.01 | 5 / 1 | 6 / 0 |
| 2026 to Aug 6 (exclusive) / v18.0.10 | +840.47 | +1,316.87 | +476.40 | 3 / 0 | 5 / 0 |

**Whole strategy — before versus after.** This includes the effects on shared capital, position sizes and other signals.

| Period / tested version | Native portfolio net PnL | Modified portfolio net PnL | Change, USDT |
|---|---:|---:|---:|
| 2021 / v18.0.10 | +20,143.02 | +20,143.02 | +0.00 |
| 2022 / v18.0.10 | +550,936.01 | +566,530.41 | +15,594.40 |
| 2023 / v18.0.19 → v18.0.20 parity | +132,604.42 | +134,025.41 | +1,420.99 |
| 2024 / v18.0.10 | +354,632.90 | +359,373.33 | +4,740.43 |
| 2025 / v18.0.10 | +331,714.73 | +346,353.42 | +14,638.69 |
| 2026 to Aug 6 (exclusive) / v18.0.10 | +36,598.50 | +37,189.02 | +590.52 |

Version labels matter: the 2023 row uses two fresh v18.0.19 full backtests, reused for v18.0.20 only after full engine-input parity. Other rows are historical v18.0.10 comparisons, with explicitly verified run reuse. 2021 starts with 100 USDT/18 available pairs; other rows use 100,000 USDT/19 pairs. Periods are independent and dollar results are not pooled. Deltas are calculated before rounding.

The modified signal removes the final `AROONU14_4h >25` requirement, retains `RSI14_1h >35`, and adds two guard groups. In the checked 2023 comparison it adds one SOL68 winner, retains all 93 original entries, and improves total PnL by 1,420.99 USDT. Loss magnitude and DD still increase slightly; full risk comparisons follow below.

Based independently on upstream `134f16ede76f52d57e585b7d3d4351de3a5a9bfd` (v18.0.20).

## Safety

Only signal 68 in `populate_entry_trend()` changes. Both requirements must pass:

- `(AROONU14_4h <80 OR ROC9_1d >-10 OR CMF20_1d >0)`
- `(RSI14_1h >45 OR RSI3_1d <75)`

Remaining entry conditions, indicators, tags, position adjustment, risk and exits are preserved. Signals 68 and 171 remain **OFF by default**. Thresholds were frozen before this comparison.

## Backtest scope

Two fresh full-2023 Freqtrade runs used plain v18.0.19 sources at `89170813`, with native68 ON versus this fixed patch ON; 171 stayed OFF. The subsequent v18.0.20 refresh adds protections to signals 1/3/42.

For the final v18.0.20 sources, two additional signal-only Freqtrade reconstructions matched all 1,997,280 engine input rows per arm, pair order and effective parameters against the corresponding completed v18.0.19 run. Indicator, exit, risk and sizing code are unchanged. The table therefore explicitly reuses the v18.0.19 trade results; these are not two new v18.0.20 trade simulations.

| 2023 metric | Native 68 ON | Patched 68 ON (B) | B minus native |
|---|---:|---:|---:|
| Portfolio trades / losses | 93 / 2 | 94 / 2 | +1 trade / no additional loss |
| **Whole-portfolio net PnL, USDT** | +132,604.42 | +134,025.41 | +1,420.99 |
| **68-tagged trades net PnL, USDT** | +940.73 | +1,675.55 | +734.83 |
| 68-tagged wins / losses | 5 / 1 | 6 / 1 | +1 winner / no additional loss |
| Sum of portfolio trade ratios, pp | 703.443023 | 719.196966 | +15.753943 |
| Losing trades only: net PnL sum, USDT | -9,647.42 | -9,706.46 | -59.04 |
| Equity maximum DD | 11.976676552% | 11.976717057% | +0.000040506 pp |
| Maximum dollar DD, USDT | 25,891.48 | 26,049.77 | +158.28 |
| All six slots losing | 5 minutes | 5 minutes | No change |

All PnL includes fees and funding. The losing-trades row sums only the losing trades and is already included in whole-portfolio net PnL; it is not an additional deduction. The 68-tagged row is the cohort within the full strategy, not a separate 68-only portfolio.

The **+1,420.99 USDT** difference comprises one additional SOL68 winner (+731.93) and +689.06 across the 93 shared trades. No reference entries were omitted; no shared winners ended or de-risked earlier. The 41 filled orders before the first changed signal match exactly. Quantities subsequently differ through portfolio state.

Costs remain: total loss magnitude increases by 59.04 USDT and maximum dollar DD by 158.28 USDT. The BTC68 14-day bad-trade loss occurs in both arms: -2,393.49 USDT in native versus -2,408.28 USDT in B (14.78 USDT larger loss). This is not a claim of unchanged risk. Exact pp sums exported trade profit ratios ×100; it is not wallet return. Equity DD uses 5m closing marks.

Both arms used Freqtrade 2026.8, `20230101-20240101`, identical Binance isolated futures data, 5m, 3x leverage, six slots, 100,000 USDT wallet, unlimited stake, 0.99 tradable balance, 0.0005 fee per side, native PA/risk/exits ON. Static USDT perpetual pairs: BTC, ETH, SOL, XRP, BNB, DOGE, ADA, AVAX, LINK, SAND, AXS, INJ, AAVE, RUNE, FIL, GALA, DOT, ALGO, CRV.

**Portfolio trade counts and drawdown — Native versus modified, using the same version/period rows as above.**

| Period | Native trades / losses | Modified trades / losses | Native equity DD | Modified equity DD | Change, pp |
|---|---:|---:|---:|---:|---:|
| 2021 | 535 / 11 | 535 / 11 | 96.198884816% | 96.198884816% | +0.000000000 |
| 2022 | 169 / 5 | 171 / 4 | 14.018494701% | 14.018412411% | -0.000082290 |
| 2023 | 93 / 2 | 94 / 2 | 11.976676552% | 11.976717057% | +0.000040506 |
| 2024 | 128 / 2 | 133 / 2 | 28.057121703% | 28.059868191% | +0.002746488 |
| 2025 | 130 / 3 | 129 / 2 | 20.854173163% | 20.854173163% | +0.000000000 |
| 2026 to Aug 6 (exclusive) | 35 / 0 | 37 / 0 | 5.860297607% | 5.860312142% | +0.000014535 |

<details>
<summary>Additional historical OFF / intermediate-A comparisons and limitations</summary>

**Historical development — v18.0.10, separate from the 2023 version-refresh check above.** Positive deltas mean higher whole-portfolio net PnL. Native ON is the original 68 entry; OFF disables 68; B is the fixed candidate in this PR.

| Historical period | B minus native 68 ON, USDT | B minus 68 OFF, USDT |
|---|---:|---:|
| 2021 | 0.00 | -3,345.39 |
| 2022 | +15,594.40 | +7,898.24 |
| 2023 | No separate native run* | +2,470.09 |
| 2024 | +4,740.43 | +7,478.94 |
| 2025 | +14,638.69 | +6,401.81 |
| 2026 through August 6 (exclusive) | +590.52 | +1,663.62 |

*The older 2023 study ran OFF, guard-only intermediate A, and B. Its B-minus-A PnL was +1,321.13 USDT. A adds the same two guards to native 68; B additionally removes the final AROONU >25 gate. This older B-minus-A result is distinct from the +1,420.99 USDT native comparison above.*

Historical 2021 used a 100 USDT wallet and 18 available pairs; other periods used 100,000 USDT and 19 pairs. These are separate runs, not one continuous multi-year return, and dollar deltas are not pooled. Some historical runs were reused after full signal-equivalence checks; this table is not a fresh multi-year test of v18.0.20.

Historical costs also remain: 2021 was unchanged versus native ON but worse versus OFF, with B equity DD of 96.198885%. Versus A, 2025 omitted three winners and added a losing INJ120 trade, while overall portfolio PnL still improved. In 2024, a RUNE winner closed 135 minutes earlier and equity DD increased slightly. The older 2023 OFF comparison omitted a SAND winner and increased portfolio losses from 3 to 4. These trade-offs remain relevant to any later activation decision.


</details>

The guards were selected using two known losses; 2023 is already exposed research data. The current-upstream check covers one year and 19 static pairs. This is a review candidate, with default activation left for separate review.

## Checks

- PR validator: PASS — selected-file scope, focused AST bindings, merge simulation, Ruff and compilation.
- `pre-commit run --files NostalgiaForInfinityX8.py`: PASS on the final commit.
- Focused committed/working/staged diffs: only the intended four added lines and one deletion; clean checkout.
- Independent source review: fixed candidate 68 block retained; entry-scope aliases/default flags checked.
- Two Freqtrade exports: PASS. Source/configuration/non-68 signals, order fee/funding accounting and PnL reconciliation independently checked; no producer discrepancies.
- v18.0.20 full-period engine-input parity: PASS in both arms (19 pairs each); source/data/configuration hashes verified.

The upstream backtest workflow runs on push/manual dispatch, not pull requests; generic PR CI does not replace the behavioral validation above.
