### PR TITLE
blacklist: add JCT to all 12 configs

### DIFF
--- a/configs/blacklist-binance.json
+++ b/configs/blacklist-binance.json
@@ -21,8 +21,9 @@
       "(龙虾|哈基米|牛来|我踏马来了|老子|人生K线|小股东|旺财)/.*",
       // Parabolic squeeze — 542 shorts liquidated on 4 accounts, 2026-08-07 (+801%/7d)
       "(TUT)/.*",
-      // Pump-and-dump knives — APR +192% then -68% (2026-08-12/15), VELVET -46% in an hour (2026-07-24)
-      "(APR|VELVET)/.*",
+      // Pump-and-dump knives — APR +192% then -68% (2026-08-12/15), VELVET -46% in an hour (2026-07-24),
+      // JCT -82.4% off its 2026-06-13 peak, single-day ranges of 96%, 96% and 83% (2026-09-10)
+      "(APR|JCT|VELVET)/.*",
       // Binance delist 2026-08-17 (full-coin) — iterativ 2026-08-03
       "(ACX|PIVX|VIC)/.*",
       // FIGHT all-12 + IDOL (MEET48) — iterativ 2026-08-02

--- a/configs/blacklist-bitget.json
+++ b/configs/blacklist-bitget.json
@@ -21,8 +21,9 @@
       "(龙虾|哈基米|牛来|我踏马来了|老子|人生K线|小股东|旺财)/.*",
       // Parabolic squeeze — 542 shorts liquidated on 4 accounts, 2026-08-07 (+801%/7d)
       "(TUT)/.*",
-      // Pump-and-dump knives — APR +192% then -68% (2026-08-12/15), VELVET -46% in an hour (2026-07-24)
-      "(APR|VELVET)/.*",
+      // Pump-and-dump knives — APR +192% then -68% (2026-08-12/15), VELVET -46% in an hour (2026-07-24),
+      // JCT -82.4% off its 2026-06-13 peak, single-day ranges of 96%, 96% and 83% (2026-09-10)
+      "(APR|JCT|VELVET)/.*",
       // Declining alt (2026-08-07; binance already covers via FAN group)
       "(CHZ)/.*",
       // Binance delist 2026-08-17 (full-coin) — iterativ 2026-08-03

--- a/configs/blacklist-bitmart.json
+++ b/configs/blacklist-bitmart.json
@@ -21,8 +21,9 @@
       "(龙虾|哈基米|牛来|我踏马来了|老子|人生K线|小股东|旺财)/.*",
       // Parabolic squeeze — 542 shorts liquidated on 4 accounts, 2026-08-07 (+801%/7d)
       "(TUT)/.*",
-      // Pump-and-dump knives — APR +192% then -68% (2026-08-12/15), VELVET -46% in an hour (2026-07-24)
-      "(APR|VELVET)/.*",
+      // Pump-and-dump knives — APR +192% then -68% (2026-08-12/15), VELVET -46% in an hour (2026-07-24),
+      // JCT -82.4% off its 2026-06-13 peak, single-day ranges of 96%, 96% and 83% (2026-09-10)
+      "(APR|JCT|VELVET)/.*",
       // Declining alt (2026-08-07; binance already covers via FAN group)
       "(CHZ)/.*",
       // Binance delist 2026-08-17 (full-coin) — iterativ 2026-08-03

--- a/configs/blacklist-bitvavo.json
+++ b/configs/blacklist-bitvavo.json
@@ -21,8 +21,9 @@
       "(龙虾|哈基米|牛来|我踏马来了|老子|人生K线|小股东|旺财)/.*",
       // Parabolic squeeze — 542 shorts liquidated on 4 accounts, 2026-08-07 (+801%/7d)
       "(TUT)/.*",
-      // Pump-and-dump knives — APR +192% then -68% (2026-08-12/15), VELVET -46% in an hour (2026-07-24)
-      "(APR|VELVET)/.*",
+      // Pump-and-dump knives — APR +192% then -68% (2026-08-12/15), VELVET -46% in an hour (2026-07-24),
+      // JCT -82.4% off its 2026-06-13 peak, single-day ranges of 96%, 96% and 83% (2026-09-10)
+      "(APR|JCT|VELVET)/.*",
       // Declining alt (2026-08-07; binance already covers via FAN group)
       "(CHZ)/.*",
       // Binance delist 2026-08-17 (full-coin) — iterativ 2026-08-03

--- a/configs/blacklist-bybit.json
+++ b/configs/blacklist-bybit.json
@@ -21,8 +21,9 @@
       "(龙虾|哈基米|牛来|我踏马来了|老子|人生K线|小股东|旺财)/.*",
       // Parabolic squeeze — 542 shorts liquidated on 4 accounts, 2026-08-07 (+801%/7d)
       "(TUT)/.*",
-      // Pump-and-dump knives — APR +192% then -68% (2026-08-12/15), VELVET -46% in an hour (2026-07-24)
-      "(APR|VELVET)/.*",
+      // Pump-and-dump knives — APR +192% then -68% (2026-08-12/15), VELVET -46% in an hour (2026-07-24),
+      // JCT -82.4% off its 2026-06-13 peak, single-day ranges of 96%, 96% and 83% (2026-09-10)
+      "(APR|JCT|VELVET)/.*",
       // Declining alt (2026-08-07; binance already covers via FAN group)
       "(CHZ)/.*",
       // Binance delist 2026-08-17 (full-coin) — iterativ 2026-08-03

--- a/configs/blacklist-gateio.json
+++ b/configs/blacklist-gateio.json
@@ -21,8 +21,9 @@
       "(龙虾|哈基米|牛来|我踏马来了|老子|人生K线|小股东|旺财)/.*",
       // Parabolic squeeze — 542 shorts liquidated on 4 accounts, 2026-08-07 (+801%/7d)
       "(TUT)/.*",
-      // Pump-and-dump knives — APR +192% then -68% (2026-08-12/15), VELVET -46% in an hour (2026-07-24)
-      "(APR|VELVET)/.*",
+      // Pump-and-dump knives — APR +192% then -68% (2026-08-12/15), VELVET -46% in an hour (2026-07-24),
+      // JCT -82.4% off its 2026-06-13 peak, single-day ranges of 96%, 96% and 83% (2026-09-10)
+      "(APR|JCT|VELVET)/.*",
       // Declining alt (2026-08-07; binance already covers via FAN group)
       "(CHZ)/.*",
       // Binance delist 2026-08-17 (full-coin) — iterativ 2026-08-03

--- a/configs/blacklist-htx.json
+++ b/configs/blacklist-htx.json
@@ -21,8 +21,9 @@
       "(龙虾|哈基米|牛来|我踏马来了|老子|人生K线|小股东|旺财)/.*",
       // Parabolic squeeze — 542 shorts liquidated on 4 accounts, 2026-08-07 (+801%/7d)
       "(TUT)/.*",
-      // Pump-and-dump knives — APR +192% then -68% (2026-08-12/15), VELVET -46% in an hour (2026-07-24)
-      "(APR|VELVET)/.*",
+      // Pump-and-dump knives — APR +192% then -68% (2026-08-12/15), VELVET -46% in an hour (2026-07-24),
+      // JCT -82.4% off its 2026-06-13 peak, single-day ranges of 96%, 96% and 83% (2026-09-10)
+      "(APR|JCT|VELVET)/.*",
       // Declining alt (2026-08-07; binance already covers via FAN group)
       "(CHZ)/.*",
       // Binance delist 2026-08-17 (full-coin) — iterativ 2026-08-03

--- a/configs/blacklist-hyperliquid.json
+++ b/configs/blacklist-hyperliquid.json
@@ -21,8 +21,9 @@
       "(龙虾|哈基米|牛来|我踏马来了|老子|人生K线|小股东|旺财)/.*",
       // Parabolic squeeze — 542 shorts liquidated on 4 accounts, 2026-08-07 (+801%/7d)
       "(TUT)/.*",
-      // Pump-and-dump knives — APR +192% then -68% (2026-08-12/15), VELVET -46% in an hour (2026-07-24)
-      "(APR|VELVET)/.*",
+      // Pump-and-dump knives — APR +192% then -68% (2026-08-12/15), VELVET -46% in an hour (2026-07-24),
+      // JCT -82.4% off its 2026-06-13 peak, single-day ranges of 96%, 96% and 83% (2026-09-10)
+      "(APR|JCT|VELVET)/.*",
       // Declining alt (2026-08-07; binance already covers via FAN group)
       "(CHZ)/.*",
       // Binance delist 2026-08-17 (full-coin) — iterativ 2026-08-03

--- a/configs/blacklist-kraken.json
+++ b/configs/blacklist-kraken.json
@@ -24,8 +24,9 @@
       "(龙虾|哈基米|牛来|我踏马来了|老子|人生K线|小股东|旺财)/.*",
       // Parabolic squeeze — 542 shorts liquidated on 4 accounts, 2026-08-07 (+801%/7d)
       "(TUT)/.*",
-      // Pump-and-dump knives — APR +192% then -68% (2026-08-12/15), VELVET -46% in an hour (2026-07-24)
-      "(APR|VELVET)/.*",
+      // Pump-and-dump knives — APR +192% then -68% (2026-08-12/15), VELVET -46% in an hour (2026-07-24),
+      // JCT -82.4% off its 2026-06-13 peak, single-day ranges of 96%, 96% and 83% (2026-09-10)
+      "(APR|JCT|VELVET)/.*",
       // Declining alt (2026-08-07; binance already covers via FAN group)
       "(CHZ)/.*",
       // Binance delist 2026-08-17 (full-coin) — iterativ 2026-08-03

--- a/configs/blacklist-kucoin.json
+++ b/configs/blacklist-kucoin.json
@@ -21,8 +21,9 @@
       "(龙虾|哈基米|牛来|我踏马来了|老子|人生K线|小股东|旺财)/.*",
       // Parabolic squeeze — 542 shorts liquidated on 4 accounts, 2026-08-07 (+801%/7d)
       "(TUT)/.*",
-      // Pump-and-dump knives — APR +192% then -68% (2026-08-12/15), VELVET -46% in an hour (2026-07-24)
-      "(APR|VELVET)/.*",
+      // Pump-and-dump knives — APR +192% then -68% (2026-08-12/15), VELVET -46% in an hour (2026-07-24),
+      // JCT -82.4% off its 2026-06-13 peak, single-day ranges of 96%, 96% and 83% (2026-09-10)
+      "(APR|JCT|VELVET)/.*",
       // Declining alt (2026-08-07; binance already covers via FAN group)
       "(CHZ)/.*",
       // Binance delist 2026-08-17 (full-coin) — iterativ 2026-08-03

--- a/configs/blacklist-mexc.json
+++ b/configs/blacklist-mexc.json
@@ -21,8 +21,9 @@
       "(龙虾|哈基米|牛来|我踏马来了|老子|人生K线|小股东|旺财)/.*",
       // Parabolic squeeze — 542 shorts liquidated on 4 accounts, 2026-08-07 (+801%/7d)
       "(TUT)/.*",
-      // Pump-and-dump knives — APR +192% then -68% (2026-08-12/15), VELVET -46% in an hour (2026-07-24)
-      "(APR|VELVET)/.*",
+      // Pump-and-dump knives — APR +192% then -68% (2026-08-12/15), VELVET -46% in an hour (2026-07-24),
+      // JCT -82.4% off its 2026-06-13 peak, single-day ranges of 96%, 96% and 83% (2026-09-10)
+      "(APR|JCT|VELVET)/.*",
       // Declining alt (2026-08-07; binance already covers via FAN group)
       "(CHZ)/.*",
       // Binance delist 2026-08-17 (full-coin) — iterativ 2026-08-03

--- a/configs/blacklist-okx.json
+++ b/configs/blacklist-okx.json
@@ -21,8 +21,9 @@
       "(龙虾|哈基米|牛来|我踏马来了|老子|人生K线|小股东|旺财)/.*",
       // Parabolic squeeze — 542 shorts liquidated on 4 accounts, 2026-08-07 (+801%/7d)
       "(TUT)/.*",
-      // Pump-and-dump knives — APR +192% then -68% (2026-08-12/15), VELVET -46% in an hour (2026-07-24)
-      "(APR|VELVET)/.*",
+      // Pump-and-dump knives — APR +192% then -68% (2026-08-12/15), VELVET -46% in an hour (2026-07-24),
+      // JCT -82.4% off its 2026-06-13 peak, single-day ranges of 96%, 96% and 83% (2026-09-10)
+      "(APR|JCT|VELVET)/.*",
       // Declining alt (2026-08-07; binance already covers via FAN group)
       "(CHZ)/.*",
       // Binance delist 2026-08-17 (full-coin) — iterativ 2026-08-03


### PR DESCRIPTION
`JCT` is currently in **none** of the twelve blacklists, which is what prompted this — checked with `re.fullmatch` across all twelve files against `JCT/USDT:USDT`, `JCT/USDT`, `JCT/BTC`, `JCT/USDC`, `JCT/BUSD` and `JCT/FDUSD`, and the string does not appear anywhere in them.

## Why

Listed 2026-01-04, peaked at `0.00827` on 2026-06-13, trades at `0.00146` today — **−82.4% off the high**. It got there in violent steps rather than a drift:

| widest single days | range |
| --- | --- |
| 2026-03-22 | 96% |
| 2026-06-13 | 96% |
| 2026-04-04 | 83% |
| 2026-08-18 | 66% |
| 2026-03-23 | 61% |

Yesterday (2026-09-09) printed a **49.5% range** and closed −11.5%; today −7.0%, −21.4% over seven days.

This is not covered by a delisting — it is live and reachable on every venue: **binance $3.8M, bybit $0.7M, bitget $0.5M** in perp volume. There is **no Binance spot market**, so it is futures-only.

## What it cost us

| bot | opened | closed | result | tag | exit |
| --- | --- | --- | --- | --- | --- |
| binance | 08-07 | 08-09 | +$8.97 | 63 | `exit_long_rebuy_d_1_13` |
| binance | 08-09 | 08-09 | +$18.24 | 3 | `exit_long_normal_d_2_119` |
| bybit | 08-07 | 08-25 | +$0.87 | 63 | `exit_long_rebuy_w_1_1` |
| bitget | 08-07 | **09-09** | **−$36.70** | 103 | `sold_on_exchange` |

Net **−$8.62** over four trades. The losing one sat open **33 days** and closed `sold_on_exchange` — from outside the bot, not through a strategy exit.

## Scope and placement

Added to the existing **pump-and-dump knives** group next to `APR` and `VELVET`, whose shape it matches, keeping the group alphabetical: `"(APR|JCT|VELVET)/.*"`.

**All twelve configs**, per the convention for junk that can surface on any venue (as with `WHITEWHALE`, `PUMPBTC`, `HIGH`, `COLLECT`) rather than a single-venue delisting.

## Verification

- `re.fullmatch` after the change: **12/12** for all six symbol forms.
- The added alternation does **not** catch `JCTX`, `AJCT` or `JC`.
- `APR` and `VELVET` still match in all twelve.
- Every file still parses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Dq23uSiXuSScTSa84tbtpa