### PR TITLE
Port X7 signal 165 and 193 entry protections to X8

### DIFF
--- a/NostalgiaForInfinityX8.py
+++ b/NostalgiaForInfinityX8.py
@@ -20066,6 +20066,14 @@ class NostalgiaForInfinityX8(IStrategy):
           # --- Protections ---
           long_entry_logic.append(num_empty_288 <= allowed_empty_candles_288)
           long_entry_logic.append(protections_long_global == True)
+          long_entry_logic.append(
+            (cmf_20_15m > 0.0)
+            & (adx_14_4h > 20.0)
+            & (change_pct_4h > -8.0)
+            & ((willr_14_15m > -40.0) | (uo_7_14_28_15m < 50.0) | (stochrsi_k_1d > 25.0))
+            & ((cmf_20_1h < 0.05) | (stochk_14_3_3_1h > 80.0) | stochrsi_k_1d_gt_10)
+            & ((cmf_20_1h > 0.15) | (cmf_20_4h > 0.0) | rsi_3_1d_gt_20)
+          )
           # --- Logic: embedded up-regime + quad-oversold + two-pivot bullish divergence ---
           long_entry_logic.append(stoch_60_10 > 80.0)
           long_entry_logic.append(stoch_9_3 < 20.0)

--- a/NostalgiaForInfinityX8.py
+++ b/NostalgiaForInfinityX8.py
@@ -19752,6 +19752,7 @@ class NostalgiaForInfinityX8(IStrategy):
         if long_entry_condition_index == 165:
           long_entry_logic.append(num_empty_288 <= allowed_empty_candles_288)
           long_entry_logic.append(protections_long_global == True)
+          long_entry_logic.append((sqz_cnt_24 > 14) | (mfi_14_1d < 45.0) | (willr_14_4h < -50.0))
           # trend filter (video: "only clear trends") + impulse quality (never draw fibs in chop)
           long_entry_logic.append(ema_12_4h > ema_200_4h)
           # R1 (eyeball): only a CLEAN ACTIVE uptrend — whipsaw chop (RIVER) has rsi_4h ~50 and stale 4h highs


### PR DESCRIPTION
## Summary

Native = unmodified X8 with the named signal ON; Modified = the matched X8 with that signal's final X7 protection block restored and the signal ON. Each test enables only one tag. These are reused real backtests, labeled by the source version actually executed: 165 on v18.0.27; 193 on v18.0.28.

**2024 Binance USDT futures, 19 pairs — signal-tagged results**

| Signal / tested version | Native net PnL, USDT | Modified net PnL, USDT | Difference (after − before), USDT | Native W/L | Modified W/L |
|---|---:|---:|---:|---:|---:|
| 165 / v18.0.27 | 59,829.42 | -40,935.99 | -100,765.40 | 463/20 | 62/8 |
| 193 / v18.0.28 | 8,157.73 | 17,878.29 | +9,720.56 | 13/1 | 11/0 |

**165 deteriorates materially in this comparison: −100,765.40 USDT versus Native. It is included as a default-disabled research restoration, not a performance improvement or activation recommendation.** 193 improves on this limited surface while omitting two Native winners. Both source flags remain False.

**Total test-account PnL** — each account contains only the named tag, so these equal tagged PnL. This is not an all-signals portfolio test. Unlimited stake permits capital and slot effects to affect results; do not pool dollars across these independent accounts.

| Signal / tested version | Native account PnL, USDT | Modified account PnL, USDT | Difference, USDT |
|---|---:|---:|---:|
| 165 / v18.0.27 | 59,829.42 | -40,935.99 | -100,765.40 |
| 193 / v18.0.28 | 8,157.73 | 17,878.29 | +9,720.56 |

| Signal / trade and risk metric | Native before | Modified after | Difference |
|---|---:|---:|---:|
| 165: Trades | 483 | 70 | -413 |
| 165: Losses | 20 | 8 | -12 |
| 165: Sum of trade returns, pp | 1,207.1348 | -108.3734 | -1,315.5082 |
| 165: Losing-trade PnL subtotal, USDT | -448,937.78 | -64,906.88 | +384,030.90 |
| 165: Closed-trade account maximum DD, % | 61.5713 | 41.4957 | -20.0756 |
| 165: Closed-trade maximum DD, USDT | 256,082.68 | 41,892.77 | -214,189.91 |
| 193: Trades | 14 | 11 | -3 |
| 193: Losses | 1 | 0 | -1 |
| 193: Sum of trade returns, pp | 62.6452 | 101.2118 | +38.5666 |
| 193: Losing-trade PnL subtotal, USDT | -10,326.91 | 0.00 | +10,326.91 |
| 193: Closed-trade account maximum DD, % | 9.9753 | 0.0000 | -9.9753 |
| 193: Closed-trade maximum DD, USDT | 10,326.91 | 0.00 | -10,326.91 |

Losing-trade PnL is already included in net PnL. Fees and funding are included once. Summed trade pp are not wallet return. DD uses Freqtrade's closed-trade profit_abs series, not marked-to-market equity; DD percentage differences are pp. Lower closed-trade DD does not establish lower intratrade risk.

- 165: 412 Native winners and 13 Native losses have no matching pair/open-time entry in Modified. There are 12 new entries ; losses among those entries: 1. Among 58 matched entries, 13 Native winners have lower return ratios; 1 close earlier. Force exits are retained: 6 before / 4 after.
- 193: 2 Native winners and 1 Native losses have no matching pair/open-time entry in Modified. There are 0 new entries ; losses among those entries: 0. Among 11 matched entries, 4 Native winners have lower return ratios; 0 close earlier. Force exits are retained: 0 before / 0 after.

Entry matching does not establish gate-level causality, win transfer, or postponement. Simultaneous-slot loss duration was not separately measured.

- Restore the final X7 entry protections for disabled signals 165 and 193 in X8: 165's squeeze/flow/washout OR filter from 36779c19/a9302c59, and 193's six conjuncts from PR #1224 (8b83ef0f). Both remained in X7 but were absent from the X8 baseline. This preserves the researched candidates for further evaluation, including 165's adverse result above.
- Independent base: upstream main 27991edaf78b47e291432e2017dd7f75e016402c, X8 v18.0.28.

## Safety

- Two append statements in populate_entry_trend, 9 added lines. Exact final X7 protection conjuncts; no new fitting or rounding. All referenced values are bound earlier. Source flags 165=False and 193=False remain unchanged; raw logic, indicators, exits, sizing, leverage and other tags are unchanged.
- Production position adjustment and de-risk remain True; V4 bad-trade exits remain True and V4 stops retain their False default. The tests enable only the selected tag. This is an intentional entry-filter change, not a claim of X7/X8 behavior parity.

## Backtest scope

- Reused completed real runs: 165 Native/Modified at v18.0.27 base 4f2333e57e850d6b06cf79be880a935a4333735c; 193 Native/Modified at v18.0.28 base 27991edaf78b47e291432e2017dd7f75e016402c. No new backtests for this update. The final combined source has not been freshly backtested; the tables retain the actual executed source identities.

- Static source-scope check: relative to the tested v18.0.27 165 arms, the final source differs only in version() and entry tags 2, 4, 42, 45, 61, all disabled in that config. Relative to the tested v18.0.28 193 Modified arm, only the disabled 165 block changes; its Native source is identical. After excluding exactly those inactive branches and the stated version function, whole-module ASTs match. This supports bounded evidence reuse, not all-signals equivalence.

- Freqtrade 2026.8 image freqtradeorg/freqtrade@sha256:4d23160b501d2b34579e76f57ad75edfa274967cd0dd824ff1c1b86d8c166ab4. 20240101-20250101 UTC, 5m, 100,000 USDT initial wallet, unlimited stake, six slots, 0.05% fee per side, observed leverage 3x. Each original arm used a fresh userdir, disabled cache and frozen read-only source/config/data mounts.

- Pairs: BTC, ETH, SOL, XRP, BNB, DOGE, ADA, AVAX, LINK, SAND, AXS, INJ, AAVE, RUNE, FIL, GALA, DOT, ALGO, CRV (all Binance USDT futures). 133 data files frozen and hashed; no gaps above expected 2024 candle/funding cadence observed. INJ daily history starts 2022-08-17, short of the requested 800-day warmup in both arms.

- Previously exposed 2024 history, with only 11 Modified 193 trades: not untouched validation, activation approval, or reproduction of the earlier 150-pair X7 study. No cross-exchange, spot, all-signals or multi-year performance claim. Four initial config-schema rejections produced no result ZIP and were excluded from measurements; their logs remain preserved.

## Checks

- `Rechecked all four exact prior ZIP hashes/CRC and embedded source bytes; retained their verified period, trade timestamps, universe, side/tag, fee, wallet, signal toggles and PnL totals. Reused-evidence AST scope checks passed.`
- `Final whole-module AST equals Native after removing exactly the two intended appends. X7 conjunct equality, introduced-use bindings, 64 exhaustive 165 boundary/NaN cases, 20,000 seeded 193 cases, empty and single-row inputs passed.`
- `pre-commit run --files NostalgiaForInfinityX8.py passed; validate_nfi_pr.py --base origin/main --strategy NostalgiaForInfinityX8.py passed (scope, merge simulation, AST bindings, Ruff, format and compilation); git diff --check passed.`
