### PR TITLE
X8: preserve OBV movement direction with an absolute denominator

### DIFF
--- a/NostalgiaForInfinityX8.py
+++ b/NostalgiaForInfinityX8.py
@@ -3052,6 +3052,17 @@ class NostalgiaForInfinityX8(IStrategy):
     return out
 
   @staticmethod
+  def obv_change_pct(obv: np.ndarray) -> np.ndarray:
+    """Measure OBV movement relative to the magnitude of its previous value."""
+    obv = np.asarray(obv, dtype=np.float64)
+    out = np.full(obv.shape, np.nan, dtype=np.float64)
+    prev = obv[:-1]
+    valid = np.isfinite(prev) & np.isfinite(obv[1:]) & (prev != 0)
+    np.divide(obv[1:] - prev, np.abs(prev), out=out[1:], where=valid)
+    out[1:] *= 100.0
+    return out
+
+  @staticmethod
   def stochrsi_k(rsi_14: np.ndarray, ta_min: np.ndarray, ta_max: np.ndarray, ta_sma: np.ndarray) -> np.ndarray:
     """
     Calculate the %K line of the Stochastic RSI.
@@ -3808,7 +3819,7 @@ class NostalgiaForInfinityX8(IStrategy):
     rsi_3_change = fast_pct_change(rsi_3)
     rsi_14_change = fast_pct_change(rsi_14)
     uo_change = fast_pct_change(uo)
-    obv_change = fast_pct_change(obv)
+    obv_change = self.obv_change_pct(obv)
     cci_change = fast_pct_change(cci_20)
 
     # =========================================================================
@@ -3990,7 +4001,7 @@ class NostalgiaForInfinityX8(IStrategy):
     # CHANGE %
     # =========================================================================
     rsi_14_change = fast_pct_change(rsi_14)
-    obv_change = fast_pct_change(obv)
+    obv_change = self.obv_change_pct(obv)
 
     # =========================================================================
     # CANDLE %


### PR DESCRIPTION
## Summary

Native below is unmodified X8 v18.0.28 with its default signals enabled. Modified is the same strategy with an absolute denominator for OBV changes. Each comparison uses identical market data and configuration, starting with 10,000 USDT.

Signal-562 trades within the full strategy (not an isolated signal-only backtest):

| Period, UTC end exclusive | Native trades / wins / losses | Modified trades / wins / losses | Native net PnL, USDT | Modified net PnL, USDT | Difference, USDT |
|---|---:|---:|---:|---:|---:|
| 2022-05-01–2022-07-01 | 0 / 0 / 0 | 5 / 5 / 0 | 0.00 | 323.91 | +323.91 |
| 2022-01-01–2023-01-01 | 0 / 0 / 0 | 15 / 14 / 1 | 0.00 | 690.12 | +690.12 |

Full portfolio, including capital and sizing effects:

| Period | Native net PnL, USDT | Modified net PnL, USDT | Difference, USDT |
|---|---:|---:|---:|
| May–June 2022 | 1,930.04 | 2,258.18 | +328.14 |
| Full 2022 | 6,162.19 | 7,176.69 | +1,014.50 |

`fast_pct_change(OBV)` divides by signed previous cumulative OBV. When that value is negative, an OBV decrease produces a positive percentage, and an increase produces a negative percentage. This reverses the direction tested by the OBV entry gates. For example, `[-100, -200]` currently produces `+100%`; this patch produces `-100%`.

Use a dedicated OBV helper with `abs(previous_obv)`, matching X6's denominator convention. Undefined ratios become NaN. Apply it at the base 5m and informative 15m call sites. Independently based on upstream `27991edaf78b47e291432e2017dd7f75e016402c`; no other candidate is stacked into this branch.

## Safety

- Changes one strategy file: adds `obv_change_pct` and replaces the two OBV calls. Leaves the shared `fast_pct_change`, other indicators, StochRSI, entry thresholds, signal activation and trade management unchanged.
- Positive finite previous-OBV cases retain the existing percentage calculation. Negative previous OBV intentionally changes direction; zero or nonfinite inputs yield NaN instead of a tradable infinite ratio. The first row stays NaN and row alignment is preserved.
- This fixes direction semantics, **not complete recursive stability**. The absolute cumulative denominator still changes with history length. It is not volume normalization and does not establish backtest/dry/live equivalence.
- Current default-enabled OBV consumers are long 47, long 65 and short 562. Long 65 has both a positive-sign requirement and a magnitude gate. Other consumers, including short 506, are default-disabled; no enable flags are changed.

Trade and risk costs remain visible:

| Metric / period | Native | Modified | Difference |
|---|---:|---:|---:|
| Trades / losses, May–June | 13 / 1 | 18 / 1 | +5 / +0 |
| Losing-trade PnL subtotal, May–June, USDT | -21.90 | -21.87 | +0.03 |
| Closed-trade maximum DD, May–June | 0.1841% / 21.90 USDT | 0.1791% / 21.87 USDT | -0.0051 pp / -0.03 USDT |
| Wallet-balance maximum DD, May–June | 0.9216% / 110.41 USDT | 0.8984% / 110.52 USDT | -0.0232 pp / +0.12 USDT |
| Trades / losses, full 2022 | 33 / 2 | 48 / 3 | +15 / +1 |
| Losing-trade PnL subtotal, full 2022, USDT | -113.98 | -335.26 | -221.28 |
| Closed-trade maximum DD, full 2022 | 0.9101% / 91.24 USDT | 1.5386% / 220.71 USDT | +0.6285 pp / +129.47 USDT |
| Wallet-balance maximum DD, full 2022 | 1.5554% / 206.02 USDT | 1.5386% / 220.71 USDT | -0.0168 pp / +14.69 USDT |

Losing-trade PnL is already included in net PnL. The additional loss is a 562 BTC short opened 2022-10-19 11:20 UTC and closed 2022-11-04 14:25 UTC: **-220.71 USDT**, through `exit_bad_trade_abandon_16d`. Native had no corresponding trade. No Native trades were omitted; shared trades retained entry/exit timestamps, including winners. Shared sizing and order amounts changed with available capital. Both DD measures above are Freqtrade exports, not a claim about continuous mark-to-market equity. Deltas are calculated before rounding.

## Backtest scope

- Fresh matched Freqtrade 2026.8 backtests on BTC, ETH, SOL and FIL Binance isolated USDT futures; 5m base timeframe, actual informative/mark/funding data, 0.0005 fees each side, unlimited stake, 0.99 tradable balance ratio, grinding enabled. Configured maximum open trades is 6; Freqtrade reports an effective maximum of 4 for the four-pair list. Zero rejected signals in these runs; larger-universe slot contention is not covered.
- Docker image pinned to `sha256:4d23160b501d2b34579e76f57ad75edfa274967cd0dd824ff1c1b86d8c166ab4`. Runs use `--cache none`, independent state directories and no network. Only exchange market-metadata reload is replaced with the same captured market definitions/currencies in all arms; trade execution, callbacks, fee/funding logic and backtest methods are unchanged. Metadata is an existing Freqtrade 2026.5.1 / CCXT 4.5.55 capture; leverage tiers are the pinned image's bundled dry-run data. This is a controlled formula comparison, not a reconstruction of historical exchange constraints.
- May–June is a separate reset-wallet run nested inside the annual period; results are not pooled. Embedded strategy source in each export matches the tested file exactly.
- At 46,720 sampled 5m/15m market checkpoints across the four pairs in 2022, changing preceding history among **800 / 999 / 1,999 candles** changed the Native `OBV change > 0` result at 14,671 checkpoints; Modified had zero such disagreements. However, the 15m `< 50` gate still changed at **487 of 11,680 checkpoints** under Modified. These are indicator-level checks, not executed-trade counts or a universal parity claim.
- Complete entry-method replay also reproduced the history-dependent 562 direction issue on SOL. Synthetic signal-65 fixtures passed 24 strict-boundary cases through the unmodified complete entry method, covering NaN/zero, the `< 50` boundary and daily-StochRSI bypass. Natural signal-65 trades were absent in the four-pair engine runs; two additional historical research timestamps did not reproduce 65 under current X8 either. **Signal-65 market performance is therefore not claimed as covered.**
- A separate volume-normalized candidate had identical exported trades/orders in these two engine periods, but synthetic complete-entry checks demonstrated that its changed units alter signal 65's existing threshold behavior. Normalization and threshold retuning are excluded from this PR.

Closed-candle replay through the actual Freqtrade dry-run analysis and cache-aging methods also isolates the cause. The pinned Binance futures cache retains 499 + 800 = 1,299 candles once mature. Across 26 selected SOL timestamps, Native differs from its growing-history batch calculation twice; Modified differs zero times. Replacing only the last-row OBV values reproduces both Native changes. With identical history, the dry-run and backtest analysis paths agree at all checked timestamps; removing the future suffix also preserves the checked OBV values and entry decisions.

| SOL decision candle (UTC) | Native growing-history OBV 15m | Native mature-cache OBV 15m | Native batch / cache decision |
|---|---:|---:|---|
| 2022-05-26 05:25 | +2.103904 | -21.204457 | no entry / short 562 |
| 2022-05-26 05:45 | +1.856677 | -20.633856 | no entry / short 562 |

The same two discrepancies reproduce with original v18.0.25; the exact supplied p1mp v18.0.25 file removes them. Replay uses the installed `DataProvider`, `Exchange._process_ohlcv_df`, `IStrategy._analyze_ticker_internal` and `get_entry_signal`, with controlled historical feeds, decision-time clock and empty portfolio. It does not simulate live order execution. All 384 SOL 5m/15m candles on the witness day also exactly match separately downloaded official Binance public archives, with published checksums verified.

Actual `recursive-analysis` CLI runs corroborate the stated limit: the absolute ratio remains variable in magnitude, while the normalized comparison is identical across the tested histories. This additional evidence does not broaden the patch into a complete recursive-stability fix.

## Checks

- Final committed source passed `validate_nfi_pr.py --base origin/main --strategy NostalgiaForInfinityX8.py`: file scope, branch naming, merge check, focused AST checks, Ruff, formatting and compilation.
- `pre-commit run --files NostalgiaForInfinityX8.py`: passed; final source hash unchanged.
- Targeted helper checks passed: negative-OBV direction, positive-OBV parity, first-row alignment, zero and invalid input handling.
- Completed the matched Native/Modified engine runs above; reviewed added/shared/removed trades, losses and DD against exported results.
- Additional local history and entry-contract checks passed as scoped above. No thresholds were tuned to these results.
