### PR TITLE
X8: signal 669: per-loss entry protections, regrouped block

### DIFF
--- a/NostalgiaForInfinityX8.py
+++ b/NostalgiaForInfinityX8.py
@@ -23003,480 +23003,364 @@ class NostalgiaForInfinityX8(IStrategy):
 
           short_entry_logic.append(
             # --- 5m: no room left below, and the break candle itself
+            # 5m down move
             (rsi_3 > 0.4)
-            # base momentum is not spent while the 4h has already given way: selling after the
-            # move, not into it
-            & ((rsi_3 < 20.0) | (rsi_4 > 25.0) | rsi_3_4h_gt_15)
-            # the base RSI is not low, the 4-period RSI is not washed and the base stochastic is
-            # off zero: the fast timeframe has nothing left to give (3 losses, free everywhere)
+            # 5m down move & still not high enough & oversold
             & ((rsi_14 > 25.0) | (rsi_4 < 10.0) | (stochrsi_k > 0.0))
-            # 4h strong with clearly positive 4h money flow: that is shorting a healthy uptrend
-            # (ARPA -6,334 + 1 more; the only one of the late chains that also pays in 2022)
-            & (rsi_14_4h_lt_50 | cmf_20_4h_lt_0_15)
-            # 4h: just printed a high, or money flow still rich (DODOX -3314 at AROONU_14_4h 78.6)
-            & aroonu_14_4h_lt_50
-            # a fully washed 4h on a pair whose DAILY has just printed a high: that is a dip inside
-            # a strong uptrend, not a breakdown. Blocked trades average -3.5% in the 2021 bull and
-            # +1.4% in 2026 (well under the tag average), so it costs nothing and saves the bull
-            & (stochrsi_k_4h_gt_10 | aroonu_14_1d_lt_85)
-            # price is not pinned at the very floor of its 40h range — there has to be room left below
-            & (willr_480 > -99.5)
-            # the base has a position at all: a dead-flat base is not a breakdown
+            # 5m flat base
             & (ph_base_pos > 0.03)
-            # something was coiled before the break; a break out of nothing has nothing behind it
+            # 5m loose pre-break
             & (ph_pre_tight > 0.4)
-            # a tight pre-break hour blown apart by a volume spike: the move is the spike itself
+            # 5m loose pre-break & volume spike
             & ((ph_pre_tight > 0.8) | (vol_rel < 10.0))
-            # the base has not been squeezed for the whole day — that is a range, not a setup
+            # 5m long coil
             & (sqz_cnt_24 < 23.0)
-            # a bearish engulfing while the DAILY is making highs and strong is a pullback inside
-            # an uptrend, not a breakdown. In the 2021 bull the blocked group averages -7.2%
-            # against a +0.2% population; in 2026/2022 it touches three trades in total
-            & ((engulf_bear < 0.5) | aroonu_14_1d_lt_70 | rsi_14_1d_lt_60)
+            # 5m at its floor
+            & (willr_480 > -99.5)
             # --- 15m: the fast timeframe has to confirm the break
-            # a 15m stuck at its low that has not made a new low, entered from above the 24h base
-            # (RUNE -29,002; 0W/1L | 2W/1L | 3W/2L)
-            & (rsi_3_1h_lt_55 | (aroond_14_15m < 100.0) | (ph_base_pos < 0.5))
+            # 15m down move
             & (rsi_14_15m > 17.0)
-            # the 15m selling is spent while the 4h RSI is nowhere near washed (ADA -20,094)
-            & (rsi_14_4h_gt_20 | (cci_20_change_pct_15m < 100.0) | rsi_3_15m_gt_20)
-            # no fresh 15m low, base and 15m money flow both drained, and the 12-candle high sits
-            # near the top of its range: sold out into a market that just topped (5 losses)
-            & ((mfi_14 < 35.0) | (mfi_14_15m < 30.0) | (quad_s93_max_12 > 60.0))
-            # 4h and 1h both printing highs while the 15m RSI is not falling (LINK -20,140;
-            # 1W/0L | 1W/1L | 0W/2L)
-            & (aroonu_14_4h_lt_40 | aroonu_14_1h_lt_70 | (rsi_14_change_pct_15m > -10.0))
-            # the 15m stochastics are both on the floor after a long coil: the fast
-            # timeframe is already spent when the break prints
-            & ((stochrsi_k_15m > 0.0) | (sqz_cnt_24 < 18.0) | (stochk_14_3_3_15m > 10.0))
-            # the 15m is already deep in its own range while its oscillator holds up: no leg left
-            # to sell (INJ -1,844; 0W/1L | 0W/0L | 0W/1L)
+            # 5m still not high enough, 15m oversold & still not high enough
             & ((quad_s93_min_12 < 15.0) | (uo_7_14_28_15m > 35.0) | (rsi_14_15m < 25.0))
-            # the 15m has already been sold off hard and the base oscillator has not confirmed
-            # (SAND 2021 -822,676; 0W/0L | 1W/1L | 0W/1L)
+            # 15m down move & high & new low
             & ((cci_20_change_pct_15m > -1200.0) | rsi_14_15m_lt_40 | (aroond_14_15m < 100.0))
-            # the 15m momentum has already collapsed and volume is coming back in: the flush is
-            # over (SOL -2,739; 0W/0L | 0W/0L | 1W/3L)
-            & ((cci_20_change_pct_15m > -850.0) | (willr_14_15m > -95.0) | (obv_change_pct_15m > 1.0))
-            # the base is pinned at its 14-bar low while the 15m stochastic is still high:
-            # the low is already in and the fast timeframe has not confirmed it
-            & ((willr_14 > -100.0) | (stochk_14_3_3_15m < 60.0))
-            # a dead 15m oscillator under a huge volume spike = climax, not a leg down
-            & ((uo_7_14_28_15m > 30.0) | (vol_rel < 10.0))
-            # the 15m oscillator is not surging: the fast timeframe must not be turning up
-            & (uo_7_14_28_change_pct_15m < 10.0)
-            # volume leaving on the 15m while the hour has just printed a high (BERA -2,049;
-            # 0W/1L | 0W/2L | 0W/1L)
-            & ((obv_change_pct > -15.0) | aroonu_14_1h_gt_20 | (uo_7_14_28_change_pct_15m < -10.0))
-            # volume leaving on the 15m while the day is dropping hard, the base RSI is low and
-            # the 15m oscillator is off its floor: selling the end of a move (5 losses)
-            & ((obv_change_pct_15m > 0.0) | (rsi_20 < 35.0) | stochrsi_k_15m_gt_20)
-            # a long coil whose base stochastic has been high while the 15m collapses: the
-            # break is the end of the coil, not the start of a move
+            # 5m long coil & off its high, 15m still not high enough
             & ((sqz_cnt_24 < 20.0) | (quad_s93_max_12 > 50.0) | (rsi_3_15m < 10.0))
+            # 5m long coil, 15m oversold
+            & ((stochrsi_k_15m > 0.0) | (sqz_cnt_24 < 18.0) | (stochk_14_3_3_15m > 10.0))
+            # 5m at its floor, 15m overbought
+            & ((willr_14 > -100.0) | (stochk_14_3_3_15m < 60.0))
+            # 5m high, 15m volume leaving & oversold
+            & ((obv_change_pct_15m > 0.0) | (rsi_20 < 35.0) | stochrsi_k_15m_gt_20)
+            # 15m down move & at its floor & volume leaving
+            & ((cci_20_change_pct_15m > -850.0) | (willr_14_15m > -95.0) | (obv_change_pct_15m > 1.0))
+            # 5m flow rich & off its high, 15m flow rich
+            & ((mfi_14 < 35.0) | (mfi_14_15m < 30.0) | (quad_s93_max_12 > 60.0))
+            # 5m volume spike, 15m oversold
+            & ((uo_7_14_28_15m > 30.0) | (vol_rel < 10.0))
+            # 15m still not high enough
+            & (uo_7_14_28_change_pct_15m < 10.0)
             # --- 1h: the hour must not already be turning back up
-            # the 5m is not really selling and the hour is flat: nothing to ride
-            & ((rsi_3 < 15.0) | (roc_9_1h < -0.25))
-            # the hour is rising into the break — momentum high, the candle green and the hourly RSI mid-
-            # range: selling a move that has not turned
+            # 5m high base, 15m new low, 1h high
+            & (rsi_3_1h_lt_55 | (aroond_14_15m < 100.0) | (ph_base_pos < 0.5))
+            # 1h high & up move
             & ((rsi_3_1h < 65.0) | (change_pct_1h < 0.5) | (rsi_14_1h < 50.0))
-            # the base ROC still falling while the 15m momentum holds up, the hourly oscillator
-            # is mid-band and price sits high in the hour's range: no leg underneath (5 losses)
-            & ((rsi_3_change_pct_15m > -50.0) | stochrsi_k_1h_lt_60 | (willr_14_1h > -75.0))
-            # hourly RSI_3 snapping up on a falling candle with 15m money flow still neutral
-            # (BTC -23,817; 0W/1L | 1W/1L | 0W/0L)
+            # 5m up move, 15m money out, 1h rising
             & ((rsi_3_change_pct_1h < 740.0) | (roc_2 < -1.5) | (cmf_20_15m > -0.05))
-            # the base is not oversold, the 15m stochastic is off its floor and the hour has
-            # not rolled over: nothing is confirming the break
-            & ((rsi_14 < 30.0) | (stochrsi_k_15m > 0.0) | (stochk_14_3_3_1h > 25.0))
-            # the base RSI is on its floor while the base stochastic is mid-range and the hour is dead: a
-            # stalled flush
+            # 5m down move & overbought, 1h down move
             & ((rsi_14 > 20.0) | (stoch_9_3 < 35.0) | (rsi_3_1h > 5.0))
-            # the base is not oversold, base money flow has not turned negative and the
-            # hour is far from its low: selling with the move not yet under way
-            & ((rsi_14 > 25.0) | (cmf_20 < -0.1) | (willr_14_1h < -70.0))
-            # the 15m is not washed out, the hour is not oversold and hourly money flow is
-            # still positive: selling before anything has given way
+            # 15m down move, 1h high & flow drained
             & ((rsi_14_15m > 20.0) | (rsi_14_1h < 35.0) | (mfi_14_1h > 40.0))
-            # hourly oversold while price is nowhere near its 40h low: the sell-off is paid for
-            # and what is left is the bounce (EIGEN -6,312, BERA -6,235)
+            # 5m at its ceiling, 1h down move
             & ((rsi_14_1h > 40.0) | (willr_480 < -85.0))
-            # high-volume break into an hour that has already recovered = squeeze fuel
-            # (NAORIS -5,028, ARB -4,918, SAND -4,261)
+            # 5m volume spike, 1h high & flow rich
             & (rsi_14_1h_lt_40 | (vol_rel < 6.0) | (mfi_14_1h < 30.0))
-            # the base momentum barely moved and the hour is not really rolling over:
-            # a break with no acceleration behind it
+            # 5m still not high enough & no new high, 1h rising
             & ((rsi_14_change_pct < -20.0) | (aroonu_14 > 0.0) | (rsi_3_change_pct_1h < 40.0))
-            # base money flow is not draining, the hourly momentum has not really given way
-            # and the hour is off its floor: the sellers are not there yet
+            # 5m money out, 1h rising & at its floor
             & ((cmf_20 > -0.25) | (rsi_3_change_pct_1h < 60.0) | (willr_14_1h > -85.0))
-            # hourly money flow still neutral while the hour is no longer falling and the 5m is
-            # not washed: nothing is actually selling (3 losses, free in all three years)
+            # 5m down move, 1h money out & up move
             & ((cmf_20_1h > -0.05) | (roc_9_1h < 0.0) | rsi_3_gt_5)
-            # money flow is intact on both the base and the hour while the hour is off its
-            # low: selling into a market that is not under pressure
-            & ((mfi_14 > 15.0) | (mfi_14_1h > 25.0) | (willr_14_1h < -70.0))
-            # 15m money flow still rich while the hour is red and the 4h has already dropped:
-            # buyers are underneath the break (6 losses, all in 2022)
-            & ((mfi_14_15m > 35.0) | rsi_3_4h_gt_10 | (change_pct_1h < 0.0))
-            # hourly money flow is not rich — buyers should not be in control of the hour
-            & (mfi_14_1h < 50.0)
-            # hourly money flow drained while price sits high in its own range = exhausted seller
-            & ((mfi_14_1h > 20.0) | (willr_14_1h < -75.0))
-            # the 15m stochastic pinned at zero with hourly money flow drained and the 15m no
-            # longer falling: the flush already happened (6 losses, mostly 2021)
-            & ((mfi_14_1h > 25.0) | (roc_9_15m > -3.0) | (stochrsi_k_15m > 0.0))
-            # no fresh 15m low while the 4h low is recent, hourly CCI already recovering and the
-            # 15m RSI not low: the 15m has finished its leg (4 losses, free in all three years)
-            & (aroond_14_15m_lt_80 | (cci_20_1h > -175.0) | rsi_14_15m_lt_35)
-            # 4h near its low, its oscillator back up, hourly off its own low
-            # (NAORIS -5,539 on 2026-04-18: AROOND_14_4h 85.7, STOCHRSIk_4h 92.0, WILLR_14_1h -70.2)
-            & (aroond_14_4h_lt_80 | stochrsi_k_4h_lt_40 | (willr_14_1h < -85.0))
-            # 4h near its low while the 1h has just printed a high and its oscillator is above
-            # mid-band: the leg down is finished (AVAX -16,736; thresholds picked on 2026+2022)
-            & (aroond_14_4h_lt_80 | aroonu_14_1h_lt_40 | (uo_7_14_28_1h < 50.0))
-            # the hourly CCI has collapsed while the 15m momentum is still alive and its oscillator rich
-            & ((cci_20_1h > -300.0) | (rsi_3_15m < 35.0) | (uo_7_14_28_15m < 50.0))
-            # the hourly CCI is exploding upward while OBV drains on both the base and the 15m
-            & ((cci_20_change_pct_1h < 250.0) | (obv_change_pct > 0.0) | (obv_change_pct_15m > 0.0))
-            # the hourly CCI has not exploded upward
-            & (cci_20_change_pct_1h < 500.0)
-            # the hourly oscillator is rich while every base RSI is elevated: nothing is oversold to sell
-            & ((uo_7_14_28_1h < 55.0) | (rsi_14 < 35.0) | (rsi_3 < 15.0))
-            # the hourly oscillator is rich, the 15m CCI has exploded and the base stochastic is on its
-            # floor
-            & ((uo_7_14_28_1h < 55.0) | (cci_20_change_pct_15m < 250.0) | (stoch_4_4 > 5.0))
-            # the 15m oscillator is turning up, the base sits on its floor and the hourly CCI is washed out
-            & ((uo_7_14_28_change_pct_15m < 5.0) | (ph_base_pos > 0.1) | (cci_20_1h > -250.0))
-            # the hour itself is not rising into the break
+            # hourly CCI washed, price off its 40h floor, hourly money still coming in
+            & ((willr_480 < -75) | (cci_20_1h > -140) | cmf_20_1h_lt_0_10)
+            # 5m volume leaving, 15m still not high enough, 1h no new high
+            & ((obv_change_pct > -15.0) | aroonu_14_1h_gt_20 | (uo_7_14_28_change_pct_15m < -10.0))
+            # 15m falling, 1h overbought & at its floor
+            & ((rsi_3_change_pct_15m > -50.0) | stochrsi_k_1h_lt_60 | (willr_14_1h > -75.0))
+            # 5m high, 15m & 1h oversold
+            & ((rsi_14 < 30.0) | (stochrsi_k_15m > 0.0) | (stochk_14_3_3_1h > 25.0))
+            # 5m still not high enough, 1h up move
+            & ((rsi_3 < 15.0) | (roc_9_1h < -0.25))
+            # 1h up move
             & (roc_2_1h < 0.5)
-            # the 15m is not falling, the 4h stochastic is maxed and the hour is not pinned:
-            # the break is a spike inside a market still holding up
-            & ((roc_9_15m < -1.0) | (willr_14_1h > -90.0) | stochrsi_k_4h_lt_90)
-            # the 15m has dropped but its RSI is not low, price is pinned at the 15m floor and
-            # the hour is flat: the move already happened on the fast timeframe (5 losses)
-            & ((roc_9_15m < -2.5) | (willr_14_15m < -75.0) | (change_pct_1h > -1.5))
-            # shorting a small red candle while the 15m has not really broken down and the
-            # hour is only mildly negative: no conviction behind the break
+            # 5m & 1h up move, 15m down move
             & ((change_pct < -0.4) | (rsi_14_change_pct_15m > -30.0) | (roc_2_1h < -2.0))
+            # 15m new low & high, 1h down move
+            & (aroond_14_15m_lt_80 | (cci_20_1h > -175.0) | rsi_14_15m_lt_35)
+            # 15m high, 1h down move
+            & ((cci_20_1h > -300.0) | (rsi_3_15m < 35.0) | (uo_7_14_28_15m < 50.0))
+            # 5m flat base, 15m still not high enough, 1h down move
+            & ((uo_7_14_28_change_pct_15m < 5.0) | (ph_base_pos > 0.1) | (cci_20_1h > -250.0))
+            # 5m & 15m volume leaving, 1h high
+            & ((cci_20_change_pct_1h < 250.0) | (obv_change_pct > 0.0) | (obv_change_pct_15m > 0.0))
+            # 1h high
+            & (cci_20_change_pct_1h < 500.0)
+            # 15m up move & at its ceiling, 1h down move
+            & ((roc_9_15m < -2.5) | (willr_14_15m < -75.0) | (change_pct_1h > -1.5))
+            # 5m flow drained, 1h flow drained & at its ceiling
+            & ((mfi_14 > 15.0) | (mfi_14_1h > 25.0) | (willr_14_1h < -70.0))
+            # 1h flow rich
+            & (mfi_14_1h < 50.0)
+            # 1h flow drained & at its ceiling
+            & ((mfi_14_1h > 20.0) | (willr_14_1h < -75.0))
+            # 15m down move & oversold, 1h flow drained
+            & ((mfi_14_1h > 25.0) | (roc_9_15m > -3.0) | (stochrsi_k_15m > 0.0))
+            # 5m high & still not high enough, 1h high
+            & ((uo_7_14_28_1h < 55.0) | (rsi_14 < 35.0) | (rsi_3 < 15.0))
+            # 5m oversold, 15m & 1h high
+            & ((uo_7_14_28_1h < 55.0) | (cci_20_change_pct_15m < 250.0) | (stoch_4_4 > 5.0))
+            # 5m down move & money in, 1h at its ceiling
+            & ((rsi_14 > 25.0) | (cmf_20 < -0.1) | (willr_14_1h < -70.0))
             # --- 4h: the higher timeframe carries the move — it must not be washed out
-            # the 4h has not been pushed to an extreme, its momentum is only mildly down and
-            # its stochastic is mid-range: the higher timeframe has not committed
+            # 5m still not high enough & down move, 4h down move
+            & ((rsi_3 < 20.0) | (rsi_4 > 25.0) | rsi_3_4h_gt_15)
+            # 4h high & money in
+            & (rsi_14_4h_lt_50 | cmf_20_4h_lt_0_15)
+            # 15m high & down move, 4h down move
+            & (rsi_14_4h_gt_20 | (cci_20_change_pct_15m < 100.0) | rsi_3_15m_gt_20)
+            # 15m flow drained, 1h up move, 4h down move
+            & ((mfi_14_15m > 35.0) | rsi_3_4h_gt_10 | (change_pct_1h < 0.0))
+            # 4h high & overbought & down move
             & ((rsi_3_4h < 45.0) | (stochk_14_3_3_4h < 40.0) | (cci_20_4h > -75.0))
-            # the 4h sits at its own high, stochastic and CCI both up there: there is no exhaustion above to
-            # sell into
+            # 4h high & overbought
             & ((rsi_3_4h < 85.0) | (stochk_14_3_3_4h < 70.0) | (cci_20_4h < 50.0))
-            # 4h momentum is dead, the pair has not fallen over the rolling day and the 15m
-            # is still alive: selling a 4h low in a market that never dropped
+            # 5m up move, 15m high, 4h down move
             & ((rsi_3_4h > 5.0) | (roc_288 < -3.0) | (rsi_3_15m < 30.0))
-            # shorting into a violent hourly bounce while the base is washed out and the 4h
-            # has barely fallen: the break is being bought back
-            & ((rsi_14 < 30.0) | (rsi_3_change_pct_1h < 250.0) | (change_pct_4h > -1.5))
-            # hourly RSI mid-range while the 4h momentum has collapsed but the 15m has not
-            # confirmed: the fast timeframe is not selling (UNI -10,291; 2W/0L | 2W/0L | 0W/1L)
+            # 15m rising, 1h high, 4h falling
             & (rsi_14_1h_lt_50 | (rsi_3_change_pct_4h > -30.0) | (rsi_3_change_pct_15m < -60.0))
-            # the 15m RSI barely moved, the 4h momentum has not given way and the base has
-            # been coiled for a while: a break out of a quiet base with nothing behind it
+            # 5m long coil, 15m down move, 4h falling
             & ((rsi_14_change_pct_15m > -30.0) | (rsi_3_change_pct_4h > -60.0) | (sqz_cnt_24 < 12.0))
-            # the hourly turning up hard while price sits high in its 84-candle range: the 4h RSI
-            # is rising as we sell (APR -14,372, our largest 2026 loss; 2W/1L | 1W/2L | 0W/1L)
+            # 1h overbought & at its ceiling, 4h still not high enough
             & ((rsi_14_change_pct_4h < 6.0) | stochrsi_k_1h_lt_60 | (willr_84_1h < -70.0))
-            # the 4h RSI is not jumping: the higher timeframe must not be recovering
+            # 4h still not high enough
             & (rsi_14_change_pct_4h < 8.0)
-            # the pair has not fallen over the rolling day, the base is not oversold and the
-            # 4h oscillator is still rich: a break with the trend untouched
-            & ((rsi_20 < 30.0) | (roc_288 > -5.0) | (uo_7_14_28_4h < 55.0))
-            # money is flowing into the base, OBV is rising and the 4h sits high: nothing is breaking down
-            & ((cmf_20 < 0.05) | (obv_change_pct < 5.0) | (stochk_14_3_3_4h < 65.0))
-            # money is entering the base, the 4h candle is green and the base stochastic is mid-range
-            & ((cmf_20 < 0.05) | (change_pct_4h < 0.0) | (stoch_9_3 < 25.0))
-            # base money has already left, the 4h stochrsi is on its floor and the 4h oscillator is low
-            & ((cmf_20 > -0.3) | (stochrsi_k_4h > 5.0) | (uo_7_14_28_4h > 40.0))
-            # 5m selling stalled and the 15m oscillator snapping back up under the break (XMR
-            # -2,340; 0W/1L | 0W/1L | 0W/1L)
-            & ((cmf_20_1h > -0.25) | (rsi_3_change_pct_15m > -70.0) | (stochrsi_k_change_pct_4h > -40.0))
-            # money is flowing into the 4h and the base stochastic has just been at its ceiling
-            & ((cmf_20_4h < 0.15) | (quad_s93_max_12 < 95.0) | (stochk_14_3_3_4h > 15.0))
-            # 4h money flow clearly positive while the 4h is pinned at its low = accumulation at
-            # the bottom, not a breakdown (AVAX -6,879; 1W/1L | 0W/2L | 1W/1L)
+            # 4h money in & at its floor & falling
             & (cmf_20_4h_lt_0_15 | (willr_14_4h > -90.0) | (rsi_3_change_pct_4h > -40.0))
-            # 15m money flow is not exhausted, the 15m RSI has barely dropped and the 4h
-            # stochastic is turning back up: the flush is already being bought
-            & ((mfi_14_15m > 10.0) | (rsi_14_change_pct_15m > -15.0) | (stochrsi_k_change_pct_4h < 10.0))
-            # hourly money flow drained, 4h already down hard, and the base timeframe printing a
-            # high (SOON -2,118; 2W/1L | 2W/3L | 3W/3L)
-            & ((mfi_14_1h > 10.0) | (roc_9_4h > -4.0) | (aroonu_14 > 30.0))
-            # 4h money flow is rich, the 15m stochastic is mid-range and its CCI has jumped: no capitulation
-            # here
-            & ((mfi_14_4h < 50.0) | (stochk_14_3_3_15m < 50.0) | (cci_20_change_pct_15m < 300.0))
-            # 4h money flow is not rich either
-            & (mfi_14_4h < 55.0)
-            # 4h money is drained and the bands are flat, yet the base never printed a low: nothing has
-            # broken
-            & ((mfi_14_4h > 20.0) | (quad_s93_min_12 < 10.0) | (willr_84_1h > -95.0))
-            # the 15m has not turned down, 15m money flow is still healthy and the 4h is
-            # not draining: a break with nothing behind it on the fast timeframes
-            & (aroonu_14_15m_lt_70 | (mfi_14_15m > 35.0) | (cmf_20_4h > -0.2))
-            # 4h already recovering off a pair that has fallen hard over the day, while the 4h
-            # itself is no longer in a live down-leg
-            & (aroonu_14_4h_lt_30 | (roc_288 > -7.0) | (cci_20_4h < -125.0))
-            # 4h at its 14-period low and the 5m selling already stopped
-            # (PLAY -16,653 on 2026-07-04: AROOND_14_4h 100 with RSI_3 20.8)
-            & ((aroond_14_4h < 100.0) | (rsi_3 < 15.0))
-            # the low printed on BOTH 4h and 15m right now, money flow above neutral
-            # (CLANKER -4,785 on 2026-04-29)
-            & ((aroond_14_4h < 100.0) | (aroond_14_15m < 100.0) | (mfi_14_1h < 40.0))
-            # the 4h is high on stochrsi while the hourly CCI has collapsed underneath it
-            & ((stochrsi_k_4h < 80.0) | (cci_20_change_pct_1h > -400.0) | (roc_2 < -0.5))
-            # the 4h stochrsi is near its ceiling, hourly money is coming in and the 4h has no downward
-            # direction
-            & ((stochrsi_k_4h < 85.0) | (cmf_20_1h < 0.05) | (plus_di_14_4h > 10.0))
-            # the 4h stochrsi sits at zero while 15m money flow and the 15m oscillator both turn up
-            & ((stochrsi_k_4h > 5.0) | (cmf_20_15m < 0.05) | (uo_7_14_28_change_pct_15m < 0.0))
-            # the 4h oscillator has stopped falling, the 4h low is not fresh, and the hourly
-            # oscillator is already at the floor (SOL 2021 -815,130; 1W/0L | 3W/0L | 0W/4L)
-            & ((stochrsi_k_change_pct_4h < 10.0) | (aroond_14_4h > 20.0) | stochrsi_k_1h_lt_30)
-            # 4h: turning back up under the break (KOMA -2725, DODOX -2051, CLANKER -1850)
-            & (stochrsi_k_change_pct_4h < 25.0)
-            # the 4h is at its ceiling on every measure — stochastic, money flow and williams
-            & ((stochk_14_3_3_4h < 75.0) | (mfi_14_4h < 50.0) | (willr_14_4h < -30.0))
-            # recovering. Floor already washed out (PLAY -1785 at 7.11, ALCH -1159 at 5.19)
-            & (stochk_14_3_3_4h > 12.0)
-            # the 4h is on its own floor — stochastic at the low, money flow drained and williams pinned:
-            # the break has nothing left underneath it
-            & ((stochk_14_3_3_4h > 15.0) | (mfi_14_4h > 25.0) | (willr_14_4h > -95.0))
-            # the 4h stochastic is on its floor and the hour's momentum has already collapsed: the break is
-            # late
-            & ((stochk_14_3_3_4h > 15.0) | (rsi_14_change_pct_1h > -20.0) | (roc_2 < -0.5))
-            # the 4h stochastic is on its floor with no trend strength while the 4h itself ticks up
-            & ((stochk_14_3_3_4h > 15.0) | (adx_14_4h > 15.0) | (roc_2_4h < 0.0))
-            # base stochastic high, 4h RSI rising and the 15m oversold: selling into a
-            # market that has already turned back up
+            # 5m overbought, 15m down move, 4h still not high enough
             & ((stoch_4_4 < 40.0) | (rsi_14_change_pct_4h < 4.0) | (rsi_14_15m > 30.0))
-            # the hourly CCI has exploded, money is entering the base and the 4h stochrsi is near its
-            # ceiling
-            & ((cci_20_change_pct_1h < 350.0) | (cmf_20 < 0.05) | (stochrsi_k_4h < 85.0))
-            # hourly CCI collapsing into a base oscillator that is already low, on a 4h that has
-            # not made a recent low (DOT -26,460; 0W/0L | 0W/1L | 0W/0L)
-            & ((cci_20_change_pct_1h > -475.0) | (stochrsi_k < 40.0) | (aroond_14_4h < 60.0))
-            # no 4h high behind it, 4h CCI still climbing, directional strength weak and the base
-            # RSI already low: selling a market with no down-leg to give
-            & ((cci_20_change_pct_4h < 200.0) | (plus_di_14_4h < 20.0) | (rsi_20 < 35.0))
-            # 4h momentum has not turned over on any reading — CCI still rising, neither the 15m
-            # nor the 4h RSI falling, and the 4h oscillator above mid-band
+            # 4h high & down move & overbought
             & ((cci_20_change_pct_4h < 200.0) | (rsi_14_change_pct_4h > -18.0) | stochrsi_k_4h_lt_60)
-            # 4h CCI collapsing into a washed 4h RSI_3 with the 4h stochastic still elevated:
-            # the down-leg is spent (APR -2,531; 0W/1L | 0W/1L | 0W/1L)
+            # 4h down move & overbought
             & ((cci_20_change_pct_4h > -600.0) | rsi_3_4h_gt_10 | (stochk_14_3_3_4h < 35.0))
-            # the 15m williams is at the absolute floor while 4h money is drained and the 4h has no
-            # direction
-            & ((willr_14_15m > -100.0) | (mfi_14_4h > 20.0) | (plus_di_14_4h > 10.0))
-            # price is on its 40h floor while the 4h stochastic collapses and the 15m barely moved: the
-            # flush already happened
-            & ((willr_480 > -95.0) | (stochrsi_k_change_pct_4h > -90.0) | (rsi_14_change_pct_15m > -30.0))
-            # price sits on its 40h floor, the base stochastic never got high all session, and the 4h shows
-            # a rejection wick above
-            & ((willr_480 > -95.0) | (quad_s93_max_12 > 25.0) | (top_wick_pct_4h < 2.0))
-            # the hourly williams is near its top and the 4h CCI is positive with no coil behind the break
-            & ((willr_84_1h < -40.0) | (cci_20_4h < 20.0) | (sqz_cnt_24 > 0.0))
-            # the 4h stochastic is high and still turning up while the hour is not washed:
-            # selling into a higher timeframe that has not rolled over yet
-            & ((willr_84_1h < -70.0) | stochrsi_k_4h_lt_80 | (stochrsi_k_change_pct_4h > -10.0))
-            # the hourly oscillator is rich while the 4h has no directional strength and no momentum left
+            # 1h high, 4h weak upside & down move
             & ((uo_7_14_28_1h < 55.0) | (plus_di_14_4h > 10.0) | (rsi_3_4h > 10.0))
-            # but the 4h oscillator is not on its floor — the move must not already be finished
-            & (uo_7_14_28_4h > 35.0)
-            # the 4h oscillator is low while the base RSI is high and the hour is on its floor
-            & ((uo_7_14_28_4h > 40.0) | (rsi_14 < 35.0) | (stochrsi_k_1h > 5.0))
-            # the pair has already fallen hard over the day and the 4h, yet the base never printed a low:
-            # the sellers are late
-            & ((roc_288 > -8.0) | (roc_9_4h > -10.0) | (quad_s93_min_12 < 15.0))
-            # both the 4h and the hour are rising into the break, with the 4h stochastic turning up
-            & ((roc_2_4h < 1.0) | (roc_9_1h < 0.0) | (stochrsi_k_change_pct_4h < 15.0))
-            # the 4h has already fallen more than 6%, its RSI is not washed, the hour is pinned
-            # at its low and flat: the drop is finished (4 losses, all in 2022)
+            # 1h at its ceiling, 4h bouncing inside a red candle
             & ((roc_9_4h < -6.0) | (rsi_14_4h > 25.0) | (willr_14_1h < -80.0))
-            # every fast timeframe is pinned at its floor while the 4h is actually rising: the flush is done
-            # and the higher timeframe never joined
-            & ((roc_9_4h < 1.0) | (willr_14_1h > -95.0) | (uo_7_14_28_1h > 35.0))
-            # the 15m candle is barely red, the hour is not accelerating down and the 4h
-            # has no downward strength: a break nobody is following
-            & ((change_pct_15m < -0.75) | (rsi_14_change_pct_1h > -25.0) | (minus_di_14_4h < 35.0))
-            # selling into a 4h that has already dropped hard while the base stochastic is not
-            # washed (APR -4,592; 0W/0L | 1W/3L | 1W/0L)
-            & ((change_pct_4h > -7.0) | (stoch_9_3 < 15.0) | (rsi_3_change_pct_15m < -60.0))
-            # the base is off its floor, the 15m has not capitulated and the 4h shows a
-            # rejection wick: the move down is not the one being sold
-            & ((ph_base_pos > 0.25) | (rsi_3_change_pct_15m > -80.0) | (top_wick_pct_4h > 0.25))
-            # a wide, choppy pre-break hour on a pair that has not really fallen over the day and
-            # whose 15m is already pinned at its floor: the "break" is just another swing inside
-            # the range with no room left under it (SAND -5,934 + others)
-            & ((ph_pre_tight < 5.0) | (roc_9_4h > -3.0) | (willr_14_15m > -95.0))
-            # a long coil has ended with every williams pinned at the floor and the 4h stochastic down there
-            # too
-            & ((sqz_cnt_24 < 15.0) | (willr_14_4h > -95.0) | (stochk_14_3_3_4h > 15.0))
-            # a high already printed on the base timeframe, 4h directional strength positive, the
-            # pair not far down over the day and the daily oscillator elevated: shorting into a
-            # market that is holding up on every reading (4 losses, free in all three years)
-            & ((plus_di_14_4h > 12.0) | (roc_288 > -7.0) | stochrsi_k_1d_lt_60)
-            # the daily low is fresh, 4h directional strength is positive, the hour is falling and
-            # price is far off its 40h low: a live daily down-leg we are late to (4 losses, and it
-            # costs nothing in any of the three years)
-            & ((plus_di_14_4h > 12.0) | (roc_9_1h < 0.0) | (willr_480 > -85.0))
-            # the 4h has no downward direction, its money flow is rich and the hour is rising
-            & ((minus_di_14_4h > 15.0) | (mfi_14_4h < 50.0) | (roc_9_1h < 0.0))
-            # the 4h trend is already strong, 15m money is coming in and the hour is not weak: the move is
-            # running, not breaking
-            & ((adx_14_4h < 45.0) | (cmf_20_15m < 0.05) | (uo_7_14_28_1h < 50.0))
-            # the 4h shows no rejection wick at all, the base stochastic is mid-range and 4h momentum is
-            # dead
+            # 5m overbought, 4h no upper wick & down move
             & ((top_wick_pct_4h > 0.25) | (stoch_4_4 < 35.0) | (rsi_3_4h > 10.0))
-            # a heavy volume flush while hourly money still comes in and the 4h has no trend behind it
+            # 4h money in & down move & off its floor
+            & ((cmf_20_4h < 0.1) | rsi_14_4h_gt_30 | (willr_14_4h < -80))
+            # 5m overbought, 4h money in & oversold
+            & ((cmf_20_4h < 0.15) | (quad_s93_max_12 < 95.0) | (stochk_14_3_3_4h > 15.0))
+            # 15m new high & flow drained, 4h money out
+            & (aroonu_14_15m_lt_70 | (mfi_14_15m > 35.0) | (cmf_20_4h > -0.2))
+            # 15m down move, 1h & 4h new high
+            & (aroonu_14_4h_lt_40 | aroonu_14_1h_lt_70 | (rsi_14_change_pct_15m > -10.0))
+            # 1h at its ceiling, 4h new low & overbought
+            & (aroond_14_4h_lt_80 | stochrsi_k_4h_lt_40 | (willr_14_1h < -85.0))
+            # 1h new high & high, 4h new low
+            & (aroond_14_4h_lt_80 | aroonu_14_1h_lt_40 | (uo_7_14_28_1h < 50.0))
+            # 5m down move, 4h new high & high
+            & (aroonu_14_4h_lt_30 | (roc_288 > -7.0) | (cci_20_4h < -125.0))
+            # 5m still not high enough, 4h new low
+            & ((aroond_14_4h < 100.0) | (rsi_3 < 15.0))
+            # 15m & 4h new low, 1h flow rich
+            & ((aroond_14_4h < 100.0) | (aroond_14_15m < 100.0) | (mfi_14_1h < 40.0))
+            # 1h overbought, 4h still not high enough & no new low
+            & ((stochrsi_k_change_pct_4h < 10.0) | (aroond_14_4h > 20.0) | stochrsi_k_1h_lt_30)
+            # 5m overbought, 1h down move, 4h new low
+            & ((cci_20_change_pct_1h > -475.0) | (stochrsi_k < 40.0) | (aroond_14_4h < 60.0))
+            # 15m up move, 1h at its floor, 4h overbought
+            & ((roc_9_15m < -1.0) | (willr_14_1h > -90.0) | stochrsi_k_4h_lt_90)
+            # 5m money in & volume coming in, 4h overbought
+            & ((cmf_20 < 0.05) | (obv_change_pct < 5.0) | (stochk_14_3_3_4h < 65.0))
+            # 5m money out, 4h oversold
+            & ((cmf_20 > -0.3) | (stochrsi_k_4h > 5.0) | (uo_7_14_28_4h > 40.0))
+            # 15m falling, 1h money out, 4h oversold
+            & ((cmf_20_1h > -0.25) | (rsi_3_change_pct_15m > -70.0) | (stochrsi_k_change_pct_4h > -40.0))
+            # 15m flow drained & down move, 4h still not high enough
+            & ((mfi_14_15m > 10.0) | (rsi_14_change_pct_15m > -15.0) | (stochrsi_k_change_pct_4h < 10.0))
+            # 5m up move, 1h down move, 4h overbought
+            & ((stochrsi_k_4h < 80.0) | (cci_20_change_pct_1h > -400.0) | (roc_2 < -0.5))
+            # 1h money in, 4h overbought & weak upside
+            & ((stochrsi_k_4h < 85.0) | (cmf_20_1h < 0.05) | (plus_di_14_4h > 10.0))
+            # 15m money in & still not high enough, 4h oversold
+            & ((stochrsi_k_4h > 5.0) | (cmf_20_15m < 0.05) | (uo_7_14_28_change_pct_15m < 0.0))
+            # 4h still not high enough
+            & (stochrsi_k_change_pct_4h < 25.0)
+            # 4h overbought & flow rich & at its ceiling
+            & ((stochk_14_3_3_4h < 75.0) | (mfi_14_4h < 50.0) | (willr_14_4h < -30.0))
+            # 4h oversold
+            & (stochk_14_3_3_4h > 12.0)
+            # 4h oversold & flow drained & at its floor
+            & ((stochk_14_3_3_4h > 15.0) | (mfi_14_4h > 25.0) | (willr_14_4h > -95.0))
+            # 5m up move, 1h down move, 4h oversold
+            & ((stochk_14_3_3_4h > 15.0) | (rsi_14_change_pct_1h > -20.0) | (roc_2 < -0.5))
+            # 4h oversold & no trend & up move
+            & ((stochk_14_3_3_4h > 15.0) | (adx_14_4h > 15.0) | (roc_2_4h < 0.0))
+            # 5m money in, 1h high, 4h overbought
+            & ((cci_20_change_pct_1h < 350.0) | (cmf_20 < 0.05) | (stochrsi_k_4h < 85.0))
+            # 5m at its floor, 15m down move, 4h still not low enough
+            & ((willr_480 > -95.0) | (stochrsi_k_change_pct_4h > -90.0) | (rsi_14_change_pct_15m > -30.0))
+            # 1h at its ceiling, 4h overbought & oversold
+            & ((willr_84_1h < -70.0) | stochrsi_k_4h_lt_80 | (stochrsi_k_change_pct_4h > -10.0))
+            # 1h up move, 4h up move & still not high enough
+            & ((roc_2_4h < 1.0) | (roc_9_1h < 0.0) | (stochrsi_k_change_pct_4h < 15.0))
+            # 5m long coil, 4h at its floor & oversold
+            & ((sqz_cnt_24 < 15.0) | (willr_14_4h > -95.0) | (stochk_14_3_3_4h > 15.0))
+            # 15m down move, 1h oversold, 4h overbought
+            & ((cci_20_15m > -250) | (stochk_14_3_3_1h > 25) | stochrsi_k_4h_lt_70)
+            # 5m no new high, 1h flow drained, 4h down move
+            & ((mfi_14_1h > 10.0) | (roc_9_4h > -4.0) | (aroonu_14 > 30.0))
+            # 5m down move & still not high enough, 4h down move
+            & ((roc_288 > -8.0) | (roc_9_4h > -10.0) | (quad_s93_min_12 < 15.0))
+            # 1h at its floor & oversold, 4h up move
+            & ((roc_9_4h < 1.0) | (willr_14_1h > -95.0) | (uo_7_14_28_1h > 35.0))
+            # 5m tight pre-break, 15m at its floor, 4h down move
+            & ((ph_pre_tight < 5.0) | (roc_9_4h > -3.0) | (willr_14_15m > -95.0))
+            # 15m money in, 1h high, 4h trending
+            & ((adx_14_4h < 45.0) | (cmf_20_15m < 0.05) | (uo_7_14_28_1h < 50.0))
+            # 5m volume spike, 1h money in, 4h no trend
             & ((vol_rel < 6.0) | (cmf_20_1h < 0.10) | (adx_14_4h > 15.0))
+            # 5m short coil, 1h at its ceiling, 4h high
+            & ((willr_84_1h < -40.0) | (cci_20_4h < 20.0) | (sqz_cnt_24 > 0.0))
+            # 5m high, 4h high & still not high enough
+            & ((cci_20_change_pct_4h < 200.0) | (plus_di_14_4h < 20.0) | (rsi_20 < 35.0))
+            # 5m high, 1h rising, 4h down move
+            & ((rsi_14 < 30.0) | (rsi_3_change_pct_1h < 250.0) | (change_pct_4h > -1.5))
+            # 5m money in & still not high enough, 4h up move
+            & ((cmf_20 < 0.05) | (change_pct_4h < 0.0) | (stoch_9_3 < 25.0))
+            # 5m still not high enough, 15m rising, 4h down move
+            & ((change_pct_4h > -7.0) | (stoch_9_3 < 15.0) | (rsi_3_change_pct_15m < -60.0))
+            # 15m overbought & high, 4h flow rich
+            & ((mfi_14_4h < 50.0) | (stochk_14_3_3_15m < 50.0) | (cci_20_change_pct_15m < 300.0))
+            # 4h flow rich
+            & (mfi_14_4h < 55.0)
+            # 5m still not high enough, 1h at its floor, 4h flow drained
+            & ((mfi_14_4h > 20.0) | (quad_s93_min_12 < 10.0) | (willr_84_1h > -95.0))
+            # 15m at its floor, 4h flow drained & weak upside
+            & ((willr_14_15m > -100.0) | (mfi_14_4h > 20.0) | (plus_di_14_4h > 10.0))
+            # 1h up move, 4h weak downside & flow rich
+            & ((minus_di_14_4h > 15.0) | (mfi_14_4h < 50.0) | (roc_9_1h < 0.0))
+            # 4h flow rich & weak downside & no upper wick
+            & ((mfi_14_4h < 50) | (minus_di_14_4h > 15) | (top_wick_pct_4h > 0.25))
+            # 15m up move, 1h down move, 4h strong downside
+            & ((change_pct_15m < -0.75) | (rsi_14_change_pct_1h > -25.0) | (minus_di_14_4h < 35.0))
+            # 5m at its floor, 1h up move, 4h weak upside
+            & ((plus_di_14_4h > 12.0) | (roc_9_1h < 0.0) | (willr_480 > -85.0))
+            # 4h new high
+            & aroonu_14_4h_lt_50
+            # 5m at its floor & off its high, 4h long upper wick
+            & ((willr_480 > -95.0) | (quad_s93_max_12 > 25.0) | (top_wick_pct_4h < 2.0))
+            # 5m flat base, 15m falling, 4h no upper wick
+            & ((ph_base_pos > 0.25) | (rsi_3_change_pct_15m > -80.0) | (top_wick_pct_4h > 0.25))
+            # 5m high & down move, 4h high
+            & ((rsi_20 < 30.0) | (roc_288 > -5.0) | (uo_7_14_28_4h < 55.0))
+            # 4h oversold
+            & (uo_7_14_28_4h > 35.0)
+            # 5m high, 1h & 4h oversold
+            & ((uo_7_14_28_4h > 40.0) | (rsi_14 < 35.0) | (stochrsi_k_1h > 5.0))
             # --- 1d: the day must not be strong underneath the break
-            # same hourly bounce, this time with no 4h rejection wick under a day that is
-            # holding up: nothing is confirming the break
-            & ((rsi_3_change_pct_1h < 250.0) | (top_wick_pct_4h > 0.25) | (change_pct_1d > -2.0))
-            # the hour is accelerating upward, the 4h has no trend and the daily stochastic is high
-            & ((rsi_3_change_pct_1h < 300.0) | (adx_14_4h > 15.0) | (stochk_14_3_3_1d < 80.0))
-            # 15m money flow already negative, the day flat and the 15m RSI_3 collapsing on a
-            # day that has not fallen: a spike being sold into a stable market (3 losses)
-            & ((cmf_20_15m > -0.2) | (roc_2_1d < 2.0) | (change_pct_1d > -2.0))
-            # 15m money flow is not draining, the hour is not oversold and the day has not
-            # fallen: selling a break into a market that is still intact
-            & ((cmf_20_15m > -0.35) | (rsi_14_1h > 25.0) | (roc_9_1d > -10.0))
-            # a bounce day on weak daily money flow with the 4h momentum not confirming — unless
-            # the hour itself is genuinely falling right now. The fifth clause is what makes this
-            # free: with four it cut $16,530 of 2026 winners, with five it blocks 8 losses across
-            # the three years and not one protected winner (blocked group averages -24% / -18% /
-            # -34% against positive populations)
+            # 5m bearish engulfing, 1d new high & high
+            & ((engulf_bear < 0.5) | aroonu_14_1d_lt_70 | rsi_14_1d_lt_60)
+            # 1d bouncing inside a red candle & money out
             & ((cmf_20_1d > -0.05) | (roc_9_1d < 5.0) | rsi_14_1d_gt_50)
-            # hourly money is still flowing in, 4h money flow is rich and the day is up: a capitulation
-            # candle, not a breakdown
-            & ((cmf_20_1h < 0.10) | (mfi_14_4h < 50.0) | (roc_2_1d < 1.0))
-            # 4h money flow negative with the base money flow at zero, a squeeze behind it and a
-            # daily candle with no upper wick: the down-move is spent (3 losses, free everywhere)
-            & ((mfi_14 > 5.0) | (sqz_cnt_24 > 4.0) | (top_wick_pct_1d < 1.5))
-            # daily money flow washed out on a pair that has actually fallen over the day, while
-            # the 15m has still printed a recent high = capitulation, and shorting there is
-            # shorting into the bounce
-            & ((mfi_14_1d > 20.0) | (roc_288 > -4.5) | (aroonu_14_15m < 5.0))
-            # daily money flow washed on a 4h that has already dropped, with the hourly RSI
-            # turning back up (OP -1,943; 2W/2L | 0W/2L | 0W/0L)
-            & ((mfi_14_1d > 20.0) | (change_pct_4h > -2.5) | (rsi_14_change_pct_1h < -15.0))
-            # 4h money is plentiful, the 15m momentum has just exploded and the daily stochrsi is at its
-            # ceiling
-            & ((mfi_14_4h < 50.0) | (rsi_3_change_pct_15m < 150.0) | (stochrsi_k_1d < 90.0))
-            # the daily has fallen and its 2-period ROC is bouncing while 4h money flow holds up
-            # (BTC 2021 -873,230; 1W/0L | 1W/0L | 1W/2L)
-            & ((mfi_14_4h > 15.0) | (change_pct_1d < -2.0) | (roc_2_1d > -4.0))
-            # no high anywhere on the base or 15m, the day is falling and not overbought: the
-            # market is already down and there is nothing left to break (5 losses)
+            # 5m no new high, 1d down move & high
             & ((aroonu_14 > 0.0) | (roc_9_1d > 0.0) | (rsi_14_1d < 55.0))
-            # the day is at a fresh high and has already run: no exhaustion to sell
-            & (aroonu_14_1d_lt_100 | (change_pct_1d < 6.0))
-            # the daily low is not fresh, the daily 5m proxy is snapping up, a long squeeze sits
-            # behind it and the 4h candle has no upper wick: a coiled market about to expand up
+            # 4h long upper wick, 1d no new low & rising
             & ((aroond_14_1d > 25.0) | (rsi_3_change_pct_1d < 50.0) | (top_wick_pct_4h < 0.25))
-            # the hour is already at its floor and the 4h is green under a day that has not
-            # fallen: nothing below to sell into
-            & (stochrsi_k_1h_lt_30 | (change_pct_4h < 0.0) | (roc_9_1d > -20.0))
-            # the hourly oscillator is high, the hour has barely fallen and the daily
-            # stochastic is mid-range: no exhaustion anywhere to sell into
-            & (stochrsi_k_1h_lt_60 | (change_pct_1h > -1.5) | (stochk_14_3_3_1d < 60.0))
-            # the 4h stochastic has collapsed to zero under a long 4h upper wick while the day is up: the
-            # rejection already happened
-            & ((stochrsi_k_4h > 5.0) | (top_wick_pct_4h < 2.0) | (roc_2_1d < 5.0))
-            # the base stochastic is still high, the 4h momentum has not collapsed and the
-            # day is far from its own low: selling into a market with room above
-            & ((stoch_4_4 < 40.0) | (rsi_3_change_pct_4h > -40.0) | (willr_14_1d < -50.0))
-            # the 15m CCI is on its floor while the 4h CCI explodes upward and the day shows no lower wick
-            & ((cci_20_15m > -250.0) | (cci_20_change_pct_4h < 400.0) | (bot_wick_pct_1d > 1.0))
-            # hourly CCI collapsing while volume comes back in and the daily sits high in its own
-            # range: squeeze fuel on a strong day (6 losses across all three years)
-            & ((cci_20_1h > -200.0) | (obv_change_pct > 0.0) | (willr_14_1d > -60.0))
-            # the 15m CCI has not really turned down, the 4h oscillator is rich and the day
-            # has barely moved: nothing has broken yet
+            # 15m & 4h high, 1d falling
             & ((cci_20_change_pct_15m < 175.0) | (uo_7_14_28_4h < 55.0) | (rsi_3_change_pct_1d > -25.0))
-            # 15m CCI already turning up while the hourly is still falling, hourly RSI low and
-            # the day barely down: a bounce forming under a tired hour (5 losses)
-            & ((cci_20_change_pct_1h < 50.0) | (rsi_14_1h < 45.0) | (change_pct_1d > -2.0))
-            # hourly CCI snapping up, daily money flow rich, the 15m oscillator above mid-band
-            # and price at the 15m floor: buyers already stepped in (5 losses)
-            & ((cci_20_change_pct_1h < 75.0) | (mfi_14_1d < 60.0) | (willr_14_15m < -75.0))
-            # hourly CCI already recovering, the daily RSI_3 snapping up and price nowhere near
-            # its 40h low: the hour has turned and there is room above, not below (3 losses)
+            # 5m at its floor, 1h down move, 1d rising
             & ((cci_20_change_pct_1h > -25.0) | (rsi_3_change_pct_1d < 75.0) | (willr_480 > -90.0))
-            # a bounce day on weak daily money flow, 4h CCI already falling, and the 5m fully
-            # spent: nothing left to sell (7 losses in 2026|2022|2021, 1 protected winner)
-            & ((cci_20_change_pct_4h > 0.0) | (mfi_14_1d > 40.0) | (roc_9_1d < 5.0))
-            # the 4h oscillator is not elevated and daily momentum is already dead: nothing
-            # left underneath to sell into
+            # 4h high, 1d down move
             & ((uo_7_14_28_4h < 60.0) | (rsi_3_1d > 10.0))
-            # the 4h oscillator is at its low while the 15m CCI explodes upward under a long daily upper
-            # wick
-            & ((uo_7_14_28_4h > 40.0) | (cci_20_change_pct_15m < 250.0) | (top_wick_pct_1d < 4.0))
-            # the 4h oscillator is on its floor under a long daily lower wick with base money already gone
-            & ((uo_7_14_28_4h > 40.0) | (bot_wick_pct_1d < 5.0) | (cmf_20 > -0.3))
-            # the 15m oscillator is turning up under a strong day while the hour is pinned at its low
+            # 15m still not high enough, 1h at its floor, 1d high
             & ((uo_7_14_28_change_pct_15m < 5.0) | (rsi_14_1d < 55.0) | (willr_14_1h > -95.0))
-            # daily still rising, no long squeeze behind it, 4h money flow not negative
-            # (AVAX 2021 -846,246; 0W/0L | 1W/2L | 0W/0L)
-            & ((roc_2_1d < 8.0) | (sqz_cnt_24 < 10.0) | (cmf_20_4h > -0.05))
-            # the day has not really fallen while both the 5m and the hourly RSI_3 are washed and
-            # the 4h sits at its low: everything is oversold except the day (5 losses)
-            & ((roc_2_1d > -10.0) | (rsi_3 < 10.0) | (willr_14_4h < -80.0))
-            # the day has already fallen hard and printed a long upper wick, with the 4h stochastic on its
-            # floor
-            & ((roc_2_1d > -10.0) | (top_wick_pct_1d < 5.0) | (stochk_14_3_3_4h > 15.0))
-            # the base has not really dropped and neither the day nor the base oscillator is
-            # weak: a break with the whole structure still intact
+            # 5m & 1d down move
             & ((roc_9 > -3.0) | (rsi_20 > 20.0) | (rsi_14_1d > 35.0))
-            # 15m has not really dropped, the hour is not accelerating down and the day shows
-            # a long upper wick: the sellers already showed up and left
-            & ((roc_9_15m > -3.5) | (mfi_14_1h < 45.0) | (top_wick_pct_1d < 3.0))
-            # the day is up hard with 15m money flow drained: shorting into a squeeze
-            & ((roc_9_1d < 80.0) | (mfi_14_15m > 20.0))
-            # the day has collapsed yet 4h money flow and the base RSI are both high: the drop is already
-            # paid for
-            & ((roc_9_1d > -25.0) | (mfi_14_4h < 50.0) | (rsi_14 < 30.0))
-            # daily down hard, 4h pinned at its low, price above the 24h base: the low is in
-            # (AVAX -20,591; 0W/0L | 1W/1L | 0W/2L)
-            & ((roc_9_1d > -30.0) | (willr_14_4h > -90.0) | (ph_base_pos > 0.5))
-            # the hour is not falling, its RSI is mid-range, the daily candle has a long lower
-            # wick and the 4h is flat: a market being bought on every dip (5 losses)
-            & ((roc_9_1h < -1.0) | (bot_wick_pct_1d < 4.0) | (change_pct_4h > -1.5))
-            # the 4h has already fallen hard, the day shows no lower wick and the base RSIs are mid-range
-            & ((roc_9_4h > -8.0) | (bot_wick_pct_1d > 0.3) | (rsi_20 < 35.0))
-            # the day is deep in the red, the daily RSI is washed and the 15m candle is enormous: the drop
-            # is over
+            # 15m & 1d down move
             & ((change_pct_15m > -2.0) | (rsi_14_1d > 30.0) | (roc_9_1d > -20.0))
-            # the 4h is not stretched down, the base was never tight and the day printed a
-            # long lower wick: the flush was already bought once
-            & ((ph_pre_tight < 4.5) | (cci_20_4h < -25.0) | (bot_wick_pct_1d > 2.5))
-            # volume has drained on the 15m while the 4h CCI explodes upward under a day taking money in
-            & ((obv_change_pct_15m > -20.0) | (cci_20_change_pct_4h < 300.0) | (cmf_20_1d < 0.15))
-            # volatility has already expanded, the day is strong and the 4h is weak: the
-            # move being sold is the one that already happened
+            # 5m bands wide, 4h down move, 1d high
             & ((bbt_40_2_0 < 15.0) | (rsi_14_4h > 35.0) | (rsi_14_1d < 60.0))
-            # volatility has already expanded, OBV is draining and the day is up: the move is behind us
-            & ((bbt_40_2_0 < 400.0) | (obv_change_pct > 0.0) | (roc_2_1d < 4.0))
-            # a trending 4h under a daily that is neither weak nor washed, out of a long squeeze:
-            # shorting strength (6 losses in 2026 and 2022)
+            # 4h no trend, 1d down move & oversold
             & ((adx_14_4h > 15.0) | rsi_14_1d_gt_40 | (stochk_14_3_3_1d > 20.0))
-            # a long upper wick on a day still taking money in, with the hour turning up underneath it
-            & ((top_wick_pct_1d < 5.0) | (roc_2_1h < 0.0) | (mfi_14_1d < 65.0))
-            # the day printed a long lower wick — buyers already stepped in — while the hour sits on its
-            # floor with no money left
-            & ((bot_wick_pct_1d < 5.0) | (willr_84_1h > -95.0) | (mfi_14_1h > 15.0))
-            # no lower wick on the day, the 4h oscillator is low and the 15m CCI is on its floor
-            & ((bot_wick_pct_1d > 0.25) | (uo_7_14_28_4h > 40.0) | (cci_20_15m > -250.0))
-            # a volume explosion while the daily stochastic is high and 15m money is flowing in: a spike
-            # inside strength
+            # 15m volume leaving, 4h high, 1d money in
+            & ((obv_change_pct_15m > -20.0) | (cci_20_change_pct_4h < 300.0) | (cmf_20_1d < 0.15))
+            # 1h at its floor, 1d long lower wick & money out
+            & ((bot_wick_pct_1d < 4.5) | (willr_84_1h > -95.0) | cmf_20_1d_gt_neg_0_10)
+            # 4h oversold, 1d new high
+            & (stochrsi_k_4h_gt_10 | aroonu_14_1d_lt_85)
+            # 1d new high & up move
+            & (aroonu_14_1d_lt_100 | (change_pct_1d < 6.0))
+            # 4h oscillator mid-range, no new daily low in two weeks, hourly money coming in
+            & (cmf_20_1h_lt_0_10 | (uo_7_14_28_4h < 60) | (aroond_14_1d > 35))
+            # 5m down move, 4h weak upside, 1d overbought
+            & ((plus_di_14_4h > 12.0) | (roc_288 > -7.0) | stochrsi_k_1d_lt_60)
+            # 1h rising, 4h no trend, 1d overbought
+            & ((rsi_3_change_pct_1h < 300.0) | (adx_14_4h > 15.0) | (stochk_14_3_3_1d < 80.0))
+            # 15m rising, 4h flow rich, 1d overbought
+            & ((mfi_14_4h < 50.0) | (rsi_3_change_pct_15m < 150.0) | (stochrsi_k_1d < 90.0))
+            # 1h overbought & down move, 1d overbought
+            & (stochrsi_k_1h_lt_60 | (change_pct_1h > -1.5) | (stochk_14_3_3_1d < 60.0))
+            # 5m volume spike, 15m money in, 1d overbought
             & ((vol_rel < 10.0) | (stochk_14_3_3_1d < 70.0) | (cmf_20_15m < 0.15))
-            # an enormous volume spike under a long daily lower wick while the 4h is rising: the
-            # capitulation candle is already being bought
+            # 15m money out, 1d bouncing inside a red candle
+            & ((cmf_20_15m > -0.2) | (roc_2_1d < 2.0) | (change_pct_1d > -2.0))
+            # 15m money out, 1h & 1d down move
+            & ((cmf_20_15m > -0.35) | (rsi_14_1h > 25.0) | (roc_9_1d > -10.0))
+            # 1h money in, 4h flow rich, 1d up move
+            & ((cmf_20_1h < 0.10) | (mfi_14_4h < 50.0) | (roc_2_1d < 1.0))
+            # 4h flow drained, 1d bouncing inside a red candle
+            & ((mfi_14_4h > 15.0) | (change_pct_1d < -2.0) | (roc_2_1d > -4.0))
+            # 1h overbought, 4h up move, 1d down move
+            & (stochrsi_k_1h_lt_30 | (change_pct_4h < 0.0) | (roc_9_1d > -20.0))
+            # 4h oversold & long upper wick, 1d up move
+            & ((stochrsi_k_4h > 5.0) | (top_wick_pct_4h < 2.0) | (roc_2_1d < 5.0))
+            # 4h down move, 1d flow drained & up move
+            & ((cci_20_change_pct_4h > 0.0) | (mfi_14_1d > 40.0) | (roc_9_1d < 5.0))
+            # 5m long coil, 4h money out, 1d up move
+            & ((roc_2_1d < 8.0) | (sqz_cnt_24 < 10.0) | (cmf_20_4h > -0.05))
+            # 5m still not high enough, 4h at its ceiling, 1d down move
+            & ((roc_2_1d > -10.0) | (rsi_3 < 10.0) | (willr_14_4h < -80.0))
+            # 4h oversold, 1d down move & long upper wick
+            & ((roc_2_1d > -10.0) | (top_wick_pct_1d < 5.0) | (stochk_14_3_3_4h > 15.0))
+            # 15m flow drained, 1d up move
+            & ((roc_9_1d < 80.0) | (mfi_14_15m > 20.0))
+            # 5m high, 4h flow rich, 1d down move
+            & ((roc_9_1d > -25.0) | (mfi_14_4h < 50.0) | (rsi_14 < 30.0))
+            # 5m flat base, 4h at its floor, 1d down move
+            & ((roc_9_1d > -30.0) | (willr_14_4h > -90.0) | (ph_base_pos > 0.5))
+            # 5m bands wide & volume leaving, 1d up move
+            & ((bbt_40_2_0 < 400.0) | (obv_change_pct > 0.0) | (roc_2_1d < 4.0))
+            # 15m down move, 4h high, 1d no lower wick
+            & ((cci_20_15m > -250.0) | (cci_20_change_pct_4h < 400.0) | (bot_wick_pct_1d > 1.0))
+            # 5m money out, 4h oversold, 1d long lower wick
+            & ((uo_7_14_28_4h > 40.0) | (bot_wick_pct_1d < 5.0) | (cmf_20 > -0.3))
+            # 1h up move, 4h down move, 1d long lower wick
+            & ((roc_9_1h < -1.0) | (bot_wick_pct_1d < 4.0) | (change_pct_4h > -1.5))
+            # 5m high, 4h down move, 1d no lower wick
+            & ((roc_9_4h > -8.0) | (bot_wick_pct_1d > 0.3) | (rsi_20 < 35.0))
+            # 5m tight pre-break, 4h high, 1d no lower wick
+            & ((ph_pre_tight < 4.5) | (cci_20_4h < -25.0) | (bot_wick_pct_1d > 2.5))
+            # 1h at its floor & flow drained, 1d long lower wick
+            & ((bot_wick_pct_1d < 5.0) | (willr_84_1h > -95.0) | (mfi_14_1h > 15.0))
+            # 15m down move, 4h oversold, 1d no lower wick
+            & ((bot_wick_pct_1d > 0.25) | (uo_7_14_28_4h > 40.0) | (cci_20_15m > -250.0))
+            # 5m volume spike, 4h up move, 1d long lower wick
             & ((vol_rel < 25.0) | (bot_wick_pct_1d < 5.0) | (roc_9_4h < 1.0))
+            # 1h rising, 4h no upper wick, 1d down move
+            & ((rsi_3_change_pct_1h < 250.0) | (top_wick_pct_4h > 0.25) | (change_pct_1d > -2.0))
+            # 1h high, 1d down move
+            & ((cci_20_change_pct_1h < 50.0) | (rsi_14_1h < 45.0) | (change_pct_1d > -2.0))
+            # 5m down move, 15m still not high enough, 1d flow drained
+            & ((mfi_14_1d > 20.0) | (roc_288 > -4.5) | (aroonu_14_15m < 5.0))
+            # 1h still not high enough, 4h down move, 1d flow drained
+            & ((mfi_14_1d > 20.0) | (change_pct_4h > -2.5) | (rsi_14_change_pct_1h < -15.0))
+            # 15m at its ceiling, 1h high, 1d flow rich
+            & ((cci_20_change_pct_1h < 75.0) | (mfi_14_1d < 60.0) | (willr_14_15m < -75.0))
+            # 1h up move, 1d long upper wick & flow rich
+            & ((top_wick_pct_1d < 5.0) | (roc_2_1h < 0.0) | (mfi_14_1d < 65.0))
+            # 5m flow drained & short coil, 1d long upper wick
+            & ((mfi_14 > 5.0) | (sqz_cnt_24 > 4.0) | (top_wick_pct_1d < 1.5))
+            # 15m high, 4h oversold, 1d long upper wick
+            & ((uo_7_14_28_4h > 40.0) | (cci_20_change_pct_15m < 250.0) | (top_wick_pct_1d < 4.0))
+            # 15m down move, 1h flow rich, 1d long upper wick
+            & ((roc_9_15m > -3.5) | (mfi_14_1h < 45.0) | (top_wick_pct_1d < 3.0))
+            # 5m overbought, 4h falling, 1d at its ceiling
+            & ((stoch_4_4 < 40.0) | (rsi_3_change_pct_4h > -40.0) | (willr_14_1d < -50.0))
+            # 5m volume leaving, 1h down move, 1d at its floor
+            & ((cci_20_1h > -200.0) | (obv_change_pct > 0.0) | (willr_14_1d > -60.0))
           )
 
           # Logic


### PR DESCRIPTION
Six new OR chains on the dump hunter (669), written one loss at a time off the chart and gated on
the union of four measured years. The block is regrouped by timeframe and reordered by family in
the same commit; that part is behaviour-neutral — 2022 before and after the reorder is
bit-identical (827 trades, 2,758,206.742, 811W/16L).

**Measured.** Isolated rig: 669 the only experimental tag enabled, `position_adjustment_enable` and
`derisk_enable` off, v4 stops on, `-gms0` configs. One real run per year, tag 669 in brackets.

| year | before | after | | tag 669 |
|---|---|---|---|---|
| 2022 | 827t 16L 2,758,206.742 | 824t 12L **3,453,693.180** | +25.2% | 11L → 6L |
| 2024 | 554t 11L 248,540.882 | 551t 9L **279,304.718** | +12.4% | 5L → 3L |
| 2025 | 541t 13L 238,914 | 538t **274,074.363** | +14.7% | 8L → 6L |
| 2026 | 507t 17L 211,314 | 506t **225,034.148** | +6.5% | 11L → 10L |

Only the 2022 and 2024 chains were written. 2025 and 2026 improved without being touched, which is
the difference between a scene and a coordinate.

**The chains**, each named for what it blocks:

| chain | target | |
|---|---|---|
| `(bot_wick_pct_1d < 4.5) \| (willr_84_1h > -95.0) \| cmf_20_1d_gt_neg_0_10` | INJ 2022-11-22 | -71,507 |
| `(cmf_20_4h < 0.1) \| rsi_14_4h_gt_30 \| (willr_14_4h < -80)` | FIL 2022-10-13 | -36,050 (+DOGE) |
| `(cci_20_15m > -250) \| (stochk_14_3_3_1h > 25) \| stochrsi_k_4h_lt_70` | FIL 2022-07-02 | -13,193 |
| `(mfi_14_4h < 50) \| (minus_di_14_4h > 15) \| (top_wick_pct_4h > 0.25)` | SAND 2022-03-27 | -1,690 |
| `(willr_480 < -75) \| (cci_20_1h > -140) \| cmf_20_1h_lt_0_10` | AAVE 2024-02-23 | -735 |
| `cmf_20_1h_lt_0_10 \| (uo_7_14_28_4h < 60) \| (aroond_14_1d > 35)` | DOGE 2024-02-23 | -914 |

**669 stays disabled.**

**What is left, and why it is not here.** The remaining losses are not reachable from the entry
side, and the measurement says so rather than the fatigue: `depth→WIN d=0.04` against
`depth→EVENT d=1.28` — the signal can tell a move is coming and cannot tell whether this trade wins
it — with winners closing in a median 5.0h against 73.1h for losses. Every chain written for them
either sat on a column's own floor or flipped sign one grid step away. Those belong to the hold
side, not to entry protections.

**Housekeeping in the same commit.** The block is grouped by highest timeframe with family order
RSI → CMF → AROON → STOCH → ROC, every chain carries one line naming the scene it blocks, and the
per-loss bookkeeping that had accumulated in the comments (dollar amounts, W/L tallies, coin names)
is gone — 300 comment lines down to 177, one per chain. No chain carries four clauses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Dq23uSiXuSScTSa84tbtpa