### PR TITLE
X8: signal 171: add CCI and daily Aroon protection

### DIFF
--- a/NostalgiaForInfinityX8.py
+++ b/NostalgiaForInfinityX8.py
@@ -20086,6 +20086,7 @@ class NostalgiaForInfinityX8(IStrategy):
             # participation, not a routine tick up in volume
             & (vol_rel > 4.0)
           )
+          long_entry_logic.append((cci_20_15m > 130) | (aroond_14_1d > 5) | (aroonu_14_1d < 80))
 
           # NOTE: the measured PUMP CHARACTER columns (PH_BASE_POS d=0.95, PH_PRE_TIGHT d=0.65,
           # PH_CROSS_CNT_12 first-fire counter) are defined above and ready for your protection


### PR DESCRIPTION
## Summary

Native is the unmodified **received v18.0.29 with signal 171 enabled**. Modified uses the same strategy and configuration with the CCI/daily Aroon guard added. The results below come from the ten completed matched Freqtrade runs.

**171-tagged trades within the full strategy** — fees/funding included; mixed 171 trades are 0 in both arms.

| Period / tested version | Native net PnL, USDT | Modified net PnL, USDT | Difference, USDT | Native wins / losses | Modified wins / losses |
|---|---:|---:|---:|---:|---:|
| 2021 / received 29 | 84,608.16 | 104,657.02 | +20,048.86 | 173 / 3 | 181 / 3 |
| 2022 / received 29 | 740,068.98 | 1,016,463.03 | +276,394.05 | 231 / 4 | 232 / 2 |
| 2024 / received 29 | 239,319.83 | 239,319.83 | +0.00 | 187 / 4 | 187 / 4 |
| 2025 / received 29 | -142,855.49 | -142,855.49 | +0.00 | 201 / 9 | 201 / 9 |
| 2026 / received 29 | 2,964.92 | 15,967.74 | +13,002.83 | 133 / 13 | 133 / 12 |

**Full portfolio, including capital and slot effects**

| Period | Native net PnL, USDT | Modified net PnL, USDT | Difference, USDT |
|---|---:|---:|---:|
| 2021 | 282,221.43 | 337,833.78 | +55,612.35 |
| 2022 | 2,394,542.06 | 2,876,852.04 | +482,309.98 |
| 2024 | 743,614.46 | 743,614.46 | +0.00 |
| 2025 | 369,620.49 | 369,620.49 | +0.00 |
| 2026 | 35,471.15 | 49,348.71 | +13,877.56 |

**Trade costs** — losing-trade PnL is a subtotal already included in the 171 net PnL above, not another deduction. Exact pp is the sum of exported trade profit ratios times 100, not wallet return.

| Period | 171 trades Native → Modified | 171 losing-trade PnL Native → Modified, USDT | Losing-trade PnL difference, USDT | 171 exact pp Native → Modified | pp difference |
|---|---:|---:|---:|---:|---:|
| 2021 | 176 → 184 | -16,282.03 → -18,210.41 | -1,928.38 | 753.46 → 753.04 | -0.42 |
| 2022 | 235 → 234 | -269,182.78 → -108,382.65 | +160,800.13 | 771.92 → 843.53 | +71.61 |
| 2024 | 191 → 191 | -75,395.03 → -75,395.03 | +0.00 | 522.42 → 522.42 | +0.00 |
| 2025 | 210 → 210 | -660,997.90 → -660,997.90 | +0.00 | 223.30 → 223.30 | +0.00 |
| 2026 | 146 → 145 | -146,669.87 → -137,307.71 | +9,362.16 | 183.72 → 217.59 | +33.87 |

**Whole-portfolio risk** — 5m marked equity, including open realized/unrealized PnL and current funding. Absolute DD is the maximum drop from any prior peak. The six-slot measure counts time when all six positions have negative realized-plus-unrealized trade PnL.

| Period | Equity DD Native → Modified | Difference, pp | Max absolute DD Native → Modified, USDT | Difference, USDT | All-six loss minutes Native → Modified |
|---|---:|---:|---:|---:|---:|
| 2021 | 49.6114% → 49.6114% | +0.0000 | 39,478.57 → 47,256.37 | +7,777.79 | 3360 → 3035 |
| 2022 | 13.4437% → 13.2679% | -0.1758 | 194,861.53 → 151,390.11 | -43,471.42 | 675 → 675 |
| 2024 | 24.1961% → 24.1961% | +0.0000 | 82,677.44 → 82,677.44 | +0.00 | 3250 → 3250 |
| 2025 | 56.2206% → 56.2206% | +0.0000 | 427,093.46 → 427,093.46 | +0.00 | 6870 → 6870 |
| 2026 | 38.9847% → 34.0311% | -4.9536 | 80,126.25 → 71,319.89 | -8,806.36 | 13155 → 13155 |

The guard reduces 171 losses from **33 to 30**: natural losses fall from 27 to 24, while six period-end force losses remain. Both 171 and full-portfolio PnL improve in 2021, 2022 and 2026; 2024 and 2025 are unchanged. There are 958 → 964 signal-171 trades and 925 → 934 winners.

The added condition is:

```python
long_entry_logic.append((cci_20_15m > 130) | (aroond_14_1d > 5) | (aroonu_14_1d < 80))
```

For finite inputs, it blocks otherwise qualifying entries when daily AroonDown is at most 5, daily AroonUp is at least 80, and 15m CCI is at most 130. It removes seven raw signal opportunities in the tested periods, including four Native losing entries and one winning entry. Subsequent trades and sizing changes are included in the measured results above.

The measured costs are:

- **2021:** the omitted FIL loss was −4,397.02 USDT. A new FIL 171 entry on July 6 loses −4,577.36 USDT. Total 171 exact pp falls by 0.415518 pp, and maximum dollar DD increases by 7,777.79 USDT. The ETH 562 winner of 205.63 USDT is also absent.
- **2022:** the BNB 171 winner of 2,496.52 USDT is omitted. A distinct entry 95 minutes later earns 2,390.10 USDT. Shared AXS 171, RUNE 171 and GALA 562 winners earn 1,835.84, 2,357.14 and 98.12 USDT less respectively, with actual leverage capped from 3x to 2x; the caps and callback arguments were checked.
- **2025:** 171 PnL remains −142,855.49 USDT and whole-equity DD remains 56.2206%. This guard does not address those losses.
- No shared winner becomes a loss, closes earlier, or receives a new/earlier de-risk. Omitted winners and lower exact pp on shared winners remain costs. Capital and sizing contribute to the dollar gains.
- The 964 candidate first fills produce 2,892 complete fixed 1/4/24h price windows, checked against raw OHLC. Mean 1h MAE slightly worsens in 2021 and 2022; the filter's benefit is concentrated in specific losses.

## Safety

- Based independently on upstream [`77659887`](https://github.com/iterativv/NostalgiaForInfinity/commit/776598874e618fce6f88bc9665ba4283548cb163), **v18.0.34**. Only the 171 branch of `populate_entry_trend()` changes. Removing this append restores the complete upstream strategy bytes and AST.
- All three variables already exist and are bound before use. Other entry conditions, indicators, tags, risk/exit/PA logic, sizing and configuration defaults are unchanged by the patch. **171 and 68 remain OFF by default.** Entry differences can change actual PA, capital, slots and subsequent trades.
- The Native and modified 171 branch ASTs each match their tested v18.0.29 counterparts. Current v18.0.34 has different controller/v4 logic, de-risk hold defaults and other entry protections; no portfolio-equivalence claim is made between versions.

## Backtest scope

- **Tested version: received v18.0.29. PR base: v18.0.34. The v18.0.34 strategy has not been trade-backtested with this patch.** The tables reuse the five completed Native-171-ON runs and five completed modified-171-ON runs; 68 stays OFF in both arms. The received source uses OR-style de-risk hold enabled and buyback disabled; its settings are preserved within both tested arms.
- Tested source hashes: Native `082f0492078dbd585eab7c1280c6ce1796aa67e1063231d0e1b12416cf8e5549`; modified `76dd42494edecbcee6bc5d18805d6869b83abbb9abe21e72fa880f0ceba8cbad`.
- Timeranges: `20210101-20220101`, `20220101-20230101`, `20240101-20250101`, `20250101-20260101`, `20260101-20260806`. No 2023; 2026 ends on August 6 exclusive. Initial wallet: 100 USDT in 2021, 100,000 USDT otherwise. Annual dollar results are not pooled.
- Freqtrade 2026.8, futures isolated, 5m, six slots, PA/grind ON, fee 0.0005 per side, requested leverage 3x with actual exchange caps verified. Configured universe: 19 pairs. In 2021, 18 load because INJ data is absent; SAND/GALA have partial histories. INJ has partial 2022 history.
- All periods were previously exposed during research. A fixed 329-query search produced six eligible masks; this is the first fixed rank, with 34 candidate scenes reviewed before the actual comparison. The directly affected Native sample is four natural losses and one winner, and adverse threshold neighbors remain. This is research/regression evidence, not an untouched holdout.
- Validation includes all filled orders, fees, funding, leverage/admission, 1,491 → 1,484 actual signal opportunities, 94 continuous feature frames with all 84 columns and missing values compared, closed-HTF timing and strict order prefixes. Engine equity and raw-cash equity are compared separately on matching bases. Exact dynamic average-price rounding was not independently replicated.

## Checks

- `validate_nfi_pr.py --base origin/main --strategy NostalgiaForInfinityX8.py`: PASS on commit `a2854397` — selected-file scope, focused AST bindings, merge simulation, Ruff and Python compilation.
- `pre-commit run --files NostalgiaForInfinityX8.py`: PASS; hooks leave the final source unchanged.
- `git diff --check origin/main...HEAD`: PASS. Final diff: one insertion in `NostalgiaForInfinityX8.py`; working tree clean.
- Manual binding/scope review and one-append byte/AST reversal: PASS. The validator identifies `populate_entry_trend()` as an active runtime change; static validation does not replace market-data backtesting.

The current backtest workflow runs on X8 pushes or manual dispatch, not on `pull_request`. Its status should be read separately from the reported local evidence.
