### PR TITLE
X8: signal 505: two per-loss entry protections

### DIFF
--- a/NostalgiaForInfinityX8.py
+++ b/NostalgiaForInfinityX8.py
@@ -21047,6 +21047,10 @@ class NostalgiaForInfinityX8(IStrategy):
             & (stochrsi_k_1h_lt_20 | rsi_3_1d_gt_20)
             # 1h stoch lifted, 1h weak
             & (stochrsi_k_1h_lt_60 | (rsi_14_1h > 40.0))
+            # base money flow mid-range, base stochastic high, no new hourly high
+            & ((mfi_14 < 65) | (stoch_9_3 > 45) | aroonu_14_1h_gt_10)
+            # base RSI barely moving, price off its 40h floor, the hour at a fresh high
+            & ((rsi_14_change_pct < 15) | (willr_480 > -90) | (aroonu_14_1h < 5))
             # 1h stoch lifted, 1h falling
             & (stochrsi_k_1h_lt_80 | (roc_2_1h > -2.5))
             # 1h strong, 4h RSI_3 collapsing


### PR DESCRIPTION
Two OR chains on the ADX trend-birth short, written one loss at a time and gated on the union of
four measured years. Isolated rig: 505 the only experimental tag enabled, `position_adjustment_enable`
and `derisk_enable` off, v4 stops on, `-gms0` configs; one real run per year.

| year | before | after | |
|---|---|---|---|
| 2022 | 192t 6L +7.072%/trade | 192t 7L +6.734% | |
| 2024 | 124t 13L +2.823% | 124t 13L +2.817% | |
| 2025 | 137t 13L +6.108% | 138t 13L +6.032% | |
| 2026 | 123t **25L** −3.276% | 122t **23L** −2.693% | **+0.58 pts/trade** |

2022's dollar column is compounding-inflated, so the loss count and the per-trade figure are the
readable ones.

The gain is 2026, which is the year that needs it — 505 wins 79.7% there against a break-even of
86.9%. The other three years are neutral: across all four, 13 losses and 10 winners were blocked and
the freed slots refilled with 12 losses and 11 winners, so the net is one loss and one winner.

```
# base money flow mid-range, base stochastic high, no new hourly high
& ((mfi_14 < 65) | (stoch_9_3 > 45) | aroonu_14_1h_gt_10)

# base RSI barely moving, price off its 40h floor, the hour at a fresh high
& ((rsi_14_change_pct < 15) | (willr_480 > -90) | (aroonu_14_1h < 5))
```

**505 stays disabled.**

**What is left is not per-loss work**, and the round measured that rather than guessing it. Nineteen
further chains were built and rejected across ten targets in 2026 and 2024; every one failed on the
same three shapes — a threshold sitting on the target's own reading, a score that flips sign one grid
step away, or twelve to twenty-five winners cut in years the chain was not written for. Three
independent measurements explain why:

* blocking 13 losses returned 12 new ones, so the loss rate regenerates from the same distribution;
* no single clause in the file's own vocabulary separates 2026's losses from its winners — the best
  is four losses against twelve winners;
* the scene these chains name is present in every year and only *loses* in 2026.

That is a regime property, not a set of bad trades, so it belongs to the logic block or the exit
side rather than to entry protections. For reference, the widest single region that helps —
`CCI_20_4h < -160` — takes 2026 from −3.276% to −0.370% per trade and improves the other three
years, at the cost of about 40% of the volume; that is a backbone decision, not a protection, so it
is not in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Dq23uSiXuSScTSa84tbtpa