### PR TITLE
X8: add existing X7 protections to signal 665

### DIFF
--- a/NostalgiaForInfinityX8.py
+++ b/NostalgiaForInfinityX8.py
@@ -23009,6 +23009,124 @@ class NostalgiaForInfinityX8(IStrategy):
         if short_entry_condition_index == 665:
           short_entry_logic.append(num_empty_288 <= allowed_empty_candles_288)
           short_entry_logic.append(protections_short_global == True)
+
+          short_entry_logic.append(
+            # daily money flowing in and 4h not oversold
+            ((cmf_20_1d > 0.05) | rsi_14_4h_lt_40)
+            # 5m money flowing in and 1h money flowing in
+            # 15m volume flow rising, 4h not extended and 5m stochastic high
+            & ((stochrsi_k < 50) | (obv_change_pct_15m < 7) | (cci_20_4h < 105))
+            # 5m stochastic high, 1h rising and daily momentum not falling sharply
+            & ((stoch_4_4 < 45) | (change_pct_1h < 0.5) | (rsi_3_change_pct_1d < -25))
+            # 1h the two-day window off its floor, 5m stochastic high and daily stochastic high
+            & ((stoch_9_3 < 30) | (willr_84_1h < -20) | (stochrsi_k_1d < 85))
+            # the last 24h fell hard and the 4h cycle is turning up
+            & ((roc_288 > -11.0) | (cci_20_change_pct_4h < -10.0))
+            # money leaving on 5m and on 1h
+            & ((mfi_14 < 30) | (mfi_14_1h < 40))
+            # 15m high in its range, 5m money drained and daily a recent low
+            & ((mfi_14 > 10) | (willr_14_15m < -65) | (aroond_14_1d < 10))
+            # 15m falling, 5m money flowing in and 1h a recent low
+            & ((mfi_14 < 50) | (roc_9_15m > -6) | (aroond_14_1h < 95))
+            # 4h oscillator low, 5m money leaving and a recent low
+            & ((cmf_20 > -0.4) | (aroond_14_4h < 90) | (uo_7_14_28_4h > 35))
+            # 5m money leaving sharply, 1h money not drained and 4h oscillator low
+            & ((cmf_20 > -0.4) | (mfi_14_1h < 30) | (uo_7_14_28_4h > 35))
+            # daily momentum snapping up, 5m volume flow falling and 4h oversold
+            & ((obv_change_pct > -0.5) | (rsi_14_4h > 35) | (rsi_3_change_pct_1d < 190))
+            # below-average volume and 1h momentum alive
+            & ((vol_rel > 1.25) | (rsi_3_1h < 20))
+            # daily a long upper wick, 5m a volume spike and no recent low
+            & ((vol_rel < 4.5) | (aroond_14_1d > 5) | (top_wick_pct_1d < 8))
+            # 15m oscillator low, 5m a new high and 1h money drained
+            & ((aroonu_14 < 45) | (uo_7_14_28_15m > 30) | (mfi_14_1h > 40))
+            # 15m money flowing in, 5m a new high and 1h money drained
+            & ((aroonu_14 < 65) | (mfi_14_15m < 55) | (mfi_14_1h > 30))
+            # 5m money flowing in, a new high and daily stochastic at the floor
+            & ((aroonu_14 < 65) | (cmf_20 < 0.1) | (stochrsi_k_1d > 50))
+            # 5m no recent low, daily oversold and 15m stochastic at the floor
+            & ((aroond_14 > 40) | (rsi_14_1d > 35) | stochrsi_k_15m_gt_40)
+            # 5m oversold, no recent low and 4h a trend established
+            & ((aroond_14 > 85) | (rsi_4 > 10) | (adx_14_4h < 25))
+            # 1h momentum rising, 5m fast stochastic high and high in its base
+            & ((ph_base_pos < 1.5) | (stoch_4_4 < 50) | (rsi_14_change_pct_1h < 5))
+            # 4h at an extreme low, 5m a tight pre-break coil and a new high
+            & ((ph_pre_tight < 6) | (aroonu_14_4h < 15) | (cci_20_4h > -225))
+            # pre-break range wide, 15m volume flow rising and 1h momentum exhausted
+            & ((ph_pre_tight < 5) | (obv_change_pct_15m < 8) | (rsi_3_1h > 10))
+            # 5m not oversold, the coil's roof low and 1h stochastic at the floor
+            & ((quad_s93_max_12 > 30) | (rsi_4 < 25) | (stochrsi_k_1h > 20))
+            # 5m not oversold, the coil's roof low and 4h a recent low
+            & ((quad_s93_max_12 > 30) | (rsi_4 < 30) | (aroond_14_4h < 55))
+            # 15m momentum falling, daily momentum snapping up and 1h a recent low
+            & ((rsi_14_change_pct_15m > -25) | (aroond_14_1h < 55) | (rsi_3_change_pct_1d < 190))
+            # 15m stochastic high, 4h high in its range and no recent low
+            & ((stochrsi_k_15m < 75) | (aroond_14_4h > 5) | (willr_14_4h < -50))
+            # 15m stochastic high, oscillator falling and daily not oversold
+            & ((stochrsi_k_15m < 75) | (uo_7_14_28_change_pct_15m > -15) | (rsi_14_1d < 45))
+            # 15m at the floor of its range, stochastic high and daily money flowing in
+            & ((stochrsi_k_15m < 55) | (willr_14_15m > -95) | (mfi_14_1d < 70))
+            # 15m at an extreme low, 1h not extended and daily no recent low
+            & ((cci_20_15m > -275) | (cci_20_1h < 20) | (aroond_14_1d > 30))
+            # 15m money flowing in, 4h downtrend weak and oscillator lifting
+            & (cmf_20_15m_lt_0_10 | (minus_di_14_4h > 25) | (uo_7_14_28_change_pct_15m < 5))
+            # 15m money leaving, a new high and 1h no recent low
+            & ((aroonu_14_15m < 65) | (cmf_20_15m > -0.3) | (aroond_14_1h > 30))
+            # 15m oversold, a new high and daily a recent low
+            & ((aroonu_14_15m < 65) | (rsi_14_15m > 20) | (aroond_14_1d < 10))
+            # 4h no trend established, not falling and 15m a new high
+            & ((aroonu_14_15m < 25) | (adx_14_4h > 20) | (roc_9_4h < 6))
+            # 1h high in its range, stochastic at the floor and daily a recent low
+            & ((stochrsi_k_1h > 20) | (willr_14_1h < -45) | (aroond_14_1d < 45))
+            # 1h stochastic at the floor, 4h momentum snapping up and daily not falling
+            & ((stochrsi_k_1h > 20) | (rsi_3_change_pct_4h < 115) | (roc_9_1d < -10))
+            # 1h at an extreme low and daily a long lower wick
+            & ((cci_20_1h > -175.0) | (bot_wick_pct_1d < 3))
+            # 1h not extended, 4h momentum dead and daily not falling
+            & ((cci_20_1h < -5) | rsi_3_4h_gt_30 | (roc_2_1d < -2.0))
+            # 1h cycle low but high in its two-day range, with a 4h trend established
+            & ((cci_20_1h > -175) | (willr_84_1h < -20) | (adx_14_4h < 20))
+            # 1h money drained, cycle falling and daily no new high
+            & ((cci_20_change_pct_1h > -240) | (mfi_14_1h > 30) | (aroonu_14_1d > 40))
+            # 1h cycle collapsing and money drained, with a 4h trend established
+            & ((cci_20_change_pct_1h > -240) | (mfi_14_1h > 25) | (adx_14_4h < 20))
+            # 1h money drained, stochastic high and daily no new high
+            & ((mfi_14_1h > 25) | (stochrsi_k_1h < 80) | (aroonu_14_1d > 5))
+            # 1h a new high, at an extreme low and daily a new high
+            & ((aroonu_14_1h < 80) | (cci_20_1h > -300) | (aroonu_14_1d < 5))
+            # 1h a recent low, falling and stochastic high
+            & ((aroond_14_1h < 80) | (roc_9_1h > -7) | stochrsi_k_1h_lt_30)
+            # 1h no recent low, 4h money drained and daily no recent low
+            & ((aroond_14_1h > 20) | (mfi_14_4h > 25) | (aroond_14_1d > 5))
+            # the two-day window off its floor and tightly squeezed
+            & ((willr_84_1h < -75) | (sqz_cnt_24 < 10))
+            # 4h momentum alive and stochastic turning up
+            & ((rsi_3_4h < 65) | (stochrsi_k_change_pct_4h < 5))
+            # 4h momentum falling and daily no upper wick
+            & ((rsi_14_change_pct_4h > -15.0) | (top_wick_pct_1d > 1.5))
+            # 4h momentum rising, a long upper wick and daily money leaving
+            & ((rsi_14_change_pct_4h < 10) | (top_wick_pct_4h < 2.5) | (cmf_20_1d > 0.05))
+            # 4h falling, daily momentum alive and a recent low
+            & ((roc_9_4h > -10) | (aroond_14_1d < 10) | (rsi_3_1d < 85))
+            # 4h money flowing in and high in its range
+            & ((mfi_14_4h < 55) | (willr_14_4h > -40))
+            # 4h money leaving and 1h at the floor of its range
+            & ((cmf_20_4h > -0.05) | (willr_14_1h < -75))
+            # 4h oscillator low, daily stochastic high and money flowing in
+            & ((cmf_20_4h < -0.05) | (uo_7_14_28_4h > 35) | (stochrsi_k_1d < 90))
+            # 4h money flowing in, at the floor of its range and daily no recent low
+            & ((cmf_20_4h < 0.2) | (willr_14_4h > -80) | (aroond_14_1d > 20))
+            # 4h a trend established, money flowing in and 5m falling
+            & ((adx_14_4h < 40) | cmf_20_4h_lt_0_15 | (roc_9 > -2))
+            # 4h no trend established and stochastic falling hard
+            & ((adx_14_4h > 20) | (stochrsi_k_change_pct_4h > -70.0))
+            # 4h stochastic at the floor, daily momentum alive and a trend established
+            & ((adx_14_4h < 20) | (stochk_14_3_3_4h > 25) | (rsi_3_1d < 90))
+            # 4h oscillator low, daily stochastic high and no new high
+            & ((aroonu_14_4h > 10) | (uo_7_14_28_4h > 35) | (stochrsi_k_1d < 70))
+            # 4h no recent low and money flowing in
+            & ((aroond_14_4h > 5) | (cmf_20_4h < 0.05))
+          )
           # breakdown must be real: price already in the lower half of the range,
           # 15m momentum actually down (losses were top-of-range fake breakdowns)
           short_entry_logic.append(willr_14 < -50.0)


### PR DESCRIPTION
## Summary

Native is unmodified X8 signal 665 **ON**; Modified is signal 665 **ON** with 57 existing X7 protection chains added. Both use the same matched **signal-only research profile**, with other entry tags OFF. The tables retain the original v18.0.34 measurements; this rebase targets v18.0.35 and does not claim fresh market backtests.

| Period / metric | Native before | Modified after | Difference |
|---|---:|---:|---:|
| 2022 / Sum of net trade returns, pp | +836.275119 | +3,611.110309 | +2,774.835190 |
| 2022 / Wins | 2,530 | 1,440 | -1,090 |
| 2022 / Losses | 282 | 68 | -214 |
| 2022 / Trades | 2,812 | 1,508 | -1,304 |
| 2022 / Net PnL, USDT | -84,966.55 | +15,556,841.04 | +15,641,807.59 |
| 2022 / Losing-trade PnL subtotal, USDT | -1,044,252.63 | -11,999,972.65 | -10,955,720.01 |
| 2022 / Maximum closed-trade account DD, % (delta pp) | 98.7051 | 26.7886 | -71.9165 |
| 2021 / Sum of net trade returns, pp | -1,433.722887 | +1,946.227835 | +3,379.950723 |
| 2021 / Wins | 369 | 1,535 | +1,166 |
| 2021 / Losses | 89 | 135 | +46 |
| 2021 / Trades | 458 | 1,670 | +1,212 |
| 2021 / Net PnL, USDT | -98.22 | +807.80 | +906.02 |
| 2021 / Losing-trade PnL subtotal, USDT | -189.57 | -3,645.53 | -3,455.95 |
| 2021 / Maximum closed-trade account DD, % (delta pp) | 98.2923 | 58.0971 | -40.1951 |

Trade pp sums individual net trade returns and is not account return. Losing-trade PnL is already included in net PnL. Engine fees/funding are retained without a second deduction. Wallets start at 100,000 USDT in 2022 and 100 USDT in 2021; dollars are not pooled between these independent runs.

**Full multi-signal production portfolio:** not tested. These figures cover only the isolated 665 research account, including its capital and slot effects.

**Actual 2021 activity differs:** Native has its last entry on February 11 at 01:10 UTC and its last close at 08:50, ending with 1.777119 USDT. The configured run continues to January 1, 2022. These annual totals do not represent equal active trading exposure. Modified has its last entry at 2021-12-31 20:35:00+00:00, last close at 2022-01-01 00:00:00+00:00, and ends with 907.799954 USDT.

**The strict annual loss-count condition is not met in 2021: +46 losses.** The port is submitted for default-disabled review based on the measured return/drawdown improvements and this activity difference, not as an all-years loss-reduction pass. The 2021 DD remains 58.0971%. A retrospective cohort of entries through Native's last entry contains 458 trades / 89 losses / -98.222881 USDT for Native and 156 / 18 / -17.546730 USDT for Modified. Complete realized exits are included: Native's last cohort exit occurs after the entry cutoff. This diagnostic is reconstructed from annual exports, is not a fresh common-end backtest or a cash comparison at one common exit time, and does not replace the adverse annual loss-count result. The early Modified cohort also loses money.

| Period / trade composition | Native winners omitted | New winners | Native losses omitted | New losses | Matched earlier closes |
|---|---:|---:|---:|---:|---:|
| 2022 | 2269 | 1179 | 270 | 56 | 0 |
| 2021 | 334 | 1500 | 82 | 128 | 0 |

The 2022 gain has a substantial trade-composition cost: 1,090 fewer net winners. New trades contribute +2,873.022885 pp to the comparison, omitted trades -59.155142 pp, and matched trades -39.032553 pp. Native is all 3x; Modified has 1,342 trades at 3x and 166 at 2x. All 273 matched entries keep their close times, but 24 have lower returns with leverage changes. This is an unlimited-stake account comparison, with endogenous sizing and leverage changes.

Six of the 56 new 2022 losses follow a guard-blocked Native loss in the same pair within 24 hours. Entry-row masks and prior positions were checked, but time proximity does not establish that all six are the same postponed setup. The losses and timerange-end force exits remain in the totals.

2021 actual leverage: Native {'3.0': 458}; Modified {'3.0': 1670}. Matched entries with materially lower returns: 0; changed close times: 0. Materiality tolerance is 0.000001 trade pp.

- Add the 57 protection chains already present in X7 v17.5.72 to the X8 short-scalp signal 665 branch. Preserve all five existing raw entry gates and global guards. No thresholds are newly optimized in this PR.
- Independent rebased base: upstream main 0d6a45db92b45b53b774ddb239b8249cd56f278e (X8 v18.0.35). Only signal 665 in populate_entry_trend changes.

## Safety

- Signal 665 stays default-disabled. Production position-adjustment/de-risk defaults, indicators, exits, routing, sizing and other signals are unchanged. When explicitly enabled, the added guards intentionally alter eligible entries.
- Removing the inserted block restores the complete Native module AST. The submitted entry AST equals the frozen backtest candidate; all 76 referenced names have reachable top-level bindings and cached predicate meanings were checked.

## Backtest scope

Rebase validation (2026-09-13): upstream changes in the X8 module are confined to version() and entry branches 171/562, which were OFF in the original single-tag runs. Full-module AST comparison after excluding exactly those branches and version() is identical before/after rebase; the selected signal entry AST is unchanged. Removing this PR's added block restores the latest upstream module AST. Indicators, exits, shared bindings and target enable defaults are unchanged. The original four engine exports are retained as historical evidence; this maintenance rebase did not rerun them.

- Four fresh Freqtrade 2026.8 runs on X8 v18.0.34: Native/Modified for UTC 20220101-20230101 and 20210101-20220101. Same 19 fixed Binance USDT futures pairs, isolated margin, 5m, six slots, unlimited stake, 0.05% fee per side and 99% tradable balance within each annual comparison. Research overrides set position_adjustment_enable=False, derisk_enable=False, and V3.2/V4 stops ON; these are not shipped. Each run has a fresh userdir and cache disabled. Exact log-named ZIPs, embedded strategies, fees, period, side/tag, pairs and hashes were verified.

INJ is absent in 2021 and begins August 17 in 2022; GALA starts September 18 and SAND January 25 in 2021. Pairs were not substituted. The source is a frozen existing X7 port, tested under X8 indicator and exit semantics (including its different OBV computation). These are exposed historical research periods, not untouched validation. No 2023/2020 run or loss mining, new threshold fitting, fresh per-axis rounding/two-sided real nudge validation, wider-universe or production-portfolio test is claimed. The result does not establish future profitability or activation readiness.

## Checks

- `pre-commit run --files NostalgiaForInfinityX8.py — passed on the 665-only source.`
- `validate_nfi_pr.py --base origin/main --strategy NostalgiaForInfinityX8.py — final committed source checked before push: file scope, bindings, merge simulation, Ruff and compilation.`
- `Manual diff/full-module AST review and four verified real backtests; table values and deltas recomputed from the pinned exports.`

- Rebase checks: pre-commit and the skill validator passed on the final rebased commit; separate whole-module and selected-entry AST proofs passed.
