### PR TITLE
Add in-browser bot report tool (index.html): GitHub Pages port of tools/bot_report.py

### DIFF
--- a/index.html
+++ b/index.html
@@ -1169,11 +1169,26 @@ table.summary td {
 #privacy-note h2 {
   margin-bottom: 0.25rem;
 }
-p.error, li.error {
-  color: var(--destructive);
+/* Semantic status colors. The framework only ships --destructive; success and
+   warning get matching oklch tokens (light + dark). Danger reuses --destructive,
+   neutral reuses --muted-foreground, so both adapt to dark mode for free. */
+:root {
+  --success: oklch(0.627 0.17 149.2);
+  --warning: oklch(0.666 0.179 58.3);
 }
+@media (prefers-color-scheme: dark) {
+  :root {
+    --success: oklch(0.772 0.164 151.8);
+    --warning: oklch(0.828 0.156 77.6);
+  }
+}
+.text-success { color: var(--success); }
+.text-warning { color: var(--warning); }
+.text-danger { color: var(--destructive); }
+.text-neutral { color: var(--muted-foreground); }
 #progress-step {
   min-height: 1.5rem;
+  color: var(--muted-foreground);
 }
 /* Code never wraps: inline code becomes a horizontally scrollable chip so the
    text is always on one line and fully readable; pre>code stays a block. */
@@ -1824,29 +1839,30 @@ function renderSuccess(container, report, filename, json) {
   const children = [];
 
   if (!meta.redacted) {
-    children.push(el("p", { class: "error" },
+    children.push(el("p", { class: "text-warning" },
       "Redaction was disabled — this report contains balances, absolute PnL and credentials. Use it for private diagnostics only, never share it."));
   }
   if (failed.length > 0) {
-    children.push(el("p", { class: "error" },
+    children.push(el("p", { class: "text-warning" },
       `${failed.length} endpoint(s) failed and were skipped: ` +
       failed.map((f) => `${f.endpoint} (HTTP ${f.http_status})`).join(", ") + "."));
   }
 
   const rows = [
-    ["Freqtrade version", meta.freqtrade_version ?? "unknown"],
-    ["Generated at (UTC)", meta.generated_at_utc],
+    ["Freqtrade version", meta.freqtrade_version ?? "unknown", ""],
+    ["Generated at (UTC)", meta.generated_at_utc, ""],
     ["Closed trades", `${report.closed_trades.trades_count} exported / ${report.closed_trades.total_trades} total` +
-      (meta.closed_trades_window ? ` — ${meta.closed_trades_window}` : "")],
-    ["Fields redacted", meta.redacted ? meta.redacted_field_count : "redaction disabled"],
-    ["Skipped endpoints", meta.skipped_endpoints.length ? meta.skipped_endpoints.join(", ") : "none"],
-    ["Failed endpoints", failed.length ? failed.map((f) => f.endpoint).join(", ") : "none"],
+      (meta.closed_trades_window ? ` — ${meta.closed_trades_window}` : ""), ""],
+    ["Fields redacted", meta.redacted ? meta.redacted_field_count : "redaction disabled", ""],
+    ["Skipped endpoints", meta.skipped_endpoints.length ? meta.skipped_endpoints.join(", ") : "none", ""],
+    ["Failed endpoints", failed.length ? failed.map((f) => f.endpoint).join(", ") : "none",
+      failed.length ? "text-warning" : "text-neutral"],
   ];
   const table = el("table", { class: "summary" });
   const tbody = el("tbody", {});
-  for (const [label, value] of rows) {
+  for (const [label, value, cls] of rows) {
     const tr = el("tr", {});
-    tr.append(el("th", { scope: "row" }, [label]), el("td", {}, [String(value)]));
+    tr.append(el("th", { scope: "row" }, [label]), el("td", { class: cls }, [String(value)]));
     tbody.append(tr);
   }
   table.append(tbody, el("caption", {}, [`Saved as ${filename}`]));
@@ -1861,19 +1877,19 @@ function renderSuccess(container, report, filename, json) {
 function renderFailure(container, err) {
   console.error("Export failed:", err);
   container.replaceChildren(
-    el("p", { class: "error" }, err.friendly || String(err)),
-    el("p", {}, ["Fix the cause and try again. Nothing was written to disk."]),
+    el("p", { class: "text-danger" }, [err.friendly || String(err)]),
+    el("p", { class: "text-neutral" }, ["Fix the cause and try again. Nothing was written to disk."]),
   );
 }
 
-function saveJson(json, filename) {
-  const blob = new Blob([json], { type: "application/json" });
-  const url = URL.createObjectURL(blob);
-  const link = el("a", { href: url, download: filename });
-  document.body.append(link);
-  link.click();
-  link.remove();
-  setTimeout(() => URL.revokeObjectURL(url), 10000);
+function renderConnectionHelp(container, diagnosis) {
+  const list = el("ol", {});
+  for (const step of diagnosis.steps) list.append(el("li", {}, [step]));
+  const children = [el("p", { class: "text-danger" }, [diagnosis.headline]), el("p", { class: "text-neutral" }, ["Do this:"]), list];
+  if (diagnosis.snippet) {
+    children.push(el("pre", {}, [el("code", {}, [diagnosis.snippet])]));
+  }
+  container.replaceChildren(...children);
 }
 
 /* Default API URL: the page's own origin when served over http(s) — handy when
@@ -2004,16 +2020,6 @@ function describeConnectionFailure(url) {
   };
 }
 
-function renderConnectionHelp(container, diagnosis) {
-  const list = el("ol", {});
-  for (const step of diagnosis.steps) list.append(el("li", {}, [step]));
-  const children = [el("p", { class: "error" }, [diagnosis.headline]), el("p", {}, ["Do this:"]), list];
-  if (diagnosis.snippet) {
-    children.push(el("pre", {}, [el("code", {}, [diagnosis.snippet])]));
-  }
-  container.replaceChildren(...children);
-}
-
 async function withBusyUi(form, initialStep, action) {
   const progressSection = document.getElementById("progress");
   const resultSection = document.getElementById("result");
@@ -2038,8 +2044,10 @@ async function withBusyUi(form, initialStep, action) {
 }
 
 function optionsErrorUi(opts, title) {
+  const titleEl = document.getElementById("result-title");
+  titleEl.textContent = title;
+  titleEl.className = "text-danger";
   document.getElementById("result").hidden = false;
-  document.getElementById("result-title").textContent = title;
   renderFailure(document.getElementById("result-body"), { friendly: opts.error });
 }
 
@@ -2054,9 +2062,11 @@ async function onExport(form) {
       const { report, json, filename } = await runExport(opts, progress);
       saveJson(json, filename);
       resultTitle.textContent = "Export finished";
+      resultTitle.className = "text-success";
       renderSuccess(resultBody, report, filename, json);
     } catch (err) {
       resultTitle.textContent = "Export failed";
+      resultTitle.className = "text-danger";
       if (err instanceof NetworkError) {
         progress.step("Diagnosing the connection problem …");
         renderConnectionHelp(resultBody, await diagnoseConnection(opts));
@@ -2078,11 +2088,13 @@ async function onTestConnection(form) {
       const api = new FreqtradeApi(opts);
       const version = await api.get("version");
       resultTitle.textContent = "Connection OK";
+      resultTitle.className = "text-success";
       resultBody.replaceChildren(
-        el("p", {}, [`freqtrade ${version.version || "unknown"} answered at ${opts.url} — CORS and credentials work. You can export the report now.`]),
+        el("p", { class: "text-success" }, [`freqtrade ${version.version || "unknown"} answered at ${opts.url} — CORS and credentials work. You can export the report now.`]),
       );
     } catch (err) {
       resultTitle.textContent = "Connection failed";
+      resultTitle.className = "text-danger";
       if (err instanceof NetworkError) {
         progress.step("Diagnosing the connection problem …");
         renderConnectionHelp(resultBody, await diagnoseConnection(opts));

--- a/index.html
+++ b/index.html
@@ -1131,7 +1131,8 @@ button {
   display: block;
 }
 #connect input[type='text'],
-#connect input[type='password'] {
+#connect input[type='password'],
+#connect select {
   display: block;
   width: 100%;
   margin-top: 0.35rem;
@@ -1174,8 +1175,14 @@ p.error, li.error {
 #progress-step {
   min-height: 1.5rem;
 }
+/* Code never wraps: inline code becomes a horizontally scrollable chip so the
+   text is always on one line and fully readable; pre>code stays a block. */
 code {
-  word-break: break-all;
+  display: inline-block;
+  max-width: 100%;
+  white-space: nowrap;
+  overflow-x: auto;
+  vertical-align: middle;
 }
 
 /* Tooltips: the framework renders them on one line (nowrap); let the longer
@@ -1194,6 +1201,7 @@ code {
 @media (max-width: 600px) {
   #connect input[type='text'],
   #connect input[type='password'],
+  #connect select,
   #connect button,
   #result-body button {
     font-size: 1rem;
@@ -1248,16 +1256,19 @@ code {
         <legend>Export options</legend>
         <label tooltip-top="Tool option, not a config value: same as --redact / --no-redact in tools/bot_report.py"><input type="checkbox" id="f-redact" checked>
           Redact confidential fields (recommended — required before sharing the report)</label>
-        <label tooltip-top="Tool option, not a config value: same as --trades-limit in tools/bot_report.py — empty means the full paginated history">Trades limit — safety cap on closed trades (empty = full paginated history)
-          <input type="text" id="f-limit" inputmode="numeric" pattern="[0-9]*" placeholder="all">
-        </label>
-        <label tooltip-top="Tool option, not a config value: same as --timeout in tools/bot_report.py — applied to each HTTP request">Per-request timeout, seconds
-          <input type="text" id="f-timeout" inputmode="numeric" pattern="[0-9]*" value="30">
+        <label tooltip-top="Web-only filter: the full history is always fetched, then only trades closed within the window are kept. All time matches the CLI output.">Closed trades window
+          <select id="f-window">
+            <option value="all" selected>All time</option>
+            <option value="day">Last day</option>
+            <option value="week">Last week</option>
+            <option value="month">Last month</option>
+            <option value="year">Last year</option>
+          </select>
         </label>
       </fieldset>
       <button type="submit" id="btn-export">Export report</button>
-      <button type="button" id="btn-test" secondary>Test connection</button>
-      <small><strong>Export report</strong> walks every endpoint and saves the JSON file. <strong>Test connection</strong> only checks the URL, CORS and credentials.</small>
+      <button type="button" id="btn-test" secondary tooltip-top="Uses the URL and credentials above: one request checks reachability, CORS headers and authentication.">Test connection</button>
+      <small><strong>Export report</strong> walks every endpoint — including the full closed-trade history — and saves the JSON file. <strong>Test connection</strong> checks the URL, CORS and credentials with a single request.</small>
     </form>
   </section>
 
@@ -1332,6 +1343,7 @@ code {
 
 const API_PREFIX = "/api/v1";
 const TRADES_PAGE_SIZE = 500;
+const REQUEST_TIMEOUT = 120; // seconds, per HTTP request
 const TOOL_VERSION = "1.3.0";
 const REDACTED = "<redacted>";
 const MAX_DAILY_DAYS = 3650;
@@ -1486,7 +1498,7 @@ class TimeoutError extends Error {
 class FreqtradeApi {
   constructor(opts) {
     this.base = opts.url.replace(/\/+$/, "");
-    this.timeoutMs = (opts.timeout ?? 30) * 1000;
+    this.timeoutMs = (opts.timeout ?? REQUEST_TIMEOUT) * 1000;
     this.auth = null;
     if (opts.username || opts.password) {
       this.auth = "Basic " + b64Utf8(`${opts.username || ""}:${opts.password || ""}`);
@@ -1663,9 +1675,10 @@ async function fetchTradeHistory(api, cap, failed, progress) {
 }
 
 /* Mirrors collect_report: same endpoint sequence, same parameters. */
-async function collectReport(api, redacted, tradesLimit, progress) {
+async function collectReport(api, redacted, tradesLimit, window, progress) {
   const raw = {};
   const failed = [];
+  const windowed = window !== "all";
 
   const fetchSection = async (section, endpoint, params) => {
     progress.step(`GET ${API_PREFIX}/${endpoint} — ${section} …`);
@@ -1685,7 +1698,7 @@ async function collectReport(api, redacted, tradesLimit, progress) {
     }
   };
 
-  progress.setTotal(20 + (redacted ? 0 : 1));
+  progress.setTotal(20 + (redacted ? 0 : 1) + (windowed ? 1 : 0));
   progress.step("Connecting to the bot — GET /api/v1/ping …");
   await api.get("ping");
   progress.done();
@@ -1705,6 +1718,16 @@ async function collectReport(api, redacted, tradesLimit, progress) {
   await fetchSection("monthly_performance", "monthly", { timescale: Math.min(Math.floor(days / 30) + 2, MAX_MONTHLY_MONTHS) });
 
   raw.closed_trades = await fetchTradeHistory(api, tradesLimit, failed, progress);
+  if (windowed) {
+    progress.step(`Filtering closed trades to the ${WINDOW_LABELS[window]} …`);
+    const cutoff = Date.now() - WINDOW_MS[window];
+    raw.closed_trades.trades = raw.closed_trades.trades.filter((trade) => {
+      const closedAt = parseUtcTimestamp(trade.close_date);
+      return !Number.isNaN(closedAt) && closedAt >= cutoff;
+    });
+    raw.closed_trades.trades_count = raw.closed_trades.trades.length;
+    progress.done();
+  }
 
   await fetchSection("whitelist", "whitelist");
   await fetchSection("blacklist", "blacklist");
@@ -1736,6 +1759,7 @@ async function collectReport(api, redacted, tradesLimit, progress) {
     skipped_endpoints: redacted ? ["balance", "logs"] : [],
     failed_endpoints: failed,
   };
+  if (windowed) metadata.closed_trades_window = WINDOW_LABELS[window];
   return { report_metadata: metadata, ...report };
 }
 
@@ -1746,7 +1770,7 @@ const nullProgress = { setTotal() {}, addTotal() {}, step() {}, done() {} };
 async function runExport(opts, progress) {
   progress = progress || nullProgress;
   const api = new FreqtradeApi(opts);
-  const report = await collectReport(api, opts.redact, opts.tradesLimit === undefined ? null : opts.tradesLimit, progress);
+  const report = await collectReport(api, opts.redact, opts.tradesLimit === undefined ? null : opts.tradesLimit, opts.window || "all", progress);
   progress.step("Serializing JSON and preparing the download …");
   const json = JSON.stringify(report, null, 2) + "\n";
   const filename = `bot-report-${stamp()}.json`;
@@ -1812,7 +1836,8 @@ function renderSuccess(container, report, filename, json) {
   const rows = [
     ["Freqtrade version", meta.freqtrade_version ?? "unknown"],
     ["Generated at (UTC)", meta.generated_at_utc],
-    ["Closed trades", `${report.closed_trades.trades_count} exported / ${report.closed_trades.total_trades} total`],
+    ["Closed trades", `${report.closed_trades.trades_count} exported / ${report.closed_trades.total_trades} total` +
+      (meta.closed_trades_window ? ` — ${meta.closed_trades_window}` : "")],
     ["Fields redacted", meta.redacted ? meta.redacted_field_count : "redaction disabled"],
     ["Skipped endpoints", meta.skipped_endpoints.length ? meta.skipped_endpoints.join(", ") : "none"],
     ["Failed endpoints", failed.length ? failed.map((f) => f.endpoint).join(", ") : "none"],
@@ -1865,24 +1890,45 @@ function defaultBaseUrl() {
   return /^https?:\/\//.test(window.location.origin) ? window.location.origin : "http://127.0.0.1:8080";
 }
 
+/* Web-only closed-trades window presets: the freqtrade API cannot filter
+   /trades by date, so the full history is fetched and filtered client-side. */
+const WINDOW_MS = {
+  day: 24 * 3600000,
+  week: 7 * 24 * 3600000,
+  month: 30 * 24 * 3600000,
+  year: 365 * 24 * 3600000,
+};
+const WINDOW_LABELS = {
+  all: "all time",
+  day: "last 24 hours",
+  week: "last 7 days",
+  month: "last 30 days",
+  year: "last 365 days",
+};
+
+/* freqtrade returns naive UTC timestamps like "2026-09-01 15:00:00"; parse
+   them as UTC instead of letting Date.parse guess the local zone. */
+function parseUtcTimestamp(value) {
+  if (typeof value !== "string") return NaN;
+  const iso = value.includes("T") ? value : value.replace(" ", "T");
+  const zoned = /[zZ]$|[+-]\d{2}:?\d{2}$/.test(iso) ? iso : `${iso}Z`;
+  return Date.parse(zoned);
+}
+
 function readFormOptions() {
   const url = document.getElementById("f-url").value.trim() || defaultBaseUrl();
-  const limitRaw = document.getElementById("f-limit").value.trim();
-  const tradesLimit = limitRaw === "" ? null : Number(limitRaw);
-  const timeout = Number(document.getElementById("f-timeout").value);
+  const win = document.getElementById("f-window").value;
   let error = null;
   if (!/^https?:\/\//i.test(url)) {
     error = `The API base URL must start with http:// or https:// — got "${url}".`;
-  } else if (tradesLimit !== null && (!Number.isInteger(tradesLimit) || tradesLimit < 1)) {
-    error = "Trades limit must be a positive whole number (or empty for the full history).";
   }
   return {
     url,
     username: document.getElementById("f-user").value.trim() || null,
     password: document.getElementById("f-pass").value || null,
     redact: document.getElementById("f-redact").checked,
-    tradesLimit,
-    timeout: timeout > 0 ? timeout : 30,
+    window: WINDOW_MS[win] ? win : "all",
+    timeout: REQUEST_TIMEOUT,
     error,
   };
 }

--- a/index.html
+++ b/index.html
@@ -1178,6 +1178,16 @@ code {
   word-break: break-all;
 }
 
+/* Tooltips: the framework renders them on one line (nowrap); let the longer
+   field hints wrap into a readable box instead. */
+[tooltip-top]::after {
+  white-space: normal;
+  width: max-content;
+  max-width: min(24rem, 90vw);
+  text-align: left;
+  line-height: 1.4;
+}
+
 /* Small screens: keep controls at 1rem (16px) — iOS Safari zooms into fields
    on focus below that threshold, which is jarring even though the surrounding
    text is now 14px. */
@@ -1219,29 +1229,29 @@ code {
     <form id="connect">
       <fieldset>
         <legend>Bot connection</legend>
-        <label>API base URL
+        <label tooltip-top="From your config.json: api_server.listen_ip_address + listen_port — default http://127.0.0.1:8080">API base URL
           <input type="text" id="f-url" placeholder="http://127.0.0.1:8080" spellcheck="false">
         </label>
         <small>Root of the freqtrade REST API — scheme, host and port only. The default install listens on <code>http://127.0.0.1:8080</code>.</small>
       </fieldset>
       <fieldset>
         <legend>Credentials</legend>
-        <label>Username
+        <label tooltip-top="From your config.json: api_server.username">Username
           <input type="text" id="f-user" autocomplete="off" spellcheck="false">
         </label>
-        <label>Password
+        <label tooltip-top="From your config.json: api_server.password">Password
           <input type="password" id="f-pass">
         </label>
         <small>The same values as in your <code>api_server</code> config, sent as HTTP Basic auth on each request — never stored, never sent anywhere else.</small>
       </fieldset>
       <fieldset>
         <legend>Export options</legend>
-        <label><input type="checkbox" id="f-redact" checked>
+        <label tooltip-top="Tool option, not a config value: same as --redact / --no-redact in tools/bot_report.py"><input type="checkbox" id="f-redact" checked>
           Redact confidential fields (recommended — required before sharing the report)</label>
-        <label>Trades limit — safety cap on closed trades (empty = full paginated history)
+        <label tooltip-top="Tool option, not a config value: same as --trades-limit in tools/bot_report.py — empty means the full paginated history">Trades limit — safety cap on closed trades (empty = full paginated history)
           <input type="text" id="f-limit" inputmode="numeric" pattern="[0-9]*" placeholder="all">
         </label>
-        <label>Per-request timeout, seconds
+        <label tooltip-top="Tool option, not a config value: same as --timeout in tools/bot_report.py — applied to each HTTP request">Per-request timeout, seconds
           <input type="text" id="f-timeout" inputmode="numeric" pattern="[0-9]*" value="30">
         </label>
       </fieldset>

--- a/index.html
+++ b/index.html
@@ -1150,7 +1150,7 @@ code {
     <h2>Bot connection</h2>
     <form id="connect">
       <label>API base URL
-        <input type="text" id="f-url" value="http://127.0.0.1:8080" placeholder="http://127.0.0.1:8080" spellcheck="false">
+        <input type="text" id="f-url" placeholder="http://127.0.0.1:8080" spellcheck="false">
       </label>
       <fieldset>
         <legend>Credentials (HTTP Basic, as in your <code>api_server</code> config)</legend>
@@ -1756,6 +1756,13 @@ function saveJson(json, filename) {
   setTimeout(() => URL.revokeObjectURL(url), 10000);
 }
 
+/* Default API URL: the page's own origin when served over http(s) — handy when
+ * the page is hosted next to the bot's reverse proxy — otherwise the freqtrade
+ * default (file:// and about:blank have no usable origin). */
+function defaultBaseUrl() {
+  return /^https?:\/\//.test(window.location.origin) ? window.location.origin : "http://127.0.0.1:8080";
+}
+
 async function onExport(form) {
   const progressSection = document.getElementById("progress");
   const resultSection = document.getElementById("result");
@@ -1763,7 +1770,7 @@ async function onExport(form) {
   const resultTitle = document.getElementById("result-title");
   const button = document.getElementById("btn-export");
 
-  const url = document.getElementById("f-url").value.trim();
+  const url = document.getElementById("f-url").value.trim() || defaultBaseUrl();
   if (!/^https?:\/\//i.test(url)) {
     resultSection.hidden = false;
     resultTitle.textContent = "Export failed";
@@ -1803,6 +1810,7 @@ async function onExport(form) {
 
 if (typeof document !== "undefined") {
   const start = () => {
+    document.getElementById("f-url").placeholder = defaultBaseUrl();
     const form = document.getElementById("connect");
     form.addEventListener("submit", (event) => {
       event.preventDefault();

--- a/index.html
+++ b/index.html
@@ -1112,6 +1112,10 @@ dl.kv {
 dl.kv dt {
   color: var(--muted-foreground);
 }
+dl.kv dd {
+  margin: 0;
+  overflow-wrap: anywhere;
+}
 p.error, li.error {
   color: var(--destructive);
 }
@@ -1120,6 +1124,31 @@ p.error, li.error {
 }
 code {
   word-break: break-all;
+}
+
+/* Small screens: stack form groups and key-value rows so nothing is squeezed
+   into a row; keep input font-size >= 16px so iOS Safari does not zoom into
+   fields on focus. */
+@media (max-width: 600px) {
+  form fieldset {
+    flex-direction: column;
+    align-items: stretch;
+  }
+  dl.kv {
+    grid-template-columns: 1fr;
+    gap: 0;
+  }
+  dl.kv dt {
+    margin-top: 0.5rem;
+  }
+  input[type='text'],
+  input[type='password'],
+  input[type='number'] {
+    font-size: 1rem;
+  }
+  #result button {
+    width: 100%;
+  }
 }
 </style>
 </head>

--- a/index.html
+++ b/index.html
@@ -1190,6 +1190,32 @@ table.summary td {
   min-height: 1.5rem;
   color: var(--muted-foreground);
 }
+
+/* Per-field collapsible hints: clicking the ⓘ line expands the description.
+   Overrides the framework's bordered accordion look for these inline hints. */
+details.field-help {
+  border: none;
+  border-radius: 0;
+  padding: 0;
+  margin: 0.3rem 0 0;
+}
+details.field-help summary {
+  list-style: none;
+  display: inline-block;
+  font-size: 0.8125rem;
+  font-weight: 400;
+  color: var(--muted-foreground);
+}
+details.field-help summary::-webkit-details-marker {
+  display: none;
+}
+details.field-help[open] summary {
+  color: var(--foreground);
+}
+details.field-help small {
+  display: block;
+  margin-top: 0.25rem;
+}
 /* Code never wraps: inline code becomes a horizontally scrollable chip so the
    text is always on one line and fully readable; pre>code stays a block. */
 code {
@@ -1252,26 +1278,42 @@ code {
     <form id="connect">
       <fieldset>
         <legend>Bot connection</legend>
-        <label tooltip-top="From your config.json: api_server.listen_ip_address + listen_port — default http://127.0.0.1:8080">API base URL
+        <label>API base URL
           <input type="text" id="f-url" placeholder="http://127.0.0.1:8080" spellcheck="false">
         </label>
+        <details class="field-help">
+          <summary>ⓘ from the freqtrade config</summary>
+          <small>From your config.json: <code>api_server.listen_ip_address</code> + <code>listen_port</code> — default <code>http://127.0.0.1:8080</code>.</small>
+        </details>
         <small>Root of the freqtrade REST API — scheme, host and port only. The default install listens on <code>http://127.0.0.1:8080</code>.</small>
       </fieldset>
       <fieldset>
         <legend>Credentials</legend>
-        <label tooltip-top="From your config.json: api_server.username">Username
+        <label>Username
           <input type="text" id="f-user" autocomplete="off" spellcheck="false">
         </label>
-        <label tooltip-top="From your config.json: api_server.password">Password
+        <details class="field-help">
+          <summary>ⓘ from the freqtrade config</summary>
+          <small>From your config.json: <code>api_server.username</code>.</small>
+        </details>
+        <label>Password
           <input type="password" id="f-pass">
         </label>
+        <details class="field-help">
+          <summary>ⓘ from the freqtrade config</summary>
+          <small>From your config.json: <code>api_server.password</code>.</small>
+        </details>
         <small>The same values as in your <code>api_server</code> config, sent as HTTP Basic auth on each request — never stored, never sent anywhere else.</small>
       </fieldset>
       <fieldset>
         <legend>Export options</legend>
-        <label tooltip-top="Tool option, not a config value: same as --redact / --no-redact in tools/bot_report.py"><input type="checkbox" id="f-redact" checked>
+        <label><input type="checkbox" id="f-redact" checked>
           Redact confidential fields (recommended — required before sharing the report)</label>
-        <label tooltip-top="Web-only filter: the full history is always fetched, then only trades closed within the window are kept. All time matches the CLI output.">Closed trades window
+        <details class="field-help">
+          <summary>ⓘ about this option</summary>
+          <small>Tool option, not a config value — same as <code>--redact</code> / <code>--no-redact</code> in <code>tools/bot_report.py</code>.</small>
+        </details>
+        <label>Closed trades window
           <select id="f-window">
             <option value="all" selected>All time</option>
             <option value="day">Last day</option>
@@ -1280,6 +1322,10 @@ code {
             <option value="year">Last year</option>
           </select>
         </label>
+        <details class="field-help">
+          <summary>ⓘ about this option</summary>
+          <small>Web-only filter: the full history is always fetched, then only trades closed within the window are kept. All time matches the CLI output.</small>
+        </details>
       </fieldset>
       <button type="submit" id="btn-export">Export report</button>
       <button type="button" id="btn-test" secondary tooltip-top="Uses the URL and credentials above: one request checks reachability, CORS headers and authentication.">Test connection</button>

--- a/index.html
+++ b/index.html
@@ -1098,6 +1098,25 @@ menu {
 <style>
 /* Page-specific additions on top of shadcn-classless (kept minimal). */
 
+/* Relax the type scale, all in rem (root stays at the browser default):
+   body 1rem -> 0.875rem (16 -> 14px), h1 2rem -> 1.75rem (32 -> 28px),
+   h2 1.25rem -> 1.125rem (20 -> 18px), hints -> 0.8125rem (13px). */
+body {
+  font-size: 0.875rem;
+}
+h1, header h1 {
+  font-size: 1.75rem;
+}
+h2 {
+  font-size: 1.125rem;
+}
+small {
+  font-size: 0.8125rem;
+}
+button {
+  font-size: 0.875rem;
+}
+
 /* Form: labels and inputs on separate rows, inputs full width; fieldsets
    group connection, credentials and options as vertical stacks. */
 #connect {
@@ -1159,11 +1178,14 @@ code {
   word-break: break-all;
 }
 
-/* Small screens: keep input font-size >= 16px so iOS Safari does not zoom
-   into fields on focus. */
+/* Small screens: keep controls at 1rem (16px) — iOS Safari zooms into fields
+   on focus below that threshold, which is jarring even though the surrounding
+   text is now 14px. */
 @media (max-width: 600px) {
-  input[type='text'],
-  input[type='password'] {
+  #connect input[type='text'],
+  #connect input[type='password'],
+  #connect button,
+  #result-body button {
     font-size: 1rem;
   }
 }

--- a/index.html
+++ b/index.html
@@ -1097,24 +1097,57 @@ menu {
 </style>
 <style>
 /* Page-specific additions on top of shadcn-classless (kept minimal). */
+
+/* Form: labels and inputs on separate rows, inputs full width; fieldsets
+   group connection, credentials and options as vertical stacks. */
+#connect {
+  max-width: 40rem;
+}
+#connect fieldset {
+  flex-direction: column;
+  align-items: stretch;
+  gap: 0.9rem;
+}
+#connect label {
+  display: block;
+}
+#connect input[type='text'],
+#connect input[type='password'] {
+  display: block;
+  width: 100%;
+  margin-top: 0.35rem;
+}
+#connect small {
+  display: block;
+  margin-top: 0.4rem;
+}
+#connect button {
+  width: 100%;
+}
+#result-body button {
+  width: 100%;
+}
+
+/* Export summary table: shrink-to-fit label column, wrapping values. */
+table.summary {
+  width: 100%;
+  margin: 0.5rem 0 1rem;
+}
+table.summary th {
+  font-weight: 500;
+  white-space: nowrap;
+  width: 1%;
+  padding-right: 1.5rem;
+}
+table.summary td {
+  overflow-wrap: anywhere;
+}
+
 #privacy-note {
   border-left: 4px solid var(--primary);
 }
-#privacy-note h3 {
+#privacy-note h2 {
   margin-bottom: 0.25rem;
-}
-dl.kv {
-  display: grid;
-  grid-template-columns: max-content 1fr;
-  gap: 0.25rem 1.5rem;
-  margin: 1rem 0;
-}
-dl.kv dt {
-  color: var(--muted-foreground);
-}
-dl.kv dd {
-  margin: 0;
-  overflow-wrap: anywhere;
 }
 p.error, li.error {
   color: var(--destructive);
@@ -1126,28 +1159,12 @@ code {
   word-break: break-all;
 }
 
-/* Small screens: stack form groups and key-value rows so nothing is squeezed
-   into a row; keep input font-size >= 16px so iOS Safari does not zoom into
-   fields on focus. */
+/* Small screens: keep input font-size >= 16px so iOS Safari does not zoom
+   into fields on focus. */
 @media (max-width: 600px) {
-  form fieldset {
-    flex-direction: column;
-    align-items: stretch;
-  }
-  dl.kv {
-    grid-template-columns: 1fr;
-    gap: 0;
-  }
-  dl.kv dt {
-    margin-top: 0.5rem;
-  }
   input[type='text'],
-  input[type='password'],
-  input[type='number'] {
+  input[type='password'] {
     font-size: 1rem;
-  }
-  #result button {
-    width: 100%;
   }
 }
 </style>
@@ -1162,7 +1179,7 @@ code {
 
 <main>
   <article id="privacy-note">
-    <h3>No server sees your data</h3>
+    <h2>No server sees your data</h2>
     <p>This page is a single static file with all logic embedded. <strong>It makes no network
     call to any server except the freqtrade API URL you enter below.</strong> There is no CDN,
     no fonts, no analytics, no uploads, nothing stored: the report is generated in your browser
@@ -1176,45 +1193,53 @@ code {
   </article>
 
   <section>
-    <h2>Bot connection</h2>
+    <h2>Generate report</h2>
     <form id="connect">
-      <label>API base URL
-        <input type="text" id="f-url" placeholder="http://127.0.0.1:8080" spellcheck="false">
-      </label>
       <fieldset>
-        <legend>Credentials (HTTP Basic, as in your <code>api_server</code> config)</legend>
+        <legend>Bot connection</legend>
+        <label>API base URL
+          <input type="text" id="f-url" placeholder="http://127.0.0.1:8080" spellcheck="false">
+        </label>
+        <small>Root of the freqtrade REST API — scheme, host and port only. The default install listens on <code>http://127.0.0.1:8080</code>.</small>
+      </fieldset>
+      <fieldset>
+        <legend>Credentials</legend>
         <label>Username
           <input type="text" id="f-user" autocomplete="off" spellcheck="false">
         </label>
         <label>Password
           <input type="password" id="f-pass">
         </label>
+        <small>The same values as in your <code>api_server</code> config, sent as HTTP Basic auth on each request — never stored, never sent anywhere else.</small>
       </fieldset>
       <fieldset>
         <legend>Export options</legend>
         <label><input type="checkbox" id="f-redact" checked>
           Redact confidential fields (recommended — required before sharing the report)</label>
         <label>Trades limit — safety cap on closed trades (empty = full paginated history)
-          <input type="number" id="f-limit" min="1" step="1" inputmode="numeric" placeholder="all">
+          <input type="text" id="f-limit" inputmode="numeric" pattern="[0-9]*" placeholder="all">
         </label>
         <label>Per-request timeout, seconds
-          <input type="number" id="f-timeout" min="1" step="1" inputmode="numeric" value="30">
+          <input type="text" id="f-timeout" inputmode="numeric" pattern="[0-9]*" value="30">
         </label>
       </fieldset>
       <button type="submit" id="btn-export">Export report</button>
       <button type="button" id="btn-test" secondary>Test connection</button>
+      <small><strong>Export report</strong> walks every endpoint and saves the JSON file. <strong>Test connection</strong> only checks the URL, CORS and credentials.</small>
     </form>
   </section>
 
   <section id="progress" hidden>
-    <h2 aria-busy="true">Exporting…</h2>
-    <p id="progress-step" aria-busy="spinner">Connecting…</p>
-    <progress id="progress-bar" max="1" value="0"></progress>
+    <article aria-busy="true">
+      <h2>Exporting…</h2>
+      <p id="progress-step" aria-busy="spinner">Connecting…</p>
+      <progress id="progress-bar" max="1" value="0"></progress>
+    </article>
   </section>
 
   <section id="result" hidden>
     <h2 id="result-title"></h2>
-    <div id="result-body"></div>
+    <article id="result-body"></article>
   </section>
 
   <details>
@@ -1752,16 +1777,23 @@ function renderSuccess(container, report, filename, json) {
       failed.map((f) => `${f.endpoint} (HTTP ${f.http_status})`).join(", ") + "."));
   }
 
-  const dl = el("dl", { class: "kv" });
-  const add = (dt, dd) => { dl.append(el("dt", {}, [String(dt)]), el("dd", {}, [String(dd)])); };
-  add("Freqtrade version", meta.freqtrade_version ?? "unknown");
-  add("Generated at (UTC)", meta.generated_at_utc);
-  add("Closed trades", `${report.closed_trades.trades_count} exported / ${report.closed_trades.total_trades} total`);
-  add("Fields redacted", meta.redacted ? meta.redacted_field_count : "redaction disabled");
-  add("Skipped endpoints", meta.skipped_endpoints.length ? meta.skipped_endpoints.join(", ") : "none");
-  add("Failed endpoints", failed.length ? failed.map((f) => f.endpoint).join(", ") : "none");
-  add("Saved as", filename);
-  children.push(dl);
+  const rows = [
+    ["Freqtrade version", meta.freqtrade_version ?? "unknown"],
+    ["Generated at (UTC)", meta.generated_at_utc],
+    ["Closed trades", `${report.closed_trades.trades_count} exported / ${report.closed_trades.total_trades} total`],
+    ["Fields redacted", meta.redacted ? meta.redacted_field_count : "redaction disabled"],
+    ["Skipped endpoints", meta.skipped_endpoints.length ? meta.skipped_endpoints.join(", ") : "none"],
+    ["Failed endpoints", failed.length ? failed.map((f) => f.endpoint).join(", ") : "none"],
+  ];
+  const table = el("table", { class: "summary" });
+  const tbody = el("tbody", {});
+  for (const [label, value] of rows) {
+    const tr = el("tr", {});
+    tr.append(el("th", { scope: "row" }, [label]), el("td", {}, [String(value)]));
+    tbody.append(tr);
+  }
+  table.append(tbody, el("caption", {}, [`Saved as ${filename}`]));
+  children.push(table);
 
   const button = el("button", { type: "button" }, ["Download again"]);
   button.addEventListener("click", () => saveJson(json, filename));

--- a/index.html
+++ b/index.html
@@ -1226,6 +1226,29 @@ code {
   vertical-align: middle;
 }
 
+/* Danger action inside the redaction confirm dialog. */
+button.danger {
+  background-color: var(--destructive);
+  color: var(--primary-foreground);
+}
+button.danger:hover {
+  background-color: color-mix(in srgb, var(--destructive) 90%, transparent);
+}
+#redact-confirm footer {
+  display: flex;
+  gap: 0.5rem;
+  justify-content: flex-end;
+}
+
+/* Collapsed redaction review inside the result card. */
+details.redaction-review ul {
+  max-height: 16rem;
+  margin-bottom: 0;
+}
+details.redaction-review li {
+  overflow-wrap: anywhere;
+}
+
 /* Tooltips: the framework renders them on one line (nowrap); let the longer
    field hints wrap into a readable box instead. */
 [tooltip-top]::after {
@@ -1309,7 +1332,7 @@ code {
       </fieldset>
       <button type="submit" id="btn-export">Export report</button>
       <button type="button" id="btn-test" secondary tooltip-top="Uses the URL and credentials above: one request checks reachability, CORS headers and authentication.">Test connection</button>
-      <small><strong>Export report</strong> walks every endpoint — including the full closed-trade history — and saves the JSON file. <strong>Test connection</strong> checks the URL, CORS and credentials with a single request.</small>
+      <small><strong>Export report</strong> walks every endpoint — including the full closed-trade history — then lets you review what was redacted before saving. <strong>Test connection</strong> checks the URL, CORS and credentials with a single request.</small>
     </form>
   </section>
 
@@ -1326,14 +1349,31 @@ code {
     <article id="result-body"></article>
   </section>
 
+  <dialog id="redact-confirm">
+    <h3>Disable redaction?</h3>
+    <p>The report will contain balances, absolute PnL and credentials — anyone you share it
+    with learns the size of your account. Only continue for private diagnostics you keep to
+    yourself.</p>
+    <footer>
+      <button type="button" id="redact-keep" secondary>Keep redaction (recommended)</button>
+      <button type="button" id="redact-disable" class="danger">Disable redaction</button>
+    </footer>
+  </dialog>
+
   <details>
-    <summary>Setup — letting this page talk to your bot</summary>
+    <summary>Setup — how to run this page and let it talk to your bot</summary>
     <ol>
       <li>Enable the freqtrade REST API (<code>"api_server": {"enabled": true, …}</code> with
         <code>username</code>/<code>password</code>) in your bot's config.</li>
-      <li>Browsers enforce CORS: add this page's exact origin (no trailing slash) —
+      <li><strong>Recommended — run this page locally.</strong> Download the file and open it
+        straight from disk, or serve it from the same machine with
+        <code>python -m http.server</code>, then point the form at
+        <code>http://127.0.0.1:8080</code>. This works with plain-HTTP bots, needs no CORS
+        setup, and the credentials you type never leave your machine.</li>
+      <li><strong>Or host the page publicly</strong> (e.g. GitHub Pages) and allow that origin.
+        Browsers enforce CORS: add the page's exact origin (no trailing slash) —
         <code id="page-origin">https://YOURNAME.github.io</code> — to
-        <code>CORS_origins</code> in the same <code>api_server</code> block and restart the bot:
+        <code>CORS_origins</code> in the <code>api_server</code> block and restart the bot:
         <pre><code>"api_server": {
     "enabled": true,
     "listen_ip_address": "127.0.0.1",
@@ -1342,14 +1382,17 @@ code {
     "password": "…",
     "CORS_origins": ["<span id="page-origin-snippet">https://YOURNAME.github.io</span>"]
 }</code></pre>
-        Without this entry the bot answers without the CORS headers browsers require, and every
-        request from this page fails before reaching freqtrade.</li>
-      <li>If this page is served over HTTPS and your bot is plain HTTP, browsers usually allow
-        <code>http://127.0.0.1</code> / <code>http://localhost</code> as an exception (Chrome may
-        additionally ask for a local-network permission). Remote bots over plain HTTP will be
-        blocked as mixed content — put them behind a TLS reverse proxy. Certificates must be
-        valid; this page cannot skip verification (there is no <code>--no-verify-tls</code> in a
-        browser).</li>
+        Keep in mind: an HTTPS page cannot reach a plain-HTTP bot at all (no CORS entry fixes
+        that — the local option above is the answer), the entry grants <em>every</em> page on
+        that origin access to the bot API — not just this tool — and it should be removed again
+        once the report is exported.</li>
+      <li><strong>Trust and TLS.</strong> These credentials give full control of the bot — the
+        same API also exposes <code>forceexit</code> and <code>stop</code> — so treat the origin
+        you put in <code>CORS_origins</code> as a standing trust decision and prefer running the
+        page locally if you do not fully control that origin. Certificates must be valid:
+        browsers reject self-signed ones and this page cannot skip verification (there is no
+        <code>--no-verify-tls</code> in a browser), so self-signed setups should run the page
+        locally or use a properly trusted reverse proxy.</li>
     </ol>
   </details>
 
@@ -1475,17 +1518,21 @@ function isAllowedNumber(path, key) {
   return false;
 }
 
-/* Mirrors Redactor.walk: recursively redacts sensitive fields, keeps structure. */
+/* Mirrors Redactor.walk: recursively redacts sensitive fields, keeps structure.
+ * state.paths records every redacted key path so the UI can show exactly what
+ * was removed before the report leaves the browser. */
 function redactWalk(obj, key, path, state) {
   if (!state.enabled) return obj;
   const fullPath = path && key ? `${path}.${key}` : (key || path);
   if (key && isSensitive(key, obj)) {
     state.count += 1;
+    state.paths.push(fullPath);
     return REDACTED;
   }
   if (typeof obj === "boolean") return obj;
   if (typeof obj === "number" && key && !isAllowedNumber(fullPath, key)) {
     state.count += 1;
+    state.paths.push(fullPath);
     return REDACTED;
   }
   if (obj !== null && typeof obj === "object") {
@@ -1783,7 +1830,7 @@ async function collectReport(api, redacted, tradesLimit, window, progress) {
   progress.step(redacted
     ? "Redacting confidential fields (credentials, money values, identifiers) …"
     : "Redaction disabled — keeping absolute values …");
-  const state = { enabled: redacted, count: 0 };
+  const state = { enabled: redacted, count: 0, paths: [] };
   const report = {};
   for (const section of Object.keys(raw)) {
     report[section] = redactWalk(raw[section], "", "", state);
@@ -1801,7 +1848,9 @@ async function collectReport(api, redacted, tradesLimit, window, progress) {
     failed_endpoints: failed,
   };
   if (windowed) metadata.closed_trades_window = WINDOW_LABELS[window];
-  return { report_metadata: metadata, ...report };
+  /* report_metadata stays the first key, matching the CLI's output order. */
+  const ordered = { report_metadata: metadata, ...report };
+  return { report: ordered, redactedPaths: state.paths };
 }
 
 const nullProgress = { setTotal() {}, addTotal() {}, step() {}, done() {} };
@@ -1811,11 +1860,11 @@ const nullProgress = { setTotal() {}, addTotal() {}, step() {}, done() {} };
 async function runExport(opts, progress) {
   progress = progress || nullProgress;
   const api = new FreqtradeApi(opts);
-  const report = await collectReport(api, opts.redact, opts.tradesLimit === undefined ? null : opts.tradesLimit, opts.window || "all", progress);
+  const { report, redactedPaths } = await collectReport(api, opts.redact, opts.tradesLimit === undefined ? null : opts.tradesLimit, opts.window || "all", progress);
   progress.step("Serializing JSON and preparing the download …");
   const json = JSON.stringify(report, null, 2) + "\n";
   const filename = `bot-report-${stamp()}.json`;
-  return { report, json, filename };
+  return { report, json, filename, redactedPaths };
 }
 
 function stamp() {
@@ -1859,7 +1908,7 @@ function el(tag, attrs, children) {
   return node;
 }
 
-function renderSuccess(container, report, filename, json) {
+function renderSuccess(container, report, filename, json, redactedPaths) {
   const meta = report.report_metadata;
   const failed = meta.failed_endpoints;
   const children = [];
@@ -1891,10 +1940,26 @@ function renderSuccess(container, report, filename, json) {
     tr.append(el("th", { scope: "row" }, [label]), el("td", { class: cls }, [String(value)]));
     tbody.append(tr);
   }
-  table.append(tbody, el("caption", {}, [`Saved as ${filename}`]));
+  table.append(tbody, el("caption", {}, [`File name: ${filename}`]));
   children.push(table);
 
-  const button = el("button", { type: "button" }, ["Download again"]);
+  /* Review-before-download: show exactly which key paths were redacted so the
+     user can confirm what left their machine before saving the file. */
+  if (meta.redacted && redactedPaths && redactedPaths.length > 0) {
+    const counts = new Map();
+    for (const p of redactedPaths) counts.set(p, (counts.get(p) || 0) + 1);
+    const review = el("details", { class: "redaction-review" });
+    review.append(el("summary", {}, [`Review what was redacted (${meta.redacted_field_count} fields)`]));
+    const list = el("ul", { "scroll-y": "" });
+    for (const path of [...counts.keys()].sort()) {
+      const n = counts.get(path);
+      list.append(el("li", {}, [n > 1 ? `${path} — ×${n}` : path]));
+    }
+    review.append(list);
+    children.push(review);
+  }
+
+  const button = el("button", { type: "button" }, ["Download report"]);
   button.addEventListener("click", () => saveJson(json, filename));
   children.push(button);
   container.replaceChildren(...children);
@@ -1906,6 +1971,16 @@ function renderFailure(container, err) {
     el("p", { class: "text-danger" }, [err.friendly || String(err)]),
     el("p", { class: "text-neutral" }, ["Fix the cause and try again. Nothing was written to disk."]),
   );
+}
+
+function saveJson(json, filename) {
+  const blob = new Blob([json], { type: "application/json" });
+  const url = URL.createObjectURL(blob);
+  const link = el("a", { href: url, download: filename });
+  document.body.append(link);
+  link.click();
+  link.remove();
+  setTimeout(() => URL.revokeObjectURL(url), 10000);
 }
 
 function renderConnectionHelp(container, diagnosis) {
@@ -2085,11 +2160,10 @@ async function onExport(form) {
   }
   await withBusyUi(form, "Connecting to the bot — GET /api/v1/ping …", async (resultTitle, resultBody, progress) => {
     try {
-      const { report, json, filename } = await runExport(opts, progress);
-      saveJson(json, filename);
-      resultTitle.textContent = "Export finished";
+      const { report, json, filename, redactedPaths } = await runExport(opts, progress);
+      resultTitle.textContent = "Report ready";
       resultTitle.className = "text-success";
-      renderSuccess(resultBody, report, filename, json);
+      renderSuccess(resultBody, report, filename, json, redactedPaths);
     } catch (err) {
       resultTitle.textContent = "Export failed";
       resultTitle.className = "text-danger";
@@ -2141,6 +2215,29 @@ if (typeof document !== "undefined") {
       document.getElementById("page-origin-snippet").textContent = origin;
     }
     document.getElementById("f-url").placeholder = defaultBaseUrl();
+    /* Unchecking redaction is gated behind an explicit dialog confirmation. */
+    const redactCheckbox = document.getElementById("f-redact");
+    const confirmDialog = document.getElementById("redact-confirm");
+    let redactApproved = false;
+    redactCheckbox.addEventListener("change", () => {
+      if (redactCheckbox.checked) return;
+      /* every open starts unapproved — a past approval must not carry over */
+      redactApproved = false;
+      confirmDialog.showModal();
+    });
+    document.getElementById("redact-disable").addEventListener("click", () => {
+      redactApproved = true;
+      confirmDialog.close();
+    });
+    document.getElementById("redact-keep").addEventListener("click", () => {
+      redactApproved = false;
+      redactCheckbox.checked = true;
+      confirmDialog.close();
+    });
+    /* Esc-close safety net: an unapproved dismissal restores redaction. */
+    confirmDialog.addEventListener("close", () => {
+      if (!redactApproved) redactCheckbox.checked = true;
+    });
     const form = document.getElementById("connect");
     form.addEventListener("submit", (event) => {
       event.preventDefault();

--- a/index.html
+++ b/index.html
@@ -1,0 +1,1817 @@
+<!doctype html>
+<!--
+  Freqtrade Bot Report — in-browser port of tools/bot_report.py
+
+  Single-file tool: the styling and all logic are embedded below, there is no
+  build step and no external dependency. The page only ever talks to the
+  freqtrade REST API URL entered into the form (read-only GET requests to
+  /api/v1/*). Everything else — fetching, derivation of relative fields,
+  redaction, JSON serialization and saving — happens locally in the browser.
+
+  Styling: shadcn-classless by fordus (https://github.com/fordus/shadcn-classless),
+  MIT licensed, embedded verbatim except for the Google Fonts @import, which was
+  removed so that the page loads no third-party resources at all.
+-->
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<meta name="referrer" content="no-referrer">
+<meta http-equiv="Content-Security-Policy"
+      content="default-src 'none'; style-src 'unsafe-inline'; script-src 'unsafe-inline'; connect-src http: https:; img-src data:; base-uri 'none'; form-action 'none'">
+<title>Freqtrade Bot Report — in-browser export</title>
+<meta name="description" content="Generate a redacted freqtrade bot report entirely in your browser. No server sees your data — the only endpoint contacted is your own bot's REST API.">
+<style>
+:root {
+  --radius: 0.5rem;
+  --background: oklch(1 0 0);
+  --foreground: oklch(0.141 0.005 285.823);
+  --card: oklch(1 0 0);
+  --card-foreground: oklch(0.141 0.005 285.823);
+  --popover: oklch(1 0 0);
+  --popover-foreground: oklch(0.141 0.005 285.823);
+  --primary: oklch(0.21 0.006 285.885);
+  --primary-foreground: oklch(0.985 0 0);
+  --secondary: oklch(0.967 0.001 286.375);
+  --secondary-foreground: oklch(0.21 0.006 285.885);
+  --muted: oklch(0.967 0.001 286.375);
+  --muted-foreground: oklch(0.552 0.016 285.938);
+  --accent: oklch(0.967 0.001 286.375);
+  --accent-foreground: oklch(0.21 0.006 285.885);
+  --destructive: oklch(0.577 0.245 27.325);
+  --border-color: oklch(0.92 0.004 286.32);
+  --input: oklch(0.92 0.004 286.32);
+  --ring: oklch(0.705 0.015 286.067);
+  --chart-1: oklch(0.646 0.222 41.116);
+  --chart-2: oklch(0.6 0.118 184.704);
+  --chart-3: oklch(0.398 0.07 227.392);
+  --chart-4: oklch(0.828 0.189 84.429);
+  --chart-5: oklch(0.769 0.188 70.08);
+  --sidebar: oklch(0.985 0 0);
+  --sidebar-foreground: oklch(0.141 0.005 285.823);
+  --sidebar-primary: oklch(0.21 0.006 285.885);
+  --sidebar-primary-foreground: oklch(0.985 0 0);
+  --sidebar-accent: oklch(0.967 0.001 286.375);
+  --sidebar-accent-foreground: oklch(0.21 0.006 285.885);
+  --sidebar-border: oklch(0.92 0.004 286.32);
+  --sidebar-ring: oklch(0.705 0.015 286.067);
+
+  --shadow: 0px 10px 15px -3px rgba(0, 0, 0, 0.1),
+    0px 4px 6px -2px rgba(0, 0, 0, 0.05);
+
+  --loading-icon-url: url("data:image/svg+xml,%3Csvg width='24' height='24' viewBox='0 0 100 100' xmlns='http://www.w3.org/2000/svg'%3E%3Ccircle cx='50' cy='50' r='40' stroke='rgb(184, 184, 184)' stroke-width='20' fill='none' stroke-linecap='round' stroke-dasharray='200' stroke-dashoffset='100'%3E%3CanimateTransform attributeName='transform' type='rotate' from='0 50 50' to='360 50 50' dur='1s' repeatCount='indefinite'/%3E%3C/circle%3E%3C/svg%3E");
+
+  --border: 1px solid var(--border-color);
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --background: oklch(0.141 0.005 285.823);
+    --foreground: oklch(0.985 0 0);
+    --card: oklch(0.21 0.006 285.885);
+    --card-foreground: oklch(0.985 0 0);
+    --popover: oklch(0.21 0.006 285.885);
+    --popover-foreground: oklch(0.985 0 0);
+    --primary: oklch(0.92 0.004 286.32);
+    --primary-foreground: oklch(0.21 0.006 285.885);
+    --secondary: oklch(0.274 0.006 286.033);
+    --secondary-foreground: oklch(0.985 0 0);
+    --muted: oklch(0.274 0.006 286.033);
+    --muted-foreground: oklch(0.705 0.015 286.067);
+    --accent: oklch(0.274 0.006 286.033);
+    --accent-foreground: oklch(0.985 0 0);
+    --destructive: oklch(0.704 0.191 22.216);
+    --border-color: oklch(1 0 0 / 10%);
+    --input: oklch(1 0 0 / 15%);
+    --ring: oklch(0.552 0.016 285.938);
+    --chart-1: oklch(0.488 0.243 264.376);
+    --chart-2: oklch(0.696 0.17 162.48);
+    --chart-3: oklch(0.769 0.188 70.08);
+    --chart-4: oklch(0.627 0.265 303.9);
+    --chart-5: oklch(0.645 0.246 16.439);
+    --sidebar: oklch(0.21 0.006 285.885);
+    --sidebar-foreground: oklch(0.985 0 0);
+    --sidebar-primary: oklch(0.488 0.243 264.376);
+    --sidebar-primary-foreground: oklch(0.985 0 0);
+    --sidebar-accent: oklch(0.274 0.006 286.033);
+    --sidebar-accent-foreground: oklch(0.985 0 0);
+    --sidebar-border: oklch(1 0 0 / 10%);
+    --sidebar-ring: oklch(0.552 0.016 285.938);
+    --border: 1px solid var(--border-color);
+  }
+}
+
+html {
+  color-scheme: light dark;
+}
+
+html[data-theme='light'] {
+  color-scheme: light;
+  --background: oklch(1 0 0);
+  --foreground: oklch(0.141 0.005 285.823);
+  --card: oklch(1 0 0);
+  --card-foreground: oklch(0.141 0.005 285.823);
+  --popover: oklch(1 0 0);
+  --popover-foreground: oklch(0.141 0.005 285.823);
+  --primary: oklch(0.21 0.006 285.885);
+  --primary-foreground: oklch(0.985 0 0);
+  --secondary: oklch(0.967 0.001 286.375);
+  --secondary-foreground: oklch(0.21 0.006 285.885);
+  --muted: oklch(0.967 0.001 286.375);
+  --muted-foreground: oklch(0.552 0.016 285.938);
+  --accent: oklch(0.967 0.001 286.375);
+  --accent-foreground: oklch(0.21 0.006 285.885);
+  --destructive: oklch(0.577 0.245 27.325);
+  --border-color: oklch(0.92 0.004 286.32);
+  --input: oklch(0.92 0.004 286.32);
+  --ring: oklch(0.705 0.015 286.067);
+  --chart-1: oklch(0.646 0.222 41.116);
+  --chart-2: oklch(0.6 0.118 184.704);
+  --chart-3: oklch(0.398 0.07 227.392);
+  --chart-4: oklch(0.828 0.189 84.429);
+  --chart-5: oklch(0.769 0.188 70.08);
+  --sidebar: oklch(0.985 0 0);
+  --sidebar-foreground: oklch(0.141 0.005 285.823);
+  --sidebar-primary: oklch(0.21 0.006 285.885);
+  --sidebar-primary-foreground: oklch(0.985 0 0);
+  --sidebar-accent: oklch(0.967 0.001 286.375);
+  --sidebar-accent-foreground: oklch(0.21 0.006 285.885);
+  --sidebar-border: oklch(0.92 0.004 286.32);
+  --sidebar-ring: oklch(0.705 0.015 286.067);
+  --shadow: 0px 10px 15px -3px rgba(0, 0, 0, 0.1),
+    0px 4px 6px -2px rgba(0, 0, 0, 0.05);
+  --border: 1px solid var(--border-color);
+}
+
+html[data-theme='dark'] {
+  color-scheme: dark;
+}
+
+html[data-theme='dark'] {
+  --background: oklch(0.141 0.005 285.823);
+  --foreground: oklch(0.985 0 0);
+  --card: oklch(0.21 0.006 285.885);
+  --card-foreground: oklch(0.985 0 0);
+  --popover: oklch(0.21 0.006 285.885);
+  --popover-foreground: oklch(0.985 0 0);
+  --primary: oklch(0.92 0.004 286.32);
+  --primary-foreground: oklch(0.21 0.006 285.885);
+  --secondary: oklch(0.274 0.006 286.033);
+  --secondary-foreground: oklch(0.985 0 0);
+  --muted: oklch(0.274 0.006 286.033);
+  --muted-foreground: oklch(0.705 0.015 286.067);
+  --accent: oklch(0.274 0.006 286.033);
+  --accent-foreground: oklch(0.985 0 0);
+  --destructive: oklch(0.704 0.191 22.216);
+  --border-color: oklch(1 0 0 / 10%);
+  --input: oklch(1 0 0 / 15%);
+  --ring: oklch(0.552 0.016 285.938);
+  --chart-1: oklch(0.488 0.243 264.376);
+  --chart-2: oklch(0.696 0.17 162.48);
+  --chart-3: oklch(0.769 0.188 70.08);
+  --chart-4: oklch(0.627 0.265 303.9);
+  --chart-5: oklch(0.645 0.246 16.439);
+  --sidebar: oklch(0.21 0.006 285.885);
+  --sidebar-foreground: oklch(0.985 0 0);
+  --sidebar-primary: oklch(0.488 0.243 264.376);
+  --sidebar-primary-foreground: oklch(0.985 0 0);
+  --sidebar-accent: oklch(0.274 0.006 286.033);
+  --sidebar-accent-foreground: oklch(0.985 0 0);
+  --sidebar-border: oklch(1 0 0 / 10%);
+  --sidebar-ring: oklch(0.552 0.016 285.938);
+  --border: 1px solid var(--border-color);
+}
+
+* {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+
+  scrollbar-width: auto;
+  scrollbar-color: var(--muted-foreground) var(--muted);
+}
+
+*::-webkit-scrollbar {
+  width: 12px;
+}
+*::-webkit-scrollbar-thumb {
+  background: var(--muted-foreground);
+  border-radius: 6px;
+  border: 2px solid var(--background);
+}
+*::-webkit-scrollbar-thumb:hover {
+  background: var(--foreground);
+}
+*::-webkit-scrollbar-track {
+  background: var(--muted);
+  border-radius: 6px;
+}
+
+body {
+  font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto',
+    'Oxygen', 'Ubuntu', 'Cantarell', sans-serif;
+  background-color: var(--background);
+  color: var(--foreground);
+  line-height: 1.5;
+  padding: 2rem 1rem 1rem 1rem;
+  transition: background-color 0.3s ease, color 0.3s ease;
+  max-width: 900px;
+  margin: 0 auto;
+}
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+  margin-bottom: 0.5em;
+  font-weight: 700;
+}
+
+h1 {
+  letter-spacing: -0.025em;
+  font-weight: 700;
+  font-size: 1.875rem;
+  line-height: 2.25rem;
+}
+
+h2 {
+  letter-spacing: -0.025em;
+  font-weight: 600;
+  font-size: 1.25rem;
+  line-height: 1.75rem;
+}
+
+h3 {
+  letter-spacing: -0.025em;
+  font-weight: 600;
+  font-size: 1.125rem;
+  line-height: 1.75rem;
+}
+
+h4 {
+  letter-spacing: -0.025em;
+  font-weight: 600;
+  font-size: 16px;
+  line-height: 1.75rem;
+}
+
+h5 {
+  font-size: 15px;
+}
+
+h6 {
+  font-size: 14px;
+}
+
+p {
+  margin: 1em 0;
+}
+a {
+  color: var(--primary);
+  text-decoration: none;
+  transition: color 0.2s ease;
+}
+a:hover {
+  text-decoration: underline;
+  color: color-mix(in srgb, var(--primary) 80%, transparent);
+}
+a:focus-visible {
+  outline: 2px solid var(--ring);
+  outline-offset: 2px;
+  border-radius: 2px;
+}
+ul,
+ol {
+  margin-bottom: 1em;
+  padding-left: 1.5em;
+}
+header {
+  margin-bottom: 2rem;
+}
+header h1 {
+  font-size: 2rem;
+}
+nav ul {
+  list-style: none;
+  padding: 0;
+  display: flex;
+  gap: 1rem;
+}
+section {
+  margin-bottom: 2rem;
+}
+form {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+input[type='password'],
+input[type='text'],
+input[type='date'],
+input[type='color'],
+input[type='time'],
+input[type='file'],
+input[type='search'],
+input[type='email'],
+select,
+textarea {
+  font-weight: 500;
+  font: inherit;
+  padding: 0.5rem;
+  border: var(--border);
+  border-radius: var(--radius);
+  background-color: var(--background);
+  color: var(--foreground);
+  font-size: 0.875rem;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+input[type='password']:focus,
+input[type='text']:focus,
+input[type='date']:focus,
+input[type='time']:focus,
+input[type='search']:focus,
+input[type='email']:focus,
+select:focus,
+textarea:focus {
+  outline: none;
+  border-color: var(--ring);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--ring) 15%, transparent);
+}
+input[type='color'] {
+  appearance: none;
+  cursor: pointer;
+  outline-style: none;
+  padding: initial;
+  max-width: initial;
+  border: none;
+  outline: none;
+  -webkit-appearance: none;
+  border-radius: var(--radius);
+}
+input[type='color']::-webkit-color-swatch {
+  border: none;
+  border-radius: var(--radius);
+}
+input[type='color']::-moz-color-swatch {
+  border-radius: var(--radius);
+  border-style: none;
+  border: none;
+}
+
+/** --- BUTTONS --- */
+input[type='reset'],
+input[type='submit'],
+input[type='button'],
+button {
+  font: inherit;
+  cursor: pointer;
+  font-size: 0.875rem;
+  font-weight: 500;
+  padding: 0.5rem 1rem;
+  border-radius: var(--radius);
+  transition: background-color 0.2s ease-in-out;
+}
+
+/** Primary */
+button {
+  border: none;
+  background-color: var(--primary);
+  color: var(--primary-foreground);
+  &:hover {
+    background-color: color-mix(in srgb, var(--primary) 90%, transparent);
+  }
+  &:focus-visible {
+    outline: none;
+    box-shadow: 0 0 0 3px color-mix(in srgb, var(--primary) 30%, transparent);
+  }
+  &:active {
+    transform: scale(0.98);
+  }
+}
+/** Secondary */
+button[secondary] {
+  background-color: var(--secondary);
+  color: var(--secondary-foreground);
+  &:hover {
+    background-color: color-mix(in srgb, var(--secondary) 90%, transparent);
+  }
+}
+
+/** Outline */
+input[type='submit'] {
+  border: var(--border);
+  background-color: transparent;
+  color: var(--foreground);
+  &:hover {
+    background-color: color-mix(in srgb, var(--muted) 90%, transparent);
+  }
+}
+
+/** Ghost */
+input[type='button'] {
+  border: none;
+  background-color: transparent;
+  color: var(--foreground);
+  &:hover {
+    background-color: var(--muted);
+  }
+}
+
+/** Desctructive */
+input[type='reset'] {
+  border: none;
+  background-color: var(--destructive);
+  color: var(--primary-foreground);
+  &:hover {
+    background-color: color-mix(in srgb, var(--destructive) 90%, transparent);
+  }
+}
+
+fieldset {
+  border: var(--border);
+  border-radius: var(--radius);
+  padding: 1rem;
+  display: flex;
+  gap: 0.5rem;
+}
+
+fieldset[role='group'] {
+  border: none;
+  padding: 1rem;
+  display: flex;
+  gap: 0;
+  > * {
+    border-radius: 0;
+    &:first-child {
+      border-top-left-radius: var(--radius);
+      border-bottom-left-radius: var(--radius);
+      border-right: 0;
+    }
+    &:last-child {
+      border-top-right-radius: var(--radius);
+      border-bottom-right-radius: var(--radius);
+      border-right: var(--border);
+    }
+  }
+}
+
+fieldset[role='otp'] {
+  border: none;
+  padding: 1rem;
+  display: flex;
+  gap: 0;
+
+  > input {
+    border-radius: 0;
+    width: 1rem;
+    text-align: center;
+    border-right: 0;
+
+    &:first-child {
+      border-top-left-radius: var(--radius);
+      border-bottom-left-radius: var(--radius);
+      border-right: 0;
+    }
+    &:last-child {
+      border-top-right-radius: var(--radius);
+      border-bottom-right-radius: var(--radius);
+      border-right: var(--border);
+    }
+  }
+}
+legend {
+  padding: 0 0.5rem;
+}
+label {
+  display: block;
+  * {
+    vertical-align: middle;
+  }
+}
+small {
+  color: var(--muted-foreground);
+}
+figure {
+  margin-bottom: 1rem;
+  overflow: hidden;
+}
+img {
+  max-width: 100%;
+  height: auto;
+  border-radius: var(--radius);
+}
+
+img[avatar] {
+  border-radius: 50%;
+}
+
+figcaption {
+  font-size: 0.875rem;
+  margin-top: 0.5rem;
+  color: var(--muted-foreground);
+}
+blockquote {
+  border-left: 4px solid var(--border-color);
+  padding-left: 1rem;
+  font-style: italic;
+  > footer {
+    text-align: center;
+  }
+}
+[type='checkbox'],
+[type='radio'] {
+  margin-right: 0.5rem;
+}
+progress {
+  width: 100%;
+}
+dialog {
+  background-color: var(--background);
+  color: var(--foreground);
+  border: var(--border);
+  border-radius: var(--radius);
+  padding: 24px;
+  margin: auto;
+}
+dialog::backdrop {
+  background-color: rgba(0, 0, 0, 0.8);
+}
+
+details {
+  border: var(--border);
+  border-radius: var(--radius);
+  padding: 0.5rem;
+  margin-bottom: 1rem;
+}
+summary {
+  cursor: pointer;
+  font-weight: bold;
+}
+article {
+  border: var(--border);
+  border-radius: var(--radius);
+  padding: 1rem;
+  margin-bottom: 1rem;
+}
+footer {
+  margin-top: 2rem;
+  color: var(--muted-foreground);
+}
+[aria-busy='true'] {
+  opacity: 0.7;
+  cursor: progress;
+}
+[aria-busy='spinner'] {
+  opacity: 0.7;
+  cursor: progress;
+  &::before {
+    content: var(--loading-icon-url);
+    padding-right: 1rem;
+  }
+}
+/* Reduced motion */
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+  }
+}
+
+/* Responsive */
+@media (max-width: 600px) {
+  body {
+    padding: 0.5rem;
+  }
+  nav ul {
+    flex-direction: column;
+  }
+}
+
+input[type='file']::file-selector-button {
+  border: none;
+  background-color: var(--background);
+  color: var(--foreground);
+  font-weight: 600;
+}
+
+:disabled,
+[disabled] {
+  cursor: not-allowed;
+  opacity: 0.5;
+}
+
+button:disabled,
+input:disabled,
+select:disabled,
+textarea:disabled {
+  pointer-events: none;
+}
+
+input[type='radio'],
+input[type='checkbox'],
+input[type='range'] {
+  accent-color: var(--primary);
+  background-color: var(--background);
+}
+
+/** Toggles */
+input[type='checkbox'][icon] {
+  display: none;
+  + * {
+    cursor: pointer;
+    border-radius: var(--radius);
+    padding: 0.5rem;
+    box-sizing: border-box;
+
+    &:hover {
+      background-color: var(--border-color);
+    }
+  }
+}
+input[type='checkbox'][icon] {
+  display: none;
+  + * {
+    cursor: pointer;
+    border-radius: var(--radius);
+    width: 2rem;
+    height: 2rem;
+    padding: 0.5rem;
+
+    &:hover {
+      background-color: var(--border-color);
+      stroke: var(--muted-foreground);
+    }
+  }
+}
+input[type='checkbox'][icon]:checked {
+  + * {
+    background-color: var(--border-color);
+
+    &:hover {
+      stroke: var(--accent-foreground);
+    }
+  }
+}
+
+/** Badge */
+kbd {
+  padding: 0.125rem 0.625rem;
+  background-color: var(--primary);
+  color: var(--primary-foreground);
+  border-radius: 6px;
+  font-weight: bold;
+}
+kbd[secondary] {
+  background-color: var(--secondary);
+  color: var(--secondary-foreground);
+}
+kbd[outline] {
+  background-color: var(--background);
+  color: var(--primary);
+  border: var(--border);
+}
+kbd[destructive] {
+  background-color: var(--destructive);
+  color: var(--primary-foreground);
+}
+
+table {
+  caption-side: bottom;
+  border-collapse: collapse;
+
+  caption {
+    color: var(--muted-foreground);
+    margin-top: 1rem;
+  }
+
+  th {
+    color: var(--muted-foreground);
+  }
+
+  tr {
+    border-bottom: var(--border);
+  }
+  tr:hover {
+    background-color: hsl(var(--muted) / 0.5);
+  }
+
+  td,
+  th {
+    vertical-align: middle;
+    padding: 0.5rem;
+    text-align: start;
+  }
+
+  tfoot {
+    background-color: var(--muted);
+  }
+}
+
+dialog[drawer] {
+  border-bottom-right-radius: 0;
+  border-bottom-left-radius: 0;
+  top: auto;
+  bottom: 0;
+  max-height: 50vh;
+
+  resize: vertical; /** Check if we can set the resize handle position to the top left/right */
+
+  &[open] {
+    animation: slideup 0.2s ease-in forwards;
+  }
+}
+
+dialog > header {
+  margin: 0;
+}
+/** Sheet */
+dialog[sheet-top],
+dialog[sheet-bottom],
+dialog[sheet-left],
+dialog[sheet-right] {
+  border-radius: 0;
+  margin: 0;
+}
+
+dialog[sheet-top],
+dialog[sheet-bottom] {
+  width: 100vw;
+  max-height: 50vh;
+}
+
+dialog[sheet-left],
+dialog[sheet-right] {
+  height: 100vh;
+  max-width: 50vw;
+}
+
+dialog[sheet-top][open] {
+  animation: slidedown 0.2s ease-in forwards;
+}
+
+dialog[sheet-bottom][open] {
+  animation: slideup 0.2s ease-in forwards;
+  top: auto;
+  bottom: 0;
+}
+dialog[sheet-left][open] {
+  animation: slideright 0.2s ease-in forwards;
+}
+
+dialog[sheet-right][open] {
+  animation: slideleft 0.2s ease-in forwards;
+  left: auto;
+  right: 0;
+}
+
+@keyframes slideup {
+  0% {
+    transform: translateY(100%);
+  }
+  100% {
+    transform: translateY(0);
+  }
+}
+@keyframes slidedown {
+  0% {
+    transform: translateY(-100%);
+  }
+  100% {
+    transform: translateY(0);
+  }
+}
+@keyframes slideleft {
+  0% {
+    transform: translateX(100%);
+  }
+  100% {
+    transform: translateX(0);
+  }
+}
+@keyframes slideright {
+  0% {
+    transform: translateX(-100%);
+  }
+  100% {
+    transform: translateX(0);
+  }
+}
+
+/** Progress */
+progress {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  height: 0.5rem;
+  border-radius: 9999px;
+  background-color: var(--muted);
+  border: 0;
+}
+progress[value]::-webkit-progress-value {
+  border-radius: 9999px;
+  background-color: var(--primary);
+}
+
+::-webkit-progress-bar {
+  border-radius: 9999px;
+  background-color: var(--muted);
+}
+::-moz-progress-bar {
+  border-radius: 9999px;
+  background-color: var(--primary);
+}
+
+progress:indeterminate {
+  background: var(--muted)
+    linear-gradient(to right, var(--primary) 35%, var(--muted) 35%) top
+    left/150% 150% no-repeat;
+  animation: progress-indeterminate 1.5s linear infinite;
+}
+progress:indeterminate::-webkit-progress-bar {
+  background-color: transparent;
+}
+progress:indeterminate::-moz-progress-bar {
+  background-color: transparent;
+}
+
+@keyframes progress-indeterminate {
+  0% {
+    background-position: 200% 0;
+  }
+  100% {
+    background-position: -200% 0;
+  }
+}
+
+hr {
+  border: 0;
+  height: 1px;
+  margin: 1rem 0;
+  background-color: var(--border-color);
+  flex-shrink: 0;
+}
+
+hr[vertical] {
+  width: 1px;
+  height: auto;
+  margin: 0 1rem;
+}
+
+/** Breadcrumbs */
+nav {
+  display: flex;
+  align-items: center;
+  --separator: attr(breadcrumb, '>');
+  > a {
+    padding: 0 0.625rem 0 0;
+    color: var(--muted-foreground);
+    &::after {
+      padding: 0 0 0 0.625rem;
+      display: inline-block;
+      content: var(--separator);
+    }
+    &:last-child {
+      color: var(--foreground);
+      &::after {
+        content: '';
+      }
+    }
+  }
+  &:hover::after {
+    text-decoration: none;
+  }
+}
+
+/** Skeleton */
+div[skeleton] {
+  background-color: var(--input);
+  animation: shimmer 2s cubic-bezier(0.4, 0, 0.6, 1) infinite;
+  border-radius: var(--radius);
+  opacity: 1;
+  * {
+    display: none;
+  }
+}
+@keyframes shimmer {
+  50% {
+    opacity: 0.5;
+  }
+}
+
+/** Popover */
+[popover] {
+  inset: unset;
+  position: absolute;
+
+  bottom: calc(anchor(top) + 5px);
+  justify-self: anchor-center;
+  margin: 0;
+
+  border: var(--border);
+  border-radius: var(--radius);
+  padding: 0.5rem;
+}
+
+/** Tooltip */
+[tooltip-top],
+[tooltip-bottom],
+[tooltip-left],
+[tooltip-right] {
+  position: relative;
+
+  &::after {
+    position: absolute;
+    white-space: nowrap;
+    background-color: var(--primary);
+    color: var(--primary-foreground);
+
+    padding: 6px 8px;
+    font-size: 0.875em;
+    border-radius: var(--radius);
+
+    opacity: 0;
+    transition: opacity 0.2s ease-in-out;
+
+    z-index: 10;
+    pointer-events: none;
+  }
+
+  &:hover::after {
+    opacity: 1;
+  }
+}
+
+[tooltip-top]::after {
+  content: attr(tooltip-top);
+  left: 50%;
+  top: -0.8rem;
+  transform: translateX(-50%) translateY(-100%);
+}
+[tooltip-bottom]::after {
+  content: attr(tooltip-bottom);
+  left: 50%;
+  top: calc(100% + 0.8rem);
+  transform: translateX(-50%) translateY(0%);
+}
+[tooltip-left]::after {
+  content: attr(tooltip-left);
+  left: -0.3rem;
+  top: 50%;
+  transform: translateX(-100%) translateY(-50%);
+}
+[tooltip-right]::after {
+  content: attr(tooltip-right);
+  left: calc(100% + 0.3rem);
+  top: 50%;
+  margin-left: 0.3rem;
+  transform: translateX(0%) translateY(-50%);
+}
+
+/** Code */
+pre {
+  border-radius: var(--radius);
+  > code {
+    display: block;
+    overflow-x: auto;
+  }
+}
+code {
+  border: var(--border);
+  border-radius: var(--radius);
+
+  background-color: var(--primary);
+  color: var(--primary-foreground);
+  padding: 0.2rem;
+}
+
+/** Toast */
+dialog[sonner],
+dialog[toast] {
+  padding: 1rem;
+  padding-right: 1.5rem;
+
+  top: auto;
+  bottom: 1rem;
+  left: auto;
+  right: 1rem;
+
+  &::backdrop {
+    opacity: 0;
+  }
+}
+
+dialog[toast] {
+  box-shadow: var(--shadow);
+
+  &[open] {
+    animation: slideup 0.2s ease-in forwards, fad-in 0.2s ease-in forwards;
+  }
+}
+
+dialog[sonner] {
+  background-color: transparent;
+  border: none;
+  display: flex;
+  flex-direction: column-reverse;
+  gap: 0.5rem;
+  transition: gap 0.15s ease-in;
+
+  > li {
+    animation: slideup 0.2s ease-in forwards, fad-in 0.2s ease-in forwards;
+
+    background-color: var(--background);
+    counter-increment: sonner-counter;
+    padding: 1rem;
+    padding-right: 1.5rem;
+    border: var(--border);
+    border-radius: var(--radius);
+    list-style: none;
+
+    &:hover {
+      scale: 1.1;
+    }
+  }
+}
+
+@keyframes fad-in {
+  0% {
+    opacity: 0;
+  }
+  100% {
+    opacity: 1;
+  }
+}
+
+/** Sidebar */
+aside {
+  background-color: var(--sidebar);
+  border: 1px solid var(--sidebar-border);
+
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+
+  position: relative;
+  padding: 0.5rem;
+
+  > main {
+    flex-grow: 1;
+    overflow-y: auto;
+    display: flex;
+    flex-direction: column;
+  }
+
+  > header,
+  > footer {
+    position: sticky;
+  }
+}
+
+/** Menubar */
+menu {
+  display: flex;
+  flex-direction: row;
+  border: var(--border);
+  border-radius: var(--radius);
+  width: fit-content;
+  > li {
+    padding: 0.25rem 0.75rem;
+    list-style: none;
+  }
+}
+
+/** Scrollarea */
+*[scroll-x] {
+  overflow-x: scroll;
+}
+
+*[scroll-y] {
+  overflow-y: scroll;
+}
+
+</style>
+<style>
+/* Page-specific additions on top of shadcn-classless (kept minimal). */
+#privacy-note {
+  border-left: 4px solid var(--primary);
+}
+#privacy-note h3 {
+  margin-bottom: 0.25rem;
+}
+dl.kv {
+  display: grid;
+  grid-template-columns: max-content 1fr;
+  gap: 0.25rem 1.5rem;
+  margin: 1rem 0;
+}
+dl.kv dt {
+  color: var(--muted-foreground);
+}
+p.error, li.error {
+  color: var(--destructive);
+}
+#progress-step {
+  min-height: 1.5rem;
+}
+code {
+  word-break: break-all;
+}
+</style>
+</head>
+<body>
+<header>
+  <h1>Freqtrade Bot Report</h1>
+  <p><small>In-browser port of <code>tools/bot_report.py</code> — exports a redacted JSON
+  telemetry report from a running freqtrade REST API, so strategy developers can review how a
+  strategy behaves in production. Everything runs locally in this browser tab.</small></p>
+</header>
+
+<main>
+  <article id="privacy-note">
+    <h3>No server sees your data</h3>
+    <p>This page is a single static file with all logic embedded. <strong>It makes no network
+    call to any server except the freqtrade API URL you enter below.</strong> There is no CDN,
+    no fonts, no analytics, no uploads, nothing stored: the report is generated in your browser
+    and saved straight to your disk. Closing the tab discards everything, including your
+    credentials.</p>
+    <p><strong>You can verify this:</strong> press <kbd>F12</kbd> to open your browser DevTools,
+    switch to the <em>Network</em> tab, and reload this page. You will see zero requests until
+    you click <em>Export report</em>, and afterwards only requests to your bot's address from
+    the form. The page also ships a strict Content-Security-Policy, so the browser itself
+    blocks anything else.</p>
+  </article>
+
+  <section>
+    <h2>Bot connection</h2>
+    <form id="connect">
+      <label>API base URL
+        <input type="text" id="f-url" value="http://127.0.0.1:8080" placeholder="http://127.0.0.1:8080" spellcheck="false">
+      </label>
+      <fieldset>
+        <legend>Credentials (HTTP Basic, as in your <code>api_server</code> config)</legend>
+        <label>Username
+          <input type="text" id="f-user" autocomplete="off" spellcheck="false">
+        </label>
+        <label>Password
+          <input type="password" id="f-pass">
+        </label>
+      </fieldset>
+      <fieldset>
+        <legend>Export options</legend>
+        <label><input type="checkbox" id="f-redact" checked>
+          Redact confidential fields (recommended — required before sharing the report)</label>
+        <label>Trades limit — safety cap on closed trades (empty = full paginated history)
+          <input type="number" id="f-limit" min="1" step="1" inputmode="numeric" placeholder="all">
+        </label>
+        <label>Per-request timeout, seconds
+          <input type="number" id="f-timeout" min="1" step="1" inputmode="numeric" value="30">
+        </label>
+      </fieldset>
+      <button type="submit" id="btn-export">Export report</button>
+    </form>
+  </section>
+
+  <section id="progress" hidden>
+    <h2 aria-busy="true">Exporting…</h2>
+    <p id="progress-step" aria-busy="spinner">Connecting…</p>
+    <progress id="progress-bar" max="1" value="0"></progress>
+  </section>
+
+  <section id="result" hidden>
+    <h2 id="result-title"></h2>
+    <div id="result-body"></div>
+  </section>
+
+  <details>
+    <summary>Setup — letting this page talk to your bot</summary>
+    <ol>
+      <li>Enable the freqtrade REST API (<code>"api_server": {"enabled": true, …}</code> with
+        <code>username</code>/<code>password</code>) in your bot's config.</li>
+      <li>Browsers enforce CORS: add this page's exact origin (no trailing slash) to
+        <code>CORS_origins</code> in the same <code>api_server</code> block and restart the bot:
+        <pre><code>"api_server": {
+    "enabled": true,
+    "listen_ip_address": "127.0.0.1",
+    "listen_port": 8080,
+    "username": "freqtrader",
+    "password": "…",
+    "CORS_origins": ["https://YOURNAME.github.io"]
+}</code></pre>
+        Without this entry the bot answers without the CORS headers browsers require, and every
+        request from this page fails before reaching freqtrade.</li>
+      <li>If this page is served over HTTPS and your bot is plain HTTP, browsers usually allow
+        <code>http://127.0.0.1</code> / <code>http://localhost</code> as an exception (Chrome may
+        additionally ask for a local-network permission). Remote bots over plain HTTP will be
+        blocked as mixed content — put them behind a TLS reverse proxy. Certificates must be
+        valid; this page cannot skip verification (there is no <code>--no-verify-tls</code> in a
+        browser).</li>
+    </ol>
+  </details>
+
+  <details>
+    <summary>What gets redacted?</summary>
+    <p>Credentials and keys (any field whose name contains <code>key</code>, <code>secret</code>,
+    <code>token</code>, <code>password</code>, <code>chat</code>, <code>webhook</code> or
+    <code>credential</code>; the whole <code>ccxt_config</code> objects), exchange order/account
+    identifiers, absolute money values (balances, stakes, costs, absolute PnL, funding fees,
+    drawdown water marks) and personal/machine-specific values (bot name, local paths).
+    Numeric redaction is fail-closed: a number is kept only when its key is recognized as safe,
+    so fields freqtrade adds in the future are hidden until reviewed. Scale-invariant relative
+    ratios are computed <em>before</em> redaction so the report stays useful without revealing
+    the account size. Full field reference: <a href="tools/bot_report.md">tools/bot_report.md</a>.</p>
+  </details>
+</main>
+
+<footer>
+  <small>Single-file tool, no build step, no dependencies. Read-only: it only ever issues
+  <code>GET</code> requests to <code>/api/v1/*</code>. Styling:
+  <a href="https://github.com/fordus/shadcn-classless">shadcn-classless</a> (MIT, embedded — no
+  external stylesheet is loaded).</small>
+</footer>
+
+<script>
+"use strict";
+
+/* =========================================================================
+ * Logic ported 1:1 from tools/bot_report.py (TOOL_VERSION 1.3.0).
+ * Pure functions live at the top; DOM wiring only runs in a browser.
+ * ========================================================================= */
+
+const API_PREFIX = "/api/v1";
+const TRADES_PAGE_SIZE = 500;
+const TOOL_VERSION = "1.3.0";
+const REDACTED = "<redacted>";
+const MAX_DAILY_DAYS = 3650;
+const MAX_WEEKLY_WEEKS = 520;
+const MAX_MONTHLY_MONTHS = 240;
+
+/* Keys that are always redacted regardless of their value. */
+const WHOLE_KEY_REDACT = new Set([
+  "bot_name", "ccxt_async_config", "ccxt_config", "db_url", "exportfilename",
+  "log_configfile", "logfile", "open_order", "open_orders", "strategy_path",
+  "uid", "user_data_dir",
+]);
+
+/* Key tokens (key split on non-alphanumerics) that mark credentials / personal data. */
+const SECRET_TOKENS = new Set([
+  "chat", "credential", "key", "passwd", "password", "secret", "token", "webhook",
+]);
+
+/* A key is treated as an identifier when it has an "id" token plus one of these.
+ * Local counters (trade_id, id) stay, exchange/account identifiers do not. */
+const ID_CONTEXT_TOKENS = new Set([
+  "account", "client", "order", "telegram", "user",
+]);
+
+/* Keys whose values can reveal the account balance / absolute PnL. */
+const MONEY_EXACT_KEYS = new Set([
+  "abs_profit", "amount", "amount_requested", "available_capital", "cost",
+  "current_drawdown_high", "current_drawdown_low", "drawdown_high", "drawdown_low",
+  "dry_run_wallet", "expectancy", "fiat_value", "filled", "funding_fee",
+  "funding_fees", "ft_fee_base", "max_stake_amount", "open_trade_value",
+  "profit_all_coin", "profit_all_fiat", "profit_closed_coin", "profit_closed_fiat",
+  "realized_profit", "remaining", "safe_cost", "stake_amount", "starting_balance",
+  "total_capital", "total_stake", "trading_volume",
+]);
+
+const MONEY_KEY_SUFFIXES = [
+  "_abs", "_balance", "_coin", "_cost", "_dist", "_fee", "_fiat", "_stake_amount", "_wallet",
+];
+/* Absolute price levels, not money: stop_loss_abs describes the market, not the account. */
+const MONEY_SUFFIX_EXCEPTIONS = new Set(["initial_stop_loss_abs", "stop_loss_abs"]);
+/* Money-like keys where a string value is behavior (e.g. "unlimited"), not an amount. */
+const MONEY_ONLY_NUMERIC_KEYS = new Set(["dry_run_wallet", "max_stake_amount", "stake_amount"]);
+
+/* Fail-closed numeric redaction: report sections whose numbers are safe as a whole. */
+const NUMBER_SAFE_SECTIONS = new Set(["config", "system_info", "plot_config"]);
+
+/* Key tokens that mark numbers safe to keep. Deny rules always take precedence. */
+const ALLOWED_NUMBER_TOKENS = new Set([
+  "average", "count", "current", "decimals", "duration", "interval", "length",
+  "max", "offset", "pct", "percent", "precision", "price", "rate", "ratio",
+  "share", "timestamp", "total", "ts", "version",
+]);
+
+/* Individual numeric keys that are safe but carry none of the tokens above. */
+const ALLOWED_NUMBER_KEYS = new Set([
+  "close_profit", "contract_size", "cagr", "calmar", "fee_close", "fee_open",
+  "initial_stop_loss_abs", "leverage", "losing_trades", "max_drawdown",
+  "current_drawdown", "nr_of_successful_entries", "nr_of_successful_exits",
+  "profit", "profit_factor", "rel_profit", "sharpe", "sortino", "sqn",
+  "stop_loss_abs", "timeframe", "winrate", "winning_trades",
+]);
+
+function keyTokens(key) {
+  return key.toLowerCase().split(/[^a-z0-9]+/).filter(Boolean);
+}
+
+function isSensitive(key, value) {
+  const lowered = key.toLowerCase();
+  const parts = keyTokens(key);
+  if (parts.length === 0 || MONEY_SUFFIX_EXCEPTIONS.has(lowered)) return false;
+  if (WHOLE_KEY_REDACT.has(lowered)) return true;
+  if (parts.some((part) => SECRET_TOKENS.has(part))) return true;
+  if (parts.includes("id") && parts.some((part) => ID_CONTEXT_TOKENS.has(part))) return true;
+  /* Ratios/percentages are never account balance, even when they mention money words. */
+  if (parts.includes("ratio") || parts[parts.length - 1] === "pct" || parts[parts.length - 1] === "percent") return false;
+  if (MONEY_EXACT_KEYS.has(lowered) || MONEY_KEY_SUFFIXES.some((suffix) => lowered.endsWith(suffix))) {
+    if (MONEY_ONLY_NUMERIC_KEYS.has(lowered)) return typeof value === "number";
+    return true;
+  }
+  return false;
+}
+
+function isAllowedNumber(path, key) {
+  /* Fail-closed: unknown keys are redacted. */
+  if (NUMBER_SAFE_SECTIONS.has(path.split(".")[0])) return true;
+  if (keyTokens(key).some((token) => ALLOWED_NUMBER_TOKENS.has(token))) return true;
+  if (ALLOWED_NUMBER_KEYS.has(key) || key.endsWith("_id") || key === "id") return true;
+  return false;
+}
+
+/* Mirrors Redactor.walk: recursively redacts sensitive fields, keeps structure. */
+function redactWalk(obj, key, path, state) {
+  if (!state.enabled) return obj;
+  const fullPath = path && key ? `${path}.${key}` : (key || path);
+  if (key && isSensitive(key, obj)) {
+    state.count += 1;
+    return REDACTED;
+  }
+  if (typeof obj === "boolean") return obj;
+  if (typeof obj === "number" && key && !isAllowedNumber(fullPath, key)) {
+    state.count += 1;
+    return REDACTED;
+  }
+  if (obj !== null && typeof obj === "object") {
+    if (Array.isArray(obj)) {
+      return obj.map((item) => redactWalk(item, key, fullPath, state));
+    }
+    const out = {};
+    for (const name of Object.keys(obj)) {
+      out[name] = redactWalk(obj[name], String(name), fullPath, state);
+    }
+    return out;
+  }
+  return obj;
+}
+
+/* ---------------------------------------------------------------- errors */
+
+class ApiError extends Error {
+  constructor(endpoint, status) {
+    super(`${endpoint} failed with HTTP ${status}`);
+    this.endpoint = endpoint;
+    this.status = status;
+    this.friendly = `${API_PREFIX}/${endpoint} answered with HTTP ${status}.`;
+  }
+}
+
+class AuthError extends Error {
+  constructor(base) {
+    super(`authentication failed for ${base}`);
+    this.friendly = "Authentication failed: check the username and password against your bot's api_server config.";
+  }
+}
+
+class NetworkError extends Error {
+  constructor(base, cause) {
+    super(`cannot reach freqtrade API at ${base}`, { cause });
+    this.friendly = `Cannot reach the freqtrade API at ${base}. The browser blocked the request or the bot is offline. Most common causes: missing "CORS_origins" entry for this page in the bot's api_server config, or a plain-HTTP bot URL blocked as mixed content (see Setup below). Details in the DevTools console.`;
+  }
+}
+
+class TimeoutError extends Error {
+  constructor(endpoint, seconds) {
+    super(`${endpoint} timed out after ${seconds}s`);
+    this.friendly = `Request to ${API_PREFIX}/${endpoint} timed out after ${seconds}s. The bot may be busy, offline, or the timeout is too small.`;
+  }
+}
+
+/* ------------------------------------------------------------ api client */
+
+/* Mirrors FreqtradeApi: minimal read-only client for the freqtrade REST API. */
+class FreqtradeApi {
+  constructor(opts) {
+    this.base = opts.url.replace(/\/+$/, "");
+    this.timeoutMs = (opts.timeout ?? 30) * 1000;
+    this.auth = null;
+    if (opts.username || opts.password) {
+      this.auth = "Basic " + b64Utf8(`${opts.username || ""}:${opts.password || ""}`);
+    }
+  }
+
+  async get(endpoint, params) {
+    let url = `${this.base}${API_PREFIX}/${endpoint}`;
+    if (params) url += "?" + new URLSearchParams(params).toString();
+    const headers = { "Accept": "application/json" };
+    if (this.auth) headers["Authorization"] = this.auth;
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), this.timeoutMs);
+    let response;
+    try {
+      response = await fetch(url, { method: "GET", headers, signal: controller.signal, credentials: "omit" });
+    } catch (err) {
+      if (err && err.name === "AbortError") throw new TimeoutError(endpoint, this.timeoutMs / 1000);
+      throw new NetworkError(this.base, err);
+    } finally {
+      clearTimeout(timer);
+    }
+    if (response.status === 401) throw new AuthError(this.base);
+    if (!response.ok) throw new ApiError(endpoint, response.status);
+    return response.json();
+  }
+}
+
+function b64Utf8(text) {
+  const bytes = new TextEncoder().encode(text);
+  let binary = "";
+  for (const byte of bytes) binary += String.fromCharCode(byte);
+  return btoa(binary);
+}
+
+/* -------------------------------------------------------- derived fields */
+
+function safeDiv(numerator, denominator) {
+  if (numerator === null || numerator === undefined || denominator === null || denominator === undefined) return null;
+  if (typeof numerator !== "number" || typeof denominator !== "number") return null;
+  if (denominator === 0) return null;
+  if (!Number.isFinite(numerator / denominator)) return null;
+  return Math.round((numerator / denominator) * 1e6) / 1e6;
+}
+
+/* Build a day -> starting-balance lookup from /daily rows (null if unavailable). */
+function balanceLookup(dailyRows) {
+  const mapping = new Map();
+  for (const row of dailyRows || []) {
+    if (!row || typeof row !== "object") continue;
+    const day = row.date;
+    const balance = row.starting_balance;
+    if (day && typeof balance === "number") mapping.set(String(day).slice(0, 10), balance);
+  }
+  if (mapping.size === 0) return null;
+  const days = Array.from(mapping.keys()).sort();
+  return function lookup(dateStr) {
+    const day = String(dateStr).slice(0, 10);
+    if (mapping.has(day)) return mapping.get(day);
+    if (day < days[0]) return mapping.get(days[0]);
+    for (let i = days.length - 1; i >= 0; i--) {
+      if (days[i] < day) return mapping.get(days[i]);
+    }
+    return mapping.get(days[0]);
+  };
+}
+
+function isEntryOrder(order, isShort) {
+  if ("ft_is_entry" in order) return Boolean(order.ft_is_entry);
+  return (order.ft_order_side === "buy") !== Boolean(isShort);
+}
+
+/* Mirrors add_derived_fields: scale-invariant ratios, computed before redaction.
+ * All derived keys carry a "ratio" or "share" token so redaction keeps them. */
+function addDerivedFields(raw, nowIso) {
+  const lookup = balanceLookup((raw.daily_performance || {}).data);
+  const balanceNow = lookup ? lookup(nowIso || new Date().toISOString()) : null;
+
+  const tradeCounts = raw.trade_counts;
+  if (tradeCounts !== null && typeof tradeCounts === "object" && !Array.isArray(tradeCounts)) {
+    tradeCounts.total_stake_to_account_balance_ratio = safeDiv(tradeCounts.total_stake, balanceNow);
+  }
+
+  const profitSummary = raw.profit_summary;
+  if (profitSummary !== null && typeof profitSummary === "object" && !Array.isArray(profitSummary)) {
+    profitSummary.trading_volume_to_account_balance_ratio = safeDiv(profitSummary.trading_volume, balanceNow);
+  }
+
+  const openTrades = Array.isArray(raw.open_trades) ? raw.open_trades : [];
+  const closedTrades = Array.isArray((raw.closed_trades || {}).trades) ? raw.closed_trades.trades : [];
+  const trades = openTrades.concat(closedTrades);
+  for (const trade of trades) {
+    if (trade === null || typeof trade !== "object" || Array.isArray(trade)) continue;
+    const stake = trade.stake_amount;
+    const balanceAtOpen = lookup ? lookup(trade.open_date) : null;
+    trade.stake_amount_to_account_balance_ratio = safeDiv(stake, balanceAtOpen);
+    let absProfit;
+    let balanceAtClose;
+    if (trade.close_date) {
+      absProfit = trade.close_profit_abs;
+      balanceAtClose = lookup ? lookup(trade.close_date) : null;
+    } else {
+      absProfit = trade.profit_abs;
+      balanceAtClose = balanceNow;
+    }
+    trade.profit_to_account_balance_ratio = safeDiv(absProfit, balanceAtClose);
+    trade.funding_fees_to_stake_amount_ratio = safeDiv(trade.funding_fees, stake);
+
+    const isShort = Boolean(trade.is_short);
+    const orders = (Array.isArray(trade.orders) ? trade.orders : []).filter((o) => o !== null && typeof o === "object" && !Array.isArray(o));
+    const filledBySide = { true: 0, false: 0 };
+    for (const order of orders) {
+      const filled = order.filled;
+      if (typeof filled === "number" && filled > 0) {
+        filledBySide[isEntryOrder(order, isShort)] += filled;
+      }
+    }
+    for (const order of orders) {
+      order.funding_fee_to_order_cost_ratio = safeDiv(order.funding_fee, order.cost);
+      const sideFilled = filledBySide[isEntryOrder(order, isShort)];
+      order.order_filled_share_of_trade_side = safeDiv(order.filled, sideFilled || null);
+    }
+  }
+}
+
+/* Days since the first trade, for full-history daily/weekly/monthly windows. */
+function historyDays(firstTradeDate, nowMs) {
+  const match = /^\d{4}-\d{2}-\d{2}/.exec(String(firstTradeDate === null || firstTradeDate === undefined ? "" : firstTradeDate));
+  if (!match) return 8;
+  const start = new Date(`${match[0]}T00:00:00Z`);
+  if (Number.isNaN(start.getTime())) return 8;
+  const days = Math.floor(((nowMs === undefined ? Date.now() : nowMs) - start.getTime()) / 86400000) + 2;
+  return Math.min(Math.max(days, 8), MAX_DAILY_DAYS);
+}
+
+/* -------------------------------------------------------------- fetching */
+
+/* Mirrors fetch_trade_history: full closed-trade history via /trades + offset. */
+async function fetchTradeHistory(api, cap, failed, progress) {
+  const trades = [];
+  const seen = new Set();
+  let offset = 0;
+  let total = null;
+  let pageNo = 0;
+  while (cap === null || trades.length < cap) {
+    pageNo += 1;
+    progress.step(`Fetching closed trades — page ${pageNo}${total !== null ? `, ${Math.min(offset, total)} of ${total}` : ""} …`);
+    let page;
+    try {
+      page = await api.get("trades", { limit: TRADES_PAGE_SIZE, offset });
+    } catch (err) {
+      if (err instanceof ApiError) {
+        failed.push({ endpoint: "trades", http_status: err.status });
+        console.warn(`warning: trades failed with HTTP ${err.status}`);
+        progress.done();
+        break;
+      }
+      throw err;
+    }
+    page = page || {};
+    const batch = page.trades || [];
+    const fresh = batch.filter((t) => t !== null && typeof t === "object" && !Array.isArray(t) && !seen.has(t.trade_id));
+    for (const t of fresh) seen.add(t.trade_id);
+    trades.push(...fresh);
+    if (page.total_trades !== undefined) total = page.total_trades;
+    if (total !== null && pageNo === 1) progress.addTotal(Math.max(Math.ceil(total / TRADES_PAGE_SIZE) - 1, 0));
+    offset += batch.length;
+    progress.done();
+    if (batch.length === 0 || (total !== null && offset >= total)) break;
+  }
+  const capped = cap !== null ? trades.slice(0, cap) : trades;
+  capped.sort((a, b) => (a.trade_id || 0) - (b.trade_id || 0));
+  return { trades: capped, trades_count: capped.length, total_trades: total || capped.length };
+}
+
+/* Mirrors collect_report: same endpoint sequence, same parameters. */
+async function collectReport(api, redacted, tradesLimit, progress) {
+  const raw = {};
+  const failed = [];
+
+  const fetchSection = async (section, endpoint, params) => {
+    progress.step(`GET ${API_PREFIX}/${endpoint} — ${section} …`);
+    try {
+      const data = await api.get(endpoint, params);
+      raw[section] = data;
+      progress.done();
+      return data;
+    } catch (err) {
+      if (err instanceof ApiError) {
+        failed.push({ endpoint, http_status: err.status });
+        console.warn(`warning: ${endpoint} failed with HTTP ${err.status}`);
+        progress.done();
+        return null;
+      }
+      throw err;
+    }
+  };
+
+  progress.setTotal(20 + (redacted ? 0 : 1));
+  progress.step("Connecting to the bot — GET /api/v1/ping …");
+  await api.get("ping");
+  progress.done();
+
+  const version = await fetchSection("freqtrade_version", "version");
+  await fetchSection("config", "show_config");
+  await fetchSection("health", "health");
+  await fetchSection("system_info", "sysinfo");
+  await fetchSection("open_trades", "status");
+  await fetchSection("trade_counts", "count");
+  await fetchSection("profit_summary", "profit");
+  await fetchSection("performance_per_pair", "performance");
+
+  const days = historyDays((raw.profit_summary || {}).first_trade_date);
+  await fetchSection("daily_performance", "daily", { timescale: days });
+  await fetchSection("weekly_performance", "weekly", { timescale: Math.min(Math.floor(days / 7) + 2, MAX_WEEKLY_WEEKS) });
+  await fetchSection("monthly_performance", "monthly", { timescale: Math.min(Math.floor(days / 30) + 2, MAX_MONTHLY_MONTHS) });
+
+  raw.closed_trades = await fetchTradeHistory(api, tradesLimit, failed, progress);
+
+  await fetchSection("whitelist", "whitelist");
+  await fetchSection("blacklist", "blacklist");
+  await fetchSection("pair_locks", "locks");
+  await fetchSection("plot_config", "plot_config");
+  if (!redacted) await fetchSection("balance", "balance");
+
+  progress.step("Computing derived relative fields (stake/profit/funding ratios) …");
+  addDerivedFields(raw);
+  progress.done();
+
+  progress.step(redacted
+    ? "Redacting confidential fields (credentials, money values, identifiers) …"
+    : "Redaction disabled — keeping absolute values …");
+  const state = { enabled: redacted, count: 0 };
+  const report = {};
+  for (const section of Object.keys(raw)) {
+    report[section] = redactWalk(raw[section], "", "", state);
+  }
+  progress.done();
+
+  const metadata = {
+    tool: "web/index.html (tools/bot_report.py port)",
+    tool_version: TOOL_VERSION,
+    generated_at_utc: new Date().toISOString().replace(/\.\d{3}Z$/, "+00:00"),
+    freqtrade_version: (version || {}).version,
+    redacted,
+    redacted_field_count: state.count,
+    skipped_endpoints: redacted ? ["balance", "logs"] : [],
+    failed_endpoints: failed,
+  };
+  return { report_metadata: metadata, ...report };
+}
+
+const nullProgress = { setTotal() {}, addTotal() {}, step() {}, done() {} };
+
+/* Full pipeline: collect -> derive -> redact -> serialize.
+ * Used by both the page and the equivalence tests. */
+async function runExport(opts, progress) {
+  progress = progress || nullProgress;
+  const api = new FreqtradeApi(opts);
+  const report = await collectReport(api, opts.redact, opts.tradesLimit === undefined ? null : opts.tradesLimit, progress);
+  progress.step("Serializing JSON and preparing the download …");
+  const json = JSON.stringify(report, null, 2) + "\n";
+  const filename = `bot-report-${stamp()}.json`;
+  return { report, json, filename };
+}
+
+function stamp() {
+  return new Date().toISOString().replace(/[-:]/g, "").replace(/\.\d{3}Z$/, "Z");
+}
+
+/* ------------------------------------------------------------- DOM layer */
+
+function makeProgress() {
+  const section = document.getElementById("progress");
+  const stepEl = document.getElementById("progress-step");
+  const bar = document.getElementById("progress-bar");
+  section.hidden = false;
+  bar.max = 1;
+  bar.value = 0;
+  stepEl.setAttribute("aria-busy", "spinner");
+  stepEl.textContent = "";
+  return {
+    setTotal(n) { bar.max = n; },
+    addTotal(n) { bar.max = Number(bar.max) + n; },
+    step(label) { stepEl.textContent = label; },
+    done() { bar.value = Number(bar.value) + 1; },
+    finish() { section.hidden = true; stepEl.removeAttribute("aria-busy"); stepEl.textContent = ""; },
+  };
+}
+
+function setFormDisabled(form, disabled) {
+  for (const el of form.querySelectorAll("input, button")) el.disabled = disabled;
+}
+
+function el(tag, attrs, children) {
+  const node = document.createElement(tag);
+  for (const [name, value] of Object.entries(attrs || {})) {
+    if (name === "class") node.className = value;
+    else if (name === "html") node.innerHTML = value;
+    else node.setAttribute(name, value);
+  }
+  for (const child of children || []) {
+    node.append(child);
+  }
+  return node;
+}
+
+function renderSuccess(container, report, filename, json) {
+  const meta = report.report_metadata;
+  const failed = meta.failed_endpoints;
+  const children = [];
+
+  if (!meta.redacted) {
+    children.push(el("p", { class: "error" },
+      "Redaction was disabled — this report contains balances, absolute PnL and credentials. Use it for private diagnostics only, never share it."));
+  }
+  if (failed.length > 0) {
+    children.push(el("p", { class: "error" },
+      `${failed.length} endpoint(s) failed and were skipped: ` +
+      failed.map((f) => `${f.endpoint} (HTTP ${f.http_status})`).join(", ") + "."));
+  }
+
+  const dl = el("dl", { class: "kv" });
+  const add = (dt, dd) => { dl.append(el("dt", {}, [String(dt)]), el("dd", {}, [String(dd)])); };
+  add("Freqtrade version", meta.freqtrade_version ?? "unknown");
+  add("Generated at (UTC)", meta.generated_at_utc);
+  add("Closed trades", `${report.closed_trades.trades_count} exported / ${report.closed_trades.total_trades} total`);
+  add("Fields redacted", meta.redacted ? meta.redacted_field_count : "redaction disabled");
+  add("Skipped endpoints", meta.skipped_endpoints.length ? meta.skipped_endpoints.join(", ") : "none");
+  add("Failed endpoints", failed.length ? failed.map((f) => f.endpoint).join(", ") : "none");
+  add("Saved as", filename);
+  children.push(dl);
+
+  const button = el("button", { type: "button" }, ["Download again"]);
+  button.addEventListener("click", () => saveJson(json, filename));
+  children.push(button);
+  container.replaceChildren(...children);
+}
+
+function renderFailure(container, err) {
+  console.error("Export failed:", err);
+  container.replaceChildren(
+    el("p", { class: "error" }, err.friendly || String(err)),
+    el("p", {}, ["Fix the cause and try again. Nothing was written to disk."]),
+  );
+}
+
+function saveJson(json, filename) {
+  const blob = new Blob([json], { type: "application/json" });
+  const url = URL.createObjectURL(blob);
+  const link = el("a", { href: url, download: filename });
+  document.body.append(link);
+  link.click();
+  link.remove();
+  setTimeout(() => URL.revokeObjectURL(url), 10000);
+}
+
+async function onExport(form) {
+  const progressSection = document.getElementById("progress");
+  const resultSection = document.getElementById("result");
+  const resultBody = document.getElementById("result-body");
+  const resultTitle = document.getElementById("result-title");
+  const button = document.getElementById("btn-export");
+
+  const url = document.getElementById("f-url").value.trim();
+  if (!/^https?:\/\//i.test(url)) {
+    resultSection.hidden = false;
+    resultTitle.textContent = "Export failed";
+    renderFailure(resultBody, { friendly: "The API base URL must start with http:// or https://." });
+    return;
+  }
+  const limitRaw = document.getElementById("f-limit").value.trim();
+  const opts = {
+    url,
+    username: document.getElementById("f-user").value.trim() || null,
+    password: document.getElementById("f-pass").value || null,
+    redact: document.getElementById("f-redact").checked,
+    tradesLimit: limitRaw === "" ? null : Number(limitRaw),
+    timeout: Number(document.getElementById("f-timeout").value) || 30,
+  };
+
+  resultSection.hidden = true;
+  setFormDisabled(form, true);
+  button.setAttribute("aria-busy", "true");
+  const progress = makeProgress();
+  try {
+    const { report, json, filename } = await runExport(opts, progress);
+    saveJson(json, filename);
+    resultTitle.textContent = "Export finished";
+    renderSuccess(resultBody, report, filename, json);
+  } catch (err) {
+    resultTitle.textContent = "Export failed";
+    renderFailure(resultBody, err);
+  } finally {
+    progress.finish();
+    progressSection.hidden = true;
+    button.removeAttribute("aria-busy");
+    setFormDisabled(form, false);
+    resultSection.hidden = false;
+  }
+}
+
+if (typeof document !== "undefined") {
+  const start = () => {
+    const form = document.getElementById("connect");
+    form.addEventListener("submit", (event) => {
+      event.preventDefault();
+      onExport(form);
+    });
+  };
+  if (document.readyState === "loading") document.addEventListener("DOMContentLoaded", start);
+  else start();
+}
+</script>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -1202,6 +1202,7 @@ code {
         </label>
       </fieldset>
       <button type="submit" id="btn-export">Export report</button>
+      <button type="button" id="btn-test" secondary>Test connection</button>
     </form>
   </section>
 
@@ -1793,42 +1794,130 @@ function defaultBaseUrl() {
   return /^https?:\/\//.test(window.location.origin) ? window.location.origin : "http://127.0.0.1:8080";
 }
 
-async function onExport(form) {
-  const progressSection = document.getElementById("progress");
-  const resultSection = document.getElementById("result");
-  const resultBody = document.getElementById("result-body");
-  const resultTitle = document.getElementById("result-title");
-  const button = document.getElementById("btn-export");
+/* Default API URL: the page's own origin when served over http(s) — handy when
+ * the page is hosted next to the bot's reverse proxy — otherwise the freqtrade
+ * default (file:// and about:blank have no usable origin). */
+function defaultBaseUrl() {
+  return /^https?:\/\//.test(window.location.origin) ? window.location.origin : "http://127.0.0.1:8080";
+}
 
+function readFormOptions() {
   const url = document.getElementById("f-url").value.trim() || defaultBaseUrl();
-  if (!/^https?:\/\//i.test(url)) {
-    resultSection.hidden = false;
-    resultTitle.textContent = "Export failed";
-    renderFailure(resultBody, { friendly: "The API base URL must start with http:// or https://." });
-    return;
-  }
   const limitRaw = document.getElementById("f-limit").value.trim();
-  const opts = {
+  const tradesLimit = limitRaw === "" ? null : Number(limitRaw);
+  const timeout = Number(document.getElementById("f-timeout").value);
+  let error = null;
+  if (!/^https?:\/\//i.test(url)) {
+    error = `The API base URL must start with http:// or https:// — got "${url}".`;
+  } else if (tradesLimit !== null && (!Number.isInteger(tradesLimit) || tradesLimit < 1)) {
+    error = "Trades limit must be a positive whole number (or empty for the full history).";
+  }
+  return {
     url,
     username: document.getElementById("f-user").value.trim() || null,
     password: document.getElementById("f-pass").value || null,
     redact: document.getElementById("f-redact").checked,
-    tradesLimit: limitRaw === "" ? null : Number(limitRaw),
-    timeout: Number(document.getElementById("f-timeout").value) || 30,
+    tradesLimit,
+    timeout: timeout > 0 ? timeout : 30,
+    error,
   };
+}
+
+/* A blocked request is ambiguous from inside the page: CORS misconfiguration,
+ * an offline bot, and mixed-content blocking all reject identically. A no-cors
+ * request needs no CORS headers, so it resolves whenever *anything* is
+ * listening at the target and rejects only on network-level failures — that
+ * distinction tells us whether the fix is config (CORS) or connectivity. */
+async function probeReachable(baseUrl, timeoutMs) {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    await fetch(`${baseUrl}${API_PREFIX}/ping`, { mode: "no-cors", cache: "no-store", signal: controller.signal });
+    return true;
+  } catch (err) {
+    return false;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+async function diagnoseConnection(opts) {
+  const reachable = await probeReachable(opts.url, Math.min(opts.timeout * 1000, 8000));
+  if (reachable) return describeCorsBlock(opts.url);
+  return describeConnectionFailure(opts.url);
+}
+
+function describeCorsBlock(url) {
+  const origin = /^https?:\/\//.test(window.location.origin) ? window.location.origin : "<this page's origin>";
+  return {
+    kind: "cors",
+    headline: `Something answered at ${url}, but it did not send the CORS headers this page needs — almost always the missing "CORS_origins" entry in the bot's api_server config.`,
+    steps: [
+      `Add this page's exact origin "${origin}" (no trailing slash) to the bot's config:`,
+      "Restart freqtrade — config changes only apply after a restart.",
+      "Press Test connection again; it should report Connection OK before you export.",
+    ],
+    snippet: `"CORS_origins": ["${origin}"]`,
+  };
+}
+
+function describeConnectionFailure(url) {
+  let target = null;
+  try {
+    target = new URL(url);
+  } catch (err) {}
+  const pageHttps = window.location.protocol === "https:";
+  const targetHttp = target !== null && target.protocol === "http:";
+  const loopback = target !== null && (["127.0.0.1", "localhost", "::1"].includes(target.hostname) || target.hostname.endsWith(".localhost"));
+
+  if (pageHttps && targetHttp && !loopback) {
+    return {
+      kind: "mixed-content",
+      headline: `The browser blocked the request to ${url} as mixed content: an HTTPS page cannot call a plain-HTTP server on a non-local host.`,
+      steps: [
+        "Put the bot's API behind a TLS reverse proxy (Caddy, nginx, …) with a valid certificate and use its https:// URL here — browsers reject self-signed certificates and this page cannot skip verification.",
+        "Alternatively run the export with tools/bot_report.py, which has no browser restrictions.",
+      ],
+    };
+  }
+  return {
+    kind: "unreachable",
+    headline: `Nothing answered at ${url}, so the bot is offline, the URL/port is wrong, or the browser blocked the request.`,
+    steps: [
+      "Check the bot is running and the REST API is enabled (\"api_server\": {\"enabled\": true, …}).",
+      "Check the URL, port, and scheme — the freqtrade defaults are http://127.0.0.1:8080 with the username/password from the same config block.",
+      "If the URL uses https://, the certificate must be valid; browsers reject self-signed ones and this page cannot skip verification.",
+      loopback
+        ? "If the bot runs in Docker, 127.0.0.1 inside the container is not your machine — publish the port and point this page at the host."
+        : "If a firewall or VPN sits between this browser and the bot, allow the port there.",
+    ],
+  };
+}
+
+function renderConnectionHelp(container, diagnosis) {
+  const list = el("ol", {});
+  for (const step of diagnosis.steps) list.append(el("li", {}, [step]));
+  const children = [el("p", { class: "error" }, [diagnosis.headline]), el("p", {}, ["Do this:"]), list];
+  if (diagnosis.snippet) {
+    children.push(el("pre", {}, [el("code", {}, [diagnosis.snippet])]));
+  }
+  container.replaceChildren(...children);
+}
+
+async function withBusyUi(form, initialStep, action) {
+  const progressSection = document.getElementById("progress");
+  const resultSection = document.getElementById("result");
+  const resultTitle = document.getElementById("result-title");
+  const resultBody = document.getElementById("result-body");
+  const button = document.getElementById("btn-export");
 
   resultSection.hidden = true;
   setFormDisabled(form, true);
   button.setAttribute("aria-busy", "true");
   const progress = makeProgress();
+  progress.step(initialStep);
   try {
-    const { report, json, filename } = await runExport(opts, progress);
-    saveJson(json, filename);
-    resultTitle.textContent = "Export finished";
-    renderSuccess(resultBody, report, filename, json);
-  } catch (err) {
-    resultTitle.textContent = "Export failed";
-    renderFailure(resultBody, err);
+    await action(resultTitle, resultBody, progress);
   } finally {
     progress.finish();
     progressSection.hidden = true;
@@ -1836,6 +1925,62 @@ async function onExport(form) {
     setFormDisabled(form, false);
     resultSection.hidden = false;
   }
+}
+
+function optionsErrorUi(opts, title) {
+  document.getElementById("result").hidden = false;
+  document.getElementById("result-title").textContent = title;
+  renderFailure(document.getElementById("result-body"), { friendly: opts.error });
+}
+
+async function onExport(form) {
+  const opts = readFormOptions();
+  if (opts.error) {
+    optionsErrorUi(opts, "Export failed");
+    return;
+  }
+  await withBusyUi(form, "Connecting to the bot — GET /api/v1/ping …", async (resultTitle, resultBody, progress) => {
+    try {
+      const { report, json, filename } = await runExport(opts, progress);
+      saveJson(json, filename);
+      resultTitle.textContent = "Export finished";
+      renderSuccess(resultBody, report, filename, json);
+    } catch (err) {
+      resultTitle.textContent = "Export failed";
+      if (err instanceof NetworkError) {
+        progress.step("Diagnosing the connection problem …");
+        renderConnectionHelp(resultBody, await diagnoseConnection(opts));
+      } else {
+        renderFailure(resultBody, err);
+      }
+    }
+  });
+}
+
+async function onTestConnection(form) {
+  const opts = readFormOptions();
+  if (opts.error) {
+    optionsErrorUi(opts, "Connection test failed");
+    return;
+  }
+  await withBusyUi(form, "Testing connection — GET /api/v1/version …", async (resultTitle, resultBody, progress) => {
+    try {
+      const api = new FreqtradeApi(opts);
+      const version = await api.get("version");
+      resultTitle.textContent = "Connection OK";
+      resultBody.replaceChildren(
+        el("p", {}, [`freqtrade ${version.version || "unknown"} answered at ${opts.url} — CORS and credentials work. You can export the report now.`]),
+      );
+    } catch (err) {
+      resultTitle.textContent = "Connection failed";
+      if (err instanceof NetworkError) {
+        progress.step("Diagnosing the connection problem …");
+        renderConnectionHelp(resultBody, await diagnoseConnection(opts));
+      } else {
+        renderFailure(resultBody, err);
+      }
+    }
+  });
 }
 
 if (typeof document !== "undefined") {
@@ -1853,6 +1998,7 @@ if (typeof document !== "undefined") {
       event.preventDefault();
       onExport(form);
     });
+    document.getElementById("btn-test").addEventListener("click", () => onTestConnection(form));
   };
   if (document.readyState === "loading") document.addEventListener("DOMContentLoaded", start);
   else start();

--- a/index.html
+++ b/index.html
@@ -1192,7 +1192,8 @@ code {
     <ol>
       <li>Enable the freqtrade REST API (<code>"api_server": {"enabled": true, …}</code> with
         <code>username</code>/<code>password</code>) in your bot's config.</li>
-      <li>Browsers enforce CORS: add this page's exact origin (no trailing slash) to
+      <li>Browsers enforce CORS: add this page's exact origin (no trailing slash) —
+        <code id="page-origin">https://YOURNAME.github.io</code> — to
         <code>CORS_origins</code> in the same <code>api_server</code> block and restart the bot:
         <pre><code>"api_server": {
     "enabled": true,
@@ -1200,7 +1201,7 @@ code {
     "listen_port": 8080,
     "username": "freqtrader",
     "password": "…",
-    "CORS_origins": ["https://YOURNAME.github.io"]
+    "CORS_origins": ["<span id="page-origin-snippet">https://YOURNAME.github.io</span>"]
 }</code></pre>
         Without this entry the bot answers without the CORS headers browsers require, and every
         request from this page fails before reaching freqtrade.</li>
@@ -1810,6 +1811,13 @@ async function onExport(form) {
 
 if (typeof document !== "undefined") {
   const start = () => {
+    /* Only swap the guide's generic example for a real origin over http(s);
+     * file:// has no usable origin, so the generic example stays. */
+    const origin = window.location.origin;
+    if (/^https?:\/\//.test(origin)) {
+      document.getElementById("page-origin").textContent = origin;
+      document.getElementById("page-origin-snippet").textContent = origin;
+    }
     document.getElementById("f-url").placeholder = defaultBaseUrl();
     const form = document.getElementById("connect");
     form.addEventListener("submit", (event) => {

--- a/index.html
+++ b/index.html
@@ -1191,30 +1191,30 @@ table.summary td {
   color: var(--muted-foreground);
 }
 
-/* Per-field collapsible hints: clicking the ⓘ line expands the description.
-   Overrides the framework's bordered accordion look for these inline hints. */
-details.field-help {
-  border: none;
-  border-radius: 0;
-  padding: 0;
-  margin: 0.3rem 0 0;
-}
-details.field-help summary {
-  list-style: none;
-  display: inline-block;
-  font-size: 0.8125rem;
-  font-weight: 400;
+/* ⓘ field info markers: the tooltip anchors on the icon only (hover or
+   keyboard focus), never on the field itself. */
+.field-info {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1rem;
+  height: 1rem;
+  margin-left: 0.3rem;
+  border: 1px solid var(--border-color);
+  border-radius: 50%;
   color: var(--muted-foreground);
+  font-size: 0.6875rem;
+  font-weight: 600;
+  line-height: 1;
+  cursor: help;
+  user-select: none;
 }
-details.field-help summary::-webkit-details-marker {
-  display: none;
+.field-info:focus {
+  outline: none;
+  border-color: var(--ring);
 }
-details.field-help[open] summary {
-  color: var(--foreground);
-}
-details.field-help small {
-  display: block;
-  margin-top: 0.25rem;
+[tooltip-top]:focus::after {
+  opacity: 1;
 }
 /* Code never wraps: inline code becomes a horizontally scrollable chip so the
    text is always on one line and fully readable; pre>code stays a block. */
@@ -1278,42 +1278,26 @@ code {
     <form id="connect">
       <fieldset>
         <legend>Bot connection</legend>
-        <label>API base URL
+        <label>API base URL<span class="field-info" tabindex="0" role="note" aria-label="From your config.json: api_server.listen_ip_address + listen_port — default http://127.0.0.1:8080" tooltip-top="From your config.json: api_server.listen_ip_address + listen_port — default http://127.0.0.1:8080">i</span>
           <input type="text" id="f-url" placeholder="http://127.0.0.1:8080" spellcheck="false">
         </label>
-        <details class="field-help">
-          <summary>ⓘ from the freqtrade config</summary>
-          <small>From your config.json: <code>api_server.listen_ip_address</code> + <code>listen_port</code> — default <code>http://127.0.0.1:8080</code>.</small>
-        </details>
         <small>Root of the freqtrade REST API — scheme, host and port only. The default install listens on <code>http://127.0.0.1:8080</code>.</small>
       </fieldset>
       <fieldset>
         <legend>Credentials</legend>
-        <label>Username
+        <label>Username<span class="field-info" tabindex="0" role="note" aria-label="From your config.json: api_server.username" tooltip-top="From your config.json: api_server.username">i</span>
           <input type="text" id="f-user" autocomplete="off" spellcheck="false">
         </label>
-        <details class="field-help">
-          <summary>ⓘ from the freqtrade config</summary>
-          <small>From your config.json: <code>api_server.username</code>.</small>
-        </details>
-        <label>Password
+        <label>Password<span class="field-info" tabindex="0" role="note" aria-label="From your config.json: api_server.password" tooltip-top="From your config.json: api_server.password">i</span>
           <input type="password" id="f-pass">
         </label>
-        <details class="field-help">
-          <summary>ⓘ from the freqtrade config</summary>
-          <small>From your config.json: <code>api_server.password</code>.</small>
-        </details>
         <small>The same values as in your <code>api_server</code> config, sent as HTTP Basic auth on each request — never stored, never sent anywhere else.</small>
       </fieldset>
       <fieldset>
         <legend>Export options</legend>
         <label><input type="checkbox" id="f-redact" checked>
-          Redact confidential fields (recommended — required before sharing the report)</label>
-        <details class="field-help">
-          <summary>ⓘ about this option</summary>
-          <small>Tool option, not a config value — same as <code>--redact</code> / <code>--no-redact</code> in <code>tools/bot_report.py</code>.</small>
-        </details>
-        <label>Closed trades window
+          Redact confidential fields (recommended — required before sharing the report)<span class="field-info" tabindex="0" role="note" aria-label="Tool option, not a config value: same as --redact / --no-redact in tools/bot_report.py" tooltip-top="Tool option, not a config value: same as --redact / --no-redact in tools/bot_report.py">i</span></label>
+        <label>Closed trades window<span class="field-info" tabindex="0" role="note" aria-label="Web-only filter: the full history is always fetched, then only trades closed within the window are kept. All time matches the CLI output." tooltip-top="Web-only filter: the full history is always fetched, then only trades closed within the window are kept. All time matches the CLI output.">i</span>
           <select id="f-window">
             <option value="all" selected>All time</option>
             <option value="day">Last day</option>
@@ -1322,10 +1306,6 @@ code {
             <option value="year">Last year</option>
           </select>
         </label>
-        <details class="field-help">
-          <summary>ⓘ about this option</summary>
-          <small>Web-only filter: the full history is always fetched, then only trades closed within the window are kept. All time matches the CLI output.</small>
-        </details>
       </fieldset>
       <button type="submit" id="btn-export">Export report</button>
       <button type="button" id="btn-test" secondary tooltip-top="Uses the URL and credentials above: one request checks reachability, CORS headers and authentication.">Test connection</button>


### PR DESCRIPTION
## Summary

Adds a single self-contained `index.html` at the repo root: a 1:1 browser port of `tools/bot_report.py` (v1.3.0), hosted via GitHub Pages. Users open the page, enter their bot's REST API URL and credentials, and download the same redacted `bot-report-<timestamp>.json` the CLI produces — no Python required.

## What it is

- **Single file, no build step, no dependencies.** Styling is [shadcn-classless](https://github.com/fordus/shadcn-classless) (MIT), embedded with semantic components only (fieldset groups, table summary, details guides, progress, tooltips, kbd badges, cards). Its Google Fonts `@import` was stripped so the page loads **zero third-party resources**.
- **Same logic as the CLI**, ported 1:1: identical endpoint sequence and query params, full `/trades` pagination, derived scale-invariant ratio fields, and the same fail-closed redactor (whole-key deny list, secret/identifier token rules, numeric allow-list).
- **Closed-trades window presets** (web-only): All time / Last day / Last week / Last month / Last year. The freqtrade API cannot filter `/trades` by date, so the full history is fetched and filtered client-side; the chosen window is recorded in `report_metadata.closed_trades_window`. All time matches the CLI output exactly.
- **Test connection** button next to Export: one request validates URL, CORS and credentials ("Connection OK — freqtrade \<version\>") before committing to a full walk.
- **Actionable failure diagnosis:** a CORS block, an offline bot and mixed-content blocking look identical to `fetch`, so the page probes with a `no-cors` request to distinguish them, then renders numbered fix steps — including the exact `CORS_origins` snippet for the page's live origin.
- **Semantic status colors:** success (green), warning (amber), danger (red, from the framework's `--destructive`) and neutral (muted) across titles, confirmations, cautions and failure panels; light and dark variants.
- **Privacy-hardened by construction:** strict Content-Security-Policy (`default-src 'none'`), `referrer: no-referrer`, read-only `GET` requests to `/api/v1/*` only, nothing stored, nothing uploaded. The page states this and tells users to verify in DevTools → Network.
- **Per-field tooltips** point at the exact `config.json` keys (`api_server.username`, `api_server.password`, `listen_ip_address` + `listen_port`) or the CLI-flag equivalents.
- **Responsive + calm typography:** field groups stack, labels/inputs on their own rows, full-width controls, 16px inputs on mobile (no iOS focus-zoom), type scale stepped down in rem, single-line scrollable `code` chips.
- Per-request timeout is fixed at 120s (no browser equivalent of CLI tuning knobs like `--no-verify-tls`; that and TLS validity are explained in the page).

## Verification

- **Equivalence vs the Python CLI:** both were run against a mock freqtrade API (CORS + Basic auth + paginated `/trades`) and the reports deep-compared — identical in redacted mode (same `redacted_field_count`), `--no-redact` mode and `--trades-limit` mode.
- **Browser end-to-end:** real browser run against the mock — preflights + GETs only hit the bot, the downloaded file deep-equals the CLI output, and the page fetches nothing besides its own `index.html`.
- Window filtering, both failure paths, form validation and the diagnosis panels verified in-browser at desktop and mobile viewports.

## Deployment

Enable GitHub Pages for this branch (root), e.g. `https://\<user\>.github.io/NostalgiaForInfinity/`. The in-page setup guide then shows the exact origin users must add to their `api_server.CORS_origins`.